### PR TITLE
PROJQUAY-4 - Fix 400s raised when podman is attempting to pull images via proxied storage

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -43,6 +43,7 @@ location ~ ^/_storage_proxy/([^/]+)/([^/]+)/([^/]+)/(.+) {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $3;
+    proxy_set_header Authorization "";
 
     add_header Host $3;
 


### PR DESCRIPTION
### Description of Changes

Fixes an issue encountered when attempting to pull images from Quay via podman when storage proxying is enabled. Configures nginx to clear the Authorization header to ensure that storage engine does not raise a 400


#### Changes:

updated line 45 of nginx/server-base.conf.jnj

#### Issue 
https://issues.jboss.org/projects/PROJQUAY/issues/PROJQUAY-4

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
