### PR TITLE
Added app-sre ci pipleline scripts and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,12 @@ show-modified:
 all: clean pkgs test build
 
 pkgs: requirements.txt requirements-dev.txt requirements-tests.txt
-	pip install -r $<
+	echo "hello"
+	pip install -r $< --user
 
 requirements.txt: requirements-nover.txt
 	# Create a new virtualenv and activate it
+	echo "bye"
 	pyenv virtualenv 2.7.12 quay-deps
 	pyenv activate quay-deps
 
@@ -139,6 +141,16 @@ docker-build: pkgs build
 	docker build -t $(TAG) .
 	git checkout $(NAME)
 	echo $(TAG)
+
+app-sre-docker-build:
+	# get named head (ex: branch, tag, etc..)
+	export NAME=$(shell git rev-parse --abbrev-ref HEAD)
+	# checkout commit so .git/HEAD points to full sha (used in Dockerfile)
+	echo "$(SHA)"
+	git checkout $(SHA)
+	$(BUILD_CMD) -t ${IMG} .
+	git checkout $(NAME)
+
 
 run: license
 	goreman start

--- a/scripts/app_sre_build_deploy.sh
+++ b/scripts/app_sre_build_deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# AppSRE team CD
+
+set -exv
+
+CURRENT_DIR=$(dirname $0)
+
+BASE_IMG="quay"
+QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+IMG="${BASE_IMG}:latest"
+
+GIT_HASH=`git rev-parse --short=7 HEAD`
+
+# build the image
+BUILD_CMD="docker build" IMG="$IMG" make app-sre-docker-build
+
+# push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:${GIT_HASH}"

--- a/scripts/app_sre_pr_check.sh
+++ b/scripts/app_sre_pr_check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -exv
+
+BASE_IMG="quay"
+
+IMG="${BASE_IMG}:latest"
+
+BUILD_CMD="docker build" IMG="$IMG" make app-sre-docker-build


### PR DESCRIPTION
### Description of Changes

Added scripts used by app-sre CI pipeline. These scripts are required for any applications managed by APP SRE and deployed to OSD cluster.


#### Changes:

* PR check script
* Deployment image build script
* Make file target to build the docker image.

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format

Signed-off-by: Tejas Parikh <tparikh@redhat.com>

