### PR TITLE
OpenSearch

### DIFF
--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -83,6 +83,16 @@ def not_found_error_display(e = None):
   resp.status_code = 404
   return resp
 
+@web.route('/opensearch.xml')
+def opensearch():
+  template = render_template('opensearch.xml', 
+                             baseurl=get_app_url(),
+                             registry_title=app.config.get('REGISTRY_TITLE', 'Quay'))
+  resp = make_response(template)
+  resp.headers['Content-Type'] = 'application/xml'
+  return resp
+  
+
 @web.route('/organization/<path:path>', methods=['GET'])
 @web.route('/organization/<path:path>/', methods=['GET'])
 @no_cache

--- a/templates/base.html
+++ b/templates/base.html
@@ -131,6 +131,8 @@ b._i.push([a,e,d])};b.__SV=1.2}})(document,window.mixpanel||[]);
 mixpanel.init("{{ mixpanel_key }}", { track_pageview : false, debug: {{ is_debug }} });</script><!-- end Mixpanel -->
 {% endif %}
 
+  <link rel="search" type="application/opensearchdescription+xml" title="{{ config_set['REGISTRY_TITLE'] }}" href="/opensearch.xml" />
+
   </head>
   <body ng-class="pageClass + ' ' + (user.anonymous ? 'anon' : 'signedin')" class="co-img-bg-network">
     <div id="co-l-footer-wrapper">

--- a/templates/opensearch.xml
+++ b/templates/opensearch.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+<ShortName>{{ registry_title }}</ShortName>
+<Description>Find public container repositories on {{ registry_title }}</Description>
+<InputEncoding>UTF-8</InputEncoding>
+<AdultContent>false</AdultContent>
+<Language>en-us</Language>
+<Image width="16" height="16" type="image/x-icon">//static/img/quay_favicon.png</Image>
+<Url type="text/html" method="get" template="{{ baseurl }}/search?q={searchTerms}"/>
+</OpenSearchDescription>


### PR DESCRIPTION
### Description

Adds [OpenSearch](https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md) capabilities to Quay. This allows searching [directly using the Chrome OmniBar](https://stackoverflow.com/questions/7630144/how-to-add-google-chrome-omnibox-search-support-for-your-site).

### Changes

- Add `/opensearch.xml` route handler and template (for specific hostname)
- Add `<link rel="search">` tag to `base.html`

### Demo

**Chrome OnmiBar search (using `ngrok` because `localhost` not allowed):**
![quay-opensearch](https://user-images.githubusercontent.com/11700385/68975307-e7113000-07c0-11ea-8429-4be20fcf5af9.gif)

Addresses https://issues.jboss.org/browse/PROJQUAY-14