### PR TITLE
PROJQUAY-12 - remove mirror/rules API

### DIFF
--- a/data/model/repo_mirror.py
+++ b/data/model/repo_mirror.py
@@ -466,17 +466,20 @@ def set_mirroring_robot(repository, robot):
 
 # -------------------- Mirroring Rules --------------------------#
 
+def validate_rule(rule_type, rule_value):
+  if rule_type != RepoMirrorRuleType.TAG_GLOB_CSV:
+    raise ValidationError('validation failed: rule_type must be TAG_GLOB_CSV')
+
+  if not rule_value or not isinstance(rule_value, list) or len(rule_value) < 1:
+    raise ValidationError('validation failed: rule_value for TAG_GLOB_CSV must be a list with at least one rule')
+
 
 def create_rule(repository, rule_value, rule_type=RepoMirrorRuleType.TAG_GLOB_CSV, left_child=None, right_child=None):
   """
   Create a new Rule for mirroring a Repository
   """
 
-  if rule_type != RepoMirrorRuleType.TAG_GLOB_CSV:
-    raise ValidationError('validation failed: rule_type must be TAG_GLOB_CSV')
-
-  if not isinstance(rule_value, list) or len(rule_value) < 1:
-    raise ValidationError('validation failed: rule_value for TAG_GLOB_CSV must be a list with at least one rule')
+  validate_rule(rule_type, rule_value)
 
   rule_kwargs = {
     'repository': repository,
@@ -509,11 +512,18 @@ def get_root_rule(repository):
     return None
 
 
-def change_rule_value(rule, value):
+def change_rule(repository, rule_type, rule_value):
   """
   Update the value of an existing rule.
   """
+
+  validate_rule(rule_type, rule_value)
+
+  mirrorRule = get_root_rule(repository)
+  if not mirrorRule:
+    raise ValidationError('validation failed: rule not found')
+
   query = (RepoMirrorRule
-          .update(rule_value=value)
-          .where(RepoMirrorRule.id == rule.id))
+          .update(rule_value=rule_value)
+          .where(RepoMirrorRule.id == mirrorRule.id))
   return query.execute()

--- a/endpoints/api/test/test_mirror.py
+++ b/endpoints/api/test/test_mirror.py
@@ -58,7 +58,7 @@ def test_create_mirror_sets_permissions(existing_robot_permission, expected_perm
       'sync_interval': 100,
       'sync_start_date': '2019-08-20T17:51:00Z',
       'root_rule': {
-        'rule_type': 'TAG_GLOB_CSV',
+        'rule_kind': 'tag_glob_csv',
         'rule_value': ['latest','foo', 'bar']
       },
       'robot_username': 'devtable+newmirrorbot',
@@ -154,6 +154,11 @@ def test_get_mirror(client):
   ('verify_tls', False, 201),
   ('verify_tls', None,  400),
   ('verify_tls', 'abc', 400),
+
+  ('root_rule', {'rule_kind': 'tag_glob_csv', 'rule_value': ['3.1', '3.1*']}, 201),
+  ('root_rule', {'rule_kind': 'tag_glob_csv'}, 400),
+  ('root_rule', {'rule_kind': 'tag_glob_csv', 'rule_value': []}, 400),
+  ('root_rule', {'rule_kind': 'incorrect', 'rule_value': ['3.1', '3.1*']}, 400),
 
 ])
 def test_change_config(key, value, expected_status, client):

--- a/endpoints/api/test/test_security.py
+++ b/endpoints/api/test/test_security.py
@@ -1417,11 +1417,6 @@ SECURITY_TESTS = [
   (RepositoryStateResource, 'PUT', {'repository': 'devtable/simple'}, None, 'devtable', 400),
   (RepositoryStateResource, 'PUT', {'repository': 'devtable/simple'}, None, 'freshuser', 403),
   (RepositoryStateResource, 'PUT', {'repository': 'devtable/simple'}, None, 'reader', 403),
-
-  (ManageRepoMirrorRule, 'PUT', {'repository': 'devtable/simple'}, None, None, 401),
-  (ManageRepoMirrorRule, 'PUT', {'repository': 'devtable/simple'}, None, 'devtable', 400),
-  (ManageRepoMirrorRule, 'PUT', {'repository': 'devtable/simple'}, None, 'freshuser', 403),
-  (ManageRepoMirrorRule, 'PUT', {'repository': 'devtable/simple'}, None, 'reader', 403),
 ]
 
 @pytest.mark.parametrize('resource,method,params,body,identity,expected', SECURITY_TESTS)

--- a/static/js/directives/repo-view/repo-panel-mirroring.js
+++ b/static/js/directives/repo-view/repo-panel-mirroring.js
@@ -70,7 +70,7 @@ angular.module('quay').directive('repoPanelMirror', function () {
             };
           }
 
-          vm.tags = resp.root_rule.rule_value || []; // TODO: Use RepoMirrorRule-specific endpoint
+          vm.tags = resp.root_rule.rule_value || [];
 
           // TODO: These are not consistently provided by the API. Correct that in the API.
           vm.verifyTLS = resp.external_registry_config.verify_tls;
@@ -356,8 +356,16 @@ angular.module('quay').directive('repoPanelMirror', function () {
        * Update Tag-Rules
        */
       vm.changeTagRules = function(data, callback) {
-        let csv = data.values.rule_value;
-        let patterns = csv.split(',');
+        let csv = data.values.rule_value,
+            patterns;
+
+        // If already an array then the data has not changed
+        if (Array.isArray(csv)) {
+          patterns = csv;
+        } else {
+          patterns = csv.split(',');
+        }
+
 
         patterns.map(s => s.trim()); // Trim excess whitespace
         patterns = Array.from(new Set(patterns)); // De-duplicate
@@ -370,7 +378,7 @@ angular.module('quay').directive('repoPanelMirror', function () {
 
         data = {
           'root_rule': {
-            'rule_type': 'TAG_GLOB_CSV',
+            'rule_kind': "tag_glob_csv",
             'rule_value': patterns
           }
         }
@@ -378,7 +386,7 @@ angular.module('quay').directive('repoPanelMirror', function () {
         let displayError = ApiService.errorDisplay('Could not change Tag Rules', callback);
 
         ApiService
-        .changeRepoMirrorRule(data, params)
+        .changeRepoMirrorConfig(data, params)
         .then(function(resp) {
           vm.getMirror();
           callback(true);
@@ -452,7 +460,7 @@ angular.module('quay').directive('repoPanelMirror', function () {
              }
            },
            'root_rule': {
-             'rule_type': 'TAG_GLOB_CSV',
+             'rule_kind': "tag_glob_csv",
              'rule_value': patterns
            }
         }

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -2246,7 +2246,7 @@ def test_repository_states(state, use_robot, create_mirror, robot_exists, expect
       'sync_interval': 1000,
       'sync_start_date': '2020-01-01T00:00:00Z',
       'root_rule': {
-        'rule_type': 'TAG_GLOB_CSV',
+        'rule_kind': "tag_glob_csv",
         'rule_value': ['latest', '1.3*', 'foo']
       },
       'robot_username': robot_full_name,


### PR DESCRIPTION
Updated API to remove mirror/rules endpoint. Rule is now handled within body of config only.

https://issues.jboss.org/browse/PROJQUAY-12

