### PR TITLE
PROJQUAY-11 - update progressDeadlineSeconds value for openshift deployment

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -184,7 +184,7 @@ parameters:
     value: "0"
     displayName: quay app deployment min ready seconds
   - name: QUAY_APP_DEPLOYMENT_PROGRESS_DEADLINE_SECONDS
-    value: "600s"
+    value: "600"
     displayName: quay app deployment progress deadline seconds
   - name: QUAY_APP_DEPLOYMENT_REVISION_HISTORY_LIMITS
     value: "10"


### PR DESCRIPTION
### Description of Changes

The value for progressDeadlineSeconds had time unit in it. It needs to be integer

#### Issue: <link to story or task>

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format

Signed-off-by: Tejas Parikh <tparikh@redhat.com>
