### PR TITLE
add required new-installation env value to configapp supervisord.conf

### DIFF
--- a/config_app/conf/supervisord.conf
+++ b/config_app/conf/supervisord.conf
@@ -23,7 +23,7 @@ result_handler = supervisor_stdout:event_handler
 
 [program:gunicorn-config]
 environment=
-  PYTHONPATH=%(ENV_QUAYDIR)s
+  PYTHONPATH=%(ENV_QUAYDIR)s,ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE=new-installation
 command=gunicorn -c %(ENV_QUAYDIR)s/config_app/conf/gunicorn_web.py config_application:application
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
### Description of Changes
* Sets ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE=new-installation in
  config_app/conf/supervisord.conf for the gunicorn service

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
