### PR TITLE
PROJQUAY-19 - correct migration logic

### DIFF
--- a/data/migrations/versions/34c8ef052ec9_repo_mirror_columns.py
+++ b/data/migrations/versions/34c8ef052ec9_repo_mirror_columns.py
@@ -81,7 +81,7 @@ def upgrade(tables, tester, progress_reporter):
   op.add_column('repomirrorconfig', sa.Column('external_reference', sa.Text(), nullable=True))
 
   from app import app
-  if app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
+  if not app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
     for repo_mirror in _iterate(RepoMirrorConfig, (RepoMirrorConfig.external_reference >> None)):
       repo = '%s/%s/%s' % (repo_mirror.external_registry, repo_mirror.external_namespace, repo_mirror.external_repository)
       logger.info('migrating %s' % repo)
@@ -112,7 +112,7 @@ def downgrade(tables, tester, progress_reporter):
   op.add_column('repomirrorconfig', sa.Column('external_repository', sa.String(length=255), nullable=True))
 
   from app import app
-  if app.config.get('SETUP_COMPLETE', False):
+  if not app.config.get('SETUP_COMPLETE', False):
     logger.info('Restoring columns from external_reference')
     for repo_mirror in _iterate(RepoMirrorConfig, (RepoMirrorConfig.external_registry >> None)):
       logger.info('Restoring %s' % repo_mirror.external_reference)

--- a/data/migrations/versions/703298a825c2_backfill_new_encrypted_fields.py
+++ b/data/migrations/versions/703298a825c2_backfill_new_encrypted_fields.py
@@ -99,7 +99,7 @@ def upgrade(tables, tester, progress_reporter):
   op = ProgressWrapper(original_op, progress_reporter)
 
   from app import app
-  if app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
+  if not app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
     # Empty all access token names to fix the bug where we put the wrong name and code
     # in for some tokens.
     AccessToken.update(token_name=None).where(AccessToken.token_name >> None).execute()

--- a/data/migrations/versions/c059b952ed76_remove_unencrypted_fields_and_data.py
+++ b/data/migrations/versions/c059b952ed76_remove_unencrypted_fields_and_data.py
@@ -40,7 +40,7 @@ def upgrade(tables, tester, progress_reporter):
 
     # Overwrite all plaintext robot credentials.
     from app import app
-    if app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
+    if not app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
         while True:
             try:
                 robot_account_token = RobotAccountToken.get(fully_migrated=False)


### PR DESCRIPTION
Migrations involving model changes had logic inverted for `SETUP_COMPLETE`

Changed
34c8ef052ec9_repo_mirror_columns.py\084:  if not app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
34c8ef052ec9_repo_mirror_columns.py\0115:  if not app.config.get('SETUP_COMPLETE', False):
703298a825c2_backfill_new_encrypted_fields.py\0102:  if not app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
c059b952ed76_remove_unencrypted_fields_and_data.py\043:    if not app.config.get('SETUP_COMPLETE', False) or tester.is_testing:

Unchanged
a6c463dfb9fe_back_fill_build_expand_config.py\029:  if not app.config.get('SETUP_COMPLETE', False):
a6c463dfb9fe_back_fill_build_expand_config.py\041:  if not app.config.get('SETUP_COMPLETE', False):
b918abdbee43_run_full_tag_backfill.py\026:    if not app.config.get('SETUP_COMPLETE', False):

https://issues.jboss.org/browse/PROJQUAY-19