### PR TITLE
added scripts to build off both rhel7 and centos7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,10 @@ docker-build: pkgs build
 	git checkout $(NAME)
 	echo $(TAG)
 
-app-sre-docker-build:
+app-sre-docker-build-rhel7:
+	$(BUILD_CMD) -t ${IMG} -f Dockerfile.osbs .
+
+app-sre-docker-build-centos7:
 	$(BUILD_CMD) -t ${IMG} -f Dockerfile.centos7.osbs .
 
 run: license

--- a/scripts/app_sre_build_deploy.sh
+++ b/scripts/app_sre_build_deploy.sh
@@ -1,25 +1,5 @@
 #!/bin/bash
 
-# AppSRE team CD
-
 set -exv
 
-CURRENT_DIR=$(dirname $0)
-
-BASE_IMG="quay"
-QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
-IMG="${BASE_IMG}:latest"
-
-GIT_HASH=`git rev-parse --short=7 HEAD`
-
-# build the image
-BUILD_CMD="docker build" IMG="$IMG" make app-sre-docker-build
-
-# push the image
-skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:${IMG}" \
-    "docker://${QUAY_IMAGE}:latest"
-
-skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:${IMG}" \
-    "docker://${QUAY_IMAGE}:${GIT_HASH}"
+# DO NOTHING

--- a/scripts/app_sre_build_deploy_centos7.sh
+++ b/scripts/app_sre_build_deploy_centos7.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# AppSRE team CD
+
+set -exv
+
+CURRENT_DIR=$(dirname $0)
+
+BASE_IMG="quay"
+QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+IMG="${BASE_IMG}:latest"
+
+GIT_HASH=`git rev-parse --short=7 HEAD`
+
+# build the image
+BUILD_CMD="docker build" IMG="$IMG" make app-sre-docker-build-centos7
+
+# push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:${GIT_HASH}"

--- a/scripts/app_sre_build_deploy_rhel7.sh
+++ b/scripts/app_sre_build_deploy_rhel7.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# AppSRE team CD
+
+set -exv
+
+CURRENT_DIR=$(dirname $0)
+
+BASE_IMG="quay"
+QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
+IMG="${BASE_IMG}:latest"
+
+GIT_HASH=`git rev-parse --short=7 HEAD`
+
+# build the image
+BUILD_CMD="docker build" IMG="$IMG" make app-sre-docker-build-rhel7
+
+# push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:${GIT_HASH}"

--- a/scripts/app_sre_pr_check _centos7.sh
+++ b/scripts/app_sre_pr_check _centos7.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -exv
+
+BASE_IMG="quay"
+
+IMG="${BASE_IMG}:latest"
+
+BUILD_CMD="docker build" IMG="$IMG" make app-sre-docker-build-centos7

--- a/scripts/app_sre_pr_check.sh
+++ b/scripts/app_sre_pr_check.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 set -exv
 
-BASE_IMG="quay"
-
-IMG="${BASE_IMG}:latest"
-
-BUILD_CMD="docker build" IMG="$IMG" make app-sre-docker-build
+# DO NOTHING

--- a/scripts/app_sre_pr_check_rhel7.sh
+++ b/scripts/app_sre_pr_check_rhel7.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -exv
+
+BASE_IMG="quay"
+
+IMG="${BASE_IMG}:latest"
+
+BUILD_CMD="docker build" IMG="$IMG" make make app-sre-docker-build-rhel7

--- a/scripts/app_sre_pr_check_rhel7.sh
+++ b/scripts/app_sre_pr_check_rhel7.sh
@@ -5,4 +5,4 @@ BASE_IMG="quay"
 
 IMG="${BASE_IMG}:latest"
 
-BUILD_CMD="docker build" IMG="$IMG" make make app-sre-docker-build-rhel7
+BUILD_CMD="docker build" IMG="$IMG" make app-sre-docker-build-rhel7


### PR DESCRIPTION
As we setup CI/CD pipeline for Quay, we may need to switch the source image for quay container images. We should achieve this code change for Jenkins job in the app-interface repository and not the upstream quay repository.

https://issues.jboss.org/browse/PROJQUAY-24

Signed-off-by: Tejas Parikh <tparikh@redhat.com>



