### PR TITLE
PROJQUAY-27 - changed source of rhel7 container image

### DIFF
--- a/Dockerfile.osbs
+++ b/Dockerfile.osbs
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel7:7.7
+FROM registry.access.redhat.com/rhel7:7.7
 LABEL maintainer "thomasmckay@redhat.com"
 
 ENV PYTHON_VERSION=2.7 \


### PR DESCRIPTION
App-SRE is able to pull RHEL7 images from registry.access.redhat.com/rhel7:7.7 and not from registry.redhat.io/rhel7:7.7

https://issues.jboss.org/browse/PROJQUAY-27

Signed-off-by: Tejas Parikh <tparikh@redhat.com>


