### PR TITLE
Change is_testing to a method under DataTester

### DIFF
--- a/data/migrations/tester.py
+++ b/data/migrations/tester.py
@@ -92,7 +92,7 @@ class MigrationTester(object):
   """
   TestDataType = DataTypes
 
-  @abstractproperty
+  @abstractmethod
   def is_testing(self):
     """ Returns whether we are currently under a migration test. """
 
@@ -111,7 +111,6 @@ class NoopTester(MigrationTester):
 
 
 class PopulateTestDataTester(MigrationTester):
-  @property
   def is_testing(self):
     return True
 

--- a/data/migrations/versions/34c8ef052ec9_repo_mirror_columns.py
+++ b/data/migrations/versions/34c8ef052ec9_repo_mirror_columns.py
@@ -81,7 +81,7 @@ def upgrade(tables, tester, progress_reporter):
   op.add_column('repomirrorconfig', sa.Column('external_reference', sa.Text(), nullable=True))
 
   from app import app
-  if app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
+  if app.config.get('SETUP_COMPLETE', False) or tester.is_testing():
     for repo_mirror in _iterate(RepoMirrorConfig, (RepoMirrorConfig.external_reference >> None)):
       repo = '%s/%s/%s' % (repo_mirror.external_registry, repo_mirror.external_namespace, repo_mirror.external_repository)
       logger.info('migrating %s' % repo)

--- a/data/migrations/versions/703298a825c2_backfill_new_encrypted_fields.py
+++ b/data/migrations/versions/703298a825c2_backfill_new_encrypted_fields.py
@@ -99,7 +99,7 @@ def upgrade(tables, tester, progress_reporter):
   op = ProgressWrapper(original_op, progress_reporter)
 
   from app import app
-  if app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
+  if app.config.get('SETUP_COMPLETE', False) or tester.is_testing():
     # Empty all access token names to fix the bug where we put the wrong name and code
     # in for some tokens.
     AccessToken.update(token_name=None).where(AccessToken.token_name >> None).execute()

--- a/data/migrations/versions/c059b952ed76_remove_unencrypted_fields_and_data.py
+++ b/data/migrations/versions/c059b952ed76_remove_unencrypted_fields_and_data.py
@@ -40,7 +40,7 @@ def upgrade(tables, tester, progress_reporter):
 
     # Overwrite all plaintext robot credentials.
     from app import app
-    if app.config.get('SETUP_COMPLETE', False) or tester.is_testing:
+    if app.config.get('SETUP_COMPLETE', False) or tester.is_testing():
         while True:
             try:
                 robot_account_token = RobotAccountToken.get(fully_migrated=False)


### PR DESCRIPTION
The no-op-er appears to return different results for abstractproperty's under different versions of Python, and this was therefore breaking the checks. We change to a method to ensure we always get a boolean response.

Correct fix for https://issues.jboss.org/browse/PROJQUAY-19