### PR TITLE
Fix deactivation of Gitlab triggers with invalid tokens

### DIFF
--- a/buildtrigger/gitlabhandler.py
+++ b/buildtrigger/gitlabhandler.py
@@ -256,7 +256,13 @@ class GitLabBuildTrigger(BuildTriggerHandler):
 
     def deactivate(self):
         config = self.config
-        gl_client = self._get_authorized_client()
+        try:
+            gl_client = self._get_authorized_client()
+        except TriggerAuthException:
+            config.pop("key_id", None)
+            config.pop("hook_id", None)
+            self.config = config
+            return config
 
         # Find the GitLab repository.
         try:


### PR DESCRIPTION
We were trying to get an authorized client, which is failing. In such a scenario, just delete the trigger.

Fixes https://issues.jboss.org/browse/PROJQUAY-35
