### PR TITLE
PROJQUAY-34 - create and chown /certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN mkdir /datastorage && chgrp 0 /datastorage && chmod g=u /datastorage && \
     mkdir -p /var/log/nginx && chgrp 0 /var/log/nginx && chmod g=u /var/log/nginx && \
     mkdir -p /conf/stack && chgrp 0 /conf/stack && chmod g=u /conf/stack && \
     mkdir -p /tmp && chgrp 0 /tmp && chmod g=u /tmp && \
+    mkdir /certificates && chgrp 0 /certificates && chmod g=u /certificates && \
     chmod g=u /etc/passwd
 
 RUN chgrp 0 /var/opt/rh/rh-nginx112/log/nginx && chmod g=u /var/opt/rh/rh-nginx112/log/nginx

--- a/Dockerfile.centos7.osbs
+++ b/Dockerfile.centos7.osbs
@@ -114,6 +114,7 @@ RUN mkdir /datastorage && chgrp 0 /datastorage && chmod g=u /datastorage && \
     mkdir -p /var/log/nginx && chgrp 0 /var/log/nginx && chmod g=u /var/log/nginx && \
     mkdir -p /conf/stack && chgrp 0 /conf/stack && chmod g=u /conf/stack && \
     mkdir -p /tmp && chgrp 0 /tmp && chmod g=u /tmp && \
+    mkdir /certificates && chgrp 0 /certificates && chmod g=u /certificates && \
     chmod g=u /etc/passwd
 
 RUN chgrp 0 /var/opt/rh/rh-nginx112/log/nginx && chmod g=u /var/opt/rh/rh-nginx112/log/nginx

--- a/Dockerfile.osbs
+++ b/Dockerfile.osbs
@@ -119,6 +119,7 @@ RUN mkdir /datastorage && chgrp 0 /datastorage && chmod g=u /datastorage && \
     mkdir -p /var/log/nginx && chgrp 0 /var/log/nginx && chmod g=u /var/log/nginx && \
     mkdir -p /conf/stack && chgrp 0 /conf/stack && chmod g=u /conf/stack && \
     mkdir -p /tmp && chgrp 0 /tmp && chmod g=u /tmp && \
+    mkdir /certificates && chgrp 0 /certificates && chmod g=u /certificates && \
     chmod g=u /etc/passwd
 
 RUN chgrp 0 /var/opt/rh/rh-nginx112/log/nginx && chmod g=u /var/opt/rh/rh-nginx112/log/nginx

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -119,6 +119,7 @@ RUN mkdir /datastorage && chgrp 0 /datastorage && chmod g=u /datastorage && \
     mkdir -p /var/log/nginx && chgrp 0 /var/log/nginx && chmod g=u /var/log/nginx && \
     mkdir -p /conf/stack && chgrp 0 /conf/stack && chmod g=u /conf/stack && \
     mkdir -p /tmp && chgrp 0 /tmp && chmod g=u /tmp && \
+    mkdir /certificates && chgrp 0 /certificates && chmod g=u /certificates && \
     chmod g=u /etc/passwd
 
 RUN chgrp 0 /var/opt/rh/rh-nginx112/log/nginx && chmod g=u /var/opt/rh/rh-nginx112/log/nginx


### PR DESCRIPTION
The `certs_create.sh` expects _/certificates_ to be writable. Dockerfiles updated.

https://issues.jboss.org/browse/PROJQUAY-34