### PR TITLE
Break the encrypted token backfill into its own phase

### DIFF
--- a/active_migration.py
+++ b/active_migration.py
@@ -22,6 +22,9 @@ ActiveDataMigration = DefinedDataMigration(
         MigrationPhase(
             "backfill-then-read-only-new", "703298a825c2", [ERTMigrationFlags.WRITE_OLD_FIELDS]
         ),
+        MigrationPhase(
+            "change-column-types", "49e1138ed12d", [ERTMigrationFlags.WRITE_OLD_FIELDS],
+        ),
         MigrationPhase("stop-writing-both", "703298a825c2", []),
         MigrationPhase("remove-old-fields", "c059b952ed76", []),
     ],

--- a/data/migrations/versions/49e1138ed12d_change_token_column_types.py
+++ b/data/migrations/versions/49e1138ed12d_change_token_column_types.py
@@ -1,0 +1,93 @@
+""" Change token column types for encrypted columns
+
+Revision ID: 49e1138ed12d
+Revises: 703298a825c2
+Create Date: 2019-08-19 16:07:48.109889
+
+"""
+# revision identifiers, used by Alembic.
+revision = "49e1138ed12d"
+down_revision = "703298a825c2"
+
+from alembic import op as original_op
+from data.migrations.progress import ProgressWrapper
+import sqlalchemy as sa
+
+
+def upgrade(tables, tester, progress_reporter):
+    op = ProgressWrapper(original_op, progress_reporter)
+
+    # Adjust existing fields to be nullable.
+    op.alter_column("accesstoken", "code", nullable=True, existing_type=sa.String(length=255))
+    op.alter_column(
+        "oauthaccesstoken", "access_token", nullable=True, existing_type=sa.String(length=255)
+    )
+    op.alter_column(
+        "oauthauthorizationcode", "code", nullable=True, existing_type=sa.String(length=255)
+    )
+    op.alter_column(
+        "appspecificauthtoken", "token_code", nullable=True, existing_type=sa.String(length=255)
+    )
+
+    # Adjust new fields to be non-nullable.
+    op.alter_column(
+        "accesstoken", "token_name", nullable=False, existing_type=sa.String(length=255)
+    )
+    op.alter_column(
+        "accesstoken", "token_code", nullable=False, existing_type=sa.String(length=255)
+    )
+
+    op.alter_column(
+        "appspecificauthtoken", "token_name", nullable=False, existing_type=sa.String(length=255)
+    )
+    op.alter_column(
+        "appspecificauthtoken", "token_secret", nullable=False, existing_type=sa.String(length=255)
+    )
+
+    op.alter_column(
+        "oauthaccesstoken", "token_name", nullable=False, existing_type=sa.String(length=255)
+    )
+    op.alter_column(
+        "oauthaccesstoken", "token_code", nullable=False, existing_type=sa.String(length=255)
+    )
+
+    op.alter_column(
+        "oauthauthorizationcode", "code_name", nullable=False, existing_type=sa.String(length=255)
+    )
+    op.alter_column(
+        "oauthauthorizationcode",
+        "code_credential",
+        nullable=False,
+        existing_type=sa.String(length=255),
+    )
+
+
+def downgrade(tables, tester, progress_reporter):
+    op = ProgressWrapper(original_op, progress_reporter)
+
+    op.alter_column("accesstoken", "token_name", nullable=True, existing_type=sa.String(length=255))
+    op.alter_column("accesstoken", "token_code", nullable=True, existing_type=sa.String(length=255))
+
+    op.alter_column(
+        "appspecificauthtoken", "token_name", nullable=True, existing_type=sa.String(length=255)
+    )
+    op.alter_column(
+        "appspecificauthtoken", "token_secret", nullable=True, existing_type=sa.String(length=255)
+    )
+
+    op.alter_column(
+        "oauthaccesstoken", "token_name", nullable=True, existing_type=sa.String(length=255)
+    )
+    op.alter_column(
+        "oauthaccesstoken", "token_code", nullable=True, existing_type=sa.String(length=255)
+    )
+
+    op.alter_column(
+        "oauthauthorizationcode", "code_name", nullable=True, existing_type=sa.String(length=255)
+    )
+    op.alter_column(
+        "oauthauthorizationcode",
+        "code_credential",
+        nullable=True,
+        existing_type=sa.String(length=255),
+    )

--- a/data/migrations/versions/703298a825c2_backfill_new_encrypted_fields.py
+++ b/data/migrations/versions/703298a825c2_backfill_new_encrypted_fields.py
@@ -314,77 +314,7 @@ def upgrade(tables, tester, progress_reporter):
             OAuthApplication.select().where(OAuthApplication.fully_migrated == False).count()
         ) == 0
 
-    # Adjust existing fields to be nullable.
-    op.alter_column("accesstoken", "code", nullable=True, existing_type=sa.String(length=255))
-    op.alter_column(
-        "oauthaccesstoken", "access_token", nullable=True, existing_type=sa.String(length=255)
-    )
-    op.alter_column(
-        "oauthauthorizationcode", "code", nullable=True, existing_type=sa.String(length=255)
-    )
-    op.alter_column(
-        "appspecificauthtoken", "token_code", nullable=True, existing_type=sa.String(length=255)
-    )
-
-    # Adjust new fields to be non-nullable.
-    op.alter_column(
-        "accesstoken", "token_name", nullable=False, existing_type=sa.String(length=255)
-    )
-    op.alter_column(
-        "accesstoken", "token_code", nullable=False, existing_type=sa.String(length=255)
-    )
-
-    op.alter_column(
-        "appspecificauthtoken", "token_name", nullable=False, existing_type=sa.String(length=255)
-    )
-    op.alter_column(
-        "appspecificauthtoken", "token_secret", nullable=False, existing_type=sa.String(length=255)
-    )
-
-    op.alter_column(
-        "oauthaccesstoken", "token_name", nullable=False, existing_type=sa.String(length=255)
-    )
-    op.alter_column(
-        "oauthaccesstoken", "token_code", nullable=False, existing_type=sa.String(length=255)
-    )
-
-    op.alter_column(
-        "oauthauthorizationcode", "code_name", nullable=False, existing_type=sa.String(length=255)
-    )
-    op.alter_column(
-        "oauthauthorizationcode",
-        "code_credential",
-        nullable=False,
-        existing_type=sa.String(length=255),
-    )
-
 
 def downgrade(tables, tester, progress_reporter):
     op = ProgressWrapper(original_op, progress_reporter)
-
-    op.alter_column("accesstoken", "token_name", nullable=True, existing_type=sa.String(length=255))
-    op.alter_column("accesstoken", "token_code", nullable=True, existing_type=sa.String(length=255))
-
-    op.alter_column(
-        "appspecificauthtoken", "token_name", nullable=True, existing_type=sa.String(length=255)
-    )
-    op.alter_column(
-        "appspecificauthtoken", "token_secret", nullable=True, existing_type=sa.String(length=255)
-    )
-
-    op.alter_column(
-        "oauthaccesstoken", "token_name", nullable=True, existing_type=sa.String(length=255)
-    )
-    op.alter_column(
-        "oauthaccesstoken", "token_code", nullable=True, existing_type=sa.String(length=255)
-    )
-
-    op.alter_column(
-        "oauthauthorizationcode", "code_name", nullable=True, existing_type=sa.String(length=255)
-    )
-    op.alter_column(
-        "oauthauthorizationcode",
-        "code_credential",
-        nullable=True,
-        existing_type=sa.String(length=255),
-    )
+    pass

--- a/data/migrations/versions/c059b952ed76_remove_unencrypted_fields_and_data.py
+++ b/data/migrations/versions/c059b952ed76_remove_unencrypted_fields_and_data.py
@@ -1,14 +1,14 @@
 """Remove unencrypted fields and data
 
 Revision ID: c059b952ed76
-Revises: 703298a825c2
+Revises: 49e1138ed12d
 Create Date: 2019-08-19 16:31:00.952773
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "c059b952ed76"
-down_revision = "703298a825c2"
+down_revision = "49e1138ed12d"
 
 import uuid
 


### PR DESCRIPTION
This will ensure that if we have an issue, we don't also have to contend with a schema change
