### PR TITLE
Allow Creating Notifications for Mirrored Repositories

### DIFF
--- a/static/directives/repository-events-table.html
+++ b/static/directives/repository-events-table.html
@@ -5,7 +5,7 @@
 
       <div class="heading-controls hidden-sm hidden-xs">
         <a href="/repository/{{ repository.namespace }}/{{ repository.name }}/create-notification"
-           class="btn btn-primary" ng-show="repository.can_write && !inReadOnlyMode">
+           class="btn btn-primary" ng-show="canCreateNotification()">
            <span class="create-notification-btn"><i class="fa fa-plus"></i> Create Notification</span>
         </a>
       </div>
@@ -16,7 +16,7 @@
 
           <div class="empty" ng-if="!notifications.length">
             <div class="empty-primary-msg">No notifications have been setup for this repository.</div>
-            <div class="empty-secondary-msg hidden-sm hidden-xs" ng-if="repository.can_write && !inReadOnlyMode">
+            <div class="empty-secondary-msg hidden-sm hidden-xs" ng-if="canCreateNotification()">
               Click the "Create Notification" button above to add a new notification for a repository event.
             </div>
             <div class="empty-secondary-msg visible-sm visible-xs" ng-if="repository.can_write">
@@ -78,7 +78,7 @@
                 </td>
 
                 <td>
-                  <span class="cor-options-menu" ng-show="!inReadOnlyMode">
+                  <span class="cor-options-menu" ng-show="canCreateNotification()">
                     <span class="cor-option" option-click="testNotification(notification)">
                       <i class="fa fa-send"></i> Test Notification
                     </span>

--- a/static/js/directives/ui/repository-events-table.js
+++ b/static/js/directives/ui/repository-events-table.js
@@ -15,7 +15,11 @@ angular.module('quay').directive('repositoryEventsTable', function () {
     },
     controller: function($scope, $element, $timeout, ApiService, Restangular, UtilService,
                          ExternalNotificationData, $location, StateService) {
-      $scope.inReadOnlyMode = StateService.inReadOnlyMode();
+      $scope.canCreateNotification = function() {
+        return StateService.inReadOnlyMode()
+          ? false
+          : $scope.repository.state === 'MIRROR' || $scope.repository.can_write;
+      };
       $scope.showNewNotificationCounter = 0;
       $scope.newNotificationData = {};
 


### PR DESCRIPTION
### Description

Previously we hid the "Create Notification" button if in readonly mode or if the user didn't have write access to the repository. For mirrored repositories, users don't have write access, but the notification worker can still create notifications, so allow users to make them.

### Screenshots

**"Create Notification" button for a mirrored repository:**
![Screenshot_20191204_143616](https://user-images.githubusercontent.com/11700385/70175448-bc6e1500-16a4-11ea-9fed-c2e9cb29297a.png)

Fixes https://issues.jboss.org/browse/PROJQUAY-42
Fixes https://jira.coreos.com/browse/QUAY-2198