### PR TITLE
[PROJQUAY-45] Specify `new-installation` migration for 3.2.

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -13,6 +13,9 @@ ENV QUAYDIR /quay-registry
 ENV QUAYCONF /quay-registry/conf
 ENV QUAYPATH "."
 
+# Determines migration path
+ENV ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE=new-installation
+
 RUN mkdir $QUAYDIR
 WORKDIR $QUAYDIR
 


### PR DESCRIPTION
### Description of Changes

This should allow the image to be executed successfully without manually providing the environment variable `ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE`.

Additionally, users who want to take advantage of the 5-phase migration can do so by overriding the environment variable upon startup/deployment.

#### Changes:

* Modified RHEL Dockerfile to specify a default for the migration environment variable.

#### Issue:

* [PROJQUAY-45](https://issues.jboss.org/browse/PROJQUAY-45)

**TESTING**

1. Build the Image
2. Run it without overriding the environment variable. It should start as expected and perform the migration in whole.
3. Run it while specifying another value for the environment variable. It should start running the associated migration.

More detail is included in the referenced Jira story.

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
