### PR TITLE
Default RHQ Product Branding

### DIFF
--- a/config.py
+++ b/config.py
@@ -435,9 +435,9 @@ class DefaultConfig(ImmutableConfig):
 
     # Custom branding
     BRANDING = {
-        "logo": "/static/img/quay-horizontal-color.svg",
-        "footer_img": None,
-        "footer_url": None,
+        "logo": "/static/img/RH_Logo_Quay_Black_UX-horizontal.svg",
+        "footer_img": "/static/img/RedHat.svg",
+        "footer_url": "https://redhat.com",
     }
 
     # How often the Garbage Collection worker runs.


### PR DESCRIPTION
### Description

Ensure running RHQ with zero config results in correct product branding.

Addresses https://jira.coreos.com/browse/QUAY-2211