### PR TITLE
PROJQUAY-39 modified quay liveness and readiness probes

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -249,9 +249,3 @@ parameters:
   - name: IMAGE_PULL_POLICY
     value: "IfNotPresent"
     displayName: image pull policy
-  # - name:
-  #   value: ""
-  #   displayName:
-
-
-

--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -95,6 +95,8 @@ objects:
       metadata:
         labels:
           ${{QUAY_APP_COMPONENT_LABEL_KEY}}: ${{QUAY_APP_COMPONENT_LABEL_VALUE}}
+        annotations:
+          ${{QUAY_APP_COMPONENT_ANNOTATIONS_KEY}}: ${{QUAY_APP_COMPONENT_ANNOTATIONS_VALUE}}
       spec:
         volumes:
         - name: configvolume
@@ -103,7 +105,7 @@ objects:
         containers:
         - name: quay-app
           image: ${IMAGE}:${IMAGE_TAG}
-          imagePullPolicy: Always
+          imagePullPolicy: ${{IMAGE_PULL_POLICY}}
           ports:
           - containerPort: 8443
           volumeMounts:
@@ -111,16 +113,20 @@ objects:
             readOnly: false
             mountPath: /conf/stack
           livenessProbe:
-            httpGet:
-              path: /health/instance
-              port: 8443
+            exec:
+              command:
+              - curl
+              - -k
+              - https://localhost:8443/health/instance
             initialDelaySeconds: ${{QUAY_APP_LIVENESS_PROBE_INITIAL_DELAY_SECONDS}}
             periodSeconds: ${{QUAY_APP_LIVENESS_PROBE_PERIOD_SECONDS}}
             timeoutSeconds: ${{QUAY_APP_LIVENESS_PROBE_TIMEOUT_SECONDS}}
           readinessProbe:
-            httpGet:
-              path: /health/endtoend
-              port: 8443
+            exec:
+              command:
+              - curl
+              - -k
+              - https://localhost:8443/health/endtoend
             initialDelaySeconds: ${{QUAY_APP_READINESS_PROBE_INITIAL_DELAY_SECONDS}}
             periodSeconds: ${{QUAY_APP_READINESS_PROBE_PERIOD_SECONDS}}
             timeoutSeconds: ${{QUAY_APP_READINESS_PROBE_TIMEOUT_SECONDS}}
@@ -136,6 +142,10 @@ objects:
               value: ${{QUAY_APP_DEPLOYMENT_NAMESPACE}}
             - name: QE_K8S_CONFIG_SECRET
               value: ${{QUAY_APP_CONFIG_SECRET}}
+            - name: ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE
+              value: ${{ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE}}
+            - name: DEBUGLOG
+              value: ${{DEBUGLOG}}
 parameters:
   - name: NAME
     value: "quay"
@@ -224,4 +234,24 @@ parameters:
   - name: QUAY_APP_READINESS_PROBE_TIMEOUT_SECONDS
     value: "10"
     displayName: quay app readiness probe timeout
+  - name: ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE
+    value: "new-installation"
+    displayName: encrypted robot token migration phase
+  - name: DEBUGLOG
+    value: "true"
+    displayName: debug log
+  - name: QUAY_APP_COMPONENT_ANNOTATIONS_KEY
+    value: "quay-app-deployment"
+    displayName: quay app annotation
+  - name: QUAY_APP_COMPONENT_ANNOTATIONS_VALUE
+    value: "update_me_when_secret_changes"
+    displayName:  quay app annotation value
+  - name: IMAGE_PULL_POLICY
+    value: "IfNotPresent"
+    displayName: image pull policy
+  # - name:
+  #   value: ""
+  #   displayName:
+
+
 


### PR DESCRIPTION
The Liveness and Readiness probes were not working because the connection to port 8443 was being rejected due to SSL cert issues. As the cert is setup for external domain name, requests to `localhost` were being rejected with `400` error code.

The modified check uses `curl` with `-k` (insecure) flag to check if the application is ready and later check if it is still live.

https://issues.redhat.com/browse/PROJQUAY-39

Signed-off-by: Tejas Parikh <tparikh@redhat.com>

