### PR TITLE
Fix Starred Application Repositories

### DIFF
--- a/endpoints/api/repository_models_pre_oci.py
+++ b/endpoints/api/repository_models_pre_oci.py
@@ -147,7 +147,7 @@ class PreOCIModel(RepositoryDataInterface):
         # in the returned results.
         star_set = set()
         if username:
-            starred_repos = model.repository.get_user_starred_repositories(user)
+            starred_repos = model.repository.get_user_starred_repositories(user, repo_kind)
             star_set = {starred.id for starred in starred_repos}
 
         return (


### PR DESCRIPTION
### Description

Ensure that the `repoList` endpoint uses the `repo_kind` when checking if a repository is starred.

Fixes https://issues.redhat.com/browse/PROJQUAY-55