### PR TITLE
Restrict Mirror Robot Dropdown Select to Just Robots

### DIFF
--- a/static/directives/repo-view/repo-panel-mirroring.html
+++ b/static/directives/repo-view/repo-panel-mirroring.html
@@ -89,6 +89,7 @@
                     skip-permissions="true"
                     placeholder="'Select a ' + (repository.is_organization ? 'team or ' : '') + 'user...'"
                     current-entity="vm.robot"
+                    allowed-entities="['robot']"
                     pull-right="true"></span>
             </td>
           </tr>

--- a/static/js/directives/ui/entity-search.js
+++ b/static/js/directives/ui/entity-search.js
@@ -1,10 +1,8 @@
-
 /**
  * An element which displays a box to search for an entity (org, user, robot, team). This control
  * allows for filtering of the entities found and whether to allow selection by e-mail.
  */
 angular.module('quay').directive('entitySearch', function () {
-  var number = 0;
   var directiveDefinitionObject = {
     priority: 0,
     templateUrl: '/static/directives/entity-search.html',


### PR DESCRIPTION
### Description

It doesn't make sense to show other entities in this dropdown.

### Screenshots 

**Robot dropdown:**

![Screenshot_20191211_112217](https://user-images.githubusercontent.com/11700385/70646901-ddd77f80-1c15-11ea-829f-8ecf839d3c91.png)

Addresses https://issues.redhat.com/browse/PROJQUAY-57