### PR TITLE
PROJQUAY-55 - cherry-pick - ensure correct repo type is used when returning 'is_starred' for repo…

### DIFF
--- a/endpoints/api/repository_models_pre_oci.py
+++ b/endpoints/api/repository_models_pre_oci.py
@@ -147,7 +147,7 @@ class PreOCIModel(RepositoryDataInterface):
         # in the returned results.
         star_set = set()
         if username:
-            starred_repos = model.repository.get_user_starred_repositories(user)
+            starred_repos = model.repository.get_user_starred_repositories(user, repo_kind)
             star_set = {starred.id for starred in starred_repos}
 
         return (


### PR DESCRIPTION
… list

(cherry picked from commit 539e005c6b80a7f4f63b21cf80c901b1a26537c6)


https://issues.redhat.com/browse/PROJQUAY-55