### PR TITLE
mount the extra_ca_certs dir in /conf/stack

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -108,6 +108,9 @@ objects:
         - name: configvolume
           secret:
             secretName: ${{QUAY_APP_CONFIG_SECRET}}
+        - name: extracacerts
+          secret:
+            secretName: ${{QUAY_EXTRA_CA_CERTS_SECRET}}
         containers:
         - name: quay-app
           image: ${IMAGE}:${IMAGE_TAG}
@@ -118,6 +121,9 @@ objects:
           - name: configvolume
             readOnly: false
             mountPath: /conf/stack
+          - name: extracacerts
+            readOnly: false
+            mountPath: /conf/stack/extra_ca_certs
           livenessProbe:
             exec:
               command:
@@ -192,6 +198,9 @@ parameters:
   - name: QUAY_APP_CONFIG_SECRET
     value: "quay-config-secret"
     displayName: quay app config secret
+  - name: QUAY_EXTRA_CA_CERTS_SECRET
+    value: "quay-extra-ca-certs"
+    displayName: quay extra ca certs secret
   - name: QUAY_APP_DEPLOYMENT_REPLICAS
     value: "1"
     displayName: quay app deployment replicas


### PR DESCRIPTION
Secrets in vault do not allow us to configure sub directories. We need to store content of sub directories in a separate secret and mount it in the right location in the container.

JIRA: https://issues.redhat.com/browse/PROJQUAY-61

Signed-off-by: Tejas Parikh <tparikh@redhat.com>

