### PR TITLE
PROJQUAY-63 - cherry-pick - Add missing parameter to call on count_repository_actions in initdb

### DIFF
--- a/initdb.py
+++ b/initdb.py
@@ -1297,7 +1297,7 @@ def populate_database(minimal=False, with_storage=False):
         if not to_count:
             break
 
-        model.repositoryactioncount.count_repository_actions(to_count)
+        model.repositoryactioncount.count_repository_actions(to_count, datetime.utcnow().day)
         model.repositoryactioncount.update_repository_score(to_count)
 
 


### PR DESCRIPTION
(cherry picked from commit 68686c0def14b4220cb08f2e5e54fd6598659972)
https://issues.redhat.com/browse/PROJQUAY-63