### PR TITLE
PROJQUAY67 - added syslog sidecar to openshift template

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -112,6 +112,55 @@ objects:
           secret:
             secretName: ${{QUAY_EXTRA_CA_CERTS_SECRET}}
         containers:
+        - name: syslog-cloudwatch-bridge
+          image:  ${SYSLOG_IMAGE}:${SYSLOG_IMAGE_TAG}
+          ports:
+          - containerPort: ${{SYSLOG_PORT}}
+            protocol: UDP
+            name: syslog-udp-port
+          - containerPort: ${{SYSLOG_PORT}}
+            protocol: TCP
+            name: syslog-tcp-port
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${{CLOUDWATCH_SECRET}}
+                key: AWS_REGION
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${{CLOUDWATCH_SECRET}}
+                key: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${{CLOUDWATCH_SECRET}}
+                key: AWS_SECRET_ACCESS_KEY
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${{CLOUDWATCH_SECRET}}
+                key: LOG_GROUP_NAME
+          resources:
+            limits:
+              cpu: ${{QUAY_SYSLOG_CPU_LIMIT}}
+              memory: ${{QUAY_SYSLOG_MEMORY_LIMIT}}
+            requests:
+              cpu: ${{QUAY_SYSLOG_CPU_REQUEST}}
+              memory: ${{QUAY_SYSLOG_MEMORY_REQUEST}}
+          readinessProbe:
+              tcpSocket:
+                port: ${{SYSLOG_PORT}}
+              initialDelaySeconds: ${{QUAY_SYSLOG_READINESS_PROBE_INITIAL_DELAY_SECONDS}}
+              periodSeconds: ${{QUAY_SYSLOG_READINESS_PROBE_PERIOD_SECONDS}}
+              timeoutSeconds: ${{QUAY_SYSLOG_READINESS_PROBE_TIMEOUT_SECONDS}}
+          livenessProbe:
+            tcpSocket:
+              port: ${{SYSLOG_PORT}}
+            initialDelaySeconds: ${{QUAY_SYSLOG_LIVENESS_PROBE_INITIAL_DELAY_SECONDS}}
+            periodSeconds: ${{QUAY_SYSLOG_LIVENESS_PROBE_PERIOD_SECONDS}}
+            timeoutSeconds: ${{QUAY_SYSLOG_LIVENESS_PROBE_TIMEOUT_SECONDS}}
         - name: quay-app
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: ${{IMAGE_PULL_POLICY}}
@@ -150,21 +199,29 @@ objects:
               cpu: ${{QUAY_APP_CPU_REQUEST}}
               memory: ${{QUAY_APP_MEMORY_REQUEST}}
           env:
-            - name: QE_K8S_NAMESPACE
-              value: ${{QUAY_APP_DEPLOYMENT_NAMESPACE}}
-            - name: QE_K8S_CONFIG_SECRET
-              value: ${{QUAY_APP_CONFIG_SECRET}}
-            - name: ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE
-              value: ${{ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE}}
-            - name: DEBUGLOG
-              value: ${{DEBUGLOG}}
+          - name: QE_K8S_NAMESPACE
+            value: ${{QUAY_APP_DEPLOYMENT_NAMESPACE}}
+          - name: QE_K8S_CONFIG_SECRET
+            value: ${{QUAY_APP_CONFIG_SECRET}}
+          - name: ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE
+            value: ${{ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE}}
+          - name: DEBUGLOG
+            value: ${{DEBUGLOG}}
+          - name: SYSLOG_SERVER
+            value: ${{SYSLOG_SERVER}}
+          - name: SYSLOG_PORT
+            value: ${{SYSLOG_PORT}}
+          - name: SYSLOG_PROTO
+            value: ${{SYSLOG_PROTO}}
+          - name: QUAY_LOGGING
+            value: ${{QUAY_LOGGING}}
 parameters:
   - name: NAME
     value: "quay"
     displayName: name
     description: Defaults to quay.
   - name: IMAGE
-    value: "quay.io/app-sre/quay"
+    value: ""
     displayName: quay image
     description: quay docker image. Defaults to quay.io/app-sre/quay.
   - name: IMAGE_TAG
@@ -256,10 +313,10 @@ parameters:
     value: "10"
     displayName: quay app readiness probe timeout
   - name: ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE
-    value: "new-installation"
+    value: ""
     displayName: encrypted robot token migration phase
   - name: DEBUGLOG
-    value: "true"
+    value: "false"
     displayName: debug log
   - name: QUAY_APP_COMPONENT_ANNOTATIONS_KEY
     value: "quay-app-deployment"
@@ -270,3 +327,56 @@ parameters:
   - name: IMAGE_PULL_POLICY
     value: "IfNotPresent"
     displayName: image pull policy
+  - name: CLOUDWATCH_SECRET
+    value: "quay-cloudwatch-iam-user"
+    displayName: cloudwatch iam user creds secret
+  - name: SYSLOG_PORT
+    value: "514"
+    displayName: syslog port
+  - name: QUAY_SYSLOG_MEMORY_REQUEST
+    value: "1Gi"
+    displayName: "quay syslog memory request"
+  - name: QUAY_SYSLOG_CPU_REQUEST
+    value: "1"
+    displayName: "quay syslog CPU request"
+  - name: QUAY_SYSLOG_MEMORY_LIMIT
+    value: "2Gi"
+    displayName: "quay syslog memory limit"
+  - name: QUAY_SYSLOG_CPU_LIMIT
+    value: "1"
+    displayName: "quay syslog CPU limit"
+  - name: QUAY_SYSLOG_LIVENESS_PROBE_INITIAL_DELAY_SECONDS
+    value: "30"
+    displayName: quay syslog liveness probe initial delay seconds
+  - name: QUAY_SYSLOG_LIVENESS_PROBE_PERIOD_SECONDS
+    value: "15"
+    displayName: quay syslog liveness probe period seconds
+  - name: QUAY_SYSLOG_LIVENESS_PROBE_TIMEOUT_SECONDS
+    value: "5"
+    displayName: quay syslog liveness probe timeout
+  - name: QUAY_SYSLOG_READINESS_PROBE_INITIAL_DELAY_SECONDS
+    value: "15"
+    displayName: quay syslog readiness probe initial delay seconds
+  - name: QUAY_SYSLOG_READINESS_PROBE_PERIOD_SECONDS
+    value: "30"
+    displayName: quay syslog readiness probe period seconds
+  - name: QUAY_SYSLOG_READINESS_PROBE_TIMEOUT_SECONDS
+    value: "5"
+    displayName: quay syslog readiness probe timeout
+  - name: SYSLOG_SERVER
+    value: "localhost"
+    displayName: syslog server
+  - name: SYSLOG_PROTO
+    value: "udp"
+    displayName: syslog protocol
+  - name: QUAY_LOGGING
+    value: "syslog"
+    displayName: quay logging handler
+  - name: SYSLOG_IMAGE
+    value: ""
+    displayName: syslog-cloudwatch-bridge image
+    description: syslog-cloudwatch-bridge docker image.
+  - name: SYSLOG_IMAGE_TAG
+    value: "latest"
+    displayName: syslog-cloudwatch-bridge version
+    description: syslog-cloudwatch-bridge version


### PR DESCRIPTION
Deploy a syslog sidecar with Quay app container and forward logs to AWS CloudWatch.

JIRA: https://issues.redhat.com/projects/PROJQUAY/issues/PROJQUAY-67

Signed-off-by: Tejas Parikh <tparikh@redhat.com>

