### PR TITLE
[WIP] Improve Unit Test Coverage for Repo Mirror Models

### DIFF
--- a/data/model/repo_mirror.py
+++ b/data/model/repo_mirror.py
@@ -153,7 +153,7 @@ def expire_mirror(mirror):
     ).where(
         RepoMirrorConfig.sync_transaction_id == mirror.sync_transaction_id,
         RepoMirrorConfig.id == mirror.id,
-        RepoMirrorConfig.state != RepoMirrorStatus.SYNCING,
+        RepoMirrorConfig.sync_status != RepoMirrorStatus.SYNCING,
     )
 
     # Fetch and return the latest updates
@@ -468,8 +468,7 @@ def change_external_registry_config(repository, config_updates):
             if key in config_updates["proxy"]:
                 if "proxy" not in external_registry_config:
                     external_registry_config["proxy"] = {}
-                else:
-                    external_registry_config["proxy"][key] = proxy_updates[key]
+                external_registry_config["proxy"][key] = proxy_updates[key]
 
     return update_with_transaction(mirror, external_registry_config=external_registry_config)
 


### PR DESCRIPTION
### Description

Increases test coverage for `data/model/repo_mirror.py`  (45% -> 67%).

Addresses https://issues.redhat.com/browse/QUAY-1955