### PR TITLE
mount extra ca certs in /conf/kube_extra_certs

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -187,7 +187,7 @@ objects:
             mountPath: /conf/stack
           - name: extracacerts
             readOnly: false
-            mountPath: /conf/stack/extra_ca_certs
+            mountPath: /conf/kube_extra_certs
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
mount extra ca certs in `/conf/kube_extra_certs` instead of `/conf/stack/extra_ca_certs`

Signed-off-by: Tejas Parikh <tparikh@redhat.com>


