### PR TITLE
PROJQUAY-117 - Set ELB timeout to 3600 seconds

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -81,6 +81,8 @@ objects:
   kind: Service
   metadata:
     name: quay-loadbalancer-service
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: ${AWS_LOAD_BALANCER_CONNECTION_IDLE_TIMEOUT}
   spec:
     ports:
     - name: loadbalancer
@@ -386,3 +388,8 @@ parameters:
     value: "latest"
     displayName: syslog-cloudwatch-bridge version
     description: syslog-cloudwatch-bridge version
+  - name: AWS_LOAD_BALANCER_CONNECTION_IDLE_TIMEOUT
+    value: "3600"
+    displayName: syslog-cloudwatch-bridge version
+    description: syslog-cloudwatch-bridge version
+


### PR DESCRIPTION
Default timeout on ELB is 60 seconds and this can cause issue when user is pushing container image with large (4GB+) layers.

JIRA: https://issues.redhat.com/browse/PROJQUAY-117

Signed-off-by: Tejas Parikh <tparikh@redhat.com>

