### PR TITLE
Update location for centos8/rhel8

### DIFF
--- a/conf/nginx/http-base.conf
+++ b/conf/nginx/http-base.conf
@@ -9,7 +9,7 @@ log_format lb_logs '$remote_addr ($proxy_protocol_addr) '
                    '($request_time $request_length $upstream_response_time)';
 
 types_hash_max_size 2048;
-include /etc/opt/rh/rh-nginx112/nginx/mime.types;
+include /etc/nginx/mime.types;
 
 default_type application/octet-stream;
 

--- a/config_app/conf/http-base.conf
+++ b/config_app/conf/http-base.conf
@@ -9,7 +9,7 @@ log_format lb_logs '$remote_addr ($proxy_protocol_addr) '
                    '($request_time $request_length $upstream_response_time)';
 
 types_hash_max_size 2048;
-include /etc/opt/rh/rh-nginx112/nginx/mime.types;
+include /etc/nginx/mime.types;
 
 default_type application/octet-stream;
 


### PR DESCRIPTION
### Description of Changes

* centos8/rhel8 changed the location of `mime.types`

#### Changes:

* ..
* ..

#### Issue: https://issues.redhat.com/browse/PROJQUAY-96


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
