### PR TITLE
Add better tagging options for build triggers.

### DIFF
--- a/buildtrigger/basehandler.py
+++ b/buildtrigger/basehandler.py
@@ -1,4 +1,6 @@
+import logging
 import os
+
 from abc import ABCMeta, abstractmethod
 from jsonschema import validate
 from six import add_metaclass
@@ -7,6 +9,10 @@ from active_migration import ActiveDataMigration, ERTMigrationFlags
 from endpoints.building import PreparedBuild
 from data import model
 from buildtrigger.triggerutil import get_trigger_config, InvalidServiceException
+from util.jsontemplate import apply_data_to_obj, JSONTemplateParseException
+
+logger = logging.getLogger(__name__)
+
 
 NAMESPACES_SCHEMA = {
     "type": "array",
@@ -66,6 +72,7 @@ BUILD_SOURCES_SCHEMA = {
             "full_name",
             "description",
             "last_updated",
+            "url",
             "has_admin_permissions",
             "private",
         ],
@@ -79,6 +86,15 @@ METADATA_SCHEMA = {
             "type": "string",
             "description": "first 7 characters of the SHA-1 identifier for a git commit",
             "pattern": "^([A-Fa-f0-9]{7,})$",
+        },
+        "parsed_ref": {
+            "type": "object",
+            "description": "The parsed information about the ref, if any",
+            "properties": {
+                "branch": {"type": "string", "description": "The branch name",},
+                "tag": {"type": "string", "description": "The tag name",},
+                "remote": {"type": "string", "description": "The remote name",},
+            },
         },
         "git_url": {"type": "string", "description": "The GIT url to use for the checkout",},
         "ref": {
@@ -94,6 +110,10 @@ METADATA_SCHEMA = {
             "type": "object",
             "description": "metadata about a git commit",
             "properties": {
+                "short_sha": {
+                    "type": "string",
+                    "description": "The short SHA for this git commit",
+                },
                 "url": {"type": "string", "description": "URL to view a git commit",},
                 "message": {"type": "string", "description": "git commit message",},
                 "date": {"type": "string", "description": "timestamp for a git commit"},
@@ -286,22 +306,86 @@ class BuildTriggerHandler(object):
         validate(metadata, METADATA_SCHEMA)
 
         config = self.config
-        ref = metadata.get("ref", None)
         commit_sha = metadata["commit"]
-        default_branch = metadata.get("default_branch", None)
+
+        # Create the prepared build.
         prepared = PreparedBuild(self.trigger)
         prepared.name_from_sha(commit_sha)
+
         prepared.subdirectory = config.get("dockerfile_path", None)
         prepared.context = config.get("context", None)
         prepared.is_manual = is_manual
         prepared.metadata = metadata
-
-        if ref is not None:
-            prepared.tags_from_ref(ref, default_branch)
-        else:
-            prepared.tags = [commit_sha[:7]]
-
+        prepared.tags = BuildTriggerHandler._determine_tags(config, metadata)
         return prepared
+
+    @classmethod
+    def _add_tag_from_ref(cls, tags, ref):
+        if not ref:
+            return
+
+        branch = ref.split("/", 2)[-1]
+        tags.add(branch)
+
+    @classmethod
+    def _add_latest_tag_if_default(cls, tags, ref, default_branch=None):
+        if not ref:
+            return
+
+        branch = ref.split("/", 2)[-1]
+        if default_branch is not None and branch == default_branch:
+            tags.add("latest")
+
+    @classmethod
+    def _determine_tags(cls, config, metadata):
+        tags = set()
+
+        ref = metadata.get("ref", None)
+        commit_sha = metadata["commit"]
+        default_branch = metadata.get("default_branch", None)
+
+        # Handle tagging. If there are defined tagging templates, use them.
+        tag_templates = config.get("tag_templates")
+        if tag_templates:
+            updated_metadata = dict(metadata)
+            updated_metadata["commit_info"] = updated_metadata.get("commit_info", {})
+            updated_metadata["commit_info"]["short_sha"] = commit_sha[:7]
+
+            if ref:
+                _, kind, name = ref.split("/", 2)
+
+                updated_metadata["parsed_ref"] = {}
+                if kind == "heads":
+                    updated_metadata["parsed_ref"]["branch"] = name
+                elif kind == "tags":
+                    updated_metadata["parsed_ref"]["tag"] = name
+                elif kind == "remotes":
+                    updated_metadata["parsed_ref"]["remote"] = name
+
+            for tag_template in tag_templates:
+                try:
+                    result = apply_data_to_obj(tag_template, updated_metadata, missing="$MISSING$")
+                    if "$MISSING$" in result:
+                        result = None
+                except JSONTemplateParseException:
+                    logger.exception("Got except when parsing tag template `%s`", tag_template)
+                    continue
+
+                if result:
+                    tags.add(result)
+
+        # If allowed, tag from the ref.
+        if ref is not None:
+            if config.get("default_tag_from_ref", True):
+                cls._add_tag_from_ref(tags, ref)
+
+            if config.get("latest_for_default_branch", True):
+                cls._add_latest_tag_if_default(tags, ref, default_branch)
+
+        if not tags:
+            tags = {commit_sha[:7]}
+
+        return tags
 
     @classmethod
     def build_sources_response(cls, sources):

--- a/endpoints/building.py
+++ b/endpoints/building.py
@@ -148,7 +148,8 @@ def start_build(repository, prepared_build, pull_robot_name=None):
 
 class PreparedBuild(object):
     """ Class which holds all the information about a prepared build. The build queuing service
-      will use this result to actually invoke the build. """
+      will use this result to actually invoke the build.
+  """
 
     def __init__(self, trigger=None):
         self._dockerfile_id = None
@@ -164,15 +165,6 @@ class PreparedBuild(object):
     @staticmethod
     def get_display_name(sha):
         return sha[0:7]
-
-    def tags_from_ref(self, ref, default_branch=None):
-        branch = ref.split("/", 2)[-1]
-        tags = {branch}
-
-        if branch == default_branch:
-            tags.add("latest")
-
-        self.tags = tags
 
     def name_from_sha(self, sha):
         self.build_name = PreparedBuild.get_display_name(sha)

--- a/endpoints/test/test_building.py
+++ b/endpoints/test/test_building.py
@@ -50,24 +50,6 @@ def test_start_build_disabled_trigger(app):
 
 
 @pytest.mark.parametrize(
-    "ref, expected_tags",
-    [
-        ("ref/heads/somebranch", ["somebranch"]),
-        ("ref/heads/master", ["master", "latest"]),
-        ("ref/tags/somebranch", ["somebranch"]),
-        ("ref/tags/master", ["master", "latest"]),
-        ("ref/heads/slash/branch", ["slash_branch"]),
-        ("ref/tags/slash/tag", ["slash_tag"]),
-        ("ref/heads/foobar#2", ["foobar_2"]),
-    ],
-)
-def test_tags_for_ref(ref, expected_tags):
-    prepared = PreparedBuild()
-    prepared.tags_from_ref(ref, default_branch="master")
-    assert set(prepared._tags) == set(expected_tags)
-
-
-@pytest.mark.parametrize(
     "metadata, config",
     [
         ({}, {}),

--- a/static/css/directives/repo-view/repo-panel-builds.css
+++ b/static/css/directives/repo-view/repo-panel-builds.css
@@ -32,3 +32,22 @@
   color: #f5c77d;
   margin-right: 4px;
 }
+
+.repo-panel-builds .trigger-tagging {
+  padding: 0px;
+  margin: 0px;
+  font-size: 12px;
+}
+
+.repo-panel-builds .trigger-tagging li {
+  padding: 0px;
+  margin: 0px;
+}
+
+.repo-panel-builds .trigger-tagging li .tag-info {
+  display: block;
+  max-width: 175px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/static/css/directives/ui/manage-trigger-control.css
+++ b/static/css/directives/ui/manage-trigger-control.css
@@ -56,32 +56,38 @@
     color: #ccc;
 }
 
-.manage-trigger-control .radio {
+.manage-trigger-control .radio, .manage-trigger-control .checkbox {
   margin-bottom: 20px;
 }
 
-.manage-trigger-control .radio input[type="radio"] {
+.manage-trigger-control .radio input[type="radio"],
+.manage-trigger-control .checkbox input[type="checkbox"] {
     padding: 4px;
 }
 
-.manage-trigger-control .radio label .title {
+.manage-trigger-control .radio label .title,
+.manage-trigger-control .checkbox label .title  {
     font-size: 16px;
 }
 
-.manage-trigger-control .radio label .weak {
+.manage-trigger-control .radio label .weak,
+.manage-trigger-control .checkbox label .weak {
     font-weight: 300;
 }
 
-.manage-trigger-control .radio label .description {
+.manage-trigger-control .radio label .description,
+.manage-trigger-control .checkbox label .description {
     margin-top: 6px;
     color: #aaa;
 }
 
-.manage-trigger-control .radio label .extended {
+.manage-trigger-control .radio label .extended,
+.manage-trigger-control .checkbox label .extended {
     margin-top: 20px;
 }
 
-.manage-trigger-control .radio label td:first-child {
+.manage-trigger-control .radio label td:first-child,
+.manage-trigger-control .checkbox label td:first-child {
     vertical-align: top;
     padding: 4px;
     padding-right: 10px;
@@ -109,4 +115,42 @@
 
 .manage-trigger-control .nowrap-col {
     white-space: nowrap;
+}
+
+.manage-trigger-control .custom-template-list {
+    border-bottom: 1px solid #eee;
+    padding-bottom: 14px;
+    margin: 14px;
+    margin-bottom: 4px;
+}
+  
+.manage-trigger-control .custom-template-list li i.fa {
+    margin-left: 4px;
+    cursor: pointer;
+    color: #aaa;
+}
+  
+.manage-trigger-control .custom-template-list li i.fa:hover {
+    color: black;
+}
+  
+.manage-trigger-control .enter-template {
+    padding: 10px;
+}
+  
+.manage-trigger-control .enter-template input[type="text"] {
+    display: inline-block;
+    width: 50%;
+    margin-left: 10px;
+    font-size: 12px;
+    height: 30px;
+}
+  
+.manage-trigger-control .enter-template button {
+    font-size: 12px;
+}
+
+.manage-trigger-control .empty {
+    margin-left: 10px;
+    color: #ccc;
 }

--- a/static/directives/repo-view/repo-panel-builds.html
+++ b/static/directives/repo-view/repo-panel-builds.html
@@ -128,6 +128,7 @@
             <td>Context Location</td>
             <td>Branches/Tags</td>
             <td>Pull Robot</td>
+            <td>Tagging Options</td>
             <td class="options-col"></td>
           </thead>
 
@@ -147,6 +148,19 @@
               <td>
                 <span class="entity-reference" entity="trigger.pull_robot" ng-if="trigger.pull_robot"></span>
                 <span class="empty" ng-if="!trigger.pull_robot">(None)</span>
+              </td>
+              <td>
+                <ul class="trigger-tagging">
+                  <li ng-if="trigger.config.default_tag_from_ref === true || trigger.config.default_tag_from_ref == null">
+                    <span class="tag-info">Branch/tag name</span>
+                  </li>
+                  <li ng-if="trigger.config.latest_for_default_branch === true || trigger.config.latest_for_default_branch == null">
+                    <span class="tag-info"><code>latest</code> if default branch</span>
+                  </li>
+                  <li ng-repeat="template in trigger.config.tag_templates || []">
+                    <span class="tag-info"><code title="{{ template }}">{{ template }}</code></span>
+                  </span>
+                </ul>
               </td>
               <td>
                 <span class="cor-options-menu" ng-show="!inReadOnlyMode">
@@ -169,19 +183,19 @@
               </td>
             </tr>
             <tr class="trigger-disabled-message" ng-if="!trigger.enabled">
-              <td colspan="5" style="text-align: center"
+              <td colspan="6" style="text-align: center"
                   ng-if="trigger.disabled_reason == 'user_toggled'">
                 <i class="fa fa-exclamation-triangle"></i>
                 This build trigger is user disabled and will not build.
                 <a ng-click="askToggleTrigger(trigger)" ng-show="!inReadOnlyMode">Re-enable this trigger</a>
               </td>
-              <td colspan="5" style="text-align: center"
+              <td colspan="6" style="text-align: center"
                   ng-if="trigger.disabled_reason == 'successive_build_failures'">
                 <i class="fa fa-exclamation-triangle"></i>
                 This build trigger was automatically disabled due to successive failures.
                 <a ng-click="askToggleTrigger(trigger)" ng-show="!inReadOnlyMode">Re-enable this trigger</a>
               </td>
-              <td colspan="5" style="text-align: center"
+              <td colspan="6" style="text-align: center"
                   ng-if="trigger.disabled_reason == 'successive_build_internal_errors'">
                 <i class="fa fa-exclamation-triangle"></i>
                 This build trigger was automatically disabled due to successive internal errors.

--- a/static/js/directives/ui/manage-trigger/manage-trigger.component.html
+++ b/static/js/directives/ui/manage-trigger/manage-trigger.component.html
@@ -250,6 +250,71 @@
       </div>
     </linear-workflow-section><!-- /Section: Trigger Options -->
 
+    <!-- Section: Tagging Options -->
+    <linear-workflow-section class="row"
+                             section-id="taggingoptions"
+                             section-title="Tagging Options"
+                             section-valid="$ctrl.local.triggerOptions.default_tag_from_ref || $ctrl.local.triggerOptions.tag_templates.length">
+      <div class="col-lg-7 col-md-7 col-sm-12 main-col">
+        <h3>Configure Tagging</h3>
+        <strong>
+          Confirm basic tagging options
+        </strong>
+        <div class="checkbox" style="margin-top: 20px;">
+          <label>
+            <input type="checkbox"
+                    ng-model="$ctrl.local.triggerOptions.default_tag_from_ref">
+            <div class="title">Tag manifest with the branch or tag name</div>
+            <div class="description">Tags the built manifest the name of the branch or tag for the git commit.</div>
+          </label>
+        </div>
+        <div class="checkbox">
+          <label>
+            <input type="checkbox"
+                   ng-model="$ctrl.local.triggerOptions.latest_for_default_branch">
+            <div class="title">Add <code>latest</code> tag if on default branch</div>
+            <div class="description">Tags the built manifest with <code>latest</code> if the build
+                                     occurred on the default branch for the repository.
+            </div>
+          </label>
+        </div>
+        <hr>
+        <strong>
+          Add custom tagging templates
+        </strong>
+        <ul class="custom-template-list" ng-show="$ctrl.local.triggerOptions.tag_templates.length">
+          <li ng-repeat="template in $ctrl.local.triggerOptions.tag_templates">
+            <code>{{ template }}</code>
+            <i class="fa fa-close" ng-click="$ctrl.removeTagTemplate(template)"></i>
+          </li>
+        </ul>
+        <div class="empty" ng-show="$ctrl.local.triggerOptions.tag_templates.length == 0">
+          No tag templates defined.
+        </div>
+        <div class="enter-template">
+          <span>Enter a tag template:</span>
+          <input class="form-control" type="text" placeholder="${commit_info.short_sha}" ng-model="$ctrl.local.currentTagTemplate">
+          <button class="btn btn-default" ng-disabled="!$ctrl.local.currentTagTemplate"
+                  ng-click="$ctrl.addTagTemplate()">Add Tag Template</button>
+        </div>
+      </div>
+      <div class="col-lg-4 col-md-4 hidden-sm hidden-xs help-col">
+        <p>By default, all built manifests will be tagged with the name of the branch or tag in
+           which the commit occurred.</p>
+        <p>To modify this default, as well as the default to add the <code>latest</code> tag,
+           change the corresponding options on the left.</p>
+        <p>Need more control over how the built manifest is tagged? Add one or more custom tag templates.</p>
+        <p>For example, if you want all built manifests to be tagged with the commit's short SHA,
+           add a template of <code>${commit_info.short_sha}</code>.
+        </p>
+        <p>As another example, if you want on those manifests committed to a <b>branch</b>
+           to be tagged with the branch name, you can add a template of <code>${parsed_ref.branch}</code>.
+        </p>
+        <p>A full reference of for these templates can be found in the <a href="https://docs.quay.io/guides/tag-templating.html" target="_blank">Tag template documentation</a>.
+        </p>
+      </div>
+    </linear-workflow-section> <!-- /Section: Tagging options -->
+
     <!-- Section: Dockerfile Location -->
     <linear-workflow-section class="row"
                              section-id="dockerfilelocation"

--- a/static/js/directives/ui/manage-trigger/manage-trigger.component.ts
+++ b/static/js/directives/ui/manage-trigger/manage-trigger.component.ts
@@ -26,10 +26,13 @@ export class ManageTriggerComponent implements OnChanges {
     selectedRepository: {name: ''},
     hasValidDockerfilePath: false,
     dockerfileLocations: [],
-    triggerOptions: {},
+    triggerOptions: {
+      'tag_templates': []
+    },
     namespaceOptions: {filter: '', predicate: 'score', reverse: false, page: 0},
     repositoryOptions: {filter: '', predicate: 'score', reverse: false, page: 0, hideStale: true},
     robotOptions: {filter: '', predicate: 'score', reverse: false, page: 0},
+    currentTagTemplate: null
   };
 
   private namespacesPerPage: number = 10;
@@ -164,6 +167,10 @@ export class ManageTriggerComponent implements OnChanges {
       config.branchtag_regex = this.local.triggerOptions['branchTagFilter'];
     }
 
+    config.default_tag_from_ref = this.local.triggerOptions['default_tag_from_ref'];
+    config.latest_for_default_branch = this.local.triggerOptions['latest_for_default_branch'];
+    config.tag_templates = this.local.triggerOptions['tag_templates'] || null;
+
     const activate = () => {
       this.activateTrigger.emit({config: config, pull_robot: Object.assign({}, this.local.robotAccount)});
     };
@@ -251,7 +258,10 @@ export class ManageTriggerComponent implements OnChanges {
     this.local.selectedRepository = null;
     this.local.repositoryRefs = null;
     this.local.triggerOptions = {
-      'hasBranchTagFilter': false
+      'hasBranchTagFilter': false,
+      'default_tag_from_ref': true,
+      'latest_for_default_branch': true,
+      'tag_templates': []
     };
 
     this.local.orderedRepositories = null;
@@ -273,10 +283,29 @@ export class ManageTriggerComponent implements OnChanges {
     }, this.apiService.errorDisplay('Could not retrieve repositories'));
   }
 
+  private addTagTemplate(): void {
+    if (!this.local.currentTagTemplate) {
+      return;
+    }
+
+    this.local.triggerOptions['tag_templates'].push(this.local.currentTagTemplate);
+    this.local.currentTagTemplate = null;
+  }
+
+  private removeTagTemplate(template: string): void {
+    var opts = this.local.triggerOptions;
+    opts['tag_templates'] = opts['tag_templates'].filter(function(item) {
+      return item != template;
+    });
+  }
+
   private loadRepositoryRefs(repository: any): void {
     this.local.repositoryRefs = null;
     this.local.triggerOptions = {
-      'hasBranchTagFilter': false
+      'hasBranchTagFilter': false,
+      'default_tag_from_ref': true,
+      'latest_for_default_branch': true,
+      'tag_templates': []
     };
 
     const params = {

--- a/static/js/types/common.types.ts
+++ b/static/js/types/common.types.ts
@@ -49,6 +49,7 @@ export type Local = {
   selectedNamespace?: Namespace;
   selectedRepository?: Repository;
   triggerAnalysis?: any;
+  currentTagTemplate?: string;
   triggerOptions?: {
     [key: string]: any;
   };
@@ -120,6 +121,9 @@ export type TriggerConfig = {
   dockerfile_path?: string;
   context?: string;
   branchtag_regex?: string;
+  default_tag_from_ref?: boolean;
+  latest_for_default_branch?: boolean;
+  tag_templates?: string[];
 };
 
 

--- a/util/jsontemplate.py
+++ b/util/jsontemplate.py
@@ -24,58 +24,61 @@ class JSONTemplate(object):
         self.apply({})
 
     def apply(self, data):
-        return self._apply(self._parsed, data)
+        return apply_data_to_obj(self._parsed, data)
 
-    def _apply(self, obj, data):
-        if isinstance(obj, basestring):
-            return self._process_string(obj, data)
-        elif isinstance(obj, dict):
-            return {
-                self._process_string(key, data): self._apply(value, data)
-                for key, value in obj.iteritems()
-            }
-        elif isinstance(obj, list):
-            return [self._apply(item, data) for item in obj]
-        else:
-            return obj
 
-    def _process_string(self, str_value, data):
-        # Check for a direct match first.
-        if re.match("^" + INLINE_PATH_PATTERN + "$", str_value):
-            expression = str_value[2:-1]
-            return self._process_inline(expression, data)
+def apply_data_to_obj(obj, data, missing="(none)"):
+    if isinstance(obj, basestring):
+        return _process_string(obj, data, missing)
+    elif isinstance(obj, dict):
+        return {
+            _process_string(key, data, missing): apply_data_to_obj(value, data, missing)
+            for key, value in obj.iteritems()
+        }
+    elif isinstance(obj, list):
+        return [apply_data_to_obj(item, data, missing) for item in obj]
+    else:
+        return obj
 
-        def process_inline(match):
-            result = self._process_inline(match.group(1), data)
-            if result is None:
-                return "(none)"
 
-            if isinstance(result, list) and len(result) > 1:
-                return ",".join(result)
+def _process_string(str_value, data, missing_filler):
+    # Check for a direct match first.
+    if re.match("^" + INLINE_PATH_PATTERN + "$", str_value):
+        expression = str_value[2:-1]
+        return _process_inline(expression, data)
 
-            return str(result)
+    def process_inline(match):
+        result = _process_inline(match.group(1), data)
+        if result is None:
+            return missing_filler
 
-        return re.sub(INLINE_PATH_PATTERN, process_inline, str_value)
+        if isinstance(result, list) and len(result) > 1:
+            return ",".join(result)
 
-    def _process_inline(self, expression, data):
-        if not expression:
-            raise JSONTemplateParseException("Empty expression found")
+        return str(result)
 
-        try:
-            parsed = parse_json_path(expression)
-        except JsonPathLexerError as jple:
-            raise JSONTemplateParseException("For expression `%s`: %s" % (expression, jple))
-        except Exception as ex:
-            raise JSONTemplateParseException("For expression `%s`: %s" % (expression, ex))
+    return re.sub(INLINE_PATH_PATTERN, process_inline, str_value)
 
-        try:
-            found = parsed.find(data)
-            if not found:
-                return None
 
-            if len(found) > 1:
-                return [f.data for f in found]
+def _process_inline(expression, data):
+    if not expression:
+        raise JSONTemplateParseException("Empty expression found")
 
-            return found[0].value
-        except IndexError:
+    try:
+        parsed = parse_json_path(expression)
+    except JsonPathLexerError as jple:
+        raise JSONTemplateParseException("For expression `%s`: %s" % (expression, jple))
+    except Exception as ex:
+        raise JSONTemplateParseException("For expression `%s`: %s" % (expression, ex))
+
+    try:
+        found = parsed.find(data)
+        if not found:
             return None
+
+        if len(found) > 1:
+            return [f.data for f in found]
+
+        return found[0].value
+    except IndexError:
+        return None


### PR DESCRIPTION
Users can now configure whether they want the default tagging options enabled (tag `latest` for the default branch, and tag with the git branch or tag name), and can also specify custom tags, including static tags and dynamic templated tags.

Fixes https://jira.coreos.com/browse/QUAY-1747
