### PR TITLE
Replace mockredis with fakeredis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ ecdsa==0.13.2
 elasticsearch-dsl==7.0.0
 elasticsearch==7.0.4
 enum34==1.1.6
+fakeredis==1.1.0
 Flask-Cors==3.0.8
 Flask-Login==0.4.1
 Flask-Mail==0.9.1
@@ -93,8 +94,6 @@ MarkupSafe==1.1.1
 maxminddb==1.4.1
 meld3==2.0.0
 mixpanel==4.5.0
-mock==3.0.5
-mockredispy==2.9.3
 monotonic==1.5
 moto==1.3.13
 msgpack==0.6.1

--- a/util/config/validators/test/test_validate_redis.py
+++ b/util/config/validators/test/test_validate_redis.py
@@ -3,7 +3,7 @@ import redis
 
 from mock import patch
 
-from mockredis import mock_strict_redis_client
+from fakeredis import FakeStrictRedis
 
 from util.config.validator import ValidatorContext
 from util.config.validators import ConfigValidationException
@@ -23,7 +23,7 @@ from util.morecollections import AttrDict
     ],
 )
 def test_validate_redis(unvalidated_config, user, user_password, use_mock, expected, app):
-    with patch("redis.StrictRedis" if use_mock else "redis.None", mock_strict_redis_client):
+    with patch("redis.StrictRedis" if use_mock else "redis.None", FakeStrictRedis):
         validator = RedisValidator()
         unvalidated_config = ValidatorContext(unvalidated_config)
 


### PR DESCRIPTION
### Description of Changes

* [PROJQUAY-134](https://issues.redhat.com/browse/PROJQUAY-134)


#### Changes:

* Replaces mockredispy (deprecated) with fakeredis
* ..

#### Issue: <link to story or task>


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
