### PR TITLE
Remove encoding arg to get str instead of bytes

### DIFF
--- a/config_app/config_util/config/baseprovider.py
+++ b/config_app/config_util/config/baseprovider.py
@@ -50,7 +50,7 @@ def import_yaml(config_obj, config_file):
 
 
 def get_yaml(config_obj):
-    return yaml.safe_dump(config_obj, encoding="utf-8", allow_unicode=True)
+    return yaml.safe_dump(config_obj, allow_unicode=True)
 
 
 def export_yaml(config_obj, config_file):

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -29,4 +29,7 @@ class FeatureNameValue(object):
         return self.value.__cmp__(other)
 
     def __bool__(self):
-        return self.value.__nonzero__()
+        if isinstance(self.value, str):
+            return self.value == 'True'
+
+        return bool(self.value)

--- a/util/config/provider/baseprovider.py
+++ b/util/config/provider/baseprovider.py
@@ -50,7 +50,7 @@ def import_yaml(config_obj, config_file):
 
 
 def get_yaml(config_obj):
-    return yaml.safe_dump(config_obj, encoding="utf-8", allow_unicode=True)
+    return yaml.safe_dump(config_obj, allow_unicode=True)
 
 
 def export_yaml(config_obj, config_file):


### PR DESCRIPTION
### Description of Changes

* Changes `yaml.safe_dump` to return a str instead of bytes

#### Changes:

* ..
* ..

#### Issue: <link to story or task>


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
