### PR TITLE
Fixed text in emailchanged template from password to email

### DIFF
--- a/emails/emailchanged.html
+++ b/emails/emailchanged.html
@@ -2,12 +2,12 @@
 
 {% block content %}
 
-<h3 style="font-weight: 400">Account password changed: <strong>{{ username }}</strong></h3>
+<h3 style="font-weight: 400">Account e-mail address changed: <strong>{{ username }}</strong></h3>
 <hr style="border:none; border-top: 1px solid #D9D9D9; margin: 25px 0">
 
 <table>
 	<tr>
-		<td style="font-size: 13px;">The password for user <strong>{{ username }}</strong> has been changed. </td>
+		<td style="font-size: 13px;">The e-mail address for user <strong>{{ username }}</strong> has been changed.</td>
 	</tr>
 </table>
 


### PR DESCRIPTION
### Description of Changes

* changed text in email template from 'password' to 'e-mail address'
* string 'e-mail-address' is used in subject as well
* seems to be a copy/paste bug

#### Changes:

* changed string to fit to purpose of email

#### Issue: <link to story or task>


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
