### PR TITLE
Fix unhashable class test failure

### DIFF
--- a/data/fields.py
+++ b/data/fields.py
@@ -168,27 +168,6 @@ def _add_encryption(field_class, requires_length_check=True):
 
             return LazyEncryptedValue(value, self)
 
-        def __eq__(self, _):
-            raise Exception("Disallowed operation; use `matches`")
-
-        def __mod__(self, _):
-            raise Exception("Disallowed operation; use `matches`")
-
-        def __pow__(self, _):
-            raise Exception("Disallowed operation; use `matches`")
-
-        def __contains__(self, _):
-            raise Exception("Disallowed operation; use `matches`")
-
-        def contains(self, _):
-            raise Exception("Disallowed operation; use `matches`")
-
-        def startswith(self, _):
-            raise Exception("Disallowed operation; use `matches`")
-
-        def endswith(self, _):
-            raise Exception("Disallowed operation; use `matches`")
-
     return indexed_class
 
 


### PR DESCRIPTION
### Description of Changes

Fixes the following test failure from `test/test_ldap.py` in Python 3
```
data/database.py:637: in <module>
    class RobotAccountToken(BaseModel):
.venv-37/lib64/python3.7/site-packages/peewee.py:6004: in __new__
    cls._meta.add_field(name, field)
.venv-37/lib64/python3.7/site-packages/peewee.py:5804: in add_field
    self.defaults[field] = field.default
E   TypeError: unhashable type: 'indexed_class'
```

#### Issue:

- https://issues.redhat.com/browse/PROJQUAY-135


**TESTING**

Ensure this test doesn't fail with the same error any longer.

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
