### PR TITLE
Run `black` on Python3 branch

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,7 +156,7 @@ if app.config["PREFERRED_URL_SCHEME"] == "https" and not app.config.get(
 # Load features from config.
 features.import_features(app.config)
 
-CONFIG_DIGEST = hashlib.sha256(json.dumps(app.config, default=str).encode('utf-8')).hexdigest()[0:8]
+CONFIG_DIGEST = hashlib.sha256(json.dumps(app.config, default=str).encode("utf-8")).hexdigest()[0:8]
 
 logger.debug("Loaded config", extra={"config": app.config})
 

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -30,6 +30,6 @@ class FeatureNameValue(object):
 
     def __bool__(self):
         if isinstance(self.value, str):
-            return self.value == 'True'
+            return self.value == "True"
 
         return bool(self.value)

--- a/util/config/superusermanager.py
+++ b/util/config/superusermanager.py
@@ -14,23 +14,23 @@ class SuperUserManager(object):
 
         self._max_length = len(usernames_str) + MAX_USERNAME_LENGTH + 1
         self._array = Array("c", self._max_length, lock=True)
-        self._array.value = usernames_str.encode('utf8')
+        self._array.value = usernames_str.encode("utf8")
 
     def is_superuser(self, username):
         """ Returns if the given username represents a super user. """
-        usernames = self._array.value.decode('utf8').split(",")
+        usernames = self._array.value.decode("utf8").split(",")
         return username in usernames
 
     def register_superuser(self, username):
         """ Registers a new username as a super user for the duration of the container.
         Note that this does *not* change any underlying config files.
     """
-        usernames = self._array.value.decode('utf8').split(",")
+        usernames = self._array.value.decode("utf8").split(",")
         usernames.append(username)
         new_string = ",".join(usernames)
 
         if len(new_string) <= self._max_length:
-            self._array.value = new_string.encode('utf8')
+            self._array.value = new_string.encode("utf8")
         else:
             raise Exception("Maximum superuser count reached. Please report this to support.")
 


### PR DESCRIPTION
### Description of Changes

It appears a few files are failing when verifying their syntax/formatting using `black`. This change-set resolves that issue.

#### Issue:

- Python 3 Upgrade Epic: https://issues.redhat.com/browse/PROJQUAY-68

**TESTING**

- CI on changes to the Python3 branch should no longer fail with `black` errors unless they are introduced in new branches.

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
