### PR TITLE
Use specific setuptools version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN INSTALL_PKGS="\
 COPY . .
 
 RUN scl enable python27 "\
-    pip install --upgrade setuptools pip && \
+    pip install --upgrade setuptools==44 pip && \
     pip install -r requirements.txt --no-cache && \
     pip install -r requirements-tests.txt --no-cache && \
     pip freeze && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -47,7 +47,7 @@ RUN INSTALL_PKGS="\
 COPY . .
 
 RUN scl enable python27 "\
-    pip install --upgrade setuptools pip && \
+    pip install --upgrade setuptools==44 pip && \
     pip install -r requirements.txt --no-cache && \
     pip freeze && \
     mkdir -p $QUAYDIR/static/webfonts && \


### PR DESCRIPTION
### Description of Changes

This is a temporary fix for the following error when building the base `Dockerfile`.

```
ERROR: Package 'setuptools' requires a different Python: 2.7.16 not in '>=3.5'
Error: error building at STEP "RUN scl enable python27 "    pip install --upgrade setuptools pip &&     pip install -r requirements.txt --no-cache &&     pip install -r requirements-tests.txt --no-cache &&     pip freeze &&     mkdir -p $QUAYDIR/static/webfonts &&     mkdir -p $QUAYDIR/static/fonts &&     mkdir -p $QUAYDIR/static/ldn &&     PYTHONPATH=$QUAYPATH python -m external_libraries     "": error while running runtime: exit status 1
```

Long-term, the issue should be addressed properly when the project transitions to Python 3.x.

#### Changes:

* Pin setuptools to the latest available version compatible with Python 2.7 in the Dockerfile.

#### Issue: 

- https://issues.redhat.com/browse/PROJQUAY-146

**TESTING**

Build the Dockerfile.

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
