### PR TITLE
PROJQUAY-38 - unpin gpg package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ pycparser==2.19
 pycryptodome==3.9.0
 pycryptodomex==3.9.0
 PyGithub==1.43.8
-gpg==1.10.0
+gpg>=1.10.0
 pyjwkest==1.4.2
 PyJWT==1.7.1
 pymemcache==2.2.2


### PR DESCRIPTION
https://issues.redhat.com/browse/PROJQUAY-68

Allow gpg package version available on fedora as well as centos8 and rhel8