### PR TITLE
[PROJQUAY-165] Replace package `bencode` with `bencode.py`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ backports.ssl-match-hostname==3.7.0.1
 backports.tempfile==1.0
 backports.weakref==1.0.post1
 beautifulsoup4==4.8.0
-bencode==1.0
+bencode.py==2.1.0
 bintrees==2.0.7
 bitmath==1.3.3.1
 blinker==1.4


### PR DESCRIPTION
### Description of Changes

Replaces Python package bencode with [bencode.py](https://pypi.org/project/bencode.py/) for Python 3 compatibility.

#### Changes:

- Replaced a single package with a newer fork.

#### Issue:

- https://issues.redhat.com/browse/PROJQUAY-165

**TESTING**

- Install `requirements.txt` in a Python 3.6 environment and ensure that it doesn't fail on `bencode`

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
