### PR TITLE
Run `black` to cleanup Python 3 code

### DIFF
--- a/data/logs_model/logs_producer/kinesis_stream_logs_producer.py
+++ b/data/logs_model/logs_producer/kinesis_stream_logs_producer.py
@@ -28,9 +28,13 @@ def _partition_key(number_of_shards=None):
     key = None
     if number_of_shards is not None:
         shard_number = random.randrange(0, number_of_shards)
-        key = hashlib.sha1((KINESIS_PARTITION_KEY_PREFIX + str(shard_number)).encode("utf-8")).hexdigest()
+        key = hashlib.sha1(
+            (KINESIS_PARTITION_KEY_PREFIX + str(shard_number)).encode("utf-8")
+        ).hexdigest()
     else:
-        key = hashlib.sha1((KINESIS_PARTITION_KEY_PREFIX + str(random.getrandbits(256))).encode("utf-8")).hexdigest()
+        key = hashlib.sha1(
+            (KINESIS_PARTITION_KEY_PREFIX + str(random.getrandbits(256))).encode("utf-8")
+        ).hexdigest()
 
     return key
 

--- a/features/__init__.py
+++ b/features/__init__.py
@@ -30,6 +30,6 @@ class FeatureNameValue(object):
 
     def __bool__(self):
         if isinstance(self.value, str):
-            return self.value.lower() == 'true'
+            return self.value.lower() == "true"
 
         return bool(self.value)


### PR DESCRIPTION
### Description of Changes

A couple of files did not meet the formatting expectations for `black` as a Python 3.6 target. This PR reformats them. 

#### Changes:

* Fix formatting in 2 files

#### Issue:

n/a

**TESTING**

- `black` should no longer fail

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
