### PR TITLE
Fix syntax error in Python 3.6+

### DIFF
--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from six import iteritems
 
 from prometheus_client import Counter, Histogram
-from asyncio import coroutine, async, sleep
+from asyncio import coroutine, ensure_future, sleep
 
 from buildman.orchestrator import (
     orchestrator_from_config,
@@ -396,7 +396,7 @@ class EphemeralBuilderManager(BaseManager):
         )
 
         # Load components for all realms currently known to the cluster
-        async(self._register_existing_realms())
+        ensure_future(self._register_existing_realms())
 
     def shutdown(self):
         logger.debug("Shutting down worker.")


### PR DESCRIPTION
### Description of Changes

Previously, a library (`trollius`) was used to take advantage of asyncio
in Python 2.7. However, one function (`async`) is now a keyword. This
causes certain parsers to encounter a syntax error when parsing the Python
file for linting and other verification purposes.

According to the Python documentation, the old `async()` function is
now simply an alias for `ensure_future()` and it has been replaced accordingly.

Example Error:
```
(quay) [kmullins@rh-laptop quay]$ mypy .
buildman/manager/ephemeral.py:12: error: invalid syntax
```

#### Changes:

- Replace `async(...)` with `ensure_future(...)` in a specific file which throws a syntax error when parsing in Python 3.6+
- Remove the import of `async` from the same file

#### Issue:

- Related to https://issues.redhat.com/browse/PROJQUAY-116

**TESTING**

- Linters should be able to parse the file successfully.

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
