### PR TITLE
scripts/ci: add run_flake8() to lint step

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -32,6 +32,14 @@ run_black() {
 }
 
 
+run_flake8() {
+    # https://issues.redhat.com/browse/PROJQUAY-92
+    # https://github.com/psf/black/issues/1207#issuecomment-566249522
+    pip install flake8
+    flake8 . --count --max-line-length=100 --select=E9,F63,F7,F82 --show-source --statistics
+}
+
+
 build_image() {
     # Build the image and save it to the shared cache.
     docker build -t "${IMAGE}:${IMAGE_TAG}" .
@@ -189,6 +197,7 @@ postgres() {
 case "$1" in
     lint)
         run_black
+        run_flake8
         ;;
 
     build)


### PR DESCRIPTION
### Description of Changes

* Run flake8 to find Python syntax errors and undefined names.

#### Changes:

* Add a flake8 run to the CI listing step

#### Issue: <link to story or task>


**TESTING** -> Yes.  Linting is part of the continuous integration testing

**BREAKING CHANGE** -> No.

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.
---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
