### PR TITLE
Travis CI: sudo: is fully deprecated in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ python:
 - 2.7
 - 3.7
 
-sudo: required
-
 services:
   - docker
 


### PR DESCRIPTION
### Description of Changes

* Travis CI have fully deprecated the __sudo:__ tag and has removed all mention of it from their documentation.

https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517


#### Changes:

* Remove the __sudo:__ tag.

#### Issue: <link to story or task>


**TESTING** -> Yes.  Travis CI is continuous integration testing.

**BREAKING CHANGE** -> No.


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
