### PR TITLE
metrics: s/endpoint/route

### DIFF
--- a/util/metrics/prometheus.py
+++ b/util/metrics/prometheus.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 request_duration = Histogram(
     "quay_request_duration_seconds",
     "seconds taken to process a request",
-    labelnames=["method", "endpoint", "status"],
+    labelnames=["method", "route", "status"],
     buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0],
 )
 


### PR DESCRIPTION
Endpoint already has semantic meaning as a label in existing Prometheus scraping. In order to avoid conflicts and simplify aggregation, this label is being renamed.