### PR TITLE
Install make for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: python
 python:
-- 3.6
+  - 3.6
 
 services:
   - docker

--- a/Dockerfile.cirun
+++ b/Dockerfile.cirun
@@ -1,9 +1,14 @@
 FROM quay-ci-base
+
+ENV ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE remove-old-fields
+
+# Install Test Dependencies
+RUN yum install -y make
+
 RUN mkdir -p conf/stack
 RUN rm -rf test/data/test.db
-ENV ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE remove-old-fields
 ADD cirun.config.yaml conf/stack/config.yaml
-RUN LOGGING_LEVEL=INFO python initdb.py && \
-    yum install -y make
+RUN LOGGING_LEVEL=INFO python initdb.py
+
 ENTRYPOINT ["/quay-registry/quay-entrypoint.sh"]
 CMD ["registry"]

--- a/scripts/ci
+++ b/scripts/ci
@@ -28,6 +28,7 @@ run_black() {
     # https://issues.redhat.com/browse/PROJQUAY-92
     # https://github.com/psf/black/issues/1207#issuecomment-566249522
     pip install black --no-binary=regex
+    echo "Running 'black' to verify Python formatting."
     black --line-length 100 --target-version py36 --check --diff .
 }
 
@@ -41,8 +42,14 @@ run_flake8() {
 
 
 build_image() {
+
+    # Build the base image
+    echo "Building Base Image"
+    docker build -t "quay-ci-base" .
+
     # Build the image and save it to the shared cache.
-    docker build -t "${IMAGE}:${IMAGE_TAG}" .
+    echo "Building CI Image"
+    docker build -t "${IMAGE}:${IMAGE_TAG}" -f Dockerfile.cirun .
 
     echo "Exporting Docker image to cache..."
     time (docker save "${IMAGE}:${IMAGE_TAG}" | gzip -2 > "${IMAGE_TAR}")
@@ -68,7 +75,7 @@ fail_clean() {
 }
 
 quay_run() {
-    docker run --net=host -e TEST_DATABASE_URI -ti "${IMAGE}:${IMAGE_TAG}" "$@"
+    docker run --net=host -e TEST_DATABASE_URI -ti "${IMAGE}:${IMAGE_TAG}-ci-run" "$@"
 }
 
 


### PR DESCRIPTION
### Description of Changes

Fixes an issue where `make` is missing during certain CI tests and causes CI to fail.

#### Changes:

* Use the CI image for all tests
* Ran `black` and corrected formatting on one file to unblock CI in the lint stage.

#### Issue: 

- https://issues.redhat.com/browse/PROJQUAY-68


**TESTING**

- CI should no longer fail on executing `make`

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
