### PR TITLE
Disable Flake8 in CI on Python 2.7 branch

### DIFF
--- a/scripts/ci
+++ b/scripts/ci
@@ -197,7 +197,7 @@ postgres() {
 case "$1" in
     lint)
         run_black
-        run_flake8
+        # run_flake8  TODO: Run this after offending files have been fixed. Ensure appropriate Python version is used.
         ;;
 
     build)


### PR DESCRIPTION
### Description of Changes

- It appears that Flake8 is raising issues with the existing Python 2.7 code.
  While it is possible that these could genuinely use some cleanup, it
  appears some errors come from the expectation of Python 3.x syntax. It  has
  been temporarily commented out until we can fix it.
- Related to: https://github.com/quay/quay/pull/162

Example CI Error:
```
35    E999 SyntaxError: invalid syntax
27    F821 undefined name 'basestring'
62
The command "scripts/ci lint" exited with 1.
```

#### Changes:

* Comment out execution of `flake8` in CI until all offending files are fixed or Flake8 is configured to verify against the correct Python version

#### Issue:

- This is a resolution to the CI failures caused in #162

**TESTING**

- The CI lint stage should no longer fail on `flake8` and `flake8` is not executed during CI at this time.

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
