### PR TITLE
Travis CI: Test on legacy Python only and drop black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 ---
 language: python
 python:
-- 2.7
-- 3.7
+  - 2.7
 
 services:
   - docker
@@ -35,81 +34,64 @@ jobs:
   include:
     - stage: lint
       name: Lint python
-      python: '3.7'
       script: scripts/ci lint
 
     - stage: build
       name: Build
-      python: '2.7'
       script: scripts/ci build
 
     # To further shard, change the script to shard_X_of_XS and add new steps
     - stage: test
       name: Unit tests (shard 1)
-      python: '2.7'
       script: scripts/ci unit shard_1_of_2
     - stage: test
       name: Unit tests (shard 2)
-      python: '2.7'
       script: scripts/ci unit shard_2_of_2
 
     - stage: test
       name: Registry tests (shard 1)
-      python: '2.7'
       script: scripts/ci registry shard_1_of_5
     - stage: test
       name: Registry tests (shard 2)
-      python: '2.7'
       script: scripts/ci registry shard_2_of_5
     - stage: test
       name: Registry tests (shard 3)
-      python: '2.7'
       script: scripts/ci registry shard_3_of_5
     - stage: test
       name: Registry tests (shard 4)
-      python: '2.7'
       script: scripts/ci registry shard_4_of_5
     - stage: test
       name: Registry tests (shard 5)
-      python: '2.7'
       script: scripts/ci registry shard_5_of_5
 
     - stage: test
       name: Legacy registry tests
-      python: '2.7'
       script: scripts/ci registry_old
 
     - stage: test
       name: Custom TLS certs test
-      python: '2.7'
       script: scripts/ci certs_test
 
     - stage: test
       name: Gunicorn worker test
-      python: '2.7'
       script: scripts/ci gunicorn_test
 
     - stage: test
       name: MySQL unit tests (shard 1)
-      python: '2.7'
       script: scripts/ci mysql shard_1_of_2
     - stage: test
       name: MySQL unit tests (shard 2)
-      python: '2.7'
       script: scripts/ci mysql shard_2_of_2
 
     - stage: test
       name: Postgres unit tests (shard 1)
-      python: '2.7'
       script: scripts/ci postgres shard_1_of_2
     - stage: test
       name: Postgres unit tests (shard 2)
-      python: '2.7'
       script: scripts/ci postgres shard_2_of_2
 
     - stage: clean
       name: Cleanup
-      python: '2.7'
       script: scripts/ci clean
 
 notifications:

--- a/config_app/config_application.py
+++ b/config_app/config_application.py
@@ -1,7 +1,7 @@
+import logging
 from config_app.c_app import app as application
+from util.log import logfile_path
 
-# Bind all of the blueprints
-import config_web
 
 if __name__ == "__main__":
     logging.config.fileConfig(logfile_path(debug=True), disable_existing_loggers=False)

--- a/config_app/config_endpoints/api/superuser.py
+++ b/config_app/config_endpoints/api/superuser.py
@@ -19,7 +19,10 @@ from config_app.config_endpoints.api import (
     log_action,
     validate_json_request,
 )
-from config_app.config_endpoints.api.superuser_models_pre_oci import pre_oci_model
+from config_app.config_endpoints.api.superuser_models_pre_oci import (
+    pre_oci_model,
+    ServiceKeyAlreadyApproved,
+)
 from config_app.config_util.ssl import load_certificate, CertInvalidException
 from config_app.c_app import app, config_provider, INIT_SCRIPTS_LOCATION
 

--- a/scripts/ci
+++ b/scripts/ci
@@ -196,7 +196,7 @@ postgres() {
 
 case "$1" in
     lint)
-        run_black
+        # run_black  # TODO: Reenable when the repo has no Python3 syntax errors
         run_flake8
         ;;
 


### PR DESCRIPTION
An alternative approach to #172 
~Blocked by: #128~

### Description of Changes

* The Python 3 branch is the place for Python 3 changes.
* pfs/black can not run on legacy Python


#### Changes:

* Run all Travis tests on legacy Python
* Disable pls/black until __master__ has no Python 3 syntax errors

#### Issue: <link to story or task>


**TESTING** -> Yes.  Travis CI runs our continuous integration tests.

**BREAKING CHANGE** -> No.


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
