### PR TITLE
PROJQUAY-181: redirect http to https for quay.io

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -102,6 +102,10 @@ objects:
       service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
   spec:
     ports:
+    - name: http
+      protocol: TCP
+      port: ${{LOADBALANCER_SERVICE_HTTP_PORT}}
+      targetPort: ${{LOADBALANCER_SERVICE_PROXY_TARGET_HTTP_PORT}}
     - name: https
       protocol: TCP
       port: ${{LOADBALANCER_SERVICE_PORT}}
@@ -283,6 +287,12 @@ parameters:
   - name: LOADBALANCER_SERVICE_PROXY_TARGET_PORT
     value: "7443"
     displayName: loadbalancer service proxy target port
+  - name: LOADBALANCER_SERVICE_HTTP_PORT
+    value: "80"
+    displayName: loadbalancer service http port
+  - name: LOADBALANCER_SERVICE_PROXY_TARGET_HTTP_PORT
+    value: "8080"
+    displayName: loadbalancer service proxy target http port
   - name: QUAY_APP_CONFIG_SECRET
     value: "quay-config-secret"
     displayName: quay app config secret


### PR DESCRIPTION
[ci skip]

JIRA: https://issues.redhat.com/browse/PROJQUAY-181

http://quay.io should be redirected to https://quay.io

Signed-off-by: Tejas Parikh <tparikh@redhat.com>
