### PR TITLE
PROJQUAY-181: updated nginx to redirect http to https for quay.io

### DIFF
--- a/conf/init/nginx_conf_create.py
+++ b/conf/init/nginx_conf_create.py
@@ -123,6 +123,17 @@ def generate_rate_limiting_config(config):
         static_dir=STATIC_DIR,
     )
 
+def generate_hosted_http_base_config(config):
+    """
+  Generates hosted http base config from the app config
+  """
+    config = config or {}
+    feature_proxy_protocol = config.get("FEATURE_PROXY_PROTOCOL", False)
+
+    write_config(
+        os.path.join(QUAYCONF_DIR, "nginx/hosted-http-base.conf"),
+        feature_proxy_protocol=feature_proxy_protocol,
+    )
 
 if __name__ == "__main__":
     if os.path.exists(os.path.join(QUAYCONF_DIR, "stack/config.yaml")):
@@ -131,6 +142,7 @@ if __name__ == "__main__":
     else:
         config = None
 
+    generate_hosted_http_base_config(config)
     generate_rate_limiting_config(config)
     generate_server_config(config)
     generate_nginx_config(config)

--- a/conf/nginx/hosted-http-base.conf.jnj
+++ b/conf/nginx/hosted-http-base.conf.jnj
@@ -1,7 +1,14 @@
 # vim: ft=nginx
 
 server {
+
+{% if feature_proxy_protocol %}
+    listen 8080 default_server proxy_protocol;
+{% else %}
     listen 8080 default_server;
+{% endif %}
+
     server_name _;
     rewrite ^ https://$host$request_uri? permanent;
 }
+


### PR DESCRIPTION
[ci skip]

JIRA: https://issues.redhat.com/browse/PROJQUAY-181

http://quay.io should be redirected to https://quay.io

Set `FEATURE_PROXY_PROTOCOL` to `True` to enable proxy protocol support for HTTP traffic.


Signed-off-by: Tejas Parikh <tparikh@redhat.com>
