### PR TITLE
Python 3: Replace basestring with six.string_types

### DIFF
--- a/util/jsontemplate.py
+++ b/util/jsontemplate.py
@@ -1,6 +1,8 @@
 import json
 import re
 
+from six import string_types
+
 from jsonpath_rw import parse as parse_json_path
 from jsonpath_rw.lexer import JsonPathLexerError
 
@@ -27,7 +29,7 @@ class JSONTemplate(object):
         return self._apply(self._parsed, data)
 
     def _apply(self, obj, data):
-        if isinstance(obj, basestring):
+        if isinstance(obj, string_types):
             return self._process_string(obj, data)
         elif isinstance(obj, dict):
             return {


### PR DESCRIPTION
Replaces #179 using https://six.readthedocs.io/index.html#six.string_types


### Description of Changes

* __basestring__ was removed in Python 3 because all __str__ are Unicode.


#### Changes:

* from six import string_types
* replace basestring with string_types

#### Issue: <link to story or task>


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
