### PR TITLE
Reformat 1 Python file using `black`

### DIFF
--- a/data/test/test_encryption.py
+++ b/data/test/test_encryption.py
@@ -55,7 +55,7 @@ def test_encryption(test_data, version, secret_key, use_valid_key):
 @pytest.mark.parametrize(
     "secret_key, encrypted_value, expected_decrypted_value",
     [
-        (u"test1234", "v0$$iE+87Qefu/2i+5zC87nlUtOskypk8MUUDS/QZPs=", ""),
+        ("test1234", "v0$$iE+87Qefu/2i+5zC87nlUtOskypk8MUUDS/QZPs=", ""),
         ("test1234", "v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==", "hello world"),
         (
             bytes("test1234"),


### PR DESCRIPTION
### Description of Changes

Fixes lint failure in branch by cleaning up a file using `black`.

#### Changes:

* Run `black` on offending file.

#### Issue: 

n/a

**TESTING**

CI should no longer fail in the lint stage on the `python3` branch.

**BREAKING CHANGE**

n/a
---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
