### PR TITLE
file() was removed in Python 3

### DIFF
--- a/digest/checksums.py
+++ b/digest/checksums.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     if len(sys.argv) < 3:
         print("Usage: {0} json_file layer_file".format(sys.argv[0]))
         sys.exit(1)
-    json_data = file(sys.argv[1]).read()
+    json_data = open(sys.argv[1]).read()
     fp = open(sys.argv[2])
     print(compute_simple(fp, json_data))
     print(compute_tarsum(fp, json_data))


### PR DESCRIPTION
### Description of Changes

* __file()__ was removed in Python 3 so replace with __open()__.

#### Changes:

* __file()__ --> __open()__

#### Issue: <link to story or task>


**TESTING** -> Discovered and verified by the flake8 testing in our continuous integration.

**BREAKING CHANGE** ->. No.  Fix ing change.


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
