### PR TITLE
xrange() was removed in Python 3

### DIFF
--- a/oauth/utils.py
+++ b/oauth/utils.py
@@ -10,7 +10,7 @@ UNICODE_ASCII_CHARACTERS = string.ascii_letters + string.digits
 
 def random_ascii_string(length):
     random = SystemRandom()
-    return "".join([random.choice(UNICODE_ASCII_CHARACTERS) for x in xrange(length)])
+    return "".join([random.choice(UNICODE_ASCII_CHARACTERS) for _ in range(length)])
 
 
 def url_query_params(url):


### PR DESCRIPTION
### Description of Changes

* __xrange()__ was removed in Python 3 so convert to __range()__ instead as recommended at:
https://portingguide.readthedocs.io/en/latest/iterators.html#new-behavior-of-range

#### Changes:

* __xrange()__ --> __range()__

#### Issue: <link to story or task>

**TESTING** -> Discovered via our flake8 in our continuous integration.

**BREAKING CHANGE** -> No.  Fixing change.


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
