### PR TITLE
StandardError was removed in Python 3

### DIFF
--- a/oauth/provider.py
+++ b/oauth/provider.py
@@ -420,7 +420,7 @@ class AuthorizationProvider(Provider):
                 return self._make_redirect_error_response(u, err)
             else:
                 return self._invalid_redirect_uri_response()
-        except StandardError as exc:
+        except Exception as exc:
             self._handle_exception(exc)
 
             # Catch all other server errors

--- a/oauth/provider.py
+++ b/oauth/provider.py
@@ -455,7 +455,7 @@ class AuthorizationProvider(Provider):
 
             # Catch missing parameters in request
             return self._make_json_error_response("invalid_request")
-        except StandardError as exc:
+        except Exception as exc:
             self._handle_exception(exc)
 
             # Catch all other server errors


### PR DESCRIPTION
### Description of Changes

* __StandardError__ was removed in Python 3 so replace all instances with __Exception__ as recommended at:
https://portingguide.readthedocs.io/en/latest/exceptions.html#the-removed-standarderror

#### Changes:

* __StandardError__ --> __Exception__

#### Issue: <link to story or task>


**TESTING** -> Discovered and tested by our flake8 tests.

**BREAKING CHANGE** -> No


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
