### PR TITLE
Fix some flake8 undefined names

### DIFF
--- a/config_app/config_application.py
+++ b/config_app/config_application.py
@@ -1,7 +1,7 @@
+import logging
 from config_app.c_app import app as application
+from util.log import logfile_path
 
-# Bind all of the blueprints
-import config_web
 
 if __name__ == "__main__":
     logging.config.fileConfig(logfile_path(debug=True), disable_existing_loggers=False)

--- a/config_app/config_application.py
+++ b/config_app/config_application.py
@@ -2,6 +2,9 @@ import logging
 from config_app.c_app import app as application
 from util.log import logfile_path
 
+# Bind all of the blueprints
+import config_web
+
 
 if __name__ == "__main__":
     logging.config.fileConfig(logfile_path(debug=True), disable_existing_loggers=False)

--- a/config_app/config_endpoints/api/superuser.py
+++ b/config_app/config_endpoints/api/superuser.py
@@ -19,7 +19,10 @@ from config_app.config_endpoints.api import (
     log_action,
     validate_json_request,
 )
-from config_app.config_endpoints.api.superuser_models_pre_oci import pre_oci_model
+from config_app.config_endpoints.api.superuser_models_pre_oci import (
+    pre_oci_model,
+    ServiceKeyAlreadyApproved
+)
 from config_app.config_util.ssl import load_certificate, CertInvalidException
 from config_app.c_app import app, config_provider, INIT_SCRIPTS_LOCATION
 

--- a/config_app/config_endpoints/api/superuser.py
+++ b/config_app/config_endpoints/api/superuser.py
@@ -21,7 +21,7 @@ from config_app.config_endpoints.api import (
 )
 from config_app.config_endpoints.api.superuser_models_pre_oci import (
     pre_oci_model,
-    ServiceKeyAlreadyApproved
+    ServiceKeyAlreadyApproved,
 )
 from config_app.config_util.ssl import load_certificate, CertInvalidException
 from config_app.c_app import app, config_provider, INIT_SCRIPTS_LOCATION

--- a/scripts/ci
+++ b/scripts/ci
@@ -33,10 +33,9 @@ run_black() {
 
 
 run_flake8() {
-    # https://issues.redhat.com/browse/PROJQUAY-92
-    # https://github.com/psf/black/issues/1207#issuecomment-566249522
-    pip install flake8
-    flake8 . --count --max-line-length=100 --select=E9,F63,F7,F82 --show-source --statistics
+    pip install flake8  # TODO (cclauss): Remove on the line --exit-zero below
+    flake8 . --count --exit-zero --max-line-length=100 --select=E9,F63,F7,F82 \
+             --show-source --statistics
 }
 
 
@@ -197,7 +196,7 @@ postgres() {
 case "$1" in
     lint)
         run_black
-        # run_flake8  TODO: Run this after offending files have been fixed. Ensure appropriate Python version is used.
+        run_flake8
         ;;
 
     build)


### PR DESCRIPTION
__python2 -m flake8 . --count --show-source --statistics --select=E9,F63,F72,F82__
```
./config_app/config_application.py:7:5: F821 undefined name 'logging'
    logging.config.fileConfig(logfile_path(debug=True), disable_existing_loggers=False)
    ^
./config_app/config_application.py:7:31: F821 undefined name 'logfile_path'
    logging.config.fileConfig(logfile_path(debug=True), disable_existing_loggers=False)
                              ^
./config_app/config_endpoints/api/superuser.py:255:16: F821 undefined name 'ServiceKeyAlreadyApproved'
        except ServiceKeyAlreadyApproved:
               ^
3     F821 undefined name 'logging'
3
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.