### PR TITLE
Travis CI: Remove the extra test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 ---
 language: python
-python:
-- 2.7
-- 3.7
 
 services:
   - docker


### PR DESCRIPTION
The __jobs__ section is driving the stages and tasks of these CI runs.  Each task specifies a particular Python.  These two _unspecified_ runs seem to consume a lot of time.  Let's try to run without them.


### Description of Changes

* details about the implementation of the changes
* motivation for the change (broken code, new feature, etc)
* contrast with previous behavior


#### Changes:

* ..
* ..

#### Issue: <link to story or task>


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
