### PR TITLE
Typo: serialized_tate --> serialized_state

### DIFF
--- a/data/fields.py
+++ b/data/fields.py
@@ -34,7 +34,7 @@ class _ResumableSHAField(TextField):
         if value is None:
             return None
 
-        serialized_tate = pickle.dumps(value)
+        serialized_state = pickle.dumps(value)
         return serialized_state
 
     def python_value(self, value):


### PR DESCRIPTION
### Description of Changes

* __serialized_state__ is an _undefined name_ in this context which has the potential to raise NameError at runtime.  __serialized_tate__ (typo) is defined on the line above.

#### Changes:

* serialized_tate --> serialized_state

#### Issue: <link to story or task>


**TESTING** ->
__flake8 . --count --show-source --statistics --select=E9,F63,F72,F82__

**BREAKING CHANGE** ->
No.  Fixing change.

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
