### PR TITLE
Install test dependencies in CI Image

### DIFF
--- a/Dockerfile.cirun
+++ b/Dockerfile.cirun
@@ -3,7 +3,8 @@ FROM quay-ci-base
 ENV ENCRYPTED_ROBOT_TOKEN_MIGRATION_PHASE remove-old-fields
 
 # Install Test Dependencies
-RUN yum install -y make
+RUN yum install -y make git
+RUN python -m pip install -r requirements-tests.txt
 
 RUN mkdir -p conf/stack
 RUN rm -rf test/data/test.db


### PR DESCRIPTION
In the `python3` branch, the installation of `requirements-tests.txt` was removed from the primary Dockerfile.

This PR installs both the Python test requirements and git when building the Dockerfile used by CI, `Dockerfile.cirun`.