### PR TITLE
Fix missing Dockerfile in CI

### DIFF
--- a/endpoints/v2/test/test_blob.py
+++ b/endpoints/v2/test/test_blob.py
@@ -37,7 +37,7 @@ def test_blob_caching(method, endpoint, client, app):
     )
 
     headers = {
-        "Authorization": "Bearer %s" % token.decode('ascii'),
+        "Authorization": "Bearer %s" % token.decode("ascii"),
     }
 
     # Run without caching to make sure the request works. This also preloads some of
@@ -115,7 +115,7 @@ def test_blob_mounting(mount_digest, source_repo, username, expect_success, clie
     )
 
     headers = {
-        "Authorization": "Bearer %s" % token.decode('ascii'),
+        "Authorization": "Bearer %s" % token.decode("ascii"),
     }
 
     expected_code = 201 if expect_success else 202

--- a/endpoints/v2/test/test_manifest.py
+++ b/endpoints/v2/test/test_manifest.py
@@ -32,7 +32,7 @@ def test_e2e_query_count_manifest_norewrite(client, app):
     )
 
     headers = {
-        "Authorization": "Bearer %s" % token.decode('ascii'),
+        "Authorization": "Bearer %s" % token.decode("ascii"),
     }
 
     # Conduct a call to prime the instance key and other caches.

--- a/scripts/ci
+++ b/scripts/ci
@@ -8,6 +8,7 @@ IMAGE="quay-ci"
 CACHE_DIR="${HOME}/docker"
 SHORT_SHA="${TRAVIS_COMMIT:0:7}"
 IMAGE_TAG="${SHORT_SHA}-${TRAVIS_BUILD_NUMBER}"
+BASE_IMAGE_TAR="${CACHE_DIR}/${IMAGE}-${IMAGE_TAG}-base.tar.gz"
 IMAGE_TAR="${CACHE_DIR}/${IMAGE}-${IMAGE_TAG}.tar.gz"
 
 MYSQL_IMAGE="mysql:5.7"
@@ -49,15 +50,21 @@ build_image() {
 
     # Build the image and save it to the shared cache.
     echo "Building CI Image"
-    docker build -t "${IMAGE}:${IMAGE_TAG}" -f Dockerfile.cirun .
+    docker build -t "${IMAGE}:${IMAGE_TAG}-ci-run" -f Dockerfile.cirun .
 
-    echo "Exporting Docker image to cache..."
-    time (docker save "${IMAGE}:${IMAGE_TAG}" | gzip -2 > "${IMAGE_TAR}")
+    echo "Exporting Docker images to cache..."
+    time (docker save "quay-ci-base" | gzip -2 > "${BASE_IMAGE_TAR}")
+    time (docker save "${IMAGE}:${IMAGE_TAG}-ci-run" | gzip -2 > "${IMAGE_TAR}")
+
 }
 
 
 load_image() {
-    # Load our cached Docker image.
+    # Load our cached Base Docker Image
+    echo "Loading Base image from cache..."
+    time (zcat "${BASE_IMAGE_TAR}" | docker load)
+
+    # Load our cached CI Docker image.
     echo "Loading Docker image from cache..."
     time (zcat "${IMAGE_TAR}" | docker load)
 }
@@ -68,10 +75,11 @@ clean_cache() {
 }
 
 fail_clean() {
-    if [[ $TRAVIS_TEST_RESULT -ne 0 ]]; then
-        echo "Job failed. Cleaning cache..."
-        clean_cache
-    fi
+    #if [[ $TRAVIS_TEST_RESULT -ne 0 ]]; then
+    #    echo "Job failed. Cleaning cache..."
+    #    clean_cache
+    #fi
+    echo "Not running fail_clean(); TravisCI should clean up after all jobs are ran."
 }
 
 quay_run() {
@@ -204,7 +212,7 @@ postgres() {
 case "$1" in
     lint)
         run_black
-        # run_flake8  TODO: Run this after offending files have been fixed. Ensure appropriate Python version is used.
+        #run_flake8  # TODO: Enable this once we're ready to tackle Flake8 revealed errors
         ;;
 
     build)

--- a/storage/downloadproxy.py
+++ b/storage/downloadproxy.py
@@ -101,7 +101,7 @@ class DownloadProxy(object):
         proxy_url = "%s://%s/_storage_proxy/%s/%s/%s/%s" % (
             url_scheme,
             server_hostname,
-            encoded_token.decode('ascii'),
+            encoded_token.decode("ascii"),
             parsed.scheme,
             parsed.netloc,
             path,

--- a/test/specs.py
+++ b/test/specs.py
@@ -108,8 +108,8 @@ class IndexV1TestSpec(object):
         self.admin_code = admin_code
 
     def gen_basic_auth(self, username, password):
-        encoded = b64encode(b"%s:%s" % (username.encode('ascii'), password.encode('ascii')))
-        return "basic %s" % encoded.decode('ascii')
+        encoded = b64encode(b"%s:%s" % (username.encode("ascii"), password.encode("ascii")))
+        return "basic %s" % encoded.decode("ascii")
 
     def set_data_from_obj(self, json_serializable):
         self._data = json.dumps(json_serializable)
@@ -597,8 +597,8 @@ class IndexV2TestSpec(object):
         return url_for(self.index_name, repository=self.repo_name, **self.kwargs)
 
     def gen_basic_auth(self, username, password):
-        encoded = b64encode(b"%s:%s" % (username.encode('ascii'), password.encode('ascii')))
-        return "basic %s" % encoded.decode('ascii')
+        encoded = b64encode(b"%s:%s" % (username.encode("ascii"), password.encode("ascii")))
+        return "basic %s" % encoded.decode("ascii")
 
     def get_scope_string(self):
         return "repository:%s:%s" % (self.repo_name, self.scope)

--- a/util/secscan/api.py
+++ b/util/secscan/api.py
@@ -244,7 +244,7 @@ class ImplementedSecurityScannerAPI(SecurityScannerAPIInterface):
             auth_token = generate_bearer_token(
                 audience, subject, context, access, TOKEN_VALIDITY_LIFETIME_S, self._instance_keys
             )
-            auth_header = "Bearer " + auth_token.decode('ascii')
+            auth_header = "Bearer " + auth_token.decode("ascii")
 
             uri = self._uri_creator(repository_and_namespace, image.storage.content_checksum)
 

--- a/util/tufmetadata/api.py
+++ b/util/tufmetadata/api.py
@@ -264,7 +264,7 @@ class ImplementedTUFMetadataAPI(TUFMetadataAPIInterface):
             TOKEN_VALIDITY_LIFETIME_S,
             self._instance_keys,
         )
-        return {"Authorization": "Bearer %s" % token.decode('ascii')}
+        return {"Authorization": "Bearer %s" % token.decode("ascii")}
 
     def _get(self, gun, metadata_file):
         return self._call(


### PR DESCRIPTION
In the Python3 work, we have introduced multiple changes to CI. Specifically, we have moved all test-dependencies from the base Dockerfile(s) into Dockerfile.cirun.

There is now the following error:
```
Unable to find image 'quay-ci:943072a-687-ci-run' locally

docker: Error response from daemon: pull access denied for quay-ci, repository does not exist or may require 'docker login'.
```

**Jira:**
https://issues.redhat.com/browse/PROJQUAY-218

