### PR TITLE
Additional fixes for config load failure in manifest creation

### DIFF
--- a/data/model/oci/retriever.py
+++ b/data/model/oci/retriever.py
@@ -5,8 +5,8 @@ from data.database import Manifest
 from data.model.oci.blob import get_repository_blob_by_digest
 from data.model.storage import get_layer_path
 
-RETRY_COUNT = 2
-RETRY_DELAY = 0.25  # seconds
+RETRY_COUNT = 5
+RETRY_DELAY = 0.3  # seconds
 
 
 class RepositoryContentRetriever(ContentRetriever):

--- a/data/secscan_model/secscan_v2_model.py
+++ b/data/secscan_model/secscan_v2_model.py
@@ -108,7 +108,9 @@ class V2SecurityScanner(SecurityScannerInterface):
             return SecurityInformationLookupResult.with_status(ScanLookupStatus.FAILED_TO_INDEX)
 
         if status == SecurityScanStatus.UNSUPPORTED:
-            return SecurityInformationLookupResult.with_status(ScanLookupStatus.UNSUPPORTED_FOR_INDEXING)
+            return SecurityInformationLookupResult.with_status(
+                ScanLookupStatus.UNSUPPORTED_FOR_INDEXING
+            )
 
         if status == SecurityScanStatus.QUEUED:
             return SecurityInformationLookupResult.with_status(ScanLookupStatus.NOT_YET_INDEXED)


### PR DESCRIPTION
- Add additional retries and slightly increase the delay time
- Add a proper exception returned on failure
- Add a test to verify that we raise the proper exception
