### PR TITLE
The incremented counters are for v2 as a whole

### DIFF
--- a/endpoints/metrics.py
+++ b/endpoints/metrics.py
@@ -9,7 +9,7 @@ image_pulls = Counter(
 image_pushes = Counter(
     "quay_registry_image_pushes_total",
     "number of images that have been uploaded via the registry",
-    labelnames=["protocol", "status"],
+    labelnames=["protocol", "status", "media_type"],
 )
 
 image_pulled_bytes = Counter(

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -279,14 +279,14 @@ def update_images(namespace_name, repo_name):
         )
         if repository_ref is None:
             # Make sure the repo actually exists.
-            image_pushes.labels("v1", 404).inc()
+            image_pushes.labels("v1", 404, "").inc()
             abort(404, message="Unknown repository", issue="unknown-repo")
 
         builder = lookup_manifest_builder(
             repository_ref, session.get("manifest_builder"), storage, docker_v2_signing_key
         )
         if builder is None:
-            image_pushes.labels("v1", 400).inc()
+            image_pushes.labels("v1", 400, "").inc()
             abort(400)
 
         # Generate a job for each notification that has been added to this repo
@@ -299,10 +299,10 @@ def update_images(namespace_name, repo_name):
 
         track_and_log("push_repo", repository_ref)
         spawn_notification(repository_ref, "repo_push", event_data)
-        image_pushes.labels("v1", 204).inc()
+        image_pushes.labels("v1", 204, "").inc()
         return make_response("Updated", 204)
 
-    image_pushes.labels("v1", 403).inc()
+    image_pushes.labels("v1", 403, "").inc()
     abort(403)
 
 

--- a/endpoints/v2/manifest.py
+++ b/endpoints/v2/manifest.py
@@ -47,7 +47,7 @@ MANIFEST_TAGNAME_ROUTE = BASE_MANIFEST_ROUTE.format(VALID_TAG_PATTERN)
 def fetch_manifest_by_tagname(namespace_name, repo_name, manifest_ref):
     repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
     if repository_ref is None:
-        image_pulls.labels("v2_1", "tag", 404).inc()
+        image_pulls.labels("v2", "tag", 404).inc()
         raise NameUnknown()
 
     tag = registry_model.get_repo_tag(repository_ref, manifest_ref)
@@ -59,23 +59,23 @@ def fetch_manifest_by_tagname(namespace_name, repo_name, manifest_ref):
             msg = (
                 "Tag %s was deleted or has expired. To pull, revive via time machine" % manifest_ref
             )
-            image_pulls.labels("v2_1", "tag", 404).inc()
+            image_pulls.labels("v2", "tag", 404).inc()
             raise TagExpired(msg)
 
-        image_pulls.labels("v2_1", "tag", 404).inc()
+        image_pulls.labels("v2", "tag", 404).inc()
         raise ManifestUnknown()
 
     manifest = registry_model.get_manifest_for_tag(tag, backfill_if_necessary=True)
     if manifest is None:
         # Something went wrong.
-        image_pulls.labels("v2_1", "tag", 400).inc()
+        image_pulls.labels("v2", "tag", 400).inc()
         raise ManifestInvalid()
 
     manifest_bytes, manifest_digest, manifest_media_type = _rewrite_schema_if_necessary(
         namespace_name, repo_name, manifest_ref, manifest
     )
     if manifest_bytes is None:
-        image_pulls.labels("v2_1", "tag", 404).inc()
+        image_pulls.labels("v2", "tag", 404).inc()
         raise ManifestUnknown()
 
     track_and_log(
@@ -85,7 +85,7 @@ def fetch_manifest_by_tagname(namespace_name, repo_name, manifest_ref):
         analytics_sample=0.01,
         tag=manifest_ref,
     )
-    image_pulls.labels("v2_1", "tag", 200).inc()
+    image_pulls.labels("v2", "tag", 200).inc()
 
     return Response(
         manifest_bytes.as_unicode(),
@@ -102,16 +102,16 @@ def fetch_manifest_by_tagname(namespace_name, repo_name, manifest_ref):
 def fetch_manifest_by_digest(namespace_name, repo_name, manifest_ref):
     repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
     if repository_ref is None:
-        image_pulls.labels("v2_1", "manifest", 404).inc()
+        image_pulls.labels("v2", "manifest", 404).inc()
         raise NameUnknown()
 
     manifest = registry_model.lookup_manifest_by_digest(repository_ref, manifest_ref)
     if manifest is None:
-        image_pulls.labels("v2_1", "manifest", 404).inc()
+        image_pulls.labels("v2", "manifest", 404).inc()
         raise ManifestUnknown()
 
     track_and_log("pull_repo", repository_ref, manifest_digest=manifest_ref)
-    image_pulls.labels("v2_1", "manifest", 200).inc()
+    image_pulls.labels("v2", "manifest", 200).inc()
 
     return Response(
         manifest.internal_manifest_bytes.as_unicode(),
@@ -305,7 +305,7 @@ def _write_manifest_and_log(namespace_name, repo_name, tag_name, manifest_impl):
 
     track_and_log("push_repo", repository_ref, tag=tag_name)
     spawn_notification(repository_ref, "repo_push", {"updated_tags": [tag_name]})
-    image_pushes.labels("v2_1", 202).inc()
+    image_pushes.labels("v2", 202).inc()
 
     return Response(
         "OK",


### PR DESCRIPTION
Currently, we mark them as v2_1, which isn't fully correct, as we serve both v2_1 and v2_2 through the same code paths
