### PR TITLE
Fix base64 encode/decode error in config app.

### DIFF
--- a/config_app/config_util/config/__init__.py
+++ b/config_app/config_util/config/__init__.py
@@ -26,13 +26,14 @@ def get_config_as_kube_secret(config_path):
     certs_dir = os.path.join(config_path, EXTRA_CA_DIRECTORY)
     if os.path.exists(certs_dir):
         for extra_cert in os.listdir(certs_dir):
-            with open(os.path.join(certs_dir, extra_cert)) as f:
-                data[EXTRA_CA_DIRECTORY_PREFIX + extra_cert] = base64.b64encode(f.read())
+            file_path = os.path.join(certs_dir, extra_cert)
+            with open(file_path, "rb") as f:
+                data[EXTRA_CA_DIRECTORY_PREFIX + extra_cert] = base64.b64encode(f.read()).decode()
 
     for name in os.listdir(config_path):
         file_path = os.path.join(config_path, name)
         if not os.path.isdir(file_path):
-            with open(file_path) as f:
-                data[name] = base64.b64encode(f.read())
+            with open(file_path, "rb") as f:
+                data[name] = base64.b64encode(f.read()).decode()
 
     return data

--- a/config_app/config_util/config/test/test_helpers.py
+++ b/config_app/config_util/config/test/test_helpers.py
@@ -36,14 +36,14 @@ def _create_temp_file_structure(file_structure):
         ),
         pytest.param(
             {"config.yaml": "test:true", "otherfile.ext": "im a file"},
-            {"config.yaml": "dGVzdDp0cnVl", "otherfile.ext": base64.b64encode("im a file")},
+            {"config.yaml": "dGVzdDp0cnVl", "otherfile.ext": base64.b64encode(b"im a file")},
             id="config and another file",
         ),
         pytest.param(
             {"config.yaml": "test:true", "extra_ca_certs": [("cert.crt", "im a cert!"),]},
             {
                 "config.yaml": "dGVzdDp0cnVl",
-                "extra_ca_certs_cert.crt": base64.b64encode("im a cert!"),
+                "extra_ca_certs_cert.crt": base64.b64encode(b"im a cert!"),
             },
             id="config and an extra cert",
         ),
@@ -58,11 +58,16 @@ def _create_temp_file_structure(file_structure):
             },
             {
                 "config.yaml": "dGVzdDp0cnVl",
-                "otherfile.ext": base64.b64encode("im a file"),
-                "extra_ca_certs_cert.crt": base64.b64encode("im a cert!"),
-                "extra_ca_certs_another.crt": base64.b64encode("im a different cert!"),
+                "otherfile.ext": base64.b64encode(b"im a file"),
+                "extra_ca_certs_cert.crt": base64.b64encode(b"im a cert!"),
+                "extra_ca_certs_another.crt": base64.b64encode(b"im a different cert!"),
             },
             id="config, files, and extra certs!",
+        ),
+        pytest.param(
+            {"config.yaml": "First line\nSecond line"},
+            {"config.yaml": "Rmlyc3QgbGluZQpTZWNvbmQgbGluZQo="},
+            id="certificate includes newline characters",
         ),
     ],
 )


### PR DESCRIPTION
### Description of Changes

This PR fixes one failing test in the configuration app's unit tests.

#### Changes:

* Explicitly read certificate files as bytes (previous behavior) and then convert them to unicode/strings after base64 encoding them (achieves previous behavior) in the configuration app.

#### Issue:
- Fixing unit test failures in the Python3 branch as we progress in our transition.

**TESTING**

- Configuration App tests should no longer fail

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
