### PR TITLE
prometheus: default histogram buckets

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -43,7 +43,6 @@ build_start_duration = Histogram(
     "quay_build_start_duration_seconds",
     "seconds taken for a executor to start executing a queued build",
     labelnames=["executor"],
-    buckets=[0.5, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 180.0, 240.0, 300.0, 600.0],
 )
 
 

--- a/util/greenlet_tracing.py
+++ b/util/greenlet_tracing.py
@@ -8,9 +8,7 @@ from prometheus_client import Counter, Histogram
 greenlet_switch = Counter("greenlet_switch_total", "number of greenlet context switches")
 greenlet_throw = Counter("greenlet_throw_total", "number of greenlet throws")
 greenlet_duration = Histogram(
-    "greenlet_duration_seconds",
-    "seconds in which a particular greenlet is executing",
-    buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0],
+    "greenlet_duration_seconds", "seconds in which a particular greenlet is executing",
 )
 
 _latest_switch = None

--- a/util/metrics/prometheus.py
+++ b/util/metrics/prometheus.py
@@ -19,7 +19,6 @@ request_duration = Histogram(
     "quay_request_duration_seconds",
     "seconds taken to process a request",
     labelnames=["method", "route", "status"],
-    buckets=[0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0],
 )
 
 


### PR DESCRIPTION
### Description of Changes

By reverting back to the default histogram buckets, additional buckets are added to make the slowest queries report more accurately.

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
