### PR TITLE
Handle integrity errors being raised in v2 auth

### DIFF
--- a/data/model/test/test_repository.py
+++ b/data/model/test/test_repository.py
@@ -2,8 +2,6 @@ from datetime import timedelta
 
 import pytest
 
-from peewee import IntegrityError
-
 from data.model.gc import purge_repository
 from data.model.repository import create_repository, is_empty
 from data.model.repository import get_filtered_matching_repositories
@@ -12,11 +10,10 @@ from test.fixtures import *
 
 def test_duplicate_repository_different_kinds(initialized_db):
     # Create an image repo.
-    create_repository("devtable", "somenewrepo", None, repo_kind="image")
+    assert create_repository("devtable", "somenewrepo", None, repo_kind="image")
 
     # Try to create an app repo with the same name, which should fail.
-    with pytest.raises(IntegrityError):
-        create_repository("devtable", "somenewrepo", None, repo_kind="application")
+    assert not create_repository("devtable", "somenewrepo", None, repo_kind="application")
 
 
 def test_is_empty(initialized_db):

--- a/endpoints/api/repository.py
+++ b/endpoints/api/repository.py
@@ -144,7 +144,7 @@ class RepositoryList(ApiResource):
                 raise InvalidRequest("Invalid repository name")
 
             kind = req.get("repo_kind", "image") or "image"
-            model.create_repo(
+            created = model.create_repo(
                 namespace_name,
                 repository_name,
                 owner,
@@ -152,6 +152,8 @@ class RepositoryList(ApiResource):
                 visibility=visibility,
                 repo_kind=kind,
             )
+            if created is None:
+                raise InvalidRequest("Could not create repository")
 
             log_action(
                 "create_repo",

--- a/endpoints/api/repository_models_pre_oci.py
+++ b/endpoints/api/repository_models_pre_oci.py
@@ -201,6 +201,9 @@ class PreOCIModel(RepositoryDataInterface):
             repo_kind=repo_kind,
             description=description,
         )
+        if repo is None:
+            return None
+
         return Repository(namespace_name, repository_name)
 
     def get_repo(self, namespace_name, repository_name, user, include_tags=True, max_tags=500):

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -255,10 +255,14 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
                 # TODO: Push-to-create functionality should be configurable
                 if CreateRepositoryPermission(namespace).can() and user is not None:
                     logger.debug("Creating repository: %s/%s", namespace, reponame)
-                    repository_ref = RepositoryReference.for_repo_obj(
-                        model.repository.create_repository(namespace, reponame, user)
-                    )
-                    final_actions.append("push")
+                    found = model.repository.get_or_create_repository(namespace, reponame, user)
+                    if found is not None:
+                        repository_ref = RepositoryReference.for_repo_obj(found)
+
+                        if repository_ref.kind != "image":
+                            raise Unsupported(message="Cannot push to an app repository")
+
+                        final_actions.append("push")
                 else:
                     logger.debug("No permission to create repository %s/%s", namespace, reponame)
 


### PR DESCRIPTION
Instead of raising an unhandled exception, we now check for the repository during the create process. If it was created since we last checked, we simply use the reference. Otherwise, we return an error to the user.

Fixes https://issues.redhat.com/projects/PROJQUAY/issues/PROJQUAY-289
