### PR TITLE
quay-entypoint.sh: fix config argument handling

### DIFF
--- a/quay-entrypoint.sh
+++ b/quay-entrypoint.sh
@@ -51,18 +51,9 @@ case "$QUAYENTRY" in
         ;;
     "config")
         echo "Entering config mode, only copying config-app entrypoints"
-        if [ -z "$2" ]
-        then
-            if [ -z "${CONFIG_APP_PASSWORD}" ]
-            then
-                echo "Missing password for configuration tool"
-                exit
-            else
-                openssl passwd -apr1 "${CONFIG_APP_PASSWORD}" >> $QUAYDIR/config_app/conf/htpasswd
-            fi
-        else
-            openssl passwd -apr1 "$2" >> $QUAYDIR/config_app/conf/htpasswd
-        fi
+        : ${CONFIG_APP_PASSWORD:=$2}
+        : ${CONFIG_APP_PASSWORD:?Missing password argument for configuration tool}
+        openssl passwd -apr1 -- "${CONFIG_APP_PASSWORD}" > "$QUAYDIR/config_app/conf/htpasswd"
 
         /usr/bin/scl enable python27 rh-nginx112 "${QUAYPATH}/config_app/init/certs_create.sh"
         /usr/bin/scl enable python27 rh-nginx112 "supervisord -c ${QUAYPATH}/config_app/conf/supervisord.conf 2>&1"


### PR DESCRIPTION
### Description of Changes
This commit properly makes the `openssl` invocation correct for passwords starting with `-`and simplifies the code.

**TESTING** ->

**BREAKING CHANGE** ->

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
