### PR TITLE
Change GitHub calls to pass client_id and secret in the Auth header

### DIFF
--- a/buildtrigger/githubhandler.py
+++ b/buildtrigger/githubhandler.py
@@ -159,10 +159,9 @@ class GithubBuildTrigger(BuildTriggerHandler):
         Returns an authenticated client for talking to the GitHub API.
         """
         return Github(
-            self.auth_token,
             base_url=github_trigger.api_endpoint(),
-            client_id=github_trigger.client_id(),
-            client_secret=github_trigger.client_secret(),
+            login_or_token=self.auth_token if self.auth_token else github_trigger.client_id(),
+            password=None if self.auth_token else github_trigger.client_secret(),
             timeout=5,
         )
 


### PR DESCRIPTION
This is a required change, as GitHub is deprecating the query parameters in a few months. See https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/ for details.

Fixes https://issues.redhat.com/browse/PROJQUAY-268
