### PR TITLE
Use Redhat Terms & Privacy links in footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -163,8 +163,8 @@ mixpanel.init("{{ mixpanel_key }}", { track_pageview : false, debug: {{ is_debug
           <li><a href="{{ config_set['BRANDING']['footer_url'] }}" ng-safenewtab><img src="{{ config_set['BRANDING']['footer_img'] }}"></a></li>
           {% endif %}
           <li quay-require="['BILLING']"><a href="https://docs.quay.io" ng-safenewtab>Documentation</a></li>
-          <li quay-require="['BILLING']"><a href="/tos" target="_self">Terms</a></li>
-          <li quay-require="['BILLING']"><a href="/privacy" target="_self">Privacy</a></li>
+          <li quay-require="['BILLING']"><a href="https://www.openshift.com/legal/terms" target="_blank">Terms</a></li>
+          <li quay-require="['BILLING']"><a href="https://www.redhat.com/en/about/privacy-policy" target="_blank">Privacy</a></li>
           <li quay-require="['BILLING']"><a href="/security/" target="_self">Security</a></li>
           <li quay-require="['BILLING']"><a href="/about/" target="_self">About</a></li>
           {% if has_contact %}


### PR DESCRIPTION
### Description of Changes

Use Redhat Terms of Service and Privacy Page links in Footer

#### Changes:

- `Terms` links to https://www.openshift.com/legal/terms
- `Privacy` links to https://www.redhat.com/en/about/privacy-policy

#### Issue:

- https://issues.redhat.com/browse/PROJQUAY-162
- https://issues.redhat.com/browse/PROJQUAY-161

**TESTING** 

- Verify `Terms` and `Privacy` links in the footer link to Redhat's official pages and open in a new tab/window.

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
