### PR TITLE
PROJQUAY-70 - default wildcard mirror tags

### DIFF
--- a/data/model/repo_mirror.py
+++ b/data/model/repo_mirror.py
@@ -527,6 +527,23 @@ def validate_rule(rule_type, rule_value):
         )
 
 
+def clean_rule(rule_type, rule_value):
+    if rule_type != RepoMirrorRuleType.TAG_GLOB_CSV:
+        return rule_value
+
+    cleaned_rule_value = []
+    for value in rule_value:
+        value = value.strip()
+        if value == "":
+            cleaned_rule_value.append("*")
+        else:
+            cleaned_rule_value.append(value)
+
+    cleaned_rule_value = list(dict.fromkeys(cleaned_rule_value))  # remove duplicates
+
+    return cleaned_rule_value
+
+
 def create_rule(
     repository,
     rule_value,
@@ -538,6 +555,7 @@ def create_rule(
     Create a new Rule for mirroring a Repository.
     """
 
+    rule_value = clean_rule(rule_type, rule_value)
     validate_rule(rule_type, rule_value)
 
     rule_kwargs = {
@@ -576,6 +594,7 @@ def change_rule(repository, rule_type, rule_value):
     Update the value of an existing rule.
     """
 
+    rule_value = clean_rule(rule_type, rule_value)
     validate_rule(rule_type, rule_value)
 
     mirrorRule = get_root_rule(repository)

--- a/data/model/test/test_repo_mirroring.py
+++ b/data/model/test/test_repo_mirroring.py
@@ -2,7 +2,9 @@
 from __future__ import absolute_import
 from jsonschema import ValidationError
 
-from data.database import RepoMirrorConfig, RepoMirrorStatus, User
+import pytest
+
+from data.database import RepoMirrorConfig, RepoMirrorRuleType, RepoMirrorStatus, User
 from data import model
 from data.model.repo_mirror import (
     create_mirroring_rule,
@@ -10,6 +12,7 @@ from data.model.repo_mirror import (
     update_sync_status_to_cancel,
     MAX_SYNC_RETRIES,
     release_mirror,
+    clean_rule,
 )
 
 from test.fixtures import *
@@ -245,3 +248,10 @@ def test_release_mirror(initialized_db):
     mirror = release_mirror(mirror, RepoMirrorStatus.FAIL)
     assert mirror.sync_retries_remaining == 3
     assert mirror.sync_start_date > original_sync_start_date
+
+
+@pytest.mark.parametrize(
+    "rule_value, cleaned_rule_value", [(["", " 1.1 ", "", "1.1"], ["*", "1.1"])]
+)
+def test_clean_rule(rule_value, cleaned_rule_value):
+    assert clean_rule(RepoMirrorRuleType.TAG_GLOB_CSV, rule_value) == cleaned_rule_value

--- a/endpoints/api/test/test_mirror.py
+++ b/endpoints/api/test/test_mirror.py
@@ -70,7 +70,7 @@ def test_create_mirror_sets_permissions(existing_robot_permission, expected_perm
     assert permissions[0].role.name == expected_permission
 
     config = model.repo_mirror.get_mirror(model.repository.get_repository("devtable", "simple"))
-    assert config.root_rule.rule_value == ["latest", "foo", "bar"]
+    assert config.root_rule.rule_value.sort() == ["bar", "latest", "foo"].sort()
 
 
 def test_get_mirror_does_not_exist(client):
@@ -188,6 +188,10 @@ def test_change_config(key, value, expected_status, client):
             assert resp.json["external_registry_config"]["verify_tls"] == value
         elif key in ("http_proxy", "https_proxy", "no_proxy"):
             assert resp.json["external_registry_config"]["proxy"][key] == value
+        elif key == "root_rule":
+            resp.json["root_rule"]["rule_value"].sort()
+            value["rule_value"].sort()
+            assert resp.json["root_rule"] == value
         else:
             assert resp.json[key] == value
     else:


### PR DESCRIPTION
https://issues.redhat.com/browse/PROJQUAY-70

When no mirror tag pattern is specified (empty string), default to wildcard (*). Additional clean up of mirror tag list to strip whitespace and remove duplicates.