### PR TITLE
Ensure that temporary tags cannot be written for repositories marked for deletion

### DIFF
--- a/data/model/blob.py
+++ b/data/model/blob.py
@@ -164,7 +164,9 @@ def _temp_link_blob(repository_id, storage, link_expiration_s):
     image = Image.create(
         storage=storage, docker_image_id=random_image_name, repository=repository_id
     )
-    tag.create_temporary_hidden_tag(repository_id, image, link_expiration_s)
+    temp_tag = tag.create_temporary_hidden_tag(repository_id, image, link_expiration_s)
+    if temp_tag is None:
+        image.delete_instance()
 
 
 def get_stale_blob_upload(stale_timespan):

--- a/data/model/gc.py
+++ b/data/model/gc.py
@@ -77,6 +77,10 @@ def purge_repository(repo, force=False):
     """
     assert repo.state == RepositoryState.MARKED_FOR_DELETION or force
 
+    # Update the repo state to ensure nothing else is written to it.
+    repo.state = RepositoryState.MARKED_FOR_DELETION
+    repo.save()
+
     # Delete the repository of all Appr-referenced entries.
     # Note that new-model Tag's must be deleted in *two* passes, as they can reference parent tags,
     # and MySQL is... particular... about such relationships when deleting.

--- a/data/model/tag.py
+++ b/data/model/tag.py
@@ -19,6 +19,7 @@ from data.model import (
 from data.database import (
     RepositoryTag,
     Repository,
+    RepositoryState,
     Image,
     ImageStorage,
     Namespace,
@@ -396,20 +397,27 @@ def create_temporary_hidden_tag(repo, image_obj, expiration_s):
     """
     Create a tag with a defined timeline, that will not appear in the UI or CLI.
 
-    Returns the name of the temporary tag.
+    Returns the name of the temporary tag or None on error.
     """
     now_ts = get_epoch_timestamp()
     expire_ts = now_ts + expiration_s
     tag_name = str(uuid4())
-    RepositoryTag.create(
-        repository=repo,
-        image=image_obj,
-        name=tag_name,
-        lifetime_start_ts=now_ts,
-        lifetime_end_ts=expire_ts,
-        hidden=True,
-    )
-    return tag_name
+
+    # Ensure the repository is not marked for deletion.
+    with db_transaction():
+        current = Repository.get(id=repo)
+        if current.state == RepositoryState.MARKED_FOR_DELETION:
+            return None
+
+        RepositoryTag.create(
+            repository=repo,
+            image=image_obj,
+            name=tag_name,
+            lifetime_start_ts=now_ts,
+            lifetime_end_ts=expire_ts,
+            hidden=True,
+        )
+        return tag_name
 
 
 def lookup_unrecoverable_tags(repo):

--- a/data/model/test/test_tag.py
+++ b/data/model/test/test_tag.py
@@ -13,6 +13,7 @@ from data.database import (
     RepositoryTag,
     ImageStorage,
     Repository,
+    RepositoryState,
     Manifest,
     ManifestBlob,
     ManifestLegacyImage,
@@ -352,11 +353,20 @@ def test_get_most_recent_tag(initialized_db):
     # Create a hidden tag that is the most recent.
     repo = model.repository.get_repository("devtable", "simple")
     image = model.tag.get_tag_image("devtable", "simple", "latest")
-    model.tag.create_temporary_hidden_tag(repo, image, 10000000)
+    assert model.tag.create_temporary_hidden_tag(repo, image, 10000000) is not None
 
     # Ensure we find a non-hidden tag.
     found = model.tag.get_most_recent_tag(repo)
     assert not found.hidden
+
+
+def test_create_temp_tag_deleted_repo(initialized_db):
+    repo = model.repository.get_repository("devtable", "simple")
+    repo.state = RepositoryState.MARKED_FOR_DELETION
+    repo.save()
+
+    image = model.tag.get_tag_image("devtable", "simple", "latest")
+    assert model.tag.create_temporary_hidden_tag(repo, image, 10000000) is None
 
 
 def test_get_active_tag_for_repo(initialized_db):

--- a/data/registry_model/manifestbuilder.py
+++ b/data/registry_model/manifestbuilder.py
@@ -135,7 +135,11 @@ class _ManifestBuilder(object):
             created = model.image.find_create_or_link_image(
                 layer_id, repository, calling_user, {}, location_name
             )
-            model.tag.create_temporary_hidden_tag(repository, created, temp_tag_expiration)
+            temp_tag_name = model.tag.create_temporary_hidden_tag(
+                repository, created, temp_tag_expiration
+            )
+            if temp_tag_name is None:
+                return None
 
             # Save its V1 metadata.
             command_list = v1_metadata.get("container_config", {}).get("Cmd", None)


### PR DESCRIPTION
The purge code assumes that once it has deleted tags, no new ones will
be added, so we need to enforce that state
