### PR TITLE
PROJQUAY-454 - version from env or git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,8 +7,6 @@ screenshots
 tools
 test/data/registry
 venv
-.git
-!.git/HEAD
 .gitignore
 .github
 Bobfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG QUAY_VERSION
 ###     git describe --tags >> VERSION && \
 ###     find . -name ".git" -exec rm -rf -- {} +
 RUN echo $QUAY_VERSION > VERSION
-RUN git describe --tags >> VERSION
+RUN git describe --tags 2> /dev/null || git rev-parse --short HEAD >> VERSION
 RUN find . -name ".git" -exec rm -rf -- {} +
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,12 @@ RUN INSTALL_PKGS="\
 COPY . .
 
 ARG QUAY_VERSION
-RUN echo $QUAY_VERSION > VERSION && \
-    git describe --tags >> VERSION && \
-    find . -name ".git" -exec rm -rf -- {} +
+### RUN echo $QUAY_VERSION > VERSION && \
+###     git describe --tags >> VERSION && \
+###     find . -name ".git" -exec rm -rf -- {} +
+RUN echo $QUAY_VERSION > VERSION
+RUN git describe --tags >> VERSION
+RUN find . -name ".git" -exec rm -rf -- {} +
 
 
 # Quay

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -45,6 +45,10 @@ RUN INSTALL_PKGS="\
     yum -y clean all
 
 COPY . .
+ARG QUAY_VERSION
+RUN echo $QUAY_VERSION > VERSION && \
+    git describe --tags >> VERSION && \
+    find . -name ".git" -exec rm -rf -- {} +
 
 RUN scl enable python27 "\
     pip install --upgrade setuptools==44 pip && \

--- a/_init.py
+++ b/_init.py
@@ -28,12 +28,27 @@ config_provider = get_config_provider(
 )
 
 
-def _get_version_number_changelog():
-    try:
-        with open(os.path.join(ROOT_DIR, "CHANGELOG.md")) as f:
-            return re.search(r"(v[0-9]+\.[0-9]+\.[0-9]+)", f.readline()).group(0)
-    except IOError:
-        return ""
+def _get_version():
+    """
+    Version is determined in following order:
+    1. First non-blank line VERSION file
+    2. environment variable QUAY_VERSION
+    3. GIT_HEAD file
+    4. git rev-parse HEAD
+    """
+    version = ""
+    if os.path.exists(os.path.join(ROOT_DIR, "VERSION")):
+        with open(os.path.join(ROOT_DIR, "VERSION")) as f:
+            for line in f:
+                if line != "":
+                    version = line.strip()
+                    break
+    if not version or version == "":
+        version = os.environ.get("QUAY_VERSION", "")
+    if not version or version == "":
+        version = _get_git_sha()
+
+    return version
 
 
 def _get_git_sha():
@@ -48,5 +63,5 @@ def _get_git_sha():
     return "unknown"
 
 
-__version__ = _get_version_number_changelog()
+__version__ = _get_version()
 __gitrev__ = _get_git_sha()

--- a/config_app/_init_config.py
+++ b/config_app/_init_config.py
@@ -14,12 +14,27 @@ TEMPLATE_DIR = os.path.join(ROOT_DIR, "templates/")
 IS_KUBERNETES = "KUBERNETES_SERVICE_HOST" in os.environ
 
 
-def _get_version_number_changelog():
-    try:
-        with open(os.path.join(ROOT_DIR, "CHANGELOG.md")) as f:
-            return re.search(r"(v[0-9]+\.[0-9]+\.[0-9]+)", f.readline()).group(0)
-    except IOError:
-        return ""
+def _get_version():
+    """
+    Version is determined in following order:
+    1. First non-blank line VERSION file
+    2. environment variable QUAY_VERSION
+    3. GIT_HEAD file
+    4. git rev-parse HEAD
+    """
+    version = ""
+    if os.path.exists(os.path.join(ROOT_DIR, "VERSION")):
+        with open(os.path.join(ROOT_DIR, "VERSION")) as f:
+            for line in f:
+                if line != "":
+                    version = line.strip()
+                    break
+    if not version or version == "":
+        version = os.environ.get("QUAY_VERSION", "")
+    if not version or version == "":
+        version = _get_git_sha()
+
+    return version
 
 
 def _get_git_sha():
@@ -34,5 +49,5 @@ def _get_git_sha():
     return "unknown"
 
 
-__version__ = _get_version_number_changelog()
+__version__ = _get_version()
 __gitrev__ = _get_git_sha()

--- a/quay-entrypoint.sh
+++ b/quay-entrypoint.sh
@@ -10,7 +10,7 @@ if ! whoami &> /dev/null; then
 fi
 
 display_usage() {
-    echo "Usage: ${0} <registry|config|migrate|repomirror|shell|help>"
+    echo "Usage: ${0} <version|registry|config|migrate|repomirror|shell|help>"
     echo
     echo "If the first argument isn't one of the above modes,"
     echo "the arguments will be exec'd directly, i.e.:"
@@ -33,10 +33,9 @@ cat << "EOF"
 \ \  \ \  / /  | |__| | | |__| | / ____ \  | |
  \ \/ \ \/ /   \_  ___/  \____/ /_/    \_\ |_|
   \__/ \__/      \ \__
-                  \___\ by Red Hat
+                  \___\
 
  Build, Store, and Distribute your Containers
-
 
 EOF
 
@@ -48,6 +47,10 @@ export DB_CONNECTION_POOLING_REGISTRY=${DB_CONNECTION_POOLING:-"true"}
 eval "$(scl enable python27 rh-nginx112 'export -p')"
 
 case "$QUAYENTRY" in
+    "version")
+        echo "Version: " `sed '/[^[:blank:]]/q;d' VERSION`
+        exit 0
+        ;;
     "shell")
         echo "Entering shell mode"
         exec /bin/bash


### PR DESCRIPTION
https://issues.redhat.com/browse/PROJQUAY-454

    Version is determined in following order:
    1. First line VERSION file
    2. environment variable QUAY_RELEASE
    3. GIT_HEAD file
    4. git rev-parse HEAD

Added a quay-entrypoint command of "version" that will print the first non-blank line from VERSION.

VERSION file is created during container build. The first line will be the ARG QUAY_VERSION and the second will be `git describe --tags`.