### PR TITLE
quay-entrypoint.sh: fix openssl commandline

### DIFF
--- a/quay-entrypoint.sh
+++ b/quay-entrypoint.sh
@@ -54,9 +54,9 @@ case "$QUAYENTRY" in
         ;;
     "config")
         echo "Entering config mode, only copying config-app entrypoints"
-        : ${CONFIG_APP_PASSWORD:=$2}
-        : ${CONFIG_APP_PASSWORD:?Missing password argument for configuration tool}
-        openssl passwd -apr1 -- "${CONFIG_APP_PASSWORD}" > "$QUAYDIR/config_app/conf/htpasswd"
+        : "${CONFIG_APP_PASSWORD:=$2}"
+        : "${CONFIG_APP_PASSWORD:?Missing password argument for configuration tool}"
+        printf '%s' "${CONFIG_APP_PASSWORD}" | openssl passwd -apr1 -stdin >> "$QUAYDIR/config_app/conf/htpasswd"
 
         "${QUAYPATH}/config_app/init/certs_create.sh" || exit
         exec supervisord -c "${QUAYPATH}/config_app/conf/supervisord.conf" 2>&1


### PR DESCRIPTION
Turns out `--` isn't in the openssl in rhel7.

This is my bad to begin with, as this argument terminator isn't
documented even on versions where it works.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>

#### Changes:

* fixes command line

#### Issue: PROJQUAY-467


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
