### PR TITLE
Disable read replica reading in critical registry paths

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -40,7 +40,7 @@ from data.fields import (
 from data.decorators import deprecated_model
 from data.text import match_mysql, match_like
 from data.encryption import FieldEncrypter
-from data.readreplica import ReadReplicaSupportedModel, ReadOnlyConfig
+from data.readreplica import ReadReplicaSupportedModel, ReadOnlyConfig, disallow_replica_use
 from data.estimate import mysql_estimate_row_count, normal_row_count
 from util.names import urn_generator
 from util.validation import validate_postgres_precondition
@@ -304,6 +304,7 @@ db_random_func = CallableProxy()
 db_match_func = CallableProxy()
 db_for_update = CallableProxy()
 db_transaction = CallableProxy()
+db_disallow_replica_use = CallableProxy()
 db_concat_func = CallableProxy()
 db_encrypter = Proxy()
 db_count_estimator = CallableProxy()
@@ -441,6 +442,9 @@ def configure(config_object, testing=False):
     def _db_transaction():
         return config_object["DB_TRANSACTION_FACTORY"](db)
 
+    def _db_disallow_replica_use():
+        return disallow_replica_use(db)
+
     @contextmanager
     def _ensure_under_transaction():
         if not testing and not config_object["TESTING"]:
@@ -450,6 +454,7 @@ def configure(config_object, testing=False):
         yield
 
     db_transaction.initialize(_db_transaction)
+    db_disallow_replica_use.initialize(_db_disallow_replica_use)
     ensure_under_transaction.initialize(_ensure_under_transaction)
 
 

--- a/endpoints/v2/manifest.py
+++ b/endpoints/v2/manifest.py
@@ -9,6 +9,7 @@ import features
 from app import app, storage
 from auth.registry_jwt_auth import process_registry_jwt_auth
 from digest import digest_tools
+from data.database import db_disallow_replica_use
 from data.registry_model import registry_model
 from data.model.oci.manifest import CreateManifestException
 from data.model.oci.tag import RetargetTagException
@@ -290,55 +291,57 @@ def delete_manifest_by_digest(namespace_name, repo_name, manifest_ref):
     Note: there is no equivalent method for deleting by tag name because it is
     forbidden by the spec.
     """
-    repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
-    if repository_ref is None:
-        raise NameUnknown()
+    with db_disallow_replica_use():
+        repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
+        if repository_ref is None:
+            raise NameUnknown()
 
-    manifest = registry_model.lookup_manifest_by_digest(repository_ref, manifest_ref)
-    if manifest is None:
-        raise ManifestUnknown()
+        manifest = registry_model.lookup_manifest_by_digest(repository_ref, manifest_ref)
+        if manifest is None:
+            raise ManifestUnknown()
 
-    tags = registry_model.delete_tags_for_manifest(manifest)
-    if not tags:
-        raise ManifestUnknown()
+        tags = registry_model.delete_tags_for_manifest(manifest)
+        if not tags:
+            raise ManifestUnknown()
 
-    for tag in tags:
-        track_and_log("delete_tag", repository_ref, tag=tag.name, digest=manifest_ref)
+        for tag in tags:
+            track_and_log("delete_tag", repository_ref, tag=tag.name, digest=manifest_ref)
 
-    return Response(status=202)
+        return Response(status=202)
 
 
 def _write_manifest_and_log(namespace_name, repo_name, tag_name, manifest_impl):
-    repository_ref, manifest, tag = _write_manifest(
-        namespace_name, repo_name, tag_name, manifest_impl
-    )
+    with db_disallow_replica_use():
+        repository_ref, manifest, tag = _write_manifest(
+            namespace_name, repo_name, tag_name, manifest_impl
+        )
 
-    # Queue all blob manifests for replication.
-    if features.STORAGE_REPLICATION:
-        blobs = registry_model.get_manifest_local_blobs(manifest)
-        if blobs is None:
-            logger.error("Could not lookup blobs for manifest `%s`", manifest.digest)
-        else:
-            with queue_replication_batch(namespace_name) as queue_storage_replication:
-                for blob_digest in blobs:
-                    queue_storage_replication(blob_digest)
+        # Queue all blob manifests for replication.
+        if features.STORAGE_REPLICATION:
+            blobs = registry_model.get_manifest_local_blobs(manifest)
+            if blobs is None:
+                logger.error("Could not lookup blobs for manifest `%s`", manifest.digest)
+            else:
+                with queue_replication_batch(namespace_name) as queue_storage_replication:
+                    for blob_digest in blobs:
+                        queue_storage_replication(blob_digest)
 
-    track_and_log("push_repo", repository_ref, tag=tag_name)
-    spawn_notification(repository_ref, "repo_push", {"updated_tags": [tag_name]})
-    image_pushes.labels("v2", 201, manifest.media_type).inc()
+        track_and_log("push_repo", repository_ref, tag=tag_name)
+        spawn_notification(repository_ref, "repo_push", {"updated_tags": [tag_name]})
+        image_pushes.labels("v2", 201, manifest.media_type).inc()
 
-    return Response(
-        "OK",
-        status=201,
-        headers={
-            "Docker-Content-Digest": manifest.digest,
-            "Location": url_for(
-                "v2.fetch_manifest_by_digest",
-                repository="%s/%s" % (namespace_name, repo_name),
-                manifest_ref=manifest.digest,
-            ),
-        },
-    )
+        return Response(
+            "OK",
+            status=201,
+            headers={
+                "Docker-Content-Digest": manifest.digest,
+                "Location": url_for(
+                    "v2.fetch_manifest_by_digest",
+                    repository="%s/%s" % (namespace_name, repo_name),
+                    manifest_ref=manifest.digest,
+                ),
+            },
+        )
 
 
 def _write_manifest(namespace_name, repo_name, tag_name, manifest_impl):


### PR DESCRIPTION
This ensures consistency when pushing when a read replica is enabled