### PR TITLE
Fix the Quay container directory Path

### DIFF
--- a/docs/development-container.md
+++ b/docs/development-container.md
@@ -77,12 +77,12 @@ Change the web resources to devel location:
 ```
 cd /quay-registry
 mv static static.bak
-ln -s $QUAY_DEVEL_HOME/static
+ln -s $QUAY_DEVEL_HOME/quay/static
 ```
 
 Build web assets:
 ```
-cd $QUAY_DEVEL_HOME
+cd $QUAY_DEVEL_HOME/quay
 mkdir -p static/webfonts
 mkdir -p static/fonts
 mkdir -p static/ldn
@@ -97,25 +97,25 @@ If `$QUAY_DEVEL_HOME/quay`, which presumably has your local code changes, has mi
 
 To run a migration:
 ```
-cd $QUAY_DEVEL_HOME
+cd $QUAY_DEVEL_HOME/quay
 PYTHONPATH=. alembic upgrade 5248ddf35167
 ```
 
 To revert a migration:
 ```
-cd $QUAY_DEVEL_HOME
+cd $QUAY_DEVEL_HOME/quay
 PYTHONPATH=. alembic downgrade -1
 ```
 
 ### Web UI Assets
 
 ```
-cd $QUAY_DEVEL_HOME
+cd $QUAY_DEVEL_HOME/quay
 yarn build && npm run watch
 ```
 
 ### Run Web Server
 ```
-cd $QUAY_DEVEL_HOME
+cd $QUAY_DEVEL_HOME/quay
 PYTHONPATH=. gunicorn -c conf/gunicorn_web.py web:application
 ```


### PR DESCRIPTION

### Description of Changes

* details about the implementation of the changes
* motivation for the change (broken code, new feature, etc)
* contrast with previous behavior


#### Changes:

I fix directory of the quay container.
Because installation does not proceed with your installation documentation.
I found that the quay container directory is wrong.

* before: $QUAY_DEVEL_HOME
* after:    $QUAY_DEVEL_HOME/quay

This is because we set it to '-e QUAY_DEVEL_HOME=$QUAY_DEVEL_HOME' above, 
and the contents performed after it are in '$QUAY_DEVEL_HOME/quay'. 

Check, please.

#### Issue: <link to story or task>


**TESTING** ->

working ! 

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
