### PR TITLE
Remove the use of a transaction for User and Repository delete

### DIFF
--- a/data/model/gc.py
+++ b/data/model/gc.py
@@ -1,6 +1,6 @@
 import logging
 
-from peewee import fn
+from peewee import fn, IntegrityError
 
 from data.model import config, db_transaction, storage, _basequery, tag as pre_oci_tag
 from data.model.oci import tag as oci_tag
@@ -127,8 +127,11 @@ def purge_repository(repo, force=False):
     except Repository.DoesNotExist:
         return False
 
-    fetched.delete_instance(recursive=True, delete_nullable=False, force=force)
-    return True
+    try:
+        fetched.delete_instance(recursive=True, delete_nullable=False, force=force)
+        return True
+    except IntegrityError:
+        return False
 
 
 def _chunk_delete_all(repo, model, force=False, chunk_size=500):

--- a/workers/namespacegcworker.py
+++ b/workers/namespacegcworker.py
@@ -20,7 +20,8 @@ class NamespaceGCWorker(QueueWorker):
     def process_queue_item(self, job_details):
         logger.debug("Got namespace GC queue item: %s", job_details)
         marker_id = job_details["marker_id"]
-        model.user.delete_namespace_via_marker(marker_id, all_queues)
+        if not model.user.delete_namespace_via_marker(marker_id, all_queues):
+            raise Exception("GC interrupted; will retry")
 
 
 if __name__ == "__main__":

--- a/workers/repositorygcworker.py
+++ b/workers/repositorygcworker.py
@@ -28,7 +28,8 @@ class RepositoryGCWorker(QueueWorker):
             return
 
         logger.debug("Purging repository %s", marker.repository)
-        model.gc.purge_repository(marker.repository)
+        if not model.gc.purge_repository(marker.repository):
+            raise Exception("GC interrupted; will retry")
 
 
 if __name__ == "__main__":

--- a/workers/test/test_namespacegcworker.py
+++ b/workers/test/test_namespacegcworker.py
@@ -1,0 +1,17 @@
+from app import namespace_gc_queue
+from data import model, database
+from workers.namespacegcworker import NamespaceGCWorker
+
+from test.fixtures import *
+
+
+def test_gc_namespace(initialized_db):
+    namespace = model.user.get_namespace_user("buynlarge")
+    marker_id = model.user.mark_namespace_for_deletion(namespace, [], namespace_gc_queue)
+
+    assert not database.User.get(id=namespace).enabled
+
+    worker = NamespaceGCWorker(None)
+    worker.process_queue_item({"marker_id": marker_id})
+
+    assert model.user.get_namespace_user("buynlarge") is None


### PR DESCRIPTION
While a transaction is obviously safer, with the number of tables
and rows referencing these tables now, a transaction is potentially
locking up a significant chunk of the database. Since we're already
performing cleanup before calling the delete, including disabling
new data being written for the User or Repository, deletion without
a transaction should (usually) be sufficient; if it isn't, an
IntegrityError will be raised, and the workers can retry continuing
the GC operation
