### PR TITLE
Implement a solution for long index names in sqlalchemybridge

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -1947,6 +1947,15 @@ class ManifestSecurityStatus(BaseModel):
     metadata_json = JSONField(default={})
 
 
+# Defines a map from full-length index names to the legacy names used in our code
+# to meet length restrictions.
+LEGACY_INDEX_MAP = {
+    "derivedstorageforimage_source_image_id_transformation_id_uniqueness_hash": "uniqueness_hash",
+    "queueitem_processing_expires_available_after_queue_name_retries_remaining_available": "queueitem_pe_aafter_qname_rremaining_available",
+    "queueitem_processing_expires_available_after_retries_remaining_available": "queueitem_pexpires_aafter_rremaining_available",
+}
+
+
 appr_classes = set(
     [
         ApprTag,

--- a/data/migrations/env.py
+++ b/data/migrations/env.py
@@ -11,7 +11,7 @@ from alembic.util import CommandError
 from sqlalchemy import engine_from_config, pool
 from peewee import SqliteDatabase
 
-from data.database import all_models, db
+from data.database import all_models, db, LEGACY_INDEX_MAP
 from data.migrations.tester import NoopTester, PopulateTestDataTester
 from data.model.sqlalchemybridge import gen_sqlalchemy_metadata
 from release import GIT_HEAD, REGION, SERVICE
@@ -24,7 +24,6 @@ from data.migrations.dba_operator import Migration, OpLogger
 config = context.config
 DB_URI = config.get_main_option("db_uri", "sqlite:///test/data/test.db")
 PROM_LABEL_PREFIX = "DBA_OP_LABEL_"
-
 
 # This option exists because alembic needs the db proxy to be configured in order
 # to perform migrations. The app import does the init of the proxy, but we don't
@@ -47,7 +46,7 @@ logger = logging.getLogger(__name__)
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = gen_sqlalchemy_metadata(all_models)
+target_metadata = gen_sqlalchemy_metadata(all_models, LEGACY_INDEX_MAP)
 tables = AttrDict(target_metadata.tables)
 
 # other values from the config, defined by the needs of env.py,


### PR DESCRIPTION
We now cap the index name length at 64 (as per MySQL restrictions). If
an index name is *longer* than that, we hash the index name in its
entirety and then append the short-sha of the hash as a suffix to a
shortened version of the index name. This ensures the index name meets
the length requirements while *also* being stable across generations.

This change also adds a legacy map of long index names to the names we
manually applied, to ensure they don't get regenerated either
