### PR TITLE
Stop relying on GitHub's admin permissions for a repository

### DIFF
--- a/buildtrigger/githubhandler.py
+++ b/buildtrigger/githubhandler.py
@@ -312,7 +312,7 @@ class GithubBuildTrigger(BuildTriggerHandler):
                 "description": repo.description or "",
                 "last_updated": timegm(repo.pushed_at.utctimetuple()) if repo.pushed_at else 0,
                 "url": repo.html_url,
-                "has_admin_permissions": repo.permissions.admin,
+                "has_admin_permissions": True,
                 "private": repo.private,
             }
 

--- a/buildtrigger/test/test_githosthandler.py
+++ b/buildtrigger/test/test_githosthandler.py
@@ -1,8 +1,10 @@
+import copy
+
 import pytest
 
 from buildtrigger.triggerutil import TriggerStartException
 from buildtrigger.test.bitbucketmock import get_bitbucket_trigger
-from buildtrigger.test.githubmock import get_github_trigger
+from buildtrigger.test.githubmock import get_github_trigger, GithubBuildTrigger
 from endpoints.building import PreparedBuild
 
 # Note: This test suite executes a common set of tests against all the trigger types specified
@@ -142,6 +144,12 @@ def test_list_build_source_namespaces():
     ],
 )
 def test_list_build_sources_for_namespace(namespace, expected, githost_trigger):
+    if isinstance(githost_trigger, GithubBuildTrigger):
+        # NOTE: We've disabled the permissions check for GitHub, so cancel them here.
+        expected = copy.deepcopy(expected)
+        for item in expected:
+            item["has_admin_permissions"] = True
+
     assert githost_trigger.list_build_sources_for_namespace(namespace) == expected
 
 


### PR DESCRIPTION
It appears GitHub has narrowed the permissions returned, so while we
might still have the ability to admin the *repo*, the permissions
list is returning `false`, so we disallow people to create triggers,
which is wrong.

Fixes https://issues.redhat.com/browse/PROJQUAY-523
