### PR TITLE
DBA operator migration generator bug fixes.

### DIFF
--- a/data/migrations/dba_operator.py
+++ b/data/migrations/dba_operator.py
@@ -49,7 +49,7 @@ class Migration(object):
                         self.hint_add_column(subop.table_name, subop.column)
                     elif isinstance(subop, ops.CreateIndexOp):
                         self.hint_create_index(
-                            subop.table_name, subop.index_name, subop.columns, subop.unique,
+                            subop.index_name, subop.table_name, subop.columns, subop.unique,
                         )
                     elif isinstance(subop, ops.DropIndexOp):
                         self.hint_drop_index(subop.index_name, subop.table_name)
@@ -96,7 +96,7 @@ class Migration(object):
             }
         )
 
-    def hint_create_index(self, table_name, index_name, columns, unique=False, **kwargs):
+    def hint_create_index(self, index_name, table_name, columns, unique=False, **kwargs):
         self._schema_hints.append(
             {
                 "operation": "createIndex",

--- a/data/migrations/dba_operator/10f45ee2310b-databasemigration.yaml
+++ b/data/migrations/dba_operator/10f45ee2310b-databasemigration.yaml
@@ -22,10 +22,10 @@ spec:
     operation: createTable
     table: tagkind
   - columns: []
-    indexName: tagkind
+    indexName: tagkind_name
     indexType: unique
     operation: createIndex
-    table: tagkind_name
+    table: tagkind
   - columns:
     - name: id
       nullable: false
@@ -38,40 +38,40 @@ spec:
     operation: createTable
     table: manifestchild
   - columns: []
-    indexName: manifestchild
+    indexName: manifestchild_child_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestchild_child_manifest_id
+    table: manifestchild
   - columns: []
-    indexName: manifestchild
+    indexName: manifestchild_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestchild_manifest_id
+    table: manifestchild
   - columns: []
-    indexName: manifestchild
+    indexName: manifestchild_manifest_id_child_manifest_id
     indexType: unique
     operation: createIndex
-    table: manifestchild_manifest_id_child_manifest_id
+    table: manifestchild
   - columns: []
-    indexName: manifestchild
+    indexName: manifestchild_repository_id
     indexType: index
     operation: createIndex
-    table: manifestchild_repository_id
+    table: manifestchild
   - columns: []
-    indexName: manifestchild
+    indexName: manifestchild_repository_id_child_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestchild_repository_id_child_manifest_id
+    table: manifestchild
   - columns: []
-    indexName: manifestchild
+    indexName: manifestchild_repository_id_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestchild_repository_id_manifest_id
+    table: manifestchild
   - columns: []
-    indexName: manifestchild
+    indexName: manifestchild_repository_id_manifest_id_child_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestchild_repository_id_manifest_id_child_manifest_id
+    table: manifestchild
   - columns:
     - name: id
       nullable: false
@@ -96,47 +96,47 @@ spec:
     operation: createTable
     table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_lifetime_end_ms
     indexType: index
     operation: createIndex
-    table: tag_lifetime_end_ms
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_linked_tag_id
     indexType: index
     operation: createIndex
-    table: tag_linked_tag_id
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_manifest_id
     indexType: index
     operation: createIndex
-    table: tag_manifest_id
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id
     indexType: index
     operation: createIndex
-    table: tag_repository_id
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id_name
     indexType: index
     operation: createIndex
-    table: tag_repository_id_name
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id_name_hidden
     indexType: index
     operation: createIndex
-    table: tag_repository_id_name_hidden
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id_name_lifetime_end_ms
     indexType: unique
     operation: createIndex
-    table: tag_repository_id_name_lifetime_end_ms
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id_name_tag_kind_id
     indexType: index
     operation: createIndex
-    table: tag_repository_id_name_tag_kind_id
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_tag_kind_id
     indexType: index
     operation: createIndex
-    table: tag_tag_kind_id
+    table: tag

--- a/data/migrations/dba_operator/13411de1c0ff-databasemigration.yaml
+++ b/data/migrations/dba_operator/13411de1c0ff-databasemigration.yaml
@@ -28,17 +28,17 @@ spec:
     operation: createTable
     table: tagmanifesttomanifest
   - columns: []
-    indexName: tagmanifesttomanifest
+    indexName: tagmanifesttomanifest_broken
     indexType: index
     operation: createIndex
-    table: tagmanifesttomanifest_broken
+    table: tagmanifesttomanifest
   - columns: []
-    indexName: tagmanifesttomanifest
+    indexName: tagmanifesttomanifest_manifest_id
     indexType: index
     operation: createIndex
-    table: tagmanifesttomanifest_manifest_id
+    table: tagmanifesttomanifest
   - columns: []
-    indexName: tagmanifesttomanifest
+    indexName: tagmanifesttomanifest_tag_manifest_id
     indexType: unique
     operation: createIndex
-    table: tagmanifesttomanifest_tag_manifest_id
+    table: tagmanifesttomanifest

--- a/data/migrations/dba_operator/1783530bee68-databasemigration.yaml
+++ b/data/migrations/dba_operator/1783530bee68-databasemigration.yaml
@@ -34,47 +34,47 @@ spec:
     operation: createTable
     table: logentry2
   - columns: []
-    indexName: logentry2
+    indexName: logentry2_account_id
     indexType: index
     operation: createIndex
-    table: logentry2_account_id
+    table: logentry2
   - columns: []
-    indexName: logentry2
+    indexName: logentry2_account_id_datetime
     indexType: index
     operation: createIndex
-    table: logentry2_account_id_datetime
+    table: logentry2
   - columns: []
-    indexName: logentry2
+    indexName: logentry2_datetime
     indexType: index
     operation: createIndex
-    table: logentry2_datetime
+    table: logentry2
   - columns: []
-    indexName: logentry2
+    indexName: logentry2_kind_id
     indexType: index
     operation: createIndex
-    table: logentry2_kind_id
+    table: logentry2
   - columns: []
-    indexName: logentry2
+    indexName: logentry2_performer_id
     indexType: index
     operation: createIndex
-    table: logentry2_performer_id
+    table: logentry2
   - columns: []
-    indexName: logentry2
+    indexName: logentry2_performer_id_datetime
     indexType: index
     operation: createIndex
-    table: logentry2_performer_id_datetime
+    table: logentry2
   - columns: []
-    indexName: logentry2
+    indexName: logentry2_repository_id
     indexType: index
     operation: createIndex
-    table: logentry2_repository_id
+    table: logentry2
   - columns: []
-    indexName: logentry2
+    indexName: logentry2_repository_id_datetime
     indexType: index
     operation: createIndex
-    table: logentry2_repository_id_datetime
+    table: logentry2
   - columns: []
-    indexName: logentry2
+    indexName: logentry2_repository_id_datetime_kind_id
     indexType: index
     operation: createIndex
-    table: logentry2_repository_id_datetime_kind_id
+    table: logentry2

--- a/data/migrations/dba_operator/224ce4c72c2f-databasemigration.yaml
+++ b/data/migrations/dba_operator/224ce4c72c2f-databasemigration.yaml
@@ -20,7 +20,7 @@ spec:
     operation: addColumn
     table: user
   - columns: []
-    indexName: user
+    indexName: user_last_accessed
     indexType: index
     operation: createIndex
-    table: user_last_accessed
+    table: user

--- a/data/migrations/dba_operator/3e8cc74a1e7b-databasemigration.yaml
+++ b/data/migrations/dba_operator/3e8cc74a1e7b-databasemigration.yaml
@@ -25,17 +25,17 @@ spec:
     operation: addColumn
     table: messages
   - columns: []
-    indexName: messages
+    indexName: messages_media_type_id
     indexType: index
     operation: createIndex
-    table: messages_media_type_id
+    table: messages
   - columns: []
-    indexName: messages
+    indexName: messages_severity
     indexType: index
     operation: createIndex
-    table: messages_severity
+    table: messages
   - columns: []
-    indexName: messages
+    indexName: messages_uuid
     indexType: index
     operation: createIndex
-    table: messages_uuid
+    table: messages

--- a/data/migrations/dba_operator/481623ba00ba-databasemigration.yaml
+++ b/data/migrations/dba_operator/481623ba00ba-databasemigration.yaml
@@ -15,7 +15,7 @@ spec:
   previous: b9045731c4de
   schemaHints:
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_logs_archived
     indexType: index
     operation: createIndex
-    table: repositorybuild_logs_archived
+    table: repositorybuild

--- a/data/migrations/dba_operator/4fd6b8463eb2-databasemigration.yaml
+++ b/data/migrations/dba_operator/4fd6b8463eb2-databasemigration.yaml
@@ -28,17 +28,17 @@ spec:
     operation: createTable
     table: deletedrepository
   - columns: []
-    indexName: deletedrepository
+    indexName: deletedrepository_original_name
     indexType: index
     operation: createIndex
-    table: deletedrepository_original_name
+    table: deletedrepository
   - columns: []
-    indexName: deletedrepository
+    indexName: deletedrepository_queue_id
     indexType: index
     operation: createIndex
-    table: deletedrepository_queue_id
+    table: deletedrepository
   - columns: []
-    indexName: deletedrepository
+    indexName: deletedrepository_repository_id
     indexType: unique
     operation: createIndex
-    table: deletedrepository_repository_id
+    table: deletedrepository

--- a/data/migrations/dba_operator/5248ddf35167-databasemigration.yaml
+++ b/data/migrations/dba_operator/5248ddf35167-databasemigration.yaml
@@ -34,30 +34,30 @@ spec:
     operation: createTable
     table: repomirrorrule
   - columns: []
-    indexName: repomirrorrule
+    indexName: repomirrorrule_left_child_id
     indexType: index
     operation: createIndex
-    table: repomirrorrule_left_child_id
+    table: repomirrorrule
   - columns: []
-    indexName: repomirrorrule
+    indexName: repomirrorrule_repository_id
     indexType: index
     operation: createIndex
-    table: repomirrorrule_repository_id
+    table: repomirrorrule
   - columns: []
-    indexName: repomirrorrule
+    indexName: repomirrorrule_right_child_id
     indexType: index
     operation: createIndex
-    table: repomirrorrule_right_child_id
+    table: repomirrorrule
   - columns: []
-    indexName: repomirrorrule
+    indexName: repomirrorrule_rule_type
     indexType: index
     operation: createIndex
-    table: repomirrorrule_rule_type
+    table: repomirrorrule
   - columns: []
-    indexName: repomirrorrule
+    indexName: repomirrorrule_uuid
     indexType: unique
     operation: createIndex
-    table: repomirrorrule_uuid
+    table: repomirrorrule
   - columns:
     - name: id
       nullable: false
@@ -100,42 +100,42 @@ spec:
     operation: createTable
     table: repomirrorconfig
   - columns: []
-    indexName: repomirrorconfig
+    indexName: repomirrorconfig_mirror_type
     indexType: index
     operation: createIndex
-    table: repomirrorconfig_mirror_type
+    table: repomirrorconfig
   - columns: []
-    indexName: repomirrorconfig
+    indexName: repomirrorconfig_repository_id
     indexType: unique
     operation: createIndex
-    table: repomirrorconfig_repository_id
+    table: repomirrorconfig
   - columns: []
-    indexName: repomirrorconfig
+    indexName: repomirrorconfig_root_rule_id
     indexType: index
     operation: createIndex
-    table: repomirrorconfig_root_rule_id
+    table: repomirrorconfig
   - columns: []
-    indexName: repomirrorconfig
+    indexName: repomirrorconfig_sync_status
     indexType: index
     operation: createIndex
-    table: repomirrorconfig_sync_status
+    table: repomirrorconfig
   - columns: []
-    indexName: repomirrorconfig
+    indexName: repomirrorconfig_sync_transaction_id
     indexType: index
     operation: createIndex
-    table: repomirrorconfig_sync_transaction_id
+    table: repomirrorconfig
   - columns: []
-    indexName: repomirrorconfig
+    indexName: repomirrorconfig_internal_robot_id
     indexType: index
     operation: createIndex
-    table: repomirrorconfig_internal_robot_id
+    table: repomirrorconfig
   - columns:
     - name: state
       nullable: false
     operation: addColumn
     table: !!python/unicode 'repository'
   - columns: []
-    indexName: repository
+    indexName: repository_state
     indexType: index
     operation: createIndex
-    table: repository_state
+    table: repository

--- a/data/migrations/dba_operator/54492a68a3cf-databasemigration.yaml
+++ b/data/migrations/dba_operator/54492a68a3cf-databasemigration.yaml
@@ -30,17 +30,17 @@ spec:
     operation: createTable
     table: namespacegeorestriction
   - columns: []
-    indexName: namespacegeorestriction
+    indexName: namespacegeorestriction_namespace_id
     indexType: index
     operation: createIndex
-    table: namespacegeorestriction_namespace_id
+    table: namespacegeorestriction
   - columns: []
-    indexName: namespacegeorestriction
+    indexName: namespacegeorestriction_namespace_id_restricted_region_iso_code
     indexType: unique
     operation: createIndex
-    table: namespacegeorestriction_namespace_id_restricted_region_iso_code
+    table: namespacegeorestriction
   - columns: []
-    indexName: namespacegeorestriction
+    indexName: namespacegeorestriction_restricted_region_iso_code
     indexType: index
     operation: createIndex
-    table: namespacegeorestriction_restricted_region_iso_code
+    table: namespacegeorestriction

--- a/data/migrations/dba_operator/610320e9dacf-databasemigration.yaml
+++ b/data/migrations/dba_operator/610320e9dacf-databasemigration.yaml
@@ -22,10 +22,10 @@ spec:
     operation: createTable
     table: apprblobplacementlocation
   - columns: []
-    indexName: apprblobplacementlocation
+    indexName: apprblobplacementlocation_name
     indexType: unique
     operation: createIndex
-    table: apprblobplacementlocation_name
+    table: apprblobplacementlocation
   - columns:
     - name: id
       nullable: false
@@ -34,10 +34,10 @@ spec:
     operation: createTable
     table: apprtagkind
   - columns: []
-    indexName: apprtagkind
+    indexName: apprtagkind_name
     indexType: unique
     operation: createIndex
-    table: apprtagkind_name
+    table: apprtagkind
   - columns:
     - name: id
       nullable: false
@@ -52,15 +52,15 @@ spec:
     operation: createTable
     table: apprblob
   - columns: []
-    indexName: apprblob
+    indexName: apprblob_digest
     indexType: unique
     operation: createIndex
-    table: apprblob_digest
+    table: apprblob
   - columns: []
-    indexName: apprblob
+    indexName: apprblob_media_type_id
     indexType: index
     operation: createIndex
-    table: apprblob_media_type_id
+    table: apprblob
   - columns:
     - name: id
       nullable: false
@@ -73,15 +73,15 @@ spec:
     operation: createTable
     table: apprmanifest
   - columns: []
-    indexName: apprmanifest
+    indexName: apprmanifest_digest
     indexType: unique
     operation: createIndex
-    table: apprmanifest_digest
+    table: apprmanifest
   - columns: []
-    indexName: apprmanifest
+    indexName: apprmanifest_media_type_id
     indexType: index
     operation: createIndex
-    table: apprmanifest_media_type_id
+    table: apprmanifest
   - columns:
     - name: id
       nullable: false
@@ -96,15 +96,15 @@ spec:
     operation: createTable
     table: apprmanifestlist
   - columns: []
-    indexName: apprmanifestlist
+    indexName: apprmanifestlist_digest
     indexType: unique
     operation: createIndex
-    table: apprmanifestlist_digest
+    table: apprmanifestlist
   - columns: []
-    indexName: apprmanifestlist
+    indexName: apprmanifestlist_media_type_id
     indexType: index
     operation: createIndex
-    table: apprmanifestlist_media_type_id
+    table: apprmanifestlist
   - columns:
     - name: id
       nullable: false
@@ -115,20 +115,20 @@ spec:
     operation: createTable
     table: apprblobplacement
   - columns: []
-    indexName: apprblobplacement
+    indexName: apprblobplacement_blob_id
     indexType: index
     operation: createIndex
-    table: apprblobplacement_blob_id
+    table: apprblobplacement
   - columns: []
-    indexName: apprblobplacement
+    indexName: apprblobplacement_blob_id_location_id
     indexType: unique
     operation: createIndex
-    table: apprblobplacement_blob_id_location_id
+    table: apprblobplacement
   - columns: []
-    indexName: apprblobplacement
+    indexName: apprblobplacement_location_id
     indexType: index
     operation: createIndex
-    table: apprblobplacement_location_id
+    table: apprblobplacement
   - columns:
     - name: id
       nullable: false
@@ -139,20 +139,20 @@ spec:
     operation: createTable
     table: apprmanifestblob
   - columns: []
-    indexName: apprmanifestblob
+    indexName: apprmanifestblob_blob_id
     indexType: index
     operation: createIndex
-    table: apprmanifestblob_blob_id
+    table: apprmanifestblob
   - columns: []
-    indexName: apprmanifestblob
+    indexName: apprmanifestblob_manifest_id
     indexType: index
     operation: createIndex
-    table: apprmanifestblob_manifest_id
+    table: apprmanifestblob
   - columns: []
-    indexName: apprmanifestblob
+    indexName: apprmanifestblob_manifest_id_blob_id
     indexType: unique
     operation: createIndex
-    table: apprmanifestblob_manifest_id_blob_id
+    table: apprmanifestblob
   - columns:
     - name: id
       nullable: false
@@ -171,30 +171,30 @@ spec:
     operation: createTable
     table: apprmanifestlistmanifest
   - columns: []
-    indexName: apprmanifestlistmanifest
+    indexName: apprmanifestlistmanifest_manifest_id
     indexType: index
     operation: createIndex
-    table: apprmanifestlistmanifest_manifest_id
+    table: apprmanifestlistmanifest
   - columns: []
-    indexName: apprmanifestlistmanifest
+    indexName: apprmanifestlistmanifest_manifest_list_id
     indexType: index
     operation: createIndex
-    table: apprmanifestlistmanifest_manifest_list_id
+    table: apprmanifestlistmanifest
   - columns: []
-    indexName: apprmanifestlistmanifest
+    indexName: apprmanifestlistmanifest_manifest_list_id_media_type_id
     indexType: index
     operation: createIndex
-    table: apprmanifestlistmanifest_manifest_list_id_media_type_id
+    table: apprmanifestlistmanifest
   - columns: []
-    indexName: apprmanifestlistmanifest
+    indexName: apprmanifestlistmanifest_manifest_list_id_operating_system_arch
     indexType: index
     operation: createIndex
-    table: apprmanifestlistmanifest_manifest_list_id_operating_system_arch
+    table: apprmanifestlistmanifest
   - columns: []
-    indexName: apprmanifestlistmanifest
+    indexName: apprmanifestlistmanifest_media_type_id
     indexType: index
     operation: createIndex
-    table: apprmanifestlistmanifest_media_type_id
+    table: apprmanifestlistmanifest
   - columns:
     - name: id
       nullable: false
@@ -221,42 +221,42 @@ spec:
     operation: createTable
     table: apprtag
   - columns: []
-    indexName: apprtag
+    indexName: apprtag_lifetime_end
     indexType: index
     operation: createIndex
-    table: apprtag_lifetime_end
+    table: apprtag
   - columns: []
-    indexName: apprtag
+    indexName: apprtag_linked_tag_id
     indexType: index
     operation: createIndex
-    table: apprtag_linked_tag_id
+    table: apprtag
   - columns: []
-    indexName: apprtag
+    indexName: apprtag_manifest_list_id
     indexType: index
     operation: createIndex
-    table: apprtag_manifest_list_id
+    table: apprtag
   - columns: []
-    indexName: apprtag
+    indexName: apprtag_repository_id
     indexType: index
     operation: createIndex
-    table: apprtag_repository_id
+    table: apprtag
   - columns: []
-    indexName: apprtag
+    indexName: apprtag_repository_id_name
     indexType: index
     operation: createIndex
-    table: apprtag_repository_id_name
+    table: apprtag
   - columns: []
-    indexName: apprtag
+    indexName: apprtag_repository_id_name_hidden
     indexType: index
     operation: createIndex
-    table: apprtag_repository_id_name_hidden
+    table: apprtag
   - columns: []
-    indexName: apprtag
+    indexName: apprtag_repository_id_name_lifetime_end
     indexType: unique
     operation: createIndex
-    table: apprtag_repository_id_name_lifetime_end
+    table: apprtag
   - columns: []
-    indexName: apprtag
+    indexName: apprtag_tag_kind_id
     indexType: index
     operation: createIndex
-    table: apprtag_tag_kind_id
+    table: apprtag

--- a/data/migrations/dba_operator/61cadbacb9fc-databasemigration.yaml
+++ b/data/migrations/dba_operator/61cadbacb9fc-databasemigration.yaml
@@ -22,10 +22,10 @@ spec:
     operation: createTable
     table: disablereason
   - columns: []
-    indexName: disablereason
+    indexName: disablereason_name
     indexType: unique
     operation: createIndex
-    table: disablereason_name
+    table: disablereason
   - columns:
     - name: disabled_reason_id
       nullable: true
@@ -37,7 +37,7 @@ spec:
     operation: addColumn
     table: !!python/unicode 'repositorybuildtrigger'
   - columns: []
-    indexName: repositorybuildtrigger
+    indexName: repositorybuildtrigger_disabled_reason_id
     indexType: index
     operation: createIndex
-    table: repositorybuildtrigger_disabled_reason_id
+    table: repositorybuildtrigger

--- a/data/migrations/dba_operator/67f0abd172ae-databasemigration.yaml
+++ b/data/migrations/dba_operator/67f0abd172ae-databasemigration.yaml
@@ -26,17 +26,17 @@ spec:
     operation: createTable
     table: tagtorepositorytag
   - columns: []
-    indexName: tagtorepositorytag
+    indexName: tagtorepositorytag_repository_id
     indexType: index
     operation: createIndex
-    table: tagtorepositorytag_repository_id
+    table: tagtorepositorytag
   - columns: []
-    indexName: tagtorepositorytag
+    indexName: tagtorepositorytag_repository_tag_id
     indexType: unique
     operation: createIndex
-    table: tagtorepositorytag_repository_tag_id
+    table: tagtorepositorytag
   - columns: []
-    indexName: tagtorepositorytag
+    indexName: tagtorepositorytag_tag_id
     indexType: unique
     operation: createIndex
-    table: tagtorepositorytag_tag_id
+    table: tagtorepositorytag

--- a/data/migrations/dba_operator/6c7014e84a5e-databasemigration.yaml
+++ b/data/migrations/dba_operator/6c7014e84a5e-databasemigration.yaml
@@ -22,10 +22,10 @@ spec:
     operation: createTable
     table: userpromptkind
   - columns: []
-    indexName: userpromptkind
+    indexName: userpromptkind_name
     indexType: index
     operation: createIndex
-    table: userpromptkind_name
+    table: userpromptkind
   - columns:
     - name: id
       nullable: false
@@ -36,17 +36,17 @@ spec:
     operation: createTable
     table: userprompt
   - columns: []
-    indexName: userprompt
+    indexName: userprompt_kind_id
     indexType: index
     operation: createIndex
-    table: userprompt_kind_id
+    table: userprompt
   - columns: []
-    indexName: userprompt
+    indexName: userprompt_user_id
     indexType: index
     operation: createIndex
-    table: userprompt_user_id
+    table: userprompt
   - columns: []
-    indexName: userprompt
+    indexName: userprompt_user_id_kind_id
     indexType: unique
     operation: createIndex
-    table: userprompt_user_id_kind_id
+    table: userprompt

--- a/data/migrations/dba_operator/6ec8726c0ace-databasemigration.yaml
+++ b/data/migrations/dba_operator/6ec8726c0ace-databasemigration.yaml
@@ -34,22 +34,22 @@ spec:
     operation: createTable
     table: logentry3
   - columns: []
-    indexName: logentry3
+    indexName: logentry3_account_id_datetime
     indexType: index
     operation: createIndex
-    table: logentry3_account_id_datetime
+    table: logentry3
   - columns: []
-    indexName: logentry3
+    indexName: logentry3_datetime
     indexType: index
     operation: createIndex
-    table: logentry3_datetime
+    table: logentry3
   - columns: []
-    indexName: logentry3
+    indexName: logentry3_performer_id_datetime
     indexType: index
     operation: createIndex
-    table: logentry3_performer_id_datetime
+    table: logentry3
   - columns: []
-    indexName: logentry3
+    indexName: logentry3_repository_id_datetime_kind_id
     indexType: index
     operation: createIndex
-    table: logentry3_repository_id_datetime_kind_id
+    table: logentry3

--- a/data/migrations/dba_operator/7367229b38d9-databasemigration.yaml
+++ b/data/migrations/dba_operator/7367229b38d9-databasemigration.yaml
@@ -34,22 +34,22 @@ spec:
     operation: createTable
     table: appspecificauthtoken
   - columns: []
-    indexName: appspecificauthtoken
+    indexName: appspecificauthtoken_token_code
     indexType: unique
     operation: createIndex
-    table: appspecificauthtoken_token_code
+    table: appspecificauthtoken
   - columns: []
-    indexName: appspecificauthtoken
+    indexName: appspecificauthtoken_user_id
     indexType: index
     operation: createIndex
-    table: appspecificauthtoken_user_id
+    table: appspecificauthtoken
   - columns: []
-    indexName: appspecificauthtoken
+    indexName: appspecificauthtoken_user_id_expiration
     indexType: index
     operation: createIndex
-    table: appspecificauthtoken_user_id_expiration
+    table: appspecificauthtoken
   - columns: []
-    indexName: appspecificauthtoken
+    indexName: appspecificauthtoken_uuid
     indexType: index
     operation: createIndex
-    table: appspecificauthtoken_uuid
+    table: appspecificauthtoken

--- a/data/migrations/dba_operator/7a525c68eb13-databasemigration.yaml
+++ b/data/migrations/dba_operator/7a525c68eb13-databasemigration.yaml
@@ -22,10 +22,10 @@ spec:
     operation: createTable
     table: tagkind
   - columns: []
-    indexName: tagkind
+    indexName: tagkind_name
     indexType: unique
     operation: createIndex
-    table: tagkind_name
+    table: tagkind
   - columns:
     - name: id
       nullable: false
@@ -34,10 +34,10 @@ spec:
     operation: createTable
     table: blobplacementlocation
   - columns: []
-    indexName: blobplacementlocation
+    indexName: blobplacementlocation_name
     indexType: unique
     operation: createIndex
-    table: blobplacementlocation_name
+    table: blobplacementlocation
   - columns:
     - name: id
       nullable: false
@@ -52,15 +52,15 @@ spec:
     operation: createTable
     table: blob
   - columns: []
-    indexName: blob
+    indexName: blob_digest
     indexType: unique
     operation: createIndex
-    table: blob_digest
+    table: blob
   - columns: []
-    indexName: blob
+    indexName: blob_media_type_id
     indexType: index
     operation: createIndex
-    table: blob_media_type_id
+    table: blob
   - columns:
     - name: id
       nullable: false
@@ -71,15 +71,15 @@ spec:
     operation: createTable
     table: blobplacementlocationpreference
   - columns: []
-    indexName: blobplacementlocationpreference
+    indexName: blobplacementlocationpreference_location_id
     indexType: index
     operation: createIndex
-    table: blobplacementlocationpreference_location_id
+    table: blobplacementlocationpreference
   - columns: []
-    indexName: blobplacementlocationpreference
+    indexName: blobplacementlocationpreference_user_id
     indexType: index
     operation: createIndex
-    table: blobplacementlocationpreference_user_id
+    table: blobplacementlocationpreference
   - columns:
     - name: id
       nullable: false
@@ -92,15 +92,15 @@ spec:
     operation: createTable
     table: manifest
   - columns: []
-    indexName: manifest
+    indexName: manifest_digest
     indexType: unique
     operation: createIndex
-    table: manifest_digest
+    table: manifest
   - columns: []
-    indexName: manifest
+    indexName: manifest_media_type_id
     indexType: index
     operation: createIndex
-    table: manifest_media_type_id
+    table: manifest
   - columns:
     - name: id
       nullable: false
@@ -115,15 +115,15 @@ spec:
     operation: createTable
     table: manifestlist
   - columns: []
-    indexName: manifestlist
+    indexName: manifestlist_digest
     indexType: unique
     operation: createIndex
-    table: manifestlist_digest
+    table: manifestlist
   - columns: []
-    indexName: manifestlist
+    indexName: manifestlist_media_type_id
     indexType: index
     operation: createIndex
-    table: manifestlist_media_type_id
+    table: manifestlist
   - columns:
     - name: id
       nullable: false
@@ -136,15 +136,15 @@ spec:
     operation: createTable
     table: bittorrentpieces
   - columns: []
-    indexName: bittorrentpieces
+    indexName: bittorrentpieces_blob_id
     indexType: index
     operation: createIndex
-    table: bittorrentpieces_blob_id
+    table: bittorrentpieces
   - columns: []
-    indexName: bittorrentpieces
+    indexName: bittorrentpieces_blob_id_piece_length
     indexType: unique
     operation: createIndex
-    table: bittorrentpieces_blob_id_piece_length
+    table: bittorrentpieces
   - columns:
     - name: id
       nullable: false
@@ -155,20 +155,20 @@ spec:
     operation: createTable
     table: blobplacement
   - columns: []
-    indexName: blobplacement
+    indexName: blobplacement_blob_id
     indexType: index
     operation: createIndex
-    table: blobplacement_blob_id
+    table: blobplacement
   - columns: []
-    indexName: blobplacement
+    indexName: blobplacement_blob_id_location_id
     indexType: unique
     operation: createIndex
-    table: blobplacement_blob_id_location_id
+    table: blobplacement
   - columns: []
-    indexName: blobplacement
+    indexName: blobplacement_location_id
     indexType: index
     operation: createIndex
-    table: blobplacement_location_id
+    table: blobplacement
   - columns:
     - name: id
       nullable: false
@@ -197,30 +197,30 @@ spec:
     operation: createTable
     table: blobuploading
   - columns: []
-    indexName: blobuploading
+    indexName: blobuploading_created
     indexType: index
     operation: createIndex
-    table: blobuploading_created
+    table: blobuploading
   - columns: []
-    indexName: blobuploading
+    indexName: blobuploading_location_id
     indexType: index
     operation: createIndex
-    table: blobuploading_location_id
+    table: blobuploading
   - columns: []
-    indexName: blobuploading
+    indexName: blobuploading_repository_id
     indexType: index
     operation: createIndex
-    table: blobuploading_repository_id
+    table: blobuploading
   - columns: []
-    indexName: blobuploading
+    indexName: blobuploading_repository_id_uuid
     indexType: unique
     operation: createIndex
-    table: blobuploading_repository_id_uuid
+    table: blobuploading
   - columns: []
-    indexName: blobuploading
+    indexName: blobuploading_uuid
     indexType: unique
     operation: createIndex
-    table: blobuploading_uuid
+    table: blobuploading
   - columns:
     - name: id
       nullable: false
@@ -241,45 +241,45 @@ spec:
     operation: createTable
     table: derivedimage
   - columns: []
-    indexName: derivedimage
+    indexName: derivedimage_blob_id
     indexType: index
     operation: createIndex
-    table: derivedimage_blob_id
+    table: derivedimage
   - columns: []
-    indexName: derivedimage
+    indexName: derivedimage_media_type_id
     indexType: index
     operation: createIndex
-    table: derivedimage_media_type_id
+    table: derivedimage
   - columns: []
-    indexName: derivedimage
+    indexName: derivedimage_signature_blob_id
     indexType: index
     operation: createIndex
-    table: derivedimage_signature_blob_id
+    table: derivedimage
   - columns: []
-    indexName: derivedimage
+    indexName: derivedimage_source_manifest_id
     indexType: index
     operation: createIndex
-    table: derivedimage_source_manifest_id
+    table: derivedimage
   - columns: []
-    indexName: derivedimage
+    indexName: derivedimage_source_manifest_id_blob_id
     indexType: unique
     operation: createIndex
-    table: derivedimage_source_manifest_id_blob_id
+    table: derivedimage
   - columns: []
-    indexName: derivedimage
+    indexName: derivedimage_source_manifest_id_media_type_id_uniqueness_hash
     indexType: unique
     operation: createIndex
-    table: derivedimage_source_manifest_id_media_type_id_uniqueness_hash
+    table: derivedimage
   - columns: []
-    indexName: derivedimage
+    indexName: derivedimage_uniqueness_hash
     indexType: unique
     operation: createIndex
-    table: derivedimage_uniqueness_hash
+    table: derivedimage
   - columns: []
-    indexName: derivedimage
+    indexName: derivedimage_uuid
     indexType: unique
     operation: createIndex
-    table: derivedimage_uuid
+    table: derivedimage
   - columns:
     - name: id
       nullable: false
@@ -290,20 +290,20 @@ spec:
     operation: createTable
     table: manifestblob
   - columns: []
-    indexName: manifestblob
+    indexName: manifestblob_blob_id
     indexType: index
     operation: createIndex
-    table: manifestblob_blob_id
+    table: manifestblob
   - columns: []
-    indexName: manifestblob
+    indexName: manifestblob_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestblob_manifest_id
+    table: manifestblob
   - columns: []
-    indexName: manifestblob
+    indexName: manifestblob_manifest_id_blob_id
     indexType: unique
     operation: createIndex
-    table: manifestblob_manifest_id_blob_id
+    table: manifestblob
   - columns:
     - name: id
       nullable: false
@@ -316,25 +316,25 @@ spec:
     operation: createTable
     table: manifestlabel
   - columns: []
-    indexName: manifestlabel
+    indexName: manifestlabel_annotated_id
     indexType: index
     operation: createIndex
-    table: manifestlabel_annotated_id
+    table: manifestlabel
   - columns: []
-    indexName: manifestlabel
+    indexName: manifestlabel_label_id
     indexType: index
     operation: createIndex
-    table: manifestlabel_label_id
+    table: manifestlabel
   - columns: []
-    indexName: manifestlabel
+    indexName: manifestlabel_repository_id
     indexType: index
     operation: createIndex
-    table: manifestlabel_repository_id
+    table: manifestlabel
   - columns: []
-    indexName: manifestlabel
+    indexName: manifestlabel_repository_id_annotated_id_label_id
     indexType: unique
     operation: createIndex
-    table: manifestlabel_repository_id_annotated_id_label_id
+    table: manifestlabel
   - columns:
     - name: id
       nullable: false
@@ -349,25 +349,25 @@ spec:
     operation: createTable
     table: manifestlayer
   - columns: []
-    indexName: manifestlayer
+    indexName: manifestlayer_blob_id
     indexType: index
     operation: createIndex
-    table: manifestlayer_blob_id
+    table: manifestlayer
   - columns: []
-    indexName: manifestlayer
+    indexName: manifestlayer_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestlayer_manifest_id
+    table: manifestlayer
   - columns: []
-    indexName: manifestlayer
+    indexName: manifestlayer_manifest_id_manifest_index
     indexType: unique
     operation: createIndex
-    table: manifestlayer_manifest_id_manifest_index
+    table: manifestlayer
   - columns: []
-    indexName: manifestlayer
+    indexName: manifestlayer_manifest_index
     indexType: index
     operation: createIndex
-    table: manifestlayer_manifest_index
+    table: manifestlayer
   - columns:
     - name: id
       nullable: false
@@ -386,30 +386,30 @@ spec:
     operation: createTable
     table: manifestlistmanifest
   - columns: []
-    indexName: manifestlistmanifest
+    indexName: manifestlistmanifest_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestlistmanifest_manifest_id
+    table: manifestlistmanifest
   - columns: []
-    indexName: manifestlistmanifest
+    indexName: manifestlistmanifest_manifest_list_id
     indexType: index
     operation: createIndex
-    table: manifestlistmanifest_manifest_list_id
+    table: manifestlistmanifest
   - columns: []
-    indexName: manifestlistmanifest
+    indexName: manifestlistmanifest_manifest_listid_os_arch_mtid
     indexType: index
     operation: createIndex
-    table: manifestlistmanifest_manifest_listid_os_arch_mtid
+    table: manifestlistmanifest
   - columns: []
-    indexName: manifestlistmanifest
+    indexName: manifestlistmanifest_manifest_listid_mtid
     indexType: index
     operation: createIndex
-    table: manifestlistmanifest_manifest_listid_mtid
+    table: manifestlistmanifest
   - columns: []
-    indexName: manifestlistmanifest
+    indexName: manifestlistmanifest_media_type_id
     indexType: index
     operation: createIndex
-    table: manifestlistmanifest_media_type_id
+    table: manifestlistmanifest
   - columns:
     - name: id
       nullable: false
@@ -436,45 +436,45 @@ spec:
     operation: createTable
     table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_lifetime_end
     indexType: index
     operation: createIndex
-    table: tag_lifetime_end
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_linked_tag_id
     indexType: index
     operation: createIndex
-    table: tag_linked_tag_id
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_manifest_list_id
     indexType: index
     operation: createIndex
-    table: tag_manifest_list_id
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id
     indexType: index
     operation: createIndex
-    table: tag_repository_id
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id_name_hidden
     indexType: index
     operation: createIndex
-    table: tag_repository_id_name_hidden
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id_name_lifetime_end
     indexType: unique
     operation: createIndex
-    table: tag_repository_id_name_lifetime_end
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id_name
     indexType: index
     operation: createIndex
-    table: tag_repository_id_name
+    table: tag
   - columns: []
-    indexName: tag
+    indexName: tag_tag_kind_id
     indexType: index
     operation: createIndex
-    table: tag_tag_kind_id
+    table: tag
   - columns:
     - name: id
       nullable: false
@@ -489,15 +489,15 @@ spec:
     operation: createTable
     table: manifestlayerdockerv1
   - columns: []
-    indexName: manifestlayerdockerv1
+    indexName: manifestlayerdockerv1_image_id
     indexType: index
     operation: createIndex
-    table: manifestlayerdockerv1_image_id
+    table: manifestlayerdockerv1
   - columns: []
-    indexName: manifestlayerdockerv1
+    indexName: manifestlayerdockerv1_manifest_layer_id
     indexType: index
     operation: createIndex
-    table: manifestlayerdockerv1_manifest_layer_id
+    table: manifestlayerdockerv1
   - columns:
     - name: id
       nullable: false
@@ -510,7 +510,7 @@ spec:
     operation: createTable
     table: manifestlayerscan
   - columns: []
-    indexName: manifestlayerscan
+    indexName: manifestlayerscan_layer_id
     indexType: unique
     operation: createIndex
-    table: manifestlayerscan_layer_id
+    table: manifestlayerscan

--- a/data/migrations/dba_operator/87fbbc224f10-databasemigration.yaml
+++ b/data/migrations/dba_operator/87fbbc224f10-databasemigration.yaml
@@ -20,7 +20,7 @@ spec:
     operation: addColumn
     table: repositorybuildtrigger
   - columns: []
-    indexName: repositorybuildtrigger
+    indexName: repositorybuildtrigger_disabled_datetime
     indexType: index
     operation: createIndex
-    table: repositorybuildtrigger_disabled_datetime
+    table: repositorybuildtrigger

--- a/data/migrations/dba_operator/8e6a363784bb-databasemigration.yaml
+++ b/data/migrations/dba_operator/8e6a363784bb-databasemigration.yaml
@@ -12,8 +12,7 @@ spec:
     - 8e6a363784bb
     image: quay.io/quay/quay
     name: 8e6a363784bb
-  previous: !!python/tuple
-  - 4fd6b8463eb2
+  previous: 4fd6b8463eb2
   schemaHints:
   - columns:
     - name: id
@@ -36,109 +35,33 @@ spec:
       nullable: false
     operation: createTable
     table: manifestsecuritystatus
-  - columns:
-    - name: index_status
-      nullable: false
+  - columns: []
     indexName: manifestsecuritystatus_index_status
     indexType: index
     operation: createIndex
     table: manifestsecuritystatus
-  - columns:
-    - name: indexer_hash
-      nullable: false
+  - columns: []
     indexName: manifestsecuritystatus_indexer_hash
     indexType: index
     operation: createIndex
     table: manifestsecuritystatus
-  - columns:
-    - name: indexer_version
-      nullable: false
+  - columns: []
     indexName: manifestsecuritystatus_indexer_version
     indexType: index
     operation: createIndex
     table: manifestsecuritystatus
-  - columns:
-    - name: last_indexed
-      nullable: false
+  - columns: []
     indexName: manifestsecuritystatus_last_indexed
     indexType: index
     operation: createIndex
     table: manifestsecuritystatus
-  - columns:
-    - name: manifest_id
-      nullable: false
+  - columns: []
     indexName: manifestsecuritystatus_manifest_id
     indexType: unique
     operation: createIndex
     table: manifestsecuritystatus
-  - columns:
-    - name: repository_id
-      nullable: false
+  - columns: []
     indexName: manifestsecuritystatus_repository_id
     indexType: index
     operation: createIndex
     table: manifestsecuritystatus
-  - indexName: apprmanifestlistmanifest_manifest_list_id_operating_system_arch
-    operation: dropIndex
-    table: apprmanifestlistmanifest
-  - columns:
-    - name: source_image_id
-      nullable: false
-    - name: transformation_id
-      nullable: false
-    - name: uniqueness_hash
-      nullable: true
-    indexName: derivedstorageforimage_source_image_id_transformation_id_uniqueness_hash
-    indexType: unique
-    operation: createIndex
-    table: derivedstorageforimage
-  - indexName: uniqueness_index
-    operation: dropIndex
-    table: derivedstorageforimage
-  - columns:
-    - name: processing_expires
-      nullable: true
-    - name: available_after
-      nullable: false
-    - name: queue_name
-      nullable: false
-    - name: retries_remaining
-      nullable: false
-    - name: available
-      nullable: false
-    indexName: queueitem_processing_expires_available_after_queue_name_retries_remaining_available
-    indexType: index
-    operation: createIndex
-    table: queueitem
-  - columns:
-    - name: processing_expires
-      nullable: true
-    - name: available_after
-      nullable: false
-    - name: retries_remaining
-      nullable: false
-    - name: available
-      nullable: false
-    indexName: queueitem_processing_expires_available_after_retries_remaining_available
-    indexType: index
-    operation: createIndex
-    table: queueitem
-  - indexName: queueitem_pe_aafter_qname_rremaining_available
-    operation: dropIndex
-    table: queueitem
-  - indexName: queueitem_pexpires_aafter_rremaining_available
-    operation: dropIndex
-    table: queueitem
-  - indexName: repomirrorconfig_sync_transaction_id
-    operation: dropIndex
-    table: repomirrorconfig
-  - indexName: repomirrorrule_uuid
-    operation: dropIndex
-    table: repomirrorrule
-  - columns:
-    - name: uuid
-      nullable: false
-    indexName: repomirrorrule_uuid
-    indexType: index
-    operation: createIndex
-    table: repomirrorrule

--- a/data/migrations/dba_operator/9093adccc784-databasemigration.yaml
+++ b/data/migrations/dba_operator/9093adccc784-databasemigration.yaml
@@ -28,30 +28,30 @@ spec:
     operation: createTable
     table: manifest
   - columns: []
-    indexName: manifest
+    indexName: manifest_digest
     indexType: index
     operation: createIndex
-    table: manifest_digest
+    table: manifest
   - columns: []
-    indexName: manifest
+    indexName: manifest_media_type_id
     indexType: index
     operation: createIndex
-    table: manifest_media_type_id
+    table: manifest
   - columns: []
-    indexName: manifest
+    indexName: manifest_repository_id
     indexType: index
     operation: createIndex
-    table: manifest_repository_id
+    table: manifest
   - columns: []
-    indexName: manifest
+    indexName: manifest_repository_id_digest
     indexType: unique
     operation: createIndex
-    table: manifest_repository_id_digest
+    table: manifest
   - columns: []
-    indexName: manifest
+    indexName: manifest_repository_id_media_type_id
     indexType: index
     operation: createIndex
-    table: manifest_repository_id_media_type_id
+    table: manifest
   - columns:
     - name: id
       nullable: false
@@ -66,30 +66,30 @@ spec:
     operation: createTable
     table: manifestblob
   - columns: []
-    indexName: manifestblob
+    indexName: manifestblob_blob_id
     indexType: index
     operation: createIndex
-    table: manifestblob_blob_id
+    table: manifestblob
   - columns: []
-    indexName: manifestblob
+    indexName: manifestblob_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestblob_manifest_id
+    table: manifestblob
   - columns: []
-    indexName: manifestblob
+    indexName: manifestblob_manifest_id_blob_id
     indexType: unique
     operation: createIndex
-    table: manifestblob_manifest_id_blob_id
+    table: manifestblob
   - columns: []
-    indexName: manifestblob
+    indexName: manifestblob_manifest_id_blob_index
     indexType: unique
     operation: createIndex
-    table: manifestblob_manifest_id_blob_index
+    table: manifestblob
   - columns: []
-    indexName: manifestblob
+    indexName: manifestblob_repository_id
     indexType: index
     operation: createIndex
-    table: manifestblob_repository_id
+    table: manifestblob
   - columns:
     - name: id
       nullable: false
@@ -102,25 +102,25 @@ spec:
     operation: createTable
     table: manifestlabel
   - columns: []
-    indexName: manifestlabel
+    indexName: manifestlabel_label_id
     indexType: index
     operation: createIndex
-    table: manifestlabel_label_id
+    table: manifestlabel
   - columns: []
-    indexName: manifestlabel
+    indexName: manifestlabel_manifest_id
     indexType: index
     operation: createIndex
-    table: manifestlabel_manifest_id
+    table: manifestlabel
   - columns: []
-    indexName: manifestlabel
+    indexName: manifestlabel_manifest_id_label_id
     indexType: unique
     operation: createIndex
-    table: manifestlabel_manifest_id_label_id
+    table: manifestlabel
   - columns: []
-    indexName: manifestlabel
+    indexName: manifestlabel_repository_id
     indexType: index
     operation: createIndex
-    table: manifestlabel_repository_id
+    table: manifestlabel
   - columns:
     - name: id
       nullable: false
@@ -133,20 +133,20 @@ spec:
     operation: createTable
     table: manifestlegacyimage
   - columns: []
-    indexName: manifestlegacyimage
+    indexName: manifestlegacyimage_image_id
     indexType: index
     operation: createIndex
-    table: manifestlegacyimage_image_id
+    table: manifestlegacyimage
   - columns: []
-    indexName: manifestlegacyimage
+    indexName: manifestlegacyimage_manifest_id
     indexType: unique
     operation: createIndex
-    table: manifestlegacyimage_manifest_id
+    table: manifestlegacyimage
   - columns: []
-    indexName: manifestlegacyimage
+    indexName: manifestlegacyimage_repository_id
     indexType: index
     operation: createIndex
-    table: manifestlegacyimage_repository_id
+    table: manifestlegacyimage
   - columns:
     - name: id
       nullable: false
@@ -159,20 +159,20 @@ spec:
     operation: createTable
     table: tagmanifesttomanifest
   - columns: []
-    indexName: tagmanifesttomanifest
+    indexName: tagmanifesttomanifest_broken
     indexType: index
     operation: createIndex
-    table: tagmanifesttomanifest_broken
+    table: tagmanifesttomanifest
   - columns: []
-    indexName: tagmanifesttomanifest
+    indexName: tagmanifesttomanifest_manifest_id
     indexType: unique
     operation: createIndex
-    table: tagmanifesttomanifest_manifest_id
+    table: tagmanifesttomanifest
   - columns: []
-    indexName: tagmanifesttomanifest
+    indexName: tagmanifesttomanifest_tag_manifest_id
     indexType: unique
     operation: createIndex
-    table: tagmanifesttomanifest_tag_manifest_id
+    table: tagmanifesttomanifest
   - columns:
     - name: id
       nullable: false
@@ -191,32 +191,32 @@ spec:
     operation: createTable
     table: tagmanifestlabelmap
   - columns: []
-    indexName: tagmanifestlabelmap
+    indexName: tagmanifestlabelmap_broken_manifest
     indexType: index
     operation: createIndex
-    table: tagmanifestlabelmap_broken_manifest
+    table: tagmanifestlabelmap
   - columns: []
-    indexName: tagmanifestlabelmap
+    indexName: tagmanifestlabelmap_label_id
     indexType: index
     operation: createIndex
-    table: tagmanifestlabelmap_label_id
+    table: tagmanifestlabelmap
   - columns: []
-    indexName: tagmanifestlabelmap
+    indexName: tagmanifestlabelmap_manifest_id
     indexType: index
     operation: createIndex
-    table: tagmanifestlabelmap_manifest_id
+    table: tagmanifestlabelmap
   - columns: []
-    indexName: tagmanifestlabelmap
+    indexName: tagmanifestlabelmap_manifest_label_id
     indexType: index
     operation: createIndex
-    table: tagmanifestlabelmap_manifest_label_id
+    table: tagmanifestlabelmap
   - columns: []
-    indexName: tagmanifestlabelmap
+    indexName: tagmanifestlabelmap_tag_manifest_id
     indexType: index
     operation: createIndex
-    table: tagmanifestlabelmap_tag_manifest_id
+    table: tagmanifestlabelmap
   - columns: []
-    indexName: tagmanifestlabelmap
+    indexName: tagmanifestlabelmap_tag_manifest_label_id
     indexType: index
     operation: createIndex
-    table: tagmanifestlabelmap_tag_manifest_label_id
+    table: tagmanifestlabelmap

--- a/data/migrations/dba_operator/b4c2d45bc132-databasemigration.yaml
+++ b/data/migrations/dba_operator/b4c2d45bc132-databasemigration.yaml
@@ -30,22 +30,22 @@ spec:
     operation: createTable
     table: deletednamespace
   - columns: []
-    indexName: deletednamespace
+    indexName: deletednamespace_namespace_id
     indexType: unique
     operation: createIndex
-    table: deletednamespace_namespace_id
+    table: deletednamespace
   - columns: []
-    indexName: deletednamespace
+    indexName: deletednamespace_original_email
     indexType: index
     operation: createIndex
-    table: deletednamespace_original_email
+    table: deletednamespace
   - columns: []
-    indexName: deletednamespace
+    indexName: deletednamespace_original_username
     indexType: index
     operation: createIndex
-    table: deletednamespace_original_username
+    table: deletednamespace
   - columns: []
-    indexName: deletednamespace
+    indexName: deletednamespace_queue_id
     indexType: index
     operation: createIndex
-    table: deletednamespace_queue_id
+    table: deletednamespace

--- a/data/migrations/dba_operator/b4df55dea4b3-databasemigration.yaml
+++ b/data/migrations/dba_operator/b4df55dea4b3-databasemigration.yaml
@@ -22,17 +22,17 @@ spec:
     operation: createTable
     table: repositorykind
   - columns: []
-    indexName: repositorykind
+    indexName: repositorykind_name
     indexType: unique
     operation: createIndex
-    table: repositorykind_name
+    table: repositorykind
   - columns:
     - name: kind_id
       nullable: false
     operation: addColumn
     table: !!python/unicode 'repository'
   - columns: []
-    indexName: repository
+    indexName: repository_kind_id
     indexType: index
     operation: createIndex
-    table: repository_kind_id
+    table: repository

--- a/data/migrations/dba_operator/b547bc139ad8-databasemigration.yaml
+++ b/data/migrations/dba_operator/b547bc139ad8-databasemigration.yaml
@@ -26,7 +26,7 @@ spec:
     operation: createTable
     table: robotaccountmetadata
   - columns: []
-    indexName: robotaccountmetadata
+    indexName: robotaccountmetadata_robot_account_id
     indexType: unique
     operation: createIndex
-    table: robotaccountmetadata_robot_account_id
+    table: robotaccountmetadata

--- a/data/migrations/dba_operator/b9045731c4de-databasemigration.yaml
+++ b/data/migrations/dba_operator/b9045731c4de-databasemigration.yaml
@@ -15,22 +15,22 @@ spec:
   previous: e184af42242d
   schemaHints:
   - columns: []
-    indexName: repositorytag
+    indexName: repositorytag_repository_id_lifetime_end_ts
     indexType: index
     operation: createIndex
-    table: repositorytag_repository_id_lifetime_end_ts
+    table: repositorytag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id_lifetime_end_ms
     indexType: index
     operation: createIndex
-    table: tag_repository_id_lifetime_end_ms
+    table: tag
   - columns: []
-    indexName: repositorytag
+    indexName: repositorytag_repository_id_lifetime_start_ts
     indexType: index
     operation: createIndex
-    table: repositorytag_repository_id_lifetime_start_ts
+    table: repositorytag
   - columns: []
-    indexName: tag
+    indexName: tag_repository_id_lifetime_start_ms
     indexType: index
     operation: createIndex
-    table: tag_repository_id_lifetime_start_ms
+    table: tag

--- a/data/migrations/dba_operator/be8d1c402ce0-databasemigration.yaml
+++ b/data/migrations/dba_operator/be8d1c402ce0-databasemigration.yaml
@@ -30,17 +30,17 @@ spec:
     operation: createTable
     table: teamsync
   - columns: []
-    indexName: teamsync
+    indexName: teamsync_last_updated
     indexType: index
     operation: createIndex
-    table: teamsync_last_updated
+    table: teamsync
   - columns: []
-    indexName: teamsync
+    indexName: teamsync_service_id
     indexType: index
     operation: createIndex
-    table: teamsync_service_id
+    table: teamsync
   - columns: []
-    indexName: teamsync
+    indexName: teamsync_team_id
     indexType: unique
     operation: createIndex
-    table: teamsync_team_id
+    table: teamsync

--- a/data/migrations/dba_operator/c13c8052f7a6-databasemigration.yaml
+++ b/data/migrations/dba_operator/c13c8052f7a6-databasemigration.yaml
@@ -26,10 +26,10 @@ spec:
     operation: createTable
     table: robotaccounttoken
   - columns: []
-    indexName: robotaccounttoken
+    indexName: robotaccounttoken_robot_account_id
     indexType: unique
     operation: createIndex
-    table: robotaccounttoken_robot_account_id
+    table: robotaccounttoken
   - columns:
     - name: token_code
       nullable: true
@@ -41,10 +41,10 @@ spec:
     operation: addColumn
     table: !!python/unicode 'accesstoken'
   - columns: []
-    indexName: accesstoken
+    indexName: accesstoken_token_name
     indexType: unique
     operation: createIndex
-    table: accesstoken_token_name
+    table: accesstoken
   - columns:
     - name: token_name
       nullable: true
@@ -56,10 +56,10 @@ spec:
     operation: addColumn
     table: !!python/unicode 'appspecificauthtoken'
   - columns: []
-    indexName: appspecificauthtoken
+    indexName: appspecificauthtoken_token_name
     indexType: unique
     operation: createIndex
-    table: appspecificauthtoken_token_name
+    table: appspecificauthtoken
   - columns:
     - name: verification_code
       nullable: true
@@ -76,10 +76,10 @@ spec:
     operation: addColumn
     table: !!python/unicode 'oauthaccesstoken'
   - columns: []
-    indexName: oauthaccesstoken
+    indexName: oauthaccesstoken_token_name
     indexType: unique
     operation: createIndex
-    table: oauthaccesstoken_token_name
+    table: oauthaccesstoken
   - columns:
     - name: secure_client_secret
       nullable: true
@@ -101,18 +101,18 @@ spec:
     operation: addColumn
     table: !!python/unicode 'oauthauthorizationcode'
   - columns: []
-    indexName: oauthauthorizationcode
+    indexName: oauthauthorizationcode_code_name
     indexType: unique
     operation: createIndex
-    table: oauthauthorizationcode_code_name
+    table: oauthauthorizationcode
   - indexName: oauthauthorizationcode_code
     operation: dropIndex
     table: oauthauthorizationcode
   - columns: []
-    indexName: oauthauthorizationcode
+    indexName: oauthauthorizationcode_code
     indexType: unique
     operation: createIndex
-    table: oauthauthorizationcode_code
+    table: oauthauthorizationcode
   - columns:
     - name: secure_auth_token
       nullable: true

--- a/data/migrations/dba_operator/c156deb8845d-databasemigration.yaml
+++ b/data/migrations/dba_operator/c156deb8845d-databasemigration.yaml
@@ -22,10 +22,10 @@ spec:
     operation: createTable
     table: accesstokenkind
   - columns: []
-    indexName: accesstokenkind
+    indexName: accesstokenkind_name
     indexType: unique
     operation: createIndex
-    table: accesstokenkind_name
+    table: accesstokenkind
   - columns:
     - name: id
       nullable: false
@@ -34,10 +34,10 @@ spec:
     operation: createTable
     table: buildtriggerservice
   - columns: []
-    indexName: buildtriggerservice
+    indexName: buildtriggerservice_name
     indexType: unique
     operation: createIndex
-    table: buildtriggerservice_name
+    table: buildtriggerservice
   - columns:
     - name: id
       nullable: false
@@ -46,10 +46,10 @@ spec:
     operation: createTable
     table: externalnotificationevent
   - columns: []
-    indexName: externalnotificationevent
+    indexName: externalnotificationevent_name
     indexType: unique
     operation: createIndex
-    table: externalnotificationevent_name
+    table: externalnotificationevent
   - columns:
     - name: id
       nullable: false
@@ -58,10 +58,10 @@ spec:
     operation: createTable
     table: externalnotificationmethod
   - columns: []
-    indexName: externalnotificationmethod
+    indexName: externalnotificationmethod_name
     indexType: unique
     operation: createIndex
-    table: externalnotificationmethod_name
+    table: externalnotificationmethod
   - columns:
     - name: id
       nullable: false
@@ -82,15 +82,15 @@ spec:
     operation: createTable
     table: imagestorage
   - columns: []
-    indexName: imagestorage
+    indexName: imagestorage_content_checksum
     indexType: index
     operation: createIndex
-    table: imagestorage_content_checksum
+    table: imagestorage
   - columns: []
-    indexName: imagestorage
+    indexName: imagestorage_uuid
     indexType: unique
     operation: createIndex
-    table: imagestorage_uuid
+    table: imagestorage
   - columns:
     - name: id
       nullable: false
@@ -99,10 +99,10 @@ spec:
     operation: createTable
     table: imagestoragelocation
   - columns: []
-    indexName: imagestoragelocation
+    indexName: imagestoragelocation_name
     indexType: unique
     operation: createIndex
-    table: imagestoragelocation_name
+    table: imagestoragelocation
   - columns:
     - name: id
       nullable: false
@@ -111,10 +111,10 @@ spec:
     operation: createTable
     table: imagestoragesignaturekind
   - columns: []
-    indexName: imagestoragesignaturekind
+    indexName: imagestoragesignaturekind_name
     indexType: unique
     operation: createIndex
-    table: imagestoragesignaturekind_name
+    table: imagestoragesignaturekind
   - columns:
     - name: id
       nullable: false
@@ -123,10 +123,10 @@ spec:
     operation: createTable
     table: imagestoragetransformation
   - columns: []
-    indexName: imagestoragetransformation
+    indexName: imagestoragetransformation_name
     indexType: unique
     operation: createIndex
-    table: imagestoragetransformation_name
+    table: imagestoragetransformation
   - columns:
     - name: id
       nullable: false
@@ -137,10 +137,10 @@ spec:
     operation: createTable
     table: labelsourcetype
   - columns: []
-    indexName: labelsourcetype
+    indexName: labelsourcetype_name
     indexType: unique
     operation: createIndex
-    table: labelsourcetype_name
+    table: labelsourcetype
   - columns:
     - name: id
       nullable: false
@@ -149,10 +149,10 @@ spec:
     operation: createTable
     table: logentrykind
   - columns: []
-    indexName: logentrykind
+    indexName: logentrykind_name
     indexType: unique
     operation: createIndex
-    table: logentrykind_name
+    table: logentrykind
   - columns:
     - name: id
       nullable: false
@@ -161,10 +161,10 @@ spec:
     operation: createTable
     table: loginservice
   - columns: []
-    indexName: loginservice
+    indexName: loginservice_name
     indexType: unique
     operation: createIndex
-    table: loginservice_name
+    table: loginservice
   - columns:
     - name: id
       nullable: false
@@ -173,10 +173,10 @@ spec:
     operation: createTable
     table: mediatype
   - columns: []
-    indexName: mediatype
+    indexName: mediatype_name
     indexType: unique
     operation: createIndex
-    table: mediatype_name
+    table: mediatype
   - columns:
     - name: id
       nullable: false
@@ -194,10 +194,10 @@ spec:
     operation: createTable
     table: notificationkind
   - columns: []
-    indexName: notificationkind
+    indexName: notificationkind_name
     indexType: unique
     operation: createIndex
-    table: notificationkind_name
+    table: notificationkind
   - columns:
     - name: id
       nullable: false
@@ -206,10 +206,10 @@ spec:
     operation: createTable
     table: quayregion
   - columns: []
-    indexName: quayregion
+    indexName: quayregion_name
     indexType: unique
     operation: createIndex
-    table: quayregion_name
+    table: quayregion
   - columns:
     - name: id
       nullable: false
@@ -218,10 +218,10 @@ spec:
     operation: createTable
     table: quayservice
   - columns: []
-    indexName: quayservice
+    indexName: quayservice_name
     indexType: unique
     operation: createIndex
-    table: quayservice_name
+    table: quayservice
   - columns:
     - name: id
       nullable: false
@@ -240,30 +240,30 @@ spec:
     operation: createTable
     table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_available
     indexType: index
     operation: createIndex
-    table: queueitem_available
+    table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_available_after
     indexType: index
     operation: createIndex
-    table: queueitem_available_after
+    table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_processing_expires
     indexType: index
     operation: createIndex
-    table: queueitem_processing_expires
+    table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_queue_name
     indexType: index
     operation: createIndex
-    table: queueitem_queue_name
+    table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_retries_remaining
     indexType: index
     operation: createIndex
-    table: queueitem_retries_remaining
+    table: queueitem
   - columns:
     - name: id
       nullable: false
@@ -272,10 +272,10 @@ spec:
     operation: createTable
     table: role
   - columns: []
-    indexName: role
+    indexName: role_name
     indexType: unique
     operation: createIndex
-    table: role_name
+    table: role
   - columns:
     - name: id
       nullable: false
@@ -290,15 +290,15 @@ spec:
     operation: createTable
     table: servicekeyapproval
   - columns: []
-    indexName: servicekeyapproval
+    indexName: servicekeyapproval_approval_type
     indexType: index
     operation: createIndex
-    table: servicekeyapproval_approval_type
+    table: servicekeyapproval
   - columns: []
-    indexName: servicekeyapproval
+    indexName: servicekeyapproval_approver_id
     indexType: index
     operation: createIndex
-    table: servicekeyapproval_approver_id
+    table: servicekeyapproval
   - columns:
     - name: id
       nullable: false
@@ -307,10 +307,10 @@ spec:
     operation: createTable
     table: teamrole
   - columns: []
-    indexName: teamrole
+    indexName: teamrole_name
     indexType: index
     operation: createIndex
-    table: teamrole_name
+    table: teamrole
   - columns:
     - name: id
       nullable: false
@@ -345,35 +345,35 @@ spec:
     operation: createTable
     table: user
   - columns: []
-    indexName: user
+    indexName: user_email
     indexType: unique
     operation: createIndex
-    table: user_email
+    table: user
   - columns: []
-    indexName: user
+    indexName: user_invoice_email_address
     indexType: index
     operation: createIndex
-    table: user_invoice_email_address
+    table: user
   - columns: []
-    indexName: user
+    indexName: user_organization
     indexType: index
     operation: createIndex
-    table: user_organization
+    table: user
   - columns: []
-    indexName: user
+    indexName: user_robot
     indexType: index
     operation: createIndex
-    table: user_robot
+    table: user
   - columns: []
-    indexName: user
+    indexName: user_stripe_id
     indexType: index
     operation: createIndex
-    table: user_stripe_id
+    table: user
   - columns: []
-    indexName: user
+    indexName: user_username
     indexType: unique
     operation: createIndex
-    table: user_username
+    table: user
   - columns:
     - name: id
       nullable: false
@@ -382,10 +382,10 @@ spec:
     operation: createTable
     table: visibility
   - columns: []
-    indexName: visibility
+    indexName: visibility_name
     indexType: unique
     operation: createIndex
-    table: visibility_name
+    table: visibility
   - columns:
     - name: id
       nullable: false
@@ -404,15 +404,15 @@ spec:
     operation: createTable
     table: emailconfirmation
   - columns: []
-    indexName: emailconfirmation
+    indexName: emailconfirmation_code
     indexType: unique
     operation: createIndex
-    table: emailconfirmation_code
+    table: emailconfirmation
   - columns: []
-    indexName: emailconfirmation
+    indexName: emailconfirmation_user_id
     indexType: index
     operation: createIndex
-    table: emailconfirmation_user_id
+    table: emailconfirmation
   - columns:
     - name: id
       nullable: false
@@ -427,25 +427,25 @@ spec:
     operation: createTable
     table: federatedlogin
   - columns: []
-    indexName: federatedlogin
+    indexName: federatedlogin_service_id
     indexType: index
     operation: createIndex
-    table: federatedlogin_service_id
+    table: federatedlogin
   - columns: []
-    indexName: federatedlogin
+    indexName: federatedlogin_service_id_service_ident
     indexType: unique
     operation: createIndex
-    table: federatedlogin_service_id_service_ident
+    table: federatedlogin
   - columns: []
-    indexName: federatedlogin
+    indexName: federatedlogin_service_id_user_id
     indexType: unique
     operation: createIndex
-    table: federatedlogin_service_id_user_id
+    table: federatedlogin
   - columns: []
-    indexName: federatedlogin
+    indexName: federatedlogin_user_id
     indexType: index
     operation: createIndex
-    table: federatedlogin_user_id
+    table: federatedlogin
   - columns:
     - name: id
       nullable: false
@@ -456,20 +456,20 @@ spec:
     operation: createTable
     table: imagestorageplacement
   - columns: []
-    indexName: imagestorageplacement
+    indexName: imagestorageplacement_location_id
     indexType: index
     operation: createIndex
-    table: imagestorageplacement_location_id
+    table: imagestorageplacement
   - columns: []
-    indexName: imagestorageplacement
+    indexName: imagestorageplacement_storage_id
     indexType: index
     operation: createIndex
-    table: imagestorageplacement_storage_id
+    table: imagestorageplacement
   - columns: []
-    indexName: imagestorageplacement
+    indexName: imagestorageplacement_storage_id_location_id
     indexType: unique
     operation: createIndex
-    table: imagestorageplacement_storage_id_location_id
+    table: imagestorageplacement
   - columns:
     - name: id
       nullable: false
@@ -484,20 +484,20 @@ spec:
     operation: createTable
     table: imagestoragesignature
   - columns: []
-    indexName: imagestoragesignature
+    indexName: imagestoragesignature_kind_id
     indexType: index
     operation: createIndex
-    table: imagestoragesignature_kind_id
+    table: imagestoragesignature
   - columns: []
-    indexName: imagestoragesignature
+    indexName: imagestoragesignature_kind_id_storage_id
     indexType: unique
     operation: createIndex
-    table: imagestoragesignature_kind_id_storage_id
+    table: imagestoragesignature
   - columns: []
-    indexName: imagestoragesignature
+    indexName: imagestoragesignature_storage_id
     indexType: index
     operation: createIndex
-    table: imagestoragesignature_storage_id
+    table: imagestoragesignature
   - columns:
     - name: id
       nullable: false
@@ -514,25 +514,25 @@ spec:
     operation: createTable
     table: label
   - columns: []
-    indexName: label
+    indexName: label_key
     indexType: index
     operation: createIndex
-    table: label_key
+    table: label
   - columns: []
-    indexName: label
+    indexName: label_media_type_id
     indexType: index
     operation: createIndex
-    table: label_media_type_id
+    table: label
   - columns: []
-    indexName: label
+    indexName: label_source_type_id
     indexType: index
     operation: createIndex
-    table: label_source_type_id
+    table: label
   - columns: []
-    indexName: label
+    indexName: label_uuid
     indexType: unique
     operation: createIndex
-    table: label_uuid
+    table: label
   - columns:
     - name: id
       nullable: false
@@ -553,50 +553,50 @@ spec:
     operation: createTable
     table: logentry
   - columns: []
-    indexName: logentry
+    indexName: logentry_account_id
     indexType: index
     operation: createIndex
-    table: logentry_account_id
+    table: logentry
   - columns: []
-    indexName: logentry
+    indexName: logentry_account_id_datetime
     indexType: index
     operation: createIndex
-    table: logentry_account_id_datetime
+    table: logentry
   - columns: []
-    indexName: logentry
+    indexName: logentry_datetime
     indexType: index
     operation: createIndex
-    table: logentry_datetime
+    table: logentry
   - columns: []
-    indexName: logentry
+    indexName: logentry_kind_id
     indexType: index
     operation: createIndex
-    table: logentry_kind_id
+    table: logentry
   - columns: []
-    indexName: logentry
+    indexName: logentry_performer_id
     indexType: index
     operation: createIndex
-    table: logentry_performer_id
+    table: logentry
   - columns: []
-    indexName: logentry
+    indexName: logentry_performer_id_datetime
     indexType: index
     operation: createIndex
-    table: logentry_performer_id_datetime
+    table: logentry
   - columns: []
-    indexName: logentry
+    indexName: logentry_repository_id
     indexType: index
     operation: createIndex
-    table: logentry_repository_id
+    table: logentry
   - columns: []
-    indexName: logentry
+    indexName: logentry_repository_id_datetime
     indexType: index
     operation: createIndex
-    table: logentry_repository_id_datetime
+    table: logentry
   - columns: []
-    indexName: logentry
+    indexName: logentry_repository_id_datetime_kind_id
     indexType: index
     operation: createIndex
-    table: logentry_repository_id_datetime_kind_id
+    table: logentry
   - columns:
     - name: id
       nullable: false
@@ -617,30 +617,30 @@ spec:
     operation: createTable
     table: notification
   - columns: []
-    indexName: notification
+    indexName: notification_created
     indexType: index
     operation: createIndex
-    table: notification_created
+    table: notification
   - columns: []
-    indexName: notification
+    indexName: notification_kind_id
     indexType: index
     operation: createIndex
-    table: notification_kind_id
+    table: notification
   - columns: []
-    indexName: notification
+    indexName: notification_lookup_path
     indexType: index
     operation: createIndex
-    table: notification_lookup_path
+    table: notification
   - columns: []
-    indexName: notification
+    indexName: notification_target_id
     indexType: index
     operation: createIndex
-    table: notification_target_id
+    table: notification
   - columns: []
-    indexName: notification
+    indexName: notification_uuid
     indexType: index
     operation: createIndex
-    table: notification_uuid
+    table: notification
   - columns:
     - name: id
       nullable: false
@@ -663,15 +663,15 @@ spec:
     operation: createTable
     table: oauthapplication
   - columns: []
-    indexName: oauthapplication
+    indexName: oauthapplication_client_id
     indexType: index
     operation: createIndex
-    table: oauthapplication_client_id
+    table: oauthapplication
   - columns: []
-    indexName: oauthapplication
+    indexName: oauthapplication_organization_id
     indexType: index
     operation: createIndex
-    table: oauthapplication_organization_id
+    table: oauthapplication
   - columns:
     - name: id
       nullable: false
@@ -688,30 +688,30 @@ spec:
     operation: createTable
     table: quayrelease
   - columns: []
-    indexName: quayrelease
+    indexName: quayrelease_created
     indexType: index
     operation: createIndex
-    table: quayrelease_created
+    table: quayrelease
   - columns: []
-    indexName: quayrelease
+    indexName: quayrelease_region_id
     indexType: index
     operation: createIndex
-    table: quayrelease_region_id
+    table: quayrelease
   - columns: []
-    indexName: quayrelease
+    indexName: quayrelease_service_id
     indexType: index
     operation: createIndex
-    table: quayrelease_service_id
+    table: quayrelease
   - columns: []
-    indexName: quayrelease
+    indexName: quayrelease_service_id_region_id_created
     indexType: index
     operation: createIndex
-    table: quayrelease_service_id_region_id_created
+    table: quayrelease
   - columns: []
-    indexName: quayrelease
+    indexName: quayrelease_service_id_version_region_id
     indexType: unique
     operation: createIndex
-    table: quayrelease_service_id_version_region_id
+    table: quayrelease
   - columns:
     - name: id
       nullable: false
@@ -728,20 +728,20 @@ spec:
     operation: createTable
     table: repository
   - columns: []
-    indexName: repository
+    indexName: repository_namespace_user_id
     indexType: index
     operation: createIndex
-    table: repository_namespace_user_id
+    table: repository
   - columns: []
-    indexName: repository
+    indexName: repository_namespace_user_id_name
     indexType: unique
     operation: createIndex
-    table: repository_namespace_user_id_name
+    table: repository
   - columns: []
-    indexName: repository
+    indexName: repository_visibility_id
     indexType: index
     operation: createIndex
-    table: repository_visibility_id
+    table: repository
   - columns:
     - name: id
       nullable: false
@@ -766,20 +766,20 @@ spec:
     operation: createTable
     table: servicekey
   - columns: []
-    indexName: servicekey
+    indexName: servicekey_approval_id
     indexType: index
     operation: createIndex
-    table: servicekey_approval_id
+    table: servicekey
   - columns: []
-    indexName: servicekey
+    indexName: servicekey_kid
     indexType: unique
     operation: createIndex
-    table: servicekey_kid
+    table: servicekey
   - columns: []
-    indexName: servicekey
+    indexName: servicekey_service
     indexType: index
     operation: createIndex
-    table: servicekey_service
+    table: servicekey
   - columns:
     - name: id
       nullable: false
@@ -794,25 +794,25 @@ spec:
     operation: createTable
     table: team
   - columns: []
-    indexName: team
+    indexName: team_name
     indexType: index
     operation: createIndex
-    table: team_name
+    table: team
   - columns: []
-    indexName: team
+    indexName: team_name_organization_id
     indexType: unique
     operation: createIndex
-    table: team_name_organization_id
+    table: team
   - columns: []
-    indexName: team
+    indexName: team_organization_id
     indexType: index
     operation: createIndex
-    table: team_organization_id
+    table: team
   - columns: []
-    indexName: team
+    indexName: team_role_id
     indexType: index
     operation: createIndex
-    table: team_role_id
+    table: team
   - columns:
     - name: id
       nullable: false
@@ -825,15 +825,15 @@ spec:
     operation: createTable
     table: torrentinfo
   - columns: []
-    indexName: torrentinfo
+    indexName: torrentinfo_storage_id
     indexType: index
     operation: createIndex
-    table: torrentinfo_storage_id
+    table: torrentinfo
   - columns: []
-    indexName: torrentinfo
+    indexName: torrentinfo_storage_id_piece_length
     indexType: unique
     operation: createIndex
-    table: torrentinfo_storage_id_piece_length
+    table: torrentinfo
   - columns:
     - name: id
       nullable: false
@@ -844,15 +844,15 @@ spec:
     operation: createTable
     table: userregion
   - columns: []
-    indexName: userregion
+    indexName: userregion_location_id
     indexType: index
     operation: createIndex
-    table: userregion_location_id
+    table: userregion
   - columns: []
-    indexName: userregion
+    indexName: userregion_user_id
     indexType: index
     operation: createIndex
-    table: userregion_user_id
+    table: userregion
   - columns:
     - name: id
       nullable: false
@@ -873,25 +873,25 @@ spec:
     operation: createTable
     table: accesstoken
   - columns: []
-    indexName: accesstoken
+    indexName: accesstoken_code
     indexType: unique
     operation: createIndex
-    table: accesstoken_code
+    table: accesstoken
   - columns: []
-    indexName: accesstoken
+    indexName: accesstoken_kind_id
     indexType: index
     operation: createIndex
-    table: accesstoken_kind_id
+    table: accesstoken
   - columns: []
-    indexName: accesstoken
+    indexName: accesstoken_repository_id
     indexType: index
     operation: createIndex
-    table: accesstoken_repository_id
+    table: accesstoken
   - columns: []
-    indexName: accesstoken
+    indexName: accesstoken_role_id
     indexType: index
     operation: createIndex
-    table: accesstoken_role_id
+    table: accesstoken
   - columns:
     - name: id
       nullable: false
@@ -920,30 +920,30 @@ spec:
     operation: createTable
     table: blobupload
   - columns: []
-    indexName: blobupload
+    indexName: blobupload_created
     indexType: index
     operation: createIndex
-    table: blobupload_created
+    table: blobupload
   - columns: []
-    indexName: blobupload
+    indexName: blobupload_location_id
     indexType: index
     operation: createIndex
-    table: blobupload_location_id
+    table: blobupload
   - columns: []
-    indexName: blobupload
+    indexName: blobupload_repository_id
     indexType: index
     operation: createIndex
-    table: blobupload_repository_id
+    table: blobupload
   - columns: []
-    indexName: blobupload
+    indexName: blobupload_repository_id_uuid
     indexType: unique
     operation: createIndex
-    table: blobupload_repository_id_uuid
+    table: blobupload
   - columns: []
-    indexName: blobupload
+    indexName: blobupload_uuid
     indexType: unique
     operation: createIndex
-    table: blobupload_uuid
+    table: blobupload
   - columns:
     - name: id
       nullable: false
@@ -976,50 +976,50 @@ spec:
     operation: createTable
     table: image
   - columns: []
-    indexName: image
+    indexName: image_ancestors
     indexType: index
     operation: createIndex
-    table: image_ancestors
+    table: image
   - columns: []
-    indexName: image
+    indexName: image_docker_image_id
     indexType: index
     operation: createIndex
-    table: image_docker_image_id
+    table: image
   - columns: []
-    indexName: image
+    indexName: image_parent_id
     indexType: index
     operation: createIndex
-    table: image_parent_id
+    table: image
   - columns: []
-    indexName: image
+    indexName: image_repository_id
     indexType: index
     operation: createIndex
-    table: image_repository_id
+    table: image
   - columns: []
-    indexName: image
+    indexName: image_repository_id_docker_image_id
     indexType: unique
     operation: createIndex
-    table: image_repository_id_docker_image_id
+    table: image
   - columns: []
-    indexName: image
+    indexName: image_security_indexed
     indexType: index
     operation: createIndex
-    table: image_security_indexed
+    table: image
   - columns: []
-    indexName: image
+    indexName: image_security_indexed_engine
     indexType: index
     operation: createIndex
-    table: image_security_indexed_engine
+    table: image
   - columns: []
-    indexName: image
+    indexName: image_security_indexed_engine_security_indexed
     indexType: index
     operation: createIndex
-    table: image_security_indexed_engine_security_indexed
+    table: image
   - columns: []
-    indexName: image
+    indexName: image_storage_id
     indexType: index
     operation: createIndex
-    table: image_storage_id
+    table: image
   - columns:
     - name: id
       nullable: false
@@ -1044,30 +1044,30 @@ spec:
     operation: createTable
     table: oauthaccesstoken
   - columns: []
-    indexName: oauthaccesstoken
+    indexName: oauthaccesstoken_access_token
     indexType: index
     operation: createIndex
-    table: oauthaccesstoken_access_token
+    table: oauthaccesstoken
   - columns: []
-    indexName: oauthaccesstoken
+    indexName: oauthaccesstoken_application_id
     indexType: index
     operation: createIndex
-    table: oauthaccesstoken_application_id
+    table: oauthaccesstoken
   - columns: []
-    indexName: oauthaccesstoken
+    indexName: oauthaccesstoken_authorized_user_id
     indexType: index
     operation: createIndex
-    table: oauthaccesstoken_authorized_user_id
+    table: oauthaccesstoken
   - columns: []
-    indexName: oauthaccesstoken
+    indexName: oauthaccesstoken_refresh_token
     indexType: index
     operation: createIndex
-    table: oauthaccesstoken_refresh_token
+    table: oauthaccesstoken
   - columns: []
-    indexName: oauthaccesstoken
+    indexName: oauthaccesstoken_uuid
     indexType: index
     operation: createIndex
-    table: oauthaccesstoken_uuid
+    table: oauthaccesstoken
   - columns:
     - name: id
       nullable: false
@@ -1082,15 +1082,15 @@ spec:
     operation: createTable
     table: oauthauthorizationcode
   - columns: []
-    indexName: oauthauthorizationcode
+    indexName: oauthauthorizationcode_application_id
     indexType: index
     operation: createIndex
-    table: oauthauthorizationcode_application_id
+    table: oauthauthorizationcode
   - columns: []
-    indexName: oauthauthorizationcode
+    indexName: oauthauthorizationcode_code
     indexType: index
     operation: createIndex
-    table: oauthauthorizationcode_code
+    table: oauthauthorizationcode
   - columns:
     - name: id
       nullable: false
@@ -1109,35 +1109,35 @@ spec:
     operation: createTable
     table: permissionprototype
   - columns: []
-    indexName: permissionprototype
+    indexName: permissionprototype_activating_user_id
     indexType: index
     operation: createIndex
-    table: permissionprototype_activating_user_id
+    table: permissionprototype
   - columns: []
-    indexName: permissionprototype
+    indexName: permissionprototype_delegate_team_id
     indexType: index
     operation: createIndex
-    table: permissionprototype_delegate_team_id
+    table: permissionprototype
   - columns: []
-    indexName: permissionprototype
+    indexName: permissionprototype_delegate_user_id
     indexType: index
     operation: createIndex
-    table: permissionprototype_delegate_user_id
+    table: permissionprototype
   - columns: []
-    indexName: permissionprototype
+    indexName: permissionprototype_org_id
     indexType: index
     operation: createIndex
-    table: permissionprototype_org_id
+    table: permissionprototype
   - columns: []
-    indexName: permissionprototype
+    indexName: permissionprototype_org_id_activating_user_id
     indexType: index
     operation: createIndex
-    table: permissionprototype_org_id_activating_user_id
+    table: permissionprototype
   - columns: []
-    indexName: permissionprototype
+    indexName: permissionprototype_role_id
     indexType: index
     operation: createIndex
-    table: permissionprototype_role_id
+    table: permissionprototype
   - columns:
     - name: id
       nullable: false
@@ -1150,20 +1150,20 @@ spec:
     operation: createTable
     table: repositoryactioncount
   - columns: []
-    indexName: repositoryactioncount
+    indexName: repositoryactioncount_date
     indexType: index
     operation: createIndex
-    table: repositoryactioncount_date
+    table: repositoryactioncount
   - columns: []
-    indexName: repositoryactioncount
+    indexName: repositoryactioncount_repository_id
     indexType: index
     operation: createIndex
-    table: repositoryactioncount_repository_id
+    table: repositoryactioncount
   - columns: []
-    indexName: repositoryactioncount
+    indexName: repositoryactioncount_repository_id_date
     indexType: unique
     operation: createIndex
-    table: repositoryactioncount_repository_id_date
+    table: repositoryactioncount
   - columns:
     - name: id
       nullable: false
@@ -1178,20 +1178,20 @@ spec:
     operation: createTable
     table: repositoryauthorizedemail
   - columns: []
-    indexName: repositoryauthorizedemail
+    indexName: repositoryauthorizedemail_code
     indexType: unique
     operation: createIndex
-    table: repositoryauthorizedemail_code
+    table: repositoryauthorizedemail
   - columns: []
-    indexName: repositoryauthorizedemail
+    indexName: repositoryauthorizedemail_email_repository_id
     indexType: unique
     operation: createIndex
-    table: repositoryauthorizedemail_email_repository_id
+    table: repositoryauthorizedemail
   - columns: []
-    indexName: repositoryauthorizedemail
+    indexName: repositoryauthorizedemail_repository_id
     indexType: index
     operation: createIndex
-    table: repositoryauthorizedemail_repository_id
+    table: repositoryauthorizedemail
   - columns:
     - name: id
       nullable: false
@@ -1212,25 +1212,25 @@ spec:
     operation: createTable
     table: repositorynotification
   - columns: []
-    indexName: repositorynotification
+    indexName: repositorynotification_event_id
     indexType: index
     operation: createIndex
-    table: repositorynotification_event_id
+    table: repositorynotification
   - columns: []
-    indexName: repositorynotification
+    indexName: repositorynotification_method_id
     indexType: index
     operation: createIndex
-    table: repositorynotification_method_id
+    table: repositorynotification
   - columns: []
-    indexName: repositorynotification
+    indexName: repositorynotification_repository_id
     indexType: index
     operation: createIndex
-    table: repositorynotification_repository_id
+    table: repositorynotification
   - columns: []
-    indexName: repositorynotification
+    indexName: repositorynotification_uuid
     indexType: index
     operation: createIndex
-    table: repositorynotification_uuid
+    table: repositorynotification
   - columns:
     - name: id
       nullable: false
@@ -1245,35 +1245,35 @@ spec:
     operation: createTable
     table: repositorypermission
   - columns: []
-    indexName: repositorypermission
+    indexName: repositorypermission_repository_id
     indexType: index
     operation: createIndex
-    table: repositorypermission_repository_id
+    table: repositorypermission
   - columns: []
-    indexName: repositorypermission
+    indexName: repositorypermission_role_id
     indexType: index
     operation: createIndex
-    table: repositorypermission_role_id
+    table: repositorypermission
   - columns: []
-    indexName: repositorypermission
+    indexName: repositorypermission_team_id
     indexType: index
     operation: createIndex
-    table: repositorypermission_team_id
+    table: repositorypermission
   - columns: []
-    indexName: repositorypermission
+    indexName: repositorypermission_team_id_repository_id
     indexType: unique
     operation: createIndex
-    table: repositorypermission_team_id_repository_id
+    table: repositorypermission
   - columns: []
-    indexName: repositorypermission
+    indexName: repositorypermission_user_id
     indexType: index
     operation: createIndex
-    table: repositorypermission_user_id
+    table: repositorypermission
   - columns: []
-    indexName: repositorypermission
+    indexName: repositorypermission_user_id_repository_id
     indexType: unique
     operation: createIndex
-    table: repositorypermission_user_id_repository_id
+    table: repositorypermission
   - columns:
     - name: id
       nullable: false
@@ -1286,20 +1286,20 @@ spec:
     operation: createTable
     table: star
   - columns: []
-    indexName: star
+    indexName: star_repository_id
     indexType: index
     operation: createIndex
-    table: star_repository_id
+    table: star
   - columns: []
-    indexName: star
+    indexName: star_user_id
     indexType: index
     operation: createIndex
-    table: star_user_id
+    table: star
   - columns: []
-    indexName: star
+    indexName: star_user_id_repository_id
     indexType: unique
     operation: createIndex
-    table: star_user_id_repository_id
+    table: star
   - columns:
     - name: id
       nullable: false
@@ -1310,20 +1310,20 @@ spec:
     operation: createTable
     table: teammember
   - columns: []
-    indexName: teammember
+    indexName: teammember_team_id
     indexType: index
     operation: createIndex
-    table: teammember_team_id
+    table: teammember
   - columns: []
-    indexName: teammember
+    indexName: teammember_user_id
     indexType: index
     operation: createIndex
-    table: teammember_user_id
+    table: teammember
   - columns: []
-    indexName: teammember
+    indexName: teammember_user_id_team_id
     indexType: unique
     operation: createIndex
-    table: teammember_user_id_team_id
+    table: teammember
   - columns:
     - name: id
       nullable: false
@@ -1340,20 +1340,20 @@ spec:
     operation: createTable
     table: teammemberinvite
   - columns: []
-    indexName: teammemberinvite
+    indexName: teammemberinvite_inviter_id
     indexType: index
     operation: createIndex
-    table: teammemberinvite_inviter_id
+    table: teammemberinvite
   - columns: []
-    indexName: teammemberinvite
+    indexName: teammemberinvite_team_id
     indexType: index
     operation: createIndex
-    table: teammemberinvite_team_id
+    table: teammemberinvite
   - columns: []
-    indexName: teammemberinvite
+    indexName: teammemberinvite_user_id
     indexType: index
     operation: createIndex
-    table: teammemberinvite_user_id
+    table: teammemberinvite
   - columns:
     - name: id
       nullable: false
@@ -1368,25 +1368,25 @@ spec:
     operation: createTable
     table: derivedstorageforimage
   - columns: []
-    indexName: derivedstorageforimage
+    indexName: derivedstorageforimage_derivative_id
     indexType: index
     operation: createIndex
-    table: derivedstorageforimage_derivative_id
+    table: derivedstorageforimage
   - columns: []
-    indexName: derivedstorageforimage
+    indexName: derivedstorageforimage_source_image_id
     indexType: index
     operation: createIndex
-    table: derivedstorageforimage_source_image_id
+    table: derivedstorageforimage
   - columns: []
-    indexName: derivedstorageforimage
+    indexName: uniqueness_index
     indexType: unique
     operation: createIndex
-    table: uniqueness_index
+    table: derivedstorageforimage
   - columns: []
-    indexName: derivedstorageforimage
+    indexName: derivedstorageforimage_transformation_id
     indexType: index
     operation: createIndex
-    table: derivedstorageforimage_transformation_id
+    table: derivedstorageforimage
   - columns:
     - name: id
       nullable: false
@@ -1411,30 +1411,30 @@ spec:
     operation: createTable
     table: repositorybuildtrigger
   - columns: []
-    indexName: repositorybuildtrigger
+    indexName: repositorybuildtrigger_connected_user_id
     indexType: index
     operation: createIndex
-    table: repositorybuildtrigger_connected_user_id
+    table: repositorybuildtrigger
   - columns: []
-    indexName: repositorybuildtrigger
+    indexName: repositorybuildtrigger_pull_robot_id
     indexType: index
     operation: createIndex
-    table: repositorybuildtrigger_pull_robot_id
+    table: repositorybuildtrigger
   - columns: []
-    indexName: repositorybuildtrigger
+    indexName: repositorybuildtrigger_repository_id
     indexType: index
     operation: createIndex
-    table: repositorybuildtrigger_repository_id
+    table: repositorybuildtrigger
   - columns: []
-    indexName: repositorybuildtrigger
+    indexName: repositorybuildtrigger_service_id
     indexType: index
     operation: createIndex
-    table: repositorybuildtrigger_service_id
+    table: repositorybuildtrigger
   - columns: []
-    indexName: repositorybuildtrigger
+    indexName: repositorybuildtrigger_write_token_id
     indexType: index
     operation: createIndex
-    table: repositorybuildtrigger_write_token_id
+    table: repositorybuildtrigger
   - columns:
     - name: id
       nullable: false
@@ -1455,30 +1455,30 @@ spec:
     operation: createTable
     table: repositorytag
   - columns: []
-    indexName: repositorytag
+    indexName: repositorytag_image_id
     indexType: index
     operation: createIndex
-    table: repositorytag_image_id
+    table: repositorytag
   - columns: []
-    indexName: repositorytag
+    indexName: repositorytag_lifetime_end_ts
     indexType: index
     operation: createIndex
-    table: repositorytag_lifetime_end_ts
+    table: repositorytag
   - columns: []
-    indexName: repositorytag
+    indexName: repositorytag_repository_id
     indexType: index
     operation: createIndex
-    table: repositorytag_repository_id
+    table: repositorytag
   - columns: []
-    indexName: repositorytag
+    indexName: repositorytag_repository_id_name
     indexType: index
     operation: createIndex
-    table: repositorytag_repository_id_name
+    table: repositorytag
   - columns: []
-    indexName: repositorytag
+    indexName: repositorytag_repository_id_name_lifetime_end_ts
     indexType: unique
     operation: createIndex
-    table: repositorytag_repository_id_name_lifetime_end_ts
+    table: repositorytag
   - columns:
     - name: id
       nullable: false
@@ -1509,55 +1509,55 @@ spec:
     operation: createTable
     table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_access_token_id
     indexType: index
     operation: createIndex
-    table: repositorybuild_access_token_id
+    table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_pull_robot_id
     indexType: index
     operation: createIndex
-    table: repositorybuild_pull_robot_id
+    table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_queue_id
     indexType: index
     operation: createIndex
-    table: repositorybuild_queue_id
+    table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_repository_id
     indexType: index
     operation: createIndex
-    table: repositorybuild_repository_id
+    table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_repository_id_started_phase
     indexType: index
     operation: createIndex
-    table: repositorybuild_repository_id_started_phase
+    table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_resource_key
     indexType: index
     operation: createIndex
-    table: repositorybuild_resource_key
+    table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_started
     indexType: index
     operation: createIndex
-    table: repositorybuild_started
+    table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_started_logs_archived_phase
     indexType: index
     operation: createIndex
-    table: repositorybuild_started_logs_archived_phase
+    table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_trigger_id
     indexType: index
     operation: createIndex
-    table: repositorybuild_trigger_id
+    table: repositorybuild
   - columns: []
-    indexName: repositorybuild
+    indexName: repositorybuild_uuid
     indexType: index
     operation: createIndex
-    table: repositorybuild_uuid
+    table: repositorybuild
   - columns:
     - name: id
       nullable: false
@@ -1570,15 +1570,15 @@ spec:
     operation: createTable
     table: tagmanifest
   - columns: []
-    indexName: tagmanifest
+    indexName: tagmanifest_digest
     indexType: index
     operation: createIndex
-    table: tagmanifest_digest
+    table: tagmanifest
   - columns: []
-    indexName: tagmanifest
+    indexName: tagmanifest_tag_id
     indexType: unique
     operation: createIndex
-    table: tagmanifest_tag_id
+    table: tagmanifest
   - columns:
     - name: id
       nullable: false
@@ -1591,22 +1591,22 @@ spec:
     operation: createTable
     table: tagmanifestlabel
   - columns: []
-    indexName: tagmanifestlabel
+    indexName: tagmanifestlabel_annotated_id
     indexType: index
     operation: createIndex
-    table: tagmanifestlabel_annotated_id
+    table: tagmanifestlabel
   - columns: []
-    indexName: tagmanifestlabel
+    indexName: tagmanifestlabel_annotated_id_label_id
     indexType: unique
     operation: createIndex
-    table: tagmanifestlabel_annotated_id_label_id
+    table: tagmanifestlabel
   - columns: []
-    indexName: tagmanifestlabel
+    indexName: tagmanifestlabel_label_id
     indexType: index
     operation: createIndex
-    table: tagmanifestlabel_label_id
+    table: tagmanifestlabel
   - columns: []
-    indexName: tagmanifestlabel
+    indexName: tagmanifestlabel_repository_id
     indexType: index
     operation: createIndex
-    table: tagmanifestlabel_repository_id
+    table: tagmanifestlabel

--- a/data/migrations/dba_operator/d42c175b439a-databasemigration.yaml
+++ b/data/migrations/dba_operator/d42c175b439a-databasemigration.yaml
@@ -18,7 +18,7 @@ spec:
     operation: dropIndex
     table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_state_id
     indexType: unique
     operation: createIndex
-    table: queueitem_state_id
+    table: queueitem

--- a/data/migrations/dba_operator/e184af42242d-databasemigration.yaml
+++ b/data/migrations/dba_operator/e184af42242d-databasemigration.yaml
@@ -15,17 +15,17 @@ spec:
   previous: 6ec8726c0ace
   schemaHints:
   - columns: []
-    indexName: permissionprototype
+    indexName: permissionprototype_uuid
     indexType: index
     operation: createIndex
-    table: permissionprototype_uuid
+    table: permissionprototype
   - columns: []
-    indexName: repositorybuildtrigger
+    indexName: repositorybuildtrigger_uuid
     indexType: index
     operation: createIndex
-    table: repositorybuildtrigger_uuid
+    table: repositorybuildtrigger
   - columns: []
-    indexName: user
+    indexName: user_uuid
     indexType: index
     operation: createIndex
-    table: user_uuid
+    table: user

--- a/data/migrations/dba_operator/e2894a3a3c19-databasemigration.yaml
+++ b/data/migrations/dba_operator/e2894a3a3c19-databasemigration.yaml
@@ -15,12 +15,12 @@ spec:
   previous: d42c175b439a
   schemaHints:
   - columns: []
-    indexName: repository
+    indexName: repository_description__fulltext
     indexType: index
     operation: createIndex
-    table: repository_description__fulltext
+    table: repository
   - columns: []
-    indexName: repository
+    indexName: repository_name__fulltext
     indexType: index
     operation: createIndex
-    table: repository_name__fulltext
+    table: repository

--- a/data/migrations/dba_operator/f30984525c86-databasemigration.yaml
+++ b/data/migrations/dba_operator/f30984525c86-databasemigration.yaml
@@ -26,12 +26,12 @@ spec:
     operation: createTable
     table: repositorysearchscore
   - columns: []
-    indexName: repositorysearchscore
+    indexName: repositorysearchscore_repository_id
     indexType: unique
     operation: createIndex
-    table: repositorysearchscore_repository_id
+    table: repositorysearchscore
   - columns: []
-    indexName: repositorysearchscore
+    indexName: repositorysearchscore_score
     indexType: index
     operation: createIndex
-    table: repositorysearchscore_score
+    table: repositorysearchscore

--- a/data/migrations/dba_operator/f5167870dd66-databasemigration.yaml
+++ b/data/migrations/dba_operator/f5167870dd66-databasemigration.yaml
@@ -15,25 +15,25 @@ spec:
   previous: 45fd8b9869d4
   schemaHints:
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_processing_expires_available
     indexType: index
     operation: createIndex
-    table: queueitem_processing_expires_available
+    table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_pe_aafter_qname_rremaining_available
     indexType: index
     operation: createIndex
-    table: queueitem_pe_aafter_qname_rremaining_available
+    table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_pexpires_aafter_rremaining_available
     indexType: index
     operation: createIndex
-    table: queueitem_pexpires_aafter_rremaining_available
+    table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_processing_expires_queue_name_available
     indexType: index
     operation: createIndex
-    table: queueitem_processing_expires_queue_name_available
+    table: queueitem
   - indexName: queueitem_available
     operation: dropIndex
     table: queueitem

--- a/data/migrations/dba_operator/fc47c1ec019f-databasemigration.yaml
+++ b/data/migrations/dba_operator/fc47c1ec019f-databasemigration.yaml
@@ -20,7 +20,7 @@ spec:
     operation: addColumn
     table: queueitem
   - columns: []
-    indexName: queueitem
+    indexName: queueitem_state_id
     indexType: index
     operation: createIndex
-    table: queueitem_state_id
+    table: queueitem

--- a/data/migrations/env.py
+++ b/data/migrations/env.py
@@ -140,7 +140,9 @@ def run_migrations_online():
 
     migration = Migration()
     version_apply_callback = report_success
-    if truthy_bool(context.get_x_argument(as_dictionary=True).get("generatedbaopmigrations", False)):
+    if truthy_bool(
+        context.get_x_argument(as_dictionary=True).get("generatedbaopmigrations", False)
+    ):
         op = OpLogger(alembic_op, migration)
         version_apply_callback = partial(finish_migration, migration)
 

--- a/data/migrations/env.py
+++ b/data/migrations/env.py
@@ -140,7 +140,7 @@ def run_migrations_online():
 
     migration = Migration()
     version_apply_callback = report_success
-    if truthy_bool(context.get_x_argument(as_dictionary=True).get("generatedbaopmigrations", None)):
+    if truthy_bool(context.get_x_argument(as_dictionary=True).get("generatedbaopmigrations", False)):
         op = OpLogger(alembic_op, migration)
         version_apply_callback = partial(finish_migration, migration)
 


### PR DESCRIPTION
Fix a bug where historical migrations had table and index names swapped.
Fix a bug where migrations were always being generated on upgrade and
downgrade.