### PR TITLE
Remove `message` as a required field in GitHub response

### DIFF
--- a/buildtrigger/githubhandler.py
+++ b/buildtrigger/githubhandler.py
@@ -65,7 +65,7 @@ GITHUB_WEBHOOK_PAYLOAD_SCHEMA = {
                     },
                 },
             },
-            "required": ["id", "url", "message", "timestamp"],
+            "required": ["id", "url", "timestamp"],
         },
         "repository": {
             "type": "object",


### PR DESCRIPTION
GitHub doesn't always send it, so we need to support the empty/missing
case.

Fixes https://issues.redhat.com/browse/PROJQUAY-210
