### PR TITLE
Deprecation Decorator for API Resources

### DIFF
--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -7,6 +7,7 @@ from functools import partial, wraps
 
 from flask import Blueprint, request, session
 from flask_restful import Resource, abort, Api, reqparse
+from flask_restful.utils import unpack
 from flask_restful.utils.cors import crossdomain
 from jsonschema import validate, ValidationError
 
@@ -471,6 +472,25 @@ def define_json_response(schema_name):
                     raise InvalidResponse(str(ex))
 
             return resp
+
+        return wrapped
+
+    return wrapper
+
+
+def deprecated():
+    """
+    Marks a given API resource operation as deprecated by adding `Deprecation` header.
+    See https://tools.ietf.org/id/draft-dalal-deprecation-header-01.html#RFC7234.
+    """
+
+    def wrapper(func):
+        @wraps(func)
+        def wrapped(self, *args, **kwargs):
+            (data, code, headers) = unpack(func(self, *args, **kwargs))
+            headers["Deprecation"] = "true"
+
+            return (data, code, headers)
 
         return wrapped
 

--- a/endpoints/api/image.py
+++ b/endpoints/api/image.py
@@ -12,6 +12,7 @@ from endpoints.api import (
     path_param,
     disallow_for_app_repositories,
     format_date,
+    deprecated,
 )
 from endpoints.exception import NotFound
 
@@ -56,6 +57,7 @@ class RepositoryImageList(RepositoryParamResource):
     @require_repo_read
     @nickname("listRepositoryImages")
     @disallow_for_app_repositories
+    @deprecated()
     def get(self, namespace, repository):
         """
         List the images for the specified repository.
@@ -79,6 +81,7 @@ class RepositoryImage(RepositoryParamResource):
     @require_repo_read
     @nickname("getImage")
     @disallow_for_app_repositories
+    @deprecated()
     def get(self, namespace, repository, image_id):
         """
         Get the information available for the specified image.

--- a/endpoints/api/secscan.py
+++ b/endpoints/api/secscan.py
@@ -21,6 +21,7 @@ from endpoints.api import (
     parse_args,
     query_param,
     disallow_for_app_repositories,
+    deprecated,
 )
 from endpoints.exception import NotFound, DownstreamIssue
 from endpoints.api.manifest import MANIFEST_DIGEST_ROUTE
@@ -86,6 +87,7 @@ class RepositoryImageSecurity(RepositoryParamResource):
     @process_basic_auth_no_pass
     @require_repo_read
     @nickname("getRepoImageSecurity")
+    @deprecated()
     @disallow_for_app_repositories
     @parse_args()
     @query_param(

--- a/endpoints/api/test/test_deprecated_route.py
+++ b/endpoints/api/test/test_deprecated_route.py
@@ -1,0 +1,27 @@
+import pytest
+
+from data import model
+from data.model.oci import shared
+from data.registry_model import registry_model
+from endpoints.api.secscan import RepositoryImageSecurity
+from endpoints.api.test.shared import conduct_api_call
+from endpoints.test.shared import client_with_identity
+from test.fixtures import *
+
+
+def test_deprecated_route(client):
+    repository_ref = registry_model.lookup_repository("devtable", "simple")
+    tag = registry_model.get_repo_tag(repository_ref, "latest", include_legacy_image=True)
+    manifest = registry_model.get_manifest_for_tag(tag, backfill_if_necessary=True)
+    image = shared.get_legacy_image_for_manifest(manifest._db_id)
+
+    with client_with_identity("devtable", client) as cl:
+        resp = conduct_api_call(
+            cl,
+            RepositoryImageSecurity,
+            "get",
+            {"repository": "devtable/simple", "imageid": image.docker_image_id},
+            expected_code=200,
+        )
+
+        assert resp.headers["Deprecation"] == "true"

--- a/endpoints/wellknown.py
+++ b/endpoints/wellknown.py
@@ -24,7 +24,10 @@ def app_capabilities():
         "appName": "io.quay",
         "capabilities": {
             "io.quay.view-image": {"url-template": view_image_tmpl,},
-            "io.quay.image-security": {"rest-api-template": image_security_tmpl,},
+            "io.quay.image-security": {
+                "rest-api-template": image_security_tmpl,
+                "deprecated": True,
+            },
             "io.quay.manifest-security": {"rest-api-template": manifest_security_tmpl,},
         },
     }


### PR DESCRIPTION
### Description

Introduces `@deprecated` decorator for API resources, which adds the [`Deprecation: true` header](https://tools.ietf.org/id/draft-dalal-deprecation-header-01.html#RFC7234) to the response. Applies this decorator to `getRepoImageSecurity`.

### Testing

```shell
$ TZ=UTC TEST=true PYTHONPATH="." py.test --verbose -x ./endpoints/api/test/test_deprecated_route.py
```

Addresses https://issues.redhat.com/browse/PROJQUAY-282
Addresses https://issues.redhat.com/browse/PROJQUAY-537