### PR TITLE
Remove squashed pull and ACI conversion from the tags UI

### DIFF
--- a/static/js/directives/ui/fetch-tag-dialog.js
+++ b/static/js/directives/ui/fetch-tag-dialog.js
@@ -38,24 +38,6 @@ angular.module('quay').directive('fetchTagDialog', function () {
             'command': 'docker pull {hostname}/{namespace}/{name}@{manifest_digest}'
           });
         }
-
-        if ($scope.repository && $scope.currentTag && !$scope.currentTag.is_manifest_list) {
-          $scope.formats.push({
-            'title': 'Squashed Docker Image',
-            'icon': 'ci-squashed',
-            'command': 'curl -L -f {http}://{pull_user}:{pull_password}@{hostname}/c1/squash/{namespace}/{name}/{tag} | docker load',
-            'require_creds': true,
-            'has_creds': UserService.isNamespaceAdmin($scope.repository.namespace)
-          });
-        }
-
-        if (Features.ACI_CONVERSION && $scope.currentTag && !$scope.currentTag.is_manifest_list) {
-          $scope.formats.push({
-            'title': 'rkt Fetch',
-            'icon': 'rocket-icon',
-            'command': 'rkt fetch {hostname}/{namespace}/{name}:{tag}'
-          });
-        }
       };
 
       $scope.$watch('currentEntity', function(entity) {


### PR DESCRIPTION
These will eventually be removed, so start the deprecation process
