### PR TITLE
Enable marking config-app fields as read only.

### DIFF
--- a/config_app/c_app.py
+++ b/config_app/c_app.py
@@ -11,6 +11,7 @@ from config_app._init_config import ROOT_DIR, IS_KUBERNETES
 from config_app.config_util.config import get_config_provider
 from util.security.instancekeys import InstanceKeys
 
+
 app = Flask(__name__)
 
 logger = logging.getLogger(__name__)

--- a/config_app/config_endpoints/setup_web.py
+++ b/config_app/config_endpoints/setup_web.py
@@ -1,3 +1,6 @@
+import os
+import re
+
 from flask import Blueprint
 from cachetools.func import lru_cache
 
@@ -6,6 +9,21 @@ from config_app.config_endpoints.api.discovery import generate_route_data
 from config_app.config_endpoints.api import no_cache
 
 setup_web = Blueprint("setup_web", __name__, template_folder="templates")
+
+
+def _get_readonly_fields():
+    """
+    Returns a list of fields which should be marked as "Read Only" in the
+    UI as they are most likely managed by an external service such as an
+    Operator.
+
+    This expects an environment variable with the following format:
+    CONFIG_READ_ONLY_FIELDS=redis,hostname
+    """
+    environment_variable_name = "CONFIG_READ_ONLY_FIELDS"
+    values = os.getenv(environment_variable_name, "").split(",")
+    selected = [value for value in values if re.match(r"^[a-z]{1,30}$", value)]
+    return selected
 
 
 @lru_cache(maxsize=1)
@@ -20,4 +38,6 @@ def render_page_template_with_routedata(name, *args, **kwargs):
 @no_cache
 @setup_web.route("/", methods=["GET"], defaults={"path": ""})
 def index(path, **kwargs):
-    return render_page_template_with_routedata("index.html", js_bundle_name="configapp", **kwargs)
+    return render_page_template_with_routedata(
+        "index.html", js_bundle_name="configapp", read_only_fields=_get_readonly_fields(), **kwargs
+    )

--- a/config_app/js/config-field-templates/config-numeric-field.html
+++ b/config_app/js/config-field-templates/config-numeric-field.html
@@ -1,6 +1,7 @@
 <div class="config-numeric-field-element">
   <form name="fieldform" novalidate>
     <input type="number" class="form-control" placeholder="{{ placeholder || '' }}"
-           ng-model="bindinginternal" ng-trim="false" ng-minlength="1" required>
+           ng-model="bindinginternal" ng-trim="false" ng-minlength="1" required
+           ng-readonly="::isReadonly">
   </form>
 </div>

--- a/config_app/js/config-field-templates/config-string-field.html
+++ b/config_app/js/config-field-templates/config-string-field.html
@@ -2,7 +2,8 @@
   <form name="fieldform" novalidate>
     <input type="text" class="form-control" placeholder="{{ placeholder || '' }}"
            ng-model="binding" ng-trim="false" ng-minlength="1"
-           ng-pattern="getRegexp(pattern)" ng-required="!isOptional">
+           ng-pattern="getRegexp(pattern)" ng-required="!isOptional"
+           ng-readonly="::isReadonly">
     <div class="alert alert-danger" ng-show="errorMessage">
         {{ errorMessage }}
     </div>

--- a/config_app/js/core-config-setup/config-setup-tool.html
+++ b/config_app/js/core-config-setup/config-setup-tool.html
@@ -54,16 +54,24 @@
         <div class="co-panel-body">
           <table class="config-table">
             <tr>
+                <div class="co-alert co-alert-danger" ng-if="isFieldReadonly('hostname')">
+                    The Hostname configuration is managed externally. These values
+                    cannot be changed.
+                </div>
+            </tr>
+            <tr>
               <td>Server Hostname:</td>
               <td>
-                <div class="co-alert co-alert-danger" ng-if="config.SERVER_HOSTNAME.indexOf('quay.io') >=0 "
+                <div class="co-alert co-alert-danger" ng-if="config.SERVER_HOSTNAME.indexOf('quay.io') >=0"
                      style="margin-bottom: 10px;">
                   The domain name <code>quay.io</code> is reserved for legacy reasons and cannot be used in
                   <span class="registry-name"></span> installations.
                 </div>
-
-                <span class="config-string-field" binding="config.SERVER_HOSTNAME"
-                      placeholder="Hostname (and optional port if non-standard)" pattern="{{ HOSTNAME_REGEX }}"></span>
+                <span class="config-string-field"
+                      binding="config.SERVER_HOSTNAME"
+                      placeholder="Hostname (and optional port if non-standard)"
+                      pattern="{{ HOSTNAME_REGEX }}"
+                      is-readonly="::isFieldReadonly('hostname')"></span>
                 <div class="help-text">
                   The HTTP host (and optionally the port number if a non-standard HTTP/HTTPS port) of the location
                   where the registry will be accessible on the network
@@ -73,7 +81,7 @@
             <tr>
               <td>TLS:</td>
               <td>
-                <select class="form-control" ng-model="mapped.TLS_SETTING">
+                <select ng-disabled="::isFieldReadonly('hostname')" class="form-control" ng-model="mapped.TLS_SETTING">
                   <option value="internal-tls">Red Hat Quay handles TLS</option>
                   <option value="external-tls">My own load balancer handles TLS (Not Recommended)</option>
                   <option value="none">None (Not For Production)</option>
@@ -101,7 +109,7 @@
                   connections on this hostname.
                 </div>
 
-                <table class="config-table" ng-if="mapped.TLS_SETTING == 'internal-tls'">
+                <table class="config-table" ng-if="mapped.TLS_SETTING == 'internal-tls' && !isFieldReadonly('hostname')">
                   <tr>
                     <td class="non-input">Certificate:</td>
                     <td>
@@ -222,16 +230,29 @@
 
           <table class="config-table">
             <tr>
+                <div class="co-alert co-alert-danger" ng-if="isFieldReadonly('redis')">
+                    The Redis configuration is managed externally. These values
+                    cannot be changed.
+                </div>
+            </tr>
+            <tr>
               <td>Redis Hostname:</td>
               <td>
-                <span class="config-string-field" binding="mapped.redis.host" placeholder="The redis server hostname"
-                      pattern="{{ HOSTNAME_REGEX }}" validator="validateHostname(value)"></span>
+                <span class="config-string-field"
+                      binding="mapped.redis.host"
+                      placeholder="The redis server hostname"
+                      pattern="{{ HOSTNAME_REGEX }}"
+                      validator="validateHostname(value)"
+                      is-readonly="::isFieldReadonly('redis')"></span>
               </td>
             </tr>
             <tr>
               <td>Redis port:</td>
               <td>
-                <span class="config-numeric-field" binding="mapped.redis.port" default-value="6379"></span>
+                <span class="config-numeric-field"
+                      binding="mapped.redis.port"
+                      default-value="6379"
+                      is-readonly="::isFieldReadonly('redis')"></span>
                 <div class="help-text">
                   Access to this port and hostname must be allowed from all hosts running
                   the enterprise registry
@@ -241,8 +262,11 @@
             <tr>
               <td>Redis password:</td>
               <td>
-                <input class="form-control" type="password" ng-model="mapped.redis.password"
-                       placeholder="Optional password for connecting to redis">
+                <input class="form-control"
+                       type="password"
+                       ng-model="mapped.redis.password"
+                       placeholder="Optional password for connecting to redis"
+                       ng-readonly="::isFieldReadonly('redis')">
               </td>
             </tr>
           </table>

--- a/config_app/js/core-config-setup/core-config-setup.js
+++ b/config_app/js/core-config-setup/core-config-setup.js
@@ -37,6 +37,14 @@ angular.module("quay-config")
         $scope.HOSTNAME_REGEX = '^[a-zA-Z-0-9\.]+(:[0-9]+)?$';
         $scope.GITHOST_REGEX = '^https?://([a-zA-Z0-9]+\.?\/?)+$';
 
+        // Determines if a particular field should be marked as "read-only".
+        // The __read_only_fields is populated using environment variables.
+        // This is usually used for the case where an external system is
+        // managing part of the configuration.
+        $scope.isFieldReadonly = function(field) {
+            return window.__read_only_fields.includes(field);
+        }
+
         $scope.SERVICES = [
           {'id': 'redis', 'title': 'Redis'},
 
@@ -1003,6 +1011,7 @@ angular.module("quay-config")
         'binding': '=binding',
         'placeholder': '@placeholder',
         'defaultValue': '@defaultValue',
+        'isReadonly': '=?isReadonly',
       },
       controller: function($scope, $element) {
         $scope.bindinginternal = 0;
@@ -1309,7 +1318,8 @@ angular.module("quay-config")
         'pattern': '@pattern',
         'defaultValue': '@defaultValue',
         'validator': '&validator',
-        'isOptional': '=isOptional'
+        'isOptional': '=isOptional',
+        'isReadonly': '=?isReadonly'
       },
       controller: function($scope, $element) {
         var firstSet = true;

--- a/config_app/templates/index.html
+++ b/config_app/templates/index.html
@@ -5,6 +5,7 @@
       window.__endpoints = {{ route_data|tojson|safe }}.paths;
       window.__config = {{ config_set|tojson|safe }};
       window.__kubernetes_namespace = {{ kubernetes_namespace|tojson|safe }};
+      window.__read_only_fields = {{ read_only_fields|tojson|safe }};
     </script>
 
     {% for style_url in external_styles %}


### PR DESCRIPTION
### Description of Changes

This change-set allows Users to mark certain fields in the Configuration application as read-only. This is helpful for cases where certain fields may be managed by an external resource, such as the Quay Operator.

The data should still be available when read from an existing configuration, but the User should not be allowed to manually edit it through the UI.

The following options are currently supported:
- Redis
- ~Storage~ Not used at the moment. Can be implemented in the future.
- Hostname

#### Changes:

* When running the Quay Configuration app, the following environment variable and options can be used to specify certain components as read-only: `READ_ONLY_FIELDS=redis,hostname`

#### Issue:

- [PROJQUAY-319](https://issues.redhat.com/browse/PROJQUAY-319)

**TESTING**

- Run the Quay Configuration application with all combinations of the mentioned environment variables. Ensure that in each case, the expected component cannot be modified by the User. Ensure that when reading the configuration from an existing cluster, the data is there (but not modifiable)

**BREAKING CHANGE**

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
