### PR TITLE
[WIP] PROJQUAY-479 - customize /health endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,14 @@ test/__pycache__
 __pycache__
 **/__pycache__
 static/build/**
+static/fonts/**
+static/webfonts/**
+static/ldn/**
+config_app/static/build/**
+config_app/static/fonts/**
+config_app/static/webfonts/**
+config_app/static/ldn/**
+src/**
 .gitlab-ci/*
 .gitlab-ci.*
 docker-compose.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 venv
+.venv*
 screenshots/screenshots/
 conf/stack
 */node_modules
@@ -9,6 +10,12 @@ node_modules
 static/ldn
 static/fonts
 static/build
+static/webfonts
+config_app/static/ldn
+config_app/static/fonts
+config_app/static/build
+config_app/static/webfonts
+src
 stack_local
 test/data/registry/
 GIT_HEAD

--- a/conf/gunicorn_healthy.py
+++ b/conf/gunicorn_healthy.py
@@ -1,0 +1,30 @@
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
+
+import logging
+
+from Crypto import Random
+from util.log import logfile_path
+from util.workers import get_worker_count
+
+
+logconfig = logfile_path(debug=False)
+
+bind = "unix:/tmp/gunicorn_healthy.sock"
+workers = get_worker_count("healthy", 2, minimum=2, maximum=32)
+worker_class = "gevent"
+pythonpath = "."
+preload_app = True
+
+
+def post_fork(server, worker):
+    # Reset the Random library to ensure it won't raise the "PID check failed." error after
+    # gunicorn forks.
+    Random.atfork()
+
+
+def when_ready(server):
+    logger = logging.getLogger(__name__)
+    logger.debug("Starting health gunicorn with %s workers and %s worker class", workers, worker_class)

--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -38,6 +38,7 @@ def default_services():
         "gunicorn-secscan": {"autostart": "true"},
         "gunicorn-verbs": {"autostart": "true"},
         "gunicorn-web": {"autostart": "true"},
+        "gunicorn-healthy": {"autostart": "false"},
         "ip-resolver-update-worker": {"autostart": "true"},
         "jwtproxy": {"autostart": "true"},
         "memcache": {"autostart": "true"},

--- a/conf/nginx/http-base.conf
+++ b/conf/nginx/http-base.conf
@@ -46,6 +46,9 @@ map $http_x_forwarded_proto $proper_scheme {
 upstream web_app_server {
     server unix:/tmp/gunicorn_web.sock fail_timeout=0;
 }
+upstream healthy_app_server {
+    server unix:/tmp/gunicorn_healthy.sock fail_timeout=0;
+}
 upstream jwtproxy_secscan {
     server unix:/tmp/jwtproxy_secscan.sock fail_timeout=0;
 }

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -25,6 +25,9 @@ location / {
 location /health {
     proxy_pass   http://healthy_app_server;
 }
+location /status {
+    proxy_pass   http://healthy_app_server;
+}
 
 location /push {
     proxy_pass   http://web_app_server;

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -22,6 +22,10 @@ location / {
     proxy_pass   http://web_app_server;
 }
 
+location /health {
+    proxy_pass   http://healthy_app_server;
+}
+
 location /push {
     proxy_pass   http://web_app_server;
     client_max_body_size 5M;

--- a/conf/supervisord.conf.jnj
+++ b/conf/supervisord.conf.jnj
@@ -208,6 +208,14 @@ autostart = {{ config['gunicorn-web']['autostart'] }}
 stdout_events_enabled = true
 stderr_events_enabled = true
 
+[program:gunicorn-healthy]
+environment=
+  PYTHONPATH=%(ENV_QUAYDIR)s
+command=gunicorn -c %(ENV_QUAYCONF)s/gunicorn_healthy.py healthy:application
+autostart = {{ config['gunicorn-healthy']['autostart'] }}
+stdout_events_enabled = true
+stderr_events_enabled = true
+
 [program:jwtproxy]
 command=/usr/local/bin/jwtproxy --config %(ENV_QUAYCONF)s/jwtproxy_conf.yaml
 autostart = {{ config['jwtproxy']['autostart'] }}

--- a/endpoints/healthy.py
+++ b/endpoints/healthy.py
@@ -1,0 +1,126 @@
+import os
+import logging
+
+from cachetools.func import lru_cache
+from flask import (
+    abort,
+    make_response,
+    Blueprint,
+    jsonify,
+    session,
+)
+
+import features
+
+from app import (
+    app,
+    config_provider,
+    instance_keys,
+)
+from auth.decorators import process_auth_or_cookie
+from data.database import db
+from endpoints.api.discovery import swagger_route_data
+from endpoints.common import render_page_template
+from endpoints.decorators import (
+    route_show_if,
+)
+from health.healthcheck import get_healthchecker
+from util.cache import no_cache
+from _init import ROOT_DIR
+
+
+PGP_KEY_MIMETYPE = "application/pgp-keys"
+
+
+@lru_cache(maxsize=1)
+def _get_route_data():
+    return swagger_route_data(include_internal=True, compact=True)
+
+
+def render_page_template_with_routedata(name, *args, **kwargs):
+    return render_page_template(name, _get_route_data(), *args, **kwargs)
+
+
+# Capture the unverified SSL errors.
+logger = logging.getLogger(__name__)
+logging.captureWarnings(True)
+
+healthy = Blueprint("healthy", __name__)
+
+STATUS_TAGS = app.config["STATUS_TAGS"]
+
+
+@healthy.route("/health", methods=["GET"])
+@healthy.route("/health/instance", methods=["GET"])
+@process_auth_or_cookie
+@no_cache
+def instance_health():
+    checker = get_healthchecker(app, config_provider, instance_keys)
+    (data, status_code) = checker.check_instance()
+    response = jsonify(dict(data=data, status_code=status_code))
+    response.status_code = status_code
+    return response
+
+
+@healthy.route("/status", methods=["GET"])
+@healthy.route("/health/endtoend", methods=["GET"])
+@process_auth_or_cookie
+@no_cache
+def endtoend_health():
+    checker = get_healthchecker(app, config_provider, instance_keys)
+    (data, status_code) = checker.check_endtoend()
+    response = jsonify(dict(data=data, status_code=status_code))
+    response.status_code = status_code
+    return response
+
+
+@healthy.route("/health/warning", methods=["GET"])
+@process_auth_or_cookie
+@no_cache
+def warning_health():
+    checker = get_healthchecker(app, config_provider, instance_keys)
+    (data, status_code) = checker.check_warning()
+    response = jsonify(dict(data=data, status_code=status_code))
+    response.status_code = status_code
+    return response
+
+
+@healthy.route("/health/dbrevision", methods=["GET"])
+@route_show_if(features.BILLING)  # Since this is only used in production.
+@process_auth_or_cookie
+@no_cache
+def dbrevision_health():
+    # Find the revision from the database.
+    result = db.execute_sql("select * from alembic_version limit 1").fetchone()
+    db_revision = result[0]
+
+    # Find the local revision from the file system.
+    with open(os.path.join(ROOT_DIR, "ALEMBIC_HEAD"), "r") as f:
+        local_revision = f.readline().split(" ")[0]
+
+    data = {
+        "db_revision": db_revision,
+        "local_revision": local_revision,
+    }
+
+    status_code = 200 if db_revision == local_revision else 400
+
+    response = jsonify(dict(data=data, status_code=status_code))
+    response.status_code = status_code
+    return response
+
+
+@healthy.route("/health/enabledebug/<secret>", methods=["GET"])
+@no_cache
+def enable_health_debug(secret):
+    if not secret:
+        abort(404)
+
+    if not app.config.get("ENABLE_HEALTH_DEBUG_SECRET"):
+        abort(404)
+
+    if app.config.get("ENABLE_HEALTH_DEBUG_SECRET") != secret:
+        abort(404)
+
+    session["health_debug"] = True
+    return make_response("Health check debug information enabled")

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -306,80 +306,80 @@ def privacy():
     return index("")
 
 
-@web.route("/health", methods=["GET"])
-@web.route("/health/instance", methods=["GET"])
-@process_auth_or_cookie
-@no_cache
-def instance_health():
-    checker = get_healthchecker(app, config_provider, instance_keys)
-    (data, status_code) = checker.check_instance()
-    response = jsonify(dict(data=data, status_code=status_code))
-    response.status_code = status_code
-    return response
+# @web.route("/health", methods=["GET"])
+# @web.route("/health/instance", methods=["GET"])
+# @process_auth_or_cookie
+# @no_cache
+# def instance_health():
+#     checker = get_healthchecker(app, config_provider, instance_keys)
+#     (data, status_code) = checker.check_instance()
+#     response = jsonify(dict(data=data, status_code=status_code))
+#     response.status_code = status_code
+#     return response
 
 
-@web.route("/status", methods=["GET"])
-@web.route("/health/endtoend", methods=["GET"])
-@process_auth_or_cookie
-@no_cache
-def endtoend_health():
-    checker = get_healthchecker(app, config_provider, instance_keys)
-    (data, status_code) = checker.check_endtoend()
-    response = jsonify(dict(data=data, status_code=status_code))
-    response.status_code = status_code
-    return response
+# @web.route("/status", methods=["GET"])
+# @web.route("/health/endtoend", methods=["GET"])
+# @process_auth_or_cookie
+# @no_cache
+# def endtoend_health():
+#     checker = get_healthchecker(app, config_provider, instance_keys)
+#     (data, status_code) = checker.check_endtoend()
+#     response = jsonify(dict(data=data, status_code=status_code))
+#     response.status_code = status_code
+#     return response
 
 
-@web.route("/health/warning", methods=["GET"])
-@process_auth_or_cookie
-@no_cache
-def warning_health():
-    checker = get_healthchecker(app, config_provider, instance_keys)
-    (data, status_code) = checker.check_warning()
-    response = jsonify(dict(data=data, status_code=status_code))
-    response.status_code = status_code
-    return response
+# @web.route("/health/warning", methods=["GET"])
+# @process_auth_or_cookie
+# @no_cache
+# def warning_health():
+#     checker = get_healthchecker(app, config_provider, instance_keys)
+#     (data, status_code) = checker.check_warning()
+#     response = jsonify(dict(data=data, status_code=status_code))
+#     response.status_code = status_code
+#     return response
 
 
-@web.route("/health/dbrevision", methods=["GET"])
-@route_show_if(features.BILLING)  # Since this is only used in production.
-@process_auth_or_cookie
-@no_cache
-def dbrevision_health():
-    # Find the revision from the database.
-    result = db.execute_sql("select * from alembic_version limit 1").fetchone()
-    db_revision = result[0]
+# @web.route("/health/dbrevision", methods=["GET"])
+# @route_show_if(features.BILLING)  # Since this is only used in production.
+# @process_auth_or_cookie
+# @no_cache
+# def dbrevision_health():
+#     # Find the revision from the database.
+#     result = db.execute_sql("select * from alembic_version limit 1").fetchone()
+#     db_revision = result[0]
 
-    # Find the local revision from the file system.
-    with open(os.path.join(ROOT_DIR, "ALEMBIC_HEAD"), "r") as f:
-        local_revision = f.readline().split(" ")[0]
+#     # Find the local revision from the file system.
+#     with open(os.path.join(ROOT_DIR, "ALEMBIC_HEAD"), "r") as f:
+#         local_revision = f.readline().split(" ")[0]
 
-    data = {
-        "db_revision": db_revision,
-        "local_revision": local_revision,
-    }
+#     data = {
+#         "db_revision": db_revision,
+#         "local_revision": local_revision,
+#     }
 
-    status_code = 200 if db_revision == local_revision else 400
+#     status_code = 200 if db_revision == local_revision else 400
 
-    response = jsonify(dict(data=data, status_code=status_code))
-    response.status_code = status_code
-    return response
+#     response = jsonify(dict(data=data, status_code=status_code))
+#     response.status_code = status_code
+#     return response
 
 
-@web.route("/health/enabledebug/<secret>", methods=["GET"])
-@no_cache
-def enable_health_debug(secret):
-    if not secret:
-        abort(404)
+# @web.route("/health/enabledebug/<secret>", methods=["GET"])
+# @no_cache
+# def enable_health_debug(secret):
+#     if not secret:
+#         abort(404)
 
-    if not app.config.get("ENABLE_HEALTH_DEBUG_SECRET"):
-        abort(404)
+#     if not app.config.get("ENABLE_HEALTH_DEBUG_SECRET"):
+#         abort(404)
 
-    if app.config.get("ENABLE_HEALTH_DEBUG_SECRET") != secret:
-        abort(404)
+#     if app.config.get("ENABLE_HEALTH_DEBUG_SECRET") != secret:
+#         abort(404)
 
-    session["health_debug"] = True
-    return make_response("Health check debug information enabled")
+#     session["health_debug"] = True
+#     return make_response("Health check debug information enabled")
 
 
 @web.route("/robots.txt", methods=["GET"])

--- a/healthy.py
+++ b/healthy.py
@@ -7,4 +7,5 @@ from app import app as application
 from endpoints.healthy import healthy
 
 
-application.register_blueprint(healthy, url_prefix="/health")
+#application.register_blueprint(healthy, url_prefix="/health")
+application.register_blueprint(healthy)

--- a/healthy.py
+++ b/healthy.py
@@ -1,0 +1,10 @@
+# NOTE: Must be before we import or call anything that may be synchronous.
+from gevent import monkey
+
+monkey.patch_all()
+
+from app import app as application
+from endpoints.healthy import healthy
+
+
+application.register_blueprint(healthy, url_prefix="/health")

--- a/web.py
+++ b/web.py
@@ -14,6 +14,7 @@ from endpoints.realtime import realtime
 from endpoints.web import web
 from endpoints.webhooks import webhooks
 from endpoints.wellknown import wellknown
+from endpoints.healthy import healthy
 
 
 application.register_blueprint(web)
@@ -26,3 +27,4 @@ application.register_blueprint(webhooks, url_prefix="/webhooks")
 application.register_blueprint(realtime, url_prefix="/realtime")
 application.register_blueprint(key_server, url_prefix="/keys")
 application.register_blueprint(wellknown, url_prefix="/.well-known")
+#application.register_blueprint(healthy, url_prefix="/health")


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/PROJQUAY-479

Split the /health endpoint into it's own endpoint and gunicorn process. This will allow it to be run standalone when gunicorn-web is not being run in container.