### PR TITLE
Fix wrong reference name in ClairSecurityScannerAPI

### DIFF
--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -127,7 +127,7 @@ class V4SecurityScanner(SecurityScannerInterface):
             )
 
         min_id = (
-            start_token
+            start_token.min_id
             if start_token is not None
             else Manifest.select(fn.Min(Manifest.id)).scalar()
         )

--- a/data/secscan_model/test/test_secscan_interface.py
+++ b/data/secscan_model/test/test_secscan_interface.py
@@ -47,7 +47,7 @@ def test_load_security_information(repository, v4_whitelist, initialized_db):
     "next_token, expected_next_token",
     [
         (None, SplitScanToken("v4", V4ScanToken(56))),
-        (SplitScanToken("v4", V4ScanToken(1)), SplitScanToken("v4", None)),
+        (SplitScanToken("v4", V4ScanToken(1)), SplitScanToken("v4", V4ScanToken(56))),
         (SplitScanToken("v4", None), SplitScanToken("v2", V2ScanToken(318))),
         (SplitScanToken("v2", V2ScanToken(318)), SplitScanToken("v2", None)),
         (SplitScanToken("v2", None), None),

--- a/util/secscan/v4/api.py
+++ b/util/secscan/v4/api.py
@@ -109,7 +109,7 @@ class ClairSecurityScannerAPI(SecurityScannerAPIInterface):
         assert isinstance(manifest, ManifestDataType) and not manifest.is_manifest_list
 
         uri_for = lambda layer: self._storage.get_direct_download_url(
-            self._storage.locations, l.blob.storage_path
+            self._storage.locations, layer.blob.storage_path
         )
         body = {
             "hash": manifest.digest,


### PR DESCRIPTION
### Description of Changes

* Fix a few references using the wrong name

#### Issue: https://issues.redhat.com/browse/PROJQUAY-620


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
