### PR TITLE
PROJQUAY-363 - Update Config App to Use apps/v1 Deployment 

### DIFF
--- a/config_app/config_util/k8saccessor.py
+++ b/config_app/config_util/k8saccessor.py
@@ -218,9 +218,7 @@ class KubernetesAccessorSingleton(object):
             self.kube_config.qe_deployment_selector,
         )
 
-        response = self._execute_k8s_api(
-            "GET", deployment_selector_url, api_prefix="apis/extensions/v1beta1"
-        )
+        response = self._execute_k8s_api("GET", deployment_selector_url, api_prefix="apis/apps/v1")
         if response.status_code != 200:
             return None
         return json.loads(response.text)
@@ -262,7 +260,7 @@ class KubernetesAccessorSingleton(object):
                             }
                         }
                     },
-                    api_prefix="apis/extensions/v1beta1",
+                    api_prefix="apis/apps/v1",
                     content_type="application/strategic-merge-patch+json",
                 )
             )
@@ -284,7 +282,7 @@ class KubernetesAccessorSingleton(object):
                         "revision": 0
                     },
                 },
-                api_prefix="apis/extensions/v1beta1",
+                api_prefix="apis/apps/v1",
             ),
             201,
         )

--- a/config_app/config_util/test/test_k8saccessor.py
+++ b/config_app/config_util/test/test_k8saccessor.py
@@ -122,17 +122,17 @@ def test_deployment_rollout_status_message(deployment_object, expected_status, e
     [
         (
             {"api_host": "www.customhost.com"},
-            "/apis/extensions/v1beta1/namespaces/quay-enterprise/deployments",
+            "/apis/apps/v1/namespaces/quay-enterprise/deployments",
             "labelSelector=quay-enterprise-component%3Dapp",
         ),
         (
             {"api_host": "www.customhost.com", "qe_deployment_selector": "custom-selector"},
-            "/apis/extensions/v1beta1/namespaces/quay-enterprise/deployments",
+            "/apis/apps/v1/namespaces/quay-enterprise/deployments",
             "labelSelector=quay-enterprise-component%3Dcustom-selector",
         ),
         (
             {"api_host": "www.customhost.com", "qe_namespace": "custom-namespace"},
-            "/apis/extensions/v1beta1/namespaces/custom-namespace/deployments",
+            "/apis/apps/v1/namespaces/custom-namespace/deployments",
             "labelSelector=quay-enterprise-component%3Dapp",
         ),
         (
@@ -141,7 +141,7 @@ def test_deployment_rollout_status_message(deployment_object, expected_status, e
                 "qe_namespace": "custom-namespace",
                 "qe_deployment_selector": "custom-selector",
             },
-            "/apis/extensions/v1beta1/namespaces/custom-namespace/deployments",
+            "/apis/apps/v1/namespaces/custom-namespace/deployments",
             "labelSelector=quay-enterprise-component%3Dcustom-selector",
         ),
     ],
@@ -171,14 +171,14 @@ def test_get_qe_deployments(kube_config, expected_api, expected_query):
         (
             {"api_host": "www.customhost.com"},
             ["myDeployment"],
-            ["/apis/extensions/v1beta1/namespaces/quay-enterprise/deployments/myDeployment"],
+            ["/apis/apps/v1/namespaces/quay-enterprise/deployments/myDeployment"],
         ),
         (
             {"api_host": "www.customhost.com", "qe_namespace": "custom-namespace"},
             ["myDeployment", "otherDeployment"],
             [
-                "/apis/extensions/v1beta1/namespaces/custom-namespace/deployments/myDeployment",
-                "/apis/extensions/v1beta1/namespaces/custom-namespace/deployments/otherDeployment",
+                "/apis/apps/v1/namespaces/custom-namespace/deployments/myDeployment",
+                "/apis/apps/v1/namespaces/custom-namespace/deployments/otherDeployment",
             ],
         ),
     ],


### PR DESCRIPTION
### Description

The `Deployment` resource was removed from the `extensions/v1beta1` APIGroup in Kubernetes 1.16. 

Fixes https://issues.redhat.com/browse/PROJQUAY-363