### PR TITLE
Ensure Security Scanning Works Without Clair V4

### DIFF
--- a/config.py
+++ b/config.py
@@ -455,7 +455,7 @@ class DefaultConfig(ImmutableConfig):
     SECURITY_SCANNER_ENDPOINT = "http://192.168.99.101:6060"
 
     # The endpoint for the V4 security scanner.
-    SECURITY_SCANNER_V4_ENDPOINT = "http://192.168.99.101:6060"
+    SECURITY_SCANNER_V4_ENDPOINT = None
 
     # The number of seconds between indexing intervals in the security scanner
     SECURITY_SCANNER_INDEXING_INTERVAL = 30

--- a/data/secscan_model/interface.py
+++ b/data/secscan_model/interface.py
@@ -4,6 +4,12 @@ from six import add_metaclass
 from deprecated import deprecated
 
 
+class InvalidConfigurationException(Exception):
+    """
+    Exception raised when attempting to initialize a secscan model fails.
+    """
+
+
 @add_metaclass(ABCMeta)
 class SecurityScannerInterface(object):
     """

--- a/data/secscan_model/test/test_secscan_interface.py
+++ b/data/secscan_model/test/test_secscan_interface.py
@@ -18,6 +18,25 @@ from app import app, instance_keys, storage
 
 @pytest.mark.parametrize(
     "repository, v4_whitelist",
+    [(("devtable", "complex"), []), (("devtable", "complex"), ["devtable"]),],
+)
+def test_load_security_information_v2_only(repository, v4_whitelist, initialized_db):
+    app.config["SECURITY_SCANNER_V4_NAMESPACE_WHITELIST"] = v4_whitelist
+
+    secscan_model.configure(app, instance_keys, storage)
+
+    repo = registry_model.lookup_repository(*repository)
+    for tag in registry_model.list_all_active_repository_tags(repo):
+        manifest = registry_model.get_manifest_for_tag(tag)
+        assert manifest
+
+        result = secscan_model.load_security_information(manifest, True)
+        assert isinstance(result, SecurityInformationLookupResult)
+        assert result.status == ScanLookupStatus.NOT_YET_INDEXED
+
+
+@pytest.mark.parametrize(
+    "repository, v4_whitelist",
     [
         (("devtable", "complex"), []),
         (("devtable", "complex"), ["devtable"]),
@@ -28,6 +47,7 @@ from app import app, instance_keys, storage
 )
 def test_load_security_information(repository, v4_whitelist, initialized_db):
     app.config["SECURITY_SCANNER_V4_NAMESPACE_WHITELIST"] = v4_whitelist
+    app.config["SECURITY_SCANNER_V4_ENDPOINT"] = "http://clairv4:6060"
     secscan_api = Mock()
 
     with patch("data.secscan_model.secscan_v4_model.ClairSecurityScannerAPI", secscan_api):
@@ -46,6 +66,26 @@ def test_load_security_information(repository, v4_whitelist, initialized_db):
 @pytest.mark.parametrize(
     "next_token, expected_next_token",
     [
+        (None, SplitScanToken("v4", None)),
+        (SplitScanToken("v4", V4ScanToken(1)), SplitScanToken("v4", None)),
+        (SplitScanToken("v4", None), SplitScanToken("v2", V2ScanToken(318))),
+        (SplitScanToken("v2", V2ScanToken(318)), SplitScanToken("v2", None)),
+        (SplitScanToken("v2", None), None),
+    ],
+)
+def test_perform_indexing_v2_only(next_token, expected_next_token, initialized_db):
+    def layer_analyzer(*args, **kwargs):
+        return Mock()
+
+    with patch("util.secscan.analyzer.LayerAnalyzer", layer_analyzer):
+        secscan_model.configure(app, instance_keys, storage)
+
+        assert secscan_model.perform_indexing(next_token) == expected_next_token
+
+
+@pytest.mark.parametrize(
+    "next_token, expected_next_token",
+    [
         (None, SplitScanToken("v4", V4ScanToken(56))),
         (SplitScanToken("v4", V4ScanToken(1)), SplitScanToken("v4", V4ScanToken(56))),
         (SplitScanToken("v4", None), SplitScanToken("v2", V2ScanToken(318))),
@@ -55,6 +95,7 @@ def test_load_security_information(repository, v4_whitelist, initialized_db):
 )
 def test_perform_indexing(next_token, expected_next_token, initialized_db):
     app.config["SECURITY_SCANNER_V4_NAMESPACE_WHITELIST"] = ["devtable"]
+    app.config["SECURITY_SCANNER_V4_ENDPOINT"] = "http://clairv4:6060"
 
     def secscan_api(*args, **kwargs):
         api = Mock()

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -688,7 +688,7 @@ CONFIG_SCHEMA = {
             "x-example": "http://192.168.99.101:6060",
         },
         "SECURITY_SCANNER_V4_ENDPOINT": {
-            "type": "string",
+            "type": ["string", "null"],
             "pattern": "^http(s)?://(.)+$",
             "description": "The endpoint for the V4 security scanner",
             "x-example": "http://192.168.99.101:6060",


### PR DESCRIPTION
### Description

The logic in the secscan model prevented indexing or retrieving vulnerability information for manifests when Quay was configured without Clair v4. Changes the logic to skip model splitting and adds tests.

### Changes

- Adds no-op implementations for `V2SecurityScanner` and `V4SecurityScanner` which are used if either are not configured (properly)
- Adds tests to ensure no-op implementations work 

Fixes https://issues.redhat.com/browse/PROJQUAY-662
Fixes https://issues.redhat.com/browse/PROJQUAY-640