### PR TITLE
Remove assertion that repos exists

### DIFF
--- a/data/appr_model/tag.py
+++ b/data/appr_model/tag.py
@@ -131,9 +131,6 @@ def get_most_recent_tag_lifetime_start(repository_ids, models_ref, tag_kind="rel
     Returns a map from repo ID to the timestamp of the most recently pushed alive tag for each
     specified repository or None if none.
     """
-
-    assert len(repository_ids) > 0 and None not in repository_ids
-
     Tag = models_ref.Tag
     tag_kind_id = Tag.tag_kind.get_id(tag_kind)
     tags = tag_is_alive(


### PR DESCRIPTION
The previous aersion would just fail when there is no app repos in
the database.


### Description of Changes

* details about the implementation of the changes
* motivation for the change (broken code, new feature, etc)
* contrast with previous behavior


#### Changes:

* ..
* ..

#### Issue: <link to story or task>


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
