### PR TITLE
Add check for no repos when getting recent tags

### DIFF
--- a/data/appr_model/tag.py
+++ b/data/appr_model/tag.py
@@ -131,6 +131,11 @@ def get_most_recent_tag_lifetime_start(repository_ids, models_ref, tag_kind="rel
     Returns a map from repo ID to the timestamp of the most recently pushed alive tag for each
     specified repository or None if none.
     """
+    if not repository_ids:
+        return {}
+
+    assert len(repository_ids) > 0 and None not in repository_ids
+
     Tag = models_ref.Tag
     tag_kind_id = Tag.tag_kind.get_id(tag_kind)
     tags = tag_is_alive(

--- a/data/appr_model/test/test_appr_tag.py
+++ b/data/appr_model/test/test_appr_tag.py
@@ -1,0 +1,10 @@
+from data.appr_model import tag as apprtags_model
+from data.appr_model.tag import get_most_recent_tag_lifetime_start
+from endpoints.appr.models_cnr import model as appr_model
+
+from test.fixtures import *
+
+
+def test_empty_get_most_recent_tag_lifetime_start(initialized_db):
+    tags = apprtags_model.get_most_recent_tag_lifetime_start([], appr_model.models_ref)
+    assert isinstance(tags, dict) and len(tags) == 0

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -198,6 +198,9 @@ def get_most_recent_tag_lifetime_start(repository_ids):
     Returns a map from repo ID to the timestamp of the most recently pushed alive tag for each
     specified repository or None if none.
     """
+    if not repository_ids:
+        return {}
+
     assert len(repository_ids) > 0 and None not in repository_ids
 
     query = (

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -69,6 +69,9 @@ def test_get_most_recent_tag_lifetime_start(initialized_db):
         tags = get_most_recent_tag_lifetime_start([repo])
         assert tags[repo.id] == tag.lifetime_start_ms
 
+    no_tags = get_most_recent_tag_lifetime_start([])
+    assert isinstance(no_tags, dict) and len(no_tags) == 0
+
 
 def test_get_most_recent_tag(initialized_db):
     repo = get_repository("outsideorg", "coolrepo")


### PR DESCRIPTION
Add an extra check and return an empty dict if no repo is given.
The assertion is needed because `Tag.repository << [rid for rid in
repository_ids]` will fail on MySQL if the list is empty.

#### Issue: https://issues.redhat.com/browse/PROJQUAY-667


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
