### PR TITLE
LDAP: Defined found_results before try block so it's always assigned

### DIFF
--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -442,6 +442,7 @@ class LDAPUsers(FederatedUsers):
                     break
 
                 while True:
+                    found_results = 0
                     try:
                         if has_pagination:
                             _, rdata, _, serverctrls = conn.result3(msgid)
@@ -449,7 +450,6 @@ class LDAPUsers(FederatedUsers):
                             _, rdata = conn.result(msgid)
 
                         # Yield any users found.
-                        found_results = 0
                         for userdata in rdata:
                             found_results = found_results + 1
                             yield self._build_user_information(userdata[1])


### PR DESCRIPTION
### Description of Changes
Up until now, the "if not found_results" line could throw an UnboundLocalError because the variable was assigned inside a try block which could fail with the variable never assigned.
