### PR TITLE
fix value for DB_CONNECTION_POOLING

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -427,4 +427,4 @@ parameters:
     displayName: aws load balancer connection idle timeout
     description: aws load balancer connection idle timeout
   - name: DB_CONNECTION_POOLING
-    value: false
+    value: "false"

--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -427,4 +427,4 @@ parameters:
     displayName: aws load balancer connection idle timeout
     description: aws load balancer connection idle timeout
   - name: DB_CONNECTION_POOLING
-    value: "false"
+    value: "true"


### PR DESCRIPTION
fixes:
```
error: failed to read input object (not a Template?): unable to decode "./quay-templates/quay.yaml": v1.Template.Parameters: []v1.Parameter: v1.Parameter.Value: ReadString: expects " or n, but found f, error found in #10 byte of ...|,"value":false}]}|..., bigger context ...|:"3600"},{"name":"DB_CONNECTION_POOLING","value":false}]}
```

https://ci-int-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/quayio/job/quay-quay-gh-build-master/246/console