### PR TITLE
[wip] Return 201 on application creation

### DIFF
--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -636,7 +636,7 @@ class OrganizationApplications(ApiResource):
 
             log_action("create_application", orgname, app_data)
 
-            return app_view(application)
+            return app_view(application), 201
         raise Unauthorized()
 
 


### PR DESCRIPTION
### Description of Changes

* On application creation via API, return a 201 response
* Documentation and convention reflect that a 201 should be returned when a resource is created
* Previously, a 200 was returned
* I do not know what changes would be required, if any, in the JS for the front-end to reflect this change.
* If you think there should be a regression test, I can dig into your tests to implement it if you would like. I have, admittedly, not looked at it at all.

#### Changes:

* Application creation now returns a 201 HTTP response code via the API

#### Issue: https://issues.redhat.com/browse/PROJQUAY-726


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
