### PR TITLE
PROJQUAY-719 - config app install extra certs

### DIFF
--- a/quay-entrypoint.sh
+++ b/quay-entrypoint.sh
@@ -59,6 +59,7 @@ case "$QUAYENTRY" in
         printf '%s' "${CONFIG_APP_PASSWORD}" | openssl passwd -apr1 -stdin >> "$QUAYDIR/config_app/conf/htpasswd"
 
         "${QUAYPATH}/config_app/init/certs_create.sh" || exit
+        "${QUAYPATH}/conf/init/certs_install.sh" || exit
         exec supervisord -c "${QUAYPATH}/config_app/conf/supervisord.conf" 2>&1
         ;;
     "migrate")


### PR DESCRIPTION
https://issues.redhat.com/browse/PROJQUAY-719

This change will install certs if they exist in /conf/stack/extra_ca_certs. This allows an LDAP cert to be included at container startup for setup.