### PR TITLE
Removed logging of 'service_key_create' and 'service_key_approve'

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -116,6 +116,7 @@ While we're here, let's set up a directory to hold image blobs:
 
 ```
 $ mkdir $QUAY/storage
+$ setfacl -m u:1001:-wx $QUAY/storage
 ```
 
 Stop the Config Tool with `CTRL-C` (or `podman stop` depending on how you ran it)- we won't need it anymore.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -116,7 +116,6 @@ While we're here, let's set up a directory to hold image blobs:
 
 ```
 $ mkdir $QUAY/storage
-$ setfacl -m u:1001:-wx $QUAY/storage
 ```
 
 Stop the Config Tool with `CTRL-C` (or `podman stop` depending on how you ran it)- we won't need it anymore.

--- a/util/generatepresharedkey.py
+++ b/util/generatepresharedkey.py
@@ -22,18 +22,6 @@ def generate_key(service, name, expiration_date=None, notes=None):
         key.kid, ServiceKeyApprovalType.AUTOMATIC, notes=notes or ""
     )
 
-    # Log the creation and auto-approval of the service key.
-    key_log_metadata = {
-        "kid": key.kid,
-        "preshared": True,
-        "service": service,
-        "name": name,
-        "expiration_date": expiration_date,
-        "auto_approved": True,
-    }
-
-    logs_model.log_action("service_key_create", metadata=key_log_metadata)
-    logs_model.log_action("service_key_approve", metadata=key_log_metadata)
     return private_key, key.kid
 
 


### PR DESCRIPTION
### Description of Changes

- Removed logging of 'service_key_create()' and 'service_key_approve()'
- Fixed peewee account_id no-null constraint caused by this logging

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
