### PR TITLE
Fixed repo list showing 'null' for state in api

### DIFF
--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -265,6 +265,7 @@ def get_visible_repositories(
             Namespace.username,
             Repository.visibility,
             Repository.kind,
+            Repository.state,
         )
         .switch(Repository)
         .join(Namespace, on=(Repository.namespace_user == Namespace.id))

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -116,6 +116,7 @@ While we're here, let's set up a directory to hold image blobs:
 
 ```
 $ mkdir $QUAY/storage
+$ setfacl -m u:1001:-wx $QUAY/storage
 ```
 
 Stop the Config Tool with `CTRL-C` (or `podman stop` depending on how you ran it)- we won't need it anymore.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -116,7 +116,6 @@ While we're here, let's set up a directory to hold image blobs:
 
 ```
 $ mkdir $QUAY/storage
-$ setfacl -m u:1001:-wx $QUAY/storage
 ```
 
 Stop the Config Tool with `CTRL-C` (or `podman stop` depending on how you ran it)- we won't need it anymore.

--- a/endpoints/api/test/test_repository.py
+++ b/endpoints/api/test/test_repository.py
@@ -68,6 +68,15 @@ def test_list_starred_repos(client):
         assert "public/publicrepo" not in repos
 
 
+def test_list_repos(client, initialized_db):
+    with client_with_identity("devtable", client) as cl:
+        params = {"starred": "true", "repo_kind": "application"}
+        response = conduct_api_call(cl, RepositoryList, "GET", params).json
+        repo_states = {r["state"] for r in response["repositories"]}
+        for state in repo_states:
+            assert state in ["NORMAL", "MIRROR", "READ_ONLY", "MARKED_FOR_DELETION"]
+
+
 def test_list_starred_app_repos(client, initialized_db):
     with client_with_identity("devtable", client) as cl:
         params = {"starred": "true", "repo_kind": "application"}
@@ -170,6 +179,7 @@ def test_get_repo(has_tag_manifest, client, initialized_db):
         params = {"repository": "devtable/simple"}
         response = conduct_api_call(cl, Repository, "GET", params).json
         assert response["kind"] == "image"
+        assert response["state"] in ["NORMAL", "MIRROR", "READ_ONLY", "MARKED_FOR_DELETION"]
 
 
 def test_get_app_repo(client, initialized_db):


### PR DESCRIPTION
### Description of Changes

- Added Repository.state to query to return in api call to list repos
- Added check for state in test_get_repo
- Added api test for listRepos endpoint
## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
