### PR TITLE
Fix Unknown Provider AngularJS Errors

### DIFF
--- a/static/js/directives/ui/build-log-error.js
+++ b/static/js/directives/ui/build-log-error.js
@@ -15,7 +15,7 @@ angular.module('quay').directive('buildLogError', function () {
     },
     controller: function($scope, $element, Config, DocumentationService) {
       $scope.localPullInfo = null;
-      $sope.DocumentationService = DocumentationService;
+      $scope.DocumentationService = DocumentationService;
 
       var calculateLocalPullInfo = function(entries) {
         var localInfo = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,7 @@ if (process.env.NODE_ENV === 'production') {
   config.optimization.minimizer = [
     new TerserPlugin({
       // Disable mangle to prevent AngularJS errors
-      terserOptions: {mangle: false},
+      terserOptions: {mangle: false, keep_classnames: true, keep_fnames: true},
       sourceMap: true,
     }),
   ];


### PR DESCRIPTION
### Description

Add the right [minification flags](https://github.com/terser/terser#minify-options) to Webpack's `TerserPlugin` to fix `unknown provider` error:
```
angular.min.js-f0f4228b82f7.js:116 Error: [$injector:unpr] http://errors.angularjs.org/1.5.3/$injector/unpr?p0=DocumentationServiceProvider%20%3C-%20DocumentationService%20%3C-%20ExternalNotificationData
```

Fixes https://issues.redhat.com/browse/PROJQUAY-732
Fixes https://issues.redhat.com/browse/PROJQUAY-733
Fixes https://issues.redhat.com/browse/PROJQUAY-734