### PR TITLE
add ServiceAccount with imagePullSecrets

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -34,6 +34,12 @@ objects:
     - patch
     - update
     - watch
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ${{NAME}}
+  imagePullSecrets:
+  - name: quayio-backup-image-pull-secret
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: RoleBinding
   metadata:
@@ -44,7 +50,7 @@ objects:
     name: ${{NAME}}
   subjects:
   - kind: ServiceAccount
-    name: default
+    name: ${{NAME}}
 - apiVersion: v1
   kind: Service
   metadata:
@@ -144,6 +150,7 @@ objects:
         - name: configvolume
           secret:
             secretName: ${{QUAY_APP_CONFIG_SECRET}}
+        serviceAccountName: ${{NAME}}
         containers:
         - name: syslog-cloudwatch-bridge
           image:  ${SYSLOG_IMAGE}:${SYSLOG_IMAGE_TAG}


### PR DESCRIPTION
In order to be able to pull a private image, we need a ServiceAccount that mounts an image pull secret.

this secret already exists in all namespaces.

this PR is safe to merge after https://gitlab.cee.redhat.com/service/app-interface/merge_requests/5183

cc @josephschorr @tparikh 