### PR TITLE
[PROJQUAY-480]  Add Prometheus Gauge for number of Gunicorn workers

### DIFF
--- a/conf/gunicorn_local.py
+++ b/conf/gunicorn_local.py
@@ -6,6 +6,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 import logging
 
 from Crypto import Random
+from prometheus_client import Gauge
+
 from util.log import logfile_path
 from util.workers import get_worker_count, get_worker_connections_count
 
@@ -20,6 +22,13 @@ pythonpath = "."
 preload_app = True
 
 
+prometheus_workers_gauge = Gauge(
+    "quay_gunicorn_workers",
+    "number of gunicorn workers handling all endpoints for development purposes",
+    labelnames=["gunicorn_workers"],
+)
+
+
 def post_fork(server, worker):
     # Reset the Random library to ensure it won't raise the "PID check failed." error after
     # gunicorn forks.
@@ -31,3 +40,14 @@ def when_ready(server):
     logger.debug(
         "Starting local gunicorn with %s workers and %s worker class", workers, worker_class
     )
+
+
+def nworkers_changed(server, new_value, old_value):
+    """
+    Called when the number of gunicorn workers is changed.
+    NOTE: old_value=None the first time this is called.
+    """
+    prometheus_workers_gauge.labels("local").set(new_value)
+    logger = logging.getLogger(__name__)
+    msg = "Changed gunicorn worker count from %s to %s" % (old_value, new_value)
+    logging.debug(msg)

--- a/conf/gunicorn_registry.py
+++ b/conf/gunicorn_registry.py
@@ -6,6 +6,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 import logging
 
 from Crypto import Random
+from prometheus_client import Gauge
+
 from util.log import logfile_path
 from util.workers import get_worker_count, get_worker_connections_count
 
@@ -19,6 +21,13 @@ pythonpath = "."
 preload_app = True
 
 
+prometheus_workers_gauge = Gauge(
+    "quay_gunicorn_workers",
+    "number of gunicorn workers handling the registry endpoints",
+    labelnames=["gunicorn_workers"],
+)
+
+
 def post_fork(server, worker):
     # Reset the Random library to ensure it won't raise the "PID check failed." error after
     # gunicorn forks.
@@ -30,3 +39,14 @@ def when_ready(server):
     logger.debug(
         "Starting registry gunicorn with %s workers and %s worker class", workers, worker_class
     )
+
+
+def nworkers_changed(server, new_value, old_value):
+    """
+    Called when the number of gunicorn workers is changed.
+    NOTE: old_value=None the first time this is called.
+    """
+    prometheus_workers_gauge.labels("registry").set(new_value)
+    logger = logging.getLogger(__name__)
+    msg = "Changed gunicorn worker count from %s to %s" % (old_value, new_value)
+    logging.debug(msg)

--- a/conf/gunicorn_secscan.py
+++ b/conf/gunicorn_secscan.py
@@ -6,6 +6,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 import logging
 
 from Crypto import Random
+from prometheus_client import Gauge
+
 from util.log import logfile_path
 from util.workers import get_worker_count, get_worker_connections_count
 
@@ -19,6 +21,13 @@ pythonpath = "."
 preload_app = True
 
 
+prometheus_workers_gauge = Gauge(
+    "quay_gunicorn_workers",
+    "number of gunicorn workers handling the security scanning endpoints",
+    labelnames=["gunicorn_workers"],
+)
+
+
 def post_fork(server, worker):
     # Reset the Random library to ensure it won't raise the "PID check failed." error after
     # gunicorn forks.
@@ -30,3 +39,14 @@ def when_ready(server):
     logger.debug(
         "Starting secscan gunicorn with %s workers and %s worker class", workers, worker_class
     )
+
+
+def nworkers_changed(server, new_value, old_value):
+    """
+    Called when the number of gunicorn workers is changed.
+    NOTE: old_value=None the first time this is called.
+    """
+    prometheus_workers_gauge.labels("secscan").set(new_value)
+    logger = logging.getLogger(__name__)
+    msg = "Changed gunicorn worker count from %s to %s" % (old_value, new_value)
+    logging.debug(msg)

--- a/conf/gunicorn_verbs.py
+++ b/conf/gunicorn_verbs.py
@@ -6,6 +6,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 import logging
 
 from Crypto import Random
+from prometheus_client import Gauge
+
 from util.log import logfile_path
 from util.workers import get_worker_count, get_worker_connections_count
 
@@ -19,6 +21,13 @@ preload_app = True
 timeout = 2000  # Because sync workers
 
 
+prometheus_workers_gauge = Gauge(
+    "quay_gunicorn_workers",
+    "number of gunicorn workers handling the verb endpoints",
+    labelnames=["gunicorn_workers"],
+)
+
+
 def post_fork(server, worker):
     # Reset the Random library to ensure it won't raise the "PID check failed." error after
     # gunicorn forks.
@@ -28,3 +37,14 @@ def post_fork(server, worker):
 def when_ready(server):
     logger = logging.getLogger(__name__)
     logger.debug("Starting verbs gunicorn with %s workers and sync worker class", workers)
+
+
+def nworkers_changed(server, new_value, old_value):
+    """
+    Called when the number of gunicorn workers is changed.
+    NOTE: old_value=None the first time this is called.
+    """
+    prometheus_workers_gauge.labels("verbs").set(new_value)
+    logger = logging.getLogger(__name__)
+    msg = "Changed gunicorn worker count from %s to %s" % (old_value, new_value)
+    logging.debug(msg)

--- a/conf/gunicorn_web.py
+++ b/conf/gunicorn_web.py
@@ -6,6 +6,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 import logging
 
 from Crypto import Random
+from prometheus_client import Gauge
+
 from util.log import logfile_path
 from util.workers import get_worker_count, get_worker_connections_count
 
@@ -20,6 +22,13 @@ pythonpath = "."
 preload_app = True
 
 
+prometheus_workers_gauge = Gauge(
+    "quay_gunicorn_workers",
+    "number of gunicorn workers handling the web endpoints",
+    labelnames=["gunicorn_workers"],
+)
+
+
 def post_fork(server, worker):
     # Reset the Random library to ensure it won't raise the "PID check failed." error after
     # gunicorn forks.
@@ -29,3 +38,14 @@ def post_fork(server, worker):
 def when_ready(server):
     logger = logging.getLogger(__name__)
     logger.debug("Starting web gunicorn with %s workers and %s worker class", workers, worker_class)
+
+
+def nworkers_changed(server, new_value, old_value):
+    """
+    Called when the number of gunicorn workers is changed.
+    NOTE: old_value=None the first time this is called.
+    """
+    prometheus_workers_gauge.labels("web").set(new_value)
+    logger = logging.getLogger(__name__)
+    msg = "Changed gunicorn worker count from %s to %s" % (old_value, new_value)
+    logging.debug(msg)


### PR DESCRIPTION
### Description of Changes

- A new Prometheus Gauge is added to keep tabs on the count of the quantity of gunicorn workers for each gunicorn parent process.
- Each time the quantity is changed (e.g. if it scales up), then the quantity is updated automatically.

NOTE: This may _not_ include defunct/zombie/orphaned processes. This relies on gunicorn's built-in hook to produce this value. As it relies upon the gunicorn hook, it is also not providing that value to the health-check.

#### Changes:

- New metric for `quay_gunicorn_workers` is now available

#### Issue:

- https://issues.redhat.com/browse/PROJQUAY-480

**TESTING** ->

- Start Quay
- Verify that `quay_gunicorn_workers` metrics are available

**BREAKING CHANGE** 

n/a

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
