### PR TITLE
OpenShift deploy template updates for log shipper

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -86,22 +86,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    name: quay-loadbalancer-service
-    annotations:
-      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: ${AWS_LOAD_BALANCER_CONNECTION_IDLE_TIMEOUT}
-  spec:
-    ports:
-    - name: loadbalancer
-      protocol: TCP
-      port: ${{LOADBALANCER_SERVICE_PORT}}
-      targetPort: ${{LOADBALANCER_SERVICE_TARGET_PORT}}
-    loadBalancerIP:
-    type: LoadBalancer
-    selector:
-      ${{QUAY_APP_COMPONENT_LABEL_KEY}}: ${{QUAY_APP_COMPONENT_LABEL_VALUE}}
-- apiVersion: v1
-  kind: Service
-  metadata:
     name: quay-load-balancer-proxy-protocol-service
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: ${AWS_LOAD_BALANCER_CONNECTION_IDLE_TIMEOUT}
@@ -162,6 +146,13 @@ objects:
             protocol: TCP
             name: syslog-tcp-port
           env:
+          - name: STREAM_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: TICKER_TIME
+            value: ${TICKER_TIME}
           - name: PORT
             value: ${SYSLOG_PORT}
           - name: AWS_REGION
@@ -434,3 +425,6 @@ parameters:
     description: aws load balancer connection idle timeout
   - name: DB_CONNECTION_POOLING
     value: "true"
+  - name: TICKER_TIME
+    value: "200"
+


### PR DESCRIPTION
This PR removes load balancer service that is no longer used. It also sets log stream name to pod name and makes ticker for syslog configurable.


