### PR TITLE
[PROJQUAY-775] [PROJQUAY-759] Expose gunicorn and zombie processes

### DIFF
--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -45,6 +45,7 @@ def default_services():
         "pushgateway": {"autostart": "true"},
         "servicekey": {"autostart": "true"},
         "repomirrorworker": {"autostart": "false"},
+        "localpromstatsworker": {"autostart": "true"},
     }
 
 

--- a/conf/supervisord.conf.jnj
+++ b/conf/supervisord.conf.jnj
@@ -249,4 +249,13 @@ command=python -m workers.repomirrorworker.repomirrorworker
 autostart = {{ config['repomirrorworker']['autostart'] }}
 stdout_events_enabled = true
 stderr_events_enabled = true
+
+[program:localpromstatsworker]
+environment=
+  PYTHONPATH=%(ENV_QUAYDIR)s
+command=python -m workers.localpromstats
+autostart = {{ config['localpromstatsworker']['autostart'] }}
+stdout_events_enabled = true
+stderr_events_enabled = true
+
 # EOF NO NEWLINE

--- a/config.py
+++ b/config.py
@@ -736,3 +736,12 @@ class DefaultConfig(ImmutableConfig):
 
     # Feature Flag: Whether the repository action count worker is enabled.
     FEATURE_REPOSITORY_ACTION_COUNTER = True
+
+    # Determines if localpromstats worker should run.
+    FEATURE_REPORT_PROMETHEUS_STATS = False
+
+    # Maximum number of zombie/defunct processes allowed to exist before health-check should fail
+    MAX_DEFUNCT_PROCESS_COUNT = 0
+
+    # Dictates how often local statistics data should be reported to prometheus. (Seconds)
+    LOCAL_PROMETHEUS_STATS_FREQUENCY = 60

--- a/health/processes.py
+++ b/health/processes.py
@@ -1,0 +1,20 @@
+import logging
+
+import psutil
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_gunicorn_processes():
+    """
+    Return all gunicorn processes running within the current system or namespace.
+    """
+    return [p for p in psutil.process_iter() if p.name() == "gunicorn"]
+
+
+def get_all_zombies():
+    """
+    Return all defunct (zombie) processes within the current system or namespace.
+    """
+    return [p for p in psutil.process_iter() if p.status() == "zombie"]

--- a/health/test/test_processes.py
+++ b/health/test/test_processes.py
@@ -1,0 +1,54 @@
+import mock
+
+from health.processes import get_gunicorn_processes, get_all_zombies
+
+
+@mock.patch("health.processes.psutil")
+def test_get_gunicorn_processes(mock_psutil):
+    """
+    Verify that get_gunicorn_processes only returns gunicorn processes or an empty list.
+    """
+
+    p1 = mock.Mock()
+    p1.name.return_value = "gunicorn"
+    p1.status.return_value = "running"
+
+    p2 = mock.Mock()
+    p2.name.return_value = "not_gunicorn"
+    p2.status.return_value = "running"
+
+    p3 = mock.Mock()
+    p3.name.return_value = "gunicorn"
+    p3.status.return_value = "zombie"
+
+    mock_psutil.process_iter.return_value = (p for p in (p1, p2, p3))
+
+    # Only includes processes named "gunicorn"
+    assert get_gunicorn_processes() == [p1, p3]
+    assert p2 not in get_gunicorn_processes()
+
+
+@mock.patch("health.processes.psutil")
+def test_get_all_zombies(mock_psutil):
+    """
+    Verify that get_all_zombies only returns processes which are known to psutil to be zombies.
+    """
+
+    p1 = mock.Mock()
+    p1.name.return_value = "gunicorn"
+    p1.status.return_value = "running"
+
+    p2 = mock.Mock()
+    p2.name.return_value = "not_gunicorn"
+    p2.status.return_value = "running"
+
+    p3 = mock.Mock()
+    p3.name.return_value = "gunicorn"
+    p3.status.return_value = "zombie"
+
+    mock_psutil.process_iter.return_value = (p for p in (p1, p2, p3))
+
+    # Only includes processes with the zombie state
+    assert get_all_zombies() == [p3]
+    assert p2 not in get_all_zombies()
+    assert p1 not in get_all_zombies()

--- a/health/test/test_services.py
+++ b/health/test/test_services.py
@@ -1,0 +1,27 @@
+import mock
+
+import pytest
+
+from health.services import _check_zombie_process_count
+from test.fixtures import *
+from test.testconfig import TestConfig
+
+
+@mock.patch("health.services.get_all_zombies")
+def test_check_zombie_process_count(mock_get_all_zombies, app):
+    """
+    Verifies the correct status is returned given a quantity of Zombies.
+    """
+    mock_get_all_zombies.return_value = ["p1", "p2"]
+
+    # Verify default threshold
+    app.config.from_object(TestConfig())  # Includes the default for MAX_DEFUNCT_PROCESS_COUNT
+    assert _check_zombie_process_count(app) == (False, "Found 2 zombie processes.")
+
+    # Too many zombies
+    app.config["MAX_DEFUNCT_PROCESS_COUNT"] = 0
+    assert _check_zombie_process_count(app) == (False, "Found 2 zombie processes.")
+
+    # Quantity of zombies within threshold
+    app.config["MAX_DEFUNCT_PROCESS_COUNT"] = 3
+    assert _check_zombie_process_count(app) == (True, "Found 2 zombie processes.")

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1126,5 +1126,31 @@ CONFIG_SCHEMA = {
             "description": "The set of hostnames to disallow from webhooks when validating, beyond localhost",
             "x-example": ["somexternaldomain.com"],
         },
+        # Max Zombie processes allowed
+        "MAX_DEFUNCT_PROCESS_COUNT": {
+            "type": "number",
+            "description": (
+                "Maximum number of defunct (zombie) processes allowed before a Quay instance "
+                "will report an error in the health-check endpoint."
+            ),
+            "x-example": 1,
+        },
+        # Interval to report local statistics to prometheus
+        "LOCAL_PROMETHEUS_STATS_FREQUENCY": {
+            "type": "number",
+            "description": (
+                "Interval, in seconds, to fetch and report local statistics to prometheus."
+            ),
+            "x-example": 60,
+        },
+        # Enable/Disable localpromstats worker
+        "FEATURE_REPORT_PROMETHEUS_STATS": {
+            "type": "boolean",
+            "description": (
+                "Toggles the localpromstats worker which reports statistics from the local machine "
+                "or container namespace to prometheus."
+            ),
+            "x-example": True,
+        },
     },
 }

--- a/workers/localpromstats.py
+++ b/workers/localpromstats.py
@@ -1,0 +1,69 @@
+import logging
+import time
+
+from prometheus_client import Gauge
+
+from app import app
+from health.processes import get_gunicorn_processes, get_all_zombies
+from workers.worker import Worker
+from util.log import logfile_path
+
+
+logger = logging.getLogger(__name__)
+
+
+gunicorn_process_gauge = Gauge("quay_gunicorn_process_count", "count of gunicorn processes")
+zombie_process_gauge = Gauge("quay_zombie_process_count", "count of zombie processes")
+
+
+WORKER_FREQUENCY = app.config["LOCAL_PROMETHEUS_STATS_FREQUENCY"]
+
+
+def get_gunicorn_process_count():
+    """
+    Returns the quantity of gunicorn processes running in the local system or namespace.
+    """
+    return len(get_gunicorn_processes())
+
+
+def get_zombie_process_count():
+    """
+    Returns the quantity of zombie processes in the local system or namespace.
+    """
+    return len(get_all_zombies())
+
+
+class LocalPrometheusStatsWorker(Worker):
+    """
+    Worker which reports local stats (# of zombies, processes, etc) to Prometheus periodically.
+    """
+
+    def __init__(self):
+        super(LocalPrometheusStatsWorker, self).__init__()
+        self.add_operation(self._report_stats, WORKER_FREQUENCY)
+
+    def _report_stats(self):
+        logger.debug("Reporting local statistics to prometheus.")
+        gunicorn_process_gauge.set(get_gunicorn_process_count())
+        zombie_process_gauge.set(get_zombie_process_count())
+
+
+def main():
+    logging.config.fileConfig(logfile_path(debug=False), disable_existing_loggers=False)
+
+    if app.config["FEATURE_REPORT_PROMETHEUS_STATS"]:
+
+        if not app.config.get("PROMETHEUS_PUSHGATEWAY_URL"):
+            logger.debug("Prometheus not enabled; skipping local stats reporting")
+            while True:
+                time.sleep(100000)
+
+        worker = LocalPrometheusStatsWorker()
+        worker.start()
+
+    else:
+        logger.info("REPORT_PROMETHEUS_STATS feature is disabled. Stopping localpromstats worker.")
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/test/test_localpromstatsworker.py
+++ b/workers/test/test_localpromstatsworker.py
@@ -1,0 +1,15 @@
+import mock
+
+from workers.localpromstats import get_gunicorn_process_count, get_zombie_process_count
+
+
+@mock.patch("workers.localpromstats.get_gunicorn_processes")
+def test_get_gunicorn_process_count(mock_get_processes):
+    mock_get_processes.return_value = ["proc1", "proc2", "proc3"]
+    assert get_gunicorn_process_count() == 3
+
+
+@mock.patch("workers.localpromstats.get_all_zombies")
+def test_get_zombie_process_count(mock_get_processes):
+    mock_get_processes.return_value = ["zombie1", "zombie2"]
+    assert get_zombie_process_count() == 2


### PR DESCRIPTION
### Description of Changes

- Queries local system (or container) for quantity of gunicorn and zombie processes
- Reports quantities to Prometheus
- Health check exposes whether ~any~ too many zombie processes exist

**TODO**
- ~Unit Tests~
- ~Verify the data in Prometheus is usable as expected when running multiple Quay pods~
- ~Ensure the worker is started by `supervisord` similar to all other workers~

#### Changes:

- New health-check value: `defunct_processes`
- New prometheus metrics: `quay_gunicorn_process_count` and `quay_zombie_process_count`
- New configuration variable: `MAX_DEFUNCT_PROCESS_COUNT`
- New configuration variable: `LOCAL_PROMETHEUS_STATS_FREQUENCY`

#### Issue:

- https://issues.redhat.com/browse/PROJQUAY-759
- https://issues.redhat.com/browse/PROJQUAY-775

**TESTING**

- Check prometheus data for zombie process and gunicorn process counts
- Verify the health-check appropriately displays True or False depending on the number of zombie processes on the same machine/namespace.
- Verify that the configuration variables are used.

**BREAKING CHANGE**

n/a


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
