### PR TITLE
Run required filemode changes in Dockerfile

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.6
 
     - name: Install dependencies
       run: |
@@ -32,7 +32,7 @@ jobs:
     - name: Check Formatting
       run: |
         # TODO(kleesc): Re-enable after buildman rewrite
-        black --line-length=100 --target-version=py38 --check --diff --exclude "/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|buildman)/" .
+        black --line-length=100 --target-version=py36 --check --diff --exclude "/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist|buildman)/" .
 
   unit:
     name: Unit Test
@@ -40,10 +40,10 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.6
 
     - name: Install dependencies
       run: |
@@ -53,7 +53,7 @@ jobs:
         cat requirements-dev.txt | grep tox | xargs pip install
 
     - name: tox
-      run: tox -e py38-unit
+      run: tox -e py36-unit
 
   registry:
     name: E2E Registry Tests
@@ -61,10 +61,10 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.6
 
     - name: Install dependencies
       run: |
@@ -74,7 +74,7 @@ jobs:
         cat requirements-dev.txt | grep tox | xargs pip install
 
     - name: tox
-      run: tox -e py38-registry
+      run: tox -e py36-registry
 
   docker:
     name: Docker Build
@@ -90,10 +90,10 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.6
 
     - name: Install dependencies
       run: |
@@ -106,7 +106,7 @@ jobs:
         cat requirements-dev.txt | grep tox | xargs pip install
 
     - name: tox
-      run: tox -e py38-mysql
+      run: tox -e py36-mysql
 
   psql:
     name: E2E Postgres Test
@@ -114,10 +114,10 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.6
 
     - name: Install dependencies
       run: |
@@ -130,7 +130,7 @@ jobs:
         cat requirements-dev.txt | grep tox | xargs pip install
 
     - name: tox
-      run: tox -e py38-psql
+      run: tox -e py36-psql
 
   oci:
     name: OCI Conformance
@@ -143,10 +143,10 @@ jobs:
         repository: opencontainers/distribution-spec
         path: dist-spec
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.6
 
     - name: Set up Go 1.14
       uses: actions/setup-go@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,17 @@ RUN mkdir /datastorage && chgrp 0 /datastorage && chmod g=u /datastorage && \
     mkdir /certificates && chgrp 0 /certificates && chmod g=u /certificates && \
     chmod g=u /etc/passwd
 
+
+# Allow TLS certs to be created and installed as non-root user
+RUN chgrp -R 0 /etc/pki/ca-trust/extracted && \
+    chmod -R g=u /etc/pki/ca-trust/extracted && \
+    chgrp -R 0 /etc/pki/ca-trust/source/anchors && \
+    chmod -R g=u /etc/pki/ca-trust/source/anchors && \
+    chgrp -R 0 /usr/local/lib/python3.6/site-packages/requests && \
+    chmod -R g=u /usr/local/lib/python3.6/site-packages/requests && \
+    chgrp -R 0 /usr/local/lib/python3.6/site-packages/certifi && \
+    chmod -R g=u /usr/local/lib/python3.6/site-packages/certifi
+
 VOLUME ["/var/log", "/datastorage", "/tmp", "/conf/stack"]
 
 USER 1001

--- a/quay-entrypoint.sh
+++ b/quay-entrypoint.sh
@@ -44,9 +44,6 @@ EOF
 # The gunicorn-registry process DB_CONNECTION_POOLING must default to true
 export DB_CONNECTION_POOLING_REGISTRY=${DB_CONNECTION_POOLING:-"true"}
 
-# Forcibly export the scl environment
-eval "$(scl enable python37 rh-nginx112 'export -p')"
-
 case "$QUAYENTRY" in
     "shell")
         echo "Entering shell mode"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-{unit,registry,mysql,psql}
+envlist = py36-{unit,registry,mysql,psql}
 skipsdist = True
 
 [pytest]
@@ -32,7 +32,7 @@ healthcheck_retries = 3
 healthcheck_start_period = 25
 ports = 3306:3306/tcp
 
-[testenv:py38-mysql]
+[testenv:py36-mysql]
 setenv = 
     PYTHONDONTWRITEBYTECODE = 1
     PYTHONPATH={toxinidir}{:}{toxinidir}
@@ -61,7 +61,7 @@ healthcheck_timeout = 10
 healthcheck_retries = 3
 healthcheck_start_period = 10
 
-[testenv:py38-psql]
+[testenv:py36-psql]
 # TODO(kleesc): Re-enable buildman tests after buildman rewrite
 setenv = 
     PYTHONDONTWRITEBYTECODE = 1


### PR DESCRIPTION


### Description of Changes

* Add the missing filemode changes that were deleted by accident while rebasing
* Reverts to using Python 3.6 for now.

@thomasmckay Need to confirm how to get Python3.8 on CentOS 8(Centos 8, RHEL 8, ...) based images, or if we just use the system default Python 3.6.

**NOTE**: Python 3.6 will be used for now as it is readily available in CentOS 8 based images. The migration from 3.6 to more modern versions should not be too involved anyways.

#### Issue: <link to story or task>


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
