### PR TITLE
Redis connection improvements

### DIFF
--- a/buildman/component/buildcomponent.py
+++ b/buildman/component/buildcomponent.py
@@ -110,7 +110,14 @@ class BuildComponent(BaseComponent):
         )
 
         self._current_job = build_job
-        self._build_status = StatusHandler(self.build_logs, build_job.repo_build.uuid)
+        build_id = build_job.repo_build.uuid
+        try:
+            self._build_status = StatusHandler(self.build_logs, build_id)
+        except Exception as bse:
+            logger.exception("Failed to set phase for build ID: %s - %s", build_id, bse)
+            self._build_status_failure(bse)
+            raise Return()
+
         self._image_info = {}
 
         yield From(self._set_status(ComponentStatus.BUILDING))

--- a/buildman/component/buildcomponent.py
+++ b/buildman/component/buildcomponent.py
@@ -291,6 +291,7 @@ class BuildComponent(BaseComponent):
         Tails log messages and updates the build status.
         """
         # Update the heartbeat.
+        build_id = self._current_job.repo_build.uuid
         self._last_heartbeat = datetime.datetime.utcnow()
 
         # Parse any of the JSON data logged.
@@ -318,47 +319,69 @@ class BuildComponent(BaseComponent):
 
         # Parse and update the phase and the status_dict. The status dictionary contains
         # the pull/push progress, as well as the current step index.
-        with self._build_status as status_dict:
-            try:
-                changed_phase = yield From(
-                    self._build_status.set_phase(phase, log_data.get("status_data"))
-                )
-                if changed_phase:
-                    logger.debug("Build %s has entered a new phase: %s", self.builder_realm, phase)
-                elif self._current_job.repo_build.phase == BUILD_PHASE.CANCELLED:
-                    build_id = self._current_job.repo_build.uuid
-                    logger.debug(
-                        "Trying to move cancelled build into phase: %s with id: %s", phase, build_id
+        try:
+            with self._build_status as status_dict:
+                try:
+                    changed_phase = yield From(
+                        self._build_status.set_phase(phase, log_data.get("status_data"))
                     )
+                    if changed_phase:
+                        logger.debug(
+                            "Build %s has entered a new phase: %s", self.builder_realm, phase
+                        )
+                    elif self._current_job.repo_build.phase == BUILD_PHASE.CANCELLED:
+                        logger.debug(
+                            "Trying to move cancelled build into phase: %s with id: %s",
+                            phase,
+                            build_id,
+                        )
+                        raise Return(False)
+                except InvalidRepositoryBuildException:
+                    build_id = self._current_job.repo_build.uuid
+                    logger.warning("Build %s was not found; repo was probably deleted", build_id)
                     raise Return(False)
-            except InvalidRepositoryBuildException:
-                build_id = self._current_job.repo_build.uuid
-                logger.warning("Build %s was not found; repo was probably deleted", build_id)
-                raise Return(False)
 
-            BuildComponent._process_pushpull_status(status_dict, phase, log_data, self._image_info)
+                BuildComponent._process_pushpull_status(
+                    status_dict, phase, log_data, self._image_info
+                )
 
-            # If the current message represents the beginning of a new step, then update the
-            # current command index.
+                # If the current message represents the beginning of a new step, then update the
+                # current command index.
+                if current_step is not None:
+                    status_dict["current_command"] = current_step
+
+                # If the json data contains an error, then something went wrong with a push or pull.
+                if "error" in log_data:
+                    yield From(self._build_status.set_error(log_data["error"]))
+        except Exception as bse:
+            logger.exception("Failed to set phase for build ID: %s - %s", build_id, bse)
+            self._build_status_failure(bse)
+            raise Return()
+
+        try:
             if current_step is not None:
-                status_dict["current_command"] = current_step
+                yield From(self._build_status.set_command(current_status_string))
+            elif phase == BUILD_PHASE.BUILDING:
+                yield From(self._build_status.append_log(current_status_string))
+        except Exception as bse:
+            logger.exception("Failed to set phase for build ID: %s - %s", build_id, bse)
+            self._build_status_failure(bse)
+            raise Return()
 
-            # If the json data contains an error, then something went wrong with a push or pull.
-            if "error" in log_data:
-                yield From(self._build_status.set_error(log_data["error"]))
-
-        if current_step is not None:
-            yield From(self._build_status.set_command(current_status_string))
-        elif phase == BUILD_PHASE.BUILDING:
-            yield From(self._build_status.append_log(current_status_string))
         raise Return(True)
 
     @trollius.coroutine
     def _determine_cache_tag(
         self, command_comments, base_image_name, base_image_tag, base_image_id
     ):
-        with self._build_status as status_dict:
-            status_dict["total_commands"] = len(command_comments) + 1
+        try:
+            with self._build_status as status_dict:
+                status_dict["total_commands"] = len(command_comments) + 1
+        except Exception as bse:
+            build_id = self._current_job.repo_build.uuid
+            logger.exception("Failed to set phase for build ID: %s - %s", build_id, bse)
+            self._build_status_failure(bse)
+            raise Return()
 
         logger.debug(
             "Checking cache on realm %s. Base image: %s:%s (%s)",
@@ -376,16 +399,34 @@ class BuildComponent(BaseComponent):
         """
         Handles and logs a failed build.
         """
-        yield From(
-            self._build_status.set_error(
-                error_message, {"internal_error": str(exception) if exception else None}
+        try:
+            yield From(
+                self._build_status.set_error(
+                    error_message, {"internal_error": str(exception) if exception else None}
+                )
             )
-        )
+        except Exception as bse:
+            build_id = self._current_job.repo_build.uuid
+            logger.exception("Failed to set phase for build ID: %s - %s", build_id, bse)
+            self._build_status_failure(bse)
+            raise Return()
 
         build_id = self._current_job.repo_build.uuid
         logger.warning("Build %s failed with message: %s", build_id, error_message)
 
         # Mark that the build has finished (in an error state)
+        yield From(self._build_finished(BuildJobResult.ERROR))
+
+    @trollius.coroutine
+    def _build_status_failure(self, exception=None):
+        """
+        Handles failure to set a build status phase.
+
+        Calls self._build_finished with ERROR _without_ logging the failed build.
+        This allows to handle Redis failures.
+        """
+        build_id = self._current_job.repo_build.uuid
+        logger.warning("Failed to set phase for build ID: %s - %s", build_id, exception)
         yield From(self._build_finished(BuildJobResult.ERROR))
 
     @trollius.coroutine
@@ -444,14 +485,19 @@ class BuildComponent(BaseComponent):
             worker_error = WorkerError(aex.error, aex.kwargs.get("base_error"))
 
             # Write the error to the log.
-            yield From(
-                self._build_status.set_error(
-                    worker_error.public_message(),
-                    worker_error.extra_data(),
-                    internal_error=worker_error.is_internal_error(),
-                    requeued=self._current_job.has_retries_remaining(),
+            try:
+                yield From(
+                    self._build_status.set_error(
+                        worker_error.public_message(),
+                        worker_error.extra_data(),
+                        internal_error=worker_error.is_internal_error(),
+                        requeued=self._current_job.has_retries_remaining(),
+                    )
                 )
-            )
+            except Exception as bse:
+                logger.exception("Failed to set phase for build ID: %s - %s", build_id, bse)
+                self._build_status_failure(bse)
+                raise Return()
 
             # Send the notification that the build has failed.
             self._current_job.send_notification(
@@ -596,24 +642,30 @@ class BuildComponent(BaseComponent):
         yield From(self._set_status(ComponentStatus.TIMED_OUT))
         logger.warning("Build component with realm %s has timed out", self.builder_realm)
 
+        build_id = self._current_job.repo_build.uuid
+
         # If we still have a running job, then it has not completed and we need to tell the parent
         # manager.
-        if self._current_job is not None:
-            yield From(
-                self._build_status.set_error(
-                    "Build worker timed out",
-                    internal_error=True,
-                    requeued=self._current_job.has_retries_remaining(),
+        try:
+            if self._current_job is not None:
+                yield From(
+                    self._build_status.set_error(
+                        "Build worker timed out",
+                        internal_error=True,
+                        requeued=self._current_job.has_retries_remaining(),
+                    )
                 )
-            )
 
-            build_id = self._current_job.build_uuid
-            logger.error("[BUILD INTERNAL ERROR: Timeout] Build ID: %s", build_id)
-            yield From(
-                self.parent_manager.job_completed(
-                    self._current_job, BuildJobResult.INCOMPLETE, self
+                logger.error("[BUILD INTERNAL ERROR: Timeout] Build ID: %s", build_id)
+                yield From(
+                    self.parent_manager.job_completed(
+                        self._current_job, BuildJobResult.INCOMPLETE, self
+                    )
                 )
-            )
+        except Exception as bse:
+            logger.exception("Failed to set phase for build ID: %s - %s", build_id, bse)
+            self._build_status_failure(bse)
+            raise Return()
 
         # Unregister the current component so that it cannot be invoked again.
         self.parent_manager.build_component_disposed(self, True)

--- a/buildman/jobutil/buildstatus.py
+++ b/buildman/jobutil/buildstatus.py
@@ -46,6 +46,7 @@ class StatusHandler(object):
             )
         except RedisError:
             logger.exception("Could not save build log for build %s: %s", self._uuid, log_message)
+            raise
 
     @coroutine
     def append_log(self, log_message, extra_data=None):
@@ -92,3 +93,4 @@ class StatusHandler(object):
             self._sync_build_logs.set_status(self._uuid, self._status)
         except RedisError:
             logger.exception("Could not set status of build %s to %s", self._uuid, self._status)
+            raise

--- a/buildman/server.py
+++ b/buildman/server.py
@@ -178,8 +178,8 @@ class BuilderServer(object):
     @trollius.coroutine
     def _job_complete(self, build_job, job_status, executor_name=None, update_phase=False):
         if update_phase:
-            status_handler = StatusHandler(self._build_logs, build_job.repo_build.uuid)
             try:
+                status_handler = StatusHandler(self._build_logs, build_job.repo_build.uuid)
                 yield From(status_handler.set_phase(RESULT_PHASES[job_status]))
             except Exception as spe:
                 logger.warning(
@@ -261,8 +261,8 @@ class BuilderServer(object):
 
             if schedule_success:
                 logger.debug("Marking build %s as scheduled", build_job.repo_build.uuid)
-                status_handler = StatusHandler(self._build_logs, build_job.repo_build.uuid)
                 try:
+                    status_handler = StatusHandler(self._build_logs, build_job.repo_build.uuid)
                     yield From(status_handler.set_phase(database.BUILD_PHASE.BUILD_SCHEDULED))
                 except Exception as spe:
                     logger.warning(

--- a/data/buildlogs.py
+++ b/data/buildlogs.py
@@ -32,7 +32,12 @@ class RedisBuildLogs(object):
 
         args = dict(self._redis_config)
         args.update(
-            {"socket_connect_timeout": 1, "socket_timeout": 2, "single_connection_client": True}
+            {
+                "socket_connect_timeout": 1,
+                "socket_timeout": 2,
+                "health_check_interval": 2,
+                "single_connection_client": True,
+            }
         )
 
         self._redis_client = redis.StrictRedis(**args)


### PR DESCRIPTION
### Description of Changes

* `health_check_interval` will attempt a roundtrip ping before running a command if the connection has been idle for more that the set value. If the ping fails, the redis client should close and reestablish the socket connection.
* Wrap calls to build phase updates (Redis calls) with try blocks. If there is an exception, calls `_build_finished` with its result set to `ERROR`. This is to allow the buildmanager to handle Redis connection errors more gracefully. 

#### Issue: [PROJQUAY-752](https://issues.redhat.com/browse/PROJQUAY-752)


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
