### PR TITLE
Confirmation prompt on repo deletion

### DIFF
--- a/static/directives/repo-view/repo-panel-settings.html
+++ b/static/directives/repo-view/repo-panel-settings.html
@@ -152,12 +152,19 @@
     <div class="cor-confirm-dialog"
        dialog-context="deleteRepoInfo"
        dialog-action="deleteRepo(info, callback)"
-       dialog-title="Delete"
-       dialog-action-title="Delete">
-     <div class="co-alert co-alert-danger" style="margin-bottom: 10px;">
-       This action cannot be undone!
-     </div>
-
-     Continue with deletion of this <span class="repository-title" repository="repository"></span>?
-  </div>
+       dialog-title="Delete {{repository.namespace}}/{{repository.name}}"
+       dialog-action-title="Delete"
+       dialog-form="context.deleterepoform"
+       dialog-button-class="btn-danger">
+      <form name="context.deleterepoform" class="co-single-field-dialog">
+        <div class="co-alert co-alert-danger">
+          You are requesting to delete the repository <strong>{{repository.namespace}}/{{repository.name}}</strong>. This action is <strong>non-reversable</strong>.
+        </div>
+        
+        You must type <code>{{repository.namespace}}/{{repository.name}}</code> below to confirm deletion:
+        <input type="text" class="form-control" placeholder="Enter repository here"
+            ng-model="deleteRepoInfo.verification" ng-pattern="deleteRepoInfo.verificationRegex" match="deleteRepoInfo.verificationRegex"
+            required>
+      </form>
+    </div>
 </div>

--- a/static/js/directives/repo-view/repo-panel-settings.js
+++ b/static/js/directives/repo-view/repo-panel-settings.js
@@ -19,6 +19,7 @@ angular.module('quay').directive('repoPanelSettings', function () {
 
       $scope.Features = Features;
       $scope.deleteDialogCounter = 0;
+      $scope.context = {}
 
       var getTitle = function(repo) {
         return repo.kind == 'application' ? 'application' : 'image';
@@ -52,7 +53,9 @@ angular.module('quay').directive('repoPanelSettings', function () {
       $scope.askDelete = function() {
         $scope.deleteDialogCounter++;
         $scope.deleteRepoInfo = {
-          'counter': $scope.deleteDialogCounter
+          'counter': $scope.deleteDialogCounter,
+          'verificationRegex': $scope.repository.namespace + "/" + $scope.repository.name,
+          'verification': ""
         };
       };
 


### PR DESCRIPTION
### Description of Changes
Added confirmation form when deleting a repository. The user must type in namespace/repo in order to delete repository. See images below:

#### Changes:
![styleA](https://user-images.githubusercontent.com/12652049/84170904-2b5b6a80-aa48-11ea-9958-60a873dffc39.png)
![wrongname](https://user-images.githubusercontent.com/12652049/84170925-33b3a580-aa48-11ea-8393-718f7eb439fd.png)

#### Issue:  https://issues.redhat.com/browse/PROJQUAY-763

## Reviewer Checklist
@kurtismullins 
@josephschorr 

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
