### PR TITLE
keystonev2: populate user.name into UserInformation

### DIFF
--- a/data/users/keystone.py
+++ b/data/users/keystone.py
@@ -137,7 +137,7 @@ class KeystoneV2Users(FederatedUsers):
             return (None, "Missing email field for user %s" % user_id)
 
         email = user.email if hasattr(user, "email") else None
-        return (UserInformation(username=username_or_email, email=email, id=user_id), None)
+        return (UserInformation(username=user.name, email=email, id=user_id), None)
 
     def query_users(self, query, limit=20):
         return (None, self.federated_service, "Unsupported in Keystone V2")

--- a/test/test_keystone_auth.py
+++ b/test/test_keystone_auth.py
@@ -110,6 +110,7 @@ def _create_app(requires_email=True):
         for user in users:
             if user["username"] == userid:
                 user_data = {}
+                user_data["name"] = userid
                 if requires_email:
                     user_data["email"] = user.get("email") or userid + "@example.com"
                 return json.dumps({"user": user_data})


### PR DESCRIPTION
The behavior between keystonev2 and keystonev3 is different today.
In keystonev3 implementation, the username comes from [user.name][1],
but keystonev2 just uses the incoming `username_or_email`.

[1]: https://github.com/quay/quay/blob/f4179e5e719ebc8e795064b8703da8a29d877b3b/data/users/keystone.py#L316