### PR TITLE
[PROJQUAY-776] Run dumb-init as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,5 +118,5 @@ VOLUME ["/var/log", "/datastorage", "/tmp", "/conf/stack"]
 
 USER 1001
 
-ENTRYPOINT ["/quay-registry/quay-entrypoint.sh"]
+ENTRYPOINT ["dumb-init", "--", "/quay-registry/quay-entrypoint.sh"]
 CMD ["registry"]

--- a/Dockerfile.centos7.osbs
+++ b/Dockerfile.centos7.osbs
@@ -140,5 +140,5 @@ VOLUME ["/var/log", "/datastorage", "/tmp", "/conf/stack"]
 
 USER 1001
 
-ENTRYPOINT ["/quay-registry/quay-entrypoint.sh"]
+ENTRYPOINT ["dumb-init", "--", "/quay-registry/quay-entrypoint.sh"]
 CMD ["registry"]

--- a/Dockerfile.osbs
+++ b/Dockerfile.osbs
@@ -145,6 +145,6 @@ VOLUME ["/var/log", "/datastorage", "/tmp", "/conf/stack"]
 
 USER 1001
 
-ENTRYPOINT ["/quay-registry/quay-entrypoint.sh"]
+ENTRYPOINT ["dumb-init", "--", "/quay-registry/quay-entrypoint.sh"]
 CMD ["registry"]
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -145,5 +145,5 @@ VOLUME ["/var/log", "/datastorage", "/tmp", "/conf/stack"]
 
 USER 1001
 
-ENTRYPOINT ["/quay-registry/quay-entrypoint.sh"]
+ENTRYPOINT ["dumb-init", "--", "/quay-registry/quay-entrypoint.sh"]
 CMD ["registry"]

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -107,7 +107,7 @@ RUN mkdir /datastorage && chgrp 0 /datastorage && chmod g=u /datastorage && \
 
 VOLUME ["/var/log", "/datastorage", "/tmp", "/conf/stack"]
 
-ENTRYPOINT ["/quay-registry/quay-entrypoint.sh"]
+ENTRYPOINT ["dumb-init", "--", "/quay-registry/quay-entrypoint.sh"]
 CMD ["registry"]
 
 # root required to create and install certs

--- a/requirements-nover.txt
+++ b/requirements-nover.txt
@@ -25,6 +25,7 @@ bitmath
 boto3
 cachetools
 cryptography
+dumb-init
 elasticsearch>=7.0.4,<8.0.0
 elasticsearch-dsl>=7.0.0,<8.0.0
 flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ decorator==4.4.1
 Deprecated==1.2.7
 docker==4.1.0
 docutils==0.15.2
+dumb-init==1.2.2
 ecdsa==0.15
 elasticsearch==7.0.4
 elasticsearch-dsl==7.0.0


### PR DESCRIPTION
### Description of Changes

Includes an init application as PID 1 in all Dockerfiles to catch and handle any potential defunct/orphaned/zombie processes.

#### Changes:

* Install [dumb-init](https://github.com/Yelp/dumb-init) using pypi as this is the easiest cross-platform (Centos7/Centos8/RHEL7/RHEL8) installation method.
* Prefix all entrypoints with dumb-init to ensure it is ran as PID 1 and will act as the container's init system.

#### Issue:

- https://issues.redhat.com/browse/PROJQUAY-776

**TESTING**

- Just verify that the container starts and runs normally.
- Verify that `dumb-init` is running as PID 1
- Optionally, build the image while including the `psmisc` package and run `pstree` to verify that all processes are children of `dumb-init`.

Example while running the `config` app:
```
[kmullins@rh-laptop quay]$ podman exec -it 78a868130034 /bin/bash
bash-4.4$ pstree
dumb-init───supervisord─┬─gunicorn───gunicorn
                        ├─nginx───8*[nginx]
                        └─supervisor_stdo

```

**BREAKING CHANGE**

None

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
