### PR TITLE
Redis Model Cache (PROJQUAY-788)

### DIFF
--- a/data/cache/impl.py
+++ b/data/cache/impl.py
@@ -2,17 +2,17 @@ import logging
 import json
 import os
 
+from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager
 from datetime import datetime
-
-from abc import ABCMeta, abstractmethod
+from pymemcache.client.base import PooledClient
+from prometheus_client import Counter
+from redis import StrictRedis, RedisError
 from six import add_metaclass
 
 from data.database import CloseForLongOperation
-
-from pymemcache.client.base import PooledClient
-
 from util.expiresdict import ExpiresDict
+from util.locking import GlobalLock, LockNotAcquiredException
 from util.timedeltastring import convert_to_timedelta
 from util.workers import get_worker_connections_count
 
@@ -20,8 +20,17 @@ from util.workers import get_worker_connections_count
 logger = logging.getLogger(__name__)
 
 
+cache_count = Counter(
+    "quay_model_cache", "number of attempts to retrieve from the model cache", labelnames=["type"]
+)
+
+
 def is_not_none(value):
     return value is not None
+
+
+def lock_key_for(cache_key):
+    return "LOCK_" + cache_key
 
 
 @add_metaclass(ABCMeta)
@@ -81,7 +90,11 @@ class InMemoryDataModelCache(DataModelCache):
         result = self.cache.get(cache_key.key, default_value=not_found)
         if result != not_found:
             logger.debug("Found result in cache for key %s: %s", cache_key.key, result)
+            cache_count.labels("hit").inc()
+
             return json.loads(result)
+        else:
+            cache_count.labels("miss").inc()
 
         logger.debug("Found no result in cache for key %s; calling loader", cache_key.key)
         result = loader()
@@ -153,7 +166,7 @@ class MemcachedModelCache(DataModelCache):
                 raise Exception("Unknown flags for value: {1}".format(flags))
 
             return PooledClient(
-                self.endpoint,
+                server=self.endpoint,
                 no_delay=True,
                 timeout=self.timeout,
                 connect_timeout=self.connect_timeout,
@@ -176,7 +189,11 @@ class MemcachedModelCache(DataModelCache):
                 result = client.get(cache_key.key, default=not_found)
                 if result != not_found:
                     logger.debug("Found result in cache for key %s: %s", cache_key.key, result)
+                    cache_count.labels("hit").inc()
+
                     return result
+                else:
+                    cache_count.labels("miss").inc()
             except:
                 logger.warning("Got exception when trying to retrieve key %s", cache_key.key)
 
@@ -205,6 +222,88 @@ class MemcachedModelCache(DataModelCache):
                     result,
                     cache_key.expiration,
                 )
+            except:
+                logger.warning(
+                    "Got exception when trying to set key %s to %s", cache_key.key, result
+                )
+        else:
+            logger.debug("Not caching loaded result for key %s: %s", cache_key.key, result)
+
+        return result
+
+
+class RedisDataModelCache(DataModelCache):
+    """
+    Implementation of the data model cache backed by a Redis service.
+    """
+
+    def __init__(
+        self,
+        host="127.0.0.1",
+        port=6379,
+        password=None,
+        db=0,
+        ca_cert=None,
+        ssl=False,
+    ):
+        self.client = StrictRedis(
+            host=host,
+            port=port,
+            password=password,
+            db=db,
+            ssl_ca_certs=ca_cert,
+            ssl=ssl,
+            socket_connect_timeout=1,
+            socket_timeout=2,
+            health_check_interval=2,
+        )
+
+    def retrieve(self, cache_key, loader, should_cache=is_not_none):
+        # TODO: We might want to have different behavior based on `cache_key` (using "sets" for `/tags/list`, single value for others...)
+        not_found = None
+        if self.client is not None:
+            logger.debug("Checking cache for key %s", cache_key.key)
+            try:
+                cached_result = self.client.get(cache_key.key)
+                if cached_result != not_found:
+                    cache_count.labels("hit").inc()
+                    logger.debug("Found result in cache for key %s", cache_key.key)
+
+                    return json.loads(cached_result)
+                else:
+                    cache_count.labels("miss").inc()
+            except RedisError as re:
+                logger.warning("Got exception when trying to retrieve key %s", cache_key.key)
+
+        logger.debug("Found no result in cache for key %s; calling loader", cache_key.key)
+        result = loader()
+        logger.debug("Got loaded result for key %s: %s", cache_key.key, result)
+        if self.client is not None and should_cache(result):
+            # NOTE: This assumes that the Redis defined in `DATA_MODEL_CACHE_CONFIG` is the same as `USER_EVENTS_REDIS`.
+            try:
+                with GlobalLock(lock_key_for(cache_key.key), lock_ttl=5):
+                    logger.debug(
+                        "Caching loaded result for key %s with expiration %s: %s",
+                        cache_key.key,
+                        result,
+                        cache_key.expiration,
+                    )
+                    expires = (
+                        convert_to_timedelta(cache_key.expiration) if cache_key.expiration else None
+                    )
+                    self.client.set(
+                        cache_key.key,
+                        json.dumps(result),
+                        ex=int(expires.total_seconds()) if expires else None,
+                    )
+                    logger.debug(
+                        "Cached loaded result for key %s with expiration %s: %s",
+                        cache_key.key,
+                        result,
+                        cache_key.expiration,
+                    )
+            except LockNotAcquiredException:
+                logger.debug("Lock for key %s is already set", cache_key.key)
             except:
                 logger.warning(
                     "Got exception when trying to set key %s to %s", cache_key.key, result


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-788

**Changelog:** Add model cache implementation backed by Redis.

**Docs:** N/a

**Testing:** Add the following section to `config.yaml`:

```yaml
DATA_MODEL_CACHE_CONFIG:
  engine: redis
  host: <redis-hostname>
  port: 6379
```

**Details:** Adds an implementation of the model cache which uses Redis. The goal is when deploying a cluster of Quay app containers, they will all use a shared Redis instance for caching requests (as opposed to a per-container memcache), which will reduce load on the database for expensive queries. [Enhancements proposal](https://github.com/quay/enhancements/blob/main/enhancements/redis-cache.md).

*NOTE:* When using this model cache implementation, the Redis dependency changes from being low priority (effectively ephemeral) to being critical (and should be HA).
*NOTE:* The Quay container will still have `memcached` running even if not being used, unless we modify the container entrypoint to read the `config.yaml`.

~Blocked by https://github.com/quay/quay/pull/745~