### PR TITLE
[PROJQUAY-753] Reduce logging noise

### DIFF
--- a/buildman/builder.py
+++ b/buildman/builder.py
@@ -103,7 +103,7 @@ def run_build_manager():
 
 
 if __name__ == "__main__":
-    logging.config.fileConfig(logfile_path(debug=True), disable_existing_loggers=False)
+    logging.config.fileConfig(logfile_path(debug=False), disable_existing_loggers=False)
     logging.getLogger("peewee").setLevel(logging.WARN)
     logging.getLogger("boto").setLevel(logging.WARN)
 

--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -183,7 +183,7 @@ class EphemeralBuilderManager(BaseManager):
 
             # Finally, we terminate the build execution for the job. We don't do this under a lock as
             # terminating a node is an atomic operation; better to make sure it is terminated than not.
-            logger.info(
+            logger.debug(
                 "Terminating expired build executor for job %s with execution id %s",
                 build_job.build_uuid,
                 build_info.execution_id,
@@ -231,7 +231,7 @@ class EphemeralBuilderManager(BaseManager):
                     await self._mark_job_incomplete(build_job, build_info)
 
                 # Cleanup the executor.
-                logger.info(
+                logger.debug(
                     "Realm %s expired for job %s, terminating executor %s with execution id %s",
                     realm_id,
                     build_uuid,
@@ -428,7 +428,7 @@ class EphemeralBuilderManager(BaseManager):
         logger.debug("Total jobs (scheduling job %s): %s", build_uuid, workers_alive)
 
         if workers_alive >= allowed_worker_count:
-            logger.info(
+            logger.debug(
                 "Too many workers alive, unable to start new worker for build job: %s. %s >= %s",
                 build_uuid,
                 workers_alive,
@@ -692,7 +692,7 @@ class EphemeralBuilderManager(BaseManager):
         logger.debug("job_completed for job %s with status: %s", build_job.build_uuid, job_status)
 
     async def kill_builder_executor(self, build_uuid):
-        logger.info("Starting termination of executor for job %s", build_uuid)
+        logger.debug("Starting termination of executor for job %s", build_uuid)
         build_info = self._build_uuid_to_info.pop(build_uuid, None)
         if build_info is None:
             logger.debug(
@@ -713,7 +713,7 @@ class EphemeralBuilderManager(BaseManager):
             return
 
         # Terminate the executor's execution.
-        logger.info("Terminating executor %s with execution id %s", executor_name, execution_id)
+        logger.debug("Terminating executor %s with execution id %s", executor_name, execution_id)
         await executor.stop_builder(execution_id)
 
     async def job_heartbeat(self, build_job):
@@ -728,7 +728,7 @@ class EphemeralBuilderManager(BaseManager):
         try:
             job_data = await self._orchestrator.get_key(self._job_key(build_job))
         except KeyError:
-            logger.info("Job %s no longer exists in the orchestrator", build_job.build_uuid)
+            logger.debug("Job %s no longer exists in the orchestrator", build_job.build_uuid)
             return
         except OrchestratorConnectionError:
             logger.exception("failed to connect when attempted to extend job")

--- a/buildman/manager/etcd_canceller.py
+++ b/buildman/manager/etcd_canceller.py
@@ -33,7 +33,7 @@ class EtcdCanceller(object):
         """
         Writes etcd message to cancel build_uuid.
         """
-        logger.info("Cancelling build %s".format(build_uuid))
+        logger.debug("Cancelling build %s".format(build_uuid))
         try:
             self._etcd_client.write(
                 "{}{}".format(self._cancel_prefix, build_uuid), build_uuid, ttl=60

--- a/buildman/manager/orchestrator_canceller.py
+++ b/buildman/manager/orchestrator_canceller.py
@@ -19,7 +19,7 @@ class OrchestratorCanceller(object):
         self._orchestrator = orchestrator_from_config(config, canceller_only=True)
 
     def try_cancel_build(self, build_uuid):
-        logger.info("Cancelling build %s", build_uuid)
+        logger.debug("Cancelling build %s", build_uuid)
         cancel_key = slash_join(CANCEL_PREFIX, build_uuid)
         try:
             self._orchestrator.set_key_sync(cancel_key, build_uuid, expiration=60)

--- a/conf/init/02_get_kube_certs.py
+++ b/conf/init/02_get_kube_certs.py
@@ -1,8 +1,13 @@
 import json
+import logging
 import os
 import base64
 
 from requests import Request, Session
+
+
+logger = logging.getLogger(__name__)
+
 
 QUAYPATH = os.environ.get("QUAYPATH", ".")
 KUBE_EXTRA_CA_CERTDIR = os.environ.get(
@@ -71,7 +76,7 @@ def main():
 
         cert_value = base64.b64decode(secret_data[cert_key])
         cert_filename = cert_key.replace(EXTRA_CA_DIRECTORY_PREFIX, "")
-        print("Found an extra cert %s in config-secret, copying to kube ca dir")
+        logger.info("Found an extra cert %s in config-secret, copying to kube ca dir")
 
         with open(os.path.join(KUBE_EXTRA_CA_CERTDIR, cert_filename), "w") as f:
             f.write(cert_value)

--- a/data/logs_model/logs_producer/__init__.py
+++ b/data/logs_model/logs_producer/__init__.py
@@ -20,9 +20,7 @@ class LogProducerProxy(object):
 
     def initialize(self, model):
         self._model = model
-        logger.info("===============================")
-        logger.info("Using producer `%s`", self._model)
-        logger.info("===============================")
+        logger.debug("Using producer `%s`", self._model)
 
     def __getattr__(self, attr):
         if not self._model:

--- a/data/model/user.py
+++ b/data/model/user.py
@@ -128,7 +128,7 @@ def create_user_noverify(
 
     try:
         existing = User.get((User.username == username) | (User.email == email))
-        logger.info("Existing user with same username or email.")
+        logger.debug("Existing user with same username or email.")
 
         # A user already exists with either the same username or email
         if existing.username == username:
@@ -335,7 +335,7 @@ def create_robot(robot_shortname, parent, description="", unstructured_metadata=
         User.get(User.username == username)
 
         msg = "Existing robot with name: %s" % username
-        logger.info(msg)
+        logger.debug(msg)
         raise InvalidRobotException(msg)
     except User.DoesNotExist:
         pass

--- a/data/secscan_model/secscan_v2_model.py
+++ b/data/secscan_model/secscan_v2_model.py
@@ -232,7 +232,7 @@ class V2SecurityScanner(SecurityScannerInterface):
                 try:
                     self._analyzer.analyze_recursively(candidate)
                 except PreemptedException:
-                    logger.info("Another worker pre-empted us for layer: %s", candidate.id)
+                    logger.debug("Another worker pre-empted us for layer: %s", candidate.id)
                     abt.set()
                 except APIRequestFailure:
                     logger.exception("Security scanner service unavailable")

--- a/util/ipresolver/__init__.py
+++ b/util/ipresolver/__init__.py
@@ -84,10 +84,10 @@ class IPResolver(IPResolverInterface):
         logger.info("Loading AWS IP ranges from disk")
         aws_ip_ranges_data = _get_aws_ip_ranges()
         if aws_ip_ranges_data is not None and aws_ip_ranges_data.get("syncToken"):
-            logger.info("Building AWS IP ranges")
+            logger.debug("Building AWS IP ranges")
             self.amazon_ranges = IPResolver._parse_amazon_ranges(aws_ip_ranges_data)
             self.sync_token = aws_ip_ranges_data["syncToken"]
-            logger.info("Finished building AWS IP ranges")
+            logger.debug("Finished building AWS IP ranges")
 
     @ttl_cache(maxsize=100, ttl=600)
     def is_ip_possible_threat(self, ip_address):

--- a/util/secscan/analyzer.py
+++ b/util/secscan/analyzer.py
@@ -135,10 +135,10 @@ class LayerAnalyzer(object):
         previously_security_indexed_successfully = layer.security_indexed
         previous_security_indexed_engine = layer.security_indexed_engine
 
-        logger.info("Analyzing layer %s", layer.docker_image_id)
+        logger.debug("Analyzing layer %s", layer.docker_image_id)
         analyzed_version = self._api.analyze_layer(layer)
 
-        logger.info(
+        logger.debug(
             "Analyzed layer %s successfully with version %s",
             layer.docker_image_id,
             analyzed_version,

--- a/util/secscan/api.py
+++ b/util/secscan/api.py
@@ -401,7 +401,7 @@ class ImplementedSecurityScannerAPI(SecurityScannerAPIInterface):
             logger.error("Could not build analyze request for layer %s", layer.id)
             raise AnalyzeLayerException
 
-        logger.info("Analyzing layer %s", request["Layer"]["Name"])
+        logger.debug("Analyzing layer %s", request["Layer"]["Name"])
         try:
             response = self._call("POST", _API_METHOD_INSERT, body=request)
         except requests.exceptions.Timeout:

--- a/workers/exportactionlogsworker.py
+++ b/workers/exportactionlogsworker.py
@@ -242,7 +242,7 @@ class ExportActionLogsWorker(QueueWorker):
         return upload_metadata, uploaded_byte_count
 
     def _report_results(self, job_details, result_status, exported_data_url=None):
-        logger.info(
+        logger.debug(
             "Reporting result of `%s` for %s; %s", result_status, job_details, exported_data_url
         )
 

--- a/workers/namespacegcworker.py
+++ b/workers/namespacegcworker.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     logging.config.fileConfig(logfile_path(debug=False), disable_existing_loggers=False)
 
     if not features.NAMESPACE_GARBAGE_COLLECTION:
-        logger.info("Namespace garbage collection is disabled; skipping")
+        logger.debug("Namespace garbage collection is disabled; skipping")
         while True:
             time.sleep(100000)
 


### PR DESCRIPTION
### Description of Changes

Reduce signal to noise ratio in Quay's default logging configuration.

#### Changes:

* Only use `info` level logging for information that is useful for system/application administrators and is not internal, implementation-level details.
* Change the build manager to emit `info` level logging instead of `debug` by default.
* Do not use `print()` statements for logging purposes.

#### Issue:

- https://issues.redhat.com/browse/PROJQUAY-753

**TESTING**

- Ensure enough useful information is logged.
- Ensure the build manager's logging is not emitting any `debug` log messages.

**BREAKING CHANGE**

None.

---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
