### PR TITLE
Have the GC workers raise a "go to sleep" exception to workers when they fail to acquire a lock

### DIFF
--- a/workers/namespacegcworker.py
+++ b/workers/namespacegcworker.py
@@ -5,7 +5,7 @@ import features
 
 from app import namespace_gc_queue, all_queues
 from data import model
-from workers.queueworker import QueueWorker
+from workers.queueworker import QueueWorker, WorkerSleepException
 from util.log import logfile_path
 from util.locking import GlobalLock, LockNotAcquiredException
 
@@ -30,6 +30,7 @@ class NamespaceGCWorker(QueueWorker):
                 self._perform_gc(job_details)
         except LockNotAcquiredException:
             logger.debug("Could not acquire global lock for garbage collection")
+            raise WorkerSleepException
 
     def _perform_gc(self, job_details):
         logger.debug("Got namespace GC queue item: %s", job_details)

--- a/workers/repositorygcworker.py
+++ b/workers/repositorygcworker.py
@@ -5,7 +5,7 @@ import features
 
 from app import repository_gc_queue, all_queues
 from data import model, database
-from workers.queueworker import QueueWorker
+from workers.queueworker import QueueWorker, WorkerSleepException
 from util.log import logfile_path
 from util.locking import GlobalLock, LockNotAcquiredException
 
@@ -30,6 +30,7 @@ class RepositoryGCWorker(QueueWorker):
                 self._perform_gc(job_details)
         except LockNotAcquiredException:
             logger.debug("Could not acquire global lock for garbage collection")
+            raise WorkerSleepException
 
     def _perform_gc(self, job_details):
         logger.debug("Got repository GC queue item: %s", job_details)

--- a/workers/test/test_namespacegcworker.py
+++ b/workers/test/test_namespacegcworker.py
@@ -12,6 +12,6 @@ def test_gc_namespace(initialized_db):
     assert not database.User.get(id=namespace).enabled
 
     worker = NamespaceGCWorker(None)
-    worker.process_queue_item({"marker_id": marker_id})
+    worker._perform_gc({"marker_id": marker_id})
 
     assert model.user.get_namespace_user("buynlarge") is None


### PR DESCRIPTION
This will ensure that the queue item gets re-queued and the worker is
put to sleep, rather than thrashing on retries

