### PR TITLE
Raise Orchestrator errors on redis errors in orchestrator

### DIFF
--- a/buildman/manager/enterprise.py
+++ b/buildman/manager/enterprise.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 
 from buildman.component.basecomponent import BaseComponent
-from buildman.component.buildcomponent import BuildComponent
+from buildman.component.buildcomponent import BuildComponent, ComponentStatus
 from buildman.manager.basemanager import BaseManager
 
 from trollius import From, Return, coroutine

--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -566,6 +566,12 @@ class EphemeralBuilderManager(BaseManager):
                 realm,
                 build_uuid,
             )
+        except OrchestratorConnectionError:
+            logger.exception(
+                "Exception when writing realm %s to orchestrator for job %s; could not connect",
+                realm,
+                build_uuid,
+            )
         except OrchestratorError:
             logger.exception(
                 "Exception when writing realm %s to orchestrator for job %s", realm, build_uuid
@@ -747,6 +753,7 @@ class EphemeralBuilderManager(BaseManager):
             raise Return()
         except OrchestratorConnectionError:
             logger.exception("failed to connect when attempted to extend job")
+            raise Return()
 
         build_job_metadata = json.loads(job_data)
 
@@ -771,6 +778,9 @@ class EphemeralBuilderManager(BaseManager):
             logger.exception(
                 "Could not update heartbeat for job as the orchestrator is not available"
             )
+            yield From(sleep(ORCHESTRATOR_UNAVAILABLE_SLEEP_DURATION))
+        except OrchestratorError:
+            logger.exception("Could not update heartbeat for job due to orchestrator error")
             yield From(sleep(ORCHESTRATOR_UNAVAILABLE_SLEEP_DURATION))
 
     @coroutine

--- a/buildman/server.py
+++ b/buildman/server.py
@@ -183,11 +183,11 @@ class BuilderServer(object):
                 yield From(status_handler.set_phase(RESULT_PHASES[job_status]))
             except Exception as spe:
                 logger.warning(
-                    "[BUILD INCOMPLETE: job complete] Build ID: %s. Retry restore. Failed to update build phase: %s",
+                    "[BUILD INCOMPLETE: job complete] Build ID: %s. Retry restored; Failed to update build phase: %s",
                     build_job.repo_build.uuid,
                     spe,
                 )
-                self._queue.incomplete(build_job.job_item, restore_retry=False, retry_after=30)
+                self._queue.incomplete(build_job.job_item, restore_retry=True, retry_after=30)
                 raise Return()
 
         if job_status == BuildJobResult.INCOMPLETE:
@@ -266,12 +266,12 @@ class BuilderServer(object):
                     yield From(status_handler.set_phase(database.BUILD_PHASE.BUILD_SCHEDULED))
                 except Exception as spe:
                     logger.warning(
-                        "[BUILD INCOMPLETE: set phase] Build ID: %s. Retry restored.",
+                        "[BUILD INCOMPLETE: set phase] Build ID: %s. Retry restored; Failed to update build phase: %s",
                         build_job.repo_build.uuid,
+                        spe,
                     )
-                    logger.exception("Exception trying to set build phase:" % str(spe))
                     self._queue.incomplete(
-                        job_item, restore_retry=true, retry_after=WORK_CHECK_TIMEOUT
+                        job_item, restore_retry=True, retry_after=WORK_CHECK_TIMEOUT
                     )
                     continue
 


### PR DESCRIPTION
### Description of Changes

* Re-raise the exceptions when using the redis orchestrator so that the build manager can handle them.
* Add missing `yield From` on some async calls
* Update the build phase on log failure


#### Changes:

* ..
* ..

#### Issue: https://issues.redhat.com/browse/PROJQUAY-752


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
