### PR TITLE
Fix the RepositoryActionCount worker to properly select rows

### DIFF
--- a/data/model/repositoryactioncount.py
+++ b/data/model/repositoryactioncount.py
@@ -1,7 +1,7 @@
 import logging
 
 from collections import namedtuple
-from peewee import IntegrityError
+from peewee import IntegrityError, JOIN
 
 from datetime import date, timedelta, datetime
 from data.database import (
@@ -146,6 +146,16 @@ def update_repository_score(repo):
     except IntegrityError:
         logger.debug("RepositorySearchScore row already existed; skipping")
         return False
+
+
+def missing_counts_query(date):
+    """ Returns a query to find all Repository's with missing RAC entries for the given date. """
+    return (
+        Repository.select()
+        .join(RepositoryActionCount, JOIN.LEFT_OUTER)
+        .where(RepositoryActionCount.id >> None)
+        .where(RepositoryActionCount.date == date)
+    )
 
 
 def delete_expired_entries(repo, limit=50):

--- a/workers/repositoryactioncounter.py
+++ b/workers/repositoryactioncounter.py
@@ -24,8 +24,10 @@ class RepositoryActionCountWorker(Worker):
         self.add_operation(self._run_counting, POLL_PERIOD_SECONDS)
 
     def _run_counting(self):
+        yesterday = date.today() - timedelta(days=1)
+
         def batch_query():
-            return database.Repository.select()
+            return model.repositoryactioncount.missing_counts_query(yesterday)
 
         min_id = model.repository.get_min_id()
         max_id = model.repository.get_max_id()
@@ -39,7 +41,6 @@ class RepositoryActionCountWorker(Worker):
             batch_query, database.Repository.id, batch_size, max_id, min_id,
         )
 
-        yesterday = date.today() - timedelta(days=1)
         for candidate, abt, num_remaining in iterator:
             if model.repositoryactioncount.has_repository_action_count(candidate, yesterday):
                 abt.set()


### PR DESCRIPTION
This selects only the rows missing, rather than all repositories