### PR TITLE
Have the RAC worker fast-check whether it needs to do work

### DIFF
--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -74,6 +74,11 @@ def get_min_id():
     return Repository.select(fn.Min(Repository.id)).scalar()
 
 
+def get_repository_count():
+    """ Returns the count of repositories. """
+    return Repository.select().count()
+
+
 def get_repo_kind_name(repo):
     return Repository.kind.get_name(repo.kind_id)
 

--- a/data/model/repositoryactioncount.py
+++ b/data/model/repositoryactioncount.py
@@ -61,6 +61,13 @@ def count_repository_actions(to_count, day):
     return actions
 
 
+def found_entry_count(day):
+    """
+    Returns the number of entries for the given day in the RAC table.
+    """
+    return RepositoryActionCount.select().where(RepositoryActionCount.date == day).count()
+
+
 def has_repository_action_count(repository, day):
     """
     Returns whether there is a stored action count for a repository for a specific day.


### PR DESCRIPTION
The RAC worker will now check the count of entries for the day, versus
the number of repos. If all entries are found, the worker will go to
sleep.