### PR TITLE
Logs a warning instead of exception on some non-critical logs

### DIFF
--- a/buildman/component/buildcomponent.py
+++ b/buildman/component/buildcomponent.py
@@ -380,7 +380,7 @@ class BuildComponent(BaseComponent):
         except RedisError as re:
             logger.warning("Failed to append log for build ID: %s - %s", build_id, re)
         except Exception as bse:
-            logger.exception("Failed to set phase for build ID: %s - %s", build_id, bse)
+            logger.warning("Failed to set phase for build ID: %s - %s", build_id, bse)
             yield From(self._build_status_failure(bse))
             raise Return()
 

--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -797,8 +797,8 @@ class EphemeralBuilderManager(BaseManager):
                 metric.labels(executor, str(job_status)).observe(time.time() - start_time)
             else:
                 metric.labels(executor).observe(time.time() - start_time)
-        except Exception:
-            logger.exception("Could not write metric for realm %s", realm)
+        except Exception as e:
+            logger.warning("Could not write metric for realm %s - %s", realm, e)
 
     def num_workers(self):
         """


### PR DESCRIPTION
### Description of Changes

* Log a warning instead of exception to avoid getting too many Sentry alerts on transient Redis issues.

#### Issue: <link to story or task>


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
