### PR TITLE
Handle buildcomponent's job being None

### DIFF
--- a/buildman/component/buildcomponent.py
+++ b/buildman/component/buildcomponent.py
@@ -451,12 +451,14 @@ class BuildComponent(BaseComponent):
         Calls self._build_finished with ERROR _without_ logging the failed build.
         This allows to handle Redis failures.
         """
-        build_id = self._current_job.repo_build.uuid
+        if self._current_job is not None:
+            build_id = self._current_job.repo_build.uuid
 
-        # The build's phase should still be updated even without logging to avoid getting into
-        # a weird state where it was complete but wasn't updated from "building" because of
-        # Redis going down.
-        build_model.update_phase_then_close(build_id, BUILD_PHASE.INTERNAL_ERROR)
+            # The build's phase should still be updated even without logging to avoid getting into
+            # a weird state where it was complete but wasn't updated from "building" because of
+            # Redis going down.
+            build_model.update_phase_then_close(build_id, BUILD_PHASE.INTERNAL_ERROR)
+
         yield From(self._build_finished(BuildJobResult.ERROR))
 
     @trollius.coroutine

--- a/buildman/server.py
+++ b/buildman/server.py
@@ -177,6 +177,10 @@ class BuilderServer(object):
 
     @trollius.coroutine
     def _job_complete(self, build_job, job_status, executor_name=None, update_phase=False):
+        if build_job is None:
+            logger.warning("[BUILD INCOMPLETE: job complete] Build component job is None",)
+            raise Return()
+
         if update_phase:
             try:
                 status_handler = StatusHandler(self._build_logs, build_job.repo_build.uuid)


### PR DESCRIPTION
### Description of Changes

* Handle the case where a buildcomponent's job is None while trying access its id. 
e.g This might happen if the build timeouts, completes or gets canceled while Redis is unavailable.

#### Changes:

* ..
* ..

#### Issue: <link to story or task>


**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
