### PR TITLE
Migrate to boto3 in the build executor

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -246,6 +246,7 @@ class EC2Executor(BuilderExecutor):
         if self.executor_config.get("EC2_VPC_SUBNET_ID", None) is not None:
             interfaces = [
                 {
+                    "DeviceIndex": 0,
                     "SubnetId": self.executor_config["EC2_VPC_SUBNET_ID"],
                     "Groups": self.executor_config["EC2_SECURITY_GROUP_IDS"],
                     "AssociatePublicIpAddress": True,
@@ -262,6 +263,8 @@ class EC2Executor(BuilderExecutor):
                     InstanceInitiatedShutdownBehavior="terminate",
                     BlockDeviceMappings=block_device_mappings,
                     NetworkInterfaces=interfaces,
+                    MinCount=1,
+                    MaxCount=1,
                 )
             )
         except (ec2_conn.exceptions.ClientError, botocore.exceptions.ClientError) as ec2e:


### PR DESCRIPTION
### Description of Changes

Python3 is not supported by boto2

* Migrate the buildman's call to aws to use boto3


#### Changes:

* ..
* ..

#### Issue:  https://issues.redhat.com/browse/PROJQUAY-834

**TESTING** ->

**BREAKING CHANGE** ->


---

## Reviewer Checklist

- [ ] It works!
- [ ] Comments provide sufficient explanations for the next contributor
- [ ] Tests cover changes and corner cases
- [ ] Follows Quay syntax patterns and format
