### PR TITLE
PROJQUAY-889 Enable adding of specific CN to certs used by the config app

### DIFF
--- a/config_app/init/certs_create.sh
+++ b/config_app/init/certs_create.sh
@@ -19,7 +19,7 @@ else
             -subj "/C=US/ST=NY/L=NYC/O=Dis/CN=self-signed" \
             -keyout quay-config-key.pem  -out quay-config.pem
         else
-            openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 \
+        openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 \
             -subj "/C=US/ST=NY/L=NYC/O=Dis/CN=${QUAY_CONFIG_HOSTNAME}" \
             -keyout quay-config-key.pem  -out quay-config.pem
     fi

--- a/config_app/init/certs_create.sh
+++ b/config_app/init/certs_create.sh
@@ -14,9 +14,15 @@ else
     # Create certs to secure connections while uploading config for secrets
     # echo '{"CN":"CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare quay-config
     mkdir -p /certificates; cd /certificates
-    openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 \
-        -subj "/C=US/ST=NY/L=NYC/O=Dis/CN=self-signed" \
-        -keyout quay-config-key.pem  -out quay-config.pem
+    if [ -z "$QUAY_CONFIG_HOSTNAME" ];      then
+        openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 \
+            -subj "/C=US/ST=NY/L=NYC/O=Dis/CN=self-signed" \
+            -keyout quay-config-key.pem  -out quay-config.pem
+        else
+            openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 \
+            -subj "/C=US/ST=NY/L=NYC/O=Dis/CN=${QUAY_CONFIG_HOSTNAME}" \
+            -keyout quay-config-key.pem  -out quay-config.pem
+    fi
     cp /certificates/quay-config-key.pem $QUAYDIR/config_app/quay-config.key
     cp /certificates/quay-config.pem $QUAYDIR/config_app/quay-config.cert
 fi


### PR DESCRIPTION
**Issue**: https://issues.redhat.com/browse/PROJQUAY-889

**Changelog**:
Added the ability to create certificates based on hostname parsed as an env. variable.

**Docs**:
When starting Quay config app, parse the additional `-e QUAY_CONFIG_HOSTNAME=some.hostname` to assign a CN to the created certificate. If the variable is not present, Quay config app will create default certificates with a bad CN that may not work in all browsers.

**Testing**:
Run Quay config app with -e `QUAY_CONFIG_HOSTNAME=some.hostname`.

**Details**:
n/a