### PR TITLE
PROJQUAY-796 - skopeo mirror all manifest list

### DIFF
--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -38,6 +38,7 @@ class SkopeoMirror(object):
             args = args + ["--debug"]
         args = args + [
             "copy",
+            "--all",
             "--src-tls-verify=%s" % src_tls_verify,
             "--dest-tls-verify=%s" % dest_tls_verify,
         ]

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -91,6 +91,7 @@ def test_successful_mirror(run_skopeo_mock, initialized_db, app):
             "args": [
                 "/usr/bin/skopeo",
                 "copy",
+                "--all",
                 "--src-tls-verify=False",
                 "--dest-tls-verify=True",
                 "--dest-creds",
@@ -148,6 +149,7 @@ def test_successful_disabled_sync_now(run_skopeo_mock, initialized_db, app):
             "args": [
                 "/usr/bin/skopeo",
                 "copy",
+                "--all",
                 "--src-tls-verify=True",
                 "--dest-tls-verify=True",
                 "--dest-creds",
@@ -204,6 +206,7 @@ def test_successful_mirror_verbose_logs(run_skopeo_mock, initialized_db, app, mo
                 "/usr/bin/skopeo",
                 "--debug",
                 "copy",
+                "--all",
                 "--src-tls-verify=True",
                 "--dest-tls-verify=True",
                 "--dest-creds",
@@ -267,6 +270,7 @@ def test_rollback(run_skopeo_mock, initialized_db, app):
             "args": [
                 "/usr/bin/skopeo",
                 "copy",
+                "--all",
                 "--src-tls-verify=True",
                 "--dest-tls-verify=True",
                 "--dest-creds",
@@ -281,6 +285,7 @@ def test_rollback(run_skopeo_mock, initialized_db, app):
             "args": [
                 "/usr/bin/skopeo",
                 "copy",
+                "--all",
                 "--src-tls-verify=True",
                 "--dest-tls-verify=True",
                 "--dest-creds",
@@ -295,6 +300,7 @@ def test_rollback(run_skopeo_mock, initialized_db, app):
             "args": [
                 "/usr/bin/skopeo",
                 "copy",
+                "--all",
                 "--src-tls-verify=True",
                 "--dest-tls-verify=True",
                 "--dest-creds",
@@ -313,9 +319,9 @@ def test_rollback(run_skopeo_mock, initialized_db, app):
             assert args == skopeo_call["args"]
             assert proxy == {}
 
-            if args[1] == "copy" and args[6].endswith(":updated"):
+            if args[1] == "copy" and args[7].endswith(":updated"):
                 _create_tag(repo, "updated")
-            elif args[1] == "copy" and args[6].endswith(":created"):
+            elif args[1] == "copy" and args[7].endswith(":created"):
                 _create_tag(repo, "created")
 
             return skopeo_call["results"]
@@ -375,6 +381,7 @@ def test_mirror_config_server_hostname(run_skopeo_mock, initialized_db, app, mon
                 "/usr/bin/skopeo",
                 "--debug",
                 "copy",
+                "--all",
                 "--src-tls-verify=True",
                 "--dest-tls-verify=True",
                 "--dest-creds",
@@ -438,6 +445,7 @@ def test_quote_params(run_skopeo_mock, initialized_db, app):
             "args": [
                 "/usr/bin/skopeo",
                 "copy",
+                "--all",
                 "--src-tls-verify=True",
                 "--dest-tls-verify=True",
                 "--dest-creds",
@@ -500,6 +508,7 @@ def test_quote_params_password(run_skopeo_mock, initialized_db, app):
             "args": [
                 "/usr/bin/skopeo",
                 "copy",
+                "--all",
                 "--src-tls-verify=True",
                 "--dest-tls-verify=True",
                 "--dest-creds",


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-796

**Changelog:** 
Repository mirroring now copies all images if source is a manifest list.

**Docs:** 
When the source repository is a manifest list, all images in the manifest will be mirrored.

**Testing:** 
Attempt to mirror a known manifest list and confirm all images were copied.

**Details:** 
The change adds the "--all" option to skopeo calls.

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.