### PR TITLE
Repin boto version with python3 fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b#egg=cnr_server
 -e git+https://github.com/DevTable/aniso8601-fake.git@bd7762c7dea0498706d3f57db60cd8a8af44ba90#egg=aniso8601
--e git+https://github.com/DevTable/boto.git@a6a5c00bd199b1492e99199251b10451970b5b08#egg=boto
+-e git+https://github.com/DevTable/boto.git@809313a0119ed5ccdd27f61fe64900b2fd0261b2#egg=boto
 -e git+https://github.com/jarus/flask-testing.git@17f19d7fee0e1e176703fc7cb04917a77913ba1a#egg=Flask_Testing
 -e git+https://github.com/quay/mockldap.git@4265554a3d89fe39bf05b18e91607bec3fcf215a#egg=mockldap
 -e git+https://github.com/quay/py-bitbucket.git@85301693ce3682f8e1244e90bd8a903181844bde#egg=py_bitbucket


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-861

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** This provides a quick fix for https://issues.redhat.com/browse/PROJQUAY-861. We should still eventually migrate from boto2 as it has mostly stopped being supported in favor of boto3

------