### PR TITLE
Change from logging exceptions to warnings

### DIFF
--- a/buildman/component/buildcomponent.py
+++ b/buildman/component/buildcomponent.py
@@ -115,7 +115,7 @@ class BuildComponent(BaseComponent):
         try:
             self._build_status = StatusHandler(self.build_logs, build_id)
         except Exception as bse:
-            logger.exception(
+            logger.warning(
                 "Failed to set phase for start build for build ID: %s - %s", build_id, bse
             )
             yield From(self._build_status_failure(bse))
@@ -368,7 +368,7 @@ class BuildComponent(BaseComponent):
             build_model.update_phase_then_close(build_id, phase)
         except Exception as bse:
             # Fail the build on other error types
-            logger.exception("Failed to set phase for on log for build ID: %s - %s", build_id, bse)
+            logger.warning("Failed to set phase for on log for build ID: %s - %s", build_id, bse)
             yield From(self._build_status_failure(bse))
             raise Return()
 
@@ -395,7 +395,7 @@ class BuildComponent(BaseComponent):
                 status_dict["total_commands"] = len(command_comments) + 1
         except Exception as bse:
             build_id = self._current_job.repo_build.uuid
-            logger.exception("Failed to set phase for cache for build ID: %s - %s", build_id, bse)
+            logger.warning("Failed to set phase for cache for build ID: %s - %s", build_id, bse)
             yield From(self._build_status_failure(bse))
             raise Return()
 
@@ -433,7 +433,7 @@ class BuildComponent(BaseComponent):
             )
         except Exception as bse:
             build_id = self._current_job.repo_build.uuid
-            logger.exception("Failed to set phase for build ID: %s - %s", build_id, bse)
+            logger.warning("Failed to set phase for build ID: %s - %s", build_id, bse)
             yield From(self._build_status_failure(bse))
             raise Return()
 
@@ -536,7 +536,7 @@ class BuildComponent(BaseComponent):
 
                 # Mark the build as completed.
                 if worker_error.is_internal_error():
-                    logger.exception(
+                    logger.warning(
                         "[BUILD INTERNAL ERROR: Remote] Build ID: %s: %s",
                         build_id,
                         worker_error.public_message(),
@@ -689,7 +689,7 @@ class BuildComponent(BaseComponent):
                     )
                 )
         except Exception as bse:
-            logger.exception("Failed to set phase for timeout for build ID: %s - %s", build_id, bse)
+            logger.warning("Failed to set phase for timeout for build ID: %s - %s", build_id, bse)
             yield From(self._build_status_failure(bse))
             raise Return()
 

--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -473,7 +473,9 @@ class EphemeralBuilderManager(BaseManager):
             )
         except KeyError:
             logger.warning(
-                "Job: %s already exists in orchestrator, timeout may be misconfigured. Removing key %s from Redis.", build_uuid, job_key
+                "Job: %s already exists in orchestrator, timeout may be misconfigured. Removing key %s from Redis.",
+                build_uuid,
+                job_key,
             )
             yield From(self._orchestrator.delete_key(job_key))
             raise Return(False, EPHEMERAL_API_TIMEOUT)


### PR DESCRIPTION
logging.exception will re-raise the enclosing exception.
Since trollius uses exceptions to yield control of the event loop,
it will complain that the exception was used without `raise`.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-???
Pull-request title must start with "PROJQUAY-??? - "

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.