### PR TITLE
PROJQUAY-907 - repo mirror initial date

### DIFF
--- a/static/js/directives/repo-view/repo-panel-mirroring.js
+++ b/static/js/directives/repo-view/repo-panel-mirroring.js
@@ -39,7 +39,7 @@ angular.module('quay').directive('repoPanelMirror', function () {
       vm.robot = null;
       vm.status = null;
       vm.syncInterval = null;
-      vm.syncStartDate = null;
+      vm.syncStartDate = moment().unix();
       vm.tags = null;
       vm.username = null;
       vm.verifyTLS = null;
@@ -440,8 +440,7 @@ angular.module('quay').directive('repoPanelMirror', function () {
       vm.setupMirror = function() {
 
         // Apply transformations
-        let now = vm.timestampToISO(moment().unix());
-        let syncStartDate = vm.timestampToISO(vm.syncStartDate) || now;
+        let syncStartDate = vm.timestampToISO(vm.syncStartDate || moment().unix());
         let patterns = Array.from(new Set(vm.tags.split(',').map(s => s.trim()))); // trim + de-dupe
 
         let requestBody = {

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -125,9 +125,9 @@ class SkopeoMirror(object):
         stderr = ""
         while True:
             stdout_nextline = job.stdout.readline()
-            stdout = stdout + stdout_nextline
+            stdout = stdout + stdout_nextline.decode("utf-8")
             stderr_nextline = job.stderr.readline()
-            stderr = stderr + stderr_nextline
+            stderr = stderr + stderr_nextline.decode("utf-8")
             if stdout_nextline == "" and stderr_nextline == "" and job.poll() is not None:
                 break
             logger.debug("Skopeo [STDERR]: %s" % stderr_nextline)

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -132,7 +132,7 @@ def perform_mirror(skopeo, mirror):
             % (mirror.external_reference, ",".join(mirror.root_rule.rule_value)),
             tags=", ".join(tags),
             stdout="Not applicable",
-            stderr=traceback.format_exc(e),
+            stderr=traceback.format_exc(),
         )
         release_mirror(mirror, RepoMirrorStatus.FAIL)
         return
@@ -242,7 +242,7 @@ def perform_mirror(skopeo, mirror):
             % (mirror.external_reference, ",".join(mirror.root_rule.rule_value)),
             tags=", ".join(tags),
             stdout="Not applicable",
-            stderr=traceback.format_exc(e),
+            stderr=traceback.format_exc(),
         )
         release_mirror(mirror, overall_status)
         return


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-907

**Changelog:** none

**Docs:** none

**Testing:** none

**Details:** 
* python3 corrections
* Set initial variable value of vm.syncStartDate allows datepicker to properly store value.

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.