### PR TITLE
Add an endpoint for tracking the secscan backfill

### DIFF
--- a/endpoints/secscan.py
+++ b/endpoints/secscan.py
@@ -1,6 +1,7 @@
 import logging
 
-from flask import make_response, Blueprint
+from flask import make_response, Blueprint, jsonify
+from data.database import ManifestSecurityStatus, Manifest
 from endpoints.decorators import anon_allowed
 
 logger = logging.getLogger(__name__)
@@ -11,3 +12,11 @@ secscan = Blueprint("secscan", __name__)
 @anon_allowed
 def internal_ping():
     return make_response("true", 200)
+
+
+@secscan.route("/_backfill_status")
+@anon_allowed
+def manifest_security_backfill_status():
+    manifest_count = Manifest.select().count()
+    mss_count = ManifestSecurityStatus.select().count()
+    return jsonify({"backfill_percent": mss_count / float(manifest_count)})


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/PROJQUAY-912

**Issue:** https://issues.redhat.com/browse/PROJQUAY-912

**Changelog:** None

**Docs:** Provide

**Testing:** Start a pre-filled Quay with Clair V4 attached and watch `/secscan/_backfill_status`

**Details:** None
