### PR TITLE
[PROJQUAY-917] Fix CSRF token encoding

### DIFF
--- a/endpoints/csrf.py
+++ b/endpoints/csrf.py
@@ -30,7 +30,7 @@ def generate_csrf_token(session_token_name=_QUAY_CSRF_TOKEN_NAME, force=False):
     Returns the generated token.
     """
     if session_token_name not in session or force:
-        session[session_token_name] = base64.b64encode(os.urandom(48)).decode("ascii")
+        session[session_token_name] = base64.urlsafe_b64encode(os.urandom(48)).decode("utf-8")
 
     return session[session_token_name]
 

--- a/endpoints/test/test_csrf.py
+++ b/endpoints/test/test_csrf.py
@@ -1,0 +1,8 @@
+from app import app
+from endpoints.csrf import generate_csrf_token
+
+
+def test_generate_csrf_token():
+    with app.test_request_context():
+        token = generate_csrf_token()
+        assert isinstance(token, str)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-917

**Changelog:** Fix CSRF token encoding in Python 3

**Docs:** n/a

**Testing:** Using any form in the UI, such as creating a User, should no longer fail with a CSRF token error.

**Details:** The CSRF token is being encoded in a way that causes the front-end to incorrectly escape certain sequences contained within the token. This causes CSRF validation to fail as the token created by the back-end and stored in the session does not match what is sent by the browser. This change fixes that issue.