### PR TITLE
Handle generated ssh keypairs in build triggers as str

### DIFF
--- a/buildtrigger/bitbuckethandler.py
+++ b/buildtrigger/bitbuckethandler.py
@@ -310,12 +310,12 @@ class BitbucketBuildTrigger(BuildTriggerHandler):
         # Add a deploy key to the repository.
         public_key, private_key = generate_ssh_keypair()
         config["credentials"] = [
-            {"name": "SSH Public Key", "value": public_key,},
+            {"name": "SSH Public Key", "value": public_key.decode("ascii"),},
         ]
 
         repository = self._get_repository_client()
         (result, created_deploykey, err_msg) = repository.deploykeys().create(
-            app.config["REGISTRY_TITLE"] + " webhook key", public_key
+            app.config["REGISTRY_TITLE"] + " webhook key", public_key.decode("ascii")
         )
 
         if not result:
@@ -337,7 +337,7 @@ class BitbucketBuildTrigger(BuildTriggerHandler):
 
         config["webhook_id"] = created_webhook["uuid"]
         self.config = config
-        return config, {"private_key": private_key}
+        return config, {"private_key": private_key.decode("ascii")}
 
     def deactivate(self):
         config = self.config

--- a/buildtrigger/customhandler.py
+++ b/buildtrigger/customhandler.py
@@ -194,11 +194,11 @@ class CustomBuildTrigger(BuildTriggerHandler):
         config = self.config
         public_key, private_key = generate_ssh_keypair()
         config["credentials"] = [
-            {"name": "SSH Public Key", "value": public_key,},
+            {"name": "SSH Public Key", "value": public_key.decode("ascii"),},
             {"name": "Webhook Endpoint URL", "value": standard_webhook_url,},
         ]
         self.config = config
-        return config, {"private_key": private_key}
+        return config, {"private_key": private_key.decode("ascii")}
 
     def deactivate(self):
         config = self.config

--- a/buildtrigger/githubhandler.py
+++ b/buildtrigger/githubhandler.py
@@ -199,11 +199,13 @@ class GithubBuildTrigger(BuildTriggerHandler):
         # Add a deploy key to the GitHub repository.
         public_key, private_key = generate_ssh_keypair()
         config["credentials"] = [
-            {"name": "SSH Public Key", "value": public_key,},
+            {"name": "SSH Public Key", "value": public_key.decode("ascii"),},
         ]
 
         try:
-            deploy_key = gh_repo.create_key("%s Builder" % app.config["REGISTRY_TITLE"], public_key)
+            deploy_key = gh_repo.create_key(
+                "%s Builder" % app.config["REGISTRY_TITLE"], public_key.decode("ascii")
+            )
             config["deploy_key_id"] = deploy_key.id
         except GithubException as ghe:
             default_msg = "Unable to add deploy key to repository: %s" % new_build_source
@@ -225,7 +227,7 @@ class GithubBuildTrigger(BuildTriggerHandler):
             msg = GithubBuildTrigger._get_error_message(ghe, default_msg)
             raise TriggerActivationException(msg)
 
-        return config, {"private_key": private_key}
+        return config, {"private_key": private_key.decode("ascii")}
 
     @_catch_ssl_errors
     def deactivate(self):

--- a/buildtrigger/gitlabhandler.py
+++ b/buildtrigger/gitlabhandler.py
@@ -227,7 +227,7 @@ class GitLabBuildTrigger(BuildTriggerHandler):
         # Add a deploy key to the repository.
         public_key, private_key = generate_ssh_keypair()
         config["credentials"] = [
-            {"name": "SSH Public Key", "value": public_key,},
+            {"name": "SSH Public Key", "value": public_key.decode("ascii"),},
         ]
 
         key = gl_project.keys.create(
@@ -259,7 +259,7 @@ class GitLabBuildTrigger(BuildTriggerHandler):
 
         config["hook_id"] = hook.get_id()
         self.config = config
-        return config, {"private_key": private_key}
+        return config, {"private_key": private_key.decode("ascii")}
 
     def deactivate(self):
         config = self.config


### PR DESCRIPTION
The keys are either part of a dict being serialized into json with
json.dumps to pass as a requests' body, or passed directly to the
client(e.g github). In both cases, the value needs to be a str.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-926

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.