### PR TITLE
Add an extra "metadata" field to Elasticsearch logentries

### DIFF
--- a/data/logs_model/datatypes.py
+++ b/data/logs_model/datatypes.py
@@ -127,7 +127,7 @@ class Log(
             pass
 
         return Log(
-            log.metadata_json,
+            json.dumps(log.metadata.to_dict()),
             str(log.ip),
             log.datetime,
             performer_email,

--- a/data/logs_model/document_logs_model.py
+++ b/data/logs_model/document_logs_model.py
@@ -501,6 +501,7 @@ class DocumentLogsModel(SharedModel, ActionLogsDataInterface, ElasticsearchLogsM
             performer_id=performer_id,
             ip=ip,
             metadata_json=metadata_json,
+            metadata=metadata or {},
             repository_id=repository_id,
             datetime=timestamp,
         )

--- a/data/logs_model/document_logs_model.py
+++ b/data/logs_model/document_logs_model.py
@@ -492,7 +492,6 @@ class DocumentLogsModel(SharedModel, ActionLogsDataInterface, ElasticsearchLogsM
         if repository is not None:
             repository_id = repository.id
 
-        metadata_json = json.dumps(metadata or {}, default=_json_serialize)
         kind_id = model.log._get_log_entry_kind(kind_name)
         log = LogEntry(
             random_id=_random_id(),
@@ -500,7 +499,6 @@ class DocumentLogsModel(SharedModel, ActionLogsDataInterface, ElasticsearchLogsM
             account_id=account_id,
             performer_id=performer_id,
             ip=ip,
-            metadata_json=metadata_json,
             metadata=metadata or {},
             repository_id=repository_id,
             datetime=timestamp,

--- a/data/logs_model/elastic_logs.py
+++ b/data/logs_model/elastic_logs.py
@@ -50,7 +50,6 @@ class LogEntry(Document):
     performer_id = Integer()
     repository_id = Integer()
     ip = Ip()
-    metadata_json = Text()
     metadata = Object()
     datetime = Date()
 

--- a/data/logs_model/elastic_logs.py
+++ b/data/logs_model/elastic_logs.py
@@ -7,7 +7,7 @@ from requests_aws4auth import AWS4Auth
 
 from elasticsearch import RequestsHttpConnection
 from elasticsearch.exceptions import NotFoundError, AuthorizationException
-from elasticsearch_dsl import Index, Document, Integer, Date, Text, Ip, Keyword
+from elasticsearch_dsl import Index, Document, Integer, Date, Text, Ip, Keyword, Object
 from elasticsearch_dsl.connections import connections
 
 
@@ -51,6 +51,7 @@ class LogEntry(Document):
     repository_id = Integer()
     ip = Ip()
     metadata_json = Text()
+    metadata = Object()
     datetime = Date()
 
     _initialized = False

--- a/data/logs_model/test/mock_elasticsearch.py
+++ b/data/logs_model/test/mock_elasticsearch.py
@@ -75,12 +75,7 @@ INDEX_REQUEST_2019_01_01 = [
         "ip": "192.168.1.1",
         "random_id": 233,
         "datetime": "2019-01-01T03:30:00",
-        "metadata_json": json.loads(
-            '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1520479800}'
-        ),
-        "metadata": json.loads(
-            '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1520479800}'
-        ),
+        "metadata": {"key": "value", "time": "2018-03-08T03:30:00", "😂": "😂👌👌👌👌"},
         "performer_id": 1,
         "kind_id": 1,
     },
@@ -94,12 +89,7 @@ INDEX_REQUEST_2017_03_08 = [
         "ip": "192.168.1.1",
         "random_id": 233,
         "datetime": "2017-03-08T03:30:00",
-        "metadata_json": json.loads(
-            '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1520479800}'
-        ),
-        "metadata": json.loads(
-            '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1520479800}'
-        ),
+        "metadata": {"key": "value", "time": "2018-03-08T03:30:00", "😂": "😂👌👌👌👌"},
         "performer_id": 1,
         "kind_id": 2,
     },
@@ -142,7 +132,7 @@ _hit2 = {
 }
 
 _log1 = Log(
-    '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1520479800}',
+    "{}",
     "192.168.1.1",
     parse("2018-03-08T03:30"),
     "user1.email",
@@ -155,7 +145,7 @@ _log1 = Log(
     1,
 )
 _log2 = Log(
-    '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1522639800}',
+    "{}",
     "192.168.1.2",
     parse("2018-04-02T03:30"),
     "user1.email",

--- a/data/logs_model/test/mock_elasticsearch.py
+++ b/data/logs_model/test/mock_elasticsearch.py
@@ -78,6 +78,9 @@ INDEX_REQUEST_2019_01_01 = [
         "metadata_json": json.loads(
             '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1520479800}'
         ),
+        "metadata": json.loads(
+            '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1520479800}'
+        ),
         "performer_id": 1,
         "kind_id": 1,
     },
@@ -92,6 +95,9 @@ INDEX_REQUEST_2017_03_08 = [
         "random_id": 233,
         "datetime": "2017-03-08T03:30:00",
         "metadata_json": json.loads(
+            '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1520479800}'
+        ),
+        "metadata": json.loads(
             '{"\\ud83d\\ude02": "\\ud83d\\ude02\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c\\ud83d\\udc4c", "key": "value", "time": 1520479800}'
         ),
         "performer_id": 1,

--- a/data/logs_model/test/test_elasticsearch.py
+++ b/data/logs_model/test/test_elasticsearch.py
@@ -173,6 +173,8 @@ def mock_elasticsearch():
         index = url.path.split("/")[1]
         body = json.loads(req.body)
         body["metadata_json"] = json.loads(body["metadata_json"])
+        body["metadata"] = body["metadata_json"]
+
         return mock.index(index, body)
 
     @urlmatch(netloc=FAKE_ES_HOST_PATTERN, path=r"/logentry_([0-9\-]*|\*)/_count")

--- a/data/logs_model/test/test_elasticsearch.py
+++ b/data/logs_model/test/test_elasticsearch.py
@@ -172,8 +172,6 @@ def mock_elasticsearch():
     def index(url, req):
         index = url.path.split("/")[1]
         body = json.loads(req.body)
-        body["metadata_json"] = json.loads(body["metadata_json"])
-        body["metadata"] = body["metadata_json"]
 
         return mock.index(index, body)
 
@@ -328,7 +326,8 @@ def test_log_action(
             repository_name,
             timestamp,
         )
-        mock_elasticsearch.index.assert_called_with(*expected_request)
+
+        mock_elasticsearch.index.assert_called_with(expected_request[0], expected_request[1])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The current "metadata_json" field is stored as a text field, and
cannot be searched easily. "metadata" will store the given dict as a
dynamically mapped Object type so that its fields can be indexed and searched more easily.
e.g Being able to filter the logs by user agents.

<img width="1383" alt="Screen Shot 2020-08-05 at 1 00 16 PM" src="https://user-images.githubusercontent.com/2530351/89441856-ceb0bf00-d71b-11ea-8fee-1c1f36c7afe9.png">


**Issue:** https://issues.redhat.com/browse/PROJQUAY-???
Pull-request title must start with "PROJQUAY-??? - "

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.