### PR TITLE
PROJQUAY-907 - properly check empty string

### DIFF
--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -124,14 +124,16 @@ class SkopeoMirror(object):
         stdout = ""
         stderr = ""
         while True:
-            stdout_nextline = job.stdout.readline()
-            stdout = stdout + stdout_nextline.decode("utf-8")
-            stderr_nextline = job.stderr.readline()
-            stderr = stderr + stderr_nextline.decode("utf-8")
+            stdout_nextline = job.stdout.readline().decode("utf-8")
+            stdout = stdout + stdout_nextline
+            stderr_nextline = job.stderr.readline().decode("utf-8")
+            stderr = stderr + stderr_nextline
             if stdout_nextline == "" and stderr_nextline == "" and job.poll() is not None:
                 break
-            logger.debug("Skopeo [STDERR]: %s" % stderr_nextline)
-            logger.debug("Skopeo [STDOUT]: %s" % stdout_nextline)
+            if stderr_nextline != "":
+                logger.debug("Skopeo [STDERR]: %s" % stderr_nextline)
+            if stdout_nextline != "":
+                logger.debug("Skopeo [STDOUT]: %s" % stdout_nextline)
 
         job.communicate()
 


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-907

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 
The check for empty string to break out of loop was checking the bytes-string instead of the decoded.

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.