### PR TITLE
Fix lookup of tag history sizes

### DIFF
--- a/data/registry_model/datatypes.py
+++ b/data/registry_model/datatypes.py
@@ -346,6 +346,7 @@ class Manifest(
         """
         return repository
 
+    @property
     @optionalinput("legacy_image_row")
     def _legacy_image_row(self, legacy_image_row):
         return legacy_image_row

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -256,6 +256,9 @@ def test_repository_tag_history(
             # Retrieve the manifest to ensure it doesn't issue extra queries.
             tag.manifest
 
+            # Verify that looking up the size doesn't issue extra queries.
+            tag.manifest_layers_size
+
     if has_expired:
         # Ensure the latest tag is marked expired, since there is an expired one.
         with assert_query_count(1):


### PR DESCRIPTION
Add missing `@property` decorator on legacy image size handler to fix
the raised exception
