### PR TITLE
Ensure shared blob layers are present on lookup

### DIFF
--- a/data/registry_model/interface.py
+++ b/data/registry_model/interface.py
@@ -269,7 +269,7 @@ class RegistryDataInterface(object):
         """
 
     @abstractmethod
-    def get_manifest_local_blobs(self, manifest, include_placements=False):
+    def get_manifest_local_blobs(self, manifest, storage, include_placements=False):
         """
         Returns the set of local blobs for the given manifest or None if none.
         """

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -467,7 +467,7 @@ def test_layers_and_blobs(repo_namespace, repo_name, registry_model):
             assert manifest_layer.estimated_size(1) is not None
             assert isinstance(manifest_layer.layer_info, ManifestImageLayer)
 
-        blobs = registry_model.get_manifest_local_blobs(manifest, include_placements=True)
+        blobs = registry_model.get_manifest_local_blobs(manifest, storage, include_placements=True)
         assert {b.digest for b in blobs} == set(parsed.local_blob_digests)
 
 
@@ -563,7 +563,7 @@ def test_mount_blob_into_repository(registry_model):
 
     target_repository_ref = registry_model.lookup_repository("devtable", "complex")
 
-    blobs = registry_model.get_manifest_local_blobs(manifest, include_placements=True)
+    blobs = registry_model.get_manifest_local_blobs(manifest, storage, include_placements=True)
     assert blobs
 
     for blob in blobs:
@@ -589,7 +589,7 @@ def test_get_cached_repo_blob(registry_model):
     latest_tag = registry_model.get_repo_tag(repository_ref, "latest")
     manifest = registry_model.get_manifest_for_tag(latest_tag)
 
-    blobs = registry_model.get_manifest_local_blobs(manifest, include_placements=True)
+    blobs = registry_model.get_manifest_local_blobs(manifest, storage, include_placements=True)
     assert blobs
 
     blob = blobs[0]

--- a/endpoints/v2/manifest.py
+++ b/endpoints/v2/manifest.py
@@ -318,7 +318,7 @@ def _write_manifest_and_log(namespace_name, repo_name, tag_name, manifest_impl):
 
         # Queue all blob manifests for replication.
         if features.STORAGE_REPLICATION:
-            blobs = registry_model.get_manifest_local_blobs(manifest)
+            blobs = registry_model.get_manifest_local_blobs(manifest, storage)
             if blobs is None:
                 logger.error("Could not lookup blobs for manifest `%s`", manifest.digest)
             else:

--- a/util/secscan/test/test_blob_retriever.py
+++ b/util/secscan/test/test_blob_retriever.py
@@ -17,7 +17,7 @@ def test_generate_url(initialized_db):
     repo_ref = registry_model.lookup_repository("devtable", "simple")
     tag = registry_model.get_repo_tag(repo_ref, "latest")
     manifest = tag.manifest
-    blobs = registry_model.get_manifest_local_blobs(manifest)
+    blobs = registry_model.get_manifest_local_blobs(manifest, storage)
 
     retriever = BlobURLRetriever(storage, instance_keys, application)
     headers = retriever.headers_for_download(repo_ref, blobs[0])


### PR DESCRIPTION
Due to the requirement for the shared empty layer for manifest schema 1,
we need to make sure it is written to the ImageStorage table, even if
the only schemas pushed are version 2

Fixes https://issues.redhat.com/browse/PROJQUAY-948

**Issue:** https://issues.redhat.com/browse/PROJQUAY-948

**Testing:** Push a schema 2 manifest and ensure Clair V4 indexing works
