### PR TITLE
fix: Missing storage argument and type error when calling file.write

### DIFF
--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -990,7 +990,7 @@ class OCIModel(RegistryDataInterface):
                 # it now. This will handle the case where the data was never pushed.
                 try:
                     return model.blob.get_or_create_shared_blob(
-                        EMPTY_LAYER_BLOB_DIGEST, EMPTY_LAYER_BYTES
+                        EMPTY_LAYER_BLOB_DIGEST, EMPTY_LAYER_BYTES, storage
                     )
                 except ReadOnlyModeException:
                     return None

--- a/storage/local.py
+++ b/storage/local.py
@@ -34,7 +34,7 @@ class LocalStorage(BaseStorageV2):
     def put_content(self, path, content):
         path = self._init_path(path, create=True)
         with open(path, mode="w") as f:
-            f.write(content)
+            f.buffer.write(content)
         return path
 
     def stream_read(self, path):

--- a/storage/local.py
+++ b/storage/local.py
@@ -28,13 +28,13 @@ class LocalStorage(BaseStorageV2):
 
     def get_content(self, path):
         path = self._init_path(path)
-        with open(path, mode="r") as f:
+        with open(path, mode="rb") as f:
             return f.read()
 
     def put_content(self, path, content):
         path = self._init_path(path, create=True)
-        with open(path, mode="w") as f:
-            f.buffer.write(content)
+        with open(path, mode="wb") as f:
+            f.write(content)
         return path
 
     def stream_read(self, path):
@@ -73,7 +73,7 @@ class LocalStorage(BaseStorageV2):
     def get_checksum(self, path):
         path = self._init_path(path)
         sha_hash = hashlib.sha256()
-        with open(path, "r") as to_hash:
+        with open(path, "rb") as to_hash:
             while True:
                 buf = to_hash.read(self.buffer_size)
                 if not buf:
@@ -88,7 +88,7 @@ class LocalStorage(BaseStorageV2):
         new_uuid = str(uuid4())
 
         # Just create an empty file at the path
-        with open(self._init_path(self._rel_upload_path(new_uuid), create=True), "w"):
+        with open(self._init_path(self._rel_upload_path(new_uuid), create=True), "wb"):
             pass
 
         return new_uuid, {}


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-948

**Testing:** 
Enable Clair v4 scanning in Quay which is configured to use local file storage.

**Details:** 

This PR fixes the build regression introduced by https://github.com/quay/quay/pull/511 where  `model.blob.get_or_create_shared_blob` doesn't pass storage argument.

It also fixes the following exception,
```
securityworker stdout | 2020-08-11 06:25:10,280 [106] [ERROR] [workers.worker] Operation raised exception
securityworker stdout | Traceback (most recent call last):
securityworker stdout |   File "/usr/local/lib/python3.6/site-packages/peewee.py", line 6741, in get
securityworker stdout |     return clone.execute(database)[0]
securityworker stdout |   File "/usr/local/lib/python3.6/site-packages/peewee.py", line 4184, in __getitem__
securityworker stdout |     return self.row_cache[item]
securityworker stdout | IndexError: list index out of range
securityworker stdout | During handling of the above exception, another exception occurred:
securityworker stdout | Traceback (most recent call last):
securityworker stdout |   File "/quay-registry/data/model/blob.py", line 238, in get_or_create_shared_blob
securityworker stdout |     return ImageStorage.get(content_checksum=digest, uploading=False)
securityworker stdout |   File "/usr/local/lib/python3.6/site-packages/peewee.py", line 6318, in get
securityworker stdout |     return sq.get()
securityworker stdout |   File "/usr/local/lib/python3.6/site-packages/peewee.py", line 6746, in get
securityworker stdout |     (clone.model, sql, params))
securityworker stdout | data.database.ImageStorageDoesNotExist: <Model: ImageStorage> instance matching query does not exist:
securityworker stdout | SQL: SELECT "t1"."id", "t1"."uuid", "t1"."image_size", "t1"."uncompressed_size", "t1"."uploading", "t1"."cas_path", "t1"."content_checksum" FROM "imagestorage" AS "t1" WHERE (("t1"."content_checksum" = %s) AND ("t1"."uploading" = %s)) LIMIT %s OFFSET %s
securityworker stdout | Params: ['sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4', False, 1, 0]
securityworker stdout | During handling of the above exception, another exception occurred:
securityworker stdout | Traceback (most recent call last):
securityworker stdout |   File "/quay-registry/workers/worker.py", line 87, in _operation_func
securityworker stdout |     return operation_func()
securityworker stdout |   File "/quay-registry/workers/securityworker/securityworker.py", line 29, in _index_in_scanner
securityworker stdout |     self._next_token = self._model.perform_indexing(self._next_token)
securityworker stdout |   File "/quay-registry/data/secscan_model/__init__.py", line 43, in perform_indexing
securityworker stdout |     return self._model.perform_indexing(next_token)
securityworker stdout |   File "/quay-registry/data/secscan_model/secscan_v4_model.py", line 216, in perform_indexing
securityworker stdout |     layers = registry_model.list_manifest_layers(manifest, self.storage, True)
securityworker stdout |   File "/quay-registry/data/registry_model/registry_oci_model.py", line 515, in list_manifest_layers
securityworker stdout |     manifest_obj.repository_id, parsed, storage, include_placements
securityworker stdout |   File "/quay-registry/data/registry_model/registry_oci_model.py", line 939, in _list_manifest_layers
securityworker stdout |     repo_id, blob_digests, storage
securityworker stdout |   File "/quay-registry/data/registry_model/registry_oci_model.py", line 1008, in _lookup_repo_storages_by_content_checksum
securityworker stdout |     shared_storage = self._get_shared_storage(checksum, storage=storage)
securityworker stdout |   File "/quay-registry/data/registry_model/registry_oci_model.py", line 993, in _get_shared_storage
securityworker stdout |     EMPTY_LAYER_BLOB_DIGEST, EMPTY_LAYER_BYTES, storage
securityworker stdout |   File "/quay-registry/data/model/blob.py", line 246, in get_or_create_shared_blob
securityworker stdout |     storage.put_content([preferred], storage_model.get_layer_path(record), byte_data)
securityworker stdout |   File "/quay-registry/storage/distributedstorage.py", line 27, in wrapper
securityworker stdout |     return storage_func(*args, **kwargs)
securityworker stdout |   File "/quay-registry/storage/local.py", line 37, in put_content
securityworker stdout |     f.write(content)
securityworker stdout | TypeError: write() argument must be str, not bytes
```

The above exception has been thrown when running Quay with local storage backend. This one seems to be a regression after enabling Python 3.

