### PR TITLE
PROJQUAY-381 - failed mirror tag cleanup

### DIFF
--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 
 logger = logging.getLogger(__name__)
 
+SKOPEO_TIMEOUT_SECONDS = 300
 
 # success: True or False whether call was successful
 # tags: list of tags or empty list
@@ -120,21 +121,14 @@ class SkopeoMirror(object):
             close_fds=True,
         )
 
-        # Poll process for new output until finished
-        stdout = ""
-        stderr = ""
-        while True:
-            stdout_nextline = job.stdout.readline().decode("utf-8")
-            stdout = stdout + stdout_nextline
-            stderr_nextline = job.stderr.readline().decode("utf-8")
-            stderr = stderr + stderr_nextline
-            if stdout_nextline == "" and stderr_nextline == "" and job.poll() is not None:
-                break
-            if stderr_nextline != "":
-                logger.debug("Skopeo [STDERR]: %s" % stderr_nextline)
-            if stdout_nextline != "":
-                logger.debug("Skopeo [STDOUT]: %s" % stdout_nextline)
-
-        job.communicate()
+        try:
+            (stdout, stderr) = job.communicate(timeout=SKOPEO_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            job.kill()
+            (stdout, stderr) = job.communicate()
+        stdout = stdout.decode("utf-8")
+        stderr = stderr.decode("utf-8")
+        logger.debug("Skopeo [STDERR]: %s" % stderr)
+        logger.debug("Skopeo [STDOUT]: %s" % stdout)
 
         return SkopeoResults(job.returncode == 0, [], stdout, stderr)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-381

**Changelog:** 
Fixed: Mirror of repos with a large number of tags may hang due to buffering skopeo output.
Fixed: When a mirror job is pre-empted, original tags may be deleted. Mirror jobs that are killed are less likely now to remove existing tags.

**Docs:** 

**Testing:** 
* Sync a repo with a lot of tags with debug logging enabled (eg. https://quay.io/repository/bitnami/sealed-secrets-controller ).
* Confirm job succeeds.
* Sync same repo again, cancelling after seeing the first skopeo inspect in the logs.
* Confirm job cancelled and any tags that were being synced are reverted in the tag history.

**Details:** 
A hung mirror job that was either pre-empted or killed would not always rollback the changes. These changes fix the hanging but also move the deletion of old tags to after all images are synced.
