### PR TITLE
Handles out of range pagination token datetime

### DIFF
--- a/data/logs_model/document_logs_model.py
+++ b/data/logs_model/document_logs_model.py
@@ -335,6 +335,8 @@ class DocumentLogsModel(SharedModel, ActionLogsDataInterface, ElasticsearchLogsM
             after_random_id = page_token["random_id"]
 
         if after_datetime is not None:
+            if after_datetime < start_datetime:
+                return LogEntriesPage([], None)
             end_datetime = min(end_datetime, after_datetime)
 
         all_logs = []


### PR DESCRIPTION
Check that "after_datetime" token used for pagination is smaller than the given starting datetime when doing a lookup

**Issue:** https://issues.redhat.com/browse/PROJQUAY-958

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** Before this, an exception would be raised if the pagination token contained a datetime that is smaller than the given starting datetime. This will return empty logs if that's the case.