### PR TITLE
Fix label application to manifests

### DIFF
--- a/data/model/oci/label.py
+++ b/data/model/oci/label.py
@@ -22,6 +22,28 @@ from util.validation import is_json
 logger = logging.getLogger(__name__)
 
 
+def lookup_manifest_labels(manifest_id, keys):
+    """
+    Returns all labels found on the given manifest with a key in the key set.
+    """
+    if not keys:
+        return []
+
+    keys = list(set(keys))
+    query = (
+        Label.select(Label, MediaType)
+        .join(MediaType)
+        .switch(Label)
+        .join(LabelSourceType)
+        .switch(Label)
+        .join(ManifestLabel)
+        .where(ManifestLabel.manifest == manifest_id)
+        .where(Label.key << list(keys))
+    )
+
+    return query
+
+
 def list_manifest_labels(manifest_id, prefix_filter=None):
     """
     Lists all labels found on the given manifest, with an optional filter by key prefix.
@@ -60,15 +82,12 @@ def get_manifest_label(label_uuid, manifest):
         return None
 
 
-def create_manifest_label(manifest_id, key, value, source_type_name, media_type_name=None):
-    """
-    Creates a new manifest label on a specific tag manifest.
-    """
+def _check_and_translate_label(key, value, source_type_name, media_type_name):
     if not key:
         raise InvalidLabelKeyException("Missing key on label")
 
-    # Note that we don't prevent invalid label names coming from the manifest to be stored, as Docker
-    # does not currently prevent them from being put into said manifests.
+    # NOTE: We don't prevent storing "invalid" label names coming from the manifest, as
+    # clients do not prevent them from being put into manifests.
     if source_type_name != "manifest" and not validate_label_key(key):
         raise InvalidLabelKeyException("Key `%s` is invalid or reserved" % key)
 
@@ -84,6 +103,42 @@ def create_manifest_label(manifest_id, key, value, source_type_name, media_type_
         raise InvalidMediaTypeException()
 
     source_type_id = Label.source_type.get_id(source_type_name)
+    return dict(key=key, value=value, source_type=source_type_id, media_type=media_type_id)
+
+
+def batch_create_manifest_labels(manifest_id, labels):
+    """ Creates labels on a manifest in a batch fashion. The labels argument
+        should be an iterator or list containing dict's whose values matches the
+        arguments to create_manifest_label (minus the manifest_id)
+    """
+    translated = [_check_and_translate_label(**label) for label in labels]
+
+    # Ensure the manifest exists.
+    try:
+        manifest = Manifest.get(id=manifest_id)
+    except Manifest.DoesNotExist:
+        return None
+
+    label_ids = list()
+
+    # Create the labels. We do this non-batch-wise because we need the returned IDs.
+    for translated_label in translated:
+        label_ids.append(Label.create(**translated_label).id)
+
+    # Batch insert the manifest rows.
+    ManifestLabel.bulk_create(
+        [
+            ManifestLabel(manifest=manifest_id, label=label_id, repository=manifest.repository_id)
+            for label_id in label_ids
+        ],
+        batch_size=100,
+    )
+
+
+def create_manifest_label(manifest_id, key, value, source_type_name, media_type_name=None):
+    """
+    Creates a new manifest label on a specific tag manifest.
+    """
 
     # Ensure the manifest exists.
     try:
@@ -97,11 +152,10 @@ def create_manifest_label(manifest_id, key, value, source_type_name, media_type_
         return None
 
     repository = manifest.repository
+    label_args = _check_and_translate_label(key, value, source_type_name, media_type_name)
 
     with db_transaction():
-        label = Label.create(
-            key=key, value=value, source_type=source_type_id, media_type=media_type_id
-        )
+        label = Label.create(**label_args)
         manifest_label = ManifestLabel.create(
             manifest=manifest_id, label=label, repository=repository
         )

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -439,34 +439,6 @@ def filter_to_alive_tags(query, now_ms=None, model=Tag):
     return filter_to_visible_tags(query)
 
 
-def set_tag_expiration_sec_for_manifest(manifest_id, expiration_seconds):
-    """
-    Sets the tag expiration for any tags that point to the given manifest ID.
-    """
-    query = Tag.select().where(Tag.manifest == manifest_id)
-    query = filter_to_alive_tags(query)
-    tags = list(query)
-    for tag in tags:
-        assert not tag.hidden
-        set_tag_end_ms(tag, tag.lifetime_start_ms + (expiration_seconds * 1000))
-
-    return tags
-
-
-def set_tag_expiration_for_manifest(manifest_id, expiration_datetime):
-    """
-    Sets the tag expiration for any tags that point to the given manifest ID.
-    """
-    query = Tag.select().where(Tag.manifest == manifest_id)
-    query = filter_to_alive_tags(query)
-    tags = list(query)
-    for tag in tags:
-        assert not tag.hidden
-        change_tag_expiration(tag, expiration_datetime)
-
-    return tags
-
-
 def change_tag_expiration(tag_id, expiration_datetime):
     """
     Changes the expiration of the specified tag to the given expiration datetime.

--- a/data/model/oci/test/test_oci_manifest.py
+++ b/data/model/oci/test/test_oci_manifest.py
@@ -178,7 +178,7 @@ def test_get_or_create_manifest(schema_version, initialized_db):
     assert created.media_type.name == sample_manifest_instance.media_type
     assert created.digest == sample_manifest_instance.digest
     assert created.manifest_bytes == sample_manifest_instance.bytes.as_encoded_str()
-    assert created_manifest.labels_to_apply == expected_labels
+    assert [l["key"] for l in created_manifest.loaded_labels] == list(expected_labels.keys())
     assert created.config_media_type == sample_manifest_instance.config_media_type
     assert created.layers_compressed_size == sample_manifest_instance.layers_compressed_size
 

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -26,7 +26,6 @@ from data.model.oci.tag import (
     delete_tag,
     delete_tags_for_manifest,
     change_tag_expiration,
-    set_tag_expiration_for_manifest,
     retarget_tag,
     create_temporary_tag_if_necessary,
     lookup_alive_tags_shallow,
@@ -290,17 +289,6 @@ def test_change_tag_expiration(timedelta, expected_timedelta, initialized_db):
 
     updated_tag = Tag.get(id=tag.id)
     assert updated_tag.lifetime_end_ms is None
-
-
-def test_set_tag_expiration_for_manifest(initialized_db):
-    tag = Tag.get()
-    manifest = tag.manifest
-    assert manifest is not None
-
-    set_tag_expiration_for_manifest(manifest, datetime.utcnow() + timedelta(weeks=1))
-
-    updated_tag = Tag.get(id=tag.id)
-    assert updated_tag.lifetime_end_ms is not None
 
 
 def test_create_temporary_tag_if_necessary(initialized_db):

--- a/data/registry_model/interface.py
+++ b/data/registry_model/interface.py
@@ -101,15 +101,6 @@ class RegistryDataInterface(object):
         """
 
     @abstractmethod
-    def batch_create_manifest_labels(self, manifest):
-        """
-        Returns a context manager for batch creation of labels on a manifest.
-
-        Can raise InvalidLabelKeyException or InvalidMediaTypeException depending on the validation
-        errors.
-        """
-
-    @abstractmethod
     def list_manifest_labels(self, manifest, key_prefix=None):
         """
         Returns all labels found on the manifest.
@@ -359,12 +350,6 @@ class RegistryDataInterface(object):
         is being pushed. Returns False if the mounting fails. Note that this function does *not*
         check security for mounting the blob and the caller is responsible for doing this check (an
         example can be found in endpoints/v2/blob.py).
-        """
-
-    @abstractmethod
-    def set_tags_expiration_for_manifest(self, manifest, expiration_sec):
-        """
-        Sets the expiration on all tags that point to the given manifest to that specified.
         """
 
     @abstractmethod

--- a/data/registry_model/label_handlers.py
+++ b/data/registry_model/label_handlers.py
@@ -1,11 +1,12 @@
 import logging
 
+from datetime import datetime
 from util.timedeltastring import convert_to_timedelta
 
 logger = logging.getLogger(__name__)
 
 
-def _expires_after(label_dict, manifest, model):
+def _expires_after(label_dict, tag, model):
     """
     Sets the expiration of a manifest based on the quay.expires-in label.
     """
@@ -13,11 +14,14 @@ def _expires_after(label_dict, manifest, model):
         timedelta = convert_to_timedelta(label_dict["value"])
     except ValueError:
         logger.exception("Could not convert %s to timedeltastring", label_dict["value"])
-        return
+        return False
 
-    total_seconds = timedelta.total_seconds()
-    logger.debug("Labeling manifest %s with expiration of %s", manifest, total_seconds)
-    model.set_tags_expiration_for_manifest(manifest, total_seconds)
+    if timedelta.total_seconds() <= 0:
+        return False
+
+    logger.debug("Labeling tag %s with expiration of %s", tag, timedelta)
+    model.change_repository_tag_expiration(tag, datetime.utcnow() + timedelta)
+    return True
 
 
 _LABEL_HANDLERS = {
@@ -25,10 +29,17 @@ _LABEL_HANDLERS = {
 }
 
 
-def apply_label_to_manifest(label_dict, manifest, model):
+def tag_label_action_keys():
+    """ Returns the set of label keys to lookup for applying labels to a tag. """
+    return _LABEL_HANDLERS.keys()
+
+
+def apply_label_to_tag(label_dict, tag, model):
     """
-    Runs the handler defined, if any, for the given label.
+    Runs the handler defined, if any, for the given label. Returns True if a change was made.
     """
     handler = _LABEL_HANDLERS.get(label_dict["key"])
     if handler is not None:
-        handler(label_dict, manifest, model)
+        return handler(label_dict, tag, model)
+
+    return False

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -163,38 +163,6 @@ def test_manifest_labels(registry_model):
     assert created not in registry_model.list_manifest_labels(found_manifest)
 
 
-def test_manifest_label_handlers(registry_model):
-    repo = model.repository.get_repository("devtable", "simple")
-    repository_ref = RepositoryReference.for_repo_obj(repo)
-    found_tag = registry_model.get_repo_tag(repository_ref, "latest")
-    found_manifest = registry_model.get_manifest_for_tag(found_tag)
-
-    # Ensure the tag has no expiration.
-    assert found_tag.lifetime_end_ts is None
-
-    # Create a new label with an expires-after.
-    registry_model.create_manifest_label(found_manifest, "quay.expires-after", "2h", "api")
-
-    # Ensure the tag now has an expiration.
-    updated_tag = registry_model.get_repo_tag(repository_ref, "latest")
-    assert updated_tag.lifetime_end_ts == (updated_tag.lifetime_start_ts + (60 * 60 * 2))
-
-
-def test_batch_labels(registry_model):
-    repo = model.repository.get_repository("devtable", "history")
-    repository_ref = RepositoryReference.for_repo_obj(repo)
-    found_tag = registry_model.find_matching_tag(repository_ref, ["latest"])
-    found_manifest = registry_model.get_manifest_for_tag(found_tag)
-
-    with registry_model.batch_create_manifest_labels(found_manifest) as add_label:
-        add_label("foo", "1", "api")
-        add_label("bar", "2", "api")
-        add_label("baz", "3", "api")
-
-    # Ensure we can look them up.
-    assert len(registry_model.list_manifest_labels(found_manifest)) == 3
-
-
 @pytest.mark.parametrize(
     "repo_namespace, repo_name",
     [


### PR DESCRIPTION
We now apply labels to manifests in batches as an optimization and we
now apply the *action* labels to tags whenever they are moved,
regardless of whether the manifest has just been created

Fixes https://issues.redhat.com/browse/PROJQUAY-279
