### PR TITLE
Set default values for templated unit timeout

### DIFF
--- a/buildman/container_cloud_config.py
+++ b/buildman/container_cloud_config.py
@@ -62,10 +62,18 @@ class CloudConfigContext(object):
         onfailure_units=[],
         requires_units=[],
         wants_units=[],
-        timeout_start_sec=None,
-        timeout_stop_sec=None,
+        timeout_start_sec=600,
+        timeout_stop_sec=2000,
         autostart=True,
     ):
+        try:
+            timeout_start_sec = int(timeout_start_sec)
+            timeout_stop_sec = int(timeout_stop_sec)
+        except (ValueError, TypeError):
+            logger.error("Invalid timeouts (%s, %s): values should be integers",
+                         timeout_start_sec,
+                         timeout_stop_sec)
+            raise
 
         path = os.path.join(os.path.dirname(__file__), "templates")
         env = Environment(loader=FileSystemLoader(path), undefined=StrictUndefined)

--- a/buildman/templates/dockersystemd.json
+++ b/buildman/templates/dockersystemd.json
@@ -25,8 +25,8 @@ Type=oneshot
 {% else -%}
 Restart={{ restart_policy }}
 {%- endif %}
-TimeoutStartSec={{ timeout_start_sec|default(600) }}
-TimeoutStopSec={{ timeout_stop_sec|default(2000) }}
+TimeoutStartSec={{ timeout_start_sec if timeout_start_sec else 600 }}
+TimeoutStopSec={{ timeout_stop_sec if timeout_stop_sec else 2000 }}
 {% if username and password %}
 ExecStartPre=/usr/bin/docker login -u {{ username }} -p {{ password }} {{ container|registry }}
 {% endif %}


### PR DESCRIPTION
Jinja's default is only used if the variable is undefined, not None.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-972

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.