### PR TITLE
Azure client update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,11 +14,8 @@ attrs==19.3.0
 autobahn==20.1.3
 aws-sam-translator==1.20.1
 aws-xray-sdk==2.4.3
-azure-common==1.1.10
-azure-nspkg==2.0.0
-azure-storage-blob==1.1.0
-azure-storage-common==1.1.0
-azure-storage-nspkg==3.0.0
+azure-core==1.8.0
+azure-storage-blob==12.4.0
 Babel==2.8.0
 backoff==1.10.0
 backports.functools-lru-cache==1.6.1

--- a/storage/azurestorage.py
+++ b/storage/azurestorage.py
@@ -13,9 +13,16 @@ import time
 
 from datetime import datetime, timedelta
 
-from azure.common import AzureException
-from azure.storage.blob import BlockBlobService, ContentSettings, BlobBlock, ContainerPermissions
-from azure.storage.common.models import CorsRule
+from azure.core.exceptions import AzureError, ResourceNotFoundError
+from azure.storage.blob import (
+    BlobServiceClient,
+    BlobType,
+    ContainerSasPermissions,
+    ContentSettings,
+    BlobBlock,
+    CorsRule,
+    generate_blob_sas,
+)
 
 from storage.basestorage import BaseStorage
 from util.registry.filelike import LimitingStream, READ_UNTIL_END
@@ -24,9 +31,16 @@ logger = logging.getLogger(__name__)
 
 _COPY_POLL_SLEEP = 0.25  # seconds
 _MAX_COPY_POLL_COUNT = 120  # _COPY_POLL_SLEEPs => 120s
-_MAX_BLOCK_SIZE = 1024 * 1024 * 100  # 100MB
+_API_VERSION_LIMITS = {
+    "2016-05-31": (datetime.strptime("2016-05-31", "%Y-%m-%d"), 1024 * 1024 * 4),  # 4MiB
+    "2019-07-07": (datetime.strptime("2019-07-07", "%Y-%m-%d"), 1024 * 1024 * 100),  # 100MiB
+    "2019-12-12": (datetime.strptime("2019-12-12", "%Y-%m-%d"), 1024 * 1024 * 1000 * 4),  # 4000MiB
+}
 _BLOCKS_KEY = "blocks"
 _CONTENT_TYPE_KEY = "content-type"
+
+
+AZURE_STORAGE_URL_STRING = "https://{}.blob.core.windows.net"
 
 
 class AzureStorage(BaseStorage):
@@ -39,29 +53,33 @@ class AzureStorage(BaseStorage):
         azure_account_key=None,
         sas_token=None,
         connection_string=None,
-        is_emulated=False,
-        socket_timeout=20,
-        request_timeout=20,
     ):
         super(AzureStorage, self).__init__()
         self._context = context
         self._storage_path = storage_path.lstrip("/")
 
-        self._azure_account_name = azure_account_key
+        self._azure_account_name = azure_account_name
         self._azure_account_key = azure_account_key
         self._azure_sas_token = sas_token
         self._azure_container = azure_container
         self._azure_connection_string = connection_string
-        self._request_timeout = request_timeout
 
-        self._blob_service = BlockBlobService(
-            account_name=azure_account_name,
-            account_key=azure_account_key,
-            sas_token=sas_token,
-            is_emulated=is_emulated,
-            connection_string=connection_string,
-            socket_timeout=socket_timeout,
+        self._blob_service_client = BlobServiceClient(
+            AZURE_STORAGE_URL_STRING.format(self._azure_account_name),
+            credential=self._azure_account_key,
         )
+
+        # https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs
+        api_version = self._blob_service_client.api_version
+        api_version_dt = datetime.strptime(api_version, "%Y-%m-%d")
+        if api_version_dt < _API_VERSION_LIMITS["2016-05-31"][0]:
+            self._max_block_size = _API_VERSION_LIMITS["2016-05-31"][1]
+        elif api_version_dt <= _API_VERSION_LIMITS["2019-07-07"][0]:
+            self._max_block_size = _API_VERSION_LIMITS["2019-07-07"][1]
+        elif api_version_dt >= _API_VERSION_LIMITS["2019-12-12"][0]:
+            self._max_block_size = _API_VERSION_LIMITS["2019-12-12"][1]
+        else:
+            raise Exception("Unknown Azure api version %s" % api_version)
 
     def _blob_name_from_path(self, object_path):
         if ".." in object_path:
@@ -75,23 +93,31 @@ class AzureStorage(BaseStorage):
     def _upload_blob_name_from_uuid(self, uuid):
         return "uploads/{0}".format(uuid)
 
+    def _blob(self, blob_name):
+        return self._blob_service_client.get_blob_client(self._azure_container, blob_name)
+
+    @property
+    def _container(self):
+        return self._blob_service_client.get_container_client(self._azure_container)
+
     def get_direct_download_url(
         self, object_path, request_ip=None, expires_in=60, requires_cors=False, head=False
     ):
         blob_name = self._blob_name_from_path(object_path)
 
         try:
-            sas_token = self._blob_service.generate_blob_shared_access_signature(
+            sas_token = generate_blob_sas(
+                self._azure_account_name,
                 self._azure_container,
                 blob_name,
-                ContainerPermissions.READ,
-                datetime.utcnow() + timedelta(seconds=expires_in),
+                account_key=self._azure_account_key,
+                permission=ContainerSasPermissions.from_string("r"),
+                expiry=datetime.utcnow() + timedelta(seconds=expires_in),
             )
 
-            blob_url = self._blob_service.make_blob_url(
-                self._azure_container, blob_name, sas_token=sas_token
-            )
-        except AzureException:
+            blob_url = "{}?{}".format(self._blob(blob_name).url, sas_token)
+
+        except AzureError:
             logger.exception(
                 "Exception when trying to get direct download for path %s", object_path
             )
@@ -101,25 +127,22 @@ class AzureStorage(BaseStorage):
 
     def validate(self, client):
         super(AzureStorage, self).validate(client)
-        self._blob_service.get_container_properties(
-            self._azure_container, timeout=self._request_timeout
-        )
 
     def get_content(self, path):
         blob_name = self._blob_name_from_path(path)
         try:
-            blob = self._blob_service.get_blob_to_bytes(self._azure_container, blob_name)
-        except AzureException:
+            blob_stream = self._blob(blob_name).download_blob()
+        except AzureError:
             logger.exception("Exception when trying to get path %s", path)
             raise IOError("Exception when trying to get path")
 
-        return blob.content
+        return blob_stream.content_as_bytes()
 
     def put_content(self, path, content):
         blob_name = self._blob_name_from_path(path)
         try:
-            self._blob_service.create_blob_from_bytes(self._azure_container, blob_name, content)
-        except AzureException:
+            self._blob(blob_name).upload_blob(content, blob_type=BlobType.BlockBlob)
+        except AzureError:
             logger.exception("Exception when trying to put path %s", path)
             raise IOError("Exception when trying to put path")
 
@@ -136,9 +159,9 @@ class AzureStorage(BaseStorage):
 
         try:
             output_stream = io.BytesIO()
-            self._blob_service.get_blob_to_stream(self._azure_container, blob_name, output_stream)
+            self._blob(blob_name).download_blob().download_to_stream(output_stream)
             output_stream.seek(0)
-        except AzureException:
+        except AzureError:
             logger.exception("Exception when trying to stream_file_read path %s", path)
             raise IOError("Exception when trying to stream_file_read path")
 
@@ -151,39 +174,40 @@ class AzureStorage(BaseStorage):
         )
 
         try:
-            self._blob_service.create_blob_from_stream(
-                self._azure_container, blob_name, fp, content_settings=content_settings
-            )
-        except AzureException as ae:
+            self._blob(blob_name).upload_blob(fp, content_settings=content_settings)
+        except AzureError as ae:
             logger.exception("Exception when trying to stream_write path %s", path)
             raise IOError("Exception when trying to stream_write path", ae)
 
     def exists(self, path):
         blob_name = self._blob_name_from_path(path)
+
         try:
-            return self._blob_service.exists(
-                self._azure_container, blob_name, timeout=self._request_timeout
-            )
-        except AzureException:
+            self._blob(blob_name).get_blob_properties()
+        except ResourceNotFoundError:
+            return False
+        except AzureError:
             logger.exception("Exception when trying to check exists path %s", path)
             raise IOError("Exception when trying to check exists path")
+
+        return True
 
     def remove(self, path):
         blob_name = self._blob_name_from_path(path)
         try:
-            self._blob_service.delete_blob(self._azure_container, blob_name)
-        except AzureException:
+            self._blob(blob_name).delete_blob()
+        except AzureError:
             logger.exception("Exception when trying to remove path %s", path)
             raise IOError("Exception when trying to remove path")
 
     def get_checksum(self, path):
         blob_name = self._blob_name_from_path(path)
         try:
-            blob = self._blob_service.get_blob_properties(self._azure_container, blob_name)
-        except AzureException:
+            blob_properties = self._blob(blob_name).get_blob_properties()
+        except AzureError:
             logger.exception("Exception when trying to get_checksum for path %s", path)
             raise IOError("Exception when trying to get_checksum path")
-        return blob.properties.etag
+        return blob_properties.etag
 
     def initiate_chunked_upload(self):
         random_uuid = str(uuid.uuid4())
@@ -205,9 +229,9 @@ class AzureStorage(BaseStorage):
         while True:
             current_length = length - total_bytes_written
             max_length = (
-                min(current_length, _MAX_BLOCK_SIZE)
+                min(current_length, self._max_block_size)
                 if length != READ_UNTIL_END
-                else _MAX_BLOCK_SIZE
+                else self._max_block_size
             )
             if max_length <= 0:
                 break
@@ -217,7 +241,7 @@ class AzureStorage(BaseStorage):
             # Note: Azure fails if a zero-length block is uploaded, so we read all the data here,
             # and, if there is none, terminate early.
             block_data = b""
-            for chunk in iter(lambda: limited.read(4096), b""):
+            for chunk in iter(lambda: limited.read(31457280), b""):
                 block_data += chunk
 
             if len(block_data) == 0:
@@ -228,14 +252,10 @@ class AzureStorage(BaseStorage):
             new_metadata[_BLOCKS_KEY].append(block_id)
 
             try:
-                self._blob_service.put_block(
-                    self._azure_container,
-                    upload_blob_path,
-                    block_data,
-                    block_id,
-                    validate_content=True,
+                self._blob(upload_blob_path).stage_block(
+                    block_id, block_data, validate_content=True
                 )
-            except AzureException as ae:
+            except AzureError as ae:
                 logger.exception(
                     "Exception when trying to stream_upload_chunk block %s for %s", block_id, uuid
                 )
@@ -258,12 +278,19 @@ class AzureStorage(BaseStorage):
         Returns nothing.
         """
         # Commit the blob's blocks.
-        upload_blob_path = self._upload_blob_path_from_uuid(uuid)
+        upload_blob_name = self._upload_blob_name_from_uuid(uuid)  # upload/<uuid>
+        upload_blob_path = self._upload_blob_path_from_uuid(uuid)  # storage/path/upload/<uuid>
         block_list = [BlobBlock(block_id) for block_id in storage_metadata[_BLOCKS_KEY]]
 
         try:
-            self._blob_service.put_block_list(self._azure_container, upload_blob_path, block_list)
-        except AzureException:
+            if storage_metadata[_CONTENT_TYPE_KEY] is not None:
+                content_settings = ContentSettings(content_type=storage_metadata[_CONTENT_TYPE_KEY])
+                self._blob(upload_blob_path).commit_block_list(
+                    block_list, content_settings=content_settings
+                )
+            else:
+                self._blob(upload_blob_path).commit_block_list(block_list)
+        except AzureError:
             logger.exception(
                 "Exception when trying to put block list for path %s from upload %s",
                 final_path,
@@ -271,41 +298,26 @@ class AzureStorage(BaseStorage):
             )
             raise IOError("Exception when trying to put block list")
 
-        # Set the content type on the blob if applicable.
-        if storage_metadata[_CONTENT_TYPE_KEY] is not None:
-            content_settings = ContentSettings(content_type=storage_metadata[_CONTENT_TYPE_KEY])
-            try:
-                self._blob_service.set_blob_properties(
-                    self._azure_container, upload_blob_path, content_settings=content_settings
-                )
-            except AzureException:
-                logger.exception(
-                    "Exception when trying to set blob properties for path %s", final_path
-                )
-                raise IOError("Exception when trying to set blob properties")
-
         # Copy the blob to its final location.
         upload_blob_name = self._upload_blob_name_from_uuid(uuid)
         copy_source_url = self.get_direct_download_url(upload_blob_name, expires_in=300)
 
         try:
-            blob_name = self._blob_name_from_path(final_path)
-            copy_prop = self._blob_service.copy_blob(
-                self._azure_container, blob_name, copy_source_url
-            )
-        except AzureException:
+            final_blob_name = self._blob_name_from_path(final_path)
+            cp = self._blob(final_blob_name).start_copy_from_url(copy_source_url)
+        except AzureError:
             logger.exception(
                 "Exception when trying to set copy uploaded blob %s to path %s", uuid, final_path
             )
             raise IOError("Exception when trying to copy uploaded blob")
 
-        self._await_copy(self._azure_container, blob_name, copy_prop)
+        self._await_copy(final_blob_name)
 
         # Delete the original blob.
         logger.debug("Deleting chunked upload %s at path %s", uuid, upload_blob_path)
         try:
-            self._blob_service.delete_blob(self._azure_container, upload_blob_path)
-        except AzureException:
+            self._blob(upload_blob_path).delete_blob()
+        except AzureError:
             logger.exception("Exception when trying to set delete uploaded blob %s", uuid)
             raise IOError("Exception when trying to delete uploaded blob")
 
@@ -317,14 +329,20 @@ class AzureStorage(BaseStorage):
         """
         upload_blob_path = self._upload_blob_path_from_uuid(uuid)
         logger.debug("Canceling chunked upload %s at path %s", uuid, upload_blob_path)
-        self._blob_service.delete_blob(self._azure_container, upload_blob_path)
+        try:
+            self._blob(upload_blob_path).delete_blob()
+        except ResourceNotFoundError:
+            pass
 
-    def _await_copy(self, container, blob_name, copy_prop):
+    def _await_copy(self, blob_name):
         # Poll for copy completion.
+        blob = self._blob(blob_name)
+        copy_prop = blob.get_blob_properties().copy
+
         count = 0
         while copy_prop.status == "pending":
-            props = self._blob_service.get_blob_properties(container, blob_name)
-            copy_prop = props.properties.copy
+            props = blob.get_blob_properties()
+            copy_prop = props.copy
 
             if copy_prop.status == "success":
                 return
@@ -349,10 +367,10 @@ class AzureStorage(BaseStorage):
             )
             copy_source_url = self.get_direct_download_url(path)
             blob_name = destination._blob_name_from_path(path)
-            copy_prop = destination._blob_service.copy_blob(
-                destination._azure_container, blob_name, copy_source_url
-            )
-            destination._await_copy(destination._azure_container, blob_name, copy_prop)
+            dest_blob = destination._blob(blob_name)
+
+            destination._blob(blob_name).start_copy_from_url(copy_source_url)
+            destination._await_copy(blob_name)
             logger.debug(
                 "Finished copying file from Azure %s to Azure %s via an Azure copy",
                 self._azure_container,
@@ -386,4 +404,4 @@ class AzureStorage(BaseStorage):
             )
         ]
 
-        self._blob_service.set_blob_service_properties(cors=cors)
+        self._blob_service_client.set_service_properties(cors=cors)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-942

**Changelog:** 
- Update Azure client library to v12
- Increase chunk size when reading stream when uploading to Azure

**Docs:** 

**Testing:** Try pushing/pulling images of different layer sizes to Quay

**Details:** 
Python 3 has some performance issues with the way streams are currently iterated over when uploading data using Azure.
This PR tweaks the chunk size to improve performance on Python 3 to be more comparable to Python 2, and updates the Azure library version used to v12.4.0 from 1.1.0, which handles large files better, and has support for newer Azure API versions.