### PR TITLE
Reduce log noise from fallbacks in executor

### DIFF
--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -501,8 +501,8 @@ class EphemeralBuilderManager(BaseManager):
             # Check if we can use this executor based on the retries remaining.
             if executor.minimum_retry_threshold > build_job.retries_remaining:
                 build_fallback.labels(executor.name).inc()
-                logger.debug(
-                    "Job %s cannot use executor %s as it is below retry threshold %s (retry #%s)",
+                logger.warning(
+                    "Job %s cannot use executor %s as it is below retry threshold %s (retry #%s) - Falling back to next configured executor",
                     build_uuid,
                     executor.name,
                     executor.minimum_retry_threshold,

--- a/data/logs_model/datatypes.py
+++ b/data/logs_model/datatypes.py
@@ -143,7 +143,7 @@ class Log(
     def to_dict(self, avatar, include_namespace=False):
         view = {
             "kind": _kinds()[self.kind_id],
-            "metadata": json.loads(self.metadata_json),
+            "metadata": json.loads(self.metadata_json or {}),
             "ip": self.ip,
             "datetime": _format_date(self.datetime),
         }


### PR DESCRIPTION
Follow-up to  https://issues.redhat.com/browse/PROJQUAY-974

**Changelog:** 
- Reduce the log level from error to warning when falling back on executors.
- Set empty default metadata when trying to serialize to JSON if for some reason it is not set in `LogEntry`.

**Docs:** 

**Testing:** 

**Details:** 
