### PR TITLE
json loads fix: given arg should be a str

### DIFF
--- a/data/logs_model/datatypes.py
+++ b/data/logs_model/datatypes.py
@@ -143,7 +143,7 @@ class Log(
     def to_dict(self, avatar, include_namespace=False):
         view = {
             "kind": _kinds()[self.kind_id],
-            "metadata": json.loads(self.metadata_json or {}),
+            "metadata": json.loads(self.metadata_json or "{}"),
             "ip": self.ip,
             "datetime": _format_date(self.datetime),
         }


### PR DESCRIPTION
Fixes bug from https://github.com/quay/quay/pull/526

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 
