### PR TITLE
PROJQUAY-984 - optimization debian package manager tweaks

### DIFF
--- a/dev.df
+++ b/dev.df
@@ -8,8 +8,8 @@ ENV HOME /root
 # Install the dependencies.
 RUN apt-get update  # 24JUN2015
 
-# New ubuntu packages should be added as their own apt-get install lines below the existing install commands
-RUN apt-get install -y git python-virtualenv python-dev libjpeg8 libjpeg62 libjpeg62-dev libevent-2.0.5 libevent-dev gdebi-core g++ libmagic1 phantomjs nodejs npm libldap-2.4-2 libldap2-dev libsasl2-modules libsasl2-dev libpq5 libpq-dev libfreetype6-dev libffi-dev libgpgme11 libgpgme11-dev
+# New ubuntu packages should be added as their own apt-get --no-install-recommends -y install lines below the existing install commands
+RUN apt-get --no-install-recommends -y install git python-virtualenv python-dev libjpeg8 libjpeg62 libjpeg62-dev libevent-2.0.5 libevent-dev gdebi-core g++ libmagic1 phantomjs nodejs npm libldap-2.4-2 libldap2-dev libsasl2-modules libsasl2-dev libpq5 libpq-dev libfreetype6-dev libffi-dev libgpgme11 libgpgme11-dev
 
 # Build the python dependencies
 ADD requirements.txt requirements.txt
@@ -21,7 +21,7 @@ ARG src_subdir
 RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D \
 	&& echo "deb https://apt.dockerproject.org/repo ubuntu-trusty main" > /etc/apt/sources.list.d/docker.list \
 	&& apt-get update \
-	&& apt-get install -y docker-engine
+	&& apt-get --no-install-recommends -y install docker-engine
 
 ENV PYTHONPATH=/
 ENV PATH=/venv/bin:$PATH

--- a/quay-base.dockerfile
+++ b/quay-base.dockerfile
@@ -23,7 +23,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 # Install system packages
 RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y \
+    && apt-get --no-install-recommends -y install \
      dnsmasq           \
      g++               \
      gdb               \

--- a/tools/phpmyadmin/Dockerfile
+++ b/tools/phpmyadmin/Dockerfile
@@ -7,13 +7,13 @@ ENV UPDATE_APT 2
 RUN apt-get update
 
 # Install LAMP
-RUN apt-get install -y lamp-server^
+RUN apt-get --no-install-recommends -y install lamp-server^
 
 # Install phpMyAdmin
 RUN mysqld & \
 	service apache2 start; \
 	sleep 5; \
-	printf y\\n\\n\\n1\\n | apt-get install -y phpmyadmin; \
+	printf y\\n\\n\\n1\\n | apt-get --no-install-recommends -y install phpmyadmin; \
 	sleep 15; \
 	mysqladmin -u root shutdown
 


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

**Issue:** https://issues.redhat.com/browse/PROJQUAY-984