### PR TITLE
PROJQUAY-987 - use `--no-cache-dir` flag to `pip` in dockerfiles, to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ENV OS=linux \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=UTF-8 \
     LC_ALL=C.UTF-8 \
-    LANG=C.UTF-8 \
-    PIP_NO_CACHE_DIR=off
+    LANG=C.UTF-8
 
 ENV QUAYDIR /quay-registry
 ENV QUAYCONF /quay-registry/conf
@@ -38,8 +37,8 @@ RUN INSTALL_PKGS="\
 COPY . .
 
 RUN alternatives --set python /usr/bin/python3 && \
-    python -m pip install --upgrade setuptools pip && \
-    python -m pip install -r requirements.txt --no-cache && \
+    python -m pip install --no-cache-dir --upgrade setuptools pip && \
+    python -m pip install --no-cache-dir -r requirements.txt --no-cache && \
     python -m pip freeze && \
     mkdir -p $QUAYDIR/static/webfonts && \
     mkdir -p $QUAYDIR/static/fonts && \

--- a/Dockerfile.centos7.osbs
+++ b/Dockerfile.centos7.osbs
@@ -8,8 +8,7 @@ ENV OS=linux \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    PIP_NO_CACHE_DIR=off
+    LANG=en_US.UTF-8
 
 ENV QUAYDIR /quay-registry
 ENV QUAYCONF /quay-registry/conf
@@ -41,9 +40,9 @@ RUN INSTALL_PKGS="\
 COPY . .
 
 RUN scl enable python36 "\
-    pip install --upgrade setuptools pip && \
-    pip install -r requirements.txt --no-cache && \
-    pip install -r requirements-dev.txt --no-cache && \
+    pip install --no-cache-dir --upgrade setuptools pip && \
+    pip install --no-cache-dir -r requirements.txt --no-cache && \
+    pip install --no-cache-dir -r requirements-dev.txt --no-cache && \
     pip freeze && \
     mkdir -p $QUAYDIR/static/webfonts && \
     mkdir -p $QUAYDIR/static/fonts && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,8 +10,8 @@ COPY requirements.txt requirements-dev.txt ./
 # Put the virtualenv outside the source directory.  This lets us mount
 # the Quay source as a volume for local development.
 RUN virtualenv --distribute /venv \
-    && /venv/bin/pip install -r requirements.txt \
-    && /venv/bin/pip install -r requirements-dev.txt \
+    && /venv/bin/pip install --no-cache-dir -r requirements.txt \
+    && /venv/bin/pip install --no-cache-dir -r requirements-dev.txt \
     && /venv/bin/pip freeze
 
 ENV PATH /venv/bin:${PATH}

--- a/Dockerfile.osbs
+++ b/Dockerfile.osbs
@@ -8,8 +8,7 @@ ENV OS=linux \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    PIP_NO_CACHE_DIR=off
+    LANG=en_US.UTF-8
 
 ENV QUAYDIR /quay-registry
 ENV QUAYCONF /quay-registry/conf
@@ -47,8 +46,8 @@ RUN INSTALL_PKGS="\
 COPY . .
 
 RUN scl enable python36 "\
-    pip install --upgrade setuptools pip && \
-    pip install -r requirements.txt --no-cache && \
+    pip install --no-cache-dir --upgrade setuptools pip && \
+    pip install --no-cache-dir -r requirements.txt --no-cache && \
     pip freeze && \
     mkdir -p $QUAYDIR/static/webfonts && \
     mkdir -p $QUAYDIR/static/fonts && \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -8,8 +8,7 @@ ENV OS=linux \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    PIP_NO_CACHE_DIR=off
+    LANG=en_US.UTF-8
 
 ENV QUAYDIR /quay-registry
 ENV QUAYCONF /quay-registry/conf
@@ -47,8 +46,8 @@ RUN INSTALL_PKGS="\
 COPY . .
 
 RUN scl enable python36 "\
-    pip install --upgrade setuptools pip && \
-    pip install -r requirements.txt --no-cache && \
+    pip install --no-cache-dir --upgrade setuptools pip && \
+    pip install --no-cache-dir -r requirements.txt --no-cache && \
     pip freeze && \
     mkdir -p $QUAYDIR/static/webfonts && \
     mkdir -p $QUAYDIR/static/fonts && \

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -8,8 +8,7 @@ ENV OS=linux \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=UTF-8 \
     LC_ALL=C.UTF-8 \
-    LANG=C.UTF-8 \
-    PIP_NO_CACHE_DIR=off
+    LANG=C.UTF-8
 
 ENV QUAYDIR /quay-registry
 ENV QUAYCONF /quay-registry/conf
@@ -39,8 +38,8 @@ RUN INSTALL_PKGS="\
 COPY . .
 
 RUN alternatives --set python /usr/bin/python3 && \
-    python -m pip install --upgrade setuptools pip && \
-    python -m pip install -r requirements.txt --no-cache && \
+    python -m pip install --no-cache-dir --upgrade setuptools pip && \
+    python -m pip install --no-cache-dir -r requirements.txt --no-cache && \
     python -m pip freeze && \
     mkdir -p $QUAYDIR/static/webfonts && \
     mkdir -p $QUAYDIR/static/fonts && \

--- a/dev.df
+++ b/dev.df
@@ -14,7 +14,7 @@ RUN apt-get install -y git python-virtualenv python-dev libjpeg8 libjpeg62 libjp
 # Build the python dependencies
 ADD requirements.txt requirements.txt
 RUN virtualenv --distribute venv
-RUN venv/bin/pip install -r requirements.txt
+RUN venv/bin/pip install --no-cache-dir -r requirements.txt
 
 ARG src_subdir
 

--- a/quay-base.dockerfile
+++ b/quay-base.dockerfile
@@ -87,8 +87,8 @@ RUN curl -fsSL https://github.com/prometheus/pushgateway/releases/download/$(PUS
 # Install python dependencies
 COPY requirements.txt requirements-dev.txt ./
 RUN virtualenv --distribute venv \
-    && venv/bin/pip install -r requirements.txt \
-    && venv/bin/pip install -r requirements-dev.txt \
+    && venv/bin/pip install --no-cache-dir -r requirements.txt \
+    && venv/bin/pip install --no-cache-dir -r requirements-dev.txt \
     && venv/bin/pip freeze
 
 # Install front-end dependencies


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

**Issue:** https://issues.redhat.com/browse/PROJQUAY-987