### PR TITLE
Allow existing blobs to be overwritten in azure

### DIFF
--- a/storage/azurestorage.py
+++ b/storage/azurestorage.py
@@ -141,7 +141,7 @@ class AzureStorage(BaseStorage):
     def put_content(self, path, content):
         blob_name = self._blob_name_from_path(path)
         try:
-            self._blob(blob_name).upload_blob(content, blob_type=BlobType.BlockBlob)
+            self._blob(blob_name).upload_blob(content, blob_type=BlobType.BlockBlob, overwrite=True)
         except AzureError:
             logger.exception("Exception when trying to put path %s", path)
             raise IOError("Exception when trying to put path")
@@ -174,7 +174,7 @@ class AzureStorage(BaseStorage):
         )
 
         try:
-            self._blob(blob_name).upload_blob(fp, content_settings=content_settings)
+            self._blob(blob_name).upload_blob(fp, content_settings=content_settings, overwrite=True)
         except AzureError as ae:
             logger.exception("Exception when trying to stream_write path %s", path)
             raise IOError("Exception when trying to stream_write path", ae)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-989

**Changelog:** 
- Allow the blobs in azure to be rewritten. This is the same behaviour as in s3. This is necessary for config validation (the same test blob is written to each time storage is validated)

**Docs:** 

**Testing:** 
- Setup quay with the config app with azure
- Try to edit the saved config from the previous setup -> Azure storage should be able to validate 

**Details:** 
