### PR TITLE
Use manifest_digest instead of image_id when accessing current tracks

### DIFF
--- a/static/js/directives/repo-view/repo-panel-tags.js
+++ b/static/js/directives/repo-view/repo-panel-tags.js
@@ -159,7 +159,7 @@ angular.module('quay').directive('repoPanelTags', function () {
               var canAddToCurrentTrack = true;
               for (var j = 0; j < currentTrack.entries.length; ++j) {
                 var currentTrackEntry = currentTrack.entries[j];
-                var entryInfo = manifestIndexMap[currentTrackEntry.image_id];
+                var entryInfo = manifestIndexMap[currentTrackEntry.manifest_digest];
                 if (Math.max(entryInfo.start, manifestIndexRange.start) <= Math.min(entryInfo.end, manifestIndexRange.end)) {
                   canAddToCurrentTrack = false;
                   break;


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-953

**Changelog:** 
Fix UI tags' tracks

**Docs:** 

**Testing:** 
- Push multiple tags with different manifest digests.
- Create new tags from the tags created above -> New tracks should be displayed correctly in the repo tags panel (even after page refresh).

**Details:** 
