### PR TITLE
PROJQUAY-1002 - properly register helm oci type

### DIFF
--- a/image/oci/test/test_oci_manifest.py
+++ b/image/oci/test/test_oci_manifest.py
@@ -4,6 +4,7 @@ import pytest
 
 from image.docker.schema1 import DOCKER_SCHEMA1_MANIFEST_CONTENT_TYPE
 from image.oci.manifest import OCIManifest, MalformedOCIManifest
+from image.oci import register_artifact_type
 from image.shared.schemautil import ContentRetrieverForTesting
 from util.bytes import Bytes
 
@@ -272,3 +273,26 @@ def test_validate_manifest_invalid_config_type():
 
     with pytest.raises(MalformedOCIManifest):
         OCIManifest(Bytes.for_string_or_unicode(manifest_bytes))
+
+
+def test_validate_helm_oci_manifest():
+    manifest_bytes = """{
+      "schemaVersion":2,
+      "config":{
+        "mediaType":"application/vnd.cncf.helm.config.v1+json",
+        "digest":"sha256:65a07b841ece031e6d0ec5eb948eacb17aa6d7294cdeb01d5348e86242951487",
+        "size":141
+      },
+    "layers": [
+      {
+        "mediaType":"application/tar+gzip",
+        "digest":"sha256:d84c9c29e0899862a0fa0f73da4d9f8c8c38e2da5d3258764aa7ba74bb914718",
+        "size":3562
+       }
+      ]
+    }"""
+
+    HELM_CHART_CONFIG_TYPE = "application/vnd.cncf.helm.config.v1+json"
+    HELM_CHART_LAYER_TYPES = ["application/tar+gzip"]
+    register_artifact_type(HELM_CHART_CONFIG_TYPE, HELM_CHART_LAYER_TYPES)
+    manifest = OCIManifest(Bytes.for_string_or_unicode(manifest_bytes))


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1002

**Changelog:** 
Fixes: FEATURE_EXPERIMENTAL_HELM_OCI_SUPPORT properly registers OCI layers

**Docs:** 
none

**Testing:** 
Using helm-3.3.0
```
helm registry login myquay
helm create mychart
helm package ./mychart
helm chart save mychart myquay/myname/mychart:v1
helm chart push myquay/myname/mychart:v1
helm chart remove myquay/myname/mychart:v1
help chart pull myquay/myname/mychart:v1
```


**Details:** 

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.