### PR TITLE
PROJQUAY-1020 chore: Fix cdnjs download failure(403) by setting custom User-Agent req header

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -27,7 +27,7 @@ jobs:
 
         # https://issues.redhat.com/browse/PROJQUAY-92
         # https://github.com/psf/black/issues/1207#issuecomment-566249522
-        pip install black --no-binary=regex
+        pip install black==19.10b0 --no-binary=regex
 
     - name: Check Formatting
       run: |

--- a/external_libraries.py
+++ b/external_libraries.py
@@ -111,9 +111,10 @@ def format_local_name(url):
 
 
 def _download_url(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "Quay Docker Image Builder",})
     for index in range(0, MAX_RETRY_COUNT):
         try:
-            response = urllib.request.urlopen(url)
+            response = urllib.request.urlopen(req)
             return response.read()
         except urllib.error.URLError:
             logger.exception(

--- a/external_libraries.py
+++ b/external_libraries.py
@@ -111,7 +111,7 @@ def format_local_name(url):
 
 
 def _download_url(url):
-    req = urllib.request.Request(url, headers={"User-Agent": "Quay Docker Image Builder",})
+    req = urllib.request.Request(url, headers={"User-Agent": "Quay (External Library Downloader)",})
     for index in range(0, MAX_RETRY_COUNT):
         try:
             response = urllib.request.urlopen(req)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1020

**Testing:** 

**Details:** 
Looks like cdjs is not happy with the default user-agent string set from python urllib.