### PR TITLE
PROJQUAY-1021 chore: Version lock black to 19.10b0

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -27,7 +27,7 @@ jobs:
 
         # https://issues.redhat.com/browse/PROJQUAY-92
         # https://github.com/psf/black/issues/1207#issuecomment-566249522
-        pip install black --no-binary=regex
+        pip install black==19.10b0 --no-binary=regex
 
     - name: Check Formatting
       run: |


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1021

**Details:** 

Github Actions step which checks python code style installs `black` without specifying a version which would always installs the latest one. This would lead to unpredictable CI build failures.

As a remedy, I proposed to version lock black to 19.10b0.

Other option is to modify the Quay code style using 20.8b1. See https://github.com/quay/quay/pull/537