### PR TITLE
[PROJQUAY-833] Update Pillow to 7.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -113,7 +113,7 @@ pathspec==0.7.0
 pathvalidate==2.0.1
 pbr==5.4.4
 peewee==3.13.1
-Pillow==7.0.0
+Pillow==7.2.0
 ply==3.11
 prometheus-client==0.7.1
 psutil==5.6.7


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-833

**Changelog:** Use Pillow to v7.2.0

**Docs:** n/a

**Testing:** n/a

**Details:** Pillow is a dependency used by xhtml2pdf. As xhtml2pdf is not as actively released, this commit manually pins a newer version of Pillow.