### PR TITLE
Fix db RepositoryBuild model attribute name used

### DIFF
--- a/endpoints/api/superuser_models_pre_oci.py
+++ b/endpoints/api/superuser_models_pre_oci.py
@@ -75,8 +75,8 @@ class PreOCIModel(SuperuserDataInterface):
         except model.InvalidRepositoryBuildException as e:
             raise InvalidRepositoryBuildException(str(e))
 
-        repo_namespace = build.repository_namespace_user_username
-        repo_name = build.repository_name
+        repo_namespace = build.repository.namespace_user.username
+        repo_name = build.repository.name
 
         can_read = ReadRepositoryPermission(repo_namespace, repo_name).can()
         can_write = ModifyRepositoryPermission(repo_namespace, repo_name).can()


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1011

**Changelog:** Fix attribute used to access build namespace

**Docs:** 

**Testing:** 
- Navigate to Quay UI -> Super user panel -> Build logs -> Get Logs

**Details:** 
