### PR TITLE
Use days instead of weeks to represent a month worth of time

### DIFF
--- a/data/logs_model/table_logs_model.py
+++ b/data/logs_model/table_logs_model.py
@@ -22,7 +22,7 @@ from data.model.log import get_stale_logs, get_stale_logs_start_id, delete_stale
 logger = logging.getLogger(__name__)
 
 MINIMUM_RANGE_SIZE = 1  # second
-MAXIMUM_RANGE_SIZE = 60 * 60 * 24 * 30  # seconds ~= 1 month
+MAXIMUM_RANGE_SIZE = 60 * 60 * 24 * 31  # seconds ~= 1 month
 EXPECTED_ITERATION_LOG_COUNT = 1000
 
 
@@ -157,7 +157,7 @@ class TableLogsModel(SharedModel, ActionLogsDataInterface):
         if filter_kinds is not None:
             assert all(isinstance(kind_name, str) for kind_name in filter_kinds)
 
-        if end_datetime - start_datetime >= timedelta(weeks=4):
+        if end_datetime - start_datetime > timedelta(seconds=MAXIMUM_RANGE_SIZE):
             raise Exception("Cannot lookup aggregated logs over a period longer than a month")
 
         repository = None

--- a/endpoints/api/logs.py
+++ b/endpoints/api/logs.py
@@ -101,6 +101,8 @@ def _get_aggregate_logs(
     start_time, end_time, performer_name=None, repository=None, namespace=None, filter_kinds=None
 ):
     (start_time, end_time) = _validate_logs_arguments(start_time, end_time)
+    if end_time < start_time:
+        abort(400)
     aggregated_logs = logs_model.get_aggregated_log_counts(
         start_time,
         end_time,
@@ -328,6 +330,8 @@ def _queue_logs_export(start_time, end_time, options, namespace_name, repository
             raise InvalidRequest("Invalid callback e-mail")
 
     (start_time, end_time) = _validate_logs_arguments(start_time, end_time)
+    if end_time < start_time:
+        abort(400)
     export_id = logs_model.queue_logs_export(
         start_time,
         end_time,


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-675

**Changelog:** Quay expects a month's time range to be 31 days. Using weeks limited the maximum time range to 28 days since a week is equivalent to 7 days only. Use days instead of weeks to represent a month's range. 

**Docs:** 

**Testing:** Try and export logs for the past n days where 28 < n < 32.

**Details:** 

