### PR TITLE
PROJQUAY-1055 - correct reindexing due to hash compare

### DIFF
--- a/util/secscan/v4/api.py
+++ b/util/secscan/v4/api.py
@@ -139,7 +139,11 @@ class ClairSecurityScannerAPI(SecurityScannerAPIInterface):
         except (Non200ResponseException, IncompatibleAPIResponse) as ex:
             raise APIRequestFailure(ex)
 
-        return (resp.json(), resp.headers["etag"])
+        # Required clair indexer hash.
+        # RFC for etag specifies surrounding double quotes, which need to be stripped (below)
+        assert resp.headers["etag"]
+
+        return (resp.json(), resp.headers["etag"].strip('"'))
 
     def index_report(self, manifest_hash):
         try:

--- a/workers/securityworker/securityworker.py
+++ b/workers/securityworker/securityworker.py
@@ -1,4 +1,5 @@
 import logging.config
+import os
 import time
 
 import features
@@ -30,6 +31,14 @@ class SecurityWorker(Worker):
 
 
 if __name__ == "__main__":
+    if os.getenv("PYDEV_DEBUG", None):
+        import pydevd_pycharm
+
+        host, port = os.getenv("PYDEV_DEBUG").split(":")
+        pydevd_pycharm.settrace(
+            host, port=int(port), stdoutToServer=True, stderrToServer=True, suspend=False
+        )
+
     app.register_blueprint(v2_bp, url_prefix="/v2")
 
     if not features.SECURITY_SCANNER:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1055

**Changelog:** 
none

**Docs:** 
none

**Testing:** 
Upload image to quay then watch `securityworker` logs (or clair logs) to confirm that after first scan, the image is not rescanned again. Prior to this fix, all manifests would be eligible for rescan after 5 minutes.

**Details:** 
The response "etag" header, by RFC, is a string that includes surrounding double quotes. Later comparison of data pulled from db would have these quotes stripped. Solution is to save string value w/o the quotes.
