### PR TITLE
Added binary mode

### DIFF
--- a/tools/generatekeypair.py
+++ b/tools/generatekeypair.py
@@ -23,7 +23,7 @@ def generate_key_pair(filename, kid=None):
         f.write(kid)
 
     print(("Writing private key to %s.pem" % filename))
-    with open("%s.pem" % filename, mode="w") as f:
+    with open("%s.pem" % filename, mode="wb") as f:
         f.truncate(0)
         f.write(private_key.exportKey())
 


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1101
Pull-request title must start with "PROJQUAY-1101 - Add binary mode to generatekeypairs.py"

**Changelog:** 
/tools/generatekeypair.py

**Docs:** 

**Testing:** 

**Details:** 
Need to add 'b' to the file open mode in line 26 (as referenced in Ivan B's article to set Quay into read-only: https://access.redhat.com/articles/5411111)
