### PR TITLE
[PROJQUAY-822] security: Hide sensitive LDAP log values

### DIFF
--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -217,7 +217,9 @@ class LDAPUsers(FederatedUsers):
             if err_msg is not None:
                 return (None, err_msg)
 
-            logger.debug("Found matching pairs: %s", pairs)
+            dn_lst = [pair[0] for pair in pairs]
+            logger.debug("Found matching DNs: %s" % dn_lst)
+
             results = [LDAPUsers._LDAPResult(*pair) for pair in take(limit, pairs)]
 
             # Filter out pairs without DNs. Some LDAP impls will return such pairs.


### PR DESCRIPTION
**Issue:** 

- https://issues.redhat.com/browse/PROJQUAY-822

**Changelog:**

- security: Modified an LDAP logging statement to exclude potentially sensitive data.

**Docs:**

- n/a

**Testing:**

Run Quay with LDAP integration and DEBUG=true. When logging in, one should see a log line similar to the following:
```
2020-10-05 23:56:01,460 [24247] [DEBUG] [data.users.externalldap] Found matching DNs: ['uid=euclid,dc=example,dc=com']
```

**Details:** 

Exclude potential passwords and other sensitive data from a given LDAP logging statement.
