### PR TITLE
[PROJQUAY-813] fix: Use database SSL certificate during migrations

### DIFF
--- a/config.py
+++ b/config.py
@@ -195,7 +195,6 @@ class DefaultConfig(ImmutableConfig):
     # DB config
     DB_URI = "sqlite:///test/data/test.db"
     DB_CONNECTION_ARGS = {
-        "threadlocals": True,
         "autorollback": True,
     }
 

--- a/data/test/test_readreplica.py
+++ b/data/test/test_readreplica.py
@@ -23,7 +23,7 @@ def test_readreplica(init_db_path, tmpdir_factory):
     db_config = {
         "DB_URI": "sqlite:///{0}".format(primary_file),
         "DB_READ_REPLICAS": [{"DB_URI": "sqlite:///{0}".format(replica_file)},],
-        "DB_CONNECTION_ARGS": {"threadlocals": True, "autorollback": True,},
+        "DB_CONNECTION_ARGS": {"autorollback": True,},
         "DB_TRANSACTION_FACTORY": lambda x: FakeTransaction(),
         "FOR_TESTING": True,
         "DATABASE_SECRET_KEY": "anothercrazykey!",

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -71,7 +71,7 @@ def _init_db_path_real_db(db_uri):
         {
             "DB_URI": db_uri,
             "SECRET_KEY": "superdupersecret!!!1",
-            "DB_CONNECTION_ARGS": {"threadlocals": True, "autorollback": True,},
+            "DB_CONNECTION_ARGS": {"autorollback": True,},
             "DB_TRANSACTION_FACTORY": _create_transaction,
             "DATABASE_SECRET_KEY": "anothercrazykey!",
         }
@@ -161,7 +161,7 @@ def appconfig(database_uri):
         "DB_URI": database_uri,
         "SECRET_KEY": "superdupersecret!!!1",
         "DATABASE_SECRET_KEY": "anothercrazykey!",
-        "DB_CONNECTION_ARGS": {"threadlocals": True, "autorollback": True,},
+        "DB_CONNECTION_ARGS": {"autorollback": True,},
         "DB_TRANSACTION_FACTORY": _create_transaction,
         "DATA_MODEL_CACHE_CONFIG": {"engine": "inmemory",},
         "USERFILES_PATH": "userfiles/",

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -251,10 +251,6 @@ CONFIG_SCHEMA = {
             "type": "object",
             "description": "If specified, connection arguments for the database such as timeouts and SSL.",
             "properties": {
-                "threadlocals": {
-                    "type": "boolean",
-                    "description": "Whether to use thread-local connections. Should *ALWAYS* be `true`",
-                },
                 "autorollback": {
                     "type": "boolean",
                     "description": "Whether to use auto-rollback connections. Should *ALWAYS* be `true`",
@@ -272,7 +268,7 @@ CONFIG_SCHEMA = {
                     "required": ["ca"],
                 },
             },
-            "required": ["threadlocals", "autorollback"],
+            "required": ["autorollback"],
         },
         "ALLOW_PULLS_WITHOUT_STRICT_LOGGING": {
             "type": "boolean",


### PR DESCRIPTION
**DRAFT**

**Issue:** 
- https://issues.redhat.com/browse/PROJQUAY-813

**Changelog:** 
- fix: Use database SSL certificate during migrations

**Docs:** 
- No new documentation needed. This just fixes expected behavior.

**Testing:** 
- Ensure that the Quay container, including migrations (alembic) run successfully when `config.yaml` specifies an SSL certificate to connect to the database.

**Details:** 
- Alembic uses its own connection mechanism for performing database schema migrations. It does not share the same connection mechanism defined within the standard Quay processes. It was excluding additional database connection arguments such as any provides SSL/TLS certificate.
- `threadlocals` is an old connection argument used by Peewee. As far as I can tell, it is no longer necessary to enable or disable this and has been excluded from the documentation and source code in the latest release of Peewee. It is *not* used by the Postgres driver `psycopg2` or the MySQL driver `pymysql` as far as I can see. Accordingly, it has been removed and any accidental inclusion of it within `config.yaml` from legacy installs will ignore it in Alembic. It's already ignored by Quay, itself, during the database connection initialization.
