### PR TITLE
Whitespace error fixed in repo-count-checker.html

### DIFF
--- a/static/directives/repo-count-checker.html
+++ b/static/directives/repo-count-checker.html
@@ -2,8 +2,8 @@
   <div class="required-plan" ng-show="isEnabled && planRequired && planRequired.title">
     <div class="co-alert co-alert-warning thin">
       In order to make this repository private under
-      <strong ng-if="isUserNamespace">your personal namespace</strong>
-      <strong ng-if="!isUserNamespace">{{ namespace }}</strong>, you will need to upgrade the namespace's plan to at least a
+      <strong ng-if="isUserNamespace">your personal namespace</strong><strong ng-if="!isUserNamespace">{{ namespace }}</strong>, 
+      you will need to upgrade the namespace's plan to at least a
       <b style="border-bottom: 1px dotted black; cursor: default" data-html="true"
          data-title="{{ '<b>' + planRequired.title + '</b><br>' + planRequired.privateRepos + ' private repositories' }}" bs-tooltip>{{ planRequired.title  }}</b> plan.
       </div>


### PR DESCRIPTION
**Issue:** n/a

**Changelog:** Fixed: removed spurious whitespace in repo-count-checker

**Docs:** n/a

**Testing:** I have not been able to emulate this exact scenario in a test instance of quay.  From observation I'm confident that the whitespace is removed as expected.

**Details:** when repo-count-checker.html is called for "isUserNameSpace", there is an embedded newline between the two ng-if lines that ends up causing a spurious space between the phrase and the comma.

**Screenshot:**

![quay-space](https://user-images.githubusercontent.com/28928338/95147026-89296600-074d-11eb-8bd0-374493ab956e.png)
