### PR TITLE
notifications: add incoming jwt verification

### DIFF
--- a/endpoints/secscan.py
+++ b/endpoints/secscan.py
@@ -1,15 +1,20 @@
 import logging
 import features
 import json
+import jwt
+import base64
 
 from flask import make_response, Blueprint, jsonify, abort, request
 
-from app import secscan_notification_queue
+from app import secscan_notification_queue, app
+from util.security.jwtutil import decode, TOKEN_REGEX
 from data.database import ManifestSecurityStatus, Manifest
 from endpoints.decorators import anon_allowed, route_show_if
 
 logger = logging.getLogger(__name__)
 secscan = Blueprint("secscan", __name__)
+
+JWT_HEADER_NAME = "Authorization"
 
 
 @secscan.route("/_internal_ping")
@@ -23,9 +28,30 @@ def internal_ping():
 @secscan.route("/notification", methods=["POST"])
 @anon_allowed
 def secscan_notification():
-    # TODO(alecmerdler): verify the JWT header is signed by the security scanner
+    # If Quay is configured with a Clair V4 PSK we assume
+    # Clair will also sign JWT's with this PSK. Therefore,
+    # attempt jwt verification.
+    key = app.config.get("SECURITY_SCANNER_V4_PSK", None)
+    if key:
+        key = base64.b64decode(key)
+        jwt_header = request.headers.get(JWT_HEADER_NAME, "")
+        match = TOKEN_REGEX.match(jwt_header)
+        if match is None:
+            logger.error("Could not find matching bearer token")
+            abort(401)
+        token = match.group(1)
+        try:
+            decode(token, key=key, algorithms=["HS256"])
+        except jwt.exceptions.InvalidTokenError as e:
+            logger.error("Could not verify jwt {}".format(e))
+            abort(401)
+        logger.debug("Successfully verified jwt")
 
     data = request.get_json()
+    if data is None:
+        logger.error("expected json request")
+        abort(400)
+
     logger.debug("Got notification from V4 Security Scanner: %s", data)
     if "notification_id" not in data or "callback" not in data:
         abort(400)

--- a/util/security/jwtutil.py
+++ b/util/security/jwtutil.py
@@ -26,7 +26,7 @@ TOKEN_REGEX = re.compile(r"\ABearer (([a-zA-Z0-9+\-_/]+\.)+[a-zA-Z0-9+\-_/]+)\Z"
 
 # ALGORITHM_WHITELIST defines a whitelist of allowed algorithms to be used in JWTs. DO NOT ADD
 # `none` here!
-ALGORITHM_WHITELIST = ["rs256"]
+ALGORITHM_WHITELIST = ["rs256", "hs256"]
 
 
 class _StrictJWT(PyJWT):


### PR DESCRIPTION
this commit adds jwt verification to the notifications post endpoint.

Signed-off-by: ldelossa <ldelossa@localhost.localdomain>

**Issue:** https://issues.redhat.com/browse/PROJQUAY-847

**Changelog:** Verify JWT from Clair notification request

**Docs:** The "SECURITY_SCANNER_V4_PSK" config value being defined enforces jwt verification for all endpoints Clair V4 will request.

**Testing:** Use the test notifier in Clair V4's repo and start the Quay local dev environment. Update both configs to use a PSK.

**Details:** 

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.