### PR TITLE
PROJQUAY-516 - requests no longer needs cacert.pem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,10 +137,8 @@ RUN chgrp -R 0 /etc/pki/ca-trust/extracted && \
     chmod -R g=u /etc/pki/ca-trust/extracted && \
     chgrp -R 0 /etc/pki/ca-trust/source/anchors && \
     chmod -R g=u /etc/pki/ca-trust/source/anchors && \
-    chgrp -R 0 /usr/local/lib/python3.6/site-packages/requests && \
-    chmod -R g=u /usr/local/lib/python3.6/site-packages/requests && \
-    chgrp -R 0 /usr/local/lib/python3.6/site-packages/certifi && \
-    chmod -R g=u /usr/local/lib/python3.6/site-packages/certifi
+    chgrp -R 0 /usr/local/lib/python$PYTHON_VERSION/site-packages/certifi && \
+    chmod -R g=u /usr/local/lib/python$PYTHON_VERSION/site-packages/certifi
 
 VOLUME ["/var/log", "/datastorage", "/tmp", "/conf/stack"]
 

--- a/conf/init/certs_install.sh
+++ b/conf/init/certs_install.sh
@@ -21,7 +21,6 @@ if [ -d $CERTDIR ]; then
   if test "$(ls -A "$CERTDIR")"; then
       echo "Installing extra certificates found in $CERTDIR directory"
       cp $CERTDIR/* ${SYSTEM_CERTDIR}
-      cat $CERTDIR/* >> $PYTHON_ROOT/site-packages/requests/cacert.pem
       cat $CERTDIR/* >> $PYTHON_ROOT/site-packages/certifi/cacert.pem
   fi
 fi
@@ -30,7 +29,6 @@ fi
 if [ -f $CERTDIR ]; then
   echo "Installing extra certificates found in $CERTDIR file"
   csplit -z -f ${SYSTEM_CERTDIR}/extra-ca- $CERTDIR  '/-----BEGIN CERTIFICATE-----/' '{*}'
-  cat $CERTDIR >> $PYTHON_ROOT/site-packages/requests/cacert.pem
   cat $CERTDIR >> $PYTHON_ROOT/site-packages/certifi/cacert.pem
 fi
 
@@ -39,7 +37,6 @@ for f in $(find -L $QUAYCONFIG/ -maxdepth 1 -type f -name "extra_ca*")
 do
  echo "Installing extra cert $f"
  cp "$f" ${SYSTEM_CERTDIR}
- cat "$f" >> $PYTHON_ROOT/site-packages/requests/cacert.pem
  cat "$f" >> $PYTHON_ROOT/site-packages/certifi/cacert.pem
 done
 


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-516

**Changelog:** none

**Docs:** none

**Testing:** none

**Details:** 
In python3 the `requests` package now uses the cacert.pem provided through `certifi`
