### PR TITLE
PROJQUAY-1131 - use /tmp for created certs

### DIFF
--- a/conf/init/certs_create.sh
+++ b/conf/init/certs_create.sh
@@ -6,10 +6,12 @@ cd ${QUAYDIR:-"/"}
 SYSTEM_CERTDIR=${SYSTEM_CERTDIR:-"/etc/pki/ca-trust/source/anchors"}
 # Create certs for jwtproxy to mitm outgoing TLS connections
 # echo '{"CN":"CA","key":{"algo":"rsa","size":2048}}' | cfssl gencert -initca - | cfssljson -bare mitm
-mkdir -p /certificates; cd /certificates
+mkdir -p /tmp/certificates; cd /tmp/certificates
 openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 \
     -subj "/C=US/ST=NY/L=NYC/O=Dis/CN=self-signed" \
     -keyout mitm-key.pem  -out mitm.pem
-cp /certificates/mitm-key.pem $QUAYCONF/mitm.key
-cp /certificates/mitm.pem $QUAYCONF/mitm.cert
-cp /certificates/mitm.pem $SYSTEM_CERTDIR/mitm.crt
+cp /tmp/certificates/mitm-key.pem $QUAYCONF/mitm.key
+cp /tmp/certificates/mitm.pem $QUAYCONF/mitm.cert
+cp /tmp/certificates/mitm.pem $SYSTEM_CERTDIR/mitm.crt
+rm -Rf /tmp/certificates
+


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1131

**Changelog:** none

**Docs:** none

**Testing:** none

**Details:** 
The / dir is not writable in ubi8 so instead use /tmp for creating jwtproxy mitm certs (/tmp/certificates).
