### PR TITLE
GitHub Actions set-env deprecation

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -156,8 +156,8 @@ jobs:
     - name: Set GOPATH
       run: |
         # temporary fix for https://github.com/actions/setup-go/issues/14
-        echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-        echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
+        echo "GOPATH=$(dirname $GITHUB_WORKSPACE)" >> $GITHUB_ENV
+        echo "PATH=$(dirname $GITHUB_WORKSPACE)/bin:${PATH}" >> $GITHUB_PATH
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -157,7 +157,7 @@ jobs:
       run: |
         # temporary fix for https://github.com/actions/setup-go/issues/14
         echo "GOPATH=$(dirname $GITHUB_WORKSPACE)" >> $GITHUB_ENV
-        echo "PATH=$(dirname $GITHUB_WORKSPACE)/bin:${PATH}" >> $GITHUB_PATH
+        echo "$(dirname $GITHUB_WORKSPACE)/bin" >> $GITHUB_PATH
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1141

**Changelog:** none

**Docs:** none

**Testing:** none

**Details:** 
Announced on October 1st, [set-env is being deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) and we've started to see warnings in various workflow runs that use it. I noticed you use it here, and wanted to offer a quick fix. I tested it out for my own workflow (thanks @jzelinskie for the tip!) [here](https://github.com/vsoch/django-oci/runs/1244736538?check_suite_focus=true) if you want to see if it works as expected to compile the conformance.test binary.

