### PR TITLE
Quayio builder chores

### DIFF
--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -118,10 +118,17 @@ class EphemeralBuilderManager(BaseManager):
             try:
                 # Clean up the bookkeeping for the job.
                 yield From(self._orchestrator.delete_key(self._job_key(build_job)))
+                yield From(self.terminate_executor(executor_name, execution_id))
             except KeyError:
                 logger.debug(
                     "Could not delete job key %s; might have been removed already",
                     build_job.build_uuid,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Error cleaning up incomplete job with key %s; %s",
+                    build_job.build_uuid,
+                    e
                 )
 
             logger.error(

--- a/external_libraries.py
+++ b/external_libraries.py
@@ -111,6 +111,7 @@ def format_local_name(url):
 
 
 def _download_url(url):
+    req = urllib2.Request(url, headers={"User-Agent": "Quay (External Library Downloader)",})
     for index in range(0, MAX_RETRY_COUNT):
         try:
             response = urllib2.urlopen(url)


### PR DESCRIPTION
Make sure to cleanup the the existing scheduled executor whenever the build is marked as incomplete and falls back to the next configured executor, if it has retries remaining. This avoid having duplicate executor for the same build, which can cause performance issues and cause an executor's control plane reach capacity.