### PR TITLE
Implement executor methods to get the count of running builders

### DIFF
--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -1,8 +1,7 @@
 {% macro overridelist() -%}
 
-REALM={{ realm }}
 TOKEN={{ token }}
-SERVER={{ websocket_scheme }}://{{ manager_hostname }}
+SERVER={{ http_scheme }}://{{ manager_hostname }}
 
 {%- endmacro %}
 


### PR DESCRIPTION
Used by the manager to schedule builds based on the current running
count. Uses the specific executors' api to get the count of running
builders instead of Redis/Orchestrator.

This is due to issues encountered in the past where the manager would
have problems scheduling builds, and go into a weird state when
Redis was unavailable.

Remove wamp's REALM parameters from executor

Remove asyncio from executor

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1169