### PR TITLE
[PROJQUAY-1190] fix: Use Python3 strings for user-facing tokens

### DIFF
--- a/data/model/user.py
+++ b/data/model/user.py
@@ -689,7 +689,7 @@ def create_confirm_email_code(user, new_email=None):
     code = EmailConfirmation.create(
         user=user, email_confirm=True, new_email=new_email, verification_code=verification_code
     )
-    return encode_public_private_token(code.code, unhashed).decode("ascii")
+    return encode_public_private_token(code.code, unhashed)
 
 
 def confirm_user_email(token):

--- a/util/security/test/test_token.py
+++ b/util/security/test/test_token.py
@@ -1,0 +1,20 @@
+from util.security.token import (
+    encode_public_private_token,
+    decode_public_private_token,
+    DecodedToken,
+)
+
+
+def test_private_token():
+
+    public_code = "PUBLIC-CODE"
+    private_token = "PRIVATE-TOKEN"
+
+    encoded_token = encode_public_private_token(public_code, private_token)
+    assert isinstance(encoded_token, str)
+
+    decoded_token = decode_public_private_token(encoded_token)
+    assert isinstance(decoded_token, DecodedToken)
+
+    assert decoded_token.public_code == public_code
+    assert decoded_token.private_token == private_token

--- a/util/security/token.py
+++ b/util/security/token.py
@@ -17,7 +17,7 @@ def encode_public_private_token(public_code, private_token, allow_public_only=Fa
     assert isinstance(private_token, str) and isinstance(public_code, str)
     b = ("%s%s%s" % (public_code, DELIMITER, private_token)).encode("utf-8")
 
-    return base64.b64encode(b)
+    return base64.b64encode(b).decode("utf-8")
 
 
 def decode_public_private_token(encoded, allow_public_only=False):

--- a/util/test/test_useremails.py
+++ b/util/test/test_useremails.py
@@ -1,6 +1,7 @@
+import mock
 import pytest
 
-from util.useremails import render_email
+from util.useremails import render_email, send_recovery_email
 from test.fixtures import *
 
 
@@ -47,3 +48,22 @@ def test_render_email():
 )
 def test_emails(template_name, params, initialized_db):
     render_email("Test App", "test.quay", "foo@example.com", "Hello There!", template_name, params)
+
+
+@mock.patch("util.useremails.send_email")
+def test_send_recovery_email(mock_send_email, initialized_db):
+
+    email = "quay_user@example.com"
+    token = "fake_token"
+
+    send_recovery_email(email, token)
+
+    # Expected call arguments
+    subject = "Account recovery"
+    template_file = "recovery"
+    parameters = {"email": email, "token": token}
+    action = mock.ANY  # TODO: assert GmailAction.view() is called
+
+    mock_send_email.assert_called_once_with(
+        email, subject, template_file, parameters, action=action
+    )


### PR DESCRIPTION
**Issue:**
- https://issues.redhat.com/browse/PROJQUAY-1190

**Changelog:** 
- fix: Use Python3 strings for user-facing tokens

**Docs:**
- n/a

**Testing:**
- Ensure recovery emails can be sent without a Python string concatenation error

**Details:** 
Addresses the following error when attempting to send recovery emails:
```
gunicorn-web stdout |     send_recovery_email(email, confirmation_code)
gunicorn-web stdout |   File "/quay-registry/util/useremails.py", line 167, in send_recovery_email
gunicorn-web stdout |     action = GmailAction.view("Recover Account", "recovery?code=" + token, "Recovery of an account")
gunicorn-web stdout | TypeError: can only concatenate str (not "bytes") to str
```