### PR TITLE
[PROJQUAY-1191] add: log sent emails (debug)

### DIFF
--- a/util/useremails.py
+++ b/util/useremails.py
@@ -68,6 +68,10 @@ def send_email(recipient, subject, template_file, parameters, action=None):
 
     try:
         mail.send(msg)
+        if app.config["TESTING"]:
+            logger.debug("Quay is configured for testing. Email not sent: '%s'", msg.subject)
+        else:
+            logger.debug("Sent email: '%s'", msg.subject)
     except Exception as ex:
         logger.exception("Error while trying to send email to %s", recipient)
         raise CannotSendEmailException(str(ex))


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1191

**Changelog:** add: log sent emails (debug)

**Docs:** When Quay is configured in such a way where `TESTING: true` or otherwise ends up in a testing configuration, emails are not actually sent. However, debug-level logging will show that those messages would have been sent.

**Testing:**

- With `DEBUGLOG=True`, trigger a user-registration confirmation email. The following line should show up in the logs: `[util.useremails] Sent email: '[Project Quay] Please confirm your e-mail address'`. The email **should be** sent successfully.
- Following the previous step, specify `TESTING: true` in the `config.yaml` file and run through the same process. The following line should be written to the logs: `[util.useremails] Quay is configured for testing. Email not sent: '[Project Quay] Please confirm your e-mail address'`. The email **should not** have been sent.

**Details:** During testing, there was an issue with emails being sent. This Pull Request does not resolve that issue but it does add additional information to the logs to better diagnose that problem and other related issues.