### PR TITLE
[PROJQUAY-813] fix: Schema migrations with MySQL and SSL

### DIFF
--- a/data/migrations/env.py
+++ b/data/migrations/env.py
@@ -1,58 +1,43 @@
 import logging
 import os
 
-from logging.config import fileConfig
-from functools import partial
 from urllib.parse import unquote
 
 from alembic import context, op as alembic_op
 from alembic.script.revision import ResolutionError
 from alembic.util import CommandError
-from sqlalchemy import engine_from_config, pool
 from peewee import SqliteDatabase
+from sqlalchemy import create_engine
 
+from app import app
 from data.database import all_models, db, LEGACY_INDEX_MAP
 from data.migrations.tester import NoopTester, PopulateTestDataTester
 from data.model.sqlalchemybridge import gen_sqlalchemy_metadata
 from release import GIT_HEAD, REGION, SERVICE
 from util.morecollections import AttrDict
-from util.parsing import truthy_bool
-from data.migrations.progress import PrometheusReporter, NullReporter, ProgressWrapper
-from data.migrations.dba_operator import Migration, OpLogger
 
-
-config = context.config
-DB_URI = config.get_main_option("db_uri", "sqlite:///test/data/test.db")
-PROM_LABEL_PREFIX = "DBA_OP_LABEL_"
-
-# This option exists because alembic needs the db proxy to be configured in order
-# to perform migrations. The app import does the init of the proxy, but we don't
-# want that in the case of the config app, as we are explicitly connecting to a
-# db that the user has passed in, and we can't have import dependency on app
-if config.get_main_option("alembic_setup_app", "True") == "True":
-    from app import app
-
-    DB_URI = app.config["DB_URI"]
-
-config.set_main_option("sqlalchemy.url", unquote(DB_URI))
-# Interpret the config file for Python logging.
-# This line sets up loggers basically.
-if config.config_file_name:
-    fileConfig(config.config_file_name)
 
 logger = logging.getLogger(__name__)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
+
+# Alembic's configuration
+config = context.config
+
+
+# Alembic is designed to be used with SQL Alchemy. These steps convert the schema as defined by the
+# Peewee models to a format usable by Alembic.
 target_metadata = gen_sqlalchemy_metadata(all_models, LEGACY_INDEX_MAP)
 tables = AttrDict(target_metadata.tables)
 
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
+
+def get_db_url():
+    """
+    Return the Database URI. This is typically set in config.yaml but may be overridden using
+    an environment variable or expected to default with a SQLite database for testing purposes.
+    """
+    db_url = app.config.get("DB_URI", "sqlite:///test/data/test.db")
+    db_url = unquote(db_url)  # TODO: determine and comment why this is important
+    return db_url
 
 
 def get_tester():
@@ -62,43 +47,28 @@ def get_tester():
     We only return the tester that populates data if the TEST_MIGRATE env var is set to `true` AND
     we make sure we're not connecting to a production database.
     """
+    db_url = get_db_url()
     if os.environ.get("TEST_MIGRATE", "") == "true":
-        url = unquote(DB_URI)
-        if url.find("amazonaws.com") < 0:
+        if db_url.find("amazonaws.com") < 0:
             return PopulateTestDataTester()
 
     return NoopTester()
 
 
-def get_progress_reporter():
-    prom_addr = os.environ.get("DBA_OP_PROMETHEUS_PUSH_GATEWAY_ADDR", None)
+def get_engine():
+    """
+    Return a SQL Alchemy engine object which Alembic uses to connect to the database.
+    """
+    db_url = get_db_url()
+    peewee_connection_args = app.config.get("DB_CONNECTION_ARGS", {})
+    sa_connection_args = {}
 
-    if prom_addr is not None:
-        prom_job = os.environ.get("DBA_OP_JOB_ID")
+    # Include MySQL/MariaDB SSL configuration
+    if "ssl" in peewee_connection_args:
+        sa_connection_args["ssl"] = peewee_connection_args["ssl"]
 
-        def _process_label_key(label_key):
-            return label_key[len(PROM_LABEL_PREFIX) :].lower()
-
-        labels = {
-            _process_label_key(k): v
-            for k, v in list(os.environ.items())
-            if k.startswith(PROM_LABEL_PREFIX)
-        }
-
-        return PrometheusReporter(prom_addr, prom_job, labels)
-    else:
-        return NullReporter()
-
-
-def report_success(ctx=None, step=None, heads=None, run_args=None):
-    progress_reporter = ctx.config.attributes["progress_reporter"]
-    progress_reporter.report_version_complete(success=True)
-
-
-def finish_migration(migration, ctx=None, step=None, heads=None, run_args=None):
-    write_dba_operator_migration(
-        migration, step.up_revision.revision, step.up_revision.down_revision
-    )
+    engine = create_engine(db_url, connect_args=sa_connection_args)
+    return engine
 
 
 def run_migrations_offline():
@@ -113,13 +83,12 @@ def run_migrations_offline():
     Calls to context.execute() here emit the given string to the
     script output.
     """
-    url = unquote(DB_URI)
-    context.configure(url=url, target_metadata=target_metadata, transactional_ddl=True)
-    context.config.attributes["progress_reporter"] = progress_reporter
-    op = ProgressWrapper(alembic_op, NullReporter())
+    db_url = get_db_url()
+    config.set_main_option("sqlalchemy.url", db_url)  # TODO: Is this required?
+    context.configure(url=db_url, target_metadata=target_metadata, transactional_ddl=True)
 
     with context.begin_transaction():
-        context.run_migrations(op=op, tables=tables, tester=get_tester())
+        context.run_migrations(op=alembic_op, tables=tables, tester=get_tester())
 
 
 def run_migrations_online():
@@ -128,48 +97,20 @@ def run_migrations_online():
 
     In this scenario we need to create an Engine and associate a connection with the context.
     """
-
-    if isinstance(db.obj, SqliteDatabase) and not "DB_URI" in os.environ:
-        print("Skipping Sqlite migration!")
+    if isinstance(db.obj, SqliteDatabase) and "DB_URI" not in os.environ:
+        logger.info("Skipping Sqlite migration!")
         return
 
-    progress_reporter = get_progress_reporter()
-    context.config.attributes["progress_reporter"] = progress_reporter
-    op = ProgressWrapper(alembic_op, progress_reporter)
-
-    migration = Migration()
-    version_apply_callback = report_success
-    if truthy_bool(
-        context.get_x_argument(as_dictionary=True).get("generatedbaopmigrations", False)
-    ):
-        op = OpLogger(alembic_op, migration)
-        version_apply_callback = partial(finish_migration, migration)
-
-    engine = engine_from_config(
-        config.get_section(config.config_ini_section), prefix="sqlalchemy.", poolclass=pool.NullPool
-    )
-
-    revision_to_migration = {}
-
-    def process_revision_directives(context, revision, directives):
-        script = directives[0]
-        migration = Migration()
-        revision_to_migration[(script.rev_id, revision)] = migration
-        migration.add_hints_from_ops(script.upgrade_ops)
-
+    engine = get_engine()
     connection = engine.connect()
     context.configure(
-        connection=connection,
-        target_metadata=target_metadata,
-        transactional_ddl=False,
-        on_version_apply=version_apply_callback,
-        process_revision_directives=process_revision_directives,
+        connection=connection, target_metadata=target_metadata, transactional_ddl=False,
     )
 
     try:
         with context.begin_transaction():
             try:
-                context.run_migrations(op=op, tables=tables, tester=get_tester())
+                context.run_migrations(op=alembic_op, tables=tables, tester=get_tester())
             except (CommandError, ResolutionError) as ex:
                 if "No such revision" not in str(ex):
                     raise
@@ -187,17 +128,6 @@ def run_migrations_online():
                     raise
     finally:
         connection.close()
-
-    for (revision, previous_revision), migration in revision_to_migration.items():
-        write_dba_operator_migration(migration, revision, previous_revision)
-
-
-def write_dba_operator_migration(migration, revision, previous_revision):
-    migration_filename = "{}-databasemigration.yaml".format(revision)
-    output_filename = os.path.join("data", "migrations", "dba_operator", migration_filename)
-    with open(output_filename, "w") as migration_file:
-        migration_file.write("\n---\n")
-        migration.dump_yaml_and_reset(migration_file, revision, previous_revision)
 
 
 if context.is_offline_mode():


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-813
**Changelog:** fix: Schema migrations with MySQL/MariaDB and SSL

**Docs:** 
- MySQL certificates now require the server's hostname or IP to be specified in both the SAN (Subject Alternative Names) and CN (Common Name) due to changes in Python >= 3.7.

**Testing:** 
- Ensure Quay can successfully run migrations when using a MySQL/MariaDB database with SSL enforced.

**Details:** 
- Alembic, the package responsible for performing schema migrations, does not share the same database connection as Quay. The config.yaml configuration portion to specify a CA bundle and other MySQL-specific SSL options are now passed to the connection used by Alembic.
- The schema migration code has been cleaned up a bit and currently unused/unsupported functionality has been removed from it to reduce complexity until they're needed or supported.
- No Postgres SSL/TLS support was explicitly added or modified in this change.
- The Prometheus-based metrics/reporting to share the status of migrations has been removed. In Quay v3.4.0, there will be no background migrations executed and it should be fairly obvious when it's finished. This behavior can be easily re-implemented in a clean and documented manner if it's needed.