### PR TITLE
Removes the http scheme from the server address

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -78,9 +78,6 @@ class BuilderExecutor(object):
         self.executor_config = executor_config
         self.manager_hostname = manager_hostname
 
-        default_scheme = app.config["PREFERRED_URL_SCHEME"]
-        self.http_scheme = executor_config.get("HTTP_SCHEME", default_scheme)
-
     @property
     def name(self):
         """
@@ -167,7 +164,6 @@ class BuilderExecutor(object):
                 quay_username=quay_username,
                 quay_password=quay_password,
                 manager_hostname=manager_hostname,
-                http_scheme=self.http_scheme,
                 coreos_channel=coreos_channel,
                 worker_image=self.executor_config.get(
                     "WORKER_IMAGE", "quay.io/coreos/registry-build-worker"

--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -1,7 +1,7 @@
 {% macro overridelist() -%}
 
 TOKEN={{ token }}
-SERVER={{ http_scheme }}://{{ manager_hostname }}
+SERVER={{ manager_hostname }}
 
 {%- endmacro %}
 


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1255
-  The http scheme is specified as a dial option on the grpc Go client, not as part of the address.