### PR TITLE
PROJQUAY-1273 - ldap bytes-like strings

### DIFF
--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -251,8 +251,15 @@ class LDAPUsers(FederatedUsers):
         if self._requires_email and not response.get(self._email_attr):
             return (None, 'Missing mail field "%s" in user record' % self._email_attr)
 
-        username = response[self._uid_attr][0]
-        email = response.get(self._email_attr, [None])[0]
+        try:
+            username = response[self._uid_attr][0].decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            username = response[self._uid_attr][0]
+        try:
+            email = response.get(self._email_attr, [None])[0].decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            email = response.get(self._email_attr, [None])[0]
+
         return (UserInformation(username=username, email=email, id=username), None)
 
     def ping(self):

--- a/test/test_ldap.py
+++ b/test/test_ldap.py
@@ -69,6 +69,14 @@ def mock_ldap(requires_email=True, user_filter=None):
             "userPassword": ["somepass"],
             "filterField": ["somevalue"],
         },
+        "uid=bytesuser,ou=employees,dc=quay,dc=io": {
+            "dc": ["quay", "io"],
+            "ou": "employees",
+            "uid": ["bytesuser"],
+            "userPassword": ["somepass"],
+            "mail": [b"bytes@bar.com"],
+            "filterField": ["somevalue"],
+        },
         "uid=cool.user,ou=employees,dc=quay,dc=io": {
             "dc": ["quay", "io"],
             "ou": "employees",
@@ -385,6 +393,11 @@ class TestLDAP(unittest.TestCase):
         with mock_ldap(requires_email=False) as ldap:
             (response, _) = ldap.get_user("nomail")
             self.assertEqual(response.username, "nomail")
+
+    def test_bytes_in_results(self):
+        with mock_ldap() as ldap:
+            (response, _) = ldap.get_user("bytesuser")
+            self.assertEqual(response.username, "bytesuser")
 
     def test_confirm_different_username(self):
         with mock_ldap() as ldap:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1273

**Changelog:** 
none

**Docs:** 
none

**Testing:** 
Login w/ LDAP and confirm working

**Details:** 
LDAP is returning bytes-like fields
