### PR TITLE
PROJQUAY-1292 - do not scan manifest lists

### DIFF
--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -511,9 +511,15 @@ class OCIModel(RegistryDataInterface):
             logger.exception("Could not parse and validate manifest `%s`", manifest._db_id)
             return None
 
-        return self._list_manifest_layers(
-            manifest_obj.repository_id, parsed, storage, include_placements
-        )
+        try:
+            layers = self._list_manifest_layers(
+                manifest_obj.repository_id, parsed, storage, include_placements
+            )
+        except Exception:
+            logger.exception("Could not list manifest layers `%s`", manifest._db_id)
+            return None
+
+        return layers
 
     def set_tags_expiration_for_manifest(self, manifest, expiration_sec):
         """

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -247,6 +247,10 @@ class V4SecurityScanner(SecurityScannerInterface):
 
         for candidate, abt, num_remaining in iterator:
             manifest = ManifestDataType.for_manifest(candidate, None)
+            if manifest.is_manifest_list:
+                mark_manifest_unsupported(manifest)
+                continue
+
             layers = registry_model.list_manifest_layers(manifest, self.storage, True)
             if layers is None or len(layers) == 0:
                 logger.warning(


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1292

**Changelog:** 
none

**Docs:** 
none

**Testing:** 
Push manifest list and see it is not scanned (no errors in securityworker logs)

**Details:** 
securityworker was erroring from assert, causing images not to be scanned. Error was result of a manifestlist making it to scanner. Both situations corrected.