### PR TITLE
Allow specifying the container runtime to the templated ignition file

### DIFF
--- a/buildman/container_cloud_config.py
+++ b/buildman/container_cloud_config.py
@@ -34,6 +34,9 @@ from jinja2 import FileSystemLoader, Environment, StrictUndefined
 logger = logging.getLogger(__name__)
 
 
+_SUPPORTED_CONTAINER_RUNTIMES = ("docker", "podman")
+
+
 class CloudConfigContext(object):
     """ Context object for easy generating of cloud config. """
 
@@ -48,6 +51,7 @@ class CloudConfigContext(object):
         self,
         name,
         container,
+        container_runtime="docker",
         username="",
         password="",
         tag="latest",
@@ -66,6 +70,8 @@ class CloudConfigContext(object):
         timeout_stop_sec=2000,
         autostart=True,
     ):
+        assert container_runtime in _SUPPORTED_CONTAINER_RUNTIMES
+
         try:
             timeout_start_sec = int(timeout_start_sec)
             timeout_stop_sec = int(timeout_stop_sec)
@@ -82,6 +88,7 @@ class CloudConfigContext(object):
         return template.render(
             name=name,
             container=container,
+            container_runtime=container_runtime,
             username=username,
             password=password,
             tag=tag,

--- a/buildman/qemu-coreos/build.sh
+++ b/buildman/qemu-coreos/build.sh
@@ -2,10 +2,16 @@ set -e
 set -o nounset
 
 TAG=${TAG:-"stable"}
+IMAGE=${IMAGE:-"quay.io/quay/quay-builder-qemu-fedoracoreos"}
+CLOUD_IMAGE=${CLOUD_IMAGE:-""}
 
-CHANNEL=${CHANNEL:-"stable"}
-CHANNEL_MANIFEST_JSON=`curl https://builds.coreos.fedoraproject.org/streams/stable.json`
-LOCATION=`echo $CHANNEL_MANIFEST_JSON | jq '.architectures.x86_64.artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"'`
-VERSION=`echo $CHANNEL_MANIFEST_JSON | jq '.architectures.x86_64.artifacts.qemu.release' | tr -d '"'`
+if [ -z "$CLOUD_IMAGE" ]; then
+    CHANNEL=${CHANNEL:-"stable"}
+    CHANNEL_MANIFEST_JSON=`curl https://builds.coreos.fedoraproject.org/streams/stable.json`
+    LOCATION=`echo $CHANNEL_MANIFEST_JSON | jq '.architectures.x86_64.artifacts.qemu.formats."qcow2.xz".disk.location' | tr -d '"'`
+    VERSION=`echo $CHANNEL_MANIFEST_JSON | jq '.architectures.x86_64.artifacts.qemu.release' | tr -d '"'`
 
-time docker build --build-arg=channel=$CHANNEL --build-arg version=$VERSION --build-arg location=$LOCATION -t quay.io/quay/quay-builder-qemu-fedoracoreos:$TAG .
+    time docker build --build-arg=channel=$CHANNEL --build-arg version=$VERSION --build-arg location=$LOCATION -t $IMAGE:$TAG .
+else
+    time docker build --build-arg=channel=$CHANNEL --build-arg version=$VERSION --build-arg location=$CLOUD_IMAGE -t $IMAGE:$TAG .
+fi

--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -106,7 +106,11 @@ WantedBy=multi-user.target
                        quay_username,
                        quay_password,
                        worker_tag,
-                       extra_args='--net=host --privileged --env-file /root/overrides.list -v /var/run/docker.sock:/var/run/docker.sock -v /etc/pki/ca-trust-source/anchors:/etc/ssl/certs',
+                       {% if container_runtime == 'podman' %}
+                       extra_args='--net=host --privileged --env-file /root/overrides.list -v /var/run/podman/podman.sock:/var/run/podman/podman.sock -v /etc/pki/ca-trust-source/anchors:/etc/ssl/certs',
+                       {% else %}
+                       extra_args='--privileged --env-file /root/overrides.list -v /var/run/docker.sock:/var/run/docker.sock -v /etc/pki/ca-trust-source/anchors:/etc/ssl/certs',
+                       {% endif %}
                        exec_stop_post=['/bin/sh -xc "/bin/sleep 120; /usr/bin/systemctl --no-block poweroff"'],
                        restart_policy='no'
                       ) | indent(6) }},

--- a/buildman/templates/dockersystemd.json
+++ b/buildman/templates/dockersystemd.json
@@ -1,8 +1,13 @@
 {% macro dockerimageservice() -%}
 
 [Unit]
+{% if container_runtime == 'podman' %}
+After=podman.service
+Requires=podman.service
+{% else %}
 After=docker.service
 Requires=docker.service
+{% endif %}
 {% if onfailure_units -%}
 OnFailure={% for failure in onfailure_units -%}{{ failure }} {% endfor %}
 {%- endif %}
@@ -27,6 +32,19 @@ Restart={{ restart_policy }}
 {%- endif %}
 TimeoutStartSec={{ timeout_start_sec if timeout_start_sec else 600 }}
 TimeoutStopSec={{ timeout_stop_sec if timeout_stop_sec else 2000 }}
+
+{% if container_runtime == 'podman' %}
+{% if username and password %}
+ExecStartPre=/usr/bin/podman login -u {{ username }} -p {{ password }} {{ container|registry }}
+{% endif %}
+ExecStart=/usr/bin/podman run --rm {{ extra_args }} --name {{ name }} {{ container }}:{{ tag }} {{ command }}
+{% for start_post in exec_start_post -%}
+ExecStartPost={{ start_post }}
+{% endfor %}
+{% if not oneshot -%}
+ExecStop=/usr/bin/podman stop {{ name }}
+{%- endif %}
+{% else %}
 {% if username and password %}
 ExecStartPre=/usr/bin/docker login -u {{ username }} -p {{ password }} {{ container|registry }}
 {% endif %}
@@ -37,6 +55,7 @@ ExecStartPost={{ start_post }}
 {% if not oneshot -%}
 ExecStop=/usr/bin/docker stop {{ name }}
 {%- endif %}
+{% endif %}
 {% for stop_post in exec_stop_post -%}
 ExecStopPost={{ stop_post }}
 {% endfor %}


### PR DESCRIPTION
Allow specifying the container runtime in the executor's ignition
file. This allow for different runtimes, e.g Docker, Podman to run a build.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1295

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 