### PR TITLE
PROJQUAY-1264 - correct doc links

### DIFF
--- a/config.py
+++ b/config.py
@@ -737,7 +737,7 @@ class DefaultConfig(ImmutableConfig):
     WEBHOOK_HOSTNAME_BLACKLIST = []
 
     # The root URL for documentation.
-    DOCUMENTATION_ROOT = "https://access.redhat.com/documentation/en-us/red_hat_quay/3.3/"
+    DOCUMENTATION_ROOT = "https://docs.projectquay.io/"
 
     # Feature Flag: Whether the repository action count worker is enabled.
     FEATURE_REPOSITORY_ACTION_COUNTER = True

--- a/static/directives/service-keys-manager.html
+++ b/static/directives/service-keys-manager.html
@@ -7,8 +7,10 @@
     </div>
 
     <div class="section-description-header twenty">
-      Service keys provide a recognized means of authentication between Red Hat Quay and external services, as well as between external services. <br>Example services include Quay Security Scanner speaking to a <a href="https://github.com/coreos/clair" target="_blank">Clair</a> cluster, or Red Hat Quay speaking to its
-      <a href="https://tectonic.com/quay-enterprise/docs/latest/build-support.html" target="_blank">build workers</a>.
+      Service keys provide a recognized means of authentication between Quay and external services, as well as
+      between external services. <br>Example services include Quay Security Scanner speaking to a
+      <a href="https://docs.projectquay.io/manage_quay.html#clair-v4" target="_blank">Clair</a> cluster, or Quay
+      speaking to its <a href="https://docs.projectquay.io/use_quay.html#build-support" target="_blank">build workers</a>.
     </div>
 
     <div class="co-check-bar" ng-show="keys.length">


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1264

**Changelog:** 
none

**Docs:** 
none

**Testing:** 
Confirm links visit valid pages

**Details:** 
Point links to docs.projectquay.io