### PR TITLE
PROJQUAY-1128 - Allow basic auth on the secscan api endpoint when anonymous api resource is set.

### DIFF
--- a/endpoints/api/secscan.py
+++ b/endpoints/api/secscan.py
@@ -24,6 +24,7 @@ from endpoints.api import (
     disallow_for_app_repositories,
     deprecated,
 )
+from endpoints.decorators import anon_allowed
 from endpoints.exception import NotFound, DownstreamIssue
 from endpoints.api.manifest import MANIFEST_DIGEST_ROUTE
 from util.parsing import truthy_bool
@@ -86,6 +87,7 @@ class RepositoryImageSecurity(RepositoryParamResource):
     """
 
     @process_basic_auth_no_pass
+    @anon_allowed
     @require_repo_read
     @nickname("getRepoImageSecurity")
     @deprecated()
@@ -119,6 +121,7 @@ class RepositoryManifestSecurity(RepositoryParamResource):
     """
 
     @process_basic_auth_no_pass
+    @anon_allowed
     @require_repo_read
     @nickname("getRepoManifestSecurity")
     @disallow_for_app_repositories

--- a/endpoints/api/test/test_secscan.py
+++ b/endpoints/api/test/test_secscan.py
@@ -1,6 +1,7 @@
 import base64
 
 import pytest
+from mock import patch
 
 from data.registry_model import registry_model
 from endpoints.test.shared import gen_basic_auth
@@ -11,25 +12,38 @@ from test.fixtures import *
 
 
 @pytest.mark.parametrize(
-    "endpoint",
+    "endpoint, anonymous_allowed, auth_headers, expected_code",
     [
-        RepositoryImageSecurity,
-        RepositoryManifestSecurity,
+        pytest.param(RepositoryImageSecurity, True, gen_basic_auth("devtable", "password"), 200),
+        pytest.param(RepositoryImageSecurity, False, gen_basic_auth("devtable", "password"), 200),
+        pytest.param(RepositoryManifestSecurity, True, gen_basic_auth("devtable", "password"), 200),
+        pytest.param(
+            RepositoryManifestSecurity, False, gen_basic_auth("devtable", "password"), 200
+        ),
+        pytest.param(RepositoryImageSecurity, True, None, 401),
+        pytest.param(RepositoryImageSecurity, False, None, 401),
+        pytest.param(RepositoryManifestSecurity, True, None, 401),
+        pytest.param(RepositoryManifestSecurity, False, None, 401),
     ],
 )
-def test_get_security_info_with_pull_secret(endpoint, client):
-    repository_ref = registry_model.lookup_repository("devtable", "simple")
-    tag = registry_model.get_repo_tag(repository_ref, "latest")
-    manifest = registry_model.get_manifest_for_tag(tag)
+def test_get_security_info_with_pull_secret(
+    endpoint, anonymous_allowed, auth_headers, expected_code, client
+):
+    with patch("features.ANONYMOUS_ACCESS", anonymous_allowed):
+        repository_ref = registry_model.lookup_repository("devtable", "simple")
+        tag = registry_model.get_repo_tag(repository_ref, "latest")
+        manifest = registry_model.get_manifest_for_tag(tag)
 
-    params = {
-        "repository": "devtable/simple",
-        "imageid": tag.manifest.legacy_image_root_id,
-        "manifestref": manifest.digest,
-    }
+        params = {
+            "repository": "devtable/simple",
+            "imageid": tag.manifest.legacy_image_root_id,
+            "manifestref": manifest.digest,
+        }
 
-    headers = {
-        "Authorization": gen_basic_auth("devtable", "password"),
-    }
+        headers = {}
+        if auth_headers is not None:
+            headers["Authorization"] = auth_headers
 
-    conduct_api_call(client, endpoint, "GET", params, None, headers=headers, expected_code=200)
+        conduct_api_call(
+            client, endpoint, "GET", params, None, headers=headers, expected_code=expected_code
+        )


### PR DESCRIPTION
Allow the auth flow to use basic auth on the secscan api resource when
FEATURE_ANONYMOUS_ACCESS (e.g CSO uses pull secrets to fetch secscan
resources)

This will still not allow anonymous acces to the secscan api resource (no auth)

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1128

**Changelog:** 

**Docs:** 

**Testing:** 
- set `FEATURE_ANONYMOUS_ACCESS` to `false`
- Try querying the secscan api with basic auth -> should succeed
- Try querying the secscan api with auth token -> should succeed
- Try querying the secscan api with no auth -> should fail with 401

- set `FEATURE_ANONYMOUS_ACCESS` to `True`
- Try querying the secscan api with basic auth -> should succeed
- Try querying the secscan api with auth token -> should succeed
- Try querying the secscan api with no auth -> should fail with 401

Examples: 
- Basic auth: `curl -k --user <user>:<password> https://quayhost.io/api/v1/repository/<namespace>/<repo>/manifest/<digest>/security`
- Bearer auth: `curl -k -H 'Authorization: Bearer <TOKEN> https://quayhost.io/api/v1/repository/<namespace>/<repo>/manifest/<digest>/security`

**Details:** 