### PR TITLE
PROJQUAY-1366

### DIFF
--- a/endpoints/api/repoemail.py
+++ b/endpoints/api/repoemail.py
@@ -48,7 +48,9 @@ class RepositoryAuthorizedEmail(RepositoryParamResource):
         if not record:
             abort(404)
 
-        return record.to_dict()
+        response = record.to_dict()
+        del response["code"]
+        return response
 
     @require_repo_admin
     @nickname("sendAuthorizeRepoEmail")
@@ -60,10 +62,15 @@ class RepositoryAuthorizedEmail(RepositoryParamResource):
         with tf(db):
             record = model.get_email_authorized_for_repo(namespace, repository, email)
             if record and record.confirmed:
-                return record.to_dict()
+                response = record.to_dict()
+                del response["code"]
+                return response
 
             if not record:
                 record = model.create_email_authorization_for_repo(namespace, repository, email)
 
             send_repo_authorization_email(namespace, repository, email, record.code)
-            return record.to_dict()
+
+            response = record.to_dict()
+            del response["code"]
+            return response


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1366

**Changelog:** 

- Code for e-mail verification is removed in response from `sendAuthorizeRepoEmail` endpoint. 

**Docs:** 

**Testing:** 

- Current tests for email notification auth is found here -> `endpoints/api/test/test_repoemail_models_pre_oci.py `

**Details:** 

------