### PR TITLE
PROJQUAY-1376 - Handle non 200 api response from executors (#619)

### DIFF
--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -583,13 +583,17 @@ class EphemeralBuilderManager(BuildStateInterface):
         logger.debug("Scheduling build %s", build_id)
 
         allowed_worker_count = self._manager_config.get("ALLOWED_WORKER_COUNT", 1)
-        if self._running_workers() >= allowed_worker_count:
-            logger.warning(
-                "Could not schedule build %s. Number of workers at capacity: %s.",
-                build_id,
-                self._running_workers(),
-            )
+        try:
+            if self._running_workers() >= allowed_worker_count:
+                logger.warning(
+                    "Could not schedule build %s. Number of workers at capacity: %s.",
+                    build_id,
+                    self._running_workers(),
+                )
             return False, TOO_MANY_WORKERS_SLEEP_DURATION
+        except Exception as exe:
+            logger.warning("Failed to get worker count from executors: %s", exe)
+            return False, EPHEMERAL_API_TIMEOUT
 
         job_id = self._job_key(build_id)
         try:


### PR DESCRIPTION
* Handle non 200 api response from executors

* Allows the CA cert to be specified in the config for server verification

Allow the CA cert used for server verification to be specified in the
config even if client certificate authentication is not used.
Handles non-200 responses from executors when trying to get worker count.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-???
Pull-request title must start with "PROJQUAY-??? - "

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 

------
(_This section may be deleted._)
**All fields are required.** If a field is not applicable (eg. no relevant CHANGELOG.md), specify "none" or "n/a".

Issue: This is the PROJQUAY jira reference. Pull-request title must start with issue name "PROJQUAY-1234 - ".

Changelog: One line description to be added to CHANGELOG.md during release builds. Typically starts with "Added:", "Fixed:", "Note:", etc.

Docs: Detailed description of changes necessary to docs.projectquay.io. Examples would be addition of config.yaml, indication of UI changes and screenshot impact, and changes in behavior of features.

Testing: Detailed description of how to test changes manually. This section combined with the _Docs_ section above must be sufficiently clear for full test cases to be performed.

Details: Other information meant for pull-request reviewers and developers.