### PR TITLE
PROJQUAY-1393 - Use correct nginx port in ignition template

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -25,7 +25,7 @@ import release
 from _init import ROOT_DIR, OVERRIDE_CONFIG_DIRECTORY
 from app import app
 from buildman.container_cloud_config import CloudConfigContext
-from buildman.server import DEFAULT_GRPC_SERVER_PORT
+from buildman.server import SECURE_GRPC_SERVER_PORT
 
 
 logger = logging.getLogger(__name__)
@@ -165,7 +165,7 @@ class BuilderExecutor(object):
         if quay_password is None:
             quay_password = self.executor_config["QUAY_PASSWORD"]
 
-        server_addr = manager_hostname.split(":", 1)[0] + ":" + str(DEFAULT_GRPC_SERVER_PORT)
+        server_addr = manager_hostname.split(":", 1)[0] + ":" + str(SECURE_GRPC_SERVER_PORT)
         rendered_json = json.load(
             io.StringIO(
                 TEMPLATE.render(

--- a/buildman/server.py
+++ b/buildman/server.py
@@ -19,7 +19,11 @@ from data import database, model
 logger = logging.getLogger(__name__)
 
 
+# Internal app grpc port
 DEFAULT_GRPC_SERVER_PORT = 50051
+# Port exposed by Nginx
+SECURE_GRPC_SERVER_PORT = 55443
+
 DEFAULT_GRPC_SERVER_WORKER_COUNT = 10
 
 

--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -2,6 +2,8 @@
 
 TOKEN={{ token }}
 SERVER={{ manager_hostname }}
+# TODO: Remove this eventually
+GODEBUG=x509ignoreCN=0
 
 {%- endmacro %}
 


### PR DESCRIPTION
Generate the ignition template used by the builder using the correct
externally exposed secured GRPC port (55443).

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1393

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 
