### PR TITLE
PROJQUAY-1228: nginx: use bigger http/2 chunks for blobs

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -142,6 +142,7 @@ location ~ /v2/([^/]+)\/[^/]+/blobs/ {
     proxy_temp_path /tmp 1 2;
 
     client_max_body_size {{ maximum_layer_size }};
+    http2_chunk_size 32k;
 
     # Setting ANY header clears all inherited proxy_set_header directives
     proxy_set_header X-Forwarded-For $proper_forwarded_for;


### PR DESCRIPTION
This should ameliorate PROJQUAY-1228.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1228

**Changelog:** yes

**Docs:** no

**Testing:** yes please

**Details:** Not totally sure how to test.
