### PR TITLE
Add a DEBUG flag to the executors to prevent cleanup (#631)

### DIFF
--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -111,6 +111,17 @@ WantedBy=multi-user.target
   "systemd": {
     "units": [
       {% if container_runtime == "podman" %}
+      {% if debug %}
+      {{ dockersystemd("quay-builder",
+                       worker_image,
+                       container_runtime,
+                       quay_username,
+                       quay_password,
+                       worker_tag,
+                       extra_args='--privileged --env-file /root/overrides.list -v /var/run/podman/podman.sock:/var/run/podman/podman.sock -v /etc/pki/ca-trust-source/anchors:/certs',
+                       restart_policy='no'
+                      ) | indent(6) }},
+      {% else %}
       {{ dockersystemd("quay-builder",
                        worker_image,
                        container_runtime,
@@ -119,6 +130,18 @@ WantedBy=multi-user.target
                        worker_tag,
                        extra_args='--privileged --env-file /root/overrides.list -v /var/run/podman/podman.sock:/var/run/podman/podman.sock -v /etc/pki/ca-trust-source/anchors:/certs',
                        exec_stop_post=['/bin/sh -xc "/bin/sleep 120; /usr/bin/systemctl --no-block poweroff"'],
+                       restart_policy='no'
+                      ) | indent(6) }},
+      {% endif %}
+      {% else %}
+      {% if debug %}
+      {{ dockersystemd("quay-builder",
+                       worker_image,
+                       container_runtime,
+                       quay_username,
+                       quay_password,
+                       worker_tag,
+                       extra_args='--net=host --privileged --env-file /root/overrides.list -v /var/run/docker.sock:/var/run/docker.sock -v /etc/pki/ca-trust-source/anchors:/certs',
                        restart_policy='no'
                       ) | indent(6) }},
       {% else %}
@@ -132,6 +155,7 @@ WantedBy=multi-user.target
                        exec_stop_post=['/bin/sh -xc "/bin/sleep 120; /usr/bin/systemctl --no-block poweroff"'],
                        restart_policy='no'
                       ) | indent(6) }},
+      {% endif %}
       {% endif %}
       {
         "name": "systemd-journal-gatewayd.socket",


### PR DESCRIPTION
When set to true, DEBUG will prevent the build nodes from shutting
down after the quay-builder service is done or fails, and will prevent the
build manager from cleaning up the instances (terminating EC2
instances or deleting k8s jobs).

This will allow debugging builder node issues, and should not be set
in a production environment.

The lifetime service will still exist. i.e The instance will still
shutdown after ~2h (EC2 instances will terminate, k8s jobs will
complete)

Setting DEBUG will also affect ALLOWED_WORKER_COUNT, as the
unterminated instances/jobs will still count towards the total number
of running workers.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1397

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 
