### PR TITLE
Use CentOS Stream in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 
 ###################
-FROM centos:8 as config-editor
+FROM registry.centos.org/centos/centos:8 as config-editor
+
+# Switch to CentOS Stream
+RUN dnf install centos-release-stream -y
+RUN dnf swap centos-{linux,stream}-repos -y
+RUN dnf distro-sync -y
+RUN dnf upgrade -y
 
 WORKDIR /config-editor
 
@@ -28,7 +34,8 @@ RUN go install ./cmd/config-tool
 
 
 ###################
-FROM centos:8
+FROM registry.centos.org/centos/centos:8
+
 LABEL maintainer "thomasmckay@redhat.com"
 
 ENV OS=linux \
@@ -44,6 +51,11 @@ ENV QUAYDIR /quay-registry
 ENV QUAYCONF /quay-registry/conf
 ENV QUAYPATH "."
 
+# Switch to CentOS Stream
+RUN dnf install centos-release-stream -y
+RUN dnf swap centos-{linux,stream}-repos -y
+RUN dnf distro-sync -y
+RUN dnf upgrade -y
 
 RUN mkdir $QUAYDIR
 WORKDIR $QUAYDIR


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-???

**Changelog:**  Use Centos Stream in Dockerfile

**Docs:**  n/a

**Testing:** Ensure Quay still works correctly when running within `Dockerfile`

**Details:** Centos 8 will be EOL after 2021. Centos Stream is the proposed solution. As there is not currently a Centos Stream image available, as far as I can see, I simply followed the [official steps to change from Centos 8 to Centos Stream](https://www.centos.org/centos-stream/). I also switched the image from Dockerhub to the [Centos registry](https://registry.centos.org/centos/centos) to avoid Dockerhub-related pull/build issues.