### PR TITLE
Add a --shrink flag when resizing the qemu image. (#635)

### DIFF
--- a/buildman/qemu-coreos/start.sh
+++ b/buildman/qemu-coreos/start.sh
@@ -9,7 +9,7 @@ set -o nounset
 
 echo "${USERDATA}" > /userdata/user_data
 
-time qemu-img resize /userdata/coreos_production_qemu_image.qcow2 "${VM_VOLUME_SIZE}"
+time qemu-img resize --shrink /userdata/coreos_production_qemu_image.qcow2 "${VM_VOLUME_SIZE}"
 
 /usr/libexec/qemu-kvm \
         -enable-kvm \


### PR DESCRIPTION
Newer version of qemu will return a non-zero error when --shrink is not set when resizing an image.

**Changelog:** 

**Docs:** 

**Testing:** 

**Details:** 
