### PR TITLE
Allow build canceller to set keys in orchestrator

### DIFF
--- a/buildman/orchestrator.py
+++ b/buildman/orchestrator.py
@@ -471,8 +471,6 @@ class RedisOrchestrator(Orchestrator):
         return value.decode("utf-8")
 
     def set_key(self, key, value, overwrite=False, expiration=None):
-        assert not self.is_canceller_only
-
         try:
             already_exists = self._client.exists(key)
             if already_exists and not overwrite:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1282

**Changelog:** 
- Allow the BuildCanceller to set "cancel" keys in the orchestrator
 
**Docs:** 

**Testing:** 
- Start a build
- Cancel in-progress build -> Should cancel successfully
-  
**Details:** 

