### PR TITLE
PROJQUAY-1392 prevent over shrinking vm image

### DIFF
--- a/buildman/qemu-coreos/start.sh
+++ b/buildman/qemu-coreos/start.sh
@@ -9,7 +9,13 @@ set -o nounset
 
 echo "${USERDATA}" > /userdata/user_data
 
-time qemu-img resize --shrink /userdata/coreos_production_qemu_image.qcow2 "${VM_VOLUME_SIZE}"
+MIN_IMAGE_SIZE_BYTES=$(qemu-img info rhcos-47.83.202011301442-0-qemu.x86_64.qcow2 | grep "virtual size" | cut -d " " -f 5 | tr -d "()")
+VM_VOLUME_SIZE_BYTES=$(numfmt --from=iec $VM_VOLUME_SIZE)
+
+if [ "$VM_VOLUME_SIZE_BYTES" -gt "$MIN_IMAGE_SIZE_BYTES" ]
+then
+    time qemu-img resize /userdata/coreos_production_qemu_image.qcow2 "${VM_VOLUME_SIZE}" || echo "Failed to resize VM image. Check VM_VOLUME_SIZE"
+fi
 
 /usr/libexec/qemu-kvm \
         -enable-kvm \

--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -61,8 +61,7 @@ WantedBy=multi-user.target
         "sshAuthorizedKeys": {{ ssh_authorized_keys | jsonify }},
         {%- endif %}
         "groups": [
-          "sudo",
-          "docker"
+          "sudo"
         ],
         "name": "core"
       }
@@ -71,7 +70,7 @@ WantedBy=multi-user.target
   "storage": {
     "files": [
       {
-        "path": "/etc/pki/ca-trust/source/anchors/ssl.cert",
+        "path": "/etc/pki/ca-trust-source/anchors/ssl.cert",
         "contents": {
           "source": {{ ca_cert | dataurl | jsonify }}
         },


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1392

**Changelog:** 
- Prevent shrinking builder vm image, as that might truncate existing partitions. If the configured volume size is smaller than the default vdisk size, the image will not be resized.
 
**Docs:** 

**Testing:** 

**Details:** 

