### PR TITLE
Make sure network is up before starting the quay-builder systemd service

### DIFF
--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -117,7 +117,7 @@ WantedBy=multi-user.target
                        quay_username,
                        quay_password,
                        worker_tag,
-                       extra_args='--privileged --env-file /root/overrides.list -v /var/run/podman/podman.sock:/var/run/podman/podman.sock -v /etc/pki/ca-trust-source/anchors:/certs',
+                       extra_args='--privileged --env-file /root/overrides.list -v /var/run/podman/podman.sock:/var/run/podman/podman.sock -v /etc/pki/ca-trust-source/anchors:/certs -e DOCKER_HOST=unix:/var/run/podman/podman.sock',
                        restart_policy='no'
                       ) | indent(6) }},
       {% else %}
@@ -127,7 +127,7 @@ WantedBy=multi-user.target
                        quay_username,
                        quay_password,
                        worker_tag,
-                       extra_args='--privileged --env-file /root/overrides.list -v /var/run/podman/podman.sock:/var/run/podman/podman.sock -v /etc/pki/ca-trust-source/anchors:/certs',
+                       extra_args='--privileged --env-file /root/overrides.list -v /var/run/podman/podman.sock:/var/run/podman/podman.sock -v /etc/pki/ca-trust-source/anchors:/certs -e DOCKER_HOST=unix:/var/run/podman/podman.sock',
                        exec_stop_post=['/bin/sh -xc "/bin/sleep 120; /usr/bin/systemctl --no-block poweroff"'],
                        restart_policy='no'
                       ) | indent(6) }},

--- a/buildman/templates/dockersystemd.json
+++ b/buildman/templates/dockersystemd.json
@@ -2,10 +2,12 @@
 
 [Unit]
 {% if container_runtime == 'podman' %}
-After=podman.service
+Wants=podman.service network-online.target
+After=podman.service network-online.target
 Requires=podman.service
 {% else %}
-After=docker.service
+Wants=docker.service network-online.target
+After=docker.service network-online.target
 Requires=docker.service
 {% endif %}
 {% if onfailure_units -%}


### PR DESCRIPTION
Occasional DNS resolution issue would happen when running `podman
login` if network-online.target was not a prerequisite for quay-builder.service

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1392

**Changelog:** 
- Start `quay-builder.service` only after `network-online.target`

**Docs:** 

**Testing:** 

**Details:** 

