### PR TITLE
Don't replace port by default 55443 if BUILDMAN_HOSTNAME is defined

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -181,7 +181,16 @@ class BuilderExecutor(object):
         if quay_password is None:
             quay_password = self.executor_config["QUAY_PASSWORD"]
 
-        server_grpc_addr = manager_hostname.split(":", 1)[0] + ":" + str(SECURE_GRPC_SERVER_PORT)
+        if self.registry_hostname == self.manager_hostname:
+            # If SERVER_HOSTNAME and BUILDMAN_HOSTNAME are served under the same host
+            # the gRPC service will be exposed at SERVER_HOSTNAME:55443
+            #
+            # If that's not the case, then BUILDMAN_HOSTNAME _should include the port at which the service is being served.
+            # For example, BUILDMAN_HOST:443 for an Openshift Route
+            server_grpc_addr = (
+                manager_hostname.split(":", 1)[0] + ":" + str(SECURE_GRPC_SERVER_PORT)
+            )
+
         rendered_json = json.load(
             io.StringIO(
                 TEMPLATE.render(


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1392

If `SERVER_HOSTNAME` and `BUILDMAN_HOSTNAME` are served under the same host, the gRPC service will be exposed at `SERVER_HOSTNAME:55443`.

If that's not the case, then `BUILDMAN_HOSTNAME` _should_ include the port at which the service is being served.
For example, `BUILDMAN_HOST:443` for an Openshift `Route`

**Changelog:** 
- Keep port to gRPC endpoint if `BUILDMAN_HOSTNAME` is set. 

**Docs:** 

**Testing:** 

**Details:** 
