### PR TITLE
Remove extra extra parameter when calling commit_sha

### DIFF
--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -407,7 +407,7 @@ class EphemeralBuilderManager(BuildStateInterface):
         if private_key is not None:
             build_args["git"] = {
                 "url": build_job.build_config["trigger_metadata"].get("git_url", ""),
-                "sha": build_job.commit_sha(build_job.build_config),
+                "sha": build_job.commit_sha(),
                 "private_key": private_key or "",
             }
 


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1441

**Changelog:** 
- Remove extra param not needed in `commit_sha` call when a private key is used during a build

**Docs:** 

**Testing:** 

**Details:** 

