### PR TITLE
Update log level when unable to write build duration metrics to a WARNING

### DIFF
--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -834,7 +834,7 @@ class EphemeralBuilderManager(BuildStateInterface):
             else:
                 metric.labels(executor).observe(time.time() - start_time)
         except Exception:
-            logger.exception("Could not write metric for build %s", build_id)
+            logger.warning("Could not write metric for build %s", build_id)
 
     def _work_checker(self):
         logger.debug("Initializing work checker")


### PR DESCRIPTION
Update the log level from EXCEPTION to WARNING when getting a KeyError
from the orchestrator to avoid geetting a traceback. The KeyError is valid and happens when a build
has expired.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1438

**Changelog:** 
- Log missing build duration metrics key as a warning instead of an exception

**Docs:** 

**Testing:** 

**Details:** 