### PR TITLE
Set default REPO_MIRROR_SERVER_HOSTNAME value to match SERVER_HOSTNAME

### DIFF
--- a/config.py
+++ b/config.py
@@ -503,7 +503,7 @@ class DefaultConfig(ImmutableConfig):
     REPO_MIRROR_TLS_VERIFY = True
 
     # Replaces the SERVER_HOSTNAME as the destination for mirroring.
-    REPO_MIRROR_SERVER_HOSTNAME = None
+    REPO_MIRROR_SERVER_HOSTNAME = "localhost:5000"
 
     # JWTProxy Settings
     # The address (sans schema) to proxy outgoing requests through the jwtproxy

--- a/util/config/configutil.py
+++ b/util/config/configutil.py
@@ -46,7 +46,9 @@ def add_enterprise_config_defaults(config_obj, current_secret_key):
 
     # Default repo mirror config.
     config_obj["REPO_MIRROR_TLS_VERIFY"] = config_obj.get("REPO_MIRROR_TLS_VERIFY", True)
-    config_obj["REPO_MIRROR_SERVER_HOSTNAME"] = config_obj.get("REPO_MIRROR_SERVER_HOSTNAME", None)
+    config_obj["REPO_MIRROR_SERVER_HOSTNAME"] = config_obj.get(
+        "REPO_MIRROR_SERVER_HOSTNAME", config_obj["SERVER_HOSTNAME"]
+    )
 
     # Default security scanner config.
     config_obj["FEATURE_SECURITY_NOTIFICATIONS"] = config_obj.get(

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -169,9 +169,7 @@ def perform_mirror(skopeo, mirror):
             )
             raise
 
-        dest_server = (
-            app.config.get("REPO_MIRROR_SERVER_HOSTNAME", None) or app.config["SERVER_HOSTNAME"]
-        )
+        dest_server = app.config.get("REPO_MIRROR_SERVER_HOSTNAME", app.config["SERVER_HOSTNAME"])
 
         for tag in tags:
             reclaimed_mirror = claim_mirror(mirror)


### PR DESCRIPTION
Set `REPO_MIRROR_SERVER_HOSTNAME` to a value instead of None in order to
match the defined json schema for the config.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1499

**Changelog:** 
- Set default `REPO_MIRROR_SERVER_HOSTNAME` value to `SERVER_HOSTNAME` instaed of `None`

**Docs:** 

**Testing:** 

**Details:** 

