### PR TITLE
Update tox.ini for tox-docker v2.0.0 (#669)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,28 +24,29 @@ commands =
     alembic upgrade head
     py.test --timeout=3600 --cov-report=html --cov-report=term-missing -x --color no --verbose --ignore=buildman/ {env:FILE} -vv {posargs}
 
-[docker:mysql:5.7]
+[docker:mysql]
+image = mysql:5.7
 healthcheck_cmd = mysql -uroot -D information_schema -e "SELECT * FROM plugins LIMIT 0;"
 healthcheck_interval = 25
 healthcheck_timeout = 10
 healthcheck_retries = 3
 healthcheck_start_period = 25
 ports = 3306:3306/tcp
+environment =
+    MYSQL_DATABASE=quay_ci
+    MYSQL_PASSWORD=quay
+    MYSQL_ALLOW_EMPTY_PASSWORD=1
+    MYSQL_USER=quay
 
 [testenv:py38-mysql]
-setenv = 
+setenv =
     PYTHONDONTWRITEBYTECODE = 1
     PYTHONPATH={toxinidir}{:}{toxinidir}
     TEST=true
     SKIP_DB_SCHEMA=true
     PYTEST_ADDOPTS=--ignore=endpoints/appr/test/
     FILE=""
-docker = mysql:5.7
-dockerenv =
-    MYSQL_DATABASE=quay_ci
-    MYSQL_PASSWORD=quay
-    MYSQL_ALLOW_EMPTY_PASSWORD=1
-    MYSQL_USER=quay
+docker = mysql
 whitelist_internals = /bin/sh
 # TODO(kleesc): Re-enable buildman tests after buildman rewrite
 commands =
@@ -54,27 +55,28 @@ commands =
     /bin/sh -c "TEST_DATABASE_URI=mysql+pymysql://quay:quay@127.0.0.1:$MYSQL_3306_TCP_PORT/quay_ci py.test --timeout=3600 --cov-report=html --cov-report=term-missing -x --color no --verbose --ignore=buildman/ {env:FILE} -vv {posargs}"
 
 
-[docker:postgres:9.6]
-healthcheck_cmd = PGPASSWORD=root psql -U postgres -c "SELECT * FROM pg_extension LIMIT 0;"
+[docker:postgres]
+image = postgres:9.6
+healthcheck_cmd = PGPASSWORD=root pg_isready -U postgres
 healthcheck_interval = 5
 healthcheck_timeout = 10
 healthcheck_retries = 3
 healthcheck_start_period = 10
+environment =
+    POSTGRES_DB=quay_ci
+    POSTGRES_PASSWORD=quay
+    POSTGRES_USER=quay
 
 [testenv:py38-psql]
 # TODO(kleesc): Re-enable buildman tests after buildman rewrite
-setenv = 
+setenv =
     PYTHONDONTWRITEBYTECODE = 1
     PYTHONPATH={toxinidir}{:}{toxinidir}
     TEST=true
     SKIP_DB_SCHEMA=true
     PYTEST_ADDOPTS=--ignore=endpoints/appr/test/
     FILE=""
-docker = postgres:9.6
-dockerenv =
-    POSTGRES_DB=quay_ci
-    POSTGRES_PASSWORD=quay
-    POSTGRES_USER=quay
+docker = postgres
 whitelist_internals = /bin/sh
 # TODO(kleesc): Re-enable buildman tests after buildman rewrite
 commands =


### PR DESCRIPTION
- Update container name + move docker specific configuration to the same section.
- Update postgres healthcheck command to use pg_isready

(cherry picked from commit 32d7063315481b8159413d1a425c9a331fb9dae4)

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1549
