### PR TITLE
PROJQUAY-1562 repo mirror config schema

### DIFF
--- a/config.py
+++ b/config.py
@@ -503,7 +503,7 @@ class DefaultConfig(ImmutableConfig):
     REPO_MIRROR_TLS_VERIFY = True
 
     # Replaces the SERVER_HOSTNAME as the destination for mirroring.
-    REPO_MIRROR_SERVER_HOSTNAME = "localhost:5000"
+    REPO_MIRROR_SERVER_HOSTNAME = None
 
     # JWTProxy Settings
     # The address (sans schema) to proxy outgoing requests through the jwtproxy

--- a/util/config/configutil.py
+++ b/util/config/configutil.py
@@ -46,9 +46,7 @@ def add_enterprise_config_defaults(config_obj, current_secret_key):
 
     # Default repo mirror config.
     config_obj["REPO_MIRROR_TLS_VERIFY"] = config_obj.get("REPO_MIRROR_TLS_VERIFY", True)
-    config_obj["REPO_MIRROR_SERVER_HOSTNAME"] = config_obj.get(
-        "REPO_MIRROR_SERVER_HOSTNAME", config_obj["SERVER_HOSTNAME"]
-    )
+    config_obj["REPO_MIRROR_SERVER_HOSTNAME"] = config_obj.get("REPO_MIRROR_SERVER_HOSTNAME", None)
 
     # Default security scanner config.
     config_obj["FEATURE_SECURITY_NOTIFICATIONS"] = config_obj.get(

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -988,7 +988,7 @@ CONFIG_SCHEMA = {
             "x-example": True,
         },
         "REPO_MIRROR_SERVER_HOSTNAME": {
-            "type": "string",
+            "type": ["string", "null"],
             "description": "Replaces the SERVER_HOSTNAME as the destination for mirroring. Defaults to unset",
             "x-example": "openshift-quay-service",
         },

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -169,7 +169,9 @@ def perform_mirror(skopeo, mirror):
             )
             raise
 
-        dest_server = app.config.get("REPO_MIRROR_SERVER_HOSTNAME", app.config["SERVER_HOSTNAME"])
+        dest_server = (
+            app.config.get("REPO_MIRROR_SERVER_HOSTNAME", None) or app.config["SERVER_HOSTNAME"]
+        )
 
         for tag in tags:
             reclaimed_mirror = claim_mirror(mirror)


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1562
Revert #667 . It wrongly assumed that `REPO_MIRROR_SERVER_HOSTNAME` shouldn't be null given the previous config schema. `REPO_MIRROR_SERVER_HOSTNAME` _can_ be null and should have the same value as `SERVER_HOSTNAME` if not explicitly set.

**Changelog:** 
- Reverts #667 
- Allow `REPO_MIRROR_SERVER_HOSTNAME` to be null in the jsonschema

**Docs:** 

**Testing:** 

**Details:** 
