### PR TITLE
PROJQUAY-1284

### DIFF
--- a/avatars/avatars.py
+++ b/avatars/avatars.py
@@ -1,6 +1,7 @@
 import hashlib
 import math
 import logging
+import features
 
 from requests.exceptions import RequestException
 
@@ -107,7 +108,16 @@ class BaseAvatar(object):
         # so use the username in that case.
         username_email_or_id = email_or_id or name
         username_email_or_id = Bytes.for_string_or_unicode(username_email_or_id).as_unicode()
-        hash_value = hashlib.md5(username_email_or_id.strip().lower().encode("utf-8")).hexdigest()
+
+        # If fips mode is enabled, we must use 256. In future Quay versions, this should be the default. Flag is set for backwards compatibility.
+        if features.FIPS:
+            hash_value = hashlib.sha256(
+                username_email_or_id.strip().lower().encode("utf-8")
+            ).hexdigest()
+        else:
+            hash_value = hashlib.md5(
+                username_email_or_id.strip().lower().encode("utf-8")
+            ).hexdigest()
 
         byte_count = int(math.ceil(math.log(len(colors), 16)))
         byte_data = hash_value[0:byte_count]

--- a/config.py
+++ b/config.py
@@ -379,6 +379,9 @@ class DefaultConfig(ImmutableConfig):
     # logging in via OIDC or a non-database internal auth provider.
     FEATURE_USERNAME_CONFIRMATION = True
 
+    # Feature Flag: If set to true, Quay will run using FIPS compliant hash functions.
+    FEATURE_FIPS = False
+
     # If a namespace is defined in the public namespace list, then it will appear on *all*
     # user's repository list pages, regardless of whether that user is a member of the namespace.
     # Typically, this is used by an enterprise customer in configuring a set of "well-known"

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -856,6 +856,12 @@ CONFIG_SCHEMA = {
             "description": "Whether super users are supported. Defaults to True",
             "x-example": True,
         },
+        # Feature Flag: Use FIPS compliant cryptography.
+        "FEATURE_FIPS": {
+            "type": "boolean",
+            "description": "If set to true, Quay will run using FIPS compliant hash functions. Defaults to False",
+            "x-example": True,
+        },
         # Feature Flag: Anonymous Users.
         "FEATURE_ANONYMOUS_ACCESS": {
             "type": "boolean",


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1284


**Changelog:** 
- Added `FEATURE_FIPS` flag to Quay config. When this feature is enabled, Quay will use sha256 hash instead of md5. This allows future FIPS users to utilize compliant hashes without breaking existing deployments (non-FIPS). 

**Docs:** 

**Testing:** 
- Tested TNG deployment on FIPS-enabled OCP. The issue is reproduced without `FEATURE_FIPS` enabled (as expected) but works correctly when `FEATURE_FIPS=true`.

**Details:** 

------