### PR TITLE
Deprecate use of pycryptodome for AES

### DIFF
--- a/data/users/__init__.py
+++ b/data/users/__init__.py
@@ -172,7 +172,7 @@ class UserAuthentication(object):
             return None
 
         try:
-            data = json.loads(message)
+            data = json.loads(message.decode("utf-8"))
         except ValueError:
             return None
 

--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -29,7 +29,7 @@ chardet==3.0.4
 click==7.1.2
 cnr-server @ git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b
 cookies==2.2.1
-cryptography==2.8
+cryptography==3.4.6
 DateTime==4.3
 debtcollector==1.22.0
 decorator==4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ cfn-lint==0.27.2
 chardet==3.0.4
 Click==7.1.2
 cookies==2.2.1
-cryptography==2.8
+cryptography==3.4.6
 DateTime==4.3
 debtcollector==1.22.0
 decorator==4.4.1

--- a/util/security/secret.py
+++ b/util/security/secret.py
@@ -2,6 +2,8 @@ import itertools
 import uuid
 
 
+# TODO(kleesc): There are probably better key derivation functions, but that would require existing ones to be rotated.
+#               Reference: https://cryptography.io/en/latest/hazmat/primitives/key-derivation-functions.html
 def convert_secret_key(config_secret_key):
     """
     Converts the secret key from the app config into a secret key that is usable by AES Cipher.

--- a/util/security/test/test_secret.py
+++ b/util/security/test/test_secret.py
@@ -1,6 +1,8 @@
+import json
 import uuid
 import pytest
 
+from util.security.aes import AESCipher
 from util.security.secret import convert_secret_key
 
 
@@ -31,3 +33,51 @@ def test_convert_secret_key(config_secret_key, expected_secret_key):
     assert len(converted_secret_key) == 32
     assert isinstance(converted_secret_key, bytes)
     assert converted_secret_key == expected_secret_key
+
+
+@pytest.mark.parametrize(
+    "secret_key, encrypted_msg, expected_msg",
+    [
+        pytest.param(
+            "60819670227914197377449333332023941570310823814007397361459893170384762698201",
+            "cLJIuEm7radxwXwqoOG/9yXYxWW8JFCvgssBP3fHDatx/ckLrX9fZ4lZVj6WEv0D",
+            json.dumps({"password": "password"}).encode("utf-8"),
+            id="Test decrypt some existing msg",
+        ),
+    ],
+)
+def test_aes_decrypt(secret_key, encrypted_msg, expected_msg):
+    converted_secret_key = convert_secret_key(secret_key)
+    cipher = AESCipher(converted_secret_key)
+    decrypted_msg = cipher.decrypt(encrypted_msg)
+
+    assert decrypted_msg == expected_msg
+
+
+@pytest.mark.parametrize(
+    "secret_key, original_msg",
+    [
+        pytest.param("somesecretkey", b"some secret message", id="Some string"),
+        pytest.param(
+            "255",
+            b"another secret message",
+            id="Some int that can be represented as a byte",
+        ),
+        pytest.param(
+            "256",
+            b"yet another secret message",
+            id="Some int that can't be represented as a byte multiple (256 is 100 in hex -> 12 bits)",
+        ),
+        pytest.param(
+            "123e4567-e89b-12d3-a456-426655440000",
+            b"yet again another secret message",
+            id="Some 16bit UUID",
+        ),
+    ],
+)
+def test_aes_encrypt_decrypt(secret_key, original_msg):
+    converted_secret_key = convert_secret_key(secret_key)
+    cipher = AESCipher(converted_secret_key)
+    encrypted_msg = cipher.encrypt(original_msg)
+
+    assert cipher.decrypt(encrypted_msg) == original_msg


### PR DESCRIPTION
Since we're already using the `cryptography` package elsewhere, there is no need to have 2 different crypto packages as dependencies.
**NOTE**: `pycryptodome` is still needed for `pyjwkest`, but the latter (https://github.com/IdentityPython/pyjwkest) is not being maintained anymore, so we should eventually move it to some other JOSE library:
- https://github.com/mpdavis/python-jose or 
- https://github.com/latchset/jwcrypto

**Issue:** 
- https://issues.redhat.com/browse/PROJQUAY-1619
- https://issues.redhat.com/browse/PROJQUAY-224

**Changelog:** 
- Use `cryptography` instead of `pycryptodome` for AES

**Docs:** 

**Testing:** 
- Generate an encrypted password with a version of Quay using `cryptography` -> encrypted password should work using `docker login`
- Generate an encrypted password using a version of Quay still using `pycryptodome`.
  - Restart an instance of Quay with this PR included -> The encrypted password should still work.

**Details:** 
