### PR TITLE
Use registry-name instead of registry-title as registry directive

### DIFF
--- a/static/partials/update-user.html
+++ b/static/partials/update-user.html
@@ -5,7 +5,7 @@
     <h2>Confirm Username</h2>
     <p>
     The username <strong>{{ user.username }}</strong> was automatically generated to conform to the
-    Docker CLI guidelines for use as a namespace in <span class="registry-title"></span>.
+    Docker CLI guidelines for use as a namespace in <span class="registry-name"></span>.
     </p>
     <p>Please confirm the selected username or enter a different username below:</p>
     <form name="usernameForm" ng-submit="updateUser({'username': username})">


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1519
Pull-request title must start with "PROJQUAY-1519 - "

**Changelog:** 
* Use `registry-name` instead of `registry-title` as the class directive 
