### PR TITLE
PROJQUAY-1711 - pin cryptography

### DIFF
--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -29,7 +29,7 @@ chardet==3.0.4
 click==7.1.2
 cnr-server @ git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b
 cookies==2.2.1
-cryptography==3.4.6
+cryptography==3.3.1
 DateTime==4.3
 debtcollector==1.22.0
 decorator==4.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ cfn-lint==0.27.2
 chardet==3.0.4
 Click==7.1.2
 cookies==2.2.1
-cryptography==3.4.6
+cryptography==3.3.1
 DateTime==4.3
 debtcollector==1.22.0
 decorator==4.4.1


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1711

**Changelog:** 
none

**Docs:** 
none

**Testing:** 
none

**Details:** 
Pin cryptography to long-term supportable 3.3.1