### PR TITLE
tags: apply tag expiry to created tags pointing to existing manifest

### DIFF
--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -24,7 +24,6 @@ from data.database import (
     ExternalNotificationEvent,
     db_random_func,
 )
-from data.model.oci.shared import get_legacy_image_for_manifest
 from data.model import config
 from image.docker.schema1 import (
     DOCKER_SCHEMA1_CONTENT_TYPES,
@@ -300,6 +299,7 @@ def retarget_tag(
     is_reversion=False,
     now_ms=None,
     raise_on_error=False,
+    expiration_seconds=None,
 ):
     """
     Creates or updates a tag with the specified name to point to the given manifest under its
@@ -342,7 +342,6 @@ def retarget_tag(
 
             return None
 
-    legacy_image = get_legacy_image_for_manifest(manifest)
     now_ms = now_ms or get_epoch_timestamp_ms()
     now_ts = int(now_ms // 1000)
 
@@ -362,6 +361,7 @@ def retarget_tag(
             name=tag_name,
             repository=manifest.repository_id,
             lifetime_start_ms=now_ms,
+            lifetime_end_ms=(now_ms + expiration_seconds * 1000) if expiration_seconds else None,
             reversion=is_reversion,
             manifest=manifest,
             tag_kind=Tag.tag_kind.get_id("tag"),

--- a/data/registry_model/label_handlers.py
+++ b/data/registry_model/label_handlers.py
@@ -5,6 +5,9 @@ from util.timedeltastring import convert_to_timedelta
 logger = logging.getLogger(__name__)
 
 
+LABEL_EXPIRY_KEY = "quay.expires-after"
+
+
 def _expires_after(label_dict, manifest, model):
     """
     Sets the expiration of a manifest based on the quay.expires-in label.
@@ -21,7 +24,7 @@ def _expires_after(label_dict, manifest, model):
 
 
 _LABEL_HANDLERS = {
-    "quay.expires-after": _expires_after,
+    LABEL_EXPIRY_KEY: _expires_after,
 }
 
 


### PR DESCRIPTION
Apply a manifest's `quay.expires-after` label expiry value to new tags pointing
to that existing manifest. Before, that label would be only applied when the
manifest was created, and new tags targeting that manifest would not
have the manifest's corresponding expiry value set.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1713

**Changelog:** 
- Fix issue where new tags targeting an existing manifest would not have manifest's `quay.expires-after` label applied

**Docs:** 

**Testing:** 
- Push an image with a valid `quay.expires-after` label/value -> the tag used should have the corresponding expiration
- Create another tag pointing to the same manifest -> the new tag should also have an expiration
  - NOTE: this should work for using both the registry api and tags api to create the tag
- Changing expiration on individual tags should not affect other tags -> new tags are always created with expiration set to `"tag creation time"` + `quay.expires-after`
- Moving a tag should apply the expiration label of the newly targeted manifest