### PR TITLE
PROJQUAY-1705 Enable Helm by default on Quay

### DIFF
--- a/config.py
+++ b/config.py
@@ -726,11 +726,11 @@ class DefaultConfig(ImmutableConfig):
     FEATURE_CLEAR_EXPIRED_RAC_ENTRIES = False
 
     # Feature Flag: Whether OCI manifest support should be enabled generally.
-    FEATURE_GENERAL_OCI_SUPPORT = False
+    FEATURE_GENERAL_OCI_SUPPORT = True
 
     # Feature Flag: Whether to allow Helm OCI content types.
     # See: https://helm.sh/docs/topics/registries/
-    FEATURE_HELM_OCI_SUPPORT = False
+    FEATURE_HELM_OCI_SUPPORT = True
 
     # The set of hostnames disallowed from webhooks, beyond localhost (which will
     # not work due to running inside a container).


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1705
Pull-request title must start with "PROJQUAY-1705 - "

**Changelog:** 

* Made Helm support enabled by default on Quay


**Testing:** 
Please follow this document for testing Helm support in Quay: https://www.openshift.com/blog/quay-oci-artifact-support-for-helm-charts
