### PR TITLE
Fixed typo in if statement

### DIFF
--- a/conf/init/d_validate_config_bundle.sh
+++ b/conf/init/d_validate_config_bundle.sh
@@ -9,8 +9,7 @@ config-tool validate -c $QUAYCONF/stack/ --mode online
 
 status=$?
 
-if [ -z "${IGNORE_VALIDATION}"]
-then
+if [ -z "${IGNORE_VALIDATION}" ]; then
     exit $status
 else
     exit 0


### PR DESCRIPTION
**Issue:** 
Not tracked by JIRA (N/A)
**Changelog:** 
N/A
**Docs:** 
N/A
**Testing:** 
Script is called during Quay startup.
**Details:** 
Error occurs if `$IGNORE_VALIDATION` is set:
`line 12: [: missing ]'`