### PR TITLE
storage: abort unfinished mpu when no bytes are written

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -380,8 +380,6 @@ class _CloudStorage(BaseStorageV2):
                     )
                     write_error = e
 
-                    multipart_uploads_completed.inc()
-
                     if cancel_on_error:
                         try:
                             mp.abort()
@@ -400,6 +398,8 @@ class _CloudStorage(BaseStorageV2):
                     "Parts": [{"ETag": p.e_tag, "PartNumber": p.part_number} for p in upload_parts],
                 },
             )
+        else:
+            mp.abort()
 
         return total_bytes_written, write_error
 


### PR DESCRIPTION
Explicitly call abort on a mpu if no bytes were written.
Noobaa and Rados will not clean the artifacts, resulting in empty
files being stuck in an "uploading" state.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1123

**Changelog:** 
- Explicitly abort MultipartUpload where no bytes were uploaded

**Docs:** 

**Testing:** 

**Details:** 
