### PR TITLE
chore: import missing logging.config module

### DIFF
--- a/buildman/builder.py
+++ b/buildman/builder.py
@@ -1,4 +1,5 @@
 import logging
+import logging.config
 import os
 import time
 import socket


### PR DESCRIPTION
Add missing module import from logging package

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1795

**Changelog:** 
- Add missing module import from logging package

**Docs:** 

**Testing:** 

**Details:** 

