### PR TITLE
format: remove extra comma from s3 connect_kwargs

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -713,8 +713,8 @@ class S3Storage(_CloudStorage):
         upload_params = {"ServerSideEncryption": "AES256"}
         connect_kwargs = {}
         if host or endpoint_url:
-            connect_kwargs["endpoint_url"] = (
-                endpoint_url or _build_endpoint_url(host, port=port, is_secure=True),
+            connect_kwargs["endpoint_url"] = endpoint_url or _build_endpoint_url(
+                host, port=port, is_secure=True
             )
 
         super(S3Storage, self).__init__(


### PR DESCRIPTION
The way it was formatted (with the top-level parentheses), the extra
comma was causing the connection parameters to be passed as a 1-tuple
instead of a string.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1787

**Changelog:** 
- Fix formating issue resulting in tuple instead of string

**Docs:** 

**Testing:** 

**Details:** 

