### PR TITLE
gc: fix GlobalLock ttl unit and increase gc workers lock timeout

### DIFF
--- a/workers/gc/gcworker.py
+++ b/workers/gc/gcworker.py
@@ -16,8 +16,8 @@ from workers.gunicorn_worker import GunicornWorker
 
 logger = logging.getLogger(__name__)
 
-REPOSITORY_GC_TIMEOUT = 15 * 60  # 15 minutes
-LOCK_TIMEOUT_PADDING = 60  # seconds
+REPOSITORY_GC_TIMEOUT = 24 * 60 * 60  # 24h
+LOCK_TIMEOUT_PADDING = 60  # 60 seconds
 
 
 @contextmanager

--- a/workers/namespacegcworker.py
+++ b/workers/namespacegcworker.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 POLL_PERIOD_SECONDS = 60
-NAMESPACE_GC_TIMEOUT = 60 * 60  # 60 minutes
-LOCK_TIMEOUT_PADDING = 60  # seconds
+NAMESPACE_GC_TIMEOUT = 24 * 60 * 60  # 24h
+LOCK_TIMEOUT_PADDING = 60  # 60 seconds
 
 
 class NamespaceGCWorker(QueueWorker):

--- a/workers/repositorygcworker.py
+++ b/workers/repositorygcworker.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 POLL_PERIOD_SECONDS = 60
-REPOSITORY_GC_TIMEOUT = 60 * 15  # 15 minutes
-LOCK_TIMEOUT_PADDING = 60  # seconds
+REPOSITORY_GC_TIMEOUT = 24 * 60 * 60  # 24h
+LOCK_TIMEOUT_PADDING = 60  # 60 seconds
 
 
 class RepositoryGCWorker(QueueWorker):


### PR DESCRIPTION
Correctly converts the given ttl from seconds to milliseconds when
passed to Redis (redlock uses 'px', not 'ex'). Also increase the lock
timeout of gc workers to 1 day.

Some iteration, for repos with large numbers of tags (1000s), will
take more than 15 minutes to complete. This change will prevent multiple
workers GCing the same repo, and one possibly preempting
another. GlobalLock's ttl will make the lock available again when
expired, but will not actually stop execution of the current GC
iteration until the GlobalLock context is done. Having a 1 day timeout
should be enough.

NOTE: The correct solution would have GlobalLock should either renew
the lock until the caller is done, or signal that it is no longer
valid to the caller.

**Issue:** https://issues.redhat.com/browse/PROJQUAY-1823