### PR TITLE
[WIP] Add Timeout To OAuth Token Exchange (PROJQUAY-1335)

### DIFF
--- a/oauth/base.py
+++ b/oauth/base.py
@@ -231,10 +231,12 @@ class OAuthService(object):
 
         token_url = self.token_endpoint().to_url()
         if form_encode:
-            get_access_token = http_client.post(token_url, data=payload, headers=headers, auth=auth)
+            get_access_token = http_client.post(
+                token_url, data=payload, headers=headers, auth=auth, timeout=5
+            )
         else:
             get_access_token = http_client.post(
-                token_url, params=payload, headers=headers, auth=auth
+                token_url, params=payload, headers=headers, auth=auth timeout=5
             )
 
         if get_access_token.status_code // 100 != 2:


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1335

**Changelog:** Add timeout to OAuth token exchange to avoid ECONNRESET from RH SSO.

**Docs:** N/a

**Testing:** TODO(alecmerdler): Find a way to simulate `ECONNRESET` from the testing SSO server.

**Details:** Attempting to log into to quay.io using Red Hat SSO would occasionally result in an `HTTP 404`/`HTTP 502` response from the server. Exception logging revealed this to be the result of a `ECONNRESET` when sending a `POST` request to the SSO service for token exchange. As this is a problem in a service we do not control, our only option is to be more defensive on Quay's side. Adding a timeout here should alleviate this problem.
