### PR TITLE
Add Timeout and Retry To OAuth Token Exchange (PROJQUAY-1335)

### DIFF
--- a/oauth/test/test_oidc.py
+++ b/oauth/test/test_oidc.py
@@ -103,6 +103,7 @@ def app_config(http_client, mailing_feature):
             },
         },
         "HTTPCLIENT": http_client,
+        "TESTING": True,
     }
 
 
@@ -188,6 +189,9 @@ def authorize_handler(discovery_content):
 def token_handler(oidc_service, id_token, valid_code):
     @urlmatch(netloc=r"fakeoidc", path=r"/token")
     def handler(_, request):
+        if int(request.headers["X-Quay-Retry-Attempts"]) < 2:
+            raise requests.ConnectionError
+
         params = urllib.parse.parse_qs(request.body)
         if params.get("redirect_uri")[0] != "http://localhost/oauth2/someoidc/callback":
             return {"status_code": 400, "content": "Invalid redirect URI"}


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/PROJQUAY-1335

**Changelog:** Add timeout to OAuth token exchange to avoid ECONNRESET from RH SSO.

**Docs:** N/a

**Testing:** `tox`

**Details:** Attempting to log into to quay.io using Red Hat SSO would occasionally result in an `HTTP 404`/`HTTP 502` response from the server. Exception logging revealed this to be the result of a `ECONNRESET` when sending a `POST` request to the SSO service for token exchange. As this is a problem in a service we do not control, our only option is to be more defensive on Quay's side. Adding a timeout here should alleviate this problem.
