### PR TITLE
queueworker: prevent stop event on WorkerSleepException (PROJQUAY-1857)

### DIFF
--- a/data/model/gc.py
+++ b/data/model/gc.py
@@ -586,6 +586,8 @@ def _garbage_collect_manifest(manifest_id, context):
     if deleted_manifest_legacy_image:
         gc_table_rows_deleted.labels(table="ManifestLegacyImage").inc(deleted_manifest_legacy_image)
 
+    gc_table_rows_deleted.labels(table="Manifest").inc()
+
     return True
 
 

--- a/workers/gc/gcworker.py
+++ b/workers/gc/gcworker.py
@@ -17,7 +17,7 @@ from util.metrics.prometheus import gc_iterations
 
 logger = logging.getLogger(__name__)
 
-REPOSITORY_GC_TIMEOUT = 24 * 60 * 60  # 24h
+REPOSITORY_GC_TIMEOUT = 3 * 60 * 60  # 3h
 LOCK_TIMEOUT_PADDING = 60  # 60 seconds
 
 
@@ -60,7 +60,6 @@ class GarbageCollectionWorker(Worker):
                     except Repository.DoesNotExist:
                         return
 
-                    gc_iterations.inc()
                     logger.debug(
                         "Starting GC of repository #%s (%s)", repository.id, repository.name
                     )
@@ -68,6 +67,7 @@ class GarbageCollectionWorker(Worker):
                     logger.debug(
                         "Finished GC of repository #%s (%s)", repository.id, repository.name
                     )
+                    gc_iterations.inc()
             except LockNotAcquiredException:
                 logger.debug("Could not acquire repo lock for garbage collection")
 

--- a/workers/namespacegcworker.py
+++ b/workers/namespacegcworker.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 POLL_PERIOD_SECONDS = 60
-NAMESPACE_GC_TIMEOUT = 24 * 60 * 60  # 24h
+NAMESPACE_GC_TIMEOUT = 3 * 60 * 60  # 3h
 LOCK_TIMEOUT_PADDING = 60  # 60 seconds
 
 

--- a/workers/queueworker.py
+++ b/workers/queueworker.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import time
 
 from threading import Event, Lock
 
@@ -9,6 +10,8 @@ from workers.worker import Worker
 
 
 logger = logging.getLogger(__name__)
+
+QUEUE_WORKER_SLEEP_DURATION = 1
 
 
 class JobException(Exception):
@@ -142,7 +145,7 @@ class QueueWorker(Worker):
             except WorkerSleepException as exc:
                 logger.debug("Worker has been requested to go to sleep")
                 self.mark_current_incomplete(restore_retry=True)
-                self._stop.set()
+                time.sleep(QUEUE_WORKER_SLEEP_DURATION)
 
             except WorkerUnhealthyException as exc:
                 logger.error(

--- a/workers/repositorygcworker.py
+++ b/workers/repositorygcworker.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 POLL_PERIOD_SECONDS = 60
-REPOSITORY_GC_TIMEOUT = 24 * 60 * 60  # 24h
+REPOSITORY_GC_TIMEOUT = 3 * 60 * 60  # 3h
 LOCK_TIMEOUT_PADDING = 60  # 60 seconds
 
 


### PR DESCRIPTION
Prevents the queueworker from setting the event to stop the poll_queue
job when a WorkerSleepException is raised. On WorkerSleepException,
the worker should instead skip this iteration (go to sleep). e.g when
the NamespaceGCWorker can't acquire a lock because it is already taken
by some other worker.

Reverts the gcworkers job timeout from 24h to 3h. In case of a
deadlock between processes (for example, redeploying the app will not
clear the existing Redis keys), 24h is too long waiting for the locks to
expires so that the workers can resume work.

Add missing Counter increment for on row deletion on the Manifest table.