### PR TITLE
lock: reuse redis client when creating locks (PROJQUAY-1872)

### DIFF
--- a/workers/queueworker.py
+++ b/workers/queueworker.py
@@ -11,7 +11,7 @@ from workers.worker import Worker
 
 logger = logging.getLogger(__name__)
 
-QUEUE_WORKER_SLEEP_DURATION = 1
+QUEUE_WORKER_SLEEP_DURATION = 5
 
 
 class JobException(Exception):

--- a/workers/test/test_exportactionlogsworker.py
+++ b/workers/test/test_exportactionlogsworker.py
@@ -151,7 +151,6 @@ def test_export_logs(initialized_db, storage_engine, has_logs):
     if url.find("http://localhost:5000/exportedlogs/") == 0:
         storage_id = url[len("http://localhost:5000/exportedlogs/") :]
     else:
-        print("TESTURL:", url)
         assert url.find("https://somebucket.s3.amazonaws.com/some/path/exportedactionlogs/") == 0
         storage_id, _ = url[
             len("https://somebucket.s3.amazonaws.com/some/path/exportedactionlogs/") :
@@ -160,7 +159,6 @@ def test_export_logs(initialized_db, storage_engine, has_logs):
     created = storage_engine.get_content(
         storage_engine.preferred_locations, "exportedactionlogs/" + storage_id
     )
-    print("TEST DATA:", created)
     created_json = json.loads(created)
 
     if has_logs:


### PR DESCRIPTION
By default, Redlock creates a new client per instance. Using the
provided factory allows Redlock to reuse a single connection per
instance and avoid running out of connections. e.g When a worker tries
to get a lock, it should not open new connections every time.

Increase sleep duration between queue polls on
WorkerSleepException. This will give more time before retrying after
failing to acquire a lock.