### PR TITLE
lock: allows global lock to be used from main app (PROJQUAY-788)

### DIFF
--- a/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
@@ -86,5 +86,6 @@ def create_gunicorn_worker():
 
 if __name__ == "__main__":
     logging.config.fileConfig(logfile_path(debug=False), disable_existing_loggers=False)
+    GlobalLock.configure(app.config)
     worker = BlobUploadCleanupWorker()
     worker.start()

--- a/workers/gc/gcworker.py
+++ b/workers/gc/gcworker.py
@@ -91,5 +91,6 @@ if __name__ == "__main__":
         while True:
             time.sleep(100000)
 
+    GlobalLock.configure(app.config)
     worker = GarbageCollectionWorker()
     worker.start()

--- a/workers/globalpromstats/globalpromstats.py
+++ b/workers/globalpromstats/globalpromstats.py
@@ -87,6 +87,7 @@ def main():
         while True:
             time.sleep(100000)
 
+    GlobalLock.configure(app.config)
     worker = GlobalPrometheusStatsWorker()
     worker.start()
 

--- a/workers/logrotateworker.py
+++ b/workers/logrotateworker.py
@@ -153,6 +153,7 @@ def main():
         while True:
             time.sleep(100000)
 
+    GlobalLock.configure(app.config)
     worker = LogRotateWorker()
     worker.start()
 

--- a/workers/namespacegcworker.py
+++ b/workers/namespacegcworker.py
@@ -69,6 +69,7 @@ if __name__ == "__main__":
         while True:
             time.sleep(100000)
 
+    GlobalLock.configure(app.config)
     logger.debug("Starting namespace GC worker")
     worker = NamespaceGCWorker(
         namespace_gc_queue,

--- a/workers/repositorygcworker.py
+++ b/workers/repositorygcworker.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
         while True:
             time.sleep(100000)
 
+    GlobalLock.configure(app.config)
     logger.debug("Starting repository GC worker")
     worker = RepositoryGCWorker(
         repository_gc_queue,


### PR DESCRIPTION
GlobalLock had a dependency on app, which would cause a circular
dependency if imported from the main app. Workaround this by requiring
to pass the configuration to the GlobalLock instead (this is done by a
classmethod, due to the use of Redlock's factory). This means before
the use of GlobalLock, "configure" will need to be called once, per process.