### PR TITLE
PROJQUAY-1880: Adding index on uploading column in the imagestore table

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -1072,7 +1072,7 @@ class ImageStorage(BaseModel):
     uuid = CharField(default=uuid_generator, index=True, unique=True)
     image_size = BigIntegerField(null=True)
     uncompressed_size = BigIntegerField(null=True)
-    uploading = BooleanField(default=True, null=True)
+    uploading = BooleanField(default=True, index=True, null=True)
     cas_path = BooleanField(default=True)
     content_checksum = CharField(null=True, index=True)
 

--- a/data/migrations/dba_operator/3bd8075919b9-databasemigration.yaml
+++ b/data/migrations/dba_operator/3bd8075919b9-databasemigration.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: dbaoperator.app-sre.redhat.com/v1alpha1
+kind: DatabaseMigration
+metadata:
+  name: 3bd8075919b9
+spec:
+  migrationContainerSpec:
+    command:
+    - /quay-registry/quay-entrypoint.sh
+    - migrate
+    - 3bd8075919b9
+    image: quay.io/quay/quay
+    name: 3bd8075919b9
+  previous: 88e64904d000
+  schemaHints:
+  - columns: []
+    indexName: imagestorage_uploading
+    indexType: index
+    operation: createIndex
+    table: imagestorage

--- a/data/migrations/versions/3bd8075919b9_add_index_on_uploading_column.py
+++ b/data/migrations/versions/3bd8075919b9_add_index_on_uploading_column.py
@@ -1,0 +1,21 @@
+"""Add Index on uploading column in imagestoreage table
+
+Revision ID: 3bd8075919b9
+Revises: 88e64904d000
+Create Date: 2021-04-14 14:33:28.053054
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "3bd8075919b9"
+down_revision = "88e64904d000"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.create_index("imagestorage_uploading", "imagestorage", ["uploading"], unique=False)
+
+
+def downgrade(op, tables, tester):
+    op.drop_index("imagestorage_uploading", table_name="imagestorage")


### PR DESCRIPTION
This follows from the DB testing on the AWS dev cluster. We found adding this index increases the filtering of imagestore x manifestblob joins from 10% to 50%