### PR TITLE
quayio: returns value from delete_user calls

### DIFF
--- a/data/model/user.py
+++ b/data/model/user.py
@@ -1236,7 +1236,11 @@ def delete_user(user, queues):
     _delete_user_linked_data(user)
 
     # Delete the user itself.
-    user.delete_instance(recursive=True, delete_nullable=True)
+    try:
+        user.delete_instance(recursive=True, delete_nullable=True)
+        return True
+    except IntegrityError:
+        return False
 
 
 def _delete_user_linked_data(user):


### PR DESCRIPTION
This was already fixed in `master` but not in the quayio branch, and is preventing the namespacegcworker from correctly reporting its metrics.