### PR TITLE
Add Quay canary deployment manifest

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -249,6 +249,151 @@ objects:
             value: ${QUAY_WORKER_MULTIPLIER_REGISTRY}
           - name: WORKER_CONNECTION_COUNT_REGISTRY
             value: ${QUAY_WORKER_CONNECTION_COUNT_REGISTRY}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: quay-app-canary
+    labels:
+      ${{QUAY_APP_COMPONENT_LABEL_KEY}}: ${{QUAY_APP_COMPONENT_LABEL_VALUE}}
+  spec:
+    replicas: ${{QUAY_APP_DEPLOYMENT_REPLICAS_CANARY}}
+    minReadySeconds: ${{QUAY_APP_DEPLOYMENT_MIN_READY_SECONDS}}
+    progressDeadlineSeconds: ${{QUAY_APP_DEPLOYMENT_PROGRESS_DEADLINE_SECONDS}}
+    revisionHistoryLimit: ${{QUAY_APP_DEPLOYMENT_REVISION_HISTORY_LIMITS}}
+    strategy:
+      type: ${{QUAY_APP_DEPLOYMENT_STRATEGY_TYPE}}
+      rollingUpdate:
+        maxUnavailable: ${{QUAY_APP_DEPLOYMENT_MAX_UNAVAILABLE}}
+        maxSurge: ${{QUAY_APP_DEPLOYMENT_MAX_SURGE}}
+    selector:
+      matchLabels:
+        ${{QUAY_APP_COMPONENT_LABEL_KEY}}: ${{QUAY_APP_COMPONENT_LABEL_VALUE}}
+    template:
+      metadata:
+        labels:
+          ${{QUAY_APP_COMPONENT_LABEL_KEY}}: ${{QUAY_APP_COMPONENT_LABEL_VALUE}}
+        annotations:
+          ${{QUAY_APP_COMPONENT_ANNOTATIONS_KEY}}: ${{QUAY_APP_COMPONENT_ANNOTATIONS_VALUE}}
+      spec:
+        volumes:
+        - name: configvolume
+          secret:
+            secretName: ${{QUAY_APP_CONFIG_SECRET_CANARY}}
+        serviceAccountName: ${{NAME}}
+        containers:
+        - name: syslog-cloudwatch-bridge
+          image:  ${SYSLOG_IMAGE}:${SYSLOG_IMAGE_TAG}
+          ports:
+          - containerPort: ${{SYSLOG_PORT}}
+            protocol: UDP
+            name: syslog-udp-port
+          - containerPort: ${{SYSLOG_PORT}}
+            protocol: TCP
+            name: syslog-tcp-port
+          env:
+          - name: STREAM_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: TICKER_TIME
+            value: ${TICKER_TIME}
+          - name: PORT
+            value: ${SYSLOG_PORT}
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${{CLOUDWATCH_SECRET}}
+                key: AWS_REGION
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${{CLOUDWATCH_SECRET}}
+                key: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${{CLOUDWATCH_SECRET}}
+                key: AWS_SECRET_ACCESS_KEY
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${{CLOUDWATCH_SECRET}}
+                key: LOG_GROUP_NAME
+          resources:
+            limits:
+              cpu: ${{QUAY_SYSLOG_CPU_LIMIT}}
+              memory: ${{QUAY_SYSLOG_MEMORY_LIMIT}}
+            requests:
+              cpu: ${{QUAY_SYSLOG_CPU_REQUEST}}
+              memory: ${{QUAY_SYSLOG_MEMORY_REQUEST}}
+          readinessProbe:
+              tcpSocket:
+                port: ${{SYSLOG_PORT}}
+              initialDelaySeconds: ${{QUAY_SYSLOG_READINESS_PROBE_INITIAL_DELAY_SECONDS}}
+              periodSeconds: ${{QUAY_SYSLOG_READINESS_PROBE_PERIOD_SECONDS}}
+              timeoutSeconds: ${{QUAY_SYSLOG_READINESS_PROBE_TIMEOUT_SECONDS}}
+          livenessProbe:
+            tcpSocket:
+              port: ${{SYSLOG_PORT}}
+            initialDelaySeconds: ${{QUAY_SYSLOG_LIVENESS_PROBE_INITIAL_DELAY_SECONDS}}
+            periodSeconds: ${{QUAY_SYSLOG_LIVENESS_PROBE_PERIOD_SECONDS}}
+            timeoutSeconds: ${{QUAY_SYSLOG_LIVENESS_PROBE_TIMEOUT_SECONDS}}
+        - name: quay-app
+          image: ${IMAGE_CANARY}:${IMAGE_TAG_CANARY}
+          imagePullPolicy: ${{IMAGE_PULL_POLICY}}
+          command:
+          - /quay-registry/quay-entrypoint.sh
+          - ${{QUAY_ENTRYPOINT}}
+          ports:
+          - containerPort: 8443
+          volumeMounts:
+          - name: configvolume
+            mountPath: /conf/stack
+          livenessProbe:
+            exec:
+              command:
+              - curl
+              - -k
+              - https://localhost:8443/health/instance
+            initialDelaySeconds: ${{QUAY_APP_LIVENESS_PROBE_INITIAL_DELAY_SECONDS}}
+            periodSeconds: ${{QUAY_APP_LIVENESS_PROBE_PERIOD_SECONDS}}
+            timeoutSeconds: ${{QUAY_APP_LIVENESS_PROBE_TIMEOUT_SECONDS}}
+          readinessProbe:
+            exec:
+              command:
+              - curl
+              - -k
+              - https://localhost:8443/health/endtoend
+            initialDelaySeconds: ${{QUAY_APP_READINESS_PROBE_INITIAL_DELAY_SECONDS}}
+            periodSeconds: ${{QUAY_APP_READINESS_PROBE_PERIOD_SECONDS}}
+            timeoutSeconds: ${{QUAY_APP_READINESS_PROBE_TIMEOUT_SECONDS}}
+          resources:
+            limits:
+              cpu: ${{QUAY_APP_CPU_LIMIT}}
+              memory: ${{QUAY_APP_MEMORY_LIMIT}}
+            requests:
+              cpu: ${{QUAY_APP_CPU_REQUEST}}
+              memory: ${{QUAY_APP_MEMORY_REQUEST}}
+          env:
+          - name: QE_K8S_NAMESPACE
+            value: ${{QUAY_APP_DEPLOYMENT_NAMESPACE}}
+          - name: QE_K8S_CONFIG_SECRET
+            value: ${{QUAY_APP_CONFIG_SECRET_CANARY}}
+          - name: DEBUGLOG
+            value: ${DEBUGLOG}
+          - name: SYSLOG_SERVER
+            value: ${{SYSLOG_SERVER}}
+          - name: SYSLOG_PORT
+            value: ${SYSLOG_PORT}
+          - name: SYSLOG_PROTO
+            value: ${{SYSLOG_PROTO}}
+          - name: QUAY_LOGGING
+            value: ${{QUAY_LOGGING}}
+          - name: WORKER_MULTIPLIER_REGISTRY
+            value: ${QUAY_WORKER_MULTIPLIER_REGISTRY}
+          - name: WORKER_CONNECTION_COUNT_REGISTRY
+            value: ${QUAY_WORKER_CONNECTION_COUNT_REGISTRY}
 parameters:
   - name: NAME
     value: "quay"
@@ -258,6 +403,10 @@ parameters:
     value: ""
     displayName: quay image
     description: quay docker image. Defaults to quay.io/app-sre/quay.
+  - name: IMAGE_CANARY
+    value: ""
+    displayName: quay canary image
+    description: quay canary docker image. Defaults to quay.io/app-sre/quay.
   - name: IMAGE_TAG
     value: "latest"
     displayName: quay version
@@ -302,9 +451,15 @@ parameters:
   - name: QUAY_APP_CONFIG_SECRET
     value: "quay-config-secret"
     displayName: quay app config secret
+  - name: QUAY_APP_CONFIG_SECRET_CANARY
+    value: "quay-config-secret"
+    displayName: quay app canary config secret
   - name: QUAY_APP_DEPLOYMENT_REPLICAS
     value: "1"
     displayName: quay app deployment replicas
+  - name: QUAY_APP_DEPLOYMENT_REPLICAS_CANARY
+    value: "0"
+    displayName: quay app canary deployment replicas
   - name: QUAY_APP_DEPLOYMENT_NAMESPACE
     value: "quay"
     displayName: quay app deployment namespace


### PR DESCRIPTION
Adds a new deployment quay-app-canary to the deployment YAML file. This
will be picked up AppSRE when deploying quay.io. The canary deployment
can have a different image than the main deployment and can point to a
differnt config secret.
