### PR TITLE
cache: remove GlobalLock from redis model cache (PROJQUAY-1902)

### DIFF
--- a/data/cache/__init__.py
+++ b/data/cache/__init__.py
@@ -1,4 +1,3 @@
-from util.locking import GlobalLock
 from data.cache.impl import (
     NoopDataModelCache,
     InMemoryDataModelCache,
@@ -40,8 +39,6 @@ def get_model_cache(config):
         host = cache_config.get("host", None)
         if host is None:
             raise Exception("Missing `host` for Redis model cache configuration")
-
-        GlobalLock.configure(config)
 
         return RedisDataModelCache(
             host=host,

--- a/data/cache/test/test_cache.py
+++ b/data/cache/test/test_cache.py
@@ -28,17 +28,6 @@ class MockClient(object):
         pass
 
 
-class MockGlobalLock(object):
-    def __init__(self, cache_key, lock_ttl):
-        pass
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, type, value, traceback):
-        pass
-
-
 @pytest.mark.parametrize(
     "cache_type",
     [
@@ -94,8 +83,7 @@ def test_redis_cache():
 
     key = CacheKey("foo", "60m")
     with patch("data.cache.impl.StrictRedis", MockClient):
-        with patch("data.cache.impl.GlobalLock", MockGlobalLock):
-            cache = RedisDataModelCache("127.0.0.1")
+        cache = RedisDataModelCache("127.0.0.1")
 
-            assert cache.retrieve(key, lambda: {"a": 1234}) == {"a": 1234}
-            assert cache.retrieve(key, lambda: {"a": 1234}) == {"a": 1234}
+        assert cache.retrieve(key, lambda: {"a": 1234}) == {"a": 1234}
+        assert cache.retrieve(key, lambda: {"a": 1234}) == {"a": 1234}


### PR DESCRIPTION
Remove GlobalLock from Redis model cache implementation in
favor of 'nx=True' when setting the key.

Signed-off-by: Alec Merdler <alecmerdler@gmail.com>