### PR TITLE
modelcache: Increase the cache TTL for blob and tags (PROJQUAY-1878)

### DIFF
--- a/data/cache/cache_key.py
+++ b/data/cache/cache_key.py
@@ -13,7 +13,7 @@ def for_repository_blob(namespace_name, repo_name, digest, version):
     """
     Returns a cache key for a blob in a repository.
     """
-    return CacheKey("repo_blob__%s_%s_%s_%s" % (namespace_name, repo_name, digest, version), "60s")
+    return CacheKey("repo_blob__%s_%s_%s_%s" % (namespace_name, repo_name, digest, version), "240s")
 
 
 def for_catalog_page(auth_context_key, start_id, limit):
@@ -36,7 +36,7 @@ def for_active_repo_tags(repository_id, start_pagination_id, limit):
     Returns a cache key for the active tags in a repository.
     """
     return CacheKey(
-        "repo_active_tags__%s_%s_%s" % (repository_id, start_pagination_id, limit), "120s"
+        "repo_active_tags__%s_%s_%s" % (repository_id, start_pagination_id, limit), "240s"
     )
 
 


### PR DESCRIPTION
Increase the cache TTL for blob and tags. This follows from our
analyzis of production quay.io memcache stats. We see that the number of
refreshes are significanlty more than the cache hits. This suggests that
our default cache expiry is too low.