### PR TITLE
deployment: Add image tag param to the deploy file (PROJQUAY-1896)

### DIFF
--- a/deploy/openshift/quay-app.yaml
+++ b/deploy/openshift/quay-app.yaml
@@ -411,6 +411,10 @@ parameters:
     value: "latest"
     displayName: quay version
     description: quay version which defaults to latest
+  - name: IMAGE_TAG_CANARY
+    value: "latest"
+    displayName: quay version
+    description: quay version which defaults to latest
   - name: QUAY_ENTRYPOINT
     value: "registry-nomigrate"
     displayName: quay container entrypoint


### PR DESCRIPTION
This change adds the parameter IMAGE_TAG_CANARY to the deployment
file quay-app.yaml to use a different image tag for the canary
deployment