### PR TITLE
migration: Add composite index in manifestblob (PROJQUAY-1922)

### DIFF
--- a/data/migrations/dba_operator/909d725887d3-databasemigration.yaml
+++ b/data/migrations/dba_operator/909d725887d3-databasemigration.yaml
@@ -1,0 +1,21 @@
+
+---
+apiVersion: dbaoperator.app-sre.redhat.com/v1alpha1
+kind: DatabaseMigration
+metadata:
+  name: 909d725887d3
+spec:
+  migrationContainerSpec:
+    command:
+    - /quay-registry/quay-entrypoint.sh
+    - migrate
+    - 909d725887d3
+    image: quay.io/quay/quay
+    name: 909d725887d3
+  previous: 88e64904d000
+  schemaHints:
+  - columns: []
+    indexName: manifestblob_repository_id_blob_id
+    indexType: index
+    operation: createIndex
+    table: manifestblob

--- a/data/migrations/versions/909d725887d3_add_composite_index_on_manifestblob.py
+++ b/data/migrations/versions/909d725887d3_add_composite_index_on_manifestblob.py
@@ -1,0 +1,25 @@
+"""Add composite index on manifestblob
+
+Revision ID: 909d725887d3
+Revises: 88e64904d000
+Create Date: 2021-04-23 14:48:21.156441
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "909d725887d3"
+down_revision = "88e64904d000"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.create_index(
+        "manifestblob_repository_id_blob_id",
+        "manifestblob",
+        ["repository_id", "blob_id"],
+    )
+
+
+def downgrade(op, tables, tester):
+    op.drop_index("manifestblob_repository_id_blob_id", table_name="manifestblob")


### PR DESCRIPTION
Adds composite index manifestblob_repository_id_blob_id.  From our
testing on the quay.io production DB, This increased the number of rows
filtered for the manifestblob & imagestorage join slow query from 1.8%
to 100%