### PR TITLE
modelcache: Make ModelCache TTL configurable

### DIFF
--- a/config.py
+++ b/config.py
@@ -640,6 +640,12 @@ class DefaultConfig(ImmutableConfig):
     DATA_MODEL_CACHE_CONFIG = {
         "engine": "memcached",
         "endpoint": ("127.0.0.1", 18080),
+        "repository_blob_cache_ttl": "60s",
+        "catalog_page_cache_ttl": "60s",
+        "namespace_geo_restrictions_cache_ttl": "240s",
+        "active_repo_tags_cache_ttl": "120s",
+        "appr_applications_list_cache_ttl": "3600s",
+        "appr_show_package_cache_ttl": "3600s",
     }
 
     # Defines the number of successive failures of a build trigger's build before the trigger is

--- a/data/cache/__init__.py
+++ b/data/cache/__init__.py
@@ -15,10 +15,10 @@ def get_model_cache(config):
     engine = cache_config.get("engine", "noop")
 
     if engine == "noop":
-        return NoopDataModelCache()
+        return NoopDataModelCache(cache_config)
 
     if engine == "inmemory":
-        return InMemoryDataModelCache()
+        return InMemoryDataModelCache(cache_config)
 
     if engine == "memcached":
         endpoint = cache_config.get("endpoint", None)
@@ -29,7 +29,9 @@ def get_model_cache(config):
         connect_timeout = cache_config.get("connect_timeout")
         predisconnect = cache_config.get("predisconnect_from_db")
 
-        cache = MemcachedModelCache(endpoint, timeout=timeout, connect_timeout=connect_timeout)
+        cache = MemcachedModelCache(
+            cache_config, endpoint, timeout=timeout, connect_timeout=connect_timeout
+        )
         if predisconnect:
             cache = DisconnectWrapper(cache, config)
 
@@ -41,6 +43,7 @@ def get_model_cache(config):
             raise Exception("Missing `host` for Redis model cache configuration")
 
         return RedisDataModelCache(
+            cache_config,
             host=host,
             port=cache_config.get("port", 6379),
             password=cache_config.get("password", None),

--- a/data/cache/cache_key.py
+++ b/data/cache/cache_key.py
@@ -9,48 +9,57 @@ class CacheKey(namedtuple("CacheKey", ["key", "expiration"])):
     pass
 
 
-def for_repository_blob(namespace_name, repo_name, digest, version):
+def for_repository_blob(namespace_name, repo_name, digest, version, cache_config):
     """
     Returns a cache key for a blob in a repository.
     """
-    return CacheKey("repo_blob__%s_%s_%s_%s" % (namespace_name, repo_name, digest, version), "60s")
+    cache_ttl = cache_config.get("repository_blob_cache_ttl", "60s")
+    return CacheKey(
+        "repo_blob__%s_%s_%s_%s" % (namespace_name, repo_name, digest, version), cache_ttl
+    )
 
 
-def for_catalog_page(auth_context_key, start_id, limit):
+def for_catalog_page(auth_context_key, start_id, limit, cache_config):
     """
     Returns a cache key for a single page of a catalog lookup for an authed context.
     """
     params = (auth_context_key or "(anon)", start_id or 0, limit or 0)
-    return CacheKey("catalog_page__%s_%s_%s" % params, "60s")
+    cache_ttl = cache_config.get("catalog_page_cache_ttl", "60s")
+    return CacheKey("catalog_page__%s_%s_%s" % params, cache_ttl)
 
 
-def for_namespace_geo_restrictions(namespace_name):
+def for_namespace_geo_restrictions(namespace_name, cache_config):
     """
     Returns a cache key for the geo restrictions for a namespace.
     """
-    return CacheKey("geo_restrictions__%s" % (namespace_name), "240s")
+    cache_ttl = cache_config.get("namespace_geo_restrictions_cache_ttl", "240s")
+    return CacheKey("geo_restrictions__%s" % namespace_name, cache_ttl)
 
 
-def for_active_repo_tags(repository_id, start_pagination_id, limit):
+def for_active_repo_tags(repository_id, start_pagination_id, limit, cache_config):
     """
     Returns a cache key for the active tags in a repository.
     """
+
+    cache_ttl = cache_config.get("active_repo_tags_cache_ttl", "120s")
     return CacheKey(
-        "repo_active_tags__%s_%s_%s" % (repository_id, start_pagination_id, limit), "120s"
+        "repo_active_tags__%s_%s_%s" % (repository_id, start_pagination_id, limit), cache_ttl
     )
 
 
-def for_appr_applications_list(namespace, limit):
+def for_appr_applications_list(namespace, limit, cache_config):
     """
     Returns a cache key for listing applications under the App Registry.
     """
-    return CacheKey("appr_applications_list_%s_%s" % (namespace, limit), "3600s")
+    cache_ttl = cache_config.get("appr_applications_list_cache_ttl", "3600s")
+    return CacheKey("appr_applications_list_%s_%s" % (namespace, limit), cache_ttl)
 
 
-def for_appr_show_package(namespace, package_name, release, media_type):
+def for_appr_show_package(namespace, package_name, release, media_type, cache_config):
     """
     Returns a cache key for showing a package under the App Registry.
     """
+    cache_ttl = cache_config.get("appr_show_package_cache_ttl", "3600s")
     return CacheKey(
-        "appr_show_package_%s_%s_%s-%s" % (namespace, package_name, release, media_type), "3600s"
+        "appr_show_package_%s_%s_%s-%s" % (namespace, package_name, release, media_type), cache_ttl
     )

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -963,7 +963,7 @@ class OCIModel(RegistryDataInterface):
             return [tag.asdict() for tag in tags]
 
         tags_cache_key = cache_key.for_active_repo_tags(
-            repository_ref._db_id, start_pagination_id, limit
+            repository_ref._db_id, start_pagination_id, limit, model_cache.cache_config
         )
         result = model_cache.retrieve(tags_cache_key, load_tags)
 
@@ -985,7 +985,9 @@ class OCIModel(RegistryDataInterface):
 
             return [restriction.restricted_region_iso_code for restriction in restrictions]
 
-        blacklist_cache_key = cache_key.for_namespace_geo_restrictions(namespace_name)
+        blacklist_cache_key = cache_key.for_namespace_geo_restrictions(
+            namespace_name, model_cache.cache_config
+        )
         result = model_cache.retrieve(blacklist_cache_key, load_blacklist)
         if result is None:
             return None
@@ -1012,7 +1014,9 @@ class OCIModel(RegistryDataInterface):
 
             return blob_found.asdict()
 
-        blob_cache_key = cache_key.for_repository_blob(namespace_name, repo_name, blob_digest, 2)
+        blob_cache_key = cache_key.for_repository_blob(
+            namespace_name, repo_name, blob_digest, 2, model_cache.cache_config
+        )
         blob_dict = model_cache.retrieve(blob_cache_key, load_blob)
 
         try:

--- a/endpoints/appr/models_cnr.py
+++ b/endpoints/appr/models_cnr.py
@@ -130,7 +130,9 @@ class CNRAppModel(AppRegistryDataInterface):
                     for found in self._list_applications(namespace=namespace, limit=limit)
                 ]
 
-            apps_cache_key = cache_key.for_appr_applications_list(namespace, limit)
+            apps_cache_key = cache_key.for_appr_applications_list(
+                namespace, limit, model_cache.cache_config
+            )
             return [
                 ApplicationSummaryView(**found)
                 for found in model_cache.retrieve(apps_cache_key, _list_applications)

--- a/endpoints/appr/registry.py
+++ b/endpoints/appr/registry.py
@@ -152,7 +152,7 @@ def show_package(namespace, package_name, release, media_type):
         return jsonify(_retrieve_package())
 
     show_package_cache_key = cache_key.for_appr_show_package(
-        namespace, package_name, release, media_type
+        namespace, package_name, release, media_type, model_cache.cache_config
     )
 
     result = model_cache.retrieve(show_package_cache_key, _retrieve_package)

--- a/endpoints/v2/catalog.py
+++ b/endpoints/v2/catalog.py
@@ -46,7 +46,9 @@ def catalog_search(start_id, limit, pagination_callback):
         ]
 
     context_key = get_authenticated_context().unique_key if get_authenticated_context() else None
-    catalog_cache_key = cache_key.for_catalog_page(context_key, start_id, limit)
+    catalog_cache_key = cache_key.for_catalog_page(
+        context_key, start_id, limit, model_cache.cache_config
+    )
     visible_repositories = [
         Repository(**repo_dict)
         for repo_dict in model_cache.retrieve(catalog_cache_key, _load_catalog)

--- a/endpoints/v2/test/test_blob.py
+++ b/endpoints/v2/test/test_blob.py
@@ -9,6 +9,7 @@ from app import instance_keys, app as realapp
 from auth.auth_context_type import ValidatedAuthContext
 from data import model
 from data.cache import InMemoryDataModelCache
+from data.cache.test.test_cache import TEST_CACHE_CONFIG
 from data.database import ImageStorageLocation
 from endpoints.test.shared import conduct_call
 from util.security.registry_jwt import generate_bearer_token, build_context_and_subject
@@ -46,7 +47,7 @@ def test_blob_caching(method, endpoint, client, app):
         client, "v2." + endpoint, url_for, method, params, expected_code=200, headers=headers
     )
 
-    with patch("endpoints.v2.blob.model_cache", InMemoryDataModelCache()):
+    with patch("endpoints.v2.blob.model_cache", InMemoryDataModelCache(TEST_CACHE_CONFIG)):
         # First request should make a DB query to retrieve the blob.
         conduct_call(
             client, "v2." + endpoint, url_for, method, params, expected_code=200, headers=headers


### PR DESCRIPTION
Adds a configuration option to modify the cache expiry timeout
for ModelCache objects