### PR TITLE
quayio: followup to 1fd8194e

### DIFF
--- a/data/model/blob.py
+++ b/data/model/blob.py
@@ -39,7 +39,6 @@ def get_repository_blob_by_digest(repository, blob_digest):
             .where(
                 Image.repository == repository,
                 ImageStorage.content_checksum == blob_digest,
-                ImageStorage.uploading == False,
             )
             .get()
         )
@@ -64,7 +63,6 @@ def get_repo_blob_by_digest(namespace, repo_name, blob_digest):
                 Repository.name == repo_name,
                 Namespace.username == namespace,
                 ImageStorage.content_checksum == blob_digest,
-                ImageStorage.uploading == False,
             )
             .get()
         )

--- a/data/model/oci/manifest.py
+++ b/data/model/oci/manifest.py
@@ -273,7 +273,6 @@ def _create_manifest(
             shared_blob = get_or_create_shared_blob(
                 EMPTY_LAYER_BLOB_DIGEST, EMPTY_LAYER_BYTES, storage
             )
-            assert not shared_blob.uploading
             assert shared_blob.content_checksum == EMPTY_LAYER_BLOB_DIGEST
             blob_map[EMPTY_LAYER_BLOB_DIGEST] = shared_blob
 

--- a/data/model/storage.py
+++ b/data/model/storage.py
@@ -353,7 +353,6 @@ def lookup_repo_storages_by_content_checksum(repo, checksums, by_manifest=False)
                     ImageStorage.uuid,
                     ImageStorage.cas_path,
                     ImageStorage.uncompressed_size,
-                    ImageStorage.uploading,
                 )
                 .join(ManifestBlob)
                 .where(ManifestBlob.repository == repo, ImageStorage.content_checksum == checksum)

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -889,7 +889,6 @@ class OCIModel(RegistryDataInterface):
             storage = derived_storage.derivative
             signature_entry = model.storage.find_or_create_storage_signature(storage, signer_name)
             signature_entry.signature = signature
-            signature_entry.uploading = False
             signature_entry.save()
 
     def delete_derived_image(self, derived_image):
@@ -916,7 +915,6 @@ class OCIModel(RegistryDataInterface):
 
             storage_entry = derived_storage.derivative
             storage_entry.image_size = compressed_size
-            storage_entry.uploading = False
             storage_entry.save()
 
     def get_torrent_info(self, blob):
@@ -1340,15 +1338,8 @@ class OCIModel(RegistryDataInterface):
         builder.add_layer(
             legacy_image_row.storage.content_checksum, legacy_image_row.v1_json_metadata
         )
-        if legacy_image_row.storage.uploading:
-            logger.error("Cannot add an uploading storage row: %s", legacy_image_row.storage.id)
-            return None
 
         for parent_image in parents:
-            if parent_image.storage.uploading:
-                logger.error("Cannot add an uploading storage row: %s", legacy_image_row.storage.id)
-                return None
-
             builder.add_layer(parent_image.storage.content_checksum, parent_image.v1_json_metadata)
 
         try:

--- a/endpoints/api/image.py
+++ b/endpoints/api/image.py
@@ -31,7 +31,7 @@ def image_dict(image, with_history=False, with_tags=False):
         "comment": image.comment,
         "command": parsed_command,
         "size": image.image_size,
-        "uploading": image.uploading,
+        "uploading": False,
         "sort_index": len(image.parents),
     }
 

--- a/endpoints/verbs/__init__.py
+++ b/endpoints/verbs/__init__.py
@@ -353,7 +353,7 @@ def _repo_verb_signature(namespace, repository, tag_name, verb, checker=None, **
         manifest, verb, storage, varying_metadata={"tag": tag.name}
     )
 
-    if derived_image is None or derived_image.blob.uploading:
+    if derived_image is None:
         return make_response("", 202)
 
     # Check if we have a valid signer configured.
@@ -419,7 +419,7 @@ def _repo_verb(
             logger.error("Could not create or lookup a derived image for manifest %s", manifest)
             abort(400)
 
-    if derived_image is not None and not derived_image.blob.uploading:
+    if derived_image is not None:
         logger.debug("Derived %s image %s exists in storage", verb, derived_image)
         is_head_request = request.method == "HEAD"
 

--- a/util/secscan/analyzer.py
+++ b/util/secscan/analyzer.py
@@ -123,14 +123,6 @@ class LayerAnalyzer(object):
             # Nothing more to do.
             return
 
-        # Make sure the image's storage is not marked as uploading. If so, nothing more to do.
-        if layer.storage.uploading:
-            if not set_secscan_status(layer, False, self._target_version):
-                raise PreemptedException
-
-            # Nothing more to do.
-            return
-
         # Analyze the image.
         previously_security_indexed_successfully = layer.security_indexed
         previous_security_indexed_engine = layer.security_indexed_engine


### PR DESCRIPTION
Removes uploading filters/asertions that were not removed when cherripicking 1fd8194e.
These changes were not in the original PR to master to begin with, which is why they didn't raise a merge conflict.