### PR TITLE
db: allow peewee connection pool through configuration (PROJQUAY-1695)

### DIFF
--- a/config.py
+++ b/config.py
@@ -204,6 +204,11 @@ class DefaultConfig(ImmutableConfig):
         "autorollback": True,
     }
 
+    # Whether to use peewee's db connection pool.
+    # This can also be specified as a env variable of the same name,
+    # and will take precedence if so.
+    DB_CONNECTION_POOLING = True
+
     @staticmethod
     def create_transaction(db):
         return db.transaction()

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -276,6 +276,12 @@ CONFIG_SCHEMA = {
             },
             "required": ["threadlocals", "autorollback"],
         },
+        "DB_CONNECTION_POOLING": {
+            "type": "boolean",
+            "description": "If true, uses peewee's connection pool. This can also be set as an environment "
+            + "variable. If an environment variable is set, it takes precedence over the configuration flag.",
+            "x-example": True,
+        },
         "ALLOW_PULLS_WITHOUT_STRICT_LOGGING": {
             "type": "boolean",
             "description": "If true, pulls in which the pull audit log entry cannot be written will "


### PR DESCRIPTION
Allows peewee's connection pooling feature to be enabled through Quay's config.
If both the environment variable and config is set, the environment variable
will take precedence.