### PR TITLE
modelcache: Add read and write endpoints to Redis (PROJQUAY-1939) (#795)

### DIFF
--- a/data/cache/__init__.py
+++ b/data/cache/__init__.py
@@ -38,18 +38,16 @@ def get_model_cache(config):
         return cache
 
     if engine == "redis":
-        host = cache_config.get("host", None)
-        if host is None:
-            raise Exception("Missing `host` for Redis model cache configuration")
+        primary_config = cache_config.get("primary", None)
+        replica_config = cache_config.get("replica", None)
+
+        if not primary_config or primary_config.get("host") is None:
+            raise Exception("Missing `primary_host` for Redis model cache configuration")
 
         return RedisDataModelCache(
             cache_config,
-            host=host,
-            port=cache_config.get("port", 6379),
-            password=cache_config.get("password", None),
-            db=cache_config.get("db", 0),
-            ca_cert=cache_config.get("ca_cert", None),
-            ssl=cache_config.get("ssl", False),
+            primary_config=primary_config,
+            replica_config=replica_config,
         )
 
     raise Exception("Unknown model cache engine `%s`" % engine)

--- a/data/cache/test/test_cache.py
+++ b/data/cache/test/test_cache.py
@@ -90,9 +90,30 @@ def test_redis_cache():
     global DATA
     DATA = {}
 
+    redis_config = {
+        "primary": {
+            "host": "127.0.0.1",
+            "port": 6279,
+            "db": 0,
+            "password": "",
+            "ssl": False,
+            "ssl_ca_certs": None,
+        },
+        "replica": {
+            "host": "127.0.0.1",
+            "port": 6279,
+            "db": 0,
+            "password": "",
+            "ssl": False,
+            "ssl_ca_certs": None,
+        },
+    }
+
     key = CacheKey("foo", "60m")
     with patch("data.cache.impl.StrictRedis", MockClient):
-        cache = RedisDataModelCache(TEST_CACHE_CONFIG, "127.0.0.1")
+        cache = RedisDataModelCache(
+            TEST_CACHE_CONFIG, redis_config.get("primary"), redis_config.get("replica")
+        )
 
         assert cache.retrieve(key, lambda: {"a": 1234}) == {"a": 1234}
         assert cache.retrieve(key, lambda: {"a": 1234}) == {"a": 1234}


### PR DESCRIPTION
Adds `read_client` and `write_client` to Redis ModelCache to separate out read
and write calls to different endpoints