### PR TITLE
util: fix matching multiples in jsontemplate.py

### DIFF
--- a/util/jsontemplate.py
+++ b/util/jsontemplate.py
@@ -81,7 +81,7 @@ def _process_inline(expression, data):
             return None
 
         if len(found) > 1:
-            return [f.data for f in found]
+            return [f.value for f in found]
 
         return found[0].value
     except IndexError:

--- a/util/test/test_jsontemplate.py
+++ b/util/test/test_jsontemplate.py
@@ -56,6 +56,18 @@ from util.jsontemplate import JSONTemplate, JSONTemplateParseException
             {"hello": "hey-(none)"},
             id="outside of array index inline expression",
         ),
+        pytest.param(
+            '{"hello": "${tags[*]}"}',
+            {"tags": ["latest", "prod", "foo"]},
+            {"hello": ["latest", "prod", "foo"]},
+            id="match multiples inline",
+        ),
+        pytest.param(
+            '{"hello": "tags: ${tags[*]}"}',
+            {"tags": ["latest", "prod", "foo"]},
+            {"hello": "tags: latest,prod,foo"},
+            id="match multiples with inline expression",
+        ),
         pytest.param('{"hello": "}', {}, JSONTemplateParseException, id="invalid template"),
         pytest.param('{"hello": "${}"}', {}, JSONTemplateParseException, id="empty expression"),
         pytest.param('{"hello": "${;;}"}', {}, JSONTemplateParseException, id="invalid expression"),


### PR DESCRIPTION
> This is my first contribution to quay. I tried my best to follow the CONTRIBUTING.md guide, but I guessed on a lot of things.

Matching multiples caused exceptions to be raised. This made it so webhook notification POST bodies could not template things like the image tags as `${tags[*]}`. This was caused by a typo in the jsonpath_rw match field that was used.

I encountered this when trying to use the notification system in quay.io and decided to dig through the code to understand why it didn't work. I did not find a relevant Jira ticket about this, so I just created this PR without a Jira ticket.

Signed-off-by: Kalle Jillheden <kalle.jillheden@iver.se>