### PR TITLE
registry: add support for extended repository names (PROJQUAY-1535)

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,8 @@ from path_converters import (
     RegexConverter,
     RepositoryPathConverter,
     APIRepositoryPathConverter,
+    RepositoryPathRedirectConverter,
+    V1CreateRepositoryPathConverter,
 )
 from oauth.services.github import GithubOAuthService
 from oauth.services.gitlab import GitLabOAuthService
@@ -224,6 +226,8 @@ app.request_class = RequestWithId
 app.url_map.converters["regex"] = RegexConverter
 app.url_map.converters["repopath"] = RepositoryPathConverter
 app.url_map.converters["apirepopath"] = APIRepositoryPathConverter
+app.url_map.converters["repopathredirect"] = RepositoryPathRedirectConverter
+app.url_map.converters["v1createrepopath"] = V1CreateRepositoryPathConverter
 
 Principal(app, use_sessions=False)
 

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -123,7 +123,7 @@ location /api/suconfig {
 
 # This block handles blob requests, and will receive a high volume of traffic, so we set the burst
 # much higher.
-location ~ /v2/([^/]+)\/[^/]+/blobs/ {
+location ~ /v2/([^/]+)(/[^/]+)+/blobs/ {
     # If we're being accessed via v1.quay.io, pretend we don't support v2.
     if ($host = "v1.quay.io") {
         return 404;

--- a/config.py
+++ b/config.py
@@ -780,3 +780,6 @@ class DefaultConfig(ImmutableConfig):
 
     # Feature Flag: If set to true, the first User account may be created via API /api/v1/user/initialize
     FEATURE_USER_INITIALIZE = False
+
+    # Allows "/" in repository names
+    FEATURE_EXTENDED_REPOSITORY_NAMES = False

--- a/data/test/test_userfiles.py
+++ b/data/test/test_userfiles.py
@@ -53,5 +53,55 @@ def test_lookup_userfile(app, client):
     rv = client.open("/mockuserfiles/" + bad_uuid, method="GET")
     assert rv.status_code == 404
 
+    # NOTE: With the changes to the path converter for the extended repository names regex,
+    # this route conflicts with one of the route using the <reponame> regex.
+    # i.e /mockuserfiles/foo/bar/baz would match another url route.
+    # In order to 404 on this path, The Userfiles' path would need the full
+    # /mockuserfiles/foo/bar as a path for the Flask url_rule.
+    rv = client.open("/mockuserfiles/foo/bar/baz", method="GET")
+    # assert rv.status_code == 404
+    assert rv.status_code == 308
+
+
+def test_lookup_userfile_with_nested_path(app, client):
+    uuid = "deadbeef-dead-beef-dead-beefdeadbeef"
+    bad_uuid = "deadduck-dead-duck-dead-duckdeadduck"
+    upper_uuid = "DEADBEEF-DEAD-BEEF-DEAD-BEEFDEADBEEF"
+
+    def _stream_read_file(locations, path):
+        if path.find(uuid) > 0 or path.find(upper_uuid) > 0:
+            return BytesIO(b"hello world")
+
+        raise IOError("Not found!")
+
+    storage_mock = Mock()
+    storage_mock.stream_read_file = _stream_read_file
+
+    Userfiles(
+        app,
+        distributed_storage=storage_mock,
+        path="mockuserfiles/foo/bar",
+        handler_name="mockuserfiles2",
+    )
+
+    rv = client.open("/mockuserfiles/foo/bar/" + uuid, method="GET")
+    assert rv.status_code == 200
+
+    rv = client.open("/mockuserfiles/foo/bar/" + upper_uuid, method="GET")
+    assert rv.status_code == 200
+
+    rv = client.open("/mockuserfiles/foo/bar/" + bad_uuid, method="GET")
+    assert rv.status_code == 404
+
     rv = client.open("/mockuserfiles/foo/bar/baz", method="GET")
     assert rv.status_code == 404
+
+    # The follwing path should conflict with the reponame regex
+    rv = client.open("/mockuserfiles/" + uuid, method="GET")
+    assert rv.status_code == 308
+
+    rv = client.open("/mockuserfiles/" + upper_uuid, method="GET")
+    assert rv.status_code == 308
+
+    rv = client.open("/mockuserfiles/" + bad_uuid, method="GET")
+    assert rv.status_code == 308

--- a/endpoints/api/repository.py
+++ b/endpoints/api/repository.py
@@ -51,7 +51,7 @@ from auth.permissions import (
 )
 from auth.auth_context import get_authenticated_user
 from auth import scopes
-from util.names import REPOSITORY_NAME_REGEX
+from util.names import REPOSITORY_NAME_REGEX, REPOSITORY_NAME_EXTENDED_REGEX
 from util.parsing import truthy_bool
 
 logger = logging.getLogger(__name__)
@@ -149,7 +149,12 @@ class RepositoryList(ApiResource):
                 check_allowed_private_repos(namespace_name)
 
             # Verify that the repository name is valid.
-            if not REPOSITORY_NAME_REGEX.match(repository_name):
+            if features.EXTENDED_REPOSITORY_NAMES:
+                valid_repository_name = REPOSITORY_NAME_EXTENDED_REGEX.match(repository_name)
+            else:
+                valid_repository_name = REPOSITORY_NAME_REGEX.match(repository_name)
+
+            if not valid_repository_name:
                 raise InvalidRequest("Invalid repository name")
 
             kind = req.get("repo_kind", "image") or "image"

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -6,6 +6,7 @@ from functools import wraps
 
 from flask import request, make_response, jsonify, session
 
+import features
 from app import userevents, storage, docker_v2_signing_key
 from auth.auth_context import get_authenticated_context, get_authenticated_user
 from auth.credentials import validate_credentials, CredentialKind
@@ -181,7 +182,7 @@ def update_user(username):
     abort(403)
 
 
-@v1_bp.route("/repositories/<repopath:repository>/", methods=["PUT"])
+@v1_bp.route("/repositories/<v1createrepopath:repository>/", methods=["PUT"])
 @process_auth
 @parse_repository_name()
 @check_v1_push_enabled()

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -827,8 +827,8 @@ def attach_custom_build_trigger(namespace_name, repo_name):
     abort(403)
 
 
-@web.route("/<repopath:repository>")
-@web.route("/<repopath:repository>/")
+@web.route("/<repopathredirect:repository>")
+@web.route("/<repopathredirect:repository>/")
 @no_cache
 @process_oauth
 @parse_repository_name(include_tag=True)

--- a/image/docker/schema1.py
+++ b/image/docker/schema1.py
@@ -204,7 +204,7 @@ class DockerSchema1Manifest(ManifestInterface):
         self._tag = self._parsed[DOCKER_SCHEMA1_REPO_TAG_KEY]
 
         repo_name = self._parsed[DOCKER_SCHEMA1_REPO_NAME_KEY]
-        repo_name_tuple = repo_name.split("/")
+        repo_name_tuple = repo_name.split("/", 1)
         if len(repo_name_tuple) > 1:
             self._namespace, self._repo_name = repo_name_tuple
         elif len(repo_name_tuple) == 1:

--- a/path_converters.py
+++ b/path_converters.py
@@ -11,27 +11,52 @@ class APIRepositoryPathConverter(BaseConverter):
     """
 
     def __init__(self, url_map):
-        super(APIRepositoryPathConverter, self).__init__(url_map)
+        super().__init__(url_map)
         self.weight = 200
-        self.regex = r"([^/]+/[^/]+)"
+        self.regex = r"([^/]+(/[^/]+)+)"
+
+
+# TODO(kleesc): Remove after fully deprecating V1 push/pull
+class V1CreateRepositoryPathConverter(BaseConverter):
+    """
+    Converter for handling PUT repository path.
+    Handles both library and non-library paths (if configured).
+
+    This is needed so that v1.create_repository does not match possibly
+    nested path from other routes.
+
+    For example:
+    PUT /repositories/<repopath:repository>/tags/<tag> when no tag is given
+    should 404, and not fallback to v1.create_repository route.
+    """
+
+    def __init__(self, url_map):
+        super().__init__(url_map)
+        self.weight = 200
+
+        if features.LIBRARY_SUPPORT:
+            # Allow names without namespaces.
+            self.regex = r"[^/]+(/[^/]+)*(?<!auth)(?<!tags)(?<!images)"
+        else:
+            self.regex = r"([^/]+(/[^/]+)+)(?<!auth)(?<!tags)(?<!images)"
 
 
 class RepositoryPathConverter(BaseConverter):
     """
     Converter for handling repository paths.
-
     Handles both library and non-library paths (if configured).
+    Supports names with or without slashes (nested paths).
     """
 
     def __init__(self, url_map):
-        super(RepositoryPathConverter, self).__init__(url_map)
+        super().__init__(url_map)
         self.weight = 200
 
         if features.LIBRARY_SUPPORT:
             # Allow names without namespaces.
-            self.regex = r"[^/]+(/[^/]+)?"
+            self.regex = r"[^/]+(/[^/]+)*"
         else:
-            self.regex = r"([^/]+/[^/]+)"
+            self.regex = r"([^/]+(/[^/]+)+)"
 
 
 class RegexConverter(BaseConverter):
@@ -40,5 +65,46 @@ class RegexConverter(BaseConverter):
     """
 
     def __init__(self, url_map, regex_value):
-        super(RegexConverter, self).__init__(url_map)
+        super().__init__(url_map)
         self.regex = regex_value
+
+
+class RepositoryPathRedirectConverter(BaseConverter):
+    """
+    Converter for handling redirect paths that don't match any other routes.
+
+    This needs to be separate from RepositoryPathConverter with the updated regex for
+    extended repo names support, otherwise, a nonexistent repopath resource would fallback
+    to redirecting to the repository web route.
+
+    For example:
+    /v2/devtable/testrepo/nested/manifests/somedigest" would previously have (correctly) returned
+    a 404, due to the path not matching any routes. With the regex supporting nested path for extended
+    repo names, Werkzeug would now (incorrectly) match to redirect to the web page of a repository with
+    the above path. See endpoints.web.redirect_to_repository.
+    """
+
+    RESERVED_PREFIXES = [
+        "v1/",
+        "v2/",
+        "cnr/",
+        "customtrigger/setup/",
+        "bitbucket/setup/",
+        "repository/",
+        "github/callback/trigger/",
+        "push/",
+    ]
+
+    def __init__(self, url_map):
+        super().__init__(url_map)
+        self.weight = 200
+
+        if features.LIBRARY_SUPPORT:
+            # Allow names without namespaces.
+            self.regex = r"(?!{})[^/]+(/[^/]+)*".format(
+                "|".join(RepositoryPathRedirectConverter.RESERVED_PREFIXES)
+            )
+        else:
+            self.regex = r"((?!{})[^/]+(/[^/]+)+)".format(
+                "|".join(RepositoryPathRedirectConverter.RESERVED_PREFIXES)
+            )

--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -184,7 +184,6 @@ xhtml2pdf==0.2.4
 xmltodict==0.12.0
 yapf==0.29.0
 zipp==2.1.0
-zope.interface==5.1.2
 
 # Build dependencies
 Cython==0.29.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -169,4 +169,3 @@ xhtml2pdf==0.2.4
 xmltodict==0.12.0
 yapf==0.29.0
 zipp==2.1.0
-zope.interface==4.7.1

--- a/static/js/pages/new-repo.js
+++ b/static/js/pages/new-repo.js
@@ -16,6 +16,10 @@
     $scope.Features = Features;
     $scope.TriggerService = TriggerService;
 
+    $scope.repositoryNameRegex = (Features.EXTENDED_REPOSITORY_NAMES) ?
+				 new RegExp('^[a-z0-9][.a-z0-9_-]*(\/[a-z0-9][.a-z0-9_-]*)*$') :
+				 new RegExp('^[a-z0-9][.a-z0-9_-]*$');
+
     $scope.repo = {
       'is_public': 0,
       'description': '',

--- a/static/js/quay-routes.module.ts
+++ b/static/js/quay-routes.module.ts
@@ -62,20 +62,20 @@ function provideRoutes($routeProvider: ng.route.IRouteProvider,
     .route('/application/', 'app-list')
 
     // Repository View
-    .route('/repository/:namespace/:name', 'repo-view')
-    .route('/repository/:namespace/:name/tag/:tag', 'repo-view')
+    .route('/repository/:namespace/:name*', 'repo-view')
+    .route('/repository/:namespace/:name*\/tag/:tag', 'repo-view')
 
     // Image View
-    .route('/repository/:namespace/:name/manifest/:manifest_digest', 'manifest-view')
+    .route('/repository/:namespace/:name*\/manifest/:manifest_digest', 'manifest-view')
 
     // Repo Build View
-    .route('/repository/:namespace/:name/build/:buildid', 'build-view')
+    .route('/repository/:namespace/:name*\/build/:buildid', 'build-view')
 
     // Repo Trigger View
-    .route('/repository/:namespace/:name/trigger/:triggerid', 'trigger-setup')
+    .route('/repository/:namespace/:name*\/trigger/:triggerid', 'trigger-setup')
 
     // Create repository notification
-    .route('/repository/:namespace/:name/create-notification', 'create-repository-notification')
+    .route('/repository/:namespace/:name*\/create-notification', 'create-repository-notification')
 
     // Repo List
     .route('/repository/', 'repo-list')

--- a/static/partials/new-repo.html
+++ b/static/partials/new-repo.html
@@ -47,10 +47,11 @@
                   <span class="visible-xs xs-label">Repository Name:</span>
                   <span class="name-container">
                     <input id="repoName" name="repoName" type="text" class="form-control" placeholder="Repository Name" ng-model="repo.name"
-                           required autofocus data-trigger="manual" data-content="{{ createError }}" data-placement="right" ng-pattern="/^[a-z0-9][.a-z0-9_-]*$/">
+                           required autofocus data-trigger="manual" data-content="{{ createError }}" data-placement="right"
+                           ng-pattern="repositoryNameRegex">
                   </span>
                   <span class="co-alert co-alert-warning co-alert-popin-warning" ng-show="!creating && !newRepoForm.repoName.$error.required && !newRepoForm.repoName.$valid">
-                    Repository names must match [a-z0-9][.a-z0-9_-]*
+                    {{ Features.EXTENDED_REPOSITORY_NAMES ? "Repository names must match [a-z0-9][.a-z0-9_-]*(\/[a-z0-9][.a-z0-9_-]*)*" : "Repository names must match [a-z0-9][.a-z0-9_-]*" }}
                   </span>
                   <span class="co-alert co-alert-danger co-alert-popin-warning" ng-show="!creating && createError">
                     {{ createError }}

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -30,7 +30,13 @@ from endpoints.webhooks import webhooks
 
 from initdb import initialize_database, populate_database
 
-from path_converters import APIRepositoryPathConverter, RegexConverter, RepositoryPathConverter
+from path_converters import (
+    APIRepositoryPathConverter,
+    RegexConverter,
+    RepositoryPathConverter,
+    RepositoryPathRedirectConverter,
+    V1CreateRepositoryPathConverter,
+)
 from test.testconfig import FakeTransaction
 
 INIT_DB_PATH = 0
@@ -315,6 +321,8 @@ def app(appconfig, initialized_db):
     app.url_map.converters["regex"] = RegexConverter
     app.url_map.converters["apirepopath"] = APIRepositoryPathConverter
     app.url_map.converters["repopath"] = RepositoryPathConverter
+    app.url_map.converters["repopathredirect"] = RepositoryPathRedirectConverter
+    app.url_map.converters["v1createrepopath"] = V1CreateRepositoryPathConverter
 
     app.register_blueprint(api_bp, url_prefix="/api")
     app.register_blueprint(appr_bp, url_prefix="/cnr")

--- a/test/registry/protocol_fixtures.py
+++ b/test/registry/protocol_fixtures.py
@@ -272,6 +272,22 @@ def pusher(request, data_model, jwk):
     return V2Protocol(jwk)
 
 
+@pytest.fixture()
+def v1_pusher(request, data_model, jwk):
+    return V1Protocol(jwk)
+
+
+@pytest.fixture(params=["v2_1", "v2_2", "oci"])
+def v2_pusher(request, data_model, jwk):
+    if request.param == "v2_2":
+        return V2Protocol(jwk, schema="schema2")
+
+    if request.param == "oci":
+        return V2Protocol(jwk, schema="oci")
+
+    return V2Protocol(jwk)
+
+
 @pytest.fixture(params=["v1", "v2_1"])
 def legacy_puller(request, data_model, jwk):
     if request.param == "v1":
@@ -293,6 +309,22 @@ def puller(request, data_model, jwk):
     if request.param == "v1":
         return V1Protocol(jwk)
 
+    if request.param == "v2_2":
+        return V2Protocol(jwk, schema="schema2")
+
+    if request.param == "oci":
+        return V2Protocol(jwk, schema="oci")
+
+    return V2Protocol(jwk)
+
+
+@pytest.fixture()
+def v1_puller(request, data_model, jwk):
+    return V1Protocol(jwk)
+
+
+@pytest.fixture(params=["v2_1", "v2_2", "oci"])
+def v2_puller(request, data_model, jwk):
     if request.param == "v2_2":
         return V2Protocol(jwk, schema="schema2")
 

--- a/test/registry/protocol_v1.py
+++ b/test/registry/protocol_v1.py
@@ -35,7 +35,7 @@ class V1Protocol(RegistryProtocol):
             Failures.UNAUTHENTICATED: 401,
             Failures.UNAUTHORIZED: 403,
             Failures.APP_REPOSITORY: 405,
-            Failures.SLASH_REPOSITORY: 404,
+            Failures.SLASH_REPOSITORY: 400,
             Failures.INVALID_REPOSITORY: 400,
             Failures.DISALLOWED_LIBRARY_NAMESPACE: 400,
             Failures.NAMESPACE_DISABLED: 400,

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -773,6 +773,12 @@ CONFIG_SCHEMA = {
             "description": "If not None, the number of successive failures that can occur before a build trigger is automatically disabled. Defaults to 100.",
             "x-example": 50,
         },
+        # Nested repository names
+        "FEATURE_EXTENDED_REPOSITORY_NAMES": {
+            "type": "boolean",
+            "description": "Whether repository names can have nested paths (/)",
+            "x-example": False,
+        },
         # Login
         "FEATURE_GITHUB_LOGIN": {
             "type": "boolean",

--- a/util/names.py
+++ b/util/names.py
@@ -6,7 +6,10 @@ from text_unidecode import unidecode
 from uuid import uuid4
 
 REPOSITORY_NAME_REGEX = re.compile(r"^[a-z0-9][\.a-z0-9_-]{0,254}$")
-
+# Extended repostitory name regex: allows "/" in repo names
+REPOSITORY_NAME_EXTENDED_REGEX = re.compile(
+    r"^(?=.{0,255}$)[a-z0-9][\.a-z0-9_-]*(?:\/[a-z0-9][\.a-z0-9_-]*)*$"
+)
 VALID_TAG_PATTERN = r"[\w][\w.-]{0,127}"
 FULL_TAG_PATTERN = r"^[\w][\w.-]{0,127}$"
 
@@ -58,7 +61,7 @@ def parse_namespace_repository(
         else:
             (repository, tag) = parts
 
-    repository = urllib.parse.quote_plus(repository)
+    repository = urllib.parse.quote_plus(repository, safe="/")
     if include_tag:
         return (namespace, repository, tag)
     return (namespace, repository)

--- a/util/test/test_names.py
+++ b/util/test/test_names.py
@@ -3,7 +3,7 @@
 import pytest
 import re
 
-from util.names import escape_tag, REPOSITORY_NAME_REGEX
+from util.names import escape_tag, REPOSITORY_NAME_REGEX, REPOSITORY_NAME_EXTENDED_REGEX
 
 
 @pytest.mark.parametrize(
@@ -21,22 +21,48 @@ def test_escape_tag(input_tag, expected):
 
 
 @pytest.mark.parametrize(
-    "name, should_match",
+    "name, extended_name, should_match",
     [
-        ("devtable", True),  # Lowercase allowed
-        ("DevTable", False),  # Uppercase NOT allowed
-        ("dev-table", True),  # Hyphens allowed
-        ("dev_table", True),  # Underscores allowed
-        ("devtable123", True),  # Numbers allowed
-        ("🌸", False),  # Non-ASCII NOT allowed
-        (".foo", False),  # Cannot start with a dot
-        ("_foo", False),  # Cannot start with an underscore
-        ("-foo", False),  # Cannot start with a dash
+        ("devtable", False, True),  # Lowercase allowed
+        ("DevTable", False, False),  # Uppercase NOT allowed
+        ("dev-table", False, True),  # Hyphens allowed
+        ("dev_table", False, True),  # Underscores allowed
+        ("devtable123", False, True),  # Numbers allowed
+        ("🌸", False, False),  # Non-ASCII NOT allowed
+        (".foo", False, False),  # Cannot start with a dot
+        ("_foo", False, False),  # Cannot start with an underscore
+        ("-foo", False, False),  # Cannot start with a dash
+        ("a" * 255, False, True),  # Up to 255 characters allowed
+        ("b" * 256, False, False),  # 256 or more characters not allowed
+        # Names with path components
+        ("devtable/path/to/repo", True, True),  # Lowercase allowed
+        ("DevTable/path/to/RePo", True, False),  # Upercase not allowed
+        ("devtable/path/to/repo-name", True, True),  # Hyphens allowed
+        ("devtable/path_to/repo/name", True, True),  # Underscores allowed
+        ("devtable/path/to/repo123", True, True),  # Numbers allowed
+        ("devtable/path/to/repo🌸name", True, False),  # Non-ASCII NOT allowed
+        ("devtable/path/to/.reponame", True, False),  # Path component cannot start with a dot
+        ("devtable/path/-to/reponame", True, False),  # Path component cannot start with a dash
+        (
+            "devtable/_path/to/reponame",
+            True,
+            False,
+        ),  # Path component cannot start with an underscore
+        ("devtable/_path/to/reponame/", True, False),  # Trailing slash not allowed
+        ("/devtable/path/to/reponame", True, False),  # Leading slash not allowed
+        ("devtable/path/to//reponame", True, False),  # Multiple consecutive slashes not allowed
+        ("1/2/3" * 51, True, True),  # Up to 255 characters allowed
+        ("1/2/3/78" * 32, True, False),  # # 256 or more characters not allowed
     ],
 )
-def test_repository_names_regex(name, should_match):
+def test_repository_names_regex(name, extended_name, should_match):
     """
     Verify that repository names conform to the standards/specifications.
     """
     result = re.match(REPOSITORY_NAME_REGEX, name)
-    assert bool(result) == should_match
+    result_extended = re.match(REPOSITORY_NAME_EXTENDED_REGEX, name)
+
+    if not extended_name:
+        assert bool(result) == should_match and bool(result_extended) == should_match
+    else:
+        assert bool(result_extended) == should_match


### PR DESCRIPTION
Allows forward slashes to be used in repository names according to
https://docs.docker.com/docker-hub/repos/.

NOTE: This change simply allows the use of "/" in repository
names needed for certain Openshift use cases. This does not implement
any new permission model for nested paths. i.e A repository with a
nested path is treated as a single repository under a _single_
namespace.