### PR TITLE
build: add full python build dependencies (PROJQUAY-2216)

### DIFF
--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -185,3 +185,21 @@ xmltodict==0.12.0
 yapf==0.29.0
 zipp==2.1.0
 zope.interface==5.1.2
+
+# Build dependencies
+Cython==0.29.23
+Pygments==2.9.0
+backcall==0.2.0
+flit-core==3.2.0
+ipython-genutils==0.2.0
+ipython==7.24.1
+jedi==0.18.0
+matplotlib-inline==0.1.2
+parso==0.8.2
+pexpect==4.8.0
+pickleshare==0.7.5
+prompt-toolkit==3.0.18
+ptyprocess==0.7.0
+traitlets==5.0.5
+traitlets==5.0.5
+wcwidth==0.2.5


### PR DESCRIPTION
Downstream build requires requirements-osbs.txt to be fully dep complete.