### PR TITLE
utility: Fixes backfillreplication script to use manifest blobs (PROJQUAY-2218)

### DIFF
--- a/util/backfillreplication.py
+++ b/util/backfillreplication.py
@@ -9,6 +9,8 @@ from data.database import (
     User,
     ImageStoragePlacement,
     ImageStorageLocation,
+    Manifest,
+    ManifestBlob,
 )
 from data import model
 from util.registry.replication import queue_storage_replication
@@ -16,36 +18,39 @@ from util.registry.replication import queue_storage_replication
 
 def backfill_replication():
     encountered = set()
+
     query = (
-        Image.select(Image, ImageStorage, Repository, User)
+        ManifestBlob.select(ManifestBlob, Repository, User)
         .join(ImageStorage)
-        .switch(Image)
+        .switch(ManifestBlob)
         .join(Repository)
         .join(User)
     )
 
-    for image in query:
-        if image.storage.uuid in encountered:
+    for manifest in query:
+        if manifest.blob.uuid in encountered:
             continue
 
-        namespace = image.repository.namespace_user
+        namespace = manifest.repository.namespace_user
         locations = model.user.get_region_locations(namespace)
         locations_required = locations | set(storage.default_locations)
 
         query = (
             ImageStoragePlacement.select(ImageStoragePlacement, ImageStorageLocation)
-            .where(ImageStoragePlacement.storage == image.storage)
+            .where(ImageStoragePlacement.storage == manifest.blob)
             .join(ImageStorageLocation)
         )
 
         existing_locations = set([p.location.name for p in query])
         locations_missing = locations_required - existing_locations
         if locations_missing:
-            print("Enqueueing image storage %s to be replicated" % (image.storage.uuid))
-            encountered.add(image.storage.uuid)
+            print("Enqueueing manifest blob %s to be replicated" % (manifest.blob.uuid))
+            encountered.add(manifest.blob.uuid)
 
-            if not image_replication_queue.alive([image.storage.uuid]):
-                queue_storage_replication(image.repository.namespace_user.username, image.storage)
+            if not image_replication_queue.alive([manifest.blob.uuid]):
+                queue_storage_replication(
+                    manifest.repository.namespace_user.username, manifest.blob
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
utility: Fixes backfillreplication script to use manifest blobs (PROJQUAY-2218)

Fixes an issue where the backfill replication script was using the `image` table and not the `manfiestblob` table which is being used since Quay 3.4.x exclusively.
JIRA: https://issues.redhat.com/browse/PROJQUAY-2218