### PR TITLE
Cherrypick f5b9492a

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -211,6 +211,9 @@ class BuilderExecutor(object):
                     container_runtime=self.executor_config.get("CONTAINER_RUNTIME", "docker"),
                     ca_cert=self.executor_config.get("CA_CERT", self._ca_cert()),
                     debug=self.executor_config.get("DEBUG", False),
+                    http_proxy=self.executor_config.get("HTTP_PROXY", None),
+                    https_proxy=self.executor_config.get("HTTPS_PROXY", None),
+                    noproxy=self.executor_config.get("NO_PROXY", None),
                 )
             )
         )

--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -2,6 +2,13 @@
 
 TOKEN={{ token }}
 SERVER={{ manager_hostname }}
+{% if http_proxy %}
+HTTP_PROXY={{ http_proxy }}
+{% elif https_proxy %}
+HTTPS_PROXY={{ https_proxy }}
+{% elif no_proxy %}
+NO_PROXY={{ no_proxy }}
+{% endif %}
 # TODO: Remove this eventually
 GODEBUG=x509ignoreCN=0
 


### PR DESCRIPTION
buildman: Add proxy variables to builds if they exist (PROJQUAY-2120) (#834)

Adds the ability to define proxy variables for builders. The proxy variables are parsed as env. variables and defined in Quay's config.yaml file.
