### PR TITLE
secscan: handle remote layer url when sending request to Clair

### DIFF
--- a/config.py
+++ b/config.py
@@ -468,7 +468,7 @@ class DefaultConfig(ImmutableConfig):
     FEATURE_SECURITY_NOTIFICATIONS = False
 
     # The endpoint for the (deprecated) V2 security scanner.
-    SECURITY_SCANNER_ENDPOINT = "http://192.168.99.101:6060"
+    SECURITY_SCANNER_ENDPOINT = None
 
     # The endpoint for the V4 security scanner.
     SECURITY_SCANNER_V4_ENDPOINT = None

--- a/data/secscan_model/secscan_v2_model.py
+++ b/data/secscan_model/secscan_v2_model.py
@@ -86,7 +86,7 @@ class V2SecurityScanner(SecurityScannerInterface):
 
         validator = V2SecurityConfigValidator(
             app.config.get("FEATURE_SECURITY_SCANNER", False),
-            app.config.get("SECURITY_SCANNER_ENDPOINT"),
+            app.config.get("SECURITY_SCANNER_ENDPOINT", None),
         )
 
         if not validator.valid():

--- a/util/secscan/v4/api.py
+++ b/util/secscan/v4/api.py
@@ -180,7 +180,9 @@ class ClairSecurityScannerAPI(SecurityScannerAPIInterface):
             "layers": [
                 {
                     "hash": str(l.layer_info.blob_digest),
-                    "uri": self._blob_url_retriever.url_for_download(manifest.repository, l.blob),
+                    "uri": self._blob_url_retriever.url_for_download(manifest.repository, l.blob)
+                    if not l.layer_info.is_remote
+                    else l.layer_info.urls[0],
                     "headers": _join(
                         {
                             "Accept": ["application/gzip"],
@@ -189,6 +191,8 @@ class ClairSecurityScannerAPI(SecurityScannerAPIInterface):
                             self._blob_url_retriever.headers_for_download(
                                 manifest.repository, l.blob, DOWNLOAD_VALIDITY_LIFETIME_S
                             )
+                            if not l.layer_info.is_remote
+                            else {}
                         ),
                     ),
                 }


### PR DESCRIPTION
Handle the case where a layer might be remote (not hosted in Quay's
storage) and add the remote blob url instead of the storage's download
url.