### PR TITLE
dockerfile: Fix downstream python site-packages location (PROJQUAY-2258)

### DIFF
--- a/Dockerfile.osbs
+++ b/Dockerfile.osbs
@@ -58,7 +58,8 @@ ENV PYTHON_VERSION=3.8 \
     PATH=$HOME/.local/bin/:$PATH \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=UTF-8 \
-    LANG=en_US.utf8
+    LANG=en_US.utf8 \
+    PYTHONUSERBASE_SITE_PACKAGE=/usr/local/lib/python3.8/site-packages
 
 ENV QUAYDIR=/quay-registry \
     QUAYCONF=/quay-registry/conf \

--- a/conf/init/certs_install.sh
+++ b/conf/init/certs_install.sh
@@ -5,8 +5,7 @@ QUAYCONF=${QUAYCONF:-"$QUAYPATH/conf"}
 QUAYCONFIG=${QUAYCONFIG:-"$QUAYCONF/stack"}
 CERTDIR=${CERTDIR:-"$QUAYCONFIG/extra_ca_certs"}
 SYSTEM_CERTDIR=${SYSTEM_CERTDIR:-"/etc/pki/ca-trust/source/anchors"}
-
-PYTHONUSERBASE_SITE_PACKAGE=$(python -m site --user-site)
+PYTHONUSERBASE_SITE_PACKAGE=${PYTHONUSERBASE_SITE_PACKAGE:-"$(python -m site --user-site)"}
 
 cd ${QUAYDIR:-"/quay-registry"}
 


### PR DESCRIPTION
- Allow PYTHONUSERBASE_SITE_PACKAGE to be added as an environment variable
- Set PYTHONUSERBASE_SITE_PACKAGE to /usr/local/lib/python3.8/site-packages in downstream Dockerfile