### PR TITLE
secscan: handle proxy model fallback to noop v2 (PROJQUAY-2289) (#847)

### DIFF
--- a/data/secscan_model/__init__.py
+++ b/data/secscan_model/__init__.py
@@ -52,7 +52,10 @@ class SecurityScannerModelProxy(SecurityScannerInterface):
         legacy_info = self._legacy_model.load_security_information(
             manifest_or_legacy_image, include_vulnerabilities
         )
-        if legacy_info.status != ScanLookupStatus.UNSUPPORTED_FOR_INDEXING:
+        if (
+            legacy_info.status != ScanLookupStatus.UNSUPPORTED_FOR_INDEXING
+            and legacy_info.status != ScanLookupStatus.COULD_NOT_LOAD
+        ):
             return legacy_info
 
         return SecurityInformationLookupResult.with_status(ScanLookupStatus.NOT_YET_INDEXED)

--- a/data/secscan_model/secscan_v2_model.py
+++ b/data/secscan_model/secscan_v2_model.py
@@ -49,7 +49,7 @@ class NoopV2SecurityScanner(SecurityScannerInterface):
     """
 
     def load_security_information(self, manifest_or_legacy_image, include_vulnerabilities=False):
-        return None
+        return SecurityInformationLookupResult.for_request_error("not implemented (noop) scanner")
 
     def perform_indexing(self, start_token=None):
         return None

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -267,7 +267,7 @@ class V4SecurityScanner(SecurityScannerInterface):
             layers = registry_model.list_manifest_layers(manifest, self.storage, True)
             if layers is None or len(layers) == 0:
                 logger.warning(
-                    "Cannot index %s/%s@%s due to manifest being invalid"
+                    "Cannot index %s/%s@%s due to manifest being invalid (manifest has no layers)"
                     % (
                         candidate.repository.namespace_user,
                         candidate.repository.name,


### PR DESCRIPTION
Handles the case where a V2 scanner is not configured (noop
implementation) and the proxy model tries to load security information
that has not been indexed in V4 yet. In such case, the noop
implementation of the V2 scanner should return a COULD_NOT_LOAD
status (instead of None, to comply to the secscan model interface),
and ignore the fallback to V2, and finally just return the V4
status (NOT_YET_INDEXED)