### PR TITLE
chore: fix rediscluster cache config key name cherry-pick 0999b (PROJQUAY-2101)

### DIFF
--- a/data/cache/__init__.py
+++ b/data/cache/__init__.py
@@ -38,7 +38,7 @@ def get_model_cache(config):
 
         return cache
 
-    if engine == "redis" or engine == "redis-cluster":
+    if engine == "redis" or engine == "rediscluster":
         redis_client = redis_cache_from_config(cache_config)
 
         return RedisDataModelCache(cache_config, redis_client)


### PR DESCRIPTION
Look for "rediscluster" instead of "redis-cluster" in the cache config.