### PR TITLE
PROJQUAY-2329: Fix links to billing in private repo notification

### DIFF
--- a/static/js/services/notification-service.js
+++ b/static/js/services/notification-service.js
@@ -60,9 +60,9 @@ function($rootScope, $interval, UserService, ApiService, StringBuilderService, P
       'page': function(metadata) {
         var organization = UserService.getOrganization(metadata['namespace']);
         if (organization) {
-          return '/organization/' + metadata['namespace'] + '?tab=billing';
+          return '/organization/' + metadata['namespace'] + '/billing';
         } else {
-          return '/user/' + metadata['namespace'] + '?tab=billing';
+          return '/user/' + metadata['namespace'] + '/billing';
         }
       }
     },


### PR DESCRIPTION
**Fixes:**
Fix an invalid link in the "too many private repository" notification you can see in this screen recording.

**Screen recording of the broken link:**
![invalid-link](https://user-images.githubusercontent.com/139310/128034317-41ad3fa6-01eb-4299-8c0e-d76a953048ee.gif)

**See also**
The changed path matches the definition in `quay-routes.module.ts`. See:

* https://github.com/quay/quay/blob/3dde364615ae3f2b839fb38b7e791805e4243c3c/static/js/quay-routes.module.ts#L98-L99
* https://github.com/quay/quay/blob/3dde364615ae3f2b839fb38b7e791805e4243c3c/static/js/quay-routes.module.ts#L107-L108