### PR TITLE
PROJQUAY-2253: OCI compliance

### DIFF
--- a/image/oci/config.py
+++ b/image/oci/config.py
@@ -60,7 +60,6 @@ Example:
 
 import copy
 import json
-import hashlib
 
 from collections import namedtuple
 from jsonschema import validate as validate_schema, ValidationError

--- a/image/oci/descriptor.py
+++ b/image/oci/descriptor.py
@@ -6,13 +6,12 @@ DESCRIPTOR_ANNOTATIONS_KEY = "annotations"
 
 
 def get_descriptor_schema(
-    allowed_media_types, additional_properties=None, additional_required=None
+    closed_media_types=None, additional_properties=None, additional_required=None
 ):
     properties = {
         DESCRIPTOR_MEDIATYPE_KEY: {
             "type": "string",
-            "description": "The MIME type of the referenced manifest",
-            "enum": allowed_media_types,
+            "description": "The MIME type of the referenced content.",
         },
         DESCRIPTOR_SIZE_KEY: {
             "type": "number",
@@ -24,6 +23,9 @@ def get_descriptor_schema(
         DESCRIPTOR_DIGEST_KEY: {
             "type": "string",
             "description": "The content addressable digest of the manifest in the blob store",
+            # This pattern is a transliteration of the grammar here:
+            # https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
+            "pattern": "^([a-z0-9]+([+._-][a-z0-9]+)*):[a-zA-Z0-9=_-]+$",
         },
         DESCRIPTOR_ANNOTATIONS_KEY: {
             "type": "object",
@@ -38,6 +40,9 @@ def get_descriptor_schema(
             },
         },
     }
+
+    if closed_media_types:
+        properties[DESCRIPTOR_MEDIATYPE_KEY].enum = closed_media_types
 
     if additional_properties:
         properties.update(additional_properties)

--- a/image/oci/index.py
+++ b/image/oci/index.py
@@ -100,7 +100,6 @@ class OCIIndex(ManifestListInterface):
                 "type": "array",
                 "description": "The manifests field contains a list of manifests for specific platforms",
                 "items": get_descriptor_schema(
-                    allowed_media_types=ALLOWED_MEDIA_TYPES,
                     additional_properties={
                         INDEX_PLATFORM_KEY: {
                             "type": "object",
@@ -174,6 +173,7 @@ class OCIIndex(ManifestListInterface):
             raise MalformedIndex("malformed manifest data: %s" % ve)
 
         try:
+            # TODO Fix to use a pre-constructed schema object.
             validate_schema(self._parsed, OCIIndex.METASCHEMA)
         except ValidationError as ve:
             raise MalformedIndex("manifest data does not match schema: %s" % ve)

--- a/image/oci/manifest.py
+++ b/image/oci/manifest.py
@@ -52,12 +52,9 @@ from image.docker.schema2 import EMPTY_LAYER_BLOB_DIGEST, EMPTY_LAYER_SIZE
 from image.oci import (
     OCI_IMAGE_MANIFEST_CONTENT_TYPE,
     OCI_IMAGE_CONFIG_CONTENT_TYPE,
-    OCI_IMAGE_LAYER_CONTENT_TYPES,
     OCI_IMAGE_NON_DISTRIBUTABLE_LAYER_CONTENT_TYPES,
     OCI_IMAGE_TAR_GZIP_LAYER_CONTENT_TYPE,
     OCI_IMAGE_TAR_GZIP_NON_DISTRIBUTABLE_LAYER_CONTENT_TYPE,
-    ADDITIONAL_LAYER_CONTENT_TYPES,
-    ALLOWED_ARTIFACT_TYPES,
 )
 from image.oci.config import OCIConfig
 from image.oci.descriptor import get_descriptor_schema
@@ -116,13 +113,11 @@ class OCIManifest(ManifestInterface):
                     "description": "The media type of the schema.",
                     "enum": [OCI_IMAGE_MANIFEST_CONTENT_TYPE],
                 },
-                OCI_MANIFEST_CONFIG_KEY: get_descriptor_schema(ALLOWED_ARTIFACT_TYPES),
+                OCI_MANIFEST_CONFIG_KEY: get_descriptor_schema(),
                 OCI_MANIFEST_LAYERS_KEY: {
                     "type": "array",
                     "description": "The array MUST have the base layer at index 0. Subsequent layers MUST then follow in stack order (i.e. from layers[0] to layers[len(layers)-1])",
-                    "items": get_descriptor_schema(
-                        OCI_IMAGE_LAYER_CONTENT_TYPES + ADDITIONAL_LAYER_CONTENT_TYPES
-                    ),
+                    "items": get_descriptor_schema(),
                 },
             },
             "required": [


### PR DESCRIPTION
This is a stab at fixing the OCI compliance.

This first patch breaks the allowlist mechanism, which was pushed too early in the validation process.
Subsequent patches should add this mechanism back to higher layers.