### PR TITLE
ui: force uses to sign-in page to fix SSO CSRF cookie issue (PROJQUAY…

### DIFF
--- a/static/directives/header-bar.html
+++ b/static/directives/header-bar.html
@@ -131,8 +131,7 @@
             </ul>
           </li>
           <li ng-switch-default>
-            <a class="user-view" href="/signin/" ng-if="!externalSigninUrl">Sign in</a>
-            <a class="user-view" ng-href="{{ externalSigninUrl }}" ng-if="externalSigninUrl">Sign in</a>
+            <a class="user-view" href="/signin/">Sign in</a>
           </li>
         </ul>
       </div><!-- /.navbar-collapse -->


### PR DESCRIPTION
…-2340)

This is because we use two different CSRF tokens for normal API calls
and OAUTH calls. The oauth token is set by the
`/externallogin/<provider>` endpoint and is set as an encrypted flask
cooke. However, v1 api calls set the cookie as a JWT token. The order of
API calls now makes a difference because the cookie from one gets
overwritten by the other.

When making the oauth call to the external provider. If we have the
wrong session cookie, the CSRF validation fails when the callback URL is
sent to the backend with the cookie containing the wrong CSRF token.

To fix this we must force users to go to the `/signin` page which makes
sure that the last API call that happens is the
`/externallogin/<provider>` which sets the correct cooke before
redirecting to the external provider