### PR TITLE
ui: change angular routing order for repo paths (PROJQUAY-2325)

### DIFF
--- a/oauth/oidc.py
+++ b/oauth/oidc.py
@@ -184,9 +184,7 @@ class OIDCLoginService(OAuthService):
 
         # Verify for impersonation
         if user_info.get("impersonated", False):
-            logger.debug(
-                "Requests from impersonated principals are not supported"
-            )
+            logger.debug("Requests from impersonated principals are not supported")
             raise OAuthLoginException("Requests from impersonated principals are not supported")
 
         # Verify subs.

--- a/static/js/quay-routes.module.ts
+++ b/static/js/quay-routes.module.ts
@@ -61,10 +61,6 @@ function provideRoutes($routeProvider: ng.route.IRouteProvider,
     // Repo List
     .route('/application/', 'app-list')
 
-    // Repository View
-    .route('/repository/:namespace/:name*', 'repo-view')
-    .route('/repository/:namespace/:name*\/tag/:tag', 'repo-view')
-
     // Image View
     .route('/repository/:namespace/:name*\/manifest/:manifest_digest', 'manifest-view')
 
@@ -76,6 +72,10 @@ function provideRoutes($routeProvider: ng.route.IRouteProvider,
 
     // Create repository notification
     .route('/repository/:namespace/:name*\/create-notification', 'create-repository-notification')
+
+    // Repository View
+    .route('/repository/:namespace/:name*\/tag/:tag', 'repo-view')
+    .route('/repository/:namespace/:name*', 'repo-view')
 
     // Repo List
     .route('/repository/', 'repo-list')


### PR DESCRIPTION
Unlike Flask, Angular does not use weights to match paths to routes,
so order matters. In order to support repository with "/" in them, we
previously added "*" to the repository name named group, allowing it
to capture subsequent "/". When that's the case, it is important that
to general "catch-all" route comes after the more specific routes (e.g
repo manifest). Otherwise, Angular will just eagerly use the first
route that matches a path, even though it may have "better" match in
subsequent routes.

e.g - '/api/v1/repository/:namespace/:name*'
      - '/api/v1/repository/:namespace/:name*\/tag/:tag'

      In this case, something like
      /api/v1/repository/devtable/testrepo/tag/testtag would match the
      first route, even though if using a weighted system, the second
      route in most case be a better fit.