### PR TITLE
dockerfile: pin setuptools to version 57 (PROJQUAY-2520)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ COPY requirements.txt .
 # flag.
 RUN set -ex\
 	; python3 -m pip install --no-cache-dir --quiet\
-		--upgrade setuptools pip\
+		--upgrade setuptools==57.5.0 pip\
 	; python3 -m pip install --no-cache-dir --progress-bar off\
 		--user --requirement requirements.txt --no-cache\
 	;

--- a/local-dev/Dockerfile
+++ b/local-dev/Dockerfile
@@ -54,7 +54,7 @@ RUN chmod +x /usr/local/bin/dumb-init
 # keep this last, will allow for fastest container rebuilds.
 COPY requirements.txt .
 RUN alternatives --set python /usr/bin/python3 && \
-    python -m pip install --no-cache-dir --upgrade setuptools pip && \
+    python -m pip install --no-cache-dir --upgrade setuptools==57.5.0 pip && \
     python -m pip install --no-cache-dir -r requirements.txt --no-cache && \
     python -m pip freeze
 


### PR DESCRIPTION
As to avoid breaking the installation of our requirements.
See https://github.com/vlasovskikh/funcparserlib/issues/69 for details.
Also fixes it on `local-dev/Dockerfile`.