### PR TITLE
notification: check certs exists for webhooks (PROJQUAY-2424)

### DIFF
--- a/notifications/notificationmethod.py
+++ b/notifications/notificationmethod.py
@@ -1,4 +1,5 @@
 import logging
+import os.path
 import re
 import json
 import mock
@@ -37,7 +38,9 @@ class NotificationMethodPerformException(JobException):
 
 def _ssl_cert():
     if app.config["PREFERRED_URL_SCHEME"] == "https":
-        return [OVERRIDE_CONFIG_DIRECTORY + f for f in SSL_FILENAMES]
+        cert_files = [OVERRIDE_CONFIG_DIRECTORY + f for f in SSL_FILENAMES]
+        cert_exists = all([os.path.isfile(f) for f in cert_files])
+        return cert_files if cert_exists else None
 
     return None
 


### PR DESCRIPTION
Make sure the Quay key/cert pair (ssl.key + ssl.cert) have been
mounted/exists whenever it tries sending a webhook request with client
cert. If that's not the case, then the webhook is sent without client
cert. This can happen when TLS is not handled by the Quay container,
in which case these certs are not required by default in the Quay
container.