### PR TITLE
secscan: continue iterating after failure (PROJQUAY-2563)

### DIFF
--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -289,10 +289,10 @@ class V4SecurityScanner(SecurityScannerInterface):
             except InvalidContentSent as ex:
                 mark_manifest_unsupported(manifest)
                 logger.exception("Failed to perform indexing, invalid content sent")
-                return None
+                continue
             except APIRequestFailure as ex:
                 logger.exception("Failed to perform indexing, security scanner API error")
-                return None
+                continue
 
             with db_transaction():
                 ManifestSecurityStatus.delete().where(


### PR DESCRIPTION
If Clair returns an error the current behaviour is to
error out, thus not indexing any subsequent manifests.
This change allows the worker to continue indexing
subsequent manifests after one failure.

Signed-off-by: crozzy <joseph.crosland@gmail.com>