### PR TITLE
secscan: continue iterating after failure (PROJQUAY-2563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v3.5.8
+
+**Release Notes**
+[Red Hat Customer Portal](https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/red_hat_quay_release_notes/index)
+
 ### v3.5.7
 
 **Release Notes**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 ###################
 FROM registry.centos.org/centos/centos:8 as config-editor
 
@@ -86,7 +85,7 @@ RUN INSTALL_PKGS="\
 COPY . .
 
 RUN alternatives --set python /usr/bin/python3 && \
-    python -m pip install --no-cache-dir --upgrade setuptools==57.5.0 pip && \
+    python -m pip install --no-cache-dir --upgrade setuptools pip && \
     python -m pip install --no-cache-dir -r requirements.txt --no-cache && \
     python -m pip freeze
 

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -287,10 +287,10 @@ class V4SecurityScanner(SecurityScannerInterface):
             except InvalidContentSent as ex:
                 mark_manifest_unsupported(manifest)
                 logger.exception("Failed to perform indexing, invalid content sent")
-                return None
+                continue
             except APIRequestFailure as ex:
                 logger.exception("Failed to perform indexing, security scanner API error")
-                return None
+                continue
 
             with db_transaction():
                 ManifestSecurityStatus.delete().where(

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -416,7 +416,7 @@ def test_perform_indexing_api_request_failure_index(initialized_db, set_secscan_
 
     next_token = secscan.perform_indexing()
 
-    assert next_token is None
+    assert next_token and next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
     assert ManifestSecurityStatus.select().count() == 0
 
     # Set security scanner to return good results and attempt indexing again

--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -84,7 +84,7 @@ maxminddb==1.5.2
 meld3==2.0.0
 mixpanel==4.5.0
 mock==3.0.5
-mockldap @ git+https://github.com/quay/mockldap.git@4265554a3d89fe39bf05b18e91607bec3fcf215a
+mockldap @ git+https://github.com/quay/mockldap.git@136253ca136fc7898944a4b37893a99440f7335e
 monotonic==1.5
 msgpack==0.6.2
 msrest==0.6.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b#egg=cnr_server
 git+https://github.com/DevTable/aniso8601-fake.git@bd7762c7dea0498706d3f57db60cd8a8af44ba90#egg=aniso8601
 git+https://github.com/jarus/flask-testing.git@17f19d7fee0e1e176703fc7cb04917a77913ba1a#egg=Flask_Testing
-git+https://github.com/quay/mockldap.git@4265554a3d89fe39bf05b18e91607bec3fcf215a#egg=mockldap
+git+https://github.com/quay/mockldap.git@136253ca136fc7898944a4b37893a99440f7335e#egg=mockldap
 git+https://github.com/quay/py-bitbucket.git@85301693ce3682f8e1244e90bd8a903181844bde#egg=py_bitbucket
 git+https://github.com/DevTable/python-etcd.git@f1168cb02a2a8c83bec1108c6fcd8615ef463b14#egg=python_etcd
 git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380#egg=supervisor_stdout
@@ -47,7 +47,7 @@ Flask-Login==0.4.1
 Flask-Mail==0.9.1
 Flask-Principal==0.4.0
 Flask-RESTful==0.3.7
-funcparserlib==0.3.6
+funcparserlib==1.0.0a0
 funcsigs==1.0.2
 furl==2.1.0
 future==0.18.2


### PR DESCRIPTION
If Clair returns an error the current behaviour is to
error out, thus not indexing any subsequent manifests.
This change allows the worker to continue indexing
subsequent manifests after one failure.

Signed-off-by: crozzy <joseph.crosland@gmail.com>