### PR TITLE
secscan: fix secscan api ApiRequestFailure test (PROJQUAY-2563)

### DIFF
--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -416,7 +416,7 @@ def test_perform_indexing_api_request_failure_index(initialized_db, set_secscan_
 
     next_token = secscan.perform_indexing()
 
-    assert next_token is None
+    assert next_token and next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
     assert ManifestSecurityStatus.select().count() == 0
 
     # Set security scanner to return good results and attempt indexing again


### PR DESCRIPTION
Follow-up to 694fa2ac. Correctly set the expected value for the
pagination token when not blocking on a failed API request.