### PR TITLE
ci: pin oci test to a specific sha

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -146,6 +146,7 @@ jobs:
       with:
         repository: opencontainers/distribution-spec
         path: dist-spec
+        ref: 7be5e8534d10ebdb6d1631a6ecc1beaa5b622f65
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v1


### PR DESCRIPTION
This pins the distribution-spec repo: https://github.com/opencontainers/distribution-spec to a specific sha
to prevent OCI CI failing because of a recent change in the source test: https://github.com/opencontainers/distribution-spec/pull/296/files 

Signed-off-by: harishsurf <hgovinda@redhat.com>