### PR TITLE
registry: update blob mount behaviour when from parameter is missing (PROJQUAY-2570)

### DIFF
--- a/endpoints/v2/blob.py
+++ b/endpoints/v2/blob.py
@@ -136,7 +136,9 @@ def _try_to_mount_blob(repository_ref, mount_blob_digest):
     logger.debug("Got mount request for blob `%s` into `%s`", mount_blob_digest, repository_ref)
     from_repo = request.args.get("from", None)
     if from_repo is None:
-        raise InvalidRequest(message="Missing `from` repository argument")
+        # If we cannot mount the blob, fall back to the standard upload behavior,
+        # since we don't support automatic mount origin discovery across all repos.
+        return None
 
     # Ensure the user has access to the repository.
     logger.debug(


### PR DESCRIPTION
Update the behaviour when attempting to mount existing blob whenever
the `from` parameter is missing. Currently, Quay throws an Bad Request
error whenever the `from parameter is missing. However, according to
the specs (Docker Registry and OCI dist-spec), we should be falling
back to the default upload behaviour.

References:
  - https://docs.docker.com/registry/spec/api/#pushing-an-image
  - https://github.com/opencontainers/distribution-spec/blob/main/spec.md#mounting-a-blob-from-another-repository
  - https://github.com/opencontainers/distribution-spec/pull/275/files