### PR TITLE
email: fix org recovery link in email (PROJQUAY-2589)

### DIFF
--- a/emails/orgrecovery.html
+++ b/emails/orgrecovery.html
@@ -28,7 +28,7 @@
 
 <table style="">
 	<tr>
-		<td style="background: #40B4E5; padding: 10px; border-radius: 3px; color: #fff; font-size: 20px; font-weight: 500"><a style="text-decoration: none; color: #ffffff;" href="https://quay.io/signin/">Login to Recover</a></td>
+		<td style="background: #40B4E5; padding: 10px; border-radius: 3px; color: #fff; font-size: 20px; font-weight: 500"><a style="text-decoration: none; color: #ffffff;" href="{{ app_link('signin/') }}">Login to Recover</a></td>
 	</tr>
 </table>
 


### PR DESCRIPTION
Signin link was always linking ton quay.io in org recovery
emails. Updated to link to whatever the SERVER_HOSTNAME is.