### PR TITLE
fix: update funcparserlib and oci check

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -146,6 +146,7 @@ jobs:
       with:
         repository: opencontainers/distribution-spec
         path: dist-spec
+        ref: 7be5e8534d10ebdb6d1631a6ecc1beaa5b622f65
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v1

--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -86,7 +86,7 @@ maxminddb==1.5.2
 meld3==2.0.0
 mixpanel==4.5.0
 mock==3.0.5
-mockldap @ git+https://github.com/quay/mockldap.git@4265554a3d89fe39bf05b18e91607bec3fcf215a
+mockldap @ git+https://github.com/quay/mockldap.git@136253ca136fc7898944a4b37893a99440f7335e
 monotonic==1.5
 moto==1.3.14
 msgpack==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b#eg
 git+https://github.com/DevTable/aniso8601-fake.git@bd7762c7dea0498706d3f57db60cd8a8af44ba90#egg=aniso8601
 git+https://github.com/quay/boto.git@0041500f529547f592194c73c0a7d23275ed81c6#egg=boto
 git+https://github.com/jarus/flask-testing.git@17f19d7fee0e1e176703fc7cb04917a77913ba1a#egg=Flask_Testing
-git+https://github.com/quay/mockldap.git@4265554a3d89fe39bf05b18e91607bec3fcf215a#egg=mockldap
+git+https://github.com/quay/mockldap.git@136253ca136fc7898944a4b37893a99440f7335e#egg=mockldap
 git+https://github.com/quay/py-bitbucket.git@85301693ce3682f8e1244e90bd8a903181844bde#egg=py_bitbucket
 git+https://github.com/DevTable/python-etcd.git@f1168cb02a2a8c83bec1108c6fcd8615ef463b14#egg=python_etcd
 git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380#egg=supervisor_stdout

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ Flask-Login==0.4.1
 Flask-Mail==0.9.1
 Flask-Principal==0.4.0
 Flask-RESTful==0.3.7
-funcparserlib==0.3.6
+funcparserlib==1.0.0a0
 funcsigs==1.0.2
 furl==2.1.0
 future==0.18.2


### PR DESCRIPTION
Aplly patch by kleesc, see https://github.com/quay/quay/commit/c7c4c0dc4ca9681482a100a831950355634c3b61

~@kleesc do we also need to apply the changes relating to [quay/mockldap](https://github.com/quay/quay/commit/c7c4c0dc4ca9681482a100a831950355634c3b61#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R4)?~ the test run answered it(👍 