### PR TITLE
superuser: add global readonly superuser (PROJQUAY-2604)

### DIFF
--- a/auth/permissions.py
+++ b/auth/permissions.py
@@ -24,6 +24,9 @@ _TeamNeed = partial(_TeamTypeNeed, "orgteam")
 _UserTypeNeed = namedtuple("userspecificneed", ["type", "username", "role"])
 _UserNeed = partial(_UserTypeNeed, "user")
 _SuperUserNeed = partial(namedtuple("superuserneed", ["type"]), "superuser")
+_GlobalReadOnlySuperUserNeed = partial(
+    namedtuple("globalreadlonlysuperuserneed", ["type"]), "globalreadonlysuperuser"
+)
 
 
 REPO_ROLES = [None, "read", "write", "admin"]
@@ -149,6 +152,10 @@ class QuayDeferredPermissionUser(Identity):
         ) and superusers.is_superuser(user_object.username):
             logger.debug("Adding superuser to user: %s", user_object.username)
             self.provides.add(_SuperUserNeed())
+
+            if superusers.is_global_readonly_superuser(user_object.username):
+                logger.debug("Adding global readonly superuser to user: %s", user_object.username)
+                self.provides.add(_GlobalReadOnlySuperUserNeed())
 
     def _populate_namespace_wide_provides(self, user_object, namespace_filter):
         """
@@ -310,6 +317,12 @@ class SuperUserPermission(QuayPermission):
     def __init__(self):
         need = _SuperUserNeed()
         super(SuperUserPermission, self).__init__(need)
+
+
+class GlobalReadOnlySuperUserPermission(QuayPermission):
+    def __init__(self):
+        need = _GlobalReadOnlySuperUserNeed()
+        super(GlobalReadOnlySuperUserPermission, self).__init__(need)
 
 
 class UserAdminPermission(QuayPermission):

--- a/config.py
+++ b/config.py
@@ -274,6 +274,11 @@ class DefaultConfig(ImmutableConfig):
     # Super user config. Note: This MUST BE an empty list for the default config.
     SUPER_USERS = []
 
+    # Global readonly user.
+    # WARNING: THIS WILL GIVE USERS OF THIS LIST READ ACCESS TO ALL REPOS,
+    # REGARDLESS OF WHETHER THEY ARE PUBLIC OR NOT
+    GLOBAL_READONLY_SUPER_USERS = []
+
     # Feature Flag: Whether sessions are permanent.
     FEATURE_PERMANENT_SESSIONS = True
 

--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -18,6 +18,7 @@ from auth.permissions import (
     AdministerRepositoryPermission,
     UserReadPermission,
     UserAdminPermission,
+    GlobalReadOnlySuperUserPermission,
 )
 from auth import scopes
 from auth.auth_context import (
@@ -289,8 +290,11 @@ def require_repo_permission(permission_class, scope, allow_public=False):
                 "Checking permission %s for repo: %s/%s", permission_class, namespace, repository
             )
             permission = permission_class(namespace, repository)
-            if permission.can() or (
-                allow_public and model.repository_is_public(namespace, repository)
+            global_readonly_permission = GlobalReadOnlySuperUserPermission()
+            if (
+                permission.can()
+                or (allow_public and model.repository_is_public(namespace, repository))
+                or global_readonly_permission.can()
             ):
                 return func(self, namespace, repository, *args, **kwargs)
             raise Unauthorized()

--- a/endpoints/v2/__init__.py
+++ b/endpoints/v2/__init__.py
@@ -16,6 +16,8 @@ from auth.permissions import (
     ReadRepositoryPermission,
     ModifyRepositoryPermission,
     AdministerRepositoryPermission,
+    GlobalReadOnlySuperUserPermission,
+    SuperUserPermission,
 )
 from auth.registry_jwt_auth import process_registry_jwt_auth, get_auth_headers
 from data.registry_model import registry_model
@@ -122,7 +124,7 @@ def _require_repo_permission(permission_class, scopes=None, allow_public=False):
             )
 
             permission = permission_class(namespace_name, repo_name)
-            if permission.can():
+            if permission.can() or GlobalReadOnlySuperUserPermission().can():
                 return func(namespace_name, repo_name, *args, **kwargs)
 
             repository = namespace_name + "/" + repo_name

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -14,6 +14,7 @@ from auth.permissions import (
     ReadRepositoryPermission,
     CreateRepositoryPermission,
     AdministerRepositoryPermission,
+    GlobalReadOnlySuperUserPermission,
 )
 from data import model
 from data.database import RepositoryState
@@ -297,7 +298,11 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
 
     if "pull" in requested_actions:
         # Grant pull if the user can read the repo or it is public.
-        if ReadRepositoryPermission(namespace, reponame).can() or repo_is_public:
+        if (
+            ReadRepositoryPermission(namespace, reponame).can()
+            or repo_is_public
+            or GlobalReadOnlySuperUserPermission().can()
+        ):
             if repository_ref is not None and repository_ref.kind != "image":
                 raise Unsupported(message=invalid_repo_message)
 

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -389,6 +389,14 @@ CONFIG_SCHEMA = {
                 "type": "string",
             },
         },
+        "GLOBAL_READONLY_SUPER_USERS": {
+            "type": "array",
+            "description": "Quay usernames of those super users to be granted global readonly privileges",
+            "uniqueItems": True,
+            "items": {
+                "type": "string",
+            },
+        },
         "DIRECT_OAUTH_CLIENTID_WHITELIST": {
             "type": "array",
             "description": "A list of client IDs of *Quay-managed* applications that are allowed "

--- a/util/config/superusermanager.py
+++ b/util/config/superusermanager.py
@@ -17,6 +17,15 @@ class SuperUserManager(object):
         self._array = Array("c", self._max_length, lock=True)
         self._array.value = usernames_str.encode("utf8")
 
+        global_readonly_usernames = app.config.get("GLOBAL_READONLY_SUPER_USERS", [])
+        global_readonly_usernames_str = ",".join(global_readonly_usernames)
+
+        self._global_readonly_max_length = (
+            len(global_readonly_usernames_str) + MAX_USERNAME_LENGTH + 1
+        )
+        self._global_readonly_array = Array("c", self._global_readonly_max_length, lock=True)
+        self._global_readonly_array.value = global_readonly_usernames_str.encode("utf8")
+
     def is_superuser(self, username):
         """
         Returns if the given username represents a super user.
@@ -44,3 +53,10 @@ class SuperUserManager(object):
         Returns whether there are any superusers defined.
         """
         return bool(self._array.value)
+
+    def is_global_readonly_superuser(self, username):
+        """
+        Returns if the given username represents a super user.
+        """
+        usernames = self._global_readonly_array.value.decode("utf8").split(",")
+        return username in usernames


### PR DESCRIPTION
Adds the ability to grant existing superusers access to every
repository across the registry. This includes image pulls, api access,
and more. This has security implications and should only be used for
very specific use cases.