### PR TITLE
oci: Accept the stricter oci layer type used by default in Helm 3.7 (PROJQUAY-2653)

### DIFF
--- a/app.py
+++ b/app.py
@@ -138,7 +138,10 @@ if features.GENERAL_OCI_SUPPORT:
 
 if features.HELM_OCI_SUPPORT:
     HELM_CHART_CONFIG_TYPE = "application/vnd.cncf.helm.config.v1+json"
-    HELM_CHART_LAYER_TYPES = ["application/tar+gzip"]
+    HELM_CHART_LAYER_TYPES = [
+        "application/tar+gzip",
+        "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+    ]
     register_artifact_type(HELM_CHART_CONFIG_TYPE, HELM_CHART_LAYER_TYPES)
 
 CONFIG_DIGEST = hashlib.sha256(json.dumps(app.config, default=str).encode("utf-8")).hexdigest()[0:8]

--- a/config.py
+++ b/config.py
@@ -752,7 +752,10 @@ class DefaultConfig(ImmutableConfig):
         "application/vnd.oci.image.config.v1+json": [
             "application/vnd.dev.cosign.simplesigning.v1+json"
         ],
-        "application/vnd.cncf.helm.config.v1+json": ["application/tar+gzip"],
+        "application/vnd.cncf.helm.config.v1+json": [
+            "application/tar+gzip",
+            "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+        ],
     }
 
     # Feature Flag: Whether to allow Helm OCI content types.


### PR DESCRIPTION
See https://github.com/helm/helm/issues/10176