### PR TITLE
deps: remove hiredis from dependencies (PROJQUAY-2675)

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -231,11 +231,6 @@
     }, 
     {
         "format": "Python", 
-        "license": "BSD License", 
-        "project": "hiredis"
-    }, 
-    {
-        "format": "Python", 
         "license": "MIT License", 
         "project": "html5lib"
     }, 

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,6 @@ gevent==1.4.0
 gipc==1.0.1
 greenlet==0.4.15
 gunicorn==19.9.0
-hiredis==1.0.0
 html5lib==0.9999999
 httmock==1.3.0
 httpretty==0.8.10


### PR DESCRIPTION
Remove hiredis as a dependency, since new version no longer supports
py2. It optimizes a the parsing the protocol of an multi-bulk
operation (LRANGE) that Quay is not using.