### PR TITLE
makefile: Add local-dev-build-frontend step (PROJQUAY-2693)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,14 +184,22 @@ black:
 local-dev-clean:
 	sudo ./local-dev/scripts/clean.sh
 
+.PHONY: local-dev-build-frontend
+local-dev-build-frontend:
+	make local-dev-clean
+	npm install --quiet --no-progress --ignore-engines --no-save
+	npm run --quiet build
+
 .PHONY: local-dev-build
 local-dev-build:
 	make local-dev-clean
+	make local-dev-build-frontend
 	docker-compose build
 
 .PHONY: local-dev-up
 local-dev-up:
 	make local-dev-clean
+	make local-dev-build-frontend
 	docker-compose up -d redis
 	docker-compose up -d quay-db
 	docker exec -it quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
@@ -200,6 +208,7 @@ local-dev-up:
 .PHONY: local-dev-up-with-clair
 local-dev-up-with-clair:
 	make local-dev-clean
+	make local-dev-build-frontend
 	docker-compose up -d redis
 	docker-compose up -d quay-db
 	docker exec -it quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'

--- a/local-dev/scripts/clean.sh
+++ b/local-dev/scripts/clean.sh
@@ -18,6 +18,7 @@ Files=(
 	'/local-dev/*.sock'
 	'node_modules'
 	'static/webfonts/'
+	'static/build'
 	'supervisord.log'
 	'supervisord.pid'
 )


### PR DESCRIPTION
When running `make local-dev-up` or `make local-dev-up-with-clair` makefile targets for the first time the containers will spin up but when trying to access the console the browser will display the following error:
`The Quay application could not be loaded, which typically indicates an external library could not be loaded (usually due to an ad blocker). Please check the JavaScript console for errors.`

This usually occurs when the browser is unable to fetch the compiled Angular Javascript files. Inspecting the individual layers of the image using [Dive](https://github.com/wagoodman/dive) shows the Javascript files do exist in the image, meaning they are most likely being overwritten during the volume mount of the local directory. The local directory won't contain the build JS files during the first run unless `npm i` and `npm run build` are ran. This change adds the commands to the makefile.