### PR TITLE
Quay: Fixing reclassified CVE ratings source (PROJQUAY-2691)

### DIFF
--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -402,7 +402,7 @@ def features_for(report):
                 [
                     Vulnerability(
                         fetch_vuln_severity(vuln, enrichments),
-                        "",
+                        vuln["updater"],
                         vuln["links"],
                         vuln["fixed_in_version"] if vuln["fixed_in_version"] != "0" else "",
                         vuln["description"],

--- a/data/secscan_model/test/securityinformation.json
+++ b/data/secscan_model/test/securityinformation.json
@@ -838,7 +838,7 @@
             },
             {
               "Severity": "Unknown",
-              "NamespaceName": "",
+              "NamespaceName": "test_updater",
               "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2781",
               "FixedBy": "",
               "Description": "chroot in GNU coreutils, when used with --userspec, allows local users to escape to the parent session via a crafted TIOCSTI ioctl call, which pushes characters to the terminal's input buffer.",
@@ -859,7 +859,7 @@
             },
             {
               "Severity": "Unknown",
-              "NamespaceName": "",
+              "NamespaceName": "test_updater",
               "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-18018",
               "FixedBy": "",
               "Description": "In GNU Coreutils through 8.29, chown-core.c in chown and chgrp does not prevent replacement of a plain file with a symlink during use of the POSIX \"-R -L\" options, which allows local users to modify the ownership of arbitrary files by leveraging a race condition.",

--- a/data/secscan_model/test/securityinformation_withenrichments.json
+++ b/data/secscan_model/test/securityinformation_withenrichments.json
@@ -114,7 +114,7 @@
         "Vulnerabilities": [
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "pyupio",
             "Link": "",
             "FixedBy": "",
             "Description": "The pip package before 19.2 for Python allows Directory Traversal when a URL is given in an install command, because a Content-Disposition header can have ../ in a filename, as demonstrated by overwriting the /root/.ssh/authorized_keys file. This occurs in _download_http_url in _internal/download.py.",
@@ -135,7 +135,7 @@
           },
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "pyupio",
             "Link": "",
             "FixedBy": "",
             "Description": "Pip 21.1 updates urllib3 to 1.26.4 to fix CVE-2021-28363. The urllib3 library 1.26.x before 1.26.4 for Python omits SSL certificate validation in some cases involving HTTPS to HTTPS proxies. The initial connection to the HTTPS proxy (if an SSLContext isn't given via proxy_config) doesn't verify the hostname of the certificate. This means certificates for different servers that still validate properly with the default urllib3 SSLContext will be silently accepted.",
@@ -165,7 +165,7 @@
         "Vulnerabilities": [
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20843",
             "FixedBy": "2.2.7-r0",
             "Description": "",
@@ -186,7 +186,7 @@
           },
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15903",
             "FixedBy": "2.2.7-r1",
             "Description": "",
@@ -286,7 +286,7 @@
         "Vulnerabilities": [
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "pyupio",
             "Link": "",
             "FixedBy": "",
             "Description": "mitmproxy before 4.0.3 does not protect mitmweb against DNS rebinding.",
@@ -307,7 +307,7 @@
           },
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "pyupio",
             "Link": "",
             "FixedBy": "",
             "Description": "mitmproxy before 4.0.4 does not protect mitmweb against DNS rebinding.",
@@ -328,7 +328,7 @@
           },
           {
             "Severity": "Unknown",
-            "NamespaceName": "",
+            "NamespaceName": "pyupio",
             "Link": "",
             "FixedBy": "",
             "Description": "Mitmproxy 5.0 fixes command injection vulnerabilities when exporting flows as curl/httpie commands. It also does not echo unsanitized user input in HTTP error responses.",
@@ -498,7 +498,7 @@
         "Vulnerabilities": [
           {
             "Severity": "Medium",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1559",
             "FixedBy": "1.0.2r-r0",
             "Description": "",
@@ -519,7 +519,7 @@
           },
           {
             "Severity": "Medium",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547",
             "FixedBy": "1.0.2t-r0",
             "Description": "",
@@ -540,7 +540,7 @@
           },
           {
             "Severity": "Low",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563",
             "FixedBy": "1.0.2t-r0",
             "Description": "",
@@ -561,7 +561,7 @@
           },
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0732",
             "FixedBy": "1.0.2o-r1",
             "Description": "",
@@ -582,7 +582,7 @@
           },
           {
             "Severity": "Medium",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0737",
             "FixedBy": "1.0.2o-r1",
             "Description": "",
@@ -603,7 +603,7 @@
           },
           {
             "Severity": "Medium",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0734",
             "FixedBy": "1.0.2q-r0",
             "Description": "",
@@ -624,7 +624,7 @@
           },
           {
             "Severity": "Medium",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5407",
             "FixedBy": "1.0.2q-r0",
             "Description": "",
@@ -724,7 +724,7 @@
         "Vulnerabilities": [
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1060",
             "FixedBy": "3.6.5-r0",
             "Description": "",
@@ -745,7 +745,7 @@
           },
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1061",
             "FixedBy": "3.6.5-r0",
             "Description": "",
@@ -766,7 +766,7 @@
           },
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14647",
             "FixedBy": "3.6.8-r0",
             "Description": "",
@@ -787,7 +787,7 @@
           },
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20406",
             "FixedBy": "3.6.8-r0",
             "Description": "",
@@ -808,7 +808,7 @@
           },
           {
             "Severity": "Critical",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9636",
             "FixedBy": "3.6.8-r0",
             "Description": "",
@@ -829,7 +829,7 @@
           },
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16056",
             "FixedBy": "3.6.8-r1",
             "Description": "",
@@ -850,7 +850,7 @@
           },
           {
             "Severity": "Medium",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16935",
             "FixedBy": "3.6.9-r1",
             "Description": "",
@@ -940,7 +940,7 @@
         "Vulnerabilities": [
           {
             "Severity": "Unknown",
-            "NamespaceName": "",
+            "NamespaceName": "pyupio",
             "Link": "",
             "FixedBy": "",
             "Description": "Cryptography 3.3 no longer allows loading of finite field Diffie-Hellman parameters of less than 512 bits in length. This change is to conform with an upcoming OpenSSL release that no longer supports smaller sizes. These keys were already wildly insecure and should not have been used in any application outside of testing.",
@@ -961,7 +961,7 @@
           },
           {
             "Severity": "Critical",
-            "NamespaceName": "",
+            "NamespaceName": "pyupio",
             "Link": "",
             "FixedBy": "",
             "Description": "In the cryptography package before 3.3.2 for Python, certain sequences of update calls to symmetrically encrypt multi-GB values could result in an integer overflow and buffer overflow, as demonstrated by the Fernet class. See CVE-2020-36242.",
@@ -982,7 +982,7 @@
           },
           {
             "Severity": "Medium",
-            "NamespaceName": "",
+            "NamespaceName": "pyupio",
             "Link": "",
             "FixedBy": "",
             "Description": "Cryptography 3.2 was released with the warning that its maintainers became aware of a Bleichenbacher vulnerability that they were only partly able to mitigate. See: CVE-2020-25659.",
@@ -1003,7 +1003,7 @@
           },
           {
             "Severity": "High",
-            "NamespaceName": "",
+            "NamespaceName": "pyupio",
             "Link": "",
             "FixedBy": "",
             "Description": "python-cryptography versions >=1.9.0 and <2.3 did not enforce a minimum tag length for finalize_with_tag API. If a user did not validate the input length prior to passing it to finalize_with_tag an attacker could craft an invalid payload with a shortened tag (e.g. 1 byte) such that they would have a 1 in 256 chance of passing the MAC check. GCM tag forgeries can cause key leakage.",
@@ -1063,7 +1063,7 @@
         "Vulnerabilities": [
           {
             "Severity": "Critical",
-            "NamespaceName": "",
+            "NamespaceName": "alpine-main-v3.7-updater",
             "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14697",
             "FixedBy": "1.1.18-r4",
             "Description": "",


### PR DESCRIPTION
The namespace of a vulnerability was propagated to the frontend as empty. This lead to use the default placeholder for source as `Unknown`. Now, the namespace of a vulnerability is updated to show the name of the updater. Please find the before and after images that reflects this change. 

Before:
<img width="1272" alt="before" src="https://user-images.githubusercontent.com/11522230/137803481-1689ec52-2aa2-494e-aa27-5b00d494fcf0.png">

After:
<img width="1160" alt="after" src="https://user-images.githubusercontent.com/11522230/137803543-86677c3d-6242-48a4-b98b-9660546a0f58.png">
