### PR TITLE
mirror: increased registry user/pass max length (PROJQUAY-2712)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -1992,8 +1992,8 @@ class RepoMirrorConfig(BaseModel):
         backref="mirrorpullrobot",
     )
     external_reference = CharField()
-    external_registry_username = EncryptedCharField(max_length=2048, null=True)
-    external_registry_password = EncryptedCharField(max_length=2048, null=True)
+    external_registry_username = EncryptedCharField(max_length=4096, null=True)
+    external_registry_password = EncryptedCharField(max_length=4096, null=True)
     external_registry_config = JSONField(default={})
 
     # Worker Queuing

--- a/data/migrations/versions/d94d328733e4_increase_repomirrorconfig_char_size.py
+++ b/data/migrations/versions/d94d328733e4_increase_repomirrorconfig_char_size.py
@@ -1,0 +1,45 @@
+"""Increase repomirrorconfig char size
+
+Revision ID: d94d328733e4
+Revises: b43b44996c26
+Create Date: 2022-04-12 14:16:07.660766
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "d94d328733e4"
+down_revision = "b43b44996c26"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.alter_column(
+        "repomirrorconfig",
+        "external_registry_username",
+        type_=sa.String(length=4096),
+        nullable=True,
+    )
+
+    op.alter_column(
+        "repomirrorconfig",
+        "external_registry_password",
+        type_=sa.String(length=4096),
+        nullable=True,
+    )
+
+
+def downgrade(op, tables, tester):
+    op.alter_column(
+        "repomirrorconfig",
+        "external_registry_username",
+        type_=sa.String(length=2048),
+        nullable=True,
+    )
+
+    op.alter_column(
+        "repomirrorconfig",
+        "external_registry_password",
+        type_=sa.String(length=2048),
+        nullable=True,
+    )


### PR DESCRIPTION
Increases the maximum length of `external_registry_username` and
`external_registry_password` fields from `2048` to `4096`. Some registries,
e.g ECR, issue a token to be used as password, whose length is longer
than 2048 after being encrypted and base64 encoded. Since JWT's specs
do not specify a maximum length, we set the combined max length of
these fields to approximately 8K, the default header size on most
servers (including nginx), since these credentials will be passed in a
auth header during the auth flow.