### PR TITLE
build: Add required setup.cfg for downstream build (PROJQUAY-2713)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+name: quay
+version: v3.7.0


### PR DESCRIPTION
Downstream build uses Cachito which needs setup.cfg forinstalling python dependencies.
related doc - https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/containers_from_source_multistage_builds_in_osbs#jive_content_id_Cachito_Integration_for_pip
