### PR TITLE
fix: Resolves issue with local docker builds not starting (PROJQUAY-2738)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex\
 		nginx \
 		openldap \
 		openssl \
-		python3 \
+		python38 \
 		python3-gpg \
 		skopeo \
 	; dnf -y -q clean all
@@ -34,7 +34,7 @@ RUN set -ex\
 		git\
 		nodejs\
 		openldap-devel\
-		python3-devel\
+		python38-devel\
 	; dnf -y -q clean all
 WORKDIR /build
 

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,21 @@ local-dev-up:
 	docker exec -it quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
 	docker-compose up -d quay
 
+local-docker-rebuild:
+	docker-compose up -d redis --build
+	docker-compose up -d quay-db --build
+	docker exec -it quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
+	docker-compose up -d quay --build
+
+ifeq ($(CLAIR),true)
+	docker-compose up -d clair-db --build
+	docker exec -it clair-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
+	docker-compose up -d clair --build
+else
+	@echo "Skipping Clair"
+endif
+
+
 .PHONY: local-dev-up-with-clair
 local-dev-up-with-clair:
 	make local-dev-clean

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
   # layers to clair over localhost.
   clair:
     container_name: quay-clair
-    image: quay.io/projectquay/clair:4.0.0-rc.22
+    image: quay.io/projectquay/clair:4.3.0
     volumes:
       - "./local-dev/clair:/src/clair/"
     environment:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,7 @@ Python 3.8 and earlier are currently supported.
  - Docker
  - docker-compose
  - Python 3.8
+ - Node 16.12.0
  - libmagic
 
 :exclamation: Be mindful that overriding your operating system's default Python version is not a good idea. Check out [this guide](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_installing-and-using-python_configuring-basic-system-settings) for instructions on installing Python 3 on RHEL 8, or alternatively use [pyenv](https://github.com/pyenv/pyenv#readme).
@@ -91,6 +92,14 @@ To support hot-reloading each worker was modified to run as a gunicorn worker su
 When the source code is updated and saved to disk the gunicorn worker is restarted.
 
 The front end code supports hot-reload by running `npm watch` in the background during container startup.
+
+## Container Reload
+
+The make target `local-docker-rebuild` focuses on reloading all running docker containers. By default only `quay-quay`, `quay-db` and `quay-redis` are rebuilt. `quay-clair` and `clair-db` can be included in rebuild by passing an optional `CLAIR` variable. 
+
+```
+CLAIR=true make local-docker-rebuild
+```
 
 ## Troubleshooting
 

--- a/local-dev/supervisord.conf.jnj
+++ b/local-dev/supervisord.conf.jnj
@@ -83,7 +83,7 @@ stderr_events_enabled = true
 [program:globalpromstats]
 environment=
   PYTHONPATH=%(ENV_QUAYDIR)s
-command=gunicorn --timeout=600 -b 'unix:/tmp/globalpromstats.sock' -c %(ENV_QUAYCONF)s/gunicorn_worker.py 'workers.globalpromstats.globalpromstats:create_gunicorn_worker()
+command=gunicorn --timeout=600 -b 'unix:/tmp/globalpromstats.sock' -c %(ENV_QUAYCONF)s/gunicorn_worker.py 'workers.globalpromstats.globalpromstats:create_gunicorn_worker()'
 autostart = {{ config['globalpromstats']['autostart'] }}
 stdout_events_enabled = true
 stderr_events_enabled = true

--- a/notifications/notificationmethod.py
+++ b/notifications/notificationmethod.py
@@ -2,7 +2,7 @@ import logging
 import os.path
 import re
 import json
-import mock
+from unittest import mock
 
 import requests
 from flask_mail import Message

--- a/util/useremails.py
+++ b/util/useremails.py
@@ -2,7 +2,7 @@ import os
 import json
 import logging
 import features
-import mock
+from unittest import mock
 
 from flask_mail import Message
 


### PR DESCRIPTION
* Updates Python to 3.8 in Quay container
* Bumps Clair version to 4.3.0
* Resolves string termination issue with `supervisor.conf`
* Adds new `Makefile` target for rebuilding docker containers
```
$ make local-docker-rebuild
docker-compose up -d redis
[+] Running 1/0
 ⠿ Container quay-redis  Running                                                                                                                         0.0s
docker-compose up -d quay-db
[+] Running 1/1
 ⠿ Container quay-db  Running                                                                                                                            0.0s
docker exec -it quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
/var/run/postgresql:5432 - accepting connections
docker-compose up -d quay
[+] Running 1/0
 ⠿ Container quay-quay  Running
 ``` 