### PR TITLE
build: Use docker-archive for post-deploy script  (PROJQUAY-2372)

### DIFF
--- a/scripts/app_sre_post_deploy_rhel7.sh
+++ b/scripts/app_sre_post_deploy_rhel7.sh
@@ -13,9 +13,9 @@ GIT_HASH=`git rev-parse --short=7 HEAD`
 
 # push the image to backup repository
 skopeo copy --dest-creds "${BACKUP_USER}:${BACKUP_TOKEN}" \
-    "docker-daemon:${IMG}" \
+    "docker-archive:${BASE_IMG}" \
     "docker://${BACKUP_IMAGE}:latest"
 
 skopeo copy --dest-creds "${BACKUP_USER}:${BACKUP_TOKEN}" \
-    "docker-daemon:${IMG}" \
+    "docker-archive:${BASE_IMG}" \
     "docker://${BACKUP_IMAGE}:${GIT_HASH}"


### PR DESCRIPTION
Update to use `docker-archive` for skopeo as `docker-daemon` is
not supported in rhel8 build nodes