### PR TITLE
blobuploadcleanupworker: Add cleanup for orphaned blobs (PROJQUAY-2313)

### DIFF
--- a/config.py
+++ b/config.py
@@ -799,3 +799,6 @@ class DefaultConfig(ImmutableConfig):
 
     # Allow creation of push to public repo
     CREATE_REPOSITORY_ON_PUSH_PUBLIC = False
+
+    # Automatically clean stale blobs leftover in the uploads storage folder from cancelled uploads
+    CLEAN_BLOB_UPLOAD_FOLDER = False

--- a/storage/basestorage.py
+++ b/storage/basestorage.py
@@ -90,6 +90,9 @@ class BaseStorage(StoragePaths):
     def get_checksum(self, path):
         raise NotImplementedError
 
+    def clean_partial_uploads(self, deletion_date_threshold):
+        raise NotImplementedError
+
     def stream_write_to_fp(self, in_fp, out_fp, num_bytes=READ_UNTIL_END):
         """
         Copy the specified number of bytes from the input file stream to the output stream.

--- a/storage/distributedstorage.py
+++ b/storage/distributedstorage.py
@@ -64,6 +64,7 @@ class DistributedStorage(StoragePaths):
     validate = _location_aware(BaseStorage.validate, requires_write=True)
     get_checksum = _location_aware(BaseStorage.get_checksum)
     get_supports_resumable_downloads = _location_aware(BaseStorage.get_supports_resumable_downloads)
+    clean_partial_uploads = _location_aware(BaseStorage.clean_partial_uploads, requires_write=True)
 
     initiate_chunked_upload = _location_aware(
         BaseStorageV2.initiate_chunked_upload, requires_write=True

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1203,5 +1203,11 @@ CONFIG_SCHEMA = {
             "description": "Whether to create a repository when pushing to an unexisting public repo",
             "x-example": False,
         },
+        # Clean partial uploads during S3 multipart upload
+        "CLEAN_BLOB_UPLOAD_FOLDER": {
+            "type": "boolean",
+            "description": "Automatically clean stale blobs leftover in the uploads storage folder from cancelled uploads",
+            "x-example": False,
+        },
     },
 }

--- a/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
@@ -28,13 +28,33 @@ class BlobUploadCleanupWorker(Worker):
     def _try_cleanup_uploads(self):
         """
         Performs garbage collection on the blobupload table.
+        Will also perform garbage collection on the uploads folder in the S3 bucket,
+        if applicable.
         """
         try:
             with GlobalLock("BLOB_CLEANUP", lock_ttl=LOCK_TTL):
                 self._cleanup_uploads()
+                if app.config.get("CLEAN_BLOB_UPLOAD_FOLDER", False):
+                    self._try_clean_partial_uploads()
         except LockNotAcquiredException:
             logger.debug("Could not acquire global lock for blob upload cleanup worker")
-            return
+
+    def _try_clean_partial_uploads(self):
+        """
+        Uploads cancelled before completion leaves the possibility of untracked blobs being
+        leftover in the uploads storage folder.
+        This function cleans those blobs older than DELETION_DATE_THRESHOLD
+        """
+        try:
+            storage.clean_partial_uploads(storage.preferred_locations, DELETION_DATE_THRESHOLD)
+        except NotImplementedError:
+            if len(storage.preferred_locations) > 0:
+                logger.debug(
+                    'Cleaning partial uploads not applicable to storage location "%s"',
+                    storage.preferred_locations[0],
+                )
+            else:
+                logger.debug("No preferred locations found")
 
     def _cleanup_uploads(self):
         """

--- a/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/test/test_blobuploadcleanupworker.py
@@ -22,6 +22,10 @@ def test_blobuploadcleanupworker(initialized_db):
             worker = BlobUploadCleanupWorker()
             worker._cleanup_uploads()
 
+            storage_mock.locations = ["default"]
+            worker._try_clean_partial_uploads()
+
+    storage_mock.clean_partial_uploads.assert_called_once()
     storage_mock.cancel_chunked_upload.assert_called_once()
 
     # Ensure the blob no longer exists.


### PR DESCRIPTION
Currently blobs leftover in the uploads directory during cancelled uploads do not get cleaned up since they are no longer tracked. This change cleans up the uploads storage directory directly.