### PR TITLE
build: Use a configtool tag in the Dockerfile instead of master (PROJ…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /build
 FROM build AS config-editor
 # This argument must be repeated, and should have the same default as
 # the other CONFIGTOOL_VERSION argument.
-ARG CONFIGTOOL_VERSION=master
+ARG CONFIGTOOL_VERSION=v0.1.5
 RUN curl -fsSL "https://github.com/quay/config-tool/archive/${CONFIGTOOL_VERSION}.tar.gz"\
 	| tar xz --strip-components=4 --exclude='*.go'
 RUN set -ex\

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -40,7 +40,7 @@ WORKDIR /build
 FROM build AS config-editor
 # This argument must be repeated, and should have the same default as
 # the other CONFIGTOOL_VERSION argument.
-ARG CONFIGTOOL_VERSION=master
+ARG CONFIGTOOL_VERSION=v0.1.5
 RUN curl -fsSL "https://github.com/quay/config-tool/archive/${CONFIGTOOL_VERSION}.tar.gz"\
 	| tar xz --strip-components=4 --exclude='*.go'
 RUN set -ex\


### PR DESCRIPTION
…QUAY-2777)

Having `master` as the config tool version causes issues where Docker
caches the layer. When there are updates to config-tool, docker won't
pull the new changes as it already has a cached version