### PR TITLE
billing: Remove annotations for type hints in billing (PROJQUAY-2777)

### DIFF
--- a/data/billing.py
+++ b/data/billing.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Dict
 import stripe
 


### PR DESCRIPTION
Type hints have become built-in since python 3.5

Python 3 code crashes here

```
Traceback (most recent call last):
  File "/quay-registry/conf/init/data_migration.py", line 3, in <module>
    from app import app
  File "/quay-registry/app.py", line 34, in <module>
    from data.billing import Billing
  File "/quay-registry/data/billing.py", line 1
    from __future__ import annotations
    ^
SyntaxError: future feature annotations is not defined
```