### PR TITLE
migration: skip existing mediatype inserts (PROJQUAY-2811)

### DIFF
--- a/data/migrations/versions/04b9d2191450_add_oci_content_types.py
+++ b/data/migrations/versions/04b9d2191450_add_oci_content_types.py
@@ -18,12 +18,15 @@ from sqlalchemy.dialects import mysql
 
 def upgrade(op, tables, tester):
     for media_type in OCI_CONTENT_TYPES:
-        op.bulk_insert(
-            tables.mediatype,
-            [
-                {"name": media_type},
-            ],
-        )
+        try:
+            op.bulk_insert(
+                tables.mediatype,
+                [
+                    {"name": media_type},
+                ],
+            )
+        except sa.exc.IntegrityError:
+            continue
 
 
 def downgrade(op, tables, tester):


### PR DESCRIPTION
Skip inserts during migration if the mediatypes were already added previously.