### PR TITLE
chore: bump gevent related packages' version (PROJQUAY-2821)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,16 +42,16 @@ funcparserlib==1.0.0a0
 furl==2.1.0
 futures==3.1.1
 geoip2==3.0.0
-gevent==1.4.0
-greenlet==0.4.15
+gevent==21.8.0
+greenlet==1.1.2
 grpcio==1.30.0
-gunicorn==20.0.4
+gunicorn==20.1.0
 hashids==1.2.0
 html5lib==1.0.1
 idna==2.8
 importlib-metadata==1.4.0
 iso8601==0.1.12
-isodate>=0.6.0
+isodate==0.6.0
 itsdangerous==1.1.0
 Jinja2==2.11.3
 jmespath==0.9.4
@@ -65,7 +65,7 @@ MarkupSafe==1.1.1
 maxminddb==1.5.2
 mixpanel==4.5.0
 msgpack==0.6.2
-msrest>=0.6.10
+msrest==0.6.21
 ndg-httpsclient==0.5.1
 netaddr==0.7.19
 netifaces==0.10.9
@@ -140,4 +140,5 @@ wrapt==1.11.2
 xhtml2pdf==0.2.4
 yapf==0.29.0
 zipp==2.1.0
+zope.event==4.5.0
 zope.interface==5.4.0


### PR DESCRIPTION
Addresses https://github.com/gevent/gevent/issues/1513. Upgrades
gevent, greenlet and gunicorn.