### PR TITLE
(3.6 backport) build: Add required setup.cfg for downstream build (PROJQUAY-2713)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+name: quay
+version: v3.6.2


### PR DESCRIPTION
Downstream build uses Cachito which needs setup.cfg for
installing python dependencies

originally added on redhat-3.7, see https://github.com/quay/quay/pull/946