### PR TITLE
remove fakeredis from osbs requirements (#996)

### DIFF
--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -39,7 +39,6 @@ docutils==0.15.2
 dumb-init==1.2.2
 elasticsearch==7.0.4
 elasticsearch-dsl==7.0.0
-fakeredis==1.6.1
 Flask==1.1.1
 Flask-Cors==3.0.9
 Flask-Login==0.4.1


### PR DESCRIPTION
it's already on requirements-dev.txt (and not on requirements.txt), so
it shouldn't be on the osbs requirements either.

can't build downstream with fakeredis present.