### PR TITLE
nginx: support client ip through x-forwarded-for header (PROJQUAY-2883)

### DIFF
--- a/conf/init/nginx_conf_create.py
+++ b/conf/init/nginx_conf_create.py
@@ -124,6 +124,19 @@ def generate_rate_limiting_config(config):
     )
 
 
+def generate_http_base_config(config):
+    """
+    Generates http base config from the app config.
+    """
+    config = config or {}
+    trusted_proxy_cidr = config.get("TRUSTED_PROXY_CIDR", None)
+
+    write_config(
+        os.path.join(QUAYCONF_DIR, "nginx/http-base.conf"),
+        trusted_proxy_cidr=trusted_proxy_cidr,
+    )
+
+
 def generate_hosted_http_base_config(config):
     """
     Generates hosted http base config from the app config.
@@ -144,6 +157,7 @@ if __name__ == "__main__":
     else:
         config = None
 
+    generate_http_base_config(config)
     generate_hosted_http_base_config(config)
     generate_rate_limiting_config(config)
     generate_server_config(config)

--- a/conf/nginx/http-base.conf
+++ b/conf/nginx/http-base.conf
@@ -1,6 +1,12 @@
 # vim: ft=nginx
 
+{% if not trusted_proxy_cidr %}
 set_real_ip_from 0.0.0.0/0;
+{% else %}
+{% for proxy_ip in trusted_proxy_cidr %}
+set_real_ip_from {{ proxy_ip }}
+{% endfor %}
+{% endif %}
 real_ip_recursive on;
 log_format lb_logs '$remote_addr ($proxy_protocol_addr) '
                    '- $remote_user [$time_local] '

--- a/conf/nginx/nginx.conf.jnj
+++ b/conf/nginx/nginx.conf.jnj
@@ -36,6 +36,8 @@ http {
         # This header must be set only for HTTPS
         add_header Strict-Transport-Security "max-age=63072000; preload";
 
+        real_ip_header X-Forwarded-For;
+
         access_log /var/log/nginx/access.log lb_logs;
     }
 


### PR DESCRIPTION
Support client ip from x-forwarded header. This is needed if one of
the intermediate proxy between the client and Quay does not support
proxy protocol.

If set, FEATURE_PROXY_PROTOCOL will use the L4 feature. If not, say,
when a L7 proxy is used, fallback to using x-forwarded-for, and allow
specifying trusted ip/cidr for Nginx.