### PR TITLE
[WIP] api: prevent unverified users from starting builds

### DIFF
--- a/config.py
+++ b/config.py
@@ -308,6 +308,9 @@ class DefaultConfig(ImmutableConfig):
     # Feature Flag: Dockerfile build support.
     FEATURE_BUILD_SUPPORT = True
 
+    # Feature Flag: Build support requires users/orgs to be verified
+    FEATURE_BUILD_REQUIRE_VERIFIED_USER = False
+
     # Feature Flag: Whether emails are enabled.
     FEATURE_MAILING = True
 

--- a/data/model/organization.py
+++ b/data/model/organization.py
@@ -20,7 +20,9 @@ from data.model import (
 )
 
 
-def create_organization(name, email, creating_user, email_required=True, is_possible_abuser=False):
+def create_organization(
+    name, email, creating_user, email_required=True, is_possible_abuser=False, auto_verify=False
+):
     with db_transaction():
         try:
             # Create the org
@@ -28,6 +30,7 @@ def create_organization(name, email, creating_user, email_required=True, is_poss
                 name, email, email_required=email_required, is_possible_abuser=is_possible_abuser
             )
             new_org.organization = True
+            new_org.verified = auto_verify
             new_org.save()
 
             # Create a team for the owners

--- a/endpoints/api/build.py
+++ b/endpoints/api/build.py
@@ -48,6 +48,7 @@ from endpoints.building import (
     PreparedBuild,
     MaximumBuildsQueuedException,
     BuildTriggerDisabledException,
+    UnverifiedNamespaceException,
 )
 from endpoints.exception import Unauthorized, NotFound, InvalidRequest
 from util.names import parse_robot_username
@@ -342,12 +343,15 @@ class RepositoryBuildList(RepositoryParamResource):
         prepared.context = context
         prepared.is_manual = True
         prepared.metadata = {}
+
         try:
             build_request = start_build(repo, prepared, pull_robot_name=pull_robot_name)
         except MaximumBuildsQueuedException:
             abort(429, message="Maximum queued build rate exceeded.")
         except BuildTriggerDisabledException:
             abort(400, message="Build trigger is disabled")
+        except UnverifiedNamespaceException:
+            abort(403, message="Namespace is unverified")
 
         resp = build_status_view(build_request)
         repo_string = "%s/%s" % (namespace, repository)

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -47,6 +47,7 @@ from data import model
 from data.billing import get_plan
 from util.names import parse_robot_username
 from util.request import get_request_ip
+from util.useremails import send_change_email, send_confirmation_email
 
 
 logger = logging.getLogger(__name__)
@@ -159,13 +160,19 @@ class OrganizationList(ApiResource):
 
         is_possible_abuser = ip_resolver.is_ip_possible_threat(get_request_ip())
         try:
-            model.organization.create_organization(
+            new_org = model.organization.create_organization(
                 org_data["name"],
                 org_data.get("email"),
                 user,
                 email_required=features.MAILING,
+                auto_verify=not features.MAILING,
                 is_possible_abuser=is_possible_abuser,
             )
+
+            if features.MAILING:
+                confirmation_code = model.user.create_confirm_email_code(new_org)
+                send_confirmation_email(org_data["name"], org_data.get("email"), confirmation_code)
+
             return "Created", 201
         except model.DataModelException as ex:
             raise request_error(exception=ex)
@@ -255,8 +262,14 @@ class Organization(ApiResource):
                     raise request_error(message="E-mail address already used")
 
                 logger.debug("Changing email address for organization: %s", org.username)
-                model.user.update_email(org, new_email)
 
+                if features.MAILING:
+                    confirmation_code = model.user.create_confirm_email_code(
+                        org, new_email=new_email
+                    )
+                    send_change_email(orgname, new_email, confirmation_code)
+                else:
+                    model.user.update_email(org, new_email)
             if features.CHANGE_TAG_EXPIRATION and "tag_expiration_s" in org_data:
                 logger.debug(
                     "Changing organization tag expiration to: %ss", org_data["tag_expiration_s"]

--- a/endpoints/api/trigger.py
+++ b/endpoints/api/trigger.py
@@ -41,6 +41,7 @@ from endpoints.building import (
     start_build,
     MaximumBuildsQueuedException,
     BuildTriggerDisabledException,
+    UnverifiedNamespaceException,
 )
 from endpoints.exception import NotFound, Unauthorized, InvalidRequest
 from util.names import parse_robot_username
@@ -470,6 +471,8 @@ class ActivateBuildTrigger(RepositoryParamResource):
             abort(429, message="Maximum queued build rate exceeded.")
         except BuildTriggerDisabledException:
             abort(400, message="Build trigger is disabled")
+        except UnverifiedNamespaceException:
+            abort(403, message="Namespace is unverified")
 
         resp = build_status_view(build_request)
         repo_string = "%s/%s" % (namespace_name, repo_name)

--- a/test/test_api_usage.py
+++ b/test/test_api_usage.py
@@ -669,10 +669,11 @@ class TestChangeUserDetails(ApiTestCase):
         self.putJsonResponse(User, data=dict(password="someunicode北京市pass"))
         self.login(READ_ACCESS_USER, password="someunicode北京市pass")
 
-    def test_changeeemail(self):
+    def test_changeemail(self):
         self.login(READ_ACCESS_USER)
-
-        self.putJsonResponse(User, data=dict(email="test+foo@devtable.com"))
+        with patch("endpoints.api.user.send_change_email") as mock_send_email:
+            self.putJsonResponse(User, data=dict(email="test+foo@devtable.com"))
+            mock_send_email.assert_called()
 
     def test_changeinvoiceemail(self):
         self.login(READ_ACCESS_USER)
@@ -1329,11 +1330,13 @@ class TestChangeOrganizationDetails(ApiTestCase):
     def test_changemail(self):
         self.login(ADMIN_ACCESS_USER)
 
-        json = self.putJsonResponse(
-            Organization, params=dict(orgname=ORGANIZATION), data=dict(email="newemail@example.com")
-        )
-
-        self.assertEqual("newemail@example.com", json["email"])
+        with patch("endpoints.api.organization.send_change_email") as mock_send_email:
+            json = self.putJsonResponse(
+                Organization,
+                params=dict(orgname=ORGANIZATION),
+                data=dict(email="newemail@example.com"),
+            )
+            mock_send_email.assert_called()
 
 
 class TestGetOrganizationPrototypes(ApiTestCase):

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -760,6 +760,11 @@ CONFIG_SCHEMA = {
             "description": "Whether to support Dockerfile build. Defaults to True",
             "x-example": True,
         },
+        "FEATURE_BUILD_REQUIRE_VERIFIED_USER": {
+            "type": "boolean",
+            "description": "Whether to only allow verified users and orgs to start builds. Defaults to False",
+            "x-example": False,
+        },
         "DEFAULT_NAMESPACE_MAXIMUM_BUILD_COUNT": {
             "type": ["number", "null"],
             "description": "If not None, the default maximum number of builds that can be queued in a namespace.",


### PR DESCRIPTION
Requires a user to be verified in order to be able to start build of a
repository.

TODO: By default, organization aren't verified. This means that as
part of this change, in addition to newly created orgs, existing orgs
would need to be verified. Which means sending new confirmation emails
for each.