### PR TITLE
auth: Fix oauth code flow (PROJQUAY-781)

### DIFF
--- a/data/model/oauth.py
+++ b/data/model/oauth.py
@@ -249,6 +249,9 @@ class DatabaseAuthorizationProvider(AuthorizationProvider):
 
         return self._make_response(headers={"Location": url}, status_code=302)
 
+    def generate_refresh_token(self):
+        return None
+
     def from_refresh_token(self, client_id, refresh_token, scope):
         raise NotImplementedError()
 

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -752,7 +752,7 @@ def request_authorization_code():
 def exchange_code_for_token():
     grant_type = request.values.get("grant_type", None)
     client_id = request.values.get("client_id", None)
-    client_secret = request.values.get("client_id", None)
+    client_secret = request.values.get("client_secret", None)
     redirect_uri = request.values.get("redirect_uri", None)
     code = request.values.get("code", None)
     scope = request.values.get("scope", None)


### PR DESCRIPTION
OAuth Authorization Code Flow is broken in quay. Code
Flow is more secure than implicit flow and is used
by server side applications to get the access token