### PR TITLE
endpoints/v2: move repository not found check from decorator to endpoint

### DIFF
--- a/endpoints/v2/__init__.py
+++ b/endpoints/v2/__init__.py
@@ -128,7 +128,10 @@ def _require_repo_permission(permission_class, scopes=None, allow_public=False):
             repository = namespace_name + "/" + repo_name
             if allow_public:
                 repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
-                if repository_ref is None or not repository_ref.is_public:
+                if repository_ref is None:
+                    return func(namespace_name, repo_name, *args, **kwargs)
+
+                if not repository_ref.is_public:
                     raise Unauthorized(repository=repository, scopes=scopes)
 
                 if repository_ref.kind != "image":


### PR DESCRIPTION
As far as I can tell this changes do _not_ affect current api behaviour.

---

our api consistently returns 401 when the user either cannot access
a resource due to lack of permissions or when the resource doesn't
exist.

this used to be handled by the `require_repo_read` decorator, but now
with the introduction of pull through proxy organizations (where
pulls to repostories that don't yet exist in our db are allowed) we
had to move the check for repositories not existing to the endpoint code.

we return a 401 because we want to keep the API behaviour compatible
with the behaviour before this change was made.

relates to [PROJQUAY-3030](https://issues.redhat.com/browse/PROJQUAY-3030)