### PR TITLE
builders: Make single_connection_client conifgurable (PROJQUAY-3025)

### DIFF
--- a/data/buildlogs.py
+++ b/data/buildlogs.py
@@ -32,7 +32,7 @@ class RedisBuildLogs(object):
 
         args = dict(self._redis_config)
         args.update(
-            {"socket_connect_timeout": 1, "socket_timeout": 2, "single_connection_client": True}
+            {"socket_connect_timeout": 1, "socket_timeout": 2}
         )
 
         self._redis_client = redis.StrictRedis(**args)
@@ -127,7 +127,7 @@ class RedisBuildLogs(object):
         try:
             args = dict(self._redis_config)
             args.update(
-                {"socket_connect_timeout": 1, "socket_timeout": 1, "single_connection_client": True}
+                {"socket_connect_timeout": 1, "socket_timeout": 1}
             )
 
             with closing(redis.StrictRedis(**args)) as connection:


### PR DESCRIPTION
single_connection_client keeps a connection open to the pool on init
which may cause issues if the master changes