### PR TITLE
deps: upgrade upstream requirements.txt package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ Pillow==8.3.2
 ply==3.11
 prometheus-client==0.7.1
 protobuf==3.12.2
-psutil==5.6.7
+psutil==5.9.0
 psycopg2-binary==2.8.4
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
@@ -94,7 +94,7 @@ PyMySQL==0.9.3
 pyOpenSSL==19.1.0
 pyparsing==2.4.6
 PyPDF2==1.26.0
-pyrsistent==0.15.7
+pyrsistent==0.18.1
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-gitlab==2.0.0
@@ -120,7 +120,7 @@ s3transfer==0.3.2
 semantic-version==2.8.4
 six==1.14.0
 soupsieve==1.9.5
-SQLAlchemy==1.3.13
+SQLAlchemy==1.4.31
 stevedore==1.31.0
 stringscore==0.1.0
 stripe==2.42.0
@@ -136,7 +136,7 @@ webencodings==0.5.1
 WebOb==1.8.6
 websocket-client==0.57.0
 Werkzeug==0.16.1
-wrapt==1.11.2
+wrapt==1.13.3
 xhtml2pdf==0.2.4
 yapf==0.29.0
 zipp==2.1.0


### PR DESCRIPTION
These outdated packages were preventing the upstream image from
starting correctly.