### PR TITLE
builders: Remove socket_timeout from the redis client (PROJQUAY-2542)

### DIFF
--- a/buildman/orchestrator.py
+++ b/buildman/orchestrator.py
@@ -297,7 +297,6 @@ class RedisOrchestrator(Orchestrator):
             ssl_ca_certs=ca_cert,
             ssl=ssl,
             socket_connect_timeout=1,
-            socket_timeout=2,
             health_check_interval=2,
         )
 


### PR DESCRIPTION
Redis needs a long-living connection for pubsub which is used by the
build manager