### PR TITLE
imagemirror: Add unsigned registries mirror option (PROJQUAY-3106)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN set -ex\
 		openssl \
 		python38 \
 		python3-gpg \
-		skopeo \
+		skopeo-1.5.0-2.module_el8.6.0+954+963caf36 \
 	; dnf -y -q clean all
 
 # Build has all the build-only tools.

--- a/data/model/repo_mirror.py
+++ b/data/model/repo_mirror.py
@@ -485,6 +485,7 @@ def change_external_registry_config(repository, config_updates):
 
     Config has:
     verify_tls: True|False
+    unsigned_images: True|False
     proxy: JSON fields 'http_proxy', 'https_proxy', andn 'no_proxy'
     """
     mirror = get_mirror(repository)
@@ -492,6 +493,9 @@ def change_external_registry_config(repository, config_updates):
 
     if "verify_tls" in config_updates:
         external_registry_config["verify_tls"] = config_updates["verify_tls"]
+
+    if "unsigned_images" in config_updates:
+        external_registry_config["unsigned_images"] = config_updates["unsigned_images"]
 
     if "proxy" in config_updates:
         proxy_updates = config_updates["proxy"]

--- a/endpoints/api/mirror.py
+++ b/endpoints/api/mirror.py
@@ -84,6 +84,13 @@ common_properties = {
                     "communicating with the external repository."
                 ),
             },
+            "unsigned_images": {
+                "type": "boolean",
+                "description": (
+                    "Determines whether the image signature will be verified when pulling from "
+                    "the external repository."
+                ),
+            },
             "proxy": {
                 "type": "object",
                 "description": "Proxy configuration for use during synchronization.",
@@ -449,6 +456,16 @@ class RepoMirrorResource(RepositoryParamResource):
                         wrap_repository(repo),
                         changed="verify_tls",
                         to=external_registry_config["verify_tls"],
+                    )
+
+            if "unsigned_images" in external_registry_config:
+                updates = {"unsigned_images": external_registry_config["unsigned_images"]}
+                if model.repo_mirror.change_external_registry_config(repo, updates):
+                    track_and_log(
+                        "repo_mirror_config_changed",
+                        wrap_repository(repo),
+                        changed="unsigned_images",
+                        to=external_registry_config["unsigned_images"],
                     )
 
             if "proxy" in external_registry_config:

--- a/static/directives/repo-view/repo-panel-mirroring.html
+++ b/static/directives/repo-view/repo-panel-mirroring.html
@@ -136,6 +136,19 @@
             </td>
           </tr>
           <tr>
+            <td>
+              <label for="sync_unsigned_images">Accept Unsigned Images</label><br>
+              <small>
+                Allow unsigned images to be mirrored.
+              </small>
+            </td>
+            <td>
+              <input type="checkbox"
+                      ng-model="vm.unsignedImages"
+                      id="sync_unsigned_images"></input>
+            </td>
+          </tr>
+          <tr>
             <td><label for="sync_http_proxy">HTTP Proxy</label></td>
             <td>
               <input ng-model="vm.httpProxy"
@@ -304,6 +317,17 @@
           </td>
           <td>
             <input type="checkbox" ng-click="vm.toggleVerifyTLS()" ng-checked="vm.verifyTLS"></input>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <label>Accept Unsigned Images</label><br>
+            <small>
+              Allow unsigned images to be mirrored.
+            </small>
+          </td>
+          <td>
+            <input type="checkbox" ng-click="vm.toggleUnsignedImages()" ng-checked="vm.unsignedImages"></input>
           </td>
         </tr>
         <tr>

--- a/static/js/directives/repo-view/repo-panel-mirroring.js
+++ b/static/js/directives/repo-view/repo-panel-mirroring.js
@@ -43,6 +43,7 @@ angular.module('quay').directive('repoPanelMirror', function () {
       vm.tags = null;
       vm.username = null;
       vm.verifyTLS = null;
+      vm.unsignedImages = null;
 
       /**
        * Fetch the latest Repository Mirror Configuration
@@ -74,6 +75,7 @@ angular.module('quay').directive('repoPanelMirror', function () {
 
           // TODO: These are not consistently provided by the API. Correct that in the API.
           vm.verifyTLS = resp.external_registry_config.verify_tls;
+          vm.unsignedImages = resp.external_registry_config.unsigned_images;
           if (resp.external_registry_config.proxy) {
             vm.httpProxy = resp.external_registry_config.proxy.http_proxy;
             vm.httpsProxy = resp.external_registry_config.proxy.https_proxy;
@@ -285,6 +287,47 @@ angular.module('quay').directive('repoPanelMirror', function () {
       }
 
       /**
+       * Enable `Accept Unsigned Images`.
+       */
+      vm.enableUnsignedImages = function() {
+        let data = {
+          'fieldName': 'Accept Unsigned Images',
+          'values': {
+            'external_registry_config': {
+              'unsigned_images': true
+            }
+          }
+        }
+
+        return vm.changeConfig(data, null);
+      }
+
+      /**
+       * Disable `Accept Unsigned Images`
+       */
+      vm.disableUnsignedImages = function() {
+        console.log("disabling unsigned images");
+        let data = {
+          'fieldName': 'Accept Unsigned Images',
+          'values': {
+            'external_registry_config': {
+              'unsigned_images': false
+            }
+          }
+        }
+
+        return vm.changeConfig(data, null);
+      }
+
+      /**
+       * Toggle `Accept Unsigned Images`.
+       */
+      vm.toggleUnsignedImages = function() {
+        if (vm.unsignedImages) return vm.disableUnsignedImages();
+        else return vm.enableUnsignedImages();
+      }
+
+      /**
        *  Change Robot user.
        */
       vm.changeRobot = function(robot) {
@@ -452,6 +495,7 @@ angular.module('quay').directive('repoPanelMirror', function () {
            'robot_username': vm.robot.name,
            'external_registry_config': {
              'verify_tls': vm.verifyTLS || false, // `null` not allowed
+             'unsigned_images': vm.unsignedImages || false,
              'proxy': {
                'http_proxy': vm.httpProxy,
                'https_proxy': vm.httpsProxy,

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -116,6 +116,9 @@ angular.module('quay').directive('logsView', function () {
             case 'verify_tls':
               metadata.changed = 'Verify TLS';
               return 'Mirror {changed} changed to {to}';
+            case 'unsigned_images':
+              metadata.changed = 'Accept Unsigned Images';
+              return 'Mirror {changed} changed to {to}';
             case 'http_proxy':
               metadata.changed = 'HTTP_PROXY';
               return 'Mirror {changed} changed to {to}';

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -32,11 +32,15 @@ class SkopeoMirror(object):
         dest_password=None,
         proxy=None,
         verbose_logs=False,
+        unsigned_images=False,
     ):
 
         args = ["/usr/bin/skopeo"]
         if verbose_logs:
             args = args + ["--debug"]
+        if unsigned_images:
+            args = args + ["--insecure-policy"]
+
         args = args + [
             "copy",
             "--all",

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -200,6 +200,7 @@ def perform_mirror(skopeo, mirror):
                     dest_password=retrieve_robot_token(mirror.internal_robot),
                     proxy=mirror.external_registry_config.get("proxy", {}),
                     verbose_logs=verbose_logs,
+                    unsigned_images=mirror.external_registry_config.get("unsigned_images", False),
                 )
 
             if not result.success:


### PR DESCRIPTION
Currently when attempting to mirror a registry containing unsigned images the mirror will fail due to not finding the source signature. This is caused by the updated version of Skopeo blocking unsigned images by default. This allows users to specify the ability to pull unsigned images per-repository. The Skopeo version is also now pinned.