### PR TITLE
builders: Update boto to fix signature error (PROJQUAY-2542)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ beautifulsoup4==4.8.2
 bintrees==2.1.0
 bitmath==1.3.3.1
 blinker==1.4
-boto3==1.17.21
-botocore==1.20.21
+boto3==1.20.46
+botocore==1.23.46
 cachetools==4.0.0
 certifi==2019.11.28
 cffi==1.13.2
@@ -116,7 +116,7 @@ requests-aws4auth==0.9
 requests-file==1.4.3
 requests-oauthlib==1.3.0
 rfc3986==1.3.2
-s3transfer==0.3.2
+s3transfer==0.5.1
 semantic-version==2.8.4
 six==1.14.0
 soupsieve==1.9.5


### PR DESCRIPTION
There is a bug in botocore which causes issues with signing
requests with awsv4. Latest version of Boto fixes it

https://github.com/boto/botocore/issues/2358 gives more context