### PR TITLE
dockerfile: ubi8 requires python38, otherwise installs 3.6 by default (PROJQUAY-3148)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN set -ex\
 		nginx \
 		openldap \
 		openssl \
-		python3 \
+		python38 \
 		python3-gpg \
 		skopeo \
 	; dnf -y -q clean all
@@ -33,7 +33,7 @@ RUN set -ex\
 		git\
 		nodejs\
 		openldap-devel\
-		python3-devel\
+		python38-devel\
 	; dnf -y -q clean all
 WORKDIR /build
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ oslo.serialization==2.29.2
 oslo.utils==3.42.1
 pbr==5.4.4
 peewee==3.13.1
-Pillow==8.4.0
+Pillow==9.0.1
 ply==3.11
 prometheus-client==0.7.1
 protobuf==3.12.2


### PR DESCRIPTION
- Specify Python38
- bump Pillow to 9.0.1