### PR TITLE
[cherry-pick 3.6] requirements-osbs.txt: remove ipython and related deps (#1069)

### DIFF
--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -45,7 +45,6 @@ Flask-Login==0.4.1
 Flask-Mail==0.9.1
 Flask-Principal==0.4.0
 Flask-RESTful==0.3.7
-Flask-Testing @ git+https://github.com/jarus/flask-testing.git@17f19d7fee0e1e176703fc7cb04917a77913ba1a
 funcparserlib==0.3.6
 funcsigs==1.0.2
 furl==2.1.0
@@ -63,7 +62,6 @@ httmock==1.3.0
 httpretty==0.9.7
 idna==2.8
 importlib-metadata==1.4.0
-ipdb==0.13.9
 iso8601==0.1.12
 isodate==0.6.0
 itsdangerous==1.1.0
@@ -72,7 +70,6 @@ jmespath==0.9.4
 jsondiff==1.1.2
 jsonpatch==1.24
 jsonpath-rw==1.4.0
-jsonpickle==1.2
 jsonpointer==2.0
 jsonschema==3.2.0
 kafka-python==1.4.7
@@ -82,8 +79,6 @@ MarkupSafe==1.1.1
 maxminddb==1.5.2
 meld3==2.0.0
 mixpanel==4.5.0
-mock==3.0.5
-mockldap @ git+https://github.com/quay/mockldap.git@136253ca136fc7898944a4b37893a99440f7335e
 monotonic==1.5
 msgpack==0.6.2
 msrest==0.6.19
@@ -121,10 +116,8 @@ pymemcache==3.0.0
 PyMySQL==0.9.3
 pyOpenSSL==19.1.0
 pyparsing==2.4.6
-#PyPDF2==1.26.0
 PyPDF2 @ https://files.pythonhosted.org/packages/b4/01/68fcc0d43daf4c6bdbc6b33cc3f77bda531c86b174cac56ef0ffdb96faab/PyPDF2-1.26.0.tar.gz#egg=PyPDF2&cachito_hash=sha256:e28f902f2f0a1603ea95ebe21dff311ef09be3d0f0ef29a3e44a932729564385
 pyrsistent==0.15.7
-pytest-runner==5.2
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-etcd @ git+https://github.com/DevTable/python-etcd.git@f1168cb02a2a8c83bec1108c6fcd8615ef463b14
@@ -146,7 +139,6 @@ requests==2.22.0
 requests-aws4auth==0.9
 requests-file==1.4.3
 requests-oauthlib==1.3.0
-responses==0.10.9
 rfc3986==1.3.2
 s3transfer==0.3.2
 scandir==1.10.0
@@ -167,7 +159,6 @@ tabulate==0.8.6
 termcolor==1.1.0
 text-unidecode==1.3
 tldextract==2.2.2
-toml==0.10.2
 toposort==1.5
 txaio==20.4.1
 tzlocal==2.0.0
@@ -180,25 +171,6 @@ Werkzeug==0.16.1
 wheel==0.35.1
 wrapt==1.11.2
 xhtml2pdf==0.2.4
-xmltodict==0.12.0
 yapf==0.29.0
 zipp==2.1.0
 zope.interface==5.1.2
-
-# Build dependencies
-Cython==0.29.23
-Pygments==2.9.0
-backcall==0.2.0
-flit-core==3.2.0
-ipython-genutils==0.2.0
-ipython==7.24.1
-jedi==0.18.0
-matplotlib-inline==0.1.2
-parso==0.8.2
-pexpect==4.8.0
-pickleshare==0.7.5
-prompt-toolkit==3.0.18
-ptyprocess==0.7.0
-traitlets==5.0.5
-traitlets==5.0.5
-wcwidth==0.2.5


### PR DESCRIPTION
also remove testing related dependencies

backports https://github.com/quay/quay/pull/1069