### PR TITLE
Remove ServerSideEncryption param from presigned URL (PROJQUAY-3180)

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -252,7 +252,6 @@ class _CloudStorage(BaseStorageV2):
             Params={
                 "Bucket": self._bucket_name,
                 "Key": path,
-                "ServerSideEncryption": "AES256",
                 "ContentType": mime_type,
             },
             ExpiresIn=300,


### PR DESCRIPTION
This parameter causes signature validation errors on the client side.
We don't store encrypted blobs so we don't really need this param.