### PR TITLE
realtime: decode byte to string before using split (PROJQUAY-3180)

### DIFF
--- a/data/userevent.py
+++ b/data/userevent.py
@@ -135,6 +135,9 @@ class UserEventListener(object):
                 yield "pulse", {}
             else:
                 channel = item["channel"]
+                if isinstance(channel, bytes):
+                    channel = channel.decode()
+
                 event_id = channel.split("/")[3]  # user/{username}/{events}/{id}
                 data = None
 


### PR DESCRIPTION
This fixes the crash in the `/realtime` endpoint for testing user
events