### PR TITLE
ui: display manifest list manifest sizes (PROJQUAY-3196)

### DIFF
--- a/data/cache/redis_cache.py
+++ b/data/cache/redis_cache.py
@@ -27,10 +27,10 @@ class ReadEndpointSupportedRedis(object):
             )
 
     def get(self, key, *args, **kwargs):
-        return self.read_client(key, *args, **kwargs)
+        return self.read_client.get(key, *args, **kwargs)
 
     def set(self, key, val, *args, **kwargs):
-        return self.write_client(key, val, *args, **kwargs)
+        return self.write_client.set(key, val, *args, **kwargs)
 
     def __getattr__(self, name):
         return getattr(self.write_client, name, None)

--- a/static/directives/repo-view/repo-panel-tags.html
+++ b/static/directives/repo-view/repo-panel-tags.html
@@ -267,7 +267,11 @@
         </manifest-security-view>
       </td>
 
-      <td colspan="1" class="hidden-xs"></td>
+      <!-- Size -->
+      <td class="hidden-xs">
+        <span bo-text="manifest.layers_compressed_size | bytes"></span>
+      </td>
+
       <td colspan="1" class="hidden-xs hidden-sm hidden-md"></td>
 
       <td class="hidden-xs hidden-sm image-id-col">


### PR DESCRIPTION
Display individual manifest size in manifest list view.
Also fixes a non-cluster Redis cache bug.

TODO: This requires making extra individiual requests to get the
children manifests. They should probably be cached.

<img width="1371" alt="Screen Shot 2022-02-14 at 10 01 47 AM" src="https://user-images.githubusercontent.com/2530351/153889020-fe4d9ece-b015-4802-b641-864cb6131d80.png">
