### PR TITLE
deploy: Add ignore validation for py3 deployment (PROJQUAY-2542)

### DIFF
--- a/deploy/openshift/quay-py3-app.yaml
+++ b/deploy/openshift/quay-py3-app.yaml
@@ -256,6 +256,8 @@ objects:
             value: ${{QUAY_APP_CONFIG_SECRET}}
           - name: DEBUGLOG
             value: ${DEBUGLOG}
+          - name: IGNORE_VALIDATION
+            value: ${IGNORE_VALIDATION}
           - name: SYSLOG_SERVER
             value: ${{SYSLOG_SERVER}}
           - name: SYSLOG_PORT
@@ -460,4 +462,7 @@ parameters:
     value: "true"
   - name: TICKER_TIME
     value: "200"
+  - name: IGNORE_VALIDATION
+    value: "false"
+
 


### PR DESCRIPTION
Add an environment variable to the deployment to disable config
validation