### PR TITLE
buildman: Add EXECUTOR parameter (PROJQUAY-3278)

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -727,6 +727,10 @@ class KubernetesPodmanExecutor(KubernetesExecutor):
                 {"name": "HTTPS_PROXY", "value": self.executor_config.get("HTTPS_PROXY", "")},
                 {"name": "NO_PROXY", "value": self.executor_config.get("NO_PROXY", "")},
                 {"name": "DOCKER_HOST", "value": "unix:///tmp/podman-run-1000/podman/podman.sock"},
+                {
+                    "name": "EXECUTOR",
+                    "value": self.executor_config.get("EXECUTOR", "kubernetesPodman"),
+                },
             ],
             "resources": self._build_job_container_resources(),
         }

--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -56,6 +56,13 @@ WantedBy=multi-user.target
 
 {%- endmacro %}
 
+{% macro podmanregistryconfig() -%}
+
+unqualified-search-registries = ["registry.fedoraproject.org", "registry.access.redhat.com", "docker.io", "quay.io"]
+short-name-mode="permissive"
+
+{%- endmacro %}
+
 
 {
   "ignition": {
@@ -90,6 +97,14 @@ WantedBy=multi-user.target
           "source": {{ ca_cert | dataurl | jsonify }}
         },
         "mode": 420
+      },
+      {
+        "overwrite": true,
+        "path": "/etc/containers/registries.conf",
+        "contents": {
+          "source": {{ podmanregistryconfig() | dataurl | jsonify }}
+        },
+        "mode": 444
       },
       {% else %}
       {

--- a/buildman/templates/dockersystemd.json
+++ b/buildman/templates/dockersystemd.json
@@ -39,7 +39,7 @@ TimeoutStopSec={{ timeout_stop_sec if timeout_stop_sec else 2000 }}
 {% if username and password %}
 ExecStartPre=/usr/bin/podman login -u {{ username }} -p {{ password }} {{ container|registry }}
 {% endif %}
-ExecStart=/usr/bin/podman run --rm {{ extra_args }} --name {{ name }} {{ container }}:{{ tag }} {{ command }}
+ExecStart=/usr/bin/podman run --user 0 --rm {{ extra_args }} --name {{ name }} {{ container }}:{{ tag }} {{ command }}
 {% for start_post in exec_start_post -%}
 ExecStartPost={{ start_post }}
 {% endfor %}
@@ -50,7 +50,7 @@ ExecStop=/usr/bin/podman stop {{ name }}
 {% if username and password %}
 ExecStartPre=/usr/bin/docker login -u {{ username }} -p {{ password }} {{ container|registry }}
 {% endif %}
-ExecStart=/usr/bin/docker run --rm {{ extra_args }} --name {{ name }} {{ container }}:{{ tag }} {{ command }}
+ExecStart=/usr/bin/docker run --user 0 --rm {{ extra_args }} --name {{ name }} {{ container }}:{{ tag }} {{ command }}
 {% for start_post in exec_start_post -%}
 ExecStartPost={{ start_post }}
 {% endfor %}


### PR DESCRIPTION
Changes made to allow use of a single quay-builder image for kubernetes and kubernetesPodman builds.
Implements the following changes:
- Added EXECUTOR env var to kubernetsPodman job configuration
- Updated the builder ignition config to overwrite the registry.conf file to set short name mode to permissive
- Always run the quay-builder in the VM as root