### PR TITLE
buildman: fix multiple build retries phase (PROJQUAY-3281)

### DIFF
--- a/buildman/orchestrator.py
+++ b/buildman/orchestrator.py
@@ -346,13 +346,6 @@ class RedisOrchestrator(Orchestrator):
                 key = self._key_from_expiration(message_tup)
                 expired_value = self._client.get(key)
 
-                if expired_value is None:
-                    logger.exception(
-                        "Exception handling expiration of key %s: - couldn't get original value. Removing keys.",
-                        key,
-                    )
-                    self.delete_key(key)
-
                 # Mark key as expired. This key is used to track post job cleanup in the callback,
                 # to allow another manager to pickup the cleanup if this fails.
                 self._client.set(slash_join(key, REDIS_EXPIRED_SUFFIX), expired_value)

--- a/buildman/orchestrator.py
+++ b/buildman/orchestrator.py
@@ -346,6 +346,13 @@ class RedisOrchestrator(Orchestrator):
                 key = self._key_from_expiration(message_tup)
                 expired_value = self._client.get(key)
 
+                if expired_value is None:
+                    logger.exception(
+                        "Exception handling expiration of key %s: - couldn't get original value. Removing keys.",
+                        key,
+                    )
+                    self.delete_key(key)
+
                 # Mark key as expired. This key is used to track post job cleanup in the callback,
                 # to allow another manager to pickup the cleanup if this fails.
                 self._client.set(slash_join(key, REDIS_EXPIRED_SUFFIX), expired_value)


### PR DESCRIPTION
Allow the build to move forward if it is already in the desired
phase/state. When a build fails, ang gets retried from the queue, its
phase doesn't get updated back to WAITING. So it is possible that it
is already in a phase such as SCHEDULED, which could prevent the
buildman from marking the new attempt as scheduled, as there would be
no aparent changes made to the build phase.