### PR TITLE
buildman: Set build token expiration to builder's lifetime (PROJQUAY-3281)

### DIFF
--- a/buildman/buildmanagerservicer.py
+++ b/buildman/buildmanagerservicer.py
@@ -68,9 +68,8 @@ class BuildManagerServicer(buildman_pb2_grpc.BuildManagerServicer):
             return buildman_pb2.BuildPack()
 
         job_id = decoded_token["job_id"]
-        max_build_time = decoded_token["expiration"]
 
-        token, build_args = self._lifecycle_manager.start_job(job_id, max_build_time)
+        token, build_args = self._lifecycle_manager.start_job(job_id)
         if not token or not build_args:
             msg = "Build manager unable to start job"
             self._handle_error(context, grpc.StatusCode.INTERNAL, msg)

--- a/buildman/interface.py
+++ b/buildman/interface.py
@@ -70,10 +70,9 @@ class BuildStateInterface(ABC):
         """
 
     @abstractmethod
-    def start_job(self, job_id, max_build_time):
+    def start_job(self, job_id):
         """Mark a job as started.
         Returns False if the job does not exists, or has already started.
-        The worker's lifetime should be set to max_build_time
         """
 
     @abstractmethod

--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -369,7 +369,7 @@ class EphemeralBuilderManager(BuildStateInterface):
 
         logger.debug("Job completed for job %s with result %s", job_id, job_result)
 
-    def start_job(self, job_id, max_build_time):
+    def start_job(self, job_id):
         """Starts the build job. This is invoked by the worker once the job has been created and
         scheduled, returing the buildpack needed to start the actual build.
         """
@@ -431,7 +431,7 @@ class EphemeralBuilderManager(BuildStateInterface):
 
         # Generate the build token
         token = self.generate_build_token(
-            BUILD_JOB_TOKEN_TYPE, build_job.build_uuid, job_id, max_build_time
+            BUILD_JOB_TOKEN_TYPE, build_job.build_uuid, job_id, self.machine_max_expiration
         )
 
         # Publish the time it took for a worker to ack the build


### PR DESCRIPTION
Make sure the build token doesn't expire before the builder instance does.