### PR TITLE
schema1: Permit signed schema1 manifests during conversion (PROJQUAY-3285)

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,6 @@ import os
 
 from functools import partial
 
-from authlib.jose import JsonWebKey
 from cryptography.hazmat.primitives import serialization
 from flask import Flask, request, Request
 from flask_login import LoginManager
@@ -68,6 +67,7 @@ from util.metrics.prometheus import PrometheusPlugin
 from util.repomirror.api import RepoMirrorAPI
 from util.tufmetadata.api import TUFMetadataAPI
 from util.security.instancekeys import InstanceKeys
+from util.security.v2_signing_key import get_docker_v2_signing_key
 from util.greenlet_tracing import enable_tracing
 
 OVERRIDE_CONFIG_YAML_FILENAME = os.path.join(OVERRIDE_CONFIG_DIRECTORY, "config.yaml")
@@ -75,7 +75,6 @@ OVERRIDE_CONFIG_PY_FILENAME = os.path.join(OVERRIDE_CONFIG_DIRECTORY, "config.py
 
 OVERRIDE_CONFIG_KEY = "QUAY_OVERRIDE_CONFIG"
 
-DOCKER_V2_SIGNINGKEY_FILENAME = "docker_v2.pem"
 INIT_SCRIPTS_LOCATION = "/conf/init/"
 
 app = Flask(__name__)
@@ -306,13 +305,7 @@ repo_mirror_api = RepoMirrorAPI(
 
 tuf_metadata_api = TUFMetadataAPI(app, app.config)
 
-# Check for a key in config. If none found, generate a new signing key for Docker V2 manifests.
-_v2_key_path = os.path.join(OVERRIDE_CONFIG_DIRECTORY, DOCKER_V2_SIGNINGKEY_FILENAME)
-if os.path.exists(_v2_key_path):
-    with open(_v2_key_path) as key_file:
-        docker_v2_signing_key = JsonWebKey.import_key(key_file.read())
-else:
-    docker_v2_signing_key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+docker_v2_signing_key = get_docker_v2_signing_key()
 
 # Configure the database.
 if app.config.get("DATABASE_SECRET_KEY") is None and app.config.get("SETUP_COMPLETE", False):

--- a/image/docker/schema1.py
+++ b/image/docker/schema1.py
@@ -787,11 +787,14 @@ class DockerSchema1ManifestBuilder(object):
         logger.debug("Generated signature: %s", signature)
         logger.debug("Generated protected block: %s", protected)
 
+        # Constructing public key
+        # Removing kid as it is optional and breaks older clients
+        # ref: https://self-issued.info/docs/rfc7517.txt
         public_members = set(json_web_key.REQUIRED_JSON_FIELDS + json_web_key.ALLOWED_PARAMS)
         public_key = {
             comp: value
             for comp, value in list(json_web_key.as_dict().items())
-            if comp in public_members
+            if comp in public_members and comp != "kid"
         }
         public_key["kty"] = json_web_key.kty
 

--- a/image/oci/manifest.py
+++ b/image/oci/manifest.py
@@ -63,6 +63,7 @@ from image.oci.config import OCIConfig
 from image.oci.descriptor import get_descriptor_schema
 from image.docker.schema1 import DockerSchema1ManifestBuilder
 from util.bytes import Bytes
+from util.security.v2_signing_key import get_docker_v2_signing_key
 
 # Keys.
 OCI_MANIFEST_VERSION_KEY = "schemaVersion"
@@ -417,7 +418,7 @@ class OCIManifest(ManifestInterface):
 
         v1_builder = DockerSchema1ManifestBuilder(namespace_name, repo_name, tag_name)
         self._populate_schema1_builder(v1_builder, content_retriever)
-        return v1_builder.build()
+        return v1_builder.build(get_docker_v2_signing_key())
 
     def unsigned(self):
         return self

--- a/image/oci/test/test_oci_manifest.py
+++ b/image/oci/test/test_oci_manifest.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from image.docker.schema1 import DOCKER_SCHEMA1_MANIFEST_CONTENT_TYPE
+from image.docker.schema1 import DOCKER_SCHEMA1_SIGNED_MANIFEST_CONTENT_TYPE
 from image.oci.manifest import OCIManifest, MalformedOCIManifest
 from image.oci import register_artifact_type
 from image.shared.schemautil import ContentRetrieverForTesting
@@ -160,7 +160,7 @@ def test_get_schema1_manifest():
 
     schema1 = manifest.get_schema1_manifest("somenamespace", "somename", "sometag", retriever)
     assert schema1 is not None
-    assert schema1.media_type == DOCKER_SCHEMA1_MANIFEST_CONTENT_TYPE
+    assert schema1.media_type == DOCKER_SCHEMA1_SIGNED_MANIFEST_CONTENT_TYPE
     assert set(schema1.local_blob_digests) == (
         set(manifest.local_blob_digests)
         - {"sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"}
@@ -220,7 +220,7 @@ def test_get_schema1_manifest_missing_history():
 
     schema1 = manifest.get_schema1_manifest("somenamespace", "somename", "sometag", retriever)
     assert schema1 is not None
-    assert schema1.media_type == DOCKER_SCHEMA1_MANIFEST_CONTENT_TYPE
+    assert schema1.media_type == DOCKER_SCHEMA1_SIGNED_MANIFEST_CONTENT_TYPE
     assert set(schema1.local_blob_digests) == (
         set(manifest.local_blob_digests)
         - {"sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"}

--- a/util/security/v2_signing_key.py
+++ b/util/security/v2_signing_key.py
@@ -1,0 +1,19 @@
+import os
+from functools import lru_cache
+
+from authlib.jose import JsonWebKey
+from _init import OVERRIDE_CONFIG_DIRECTORY
+
+DOCKER_V2_SIGNINGKEY_FILENAME = "docker_v2.pem"
+
+
+# Check for a key in config. If none found, generate a new signing key for Docker V2 manifests.
+@lru_cache(maxsize=1)
+def get_docker_v2_signing_key():
+    _v2_key_path = os.path.join(OVERRIDE_CONFIG_DIRECTORY, DOCKER_V2_SIGNINGKEY_FILENAME)
+    if os.path.exists(_v2_key_path):
+        with open(_v2_key_path) as key_file:
+            docker_v2_signing_key = JsonWebKey.import_key(key_file.read())
+    else:
+        docker_v2_signing_key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    return docker_v2_signing_key


### PR DESCRIPTION

Currently if an image with an OCI manifest is requested and the client does not support Docker Schema 2 or OCI manifests it will default to returning an unsigned Docker V2 Schema 1 manifest. Older clients who send a `application/vnd.docker.distribution.manifest.v1+prettyjws` media type header expect a signed Docker V2 Schema 1 manifest and break when an unsigned manifest is recieved. This change defaults to returning a signed manifest for OCI images if the `application/vnd.docker.distribution.manifest.v1+prettyjws` is present before falling back to an unsigned manifest.