### PR TITLE
buildman: prevent systemd oneshot service from timing (PROJQUAY-3304)

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -207,6 +207,7 @@ class BuilderExecutor(object):
                     worker_tag=self.executor_config["WORKER_TAG"],
                     volume_size=self.executor_config.get("VOLUME_SIZE", "42G"),
                     max_lifetime_s=self.executor_config.get("MAX_LIFETIME_S", 10800),
+                    timeout_start_sec=self.executor_config.get("MAX_LIFETIME_S", 10800),
                     ssh_authorized_keys=self.executor_config.get("SSH_AUTHORIZED_KEYS", []),
                     container_runtime=self.executor_config.get("CONTAINER_RUNTIME", "docker"),
                     ca_cert=self.executor_config.get("CA_CERT", self._ca_cert()),

--- a/buildman/templates/cloudconfig.json
+++ b/buildman/templates/cloudconfig.json
@@ -144,6 +144,7 @@ WantedBy=multi-user.target
                        extra_args='--privileged --env-file /root/overrides.list -v /var/run/podman/podman.sock:/var/run/podman/podman.sock -v /etc/pki/ca-trust-source/anchors:/certs -e DOCKER_HOST=unix:/var/run/podman/podman.sock',
                        restart_policy='no',
                        oneshot=True,
+                       timeout_start_sec=timeout_start_sec,
                       ) | indent(6) }},
       {% else %}
       {{ dockersystemd("quay-builder",
@@ -156,6 +157,7 @@ WantedBy=multi-user.target
                        exec_stop_post=['/bin/sh -xc "/bin/sleep 120; /usr/bin/systemctl --no-block poweroff"'],
                        restart_policy='no',
                        oneshot=True,
+                       timeout_start_sec=timeout_start_sec,
                       ) | indent(6) }},
       {% endif %}
       {% else %}
@@ -169,6 +171,7 @@ WantedBy=multi-user.target
                        extra_args='--net=host --privileged --env-file /root/overrides.list -v /var/run/docker.sock:/var/run/docker.sock -v /etc/pki/ca-trust-source/anchors:/certs',
                        restart_policy='no',
                        oneshot=True,
+                       timeout_start_sec=timeout_start_sec,
                       ) | indent(6) }},
       {% else %}
       {{ dockersystemd("quay-builder",
@@ -181,6 +184,7 @@ WantedBy=multi-user.target
                        exec_stop_post=['/bin/sh -xc "/bin/sleep 120; /usr/bin/systemctl --no-block poweroff"'],
                        restart_policy='no',
                        oneshot=True,
+                       timeout_start_sec=timeout_start_sec,
                       ) | indent(6) }},
       {% endif %}
       {% endif %}


### PR DESCRIPTION
If not set, TimeoutStartSec for the Docker service is set to
600. Since it's a service of type oneshot, this should either not be
set, or at least the length of the machine's lifetime.