### PR TITLE
chore: Remove unneeded flags fromt he config schema (PROJQUAY-3309)

### DIFF
--- a/config.py
+++ b/config.py
@@ -794,8 +794,5 @@ class DefaultConfig(ImmutableConfig):
     # Allows "/" in repository names
     FEATURE_EXTENDED_REPOSITORY_NAMES = True
 
-    # Allow creation of push to public repo
-    CREATE_REPOSITORY_ON_PUSH_PUBLIC = False
-
     # Automatically clean stale blobs leftover in the uploads storage folder from cancelled uploads
     CLEAN_BLOB_UPLOAD_FOLDER = False

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1192,12 +1192,6 @@ CONFIG_SCHEMA = {
                 ],
             },
         },
-        # Create repo on public push
-        "CREATE_REPOSITORY_ON_PUSH_PUBLIC": {
-            "type": "boolean",
-            "description": "Whether to create a repository when pushing to an unexisting public repo",
-            "x-example": False,
-        },
         # Clean partial uploads during S3 multipart upload
         "CLEAN_BLOB_UPLOAD_FOLDER": {
             "type": "boolean",


### PR DESCRIPTION
The flag `CREATE_REPOSITORY_ON_PUSH_PUBLIC` is not referenced anywhere in the code. This PR removes it along with its entry in the schema.