### PR TITLE
ci: Enable workflow dispatch for build and publish (PROJQUAY-3310)

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -5,7 +5,12 @@ on:
   push:
     branches:
       - redhat-** # IMPORTANT! this must match the jobs.build-and-publish.env.BRANCH_PREFIX (save the **).
-
+  workflow_dispatch:
+      # Allows you to run this workflow manually from the Actions tab
+    inputs:
+      tag:
+        description: 'Tag to attach to image'     
+        required: true
 jobs:
   build-and-publish:
     name: Publish container image
@@ -40,5 +45,5 @@ jobs:
           TAG: ${{ steps.version-from-branch.outputs.version }}${{ env.TAG_SUFFIX }}
         with:
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ env.TAG }}
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}
 


### PR DESCRIPTION
- Enable workflow dispatch for the build and publish job
- This is a requirement to call the workflow from releases repository