### PR TITLE
database: handle nested transaaction when trying to close before transaction (PROJQUAY-3303)

### DIFF
--- a/config.py
+++ b/config.py
@@ -208,6 +208,22 @@ class DefaultConfig(ImmutableConfig):
 
     @staticmethod
     def create_transaction(db):
+        # This hack is for handling possible MySQL closing idle connections.
+        # Peewee/pymysql's will try to reuse the existing connection after the MySQL server
+        # has already closed it, which will return an InterfaceError.
+        # AFAIK, there isn't a way to actually test for a a stale connection without actually
+        # running a query. Closing the connection before the transaction forces peewee/pymysql
+        # to reopen a new session to MySQL. This should only applies to non-registry workers,
+        # as the registry workers use a pool by default, and shouldn't have this issue.
+        if type(db.obj).__name__ == "ObservableRetryingMySQLDatabase":
+            try:
+                db.close()
+            except:
+                # Only try to close the connection. Otherwise closing connections in a nested transaction
+                # will return an OperationalError. In that case, we can just continue with the normal flow,
+                # as we know the connection is likely in use and not stale.
+                pass
+
         return db.transaction()
 
     DB_TRANSACTION_FACTORY = create_transaction

--- a/config.py
+++ b/config.py
@@ -208,16 +208,6 @@ class DefaultConfig(ImmutableConfig):
 
     @staticmethod
     def create_transaction(db):
-        # This hack is for handling possible MySQL closing idle connections.
-        # Peewee/pymysql's will try to reuse the existing connection after the MySQL server
-        # has already closed it, which will return an InterfaceError.
-        # AFAIK, there isn't a way to actually test for a a stale connection without actually
-        # running a query. Closing the connection before the transaction forces peewee/pymysql
-        # to reopen a new session to MySQL. This should only applies to non-registry workers,
-        # as the registry workers use a pool by default, and shouldn't have this issue.
-        if type(db.obj).__name__ == "ObservableRetryingMySQLDatabase":
-            db.close()
-
         return db.transaction()
 
     DB_TRANSACTION_FACTORY = create_transaction


### PR DESCRIPTION
Handle nested transaction when trying to catch InterfaceError from
pymsql/mysql's idle connections. If the connection is already in a
transaction, then we'll assume it doesn't need to be closed
beforehand, as it's probably in-use, and unlikely to be cleaned up.