### PR TITLE
builders: Update py-bitbucket to fix bitbucket triggers (PROJQUAY-3362)

### DIFF
--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -91,7 +91,7 @@ psutil==5.6.7
 psycopg2-binary==2.8.4
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-py-bitbucket @ git+https://github.com/quay/py-bitbucket.git@85301693ce3682f8e1244e90bd8a903181844bde
+py-bitbucket @ git+https://github.com/quay/py-bitbucket.git@3ba167408d92eb4ba2cae78c0047b8f1e8821c67
 pycparser==2.20
 PyGithub==1.45
 PyJWT==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b#egg=cnr_server
 git+https://github.com/DevTable/aniso8601-fake.git@bd7762c7dea0498706d3f57db60cd8a8af44ba90#egg=aniso8601
-git+https://github.com/quay/py-bitbucket.git@85301693ce3682f8e1244e90bd8a903181844bde#egg=py_bitbucket
+git+https://github.com/quay/py-bitbucket.git@3ba167408d92eb4ba2cae78c0047b8f1e8821c67#egg=py_bitbucket
 git+https://github.com/DevTable/python-etcd.git@f1168cb02a2a8c83bec1108c6fcd8615ef463b14#egg=python_etcd
 git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380#egg=supervisor_stdout
 aiowsgi==0.7


### PR DESCRIPTION
Upgrade to py3 broke py-bitbucket which is the
bitbucket API wriapper. This was fixed in
https://github.com/quay/py-bitbucket/pull/2