### PR TITLE
billing: use BytesIO when rendering invoice (PROJQUAY-3267)

### DIFF
--- a/util/invoice.py
+++ b/util/invoice.py
@@ -18,7 +18,7 @@ def renderInvoiceToPdf(invoice, user):
     Renders a nice PDF display for the given invoice.
     """
     sourceHtml = renderInvoiceToHtml(invoice, user)
-    output = io.StringIO()
+    output = io.BytesIO()
     pisaStatus = pisa.CreatePDF(sourceHtml, dest=output)
     if pisaStatus.err:
         return None


### PR DESCRIPTION


Migrating to py3 broke invoices. xhtml2pdf returns `bytes` instead of `str`