### PR TITLE
builders: Add DEBUG and JOB_REGISTRATION_TIMEOUT options (PROJQUAY-3395)

### DIFF
--- a/buildman/jobutil/buildjob.py
+++ b/buildman/jobutil/buildjob.py
@@ -122,7 +122,7 @@ class BuildJob(object):
         Returns the tag to pull to prime the cache or None if none.
         """
         cached_tag = self._determine_cached_tag_by_tag()
-        logger.debug("Determined cached tag %s for %s: %s", cached_tag, base_image_id)
+        logger.debug("Determined cached tag %s for %s", cached_tag, base_image_id)
         return cached_tag
 
     def _determine_cached_tag_by_tag(self):

--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -627,11 +627,14 @@ class EphemeralBuilderManager(BuildStateInterface):
             )
             return False, ORCHESTRATOR_UNAVAILABLE_SLEEP_DURATION
 
+        registration_timeout = self._manager_config.get(
+            "JOB_REGISTRATION_TIMEOUT", JOB_REGISTRATION_TIMEOUT
+        )
         registration_token = self.generate_build_token(
             BUILD_JOB_REGISTRATION_TYPE,
             build_job.build_uuid,
             job_id,
-            JOB_REGISTRATION_TIMEOUT + SETUP_LEEWAY_SECONDS,
+            registration_timeout + SETUP_LEEWAY_SECONDS,
         )
 
         started_with_executor = None

--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -723,7 +723,7 @@ class KubernetesPodmanExecutor(KubernetesExecutor):
                     "name": "SSL_CERT_FILE",
                     "value": "/certs/cacert.crt",
                 },  # Used for other Podman and other Go libraries
-                {"name": "DEBUG", "value": "false"},
+                {"name": "DEBUG", "value": str(self.executor_config.get("DEBUG", False)).lower()},
                 {"name": "HTTP_PROXY", "value": self.executor_config.get("HTTP_PROXY", "")},
                 {"name": "HTTPS_PROXY", "value": self.executor_config.get("HTTPS_PROXY", "")},
                 {"name": "NO_PROXY", "value": self.executor_config.get("NO_PROXY", "")},


### PR DESCRIPTION
Making the following changes:
- Adding JOB_REGISTRATION_TIMEOUT to take effect on generating the build registration token. 
- Adding the DEBUG option to the kubernetesPodman executor.
- Fixed issue logging out cached tag