### PR TITLE
refactor: move quota logic from api endpoints

### DIFF
--- a/data/model/__init__.py
+++ b/data/model/__init__.py
@@ -107,6 +107,12 @@ class TooManyLoginAttemptsException(Exception):
         self.retry_after = retry_after
 
 
+class QuotaExceeded(DataModelException):
+    def __init__(self):
+        msg = "Quota has been exceeded on namespace"
+        super(QuotaExceeded, self).__init__(msg)
+
+
 class Config(object):
     def __init__(self):
         self.app_config = None

--- a/data/model/namespacequota.py
+++ b/data/model/namespacequota.py
@@ -33,6 +33,8 @@ def verify_namespace_quota(repository_ref):
 def verify_namespace_quota_force_cache(repository_ref):
     force_cache_repo_size(repository_ref)
     namespace_size = get_namespace_size(repository_ref.namespace_name)
+    if namespace_size is None:
+        namespace_size = 0
     return check_limits(repository_ref.namespace_name, namespace_size)
 
 

--- a/endpoints/v2/errors.py
+++ b/endpoints/v2/errors.py
@@ -144,11 +144,9 @@ class LayerTooLarge(V2RegistryException):
             )
 
 
-class QuotaExceeded(V2RegistryException):
-    def __init__(self):
-        super(QuotaExceeded, self).__init__(
-            "DENIED", "Quota has been exceeded on namespace", {}, 403
-        )
+class Denied(V2RegistryException):
+    def __init__(self, msg):
+        super(Denied, self).__init__("DENIED", msg, {}, 403)
 
 
 class Unauthorized(V2RegistryException):


### PR DESCRIPTION
This makes it easier for the pull-thru cache code to incorporate the same logic where needed.