### PR TITLE
superuser: Fix display of build logs (PROJQUAY-3404)

### DIFF
--- a/endpoints/api/superuser_models_interface.py
+++ b/endpoints/api/superuser_models_interface.py
@@ -24,15 +24,12 @@ def user_view(user):
 
 
 class BuildTrigger(
-    namedtuple(
-        "BuildTrigger", ["uuid", "service_name", "pull_robot", "can_read", "can_admin", "for_build"]
-    )
+    namedtuple("BuildTrigger", ["trigger", "pull_robot", "can_read", "can_admin", "for_build"])
 ):
     """
     BuildTrigger represent a trigger that is associated with a build.
 
-    :type uuid: string
-    :type service_name: string
+    :type trigger: RepositoryBuildTrigger
     :type pull_robot: User
     :type can_read: boolean
     :type can_admin: boolean
@@ -40,18 +37,18 @@ class BuildTrigger(
     """
 
     def to_dict(self):
-        if not self.uuid:
+        if not self.trigger and not self.trigger.uuid:
             return None
 
-        build_trigger = BuildTriggerHandler.get_handler(self)
+        build_trigger = BuildTriggerHandler.get_handler(self.trigger)
         build_source = build_trigger.config.get("build_source")
 
         repo_url = build_trigger.get_repository_url() if build_source else None
         can_read = self.can_read or self.can_admin
 
         trigger_data = {
-            "id": self.uuid,
-            "service": self.service_name,
+            "id": self.trigger.uuid,
+            "service": self.trigger.service.name,
             "is_active": build_trigger.is_active(),
             "build_source": build_source if can_read else None,
             "repository_url": repo_url if can_read else None,

--- a/endpoints/api/superuser_models_pre_oci.py
+++ b/endpoints/api/superuser_models_pre_oci.py
@@ -83,7 +83,9 @@ class PreOCIModel(SuperuserDataInterface):
         can_admin = AdministerRepositoryPermission(repo_namespace, repo_name).can()
         job_config = get_job_config(build.job_config)
         phase, status, error = _get_build_status(build)
-        url = userfiles.get_file_url(self.resource_key, get_request_ip(), requires_cors=True)
+        url = ""
+        if build.resource_key is not None:
+            url = userfiles.get_file_url(build.resource_key, get_request_ip(), requires_cors=True)
 
         return RepositoryBuild(
             build.uuid,
@@ -95,14 +97,12 @@ class PreOCIModel(SuperuserDataInterface):
             _create_user(build.pull_robot),
             build.resource_key,
             BuildTrigger(
-                build.trigger.uuid,
-                build.trigger.service.name,
+                build.trigger,
                 _create_user(build.trigger.pull_robot),
                 can_read,
                 can_admin,
                 True,
             ),
-            build.display_name,
             build.display_name,
             build.started,
             job_config,


### PR DESCRIPTION
Build logs in the superuser admin panel do not show up. Errors out due to some syntax errors on the backend which this PR resolves.

- Checks for presence of `resource_key` before constructing archive URL
- Correctly passes a `RepositoryBuildTrigger` object to `BuildTriggerHandler.get_handler()`