### PR TITLE
config: Allow envelope mediatype (PROJQUAY-3386)

### DIFF
--- a/config.py
+++ b/config.py
@@ -765,7 +765,8 @@ class DefaultConfig(ImmutableConfig):
     FEATURE_GENERAL_OCI_SUPPORT = True
     ALLOWED_OCI_ARTIFACT_TYPES = {
         "application/vnd.oci.image.config.v1+json": [
-            "application/vnd.dev.cosign.simplesigning.v1+json"
+            "application/vnd.dev.cosign.simplesigning.v1+json",
+            "application/vnd.dsse.envelope.v1+json",
         ],
         "application/vnd.cncf.helm.config.v1+json": [
             "application/tar+gzip",


### PR DESCRIPTION
Media type required for pushing cosign attestations to the registry as described in the following document.
https://github.com/sigstore/cosign/blob/92ce88e0fa077b50de9f9fe8772cdc893d58ca38/specs/ATTESTATION_SPEC.md#overall-layout.