### PR TITLE
ui: remove deprecated docker-image-id references from ui (PROJQUAY-3418)

### DIFF
--- a/static/directives/repo-tag-history.html
+++ b/static/directives/repo-tag-history.html
@@ -40,13 +40,11 @@
                   <span ng-switch-when="recreate">
                     was recreated pointing to
                     <manifest-link repository="repository"
-                          image-id="entry.docker_image_id"
                           manifest-digest="entry.manifest_digest"></manifest-link>
                   </span>
                   <span ng-switch-when="create">
                     was created pointing to
                     <manifest-link repository="repository"
-                          image-id="entry.docker_image_id"
                           manifest-digest="entry.manifest_digest"></manifest-link>
                   </span>
                   <span ng-switch-when="delete">
@@ -56,21 +54,17 @@
                   <span ng-switch-when="move">
                     was moved to
                     <manifest-link repository="repository"
-                          image-id="entry.docker_image_id"
                           manifest-digest="entry.manifest_digest"></manifest-link>
                     from
                     <manifest-link repository="repository"
-                          image-id="entry.old_docker_image_id"
                           manifest-digest="entry.old_manifest_digest"></manifest-link>
                   </span>
                   <span ng-switch-when="revert">
                     was reverted to
                     <manifest-link repository="repository"
-                          image-id="entry.docker_image_id"
                           manifest-digest="entry.manifest_digest"></manifest-link>
                     from
                     <manifest-link repository="repository"
-                          image-id="entry.old_docker_image_id"
                           manifest-digest="entry.old_manifest_digest"></manifest-link>
                   </span>
                 </span>
@@ -90,19 +84,16 @@
                   <a ng-switch-when="delete" ng-click="askRestoreTag(entry, true)">
                     Restore to
                     <manifest-link repository="repository"
-                          image-id="entry.docker_image_id"
                           manifest-digest="entry.manifest_digest"></manifest-link>
                   </a>
                   <a ng-switch-when="move" ng-click="askRestoreTag(entry, false)">
                     Revert to
                     <manifest-link repository="repository"
-                          image-id="entry.old_docker_image_id"
                           manifest-digest="entry.old_manifest_digest"></manifest-link>
                   </a>
                   <a ng-switch-when="revert" ng-click="askRestoreTag(entry, false)">
                     Restore to
                     <manifest-link repository="repository"
-                          image-id="entry.old_docker_image_id"
                           manifest-digest="entry.old_manifest_digest"></manifest-link>
                   </a>
                 </span>

--- a/static/directives/tag-operations-dialog.html
+++ b/static/directives/tag-operations-dialog.html
@@ -47,9 +47,9 @@
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal"
                   aria-hidden="true" ng-show="!addingTag">&times;</button>
-          <h4 class="modal-title">{{ isAnotherImageTag(toTagImage, tagToCreate) ? 'Move' : 'Add' }} Tag to {{ toTagManifestDigest ? ('Manifest ' + toTagManifestDigest.substr(0, 19)) : ('Image ' + toTagImage.substr(0, 12)) }}</h4>
+          <h4 class="modal-title">{{ isAnotherImageTag(toTagManifestDigest, tagToCreate) ? 'Move' : 'Add' }} Tag to {{ 'Manifest ' + toTagManifestDigest.substr(0, 19) }}</h4>
         </div>
-        <form name="addTagForm" ng-submit="createOrMoveTag(toTagImage, tagToCreate, toTagManifestDigest);">
+        <form name="addTagForm" ng-submit="createOrMoveTag(toTagManifestDigest, tagToCreate);">
           <div class="modal-body">
             <div class="cor-loader" ng-show="addingTag"></div>
             <div ng-show="!addingTag">
@@ -59,22 +59,22 @@
                      ng-disabled="creatingTag" autofocus required>
 
               <div style="margin: 10px; margin-top: 20px;"
-                   ng-show="isOwnedTag(toTagImage, tagToCreate)">
+                   ng-show="isOwnedTag(toTagManifestDigest, tagToCreate)">
                 Note: <span class="label tag label-default">{{ tagToCreate }}</span> is already applied to this image.
               </div>
 
               <div style="margin: 10px; margin-top: 20px;"
-                   ng-show="isAnotherImageTag(toTagImage, tagToCreate)">
+                   ng-show="isAnotherImageTag(toTagManifestDigest, tagToCreate)">
                 Note: <span class="label tag label-default">{{ tagToCreate }}</span> is already applied to another image. This will <b>move</b> the tag.
               </div>
             </div>
           </div>
           <div class="modal-footer" ng-show="!addingTag">
             <button type="submit" class="btn btn-primary"
-                    ng-disabled="addTagForm.$invalid || isOwnedTag(toTagImage, tagToCreate)"
-                    ng-class="isAnotherImageTag(toTagImage, tagToCreate) ? 'btn-warning' : 'btn-primary'"
+                    ng-disabled="addTagForm.$invalid || isOwnedTag(toTagManifestDigest, tagToCreate)"
+                    ng-class="isAnotherImageTag(toTagManifestDigest, tagToCreate) ? 'btn-warning' : 'btn-primary'"
                     ng-show="!creatingTag">
-              {{ isAnotherImageTag(toTagImage, tagToCreate) ? 'Move Tag' : 'Create Tag' }}
+              {{ isAnotherImageTag(toTagManifestDigest, tagToCreate) ? 'Move Tag' : 'Create Tag' }}
             </button>
             <button class="btn btn-default" data-dismiss="modal" ng-show="!addingTag">Cancel</button>
           </div>
@@ -137,7 +137,7 @@
   <!-- Restore Tag Confirm -->
   <div class="cor-confirm-dialog"
        dialog-context="restoreTagInfo"
-       dialog-action="restoreTag(info.tag, info.image_id, info.manifest_digest, callback)"
+       dialog-action="restoreTag(info.tag, info.manifest_digest, callback)"
        dialog-title="Restore Tag"
        dialog-action-title="Restore Tag">
 
@@ -148,7 +148,6 @@
     Are you sure you want to restore tag
     <span class="label label-default tag">{{ restoreTagInfo.tag.name }}</span> to image
     <manifest-link repository="repository"
-                   image-id="restoreTagInfo.image_id"
                    manifest-digest="restoreTagInfo.manifest_digest"></manifest-link>?
   </div>
 

--- a/static/js/directives/repo-view/repo-panel-tags.js
+++ b/static/js/directives/repo-view/repo-panel-tags.js
@@ -373,7 +373,7 @@ angular.module('quay').directive('repoPanelTags', function () {
         if ($scope.inReadOnlyMode) {
           return;
         }
-        $scope.tagActionHandler.askAddTag(tag.image_id, tag.manifest_digest);
+        $scope.tagActionHandler.askAddTag(tag.manifest_digest);
       };
 
       $scope.showLabelEditor = function(tag) {

--- a/static/js/directives/ui/manifest-link/manifest-link.component.html
+++ b/static/js/directives/ui/manifest-link/manifest-link.component.html
@@ -1,10 +1,4 @@
 <span class="manifest-link">
-    <span class="id-label" ng-if="::!$ctrl.hasSHA256($ctrl.manifestDigest)"
-            data-title="The Docker V1 ID for this image. This ID is not content addressable nor is it stable across pulls."
-            data-container="body"
-            ng-click="$ctrl.showCopyBox()"
-            bs-tooltip>V1ID</span>
-
     <span class="id-label cas" ng-if="::$ctrl.hasSHA256($ctrl.manifestDigest)"
             data-title="The content-addressable SHA256 hash of this tag."
             data-container="body"
@@ -26,7 +20,7 @@
             <h4 class="modal-title"><span ng-if="$ctrl.hasSHA256($ctrl.manifestDigest)">Manifest SHA256</span><span ng-if="!$ctrl.hasSHA256($ctrl.manifestDigest)">V1 ID</span></h4>
             </div>
             <div class="modal-body">
-            <div class="copy-box" value="$ctrl.hasSHA256($ctrl.manifestDigest) ? $ctrl.manifestDigest : $ctrl.imageId"></div>            
+            <div class="copy-box" value="$ctrl.manifestDigest"></div>
             </div>
             <div class="modal-footer" ng-show="!working">
             <button type="button" class="btn btn-default" ng-click="$ctrl.hideCopyBox()">Close</button>

--- a/static/js/directives/ui/tag-operations-dialog.js
+++ b/static/js/directives/ui/tag-operations-dialog.js
@@ -66,23 +66,23 @@ angular.module('quay').directive('tagOperationsDialog', function () {
         return false;
       };
 
-      $scope.isAnotherImageTag = function(image, tag) {
+      $scope.isAnotherImageTag = function(manifest_digest, tag) {
         if (!$scope.repositoryTags) { return; }
 
         var found = $scope.repositoryTags[tag];
         if (found == null) { return false; }
-        return found.image_id != image;
+        return found.manifest_digest != manifest_digest;
       };
 
-      $scope.isOwnedTag = function(image, tag) {
+      $scope.isOwnedTag = function(manifest_digest, tag) {
         if (!$scope.repositoryTags) { return; }
 
         var found = $scope.repositoryTags[tag];
         if (found == null) { return false; }
-        return found.image_id == image;
+        return found.manifest_digest == manifest_digest;
       };
 
-      $scope.createOrMoveTag = function(image, tag, opt_manifest_digest) {
+      $scope.createOrMoveTag = function(manifest_digest, tag) {
         if (!$scope.repository.can_write) { return; }
         if ($scope.alertOnTagOpsDisabled()) {
           return;
@@ -96,12 +96,8 @@ angular.module('quay').directive('tagOperationsDialog', function () {
         };
 
         var data = {};
-        if (image) {
-          data['image'] = image;
-        }
-
-        if (opt_manifest_digest) {
-          data['manifest_digest'] = opt_manifest_digest;
+        if (manifest_digest) {
+          data['manifest_digest'] = manifest_digest;
         }
 
         var errorHandler = ApiService.errorDisplay('Cannot create or move tag', function(resp) {
@@ -202,7 +198,7 @@ angular.module('quay').directive('tagOperationsDialog', function () {
         }, errorHandler);
       };
 
-      $scope.restoreTag = function(tag, image_id, opt_manifest_digest, callback) {
+      $scope.restoreTag = function(tag, manifest_digest, callback) {
         if (!$scope.repository.can_write) { return; }
 
         var params = {
@@ -211,12 +207,8 @@ angular.module('quay').directive('tagOperationsDialog', function () {
         };
 
         var data = {
-          'image': image_id
+          'manifest_digest': manifest_digest
         };
-
-        if (opt_manifest_digest) {
-          data['manifest_digest'] = opt_manifest_digest;
-        }
 
         var errorHandler = ApiService.errorDisplay('Cannot restore tag', callback);
         ApiService.restoreTag(data, params).then(function() {
@@ -333,14 +325,13 @@ angular.module('quay').directive('tagOperationsDialog', function () {
           };
         },
 
-        'askAddTag': function(image, opt_manifest_digest) {
+        'askAddTag': function(manifest_digest) {
           if ($scope.alertOnTagOpsDisabled()) {
             return;
           }
 
           $scope.tagToCreate = '';
-          $scope.toTagImage = image;
-          $scope.toTagManifestDigest = opt_manifest_digest;
+          $scope.toTagManifestDigest = manifest_digest;
           $scope.addingTag = false;
           $scope.addTagForm.$setPristine();
           $element.find('#createOrMoveTagModal').modal('show');
@@ -382,15 +373,14 @@ angular.module('quay').directive('tagOperationsDialog', function () {
           };
         },
 
-        'askRestoreTag': function(tag, image_id, opt_manifest_digest) {
+        'askRestoreTag': function(tag, manifest_digest) {
           if ($scope.alertOnTagOpsDisabled()) {
             return;
           }
 
           $scope.restoreTagInfo = {
             'tag': tag,
-            'image_id': image_id,
-            'manifest_digest': opt_manifest_digest
+            'manifest_digest': manifest_digest,
           };
 
           $element.find('#restoreTagModal').modal('show');


### PR DESCRIPTION
Remove docker id references from ui. Tags should now be referencing
the manifest it is pointing to
<img width="1368" alt="Screen Shot 2022-03-23 at 3 27 11 PM" src="https://user-images.githubusercontent.com/2530351/159780773-f83a703c-3a65-43e3-ae45-8661e8cd0c80.png">
<img width="1368" alt="Screen Shot 2022-03-23 at 3 27 20 PM" src="https://user-images.githubusercontent.com/2530351/159780777-3035e1d2-19f8-4776-af6f-68da64e84531.png">
<img width="861" alt="Screen Shot 2022-03-23 at 3 27 34 PM" src="https://user-images.githubusercontent.com/2530351/159780779-06a12822-9c0f-415b-a309-b54120ed68d2.png">
.