### PR TITLE
nginx: Increase body timeout for buildman (PROJQUAY-3406)

### DIFF
--- a/conf/nginx/nginx.conf.jnj
+++ b/conf/nginx/nginx.conf.jnj
@@ -69,6 +69,10 @@ http {
         listen 55443 ssl http2 default;
         ssl on;
 
+        # Required for gRPC streaming
+        client_header_timeout 2h;
+        client_body_timeout 2h;
+
         location / {
                  grpc_pass grpc://build_manager_server;
         }


### PR DESCRIPTION
Nginx currently kills body reads that last longer than 60s. Bi-directional RPC calls like streaming logs requires longer reads. This change extends that timeout.