### PR TITLE
proxy: don't store entire blob in memory when caching

### DIFF
--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -3,16 +3,13 @@ The proxy module provides the means to proxy images from other registry instance
 Registries following the distribution spec are supported.
 """
 from __future__ import annotations
-from typing import Any
 import re
-import json
 
 import requests
 
 from app import model_cache
 from data.cache import cache_key
 from data.database import ProxyCacheConfig
-from digest.digest_tools import sha256_digest
 
 
 WWW_AUTHENTICATE_REGEX = re.compile(r'(\w+)[=] ?"?([^",]+)"?')
@@ -94,12 +91,9 @@ class Proxy:
         resp = self.get(
             url,
             allow_redirects=True,
+            stream=True,
         )
-        size = resp.headers.get("content-length")
-        content_digest = sha256_digest(resp.content)
-        if digest != content_digest:
-            UpstreamRegistryError(f"digest mismatch, expected {digest}, got {content_digest}")
-        return resp.content, size
+        return resp
 
     def blob_exists(self, digest: str):
         url = f"{self.base_url}/v2/{self._repo}/blobs/{digest}"

--- a/proxy/fixtures.py
+++ b/proxy/fixtures.py
@@ -1,3 +1,4 @@
+import io
 from unittest.mock import MagicMock
 
 import pytest
@@ -29,7 +30,7 @@ def proxy_manifest_response():
             return {"status": 200}
 
         def mock_get_blob(digest):
-            return b"test", 4
+            return io.BytesIO(b"test"), 4
 
         proxy_mock = MagicMock()
         proxy_mock.manifest_exists.side_effect = mock_manifest_exists


### PR DESCRIPTION
also uses blob uploader to upload the blob to storage.

[PROJQUAY-3459](https://issues.redhat.com/browse/PROJQUAY-3459)