### PR TITLE
ui: Copy build logs error fix (PROJQUAY-3405)

### DIFF
--- a/static/directives/build-logs-view.html
+++ b/static/directives/build-logs-view.html
@@ -1,7 +1,7 @@
 <div class="build-logs-view-element" ng-class="useTimestamps ? 'with-timestamps' : ''">
   <span ng-show="logEntries">
     <button id="copyButton" class="btn btn-primary copy-button"
-            clipboard-copy="#{{ ::buildLogsText }}">
+            clipboard-copy="#build-logs">
       <i class="fa fa-clipboard"></i>Copy Logs
     </button>
   </span>

--- a/static/directives/super-user-build-logs.html
+++ b/static/directives/super-user-build-logs.html
@@ -12,6 +12,7 @@
   <div class="resource-view" resource="buildResource" error-message="'Cannot find or load build'"
        ng-show="buildId">
     <div class="build-logs-view"
+         id="build-logs"
          build="build"
          use-timestamps="showLogTimestamps"
          is-super-user="true"

--- a/static/partials/build-view.html
+++ b/static/partials/build-view.html
@@ -55,6 +55,7 @@
 
         <!-- Build Logs -->
         <div class="build-logs-view"
+             id="build-logs"
              build="originalBuild"
              use-timestamps="showLogTimestamps"
              build-updated="setUpdatedBuild(build)"


### PR DESCRIPTION
Currently when viewing the build logs and selecting `Copy Logs` the copy to clipboard will fail. This is because the content of the logs was being passed to the copy-clipboard function when it requires the ID of the element containing the text to copy. This passes the selector of the ID of the element containing the build logs.