### PR TITLE
chore: Remove unused dep (PROJQUAY-3437) 

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -2,11 +2,6 @@
     {
         "format": "Python", 
         "license": "MIT License", 
-        "project": "aiowsgi"
-    }, 
-    {
-        "format": "Python", 
-        "license": "MIT License", 
         "project": "alembic"
     }, 
     {

--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -2,7 +2,6 @@
 # needed for building with cachito
 # https://github.com/release-engineering/cachito/blob/master/docs/pip.md
 #
-aiowsgi==0.7
 alembic==1.3.3
 aniso8601 @ git+https://github.com/DevTable/aniso8601-fake.git@bd7762c7dea0498706d3f57db60cd8a8af44ba90
 APScheduler==3.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ git+https://github.com/DevTable/aniso8601-fake.git@bd7762c7dea0498706d3f57db60cd
 git+https://github.com/quay/py-bitbucket.git@3ba167408d92eb4ba2cae78c0047b8f1e8821c67#egg=py_bitbucket
 git+https://github.com/DevTable/python-etcd.git@f1168cb02a2a8c83bec1108c6fcd8615ef463b14#egg=python_etcd
 git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380#egg=supervisor_stdout
-aiowsgi==0.7
 alembic==1.3.3
 APScheduler==3.6.3
 attrs==19.3.0


### PR DESCRIPTION
* Removes `aiowsgi`, which required `waitress`
* Follow up to https://github.com/quay/quay/pull/1202

```
vagrant@ibm-p8-kvm-03-guest-02 ~/git/forks/quay/quay (fix/remove_aiowsgi) $ docker exec -it -u root quay-quay bash -c "pip3 freeze | grep aiowsgi"
vagrant@ibm-p8-kvm-03-guest-02 ~/git/forks/quay/quay (fix/remove_aiowsgi) $ docker exec -it -u root quay-quay bash -c "pip3 freeze | grep waitress"
```