### PR TITLE
endpoints/v2: handle generic proxy related errors

### DIFF
--- a/data/cache/cache_key.py
+++ b/data/cache/cache_key.py
@@ -9,11 +9,13 @@ class CacheKey(namedtuple("CacheKey", ["key", "expiration"])):
     pass
 
 
-def for_upstream_registry_token(org_name, repo_name, expires_in):
+def for_upstream_registry_token(org_name, upstream_registry, repo_name, expires_in):
     """
     Returns a cache key for an upstream registry auth token.
     """
-    key = f"upstream_token__{org_name}_{repo_name}"
+    # use / to separate input values because org names cannot contain /, meaning
+    # that the token cannot be spoofed by a malicious actor.
+    key = f"upstream_token__{org_name}/{upstream_registry}/{repo_name}"
     return CacheKey(key, expires_in)
 
 

--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -170,7 +170,9 @@ class Proxy:
 
         resp = self._session.get(auth_url, auth=basic_auth)
         if not resp.ok:
-            raise Exception(f"Failed to get token from '{auth_url}', {resp.status_code}")
+            raise UpstreamRegistryError(
+                f"Failed to get token from '{auth_url}', {resp.status_code}"
+            )
 
         resp_json = resp.json()
         token = resp_json.get("token")
@@ -187,6 +189,7 @@ class Proxy:
     def _cache_key(self, expires_in=TOKEN_VALIDITY_LIFETIME_S):
         key = cache_key.for_upstream_registry_token(
             self._config.organization.username,
+            self._config.upstream_registry,
             self._repo,
             f"{expires_in}s",
         )


### PR DESCRIPTION
also add upstream registry to proxy cache key. if a user changes their
mind about what registry to proxy, we shouldn't try to reuse the token.

----

this can be tested by setting up a proxy org and specifying the wrong credentials for the proxied registry. see https://gist.github.com/flavianmissi/48a7bd19270fd12876c488fa3332fb3b#proxy--auth-for-quayio-namespace for step-by-step setup
the client should see something like:
```
Error: initializing source docker://quay:8080/fmissi-cache/busybox-v2s1:latest: reading manifest latest in quay:8080/fmissi-cache/busybox-v2s1: unknown: Error requesting upstream registry: Failed to get token from 'https://quay.io/v2/auth?service=quay.io&scope=repository:fmisse/busybox-v2s1:pull', 429
```
(in my case I'm getting a 429 due to too many attempts to login with the wrong credentials 🤷)