### PR TITLE
builders: add a check for expired key (PROJQUAY-3489)

### DIFF
--- a/buildman/orchestrator.py
+++ b/buildman/orchestrator.py
@@ -348,8 +348,10 @@ class RedisOrchestrator(Orchestrator):
 
                 # Mark key as expired. This key is used to track post job cleanup in the callback,
                 # to allow another manager to pickup the cleanup if this fails.
-                self._client.set(slash_join(key, REDIS_EXPIRED_SUFFIX), expired_value)
-                self._client.delete(key)
+                if expired_value:
+                    self._client.set(slash_join(key, REDIS_EXPIRED_SUFFIX), expired_value)
+                    self._client.delete(key)
+
         except redis.ConnectionError:
             _sleep_orchestrator()
         except redis.RedisError as re:


### PR DESCRIPTION
This fixes the crash:

DataError: Invalid input of type: 'NoneType'. Convert to a bytes, string, int or float first.

This is happening because we access a value of a key which has expired