### PR TITLE
chore: Align requirements files (PROJQUAY-3184)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,16 +209,16 @@ local-dev-up: local-dev-clean node_modules | quay-build-image
 	@echo "You can now access the frontend at http://localhost:8080"
 
 local-docker-rebuild:
-	docker-compose up -d redis --build
-	docker-compose up -d quay-db --build
+	docker-compose up -d --build redis
+	docker-compose up -d --build quay-db
 	docker exec -it quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
-	DOCKER_USER="$$(id -u):0" docker-compose up -d quay --build
+	DOCKER_USER="$$(id -u):0" docker-compose up -d --build quay
 	docker-compose restart quay
 
 ifeq ($(CLAIR),true)
-	docker-compose up -d clair-db --build
+	docker-compose up -d --build clair-db
 	docker exec -it clair-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
-	docker-compose up -d clair --build
+	docker-compose up -d --build clair
 	docker-compose restart clair
 else
 	@echo "Skipping Clair"

--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -1,24 +1,19 @@
-# See below for guidance and scripts to assist in generating the full dependencies
-# needed for building with cachito
-# https://github.com/release-engineering/cachito/blob/master/docs/pip.md
-#
 alembic==1.3.3
 aniso8601 @ git+https://github.com/DevTable/aniso8601-fake.git@bd7762c7dea0498706d3f57db60cd8a8af44ba90
 APScheduler==3.6.3
 attrs==19.3.0
+Authlib==1.0.0a1
 aws-sam-translator==1.20.1
-aws-xray-sdk==2.4.3
 azure-core==1.8.0
 azure-storage-blob==12.4.0
-Authlib==1.0.0a1
 Babel==2.9.1
 bcrypt==3.1.7
 beautifulsoup4==4.8.2
 bintrees==2.1.0
 bitmath==1.3.3.1
 blinker==1.4
-boto3==1.17.21
-botocore==1.20.21
+boto3==1.20.46
+botocore==1.23.46
 cachetools==4.0.0
 certifi==2019.11.28
 cffi==1.14.3
@@ -39,15 +34,13 @@ Flask-Login==0.4.1
 Flask-Mail==0.9.1
 Flask-Principal==0.4.0
 Flask-RESTful==0.3.7
-funcparserlib==0.3.6
 furl==2.1.0
-future==0.18.2
 futures==3.1.1
 geoip2==3.0.0
-gevent==1.4.0
-greenlet==0.4.15
+gevent==21.8.0
+greenlet==1.1.2
 grpcio==1.30.0
-gunicorn==20.0.4
+gunicorn==20.1.0
 hashids==1.2.0
 html5lib==1.0.1
 idna==2.8
@@ -67,26 +60,24 @@ MarkupSafe==1.1.1
 maxminddb==1.5.2
 mixpanel==4.5.0
 msgpack==0.6.2
-msrest==0.6.19
+msrest==0.6.21
 ndg-httpsclient==0.5.1
 netaddr==0.7.19
 netifaces==0.10.9
 oauthlib==3.1.0
 orderedmultidict==1.0.1
+os-service-types==1.7.0
 oslo.config==7.0.0
 oslo.i18n==3.25.1
 oslo.serialization==2.29.2
 oslo.utils==3.42.1
-os-service-types==1.7.0
 pbr==5.4.4
 peewee==3.13.1
-Pillow==8.3.2
-pip==21.1
-pipdeptree==1.0.0
+Pillow==9.0.1
 ply==3.11
 prometheus-client==0.7.1
 protobuf==3.15.0
-psutil==5.6.7
+psutil==5.9.0
 psycopg2-binary==2.8.4
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
@@ -98,8 +89,8 @@ pymemcache==3.0.0
 PyMySQL==0.9.3
 pyOpenSSL==19.1.0
 pyparsing==2.4.6
-PyPDF2 @ https://files.pythonhosted.org/packages/b4/01/68fcc0d43daf4c6bdbc6b33cc3f77bda531c86b174cac56ef0ffdb96faab/PyPDF2-1.26.0.tar.gz#egg=PyPDF2&cachito_hash=sha256:e28f902f2f0a1603ea95ebe21dff311ef09be3d0f0ef29a3e44a932729564385
-pyrsistent==0.15.7
+PyPDF2==1.26.0
+pyrsistent==0.18.0
 python-dateutil==2.8.1
 python-editor==1.0.4
 python-etcd @ git+https://github.com/DevTable/python-etcd.git@f1168cb02a2a8c83bec1108c6fcd8615ef463b14
@@ -122,13 +113,11 @@ requests-aws4auth==0.9
 requests-file==1.4.3
 requests-oauthlib==1.3.0
 rfc3986==1.3.2
-s3transfer==0.3.2
+s3transfer==0.5.1
 semantic-version==2.8.4
-setuptools==50.3.0
-setuptools-scm[toml]==4.1.2
 six==1.14.0
 soupsieve==1.9.5
-SQLAlchemy==1.3.13
+SQLAlchemy==1.4.31
 stevedore==1.31.0
 stringscore==0.1.0
 stripe==2.42.0
@@ -138,21 +127,22 @@ supervisor-stdout @ git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d
 text-unidecode==1.3
 tldextract==2.2.2
 toposort==1.5
-txaio==20.4.1
 tzlocal==2.0.0
 urllib3==1.25.8
 webencodings==0.5.1
 WebOb==1.8.6
 websocket-client==0.57.0
 Werkzeug==0.16.1
-wheel==0.35.1
-wrapt==1.11.2
+wrapt==1.13.3
 xhtml2pdf==0.2.4
 yapf==0.29.0
 zipp==2.1.0
-zope.interface==5.1.2
+zope.event==4.5.0
+zope.interface==5.4.0
 
 # Build dependencies
 Cython==0.29.23
 toml==0.10.2
 jsonpickle==1.2
+setuptools==56.0.0
+setuptools-scm[toml]==4.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
-git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b#egg=cnr_server
-git+https://github.com/DevTable/aniso8601-fake.git@bd7762c7dea0498706d3f57db60cd8a8af44ba90#egg=aniso8601
-git+https://github.com/quay/py-bitbucket.git@3ba167408d92eb4ba2cae78c0047b8f1e8821c67#egg=py_bitbucket
-git+https://github.com/DevTable/python-etcd.git@f1168cb02a2a8c83bec1108c6fcd8615ef463b14#egg=python_etcd
-git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380#egg=supervisor_stdout
 alembic==1.3.3
+aniso8601 @ git+https://github.com/DevTable/aniso8601-fake.git@bd7762c7dea0498706d3f57db60cd8a8af44ba90
 APScheduler==3.6.3
 attrs==19.3.0
 Authlib==1.0.0a1
@@ -20,9 +16,10 @@ boto3==1.20.46
 botocore==1.23.46
 cachetools==4.0.0
 certifi==2019.11.28
-cffi==1.13.2
+cffi==1.14.3
 chardet==3.0.4
 click==7.1.2
+cnr-server @ git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b
 cryptography==3.3.2
 DateTime==4.3
 debtcollector==1.22.0
@@ -37,7 +34,6 @@ Flask-Login==0.4.1
 Flask-Mail==0.9.1
 Flask-Principal==0.4.0
 Flask-RESTful==0.3.7
-funcparserlib==1.0.0a0
 furl==2.1.0
 futures==3.1.1
 geoip2==3.0.0
@@ -85,7 +81,8 @@ psutil==5.9.0
 psycopg2-binary==2.8.4
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pycparser==2.19
+py-bitbucket @ git+https://github.com/quay/py-bitbucket.git@3ba167408d92eb4ba2cae78c0047b8f1e8821c67
+pycparser==2.20
 PyGithub==1.45
 PyJWT==1.7.1
 pymemcache==3.0.0
@@ -96,6 +93,7 @@ PyPDF2==1.26.0
 pyrsistent==0.18.0
 python-dateutil==2.8.1
 python-editor==1.0.4
+python-etcd @ git+https://github.com/DevTable/python-etcd.git@f1168cb02a2a8c83bec1108c6fcd8615ef463b14
 python-gitlab==2.0.0
 python-keystoneclient==3.22.0
 python-ldap==3.4.0
@@ -125,6 +123,7 @@ stringscore==0.1.0
 stripe==2.42.0
 supervisor==4.1.0
 supervisor-logging==0.0.9
+supervisor-stdout @ git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380
 text-unidecode==1.3
 tldextract==2.2.2
 toposort==1.5
@@ -140,3 +139,10 @@ yapf==0.29.0
 zipp==2.1.0
 zope.event==4.5.0
 zope.interface==5.4.0
+
+# Build dependencies
+Cython==0.29.23
+toml==0.10.2
+jsonpickle==1.2
+setuptools==56.0.0
+setuptools-scm[toml]==4.1.2


### PR DESCRIPTION
* First step in getting rid of `requirements-osbs.txt`
* Updates versions in `requirements-osbs.txt` to match `requirements.txt`
* Adds support for docker-compose v1 to `make local-docker-rebuild`
* Removes `funcparserlib` - looks unused
* Adds some additional build dependencies