### PR TITLE
chore: Bump cython version (PROJQUAY-3184)

### DIFF
--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -141,7 +141,7 @@ zope.event==4.5.0
 zope.interface==5.4.0
 
 # Build dependencies
-Cython==0.29.23
+Cython==3.0a9
 toml==0.10.2
 jsonpickle==1.2
 pip==21.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -141,7 +141,7 @@ zope.event==4.5.0
 zope.interface==5.4.0
 
 # Build dependencies
-Cython==0.29.23
+Cython==3.0a9
 toml==0.10.2
 jsonpickle==1.2
 pip==21.1


### PR DESCRIPTION
* Bumps Cython version as required by `wheel` `ERROR: Could not find a version that satisfies the requirement Cython>=3.0a9 (from versions: 0.29.23)`