### PR TITLE
nginx: Update rate limiting for tags API (PROJQUAY-3283)

### DIFF
--- a/conf/nginx/rate-limiting.conf.jnj
+++ b/conf/nginx/rate-limiting.conf.jnj
@@ -57,10 +57,10 @@ limit_req_zone $namespaced_http2_bucket zone=namespaced_dynamicauth_light_http2:
 # limit is very low on purpose but should allow for the burst of traffic
 # required for a registry operation. The burst number should also vary per
 # endpoint.
-limit_req_zone $http1_bucket zone=dynamicauth_heavy_http1:10m rate=20r/s;
-limit_req_zone $http2_bucket zone=dynamicauth_heavy_http2:10m rate=200r/s;
-limit_req_zone $namespaced_http1_bucket zone=namespaced_dynamicauth_heavy_http1:10m rate=20r/s;
-limit_req_zone $namespaced_http2_bucket zone=namespaced_dynamicauth_heavy_http2:10m rate=200r/s;
+limit_req_zone $http1_bucket zone=dynamicauth_heavy_http1:10m rate=5r/s;
+limit_req_zone $http2_bucket zone=dynamicauth_heavy_http2:10m rate=50r/s;
+limit_req_zone $namespaced_http1_bucket zone=namespaced_dynamicauth_heavy_http1:10m rate=5r/s;
+limit_req_zone $namespaced_http2_bucket zone=namespaced_dynamicauth_heavy_http2:10m rate=50r/s;
 
 limit_req_status 429;
 limit_req_log_level warn;


### PR DESCRIPTION
Current rate limits for list tags is too high and causing
issues in quay.io reduce it to saner limits