### PR TITLE
secscan: fix database manifest allocator for securityworker (PROJQUAY-3501)

### DIFF
--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -296,7 +296,7 @@ def test_perform_indexing_needs_reindexing_skip_unsupported(initialized_db, set_
         ),
         # Old hash and recent scan, don't rescan
         (IndexStatus.COMPLETED, {"status": "old hash"}, 0, True),
-        # Old hash and old scan, rescan
+        # old hash and old scan, rescan
         (
             IndexStatus.COMPLETED,
             {"status": "old hash"},
@@ -354,6 +354,8 @@ def test_manifest_iterator(
         indexer_state,
         Manifest.select(fn.Min(Manifest.id)).scalar(),
         Manifest.select(fn.Max(Manifest.id)).scalar(),
+        reindex_threshold=datetime.utcnow()
+        - timedelta(seconds=app.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"]),
     )
 
     count = 0


### PR DESCRIPTION
Have the securityworker send an abort signal in the case where the
conditions for indexing a manifest are not met after running the
candidate query. This could be when:
- a manifest has a reference to a manifestsecuritystatus instance
- the manifestsecuritystatus reindex threshold is no longer
valid (because it was recently updated)

This signals that another worker overlapped, and allows the current
worker to move on to the next set.