### PR TITLE
namespacequota: return 0 when namespace has no size yet

### DIFF
--- a/data/model/namespacequota.py
+++ b/data/model/namespacequota.py
@@ -166,9 +166,6 @@ def verify_namespace_quota_force_cache(repository_ref):
 def verify_namespace_quota_during_upload(repository_ref):
     size = model.repository.get_size_during_upload(repository_ref._db_id)
     namespace_size = get_namespace_size(repository_ref.namespace_name)
-    if namespace_size is None:
-        namespace_size = 0
-
     return check_limits(repository_ref.namespace_name, size + namespace_size)
 
 
@@ -273,7 +270,7 @@ def get_namespace_size(namespace_name):
         .where(Repository.namespace_user == namespace.id)
     ).scalar()
 
-    return namespace_size
+    return namespace_size or 0
 
 
 def get_repo_quota_for_view(namespace_name, repo_name):


### PR DESCRIPTION
for non-cache orgs, get_namespace_size will almost never be called for
an org with no manifests.
for cache orgs, get_namespace_size is garanteed to be called once when
the org doesn't have any manifests: a first pull from a cache org will
ensure that.

this change does not negatively affect callers, as no callers rely on
get_namespace_size to return None.

fixes [PROJQUAY-3538](https://issues.redhat.com/browse/PROJQUAY-3538)