### PR TITLE
proxy: make upstream related error message more actionable

### DIFF
--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -23,7 +23,10 @@ REGISTRY_URLS = {"docker.io": "registry-1.docker.io"}
 
 class UpstreamRegistryError(Exception):
     def __init__(self, detail):
-        msg = f"Error requesting upstream registry: {detail}"
+        msg = (
+            "the requested image may not exist in the upstream registry, or the configured "
+            f"Quay organization credentials have insufficient rights to access it ({detail})"
+        )
         super().__init__(msg)
 
 


### PR DESCRIPTION
Example trying to pull a private image after having configured a proxy org without any credentials:
![image](https://user-images.githubusercontent.com/444856/162935050-90f0c826-0404-4de7-a2f8-1205e2872a82.png)


fixes [PROJQUAY-3553](https://issues.redhat.com//browse/PROJQUAY-3553)