### PR TITLE
secscan: add indexer service request duration metric (PROJQUAY-3501)

### DIFF
--- a/util/metrics/prometheus.py
+++ b/util/metrics/prometheus.py
@@ -58,6 +58,11 @@ gc_namespaces_purged = Counter(
 )
 gc_iterations = Counter("quay_gc_iterations", "number of iterations by the GCWorker")
 
+secscan_index_request_duration = Histogram(
+    "quay_secscan_index_duration_seconds",
+    "seconds taken to make an index request to the secscan service",
+)
+
 
 PROMETHEUS_PUSH_INTERVAL_SECONDS = 30
 ONE_DAY_IN_SECONDS = 60 * 60 * 24


### PR DESCRIPTION
Add histogram for request duration on indexer service. Add random
batch to manifest iterator to reduce duplicate work while manifests
are being backfilled.