### PR TITLE
builders: Set backoffLimit to 1 (PROJQUAY-3587)

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -602,6 +602,7 @@ class KubernetesExecutor(BuilderExecutor):
             },
             "spec": {
                 "activeDeadlineSeconds": self.executor_config.get("MAXIMUM_JOB_TIME", 7200),
+                "backoffLimit": 1,
                 "ttlSecondsAfterFinished": self.executor_config.get(
                     "RETENTION_AFTER_FINISHED", 120
                 ),


### PR DESCRIPTION
Setting the backoffLimit to 1 for kubernetes and kubernetesPodman builds. Prevents subsequent attempts from failing due to the token expiring. Having the job recreate pods is unnecessary as the build manager already has the retry logic.