### PR TITLE
secscan: optimize deduplicating manifests for indexing in securityworker (PROJQUAY-3501)

### DIFF
--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -157,6 +157,7 @@ def test_perform_indexing_whitelist(initialized_db, set_secscan_config):
         "abc",
     )
 
+    secscan.perform_indexing_recent_manifests()
     next_token = secscan.perform_indexing()
 
     assert next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
@@ -189,6 +190,7 @@ def test_perform_indexing_failed(initialized_db, set_secscan_config):
             metadata_json={},
         )
 
+    secscan.perform_indexing_recent_manifests()
     secscan.perform_indexing()
 
     assert ManifestSecurityStatus.select().count() == Manifest.select().count()
@@ -218,6 +220,7 @@ def test_perform_indexing_failed_within_reindex_threshold(initialized_db, set_se
             metadata_json={},
         )
 
+    secscan.perform_indexing_recent_manifests()
     secscan.perform_indexing()
 
     assert ManifestSecurityStatus.select().count() == Manifest.select().count()
@@ -247,6 +250,7 @@ def test_perform_indexing_needs_reindexing(initialized_db, set_secscan_config):
             metadata_json={},
         )
 
+    secscan.perform_indexing_recent_manifests()
     secscan.perform_indexing()
 
     assert ManifestSecurityStatus.select().count() == Manifest.select().count()
@@ -276,6 +280,7 @@ def test_perform_indexing_needs_reindexing_skip_unsupported(initialized_db, set_
             metadata_json={},
         )
 
+    secscan.perform_indexing_recent_manifests()
     secscan.perform_indexing()
 
     # Since this manifest should not be scanned, the old hash should remain
@@ -392,6 +397,7 @@ def test_perform_indexing_needs_reindexing_within_reindex_threshold(
             metadata_json={},
         )
 
+    secscan.perform_indexing_recent_manifests()
     secscan.perform_indexing()
 
     assert ManifestSecurityStatus.select().count() == Manifest.select().count()
@@ -404,6 +410,7 @@ def test_perform_indexing_api_request_failure_state(initialized_db, set_secscan_
     secscan._secscan_api = mock.Mock()
     secscan._secscan_api.state.side_effect = APIRequestFailure()
 
+    secscan.perform_indexing_recent_manifests()
     next_token = secscan.perform_indexing()
 
     assert next_token is None
@@ -419,6 +426,7 @@ def test_perform_indexing_api_request_index_error_response(initialized_db, set_s
         "xyz",
     )
 
+    secscan.perform_indexing_recent_manifests()
     next_token = secscan.perform_indexing()
     assert next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
     assert ManifestSecurityStatus.select().count() == Manifest.select(fn.Max(Manifest.id)).count()
@@ -435,6 +443,7 @@ def test_perform_indexing_api_request_non_finished_state(initialized_db, set_sec
         "xyz",
     )
 
+    secscan.perform_indexing_recent_manifests()
     next_token = secscan.perform_indexing()
     assert next_token and next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
     assert ManifestSecurityStatus.select().count() == 0
@@ -446,6 +455,7 @@ def test_perform_indexing_api_request_failure_index(initialized_db, set_secscan_
     secscan._secscan_api.state.return_value = {"state": "abc"}
     secscan._secscan_api.index.side_effect = APIRequestFailure()
 
+    secscan.perform_indexing_recent_manifests()
     next_token = secscan.perform_indexing()
 
     assert next_token and next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
@@ -458,6 +468,7 @@ def test_perform_indexing_api_request_failure_index(initialized_db, set_secscan_
         "abc",
     )
 
+    secscan.perform_indexing_recent_manifests()
     next_token = secscan.perform_indexing()
 
     assert next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
@@ -505,6 +516,7 @@ def test_perform_indexing_invalid_manifest(initialized_db, set_secscan_config):
     # Delete all ManifestBlob rows to cause the manifests to be invalid.
     ManifestBlob.delete().execute()
 
+    secscan.perform_indexing_recent_manifests()
     secscan.perform_indexing()
 
     assert ManifestSecurityStatus.select().count() == Manifest.select().count()
@@ -605,6 +617,7 @@ def test_perform_indexing_manifest_list(initialized_db, set_secscan_config):
     secscan = V4SecurityScanner(app, instance_keys, storage)
     secscan._secscan_api = mock.Mock()
 
+    secscan.perform_indexing_recent_manifests()
     secscan.perform_indexing()
 
     assert ManifestSecurityStatus.select().count() == Manifest.select().count()

--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -98,6 +98,7 @@ python-gitlab==2.0.0
 python-keystoneclient==3.22.0
 python-ldap==3.4.0
 python-magic==0.4.15
+python-redis-lock==3.7.0
 python-swiftclient==3.8.1
 pytz==2019.3
 PyYAML==5.4
@@ -105,7 +106,6 @@ raven==6.10.0
 recaptcha2==0.1
 redis==3.5.3
 redis-py-cluster==2.1.3
-redlock==1.2.0
 rehash==1.0.0
 reportlab==3.5.55
 requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,6 +98,7 @@ python-gitlab==2.0.0
 python-keystoneclient==3.22.0
 python-ldap==3.4.0
 python-magic==0.4.15
+python-redis-lock==3.7.0
 python-swiftclient==3.8.1
 pytz==2019.3
 PyYAML==5.4
@@ -105,7 +106,6 @@ raven==6.10.0
 recaptcha2==0.1
 redis==3.5.3
 redis-py-cluster==2.1.3
-redlock==1.2.0
 rehash==1.0.0
 reportlab==3.5.55
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ packages = [
     "PyJWT",
     "pyOpenSSL",
     "raven",
-    "redlock",
     "requests",
     "Werkzeug",
     "xhtml2pdf",

--- a/util/locking.py
+++ b/util/locking.py
@@ -1,7 +1,8 @@
+import functools
 import logging
 
-from redis import RedisError
-from redlock import RedLockFactory, RedLockError
+from redis import Redis, RedisError
+import redis_lock
 
 logger = logging.getLogger(__name__)
 
@@ -12,7 +13,7 @@ class LockNotAcquiredException(Exception):
     """
 
 
-def _redlock_factory(config):
+def _redis_lock_factory(config):
     _redis_info = dict(config["USER_EVENTS_REDIS"])
     _redis_info.update(
         {
@@ -21,14 +22,12 @@ def _redlock_factory(config):
             "single_connection_client": True,
         }
     )
-    lock_factory = RedLockFactory(connection_details=[_redis_info])
-    return lock_factory
+
+    _conn = Redis(**_redis_info)
+
+    return functools.partial(redis_lock.Lock, _conn)
 
 
-# TODO(kleesc): GlobalLock should either renew the lock until the caller is done,
-# or signal that it is no longer valid to the caller. Currently, GlobalLock will
-# just silently expire the redis key, making the lock available again while any
-# ongoing job in a GlobalLock context will still be running
 class GlobalLock(object):
     """
     A lock object that blocks globally via Redis.
@@ -42,15 +41,16 @@ class GlobalLock(object):
     @classmethod
     def configure(cls, config):
         if cls.lock_factory is None:
-            cls.lock_factory = _redlock_factory(config)
+            cls.lock_factory = _redis_lock_factory(config)
 
-    def __init__(self, name, lock_ttl=600):
+    def __init__(self, name, lock_ttl=600, auto_renewal=False):
         if GlobalLock.lock_factory is None:
             raise LockNotAcquiredException("GlobalLock not configured")
 
         self._lock_name = name
         self._lock_ttl = lock_ttl
-        self._redlock = None
+        self._auto_renewal = auto_renewal
+        self._lock = None
 
     def __enter__(self):
         if not self.acquire():
@@ -62,35 +62,35 @@ class GlobalLock(object):
     def acquire(self):
         logger.debug("Acquiring global lock %s", self._lock_name)
         try:
-            self._redlock = GlobalLock.lock_factory.create_lock(
-                self._lock_name, ttl=self._lock_ttl * 1000
+            self._lock = GlobalLock.lock_factory(
+                self._lock_name, expire=self._lock_ttl, auto_renewal=self._auto_renewal
             )
 
-            acquired = self._redlock.acquire()
+            acquired = self._lock.acquire()
             if not acquired:
                 logger.debug("Was unable to not acquire lock %s", self._lock_name)
                 return False
 
             logger.debug("Acquired lock %s", self._lock_name)
             return True
-        except RedLockError:
-            logger.debug("Could not acquire lock %s", self._lock_name)
-            return False
         except RedisError as re:
             logger.debug("Could not connect to Redis for lock %s: %s", self._lock_name, re)
             return False
+        except:
+            logger.debug("Could not acquire lock %s", self._lock_name)
+            return False
 
     def release(self):
-        if self._redlock is not None:
+        if self._lock is not None:
             logger.debug("Releasing lock %s", self._lock_name)
             try:
-                self._redlock.release()
-            except RedLockError:
-                logger.debug("Could not release lock %s", self._lock_name)
+                self._lock.release()
             except RedisError as re:
                 logger.debug(
                     "Could not connect to Redis for releasing lock %s: %s", self._lock_name, re
                 )
+            except:
+                logger.debug("Could not release lock %s", self._lock_name)
 
             logger.debug("Released lock %s", self._lock_name)
-            self._redlock = None
+            self._lock = None

--- a/workers/securityworker/securityworker.py
+++ b/workers/securityworker/securityworker.py
@@ -29,7 +29,7 @@ class SecurityWorker(Worker):
         self.add_operation(self._index_in_scanner, interval)
 
     def _index_in_scanner(self):
-        self._next_token = self._model.perform_indexing(self._next_token)
+        self._next_token = self._model.index_manifests(self._next_token)
 
 
 def create_gunicorn_worker():


### PR DESCRIPTION
Acquire lock on recent manifests batch to prevent multiple workers
from working on the same set.