### PR TITLE
nginx: block v1/tag for helium miner curl calls (PROJQUAY-3594)

### DIFF
--- a/conf/nginx/nginx.conf.jnj
+++ b/conf/nginx/nginx.conf.jnj
@@ -39,6 +39,10 @@ http {
         real_ip_header X-Forwarded-For;
 
         access_log /var/log/nginx/access.log lb_logs;
+
+        if ($miner_tag_block = 1) {
+            return 400;
+        }
     }
 
     server {
@@ -58,6 +62,10 @@ http {
         real_ip_header proxy_protocol;
 
         access_log /var/log/nginx/access.log lb_logs;
+
+        if ($miner_tag_block = 1) {
+            return 400;
+        }
     }
 
     server {
@@ -84,6 +92,10 @@ http {
         real_ip_header proxy_protocol;
 
         access_log /var/log/nginx/access.log lb_logs;
+
+        if ($miner_tag_block = 1) {
+            return 400;
+        }
     }
 
 {% if v1_only_domain %}

--- a/conf/nginx/rate-limiting.conf.jnj
+++ b/conf/nginx/rate-limiting.conf.jnj
@@ -12,6 +12,12 @@ map $http2 $http2_bucket {
   default $connection;          # HTTP2 case: use the connection serial number to limit.
 }
 
+map $uri:$http_user_agent $miner_tag_block {
+    "~/api/v1/repository/team-helium/miner/tag/:curl/*" 1;
+    default 0;
+}
+
+
 # Define two additional buckets that fall to $request_id (thus no effective rate limiting) if
 # a specific set of namespaces is matched. This allows us to turn off rate limiting selectively
 # for special internal namespaces.


### PR DESCRIPTION
There are scripts calling the v1/tags API for helium miner
causing an DB load