### PR TITLE
chore: Bump python dependencies (PROJQUAY-2175)

### DIFF
--- a/requirements-osbs.txt
+++ b/requirements-osbs.txt
@@ -12,8 +12,8 @@ beautifulsoup4==4.8.2
 bintrees==2.1.0
 bitmath==1.3.3.1
 blinker==1.4
-boto3==1.20.46
-botocore==1.23.46
+boto3==1.21.42
+botocore==1.24.42
 cachetools==4.0.0
 certifi==2019.11.28
 cffi==1.14.3
@@ -70,7 +70,7 @@ os-service-types==1.7.0
 oslo.config==7.0.0
 oslo.i18n==3.25.1
 oslo.serialization==2.29.2
-oslo.utils==3.42.1
+oslo.utils==4.12.2
 pbr==5.4.4
 peewee==3.13.1
 Pillow==9.0.1
@@ -89,7 +89,7 @@ pymemcache==3.0.0
 PyMySQL==0.9.3
 pyOpenSSL==19.1.0
 pyparsing==2.4.6
-PyPDF2 @ https://files.pythonhosted.org/packages/b4/01/68fcc0d43daf4c6bdbc6b33cc3f77bda531c86b174cac56ef0ffdb96faab/PyPDF2-1.26.0.tar.gz#egg=PyPDF2&cachito_hash=sha256:e28f902f2f0a1603ea95ebe21dff311ef09be3d0f0ef29a3e44a932729564385
+PyPDF2 @ https://files.pythonhosted.org/packages/3d/48/0966606e08dd93a77e839803789151ff81ac27ec6767957af8afb9588501/PyPDF2-1.27.6.tar.gz#egg=PyPDF2&cachito_hash=sha256:3a3c0585678279b93a4c0fa31fb6f6217cfbdac3f6d3dcd1dfc9888579f3e858 # Generated from PyPi download link + sha256
 pyrsistent==0.18.0
 python-dateutil==2.8.1
 python-editor==1.0.4
@@ -108,7 +108,7 @@ redis-py-cluster==2.1.3
 redlock==1.2.0
 rehash==1.0.0
 reportlab==3.5.55
-requests==2.22.0
+requests==2.27.1
 requests-aws4auth==0.9
 requests-file==1.4.3
 requests-oauthlib==1.3.0
@@ -128,7 +128,7 @@ text-unidecode==1.3
 tldextract==2.2.2
 toposort==1.5
 tzlocal==2.0.0
-urllib3==1.25.8
+urllib3==1.26.9 
 webencodings==0.5.1
 WebOb==1.8.6
 websocket-client==0.57.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ beautifulsoup4==4.8.2
 bintrees==2.1.0
 bitmath==1.3.3.1
 blinker==1.4
-boto3==1.20.46
-botocore==1.23.46
+boto3==1.21.42
+botocore==1.24.42
 cachetools==4.0.0
 certifi==2019.11.28
 cffi==1.14.3
@@ -70,7 +70,7 @@ os-service-types==1.7.0
 oslo.config==7.0.0
 oslo.i18n==3.25.1
 oslo.serialization==2.29.2
-oslo.utils==3.42.1
+oslo.utils==4.12.2
 pbr==5.4.4
 peewee==3.13.1
 Pillow==9.0.1
@@ -89,7 +89,7 @@ pymemcache==3.0.0
 PyMySQL==0.9.3
 pyOpenSSL==19.1.0
 pyparsing==2.4.6
-PyPDF2 @ https://files.pythonhosted.org/packages/b4/01/68fcc0d43daf4c6bdbc6b33cc3f77bda531c86b174cac56ef0ffdb96faab/PyPDF2-1.26.0.tar.gz#egg=PyPDF2&cachito_hash=sha256:e28f902f2f0a1603ea95ebe21dff311ef09be3d0f0ef29a3e44a932729564385
+PyPDF2 @ https://files.pythonhosted.org/packages/3d/48/0966606e08dd93a77e839803789151ff81ac27ec6767957af8afb9588501/PyPDF2-1.27.6.tar.gz#egg=PyPDF2&cachito_hash=sha256:3a3c0585678279b93a4c0fa31fb6f6217cfbdac3f6d3dcd1dfc9888579f3e858 # Generated from PyPi download link + sha256
 pyrsistent==0.18.0
 python-dateutil==2.8.1
 python-editor==1.0.4
@@ -108,7 +108,7 @@ redis-py-cluster==2.1.3
 redlock==1.2.0
 rehash==1.0.0
 reportlab==3.5.55
-requests==2.22.0
+requests==2.27.1
 requests-aws4auth==0.9
 requests-file==1.4.3
 requests-oauthlib==1.3.0
@@ -128,7 +128,7 @@ text-unidecode==1.3
 tldextract==2.2.2
 toposort==1.5
 tzlocal==2.0.0
-urllib3==1.25.8
+urllib3==1.26.9 
 webencodings==0.5.1
 WebOb==1.8.6
 websocket-client==0.57.0


### PR DESCRIPTION
Bumps:
* boto3
* botocore
* oslo.utils
* pypdf2
* requests
* urllib3

Resolves the following CVEs

* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26137
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0718
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33503