### PR TITLE
secscan: update the secscan model interface (PROJQUAY-3501)

### DIFF
--- a/data/secscan_model/__init__.py
+++ b/data/secscan_model/__init__.py
@@ -35,12 +35,19 @@ class SecurityScannerModelProxy(SecurityScannerInterface):
 
         return self
 
-    def perform_indexing(self, next_token=None):
+    def index_manifests(self, next_token=None):
         if next_token is not None:
             assert isinstance(next_token, V4ScanToken)
             assert isinstance(next_token.min_id, int)
 
-        return self._model.perform_indexing(next_token)
+        return self._model.index_manifests(next_token)
+
+    def perform_indexing(self, next_token=None, batch_size=None):
+        if next_token is not None:
+            assert isinstance(next_token, V4ScanToken)
+            assert isinstance(next_token.min_id, int)
+
+        return self._model.perform_indexing(next_token, batch_size)
 
     def load_security_information(self, manifest_or_legacy_image, include_vulnerabilities):
         manifest = manifest_or_legacy_image.as_manifest()

--- a/data/secscan_model/interface.py
+++ b/data/secscan_model/interface.py
@@ -30,7 +30,20 @@ class SecurityScannerInterface(object):
         """
 
     @abstractmethod
-    def perform_indexing(self, start_token=None):
+    def index_manifests(self, start_token=None):
+        """
+        Performs indexing of the next set of unindexed manifests/images AND a recent batch
+        of unindexed manifests. This allows for recent results to be indexed, while still serving
+        security results from the v2 model.
+
+        If start_token is given, the indexing should resume from that point. Returns a new start
+        index for the next iteration of indexing. The tokens returned and given are assumed to be
+        opaque outside of this implementation and should not be relied upon by the caller to conform
+        to any particular format.
+        """
+
+    @abstractmethod
+    def perform_indexing(self, start_token=None, batch_size=None):
         """
         Performs indexing of the next set of unindexed manifests/images.
 

--- a/data/secscan_model/secscan_v2_model.py
+++ b/data/secscan_model/secscan_v2_model.py
@@ -48,7 +48,10 @@ class NoopV2SecurityScanner(SecurityScannerInterface):
     def load_security_information(self, manifest_or_legacy_image, include_vulnerabilities=False):
         return SecurityInformationLookupResult.for_request_error("not implemented (noop) scanner")
 
-    def perform_indexing(self, start_token=None):
+    def index_manifests(self, start_token=None):
+        return None
+
+    def perform_indexing(self, start_token=None, batch_size=None):
         return None
 
     def register_model_cleanup_callbacks(self, data_model_config):
@@ -153,7 +156,10 @@ class V2SecurityScanner(SecurityScannerInterface):
 
         return SecurityInformationLookupResult.for_data(SecurityInformation.from_dict(data))
 
-    def perform_indexing(self, start_token=None):
+    def index_manifests(self, start_token=None):
+        raise NotImplementedError("Unsupported for this security scanner version")
+
+    def perform_indexing(self, start_token=None, batch_size=None):
         """
         Performs indexing of the next set of unindexed manifests/images.
         NOTE: Raises `NotImplementedError` because indexing for v2 is not supported.

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -73,7 +73,10 @@ class NoopV4SecurityScanner(SecurityScannerInterface):
     def load_security_information(self, manifest_or_legacy_image, include_vulnerabilities=False):
         return SecurityInformationLookupResult.for_request_error("security scanner misconfigured")
 
-    def perform_indexing(self, start_token=None):
+    def index_manifests(self, start_token=None):
+        return None
+
+    def perform_indexing(self, start_token=None, batch_size=None):
         return None
 
     def register_model_cleanup_callbacks(self, data_model_config):


### PR DESCRIPTION
Add `index_manifests` as part of secscan interface. `index_manifests` is
a superset of perform_indexing, but also indexes a batch of recent manifests.