### PR TITLE
app.py: filter proxy cache login details from debug logs

### DIFF
--- a/app.py
+++ b/app.py
@@ -181,6 +181,8 @@ def _request_start():
 DEFAULT_FILTER = lambda x: "[FILTERED]"
 FILTERED_VALUES = [
     {"key": ["password"], "fn": DEFAULT_FILTER},
+    {"key": ["upstream_registry_password"], "fn": DEFAULT_FILTER},
+    {"key": ["upstream_registry_username"], "fn": DEFAULT_FILTER},
     {"key": ["user", "password"], "fn": DEFAULT_FILTER},
     {"key": ["blob"], "fn": lambda x: x[0:8]},
 ]
@@ -194,6 +196,9 @@ def _request_end(resp):
         jsonbody = None
 
     values = request.values.to_dict()
+
+    if isinstance(jsonbody, dict):
+        filter_logs(jsonbody, FILTERED_VALUES)
 
     if jsonbody and not isinstance(jsonbody, dict):
         jsonbody = {"_parsererror": jsonbody}


### PR DESCRIPTION
fixes [PROJQUAY-3591](https://issues.redhat.com//browse/PROJQUAY-3591)

----

```
quay-quay  | gunicorn-web stdout | 2022-04-20 08:20:46,917 [194] [DEBUG] [app] Ending request: 
urn:request:327c9b42-841b-464b-8970-ab063f199b59 (/api/v1/organization/cache-quayio/validateproxycache) 
{'endpoint': 'api.proxycacheconfigvalidation', 'request_id': 'urn:request:327c9b42-841b-464b-8970-ab063f199b59', 
'remote_addr': '172.23.0.1', 'http_method': 'POST', 'original_url': 'http://quay/api/v1/organization/cache-quayio
/validateproxycache', 'path': '/api/v1/organization/cache-quayio/validateproxycache', 'parameters': {}, 'json_body': 
{'org_name': 'cache-quayio', 'expiration_s': 86400, 'insecure': False, 'upstream_registry': 'quay.io', 
'upstream_registry_username': '[FILTERED]', 'upstream_registry_password': '[FILTERED]'}, 'confsha': 'ab5dc0d3', 'user-
agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:99.0) Gecko/20100101 Firefox/99.0'}
```

Note the **'upstream_registry_username': '[FILTERED]', 'upstream_registry_password': '[FILTERED]**