### PR TITLE
storage: Add Cloudflare as a CDN provider for an S3 backed storage (PROJQUAY-3699)

### DIFF
--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -1,3 +1,4 @@
+from storage.cloudflarestorage import CloudFlareS3Storage
 from storage.local import LocalStorage
 from storage.cloud import (
     S3Storage,
@@ -24,6 +25,7 @@ STORAGE_DRIVER_CLASSES = {
     "CloudFrontedS3Storage": CloudFrontedS3Storage,
     "AzureStorage": AzureStorage,
     "RHOCSStorage": RHOCSStorage,
+    "CloudFlareStorage": CloudFlareS3Storage,
 }
 
 

--- a/storage/cloudflarestorage.py
+++ b/storage/cloudflarestorage.py
@@ -1,0 +1,100 @@
+import base64
+import logging
+import urllib.parse
+from datetime import datetime, timedelta
+from functools import lru_cache
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
+logger = logging.getLogger(__name__)
+
+from storage.cloud import S3Storage
+
+
+class CloudFlareS3Storage(S3Storage):
+    """
+    CloudFlare CDN backed by S3 storage
+    """
+
+    def __init__(
+            self,
+            context,
+            cloudflare_domain,
+            cloudflare_privatekey_filename,
+            storage_path,
+            s3_bucket,
+            *args,
+            **kwargs,
+    ):
+        super(CloudFlareS3Storage, self).__init__(
+            context, storage_path, s3_bucket, *args, **kwargs
+        )
+
+        self.cloudflare_domain = cloudflare_domain
+        self.cloudflare_privatekey = self._load_private_key(cloudflare_privatekey_filename)
+
+    def get_direct_download_url(
+            self, path, request_ip=None, expires_in=60, requires_cors=False, head=False
+    ):
+        # If CloudFront could not be loaded, fall back to normal S3.
+        s3_presigned_url = super(CloudFlareS3Storage, self).get_direct_download_url(
+                path, request_ip, expires_in, requires_cors, head
+            )
+        logger.debug(f's3 presigned_url: {s3_presigned_url}')
+        if self.cloudflare_privatekey is None or request_ip is None:
+            return s3_presigned_url
+
+        logger.debug('Got direct download request for path "%s" with IP "%s"', path, request_ip)
+
+        s3_url_parsed = urllib.parse.urlparse(s3_presigned_url)
+
+        cf_url_parsed = s3_url_parsed._replace(netloc=self.cloudflare_domain)
+
+        expire_date = datetime.now() + timedelta(seconds=expires_in)
+        signed_url = self._cf_sign_url(cf_url_parsed, date_less_than=expire_date)
+        logger.debug(
+            'Returning CloudFlare URL for path "%s" with IP "%s": %s',
+            path,
+            request_ip,
+            signed_url,
+        )
+        return signed_url
+
+    def _cf_sign_url(self, cf_url_parsed, date_less_than):
+        expiry_ts = date_less_than.timestamp()
+        sign_data = '%s@%d' % (cf_url_parsed.path, expiry_ts)
+        signature = self.cloudflare_privatekey.sign(sign_data.encode('utf8'), padding.PKCS1v15(), hashes.SHA256())
+        signature_b64 = base64.b64encode(signature)
+
+        return self._build_signed_url(cf_url_parsed, signature_b64, date_less_than)
+
+    def _build_signed_url(self, cf_url_parsed, signature, expiry_date):
+        query = cf_url_parsed.query
+        url_dict = dict(urllib.parse.parse_qsl(query))
+        params = {
+            'cf_sign': signature,
+            'cf_expiry': '%d' % expiry_date.timestamp()
+        }
+        url_dict.update(params)
+        url_new_query = urllib.parse.urlencode(url_dict)
+        url_parse = cf_url_parsed._replace(query=url_new_query)
+        return urllib.parse.urlunparse(url_parse)
+
+    @lru_cache(maxsize=1)
+    def _load_private_key(self, cloudfront_privatekey_filename):
+        """
+        Returns the private key, loaded from the config provider, used to sign direct download URLs
+        to CloudFront.
+        """
+        if self._context.config_provider is None:
+            return None
+
+        with self._context.config_provider.get_volume_file(
+                cloudfront_privatekey_filename,
+                mode="rb",
+        ) as key_file:
+            return serialization.load_pem_private_key(
+                key_file.read(), password=None, backend=default_backend()
+            )

--- a/storage/cloudflarestorage.py
+++ b/storage/cloudflarestorage.py
@@ -19,30 +19,28 @@ class CloudFlareS3Storage(S3Storage):
     """
 
     def __init__(
-            self,
-            context,
-            cloudflare_domain,
-            cloudflare_privatekey_filename,
-            storage_path,
-            s3_bucket,
-            *args,
-            **kwargs,
+        self,
+        context,
+        cloudflare_domain,
+        cloudflare_privatekey_filename,
+        storage_path,
+        s3_bucket,
+        *args,
+        **kwargs,
     ):
-        super(CloudFlareS3Storage, self).__init__(
-            context, storage_path, s3_bucket, *args, **kwargs
-        )
+        super(CloudFlareS3Storage, self).__init__(context, storage_path, s3_bucket, *args, **kwargs)
 
         self.cloudflare_domain = cloudflare_domain
         self.cloudflare_privatekey = self._load_private_key(cloudflare_privatekey_filename)
 
     def get_direct_download_url(
-            self, path, request_ip=None, expires_in=60, requires_cors=False, head=False
+        self, path, request_ip=None, expires_in=60, requires_cors=False, head=False
     ):
         # If CloudFront could not be loaded, fall back to normal S3.
         s3_presigned_url = super(CloudFlareS3Storage, self).get_direct_download_url(
-                path, request_ip, expires_in, requires_cors, head
-            )
-        logger.debug(f's3 presigned_url: {s3_presigned_url}')
+            path, request_ip, expires_in, requires_cors, head
+        )
+        logger.debug(f"s3 presigned_url: {s3_presigned_url}")
         if self.cloudflare_privatekey is None or request_ip is None:
             return s3_presigned_url
 
@@ -64,8 +62,10 @@ class CloudFlareS3Storage(S3Storage):
 
     def _cf_sign_url(self, cf_url_parsed, date_less_than):
         expiry_ts = date_less_than.timestamp()
-        sign_data = '%s@%d' % (cf_url_parsed.path, expiry_ts)
-        signature = self.cloudflare_privatekey.sign(sign_data.encode('utf8'), padding.PKCS1v15(), hashes.SHA256())
+        sign_data = "%s@%d" % (cf_url_parsed.path, expiry_ts)
+        signature = self.cloudflare_privatekey.sign(
+            sign_data.encode("utf8"), padding.PKCS1v15(), hashes.SHA256()
+        )
         signature_b64 = base64.b64encode(signature)
 
         return self._build_signed_url(cf_url_parsed, signature_b64, date_less_than)
@@ -73,10 +73,7 @@ class CloudFlareS3Storage(S3Storage):
     def _build_signed_url(self, cf_url_parsed, signature, expiry_date):
         query = cf_url_parsed.query
         url_dict = dict(urllib.parse.parse_qsl(query))
-        params = {
-            'cf_sign': signature,
-            'cf_expiry': '%d' % expiry_date.timestamp()
-        }
+        params = {"cf_sign": signature, "cf_expiry": "%d" % expiry_date.timestamp()}
         url_dict.update(params)
         url_new_query = urllib.parse.urlencode(url_dict)
         url_parse = cf_url_parsed._replace(query=url_new_query)
@@ -92,8 +89,8 @@ class CloudFlareS3Storage(S3Storage):
             return None
 
         with self._context.config_provider.get_volume_file(
-                cloudfront_privatekey_filename,
-                mode="rb",
+            cloudfront_privatekey_filename,
+            mode="rb",
         ) as key_file:
             return serialization.load_pem_private_key(
                 key_file.read(), password=None, backend=default_backend()


### PR DESCRIPTION

This adds CloudFlare as a CDN provider for quay for any storage backed
by S3. This requires a worker script that needs to be setup seperately
on CloudFlare. More details on the worker at
https://github.com/quay/quay-cloudflare-cdn-worker