### PR TITLE
builders: Persist build pod when DEBUG is true (PROJQUAY-3710)

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -603,9 +603,6 @@ class KubernetesExecutor(BuilderExecutor):
             "spec": {
                 "activeDeadlineSeconds": self.executor_config.get("MAXIMUM_JOB_TIME", 7200),
                 "backoffLimit": 1,
-                "ttlSecondsAfterFinished": self.executor_config.get(
-                    "RETENTION_AFTER_FINISHED", 120
-                ),
                 "template": {
                     "metadata": {
                         "labels": {
@@ -624,6 +621,12 @@ class KubernetesExecutor(BuilderExecutor):
                 },
             },
         }
+
+        # If DEBUG isn't enabled, add a TTL on the job
+        if not self.executor_config.get("DEBUG", False):
+            job_resource["spec"]["ttlSecondsAfterFinished"] = self.executor_config.get(
+                "RETENTION_AFTER_FINISHED", 120
+            )
 
         if self._is_openshift_kubernetes_distribution():
             # Setting `automountServiceAccountToken` to false will prevent automounting API credentials for a service account.


### PR DESCRIPTION
In the previous kubernetes executor the build job was persisted in DEBUG mode due to the virtual machine in the pod never exiting. This kept the job alive for users to view the debug information. The `kubernetesPodman` executor does not run the VM so it will be cleaned up due to `ttlSecondsAfterFinished` being set on the job. This change prevents the `ttlSecondsAfterFinished` field from being set when DEBUG is true, allowing the pod to stay alive to retrieve the logs.