### PR TITLE
init: Add support for QUAY_VERSION env variable (PROJQUAY-3514)

### DIFF
--- a/_init.py
+++ b/_init.py
@@ -34,6 +34,17 @@ config_provider = get_config_provider(
 )
 
 
+def _get_version_number():
+    # Try to get version from environment
+    version = os.getenv("QUAY_VERSION", "")
+
+    if not version:
+        # Fallback to getting version from changelog for standalone
+        version = _get_version_number_changelog()
+
+    return version
+
+
 def _get_version_number_changelog():
     try:
         with open(os.path.join(ROOT_DIR, "CHANGELOG.md")) as f:
@@ -56,5 +67,5 @@ def _get_git_sha():
     return "unknown"
 
 
-__version__ = _get_version_number_changelog()
+__version__ = _get_version_number()
 __gitrev__ = _get_git_sha()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,6 +81,7 @@ services:
       - "8080:8080" 
       - "8443:8443"
     environment:
+      QUAY_VERSION: local-dev
       QUAY_HOTRELOAD: "true"
       DEBUGLOG: "true"
       IGNORE_VALIDATION: "true"


### PR DESCRIPTION
* Configures version to be pulled from an environment variable. Falls back to existing behavior if variable isn't set.
![Screen Shot 2022-05-02 at 10 01 28 AM](https://user-images.githubusercontent.com/1656866/166250993-efe066a6-dd7e-4af8-9ca1-261151b2bfde.png)
![Screen Shot 2022-05-02 at 9 49 13 AM](https://user-images.githubusercontent.com/1656866/166250995-f20b8313-dd7b-427d-bf5a-f29582af327b.png)
 