### PR TITLE
builders: Add dnsPolicy option (PROJQUAY-3755)

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -615,7 +615,7 @@ class KubernetesExecutor(BuilderExecutor):
                     "spec": {
                         "imagePullSecrets": [{"name": image_pull_secret_name}],
                         "restartPolicy": "Never",
-                        "dnsPolicy": "Default",
+                        "dnsPolicy": self.executor_config.get("DNS_POLICY", "Default"),
                         "containers": [self._build_job_containers(token, build_uuid)],
                     },
                 },


### PR DESCRIPTION
Some clusters use `dnsPolicy: ClusterFirst` while we have the field hardcoded to `Default`. This change allows the field to be configurable.