### PR TITLE
PROJQUAY-3750: support registries that do not return a digest header

### DIFF
--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -314,14 +314,24 @@ class ProxyModel(OCIModel):
         freshly out of the database, and a boolean indicating whether the returned
         tag was newly created or not.
         """
+        upstream_manifest = None
         upstream_digest = self._proxy.manifest_exists(manifest_ref, ACCEPTED_MEDIA_TYPES)
         up_to_date = manifest.digest == upstream_digest
+
+        # manifest_exists will return an empty/None digest when the upstream
+        # registry omits the docker-content-digest header.
+        if not upstream_digest:
+            upstream_manifest = self._pull_upstream_manifest(repo_ref.name, manifest_ref)
+            up_to_date = manifest.digest == upstream_manifest.digest
+
         placeholder = manifest.internal_manifest_bytes.as_unicode() == ""
         if up_to_date and not placeholder:
             return tag, False
 
+        if upstream_manifest is None:
+            upstream_manifest = self._pull_upstream_manifest(repo_ref.name, manifest_ref)
+
         self._enforce_repository_quota(repo_ref)
-        upstream_manifest = self._pull_upstream_manifest(repo_ref.name, manifest_ref)
         if up_to_date and placeholder:
             with db_disallow_replica_use():
                 with db_transaction():

--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -79,8 +79,10 @@ class Proxy:
 
     def manifest_exists(self, image_ref: str, media_types: list[str] | None = None) -> str | None:
         """
-        Returns the manifest digest (docker-content-digest) if given by the
-        upstream registry.
+        Returns the manifest digest.
+
+        Looks for the digest in the docker-content-digest header. If not
+        present in the response, parses the manifest then calculate the digest.
 
         If the manifest does not exist or the upstream registry errors, raises
         an UpstreamRegistryError exception.
@@ -96,6 +98,9 @@ class Proxy:
         url = f"{self.base_url}/v2/{self._repo}/blobs/{digest}"
         resp = self.get(
             url,
+            headers={
+                "Accept-Encoding": "identity",
+            },
             allow_redirects=True,
             stream=True,
         )


### PR DESCRIPTION
The distribution spec does not require the docker-content-digest header
to be set in response to a manifest GET/HEAD request.

This changes both the proxy client and the registry proxy model to
correctly check whether a manifest is up-to-date with the upstream
registry or not when no digest header is received.

NOTE: when checking staleness against registries that do not return the
docker-content-digest header, Quay will make a GET request to the
registry and calculate the digest from the manifest itself. GET requests
usually count towards rate-limiting.

This change also sets the accept-encoding header to 'identity'. The python
requests library seems to automatically set the accept-encoding header to
'gzip'. Dockerhub ignores that header when serving blobs, but some
registries don't (namely registry.access.redhat.com). When Quay receives a
gzipped config blob (have not tested non-config blobs) for some reason it
doesn't know how to handle it. I suspect it has to do wit the fact that in
this case the content-length header will differ from the actual size of
the response body, so when Quay tries to upload the blob it cannot
correctly calculate the actual blob size, so it does a partial upload to
its object storage, which then results in a digest mismatch error
(BlobDigestMismatchException).