### PR TITLE
v2auth: Check for user before creating org (PROJQUAY-3766)

### DIFF
--- a/endpoints/v2/test/test_v2auth.py
+++ b/endpoints/v2/test/test_v2auth.py
@@ -286,6 +286,17 @@ def get_robot_password(username):
             "public",
             False,
         ),
+        # Push to existing user namespace
+        (
+            "repository:devtable/visibility:pull,push,*",
+            "devtable",
+            "password",
+            200,
+            ["devtable/visibility:push,pull,*"],
+            True,
+            "public",
+            True,
+        ),
         # Pushed namespace created
         (
             "repository:neworg/visibility:pull,push,*",


### PR DESCRIPTION
Currently when Quay is set to automatically create organizations it will check the user table for a matching username with organization set to true. This causes conflicts when a user already exists with the same username, where the check will fail and Quay will attempt to create an organization with the same name as the user. This change checks for only a matching username.