### PR TITLE
sso: Use trusted cert from extra_ca_certs directory (PROJQUAY-2056)

### DIFF
--- a/oauth/services/rhsso.py
+++ b/oauth/services/rhsso.py
@@ -27,7 +27,6 @@ class RHSSOOAuthService(OIDCLoginService):
                         "/conf/stack/export-compliance-client.crt",
                         "/conf/stack/export-compliance-client.key",
                     ),
-                    verify="/conf/stack/export-compliance-ca.crt",
                     json={"user": {"login": lusername}, "account": {"primary": True}},
                     timeout=5,
                 )


### PR DESCRIPTION
- Do not pass certificate in verify parameter, instead load automatically from extra_ca_certs dir