### PR TITLE
pull-thru: don't bump parent manifest expiration on pull by digest

### DIFF
--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -180,15 +180,6 @@ class ProxyModel(OCIModel):
                     else None
                 )
                 oci.tag.set_tag_end_ms(db_tag, new_expiration)
-                # if the manifest is a child of a manifest list in this repo, renew
-                # the parent manifest list tag too.
-                parent = ManifestChild.select(ManifestChild.manifest_id).where(
-                    (ManifestChild.repository_id == repository_ref.id)
-                    & (ManifestChild.child_manifest_id == wrapped_manifest.id)
-                )
-                parent_tag = oci.tag.get_tag_by_manifest_id(repository_ref.id, parent)
-                if parent_tag is not None:
-                    oci.tag.set_tag_end_ms(parent_tag, new_expiration)
 
         return super().lookup_manifest_by_digest(
             repository_ref,


### PR DESCRIPTION
Quay already bumps the manifest list's tag expiration on pulls by tag,
so the parent expiration tag bump in the pull by digest code wasn't
necessary.

This relies on the client behaviour of always pulling a manifest list
first, followed by a pull of one of its children.

**NOTE**: if users point to a sub-manifest's digest and never pull the
parent-manifest (either via tag or digest), the parent-manifest tag will
be garbage collected, most likely leading to unexpected behaviour.

fixes https://issues.redhat.com/browse/PROJQUAY-3456