### PR TITLE
[redhat-3.6] chore: Add support for QUAY_VERSION env variable (PROJQUAY-3514)

### DIFF
--- a/_init.py
+++ b/_init.py
@@ -34,6 +34,17 @@ config_provider = get_config_provider(
 )
 
 
+def _get_version_number():
+    # Try to get version from environment
+    version = os.getenv("QUAY_VERSION", "")
+
+    if not version:
+        # Fallback to getting version from changelog for standalone
+        version = _get_version_number_changelog()
+
+    return version
+
+
 def _get_version_number_changelog():
     try:
         with open(os.path.join(ROOT_DIR, "CHANGELOG.md")) as f:
@@ -56,5 +67,5 @@ def _get_git_sha():
     return "unknown"
 
 
-__version__ = _get_version_number_changelog()
+__version__ = _get_version_number()
 __gitrev__ = _get_git_sha()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
       - "8080:8080" 
       - "8443:8443"
     environment:
+      QUAY_VERSION: local-dev
       DEBUGLOG: "true"
       IGNORE_VALIDATION: "true"
 


### PR DESCRIPTION
* Cherry pick of https://github.com/quay/quay/pull/1298
* Enables `QUAY_VERSION` environment variable 