### PR TITLE
secscan: update https proxy scheme

### DIFF
--- a/util/secscan/api.py
+++ b/util/secscan/api.py
@@ -281,7 +281,7 @@ class ImplementedSecurityScannerAPI(SecurityScannerAPIInterface):
             timeout=timeout,
             verify=MITM_CERT_PATH,
             headers=DEFAULT_HTTP_HEADERS,
-            proxies={"https": "https://" + signer_proxy_url, "http": "http://" + signer_proxy_url},
+            proxies={"https": "http://" + signer_proxy_url, "http": "http://" + signer_proxy_url},
         )
         if resp.status_code // 100 != 2:
             raise Non200ResponseException(resp)


### PR DESCRIPTION
Update the https proxy scheme from "https" to "http". The scheme was
ignored prior to urllib3 1.26, which is why it was working.

https://github.com/psf/requests/issues/5943#issuecomment-926615360
https://github.com/quay/quay/pull/1250/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R131