### PR TITLE
Dockerfile: use nodejs ubi8 image to build frontends

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -54,7 +54,7 @@ services:
     container_name: quay-local-dev-frontend
     build:
       context: .
-      target: build-python
+      target: build-static
     image: quay-build:latest
     init: true
     volumes:


### PR DESCRIPTION
Also add nginx module before installing it, without this dnf won't find it.

Note that we're using ubi8/node-10, which is deprecated - but this is
the version previously installed (before the nodejs package disappeared
on us).