### PR TITLE
init: ensure a newline is present before appending certs (PROJQUAY-3881)

### DIFF
--- a/conf/init/certs_install.sh
+++ b/conf/init/certs_install.sh
@@ -9,50 +9,58 @@ PYTHONUSERBASE_SITE_PACKAGE=${PYTHONUSERBASE_SITE_PACKAGE:-"$(python -m site --u
 
 cd ${QUAYDIR:-"/quay-registry"}
 
-function ensure_newline() {
-    lastline=$(tail -c 1 $1)
-    if [ "$lastline" != "" ]; then
-	echo >> "$1"
-    fi
-}
-
 # Add the custom LDAP certificate
-if [ -e $QUAYCONFIG/ldap.crt ]
-then
-  cp $QUAYCONFIG/ldap.crt ${SYSTEM_CERTDIR}/ldap.crt
+if [ -e $QUAYCONFIG/ldap.crt ]; then
+    cp $QUAYCONFIG/ldap.crt ${SYSTEM_CERTDIR}/ldap.crt
 fi
 
 # Add extra trusted certificates (as a directory)
 if [ -d $CERTDIR ]; then
-  if test "$(ls -A "$CERTDIR")"; then
-      echo "Installing extra certificates found in $CERTDIR directory"
-      cp $CERTDIR/* ${SYSTEM_CERTDIR}
+    if test "$(ls -A "$CERTDIR")"; then
+	echo "Installing extra certificates found in $CERTDIR directory"
+	cp $CERTDIR/* ${SYSTEM_CERTDIR}
 
-      CERT_FILES="$CERTDIR/*"
-      for f in $CERT_FILES
-      do
-	  ensure_newline "$f"
-      done
+	CERT_FILES="$CERTDIR/*"
 
-      cat $CERTDIR/* >> $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem
-  fi
+	for f in $CERT_FILES
+	do
+	    lastline=$(tail -c 1 $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem)
+
+	    if [ "$lastline" != "" ]; then
+		echo >> $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem
+	    fi
+
+	    cat $CERTDIR/$f >> $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem
+	done
+    fi
 fi
 
 # Add extra trusted certificates (as a file)
 if [ -f $CERTDIR ]; then
-  echo "Installing extra certificates found in $CERTDIR file"
-  csplit -z -f ${SYSTEM_CERTDIR}/extra-ca- $CERTDIR  '/-----BEGIN CERTIFICATE-----/' '{*}'
-  ensure_newline "$CERTDIR"
-  cat $CERTDIR >> $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem
+    echo "Installing extra certificates found in $CERTDIR file"
+    csplit -z -f ${SYSTEM_CERTDIR}/extra-ca- $CERTDIR  '/-----BEGIN CERTIFICATE-----/' '{*}'
+
+    lastline=$(tail -c 1 $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem)
+
+    if [ "$lastline" != "" ]; then
+	echo >> $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem
+    fi
+
+    cat $CERTDIR >> $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem
 fi
 
 # Add extra trusted certificates (prefixed)
 for f in $(find -L $QUAYCONFIG/ -maxdepth 1 -type f -name "extra_ca*")
 do
- echo "Installing extra cert $f"
- cp "$f" ${SYSTEM_CERTDIR}
- ensure_newline "$f"
- cat "$f" >> $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem
+    echo "Installing extra cert $f"
+    cp "$f" ${SYSTEM_CERTDIR}
+
+    lastline=$(tail -c 1 $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem)
+    if [ "$lastline" != "" ]; then
+	echo >> $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem
+    fi
+
+    cat "$f" >> $PYTHONUSERBASE_SITE_PACKAGE/certifi/cacert.pem
 done
 
 # Update all CA certificates.


### PR DESCRIPTION
Make sure the script still works when mounting certs as a read-only fs.