### PR TITLE
UI: Superuser user panel settings icon permissions fix (PROJQUAY-3905)

### DIFF
--- a/static/directives/manage-users-tab.html
+++ b/static/directives/manage-users-tab.html
@@ -73,7 +73,7 @@
         </td>
         <td style="text-align: center;">
                   <span class="cor-options-menu"
-                        ng-if="((current_user.super_user && user.username == current_user.username) ||
+                        ng-if="((current_user.super_user && user.username == current_user.username && Features.QUOTA_MANAGEMENT) ||
                                !current_user.super_user) && !inReadOnlyMode">
                     <span class="cor-option" option-click="showChangeEmail(current_user)" ng-if="!current_user.super_user"
                           quay-show="Config.AUTHENTICATION_TYPE == 'Database' || Config.AUTHENTICATION_TYPE == 'AppToken'">
@@ -103,7 +103,7 @@
                       <i class="fa fa-bolt"></i> Take Ownership
                     </span>
                     <span class="cor-option" option-click="showQuotaConfig(current_user)"
-                        quay-show="Features.QUOTA_MANAGEMENT" ng-if="user.username == current_user.username">
+                        quay-show="Features.QUOTA_MANAGEMENT" ng-if="(current_user.super_user && user.username == current_user.username) || !current_user.super_user">
                       <i class="fa fa-gear"></i> Configure Quota
                     </span>
                   </span>

--- a/static/js/directives/ui/manage-user-tab.js
+++ b/static/js/directives/ui/manage-user-tab.js
@@ -15,7 +15,7 @@ angular.module('quay').directive('manageUserTab', function () {
                           TableService, Features, StateService) {
       $scope.inReadOnlyMode = StateService.inReadOnlyMode();
       $scope.Features = Features;
-      $scope.user = UserService.currentUser();
+      UserService.updateUserIn($scope);
       $scope.users = null;
       $scope.orderedUsers = [];
       $scope.usersPerPage = 10;

--- a/static/js/directives/ui/quota-management-view.js
+++ b/static/js/directives/ui/quota-management-view.js
@@ -72,6 +72,10 @@ angular.module('quay').directive('quotaManagementView', function () {
       }
 
       var loadOrgQuota = function () {
+        if (!Features.QUOTA_MANAGEMENT) {
+          return;
+        }
+
         let params = null;
         let method = null;
         if ($scope.organization != null){


### PR DESCRIPTION
Should resolve [PROJQUAY-3920](https://issues.redhat.com/browse/PROJQUAY-3920).
Logged in as Superuser - `admin`
<img width="1906" alt="Screen Shot 2022-06-07 at 5 14 13 PM" src="https://user-images.githubusercontent.com/11522230/172490326-5edce611-e2b8-48be-8841-9b12fbf80a9a.png">
Logged in as Superuser - `admin2`
<img width="1903" alt="Screen Shot 2022-06-07 at 5 13 49 PM" src="https://user-images.githubusercontent.com/11522230/172490404-f40d61d3-fca7-4cc9-bf93-6be29c1fd684.png">
When `QUOTA_MANAGEMENT` feature is enabled:
<img width="1897" alt="Screen Shot 2022-06-07 at 5 55 00 PM" src="https://user-images.githubusercontent.com/11522230/172490642-bf322afb-7a29-42ed-a075-8a123bdb4e21.png">
When `QUOTA_MANAGEMENT` feature is disabled:
<img width="1894" alt="Screen Shot 2022-06-07 at 5 27 26 PM" src="https://user-images.githubusercontent.com/11522230/172490556-59f1d052-f22b-476c-af77-5c1764cff890.png">

