### PR TITLE
requirements.txt: bump flask-restful from 0.3.7 to 0.3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ Flask-Cors==3.0.9
 Flask-Login==0.4.1
 Flask-Mail==0.9.1
 Flask-Principal==0.4.0
-Flask-RESTful==0.3.7
+Flask-RESTful==0.3.9
 furl==2.1.0
 futures==3.1.1
 geoip2==3.0.0


### PR DESCRIPTION
fixes some warnings as well as adds supports for flask 2.

---

Changelogs: https://github.com/flask-restful/flask-restful/blob/v0.3.9/CHANGES.md#versopn-039