### PR TITLE
Remove app from GunicornWorker

### DIFF
--- a/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
+++ b/workers/blobuploadcleanupworker/blobuploadcleanupworker.py
@@ -93,7 +93,7 @@ class BlobUploadCleanupWorker(Worker):
             logger.debug("Removed stale blob upload %s", stale_upload.uuid)
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -102,7 +102,7 @@ def create_gunicorn_worker():
 
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
-    worker = GunicornWorker(__name__, app, BlobUploadCleanupWorker(), True)
+    worker = GunicornWorker(__name__, BlobUploadCleanupWorker(), True)
     return worker
 
 

--- a/workers/buildlogsarchiver/buildlogsarchiver.py
+++ b/workers/buildlogsarchiver/buildlogsarchiver.py
@@ -66,7 +66,7 @@ class ArchiveBuildLogsWorker(Worker):
             logger.debug("Another worker pre-empted us when archiving: %s", to_archive.uuid)
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -75,7 +75,7 @@ def create_gunicorn_worker():
 
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
-    worker = GunicornWorker(__name__, app, ArchiveBuildLogsWorker(), True)
+    worker = GunicornWorker(__name__, ArchiveBuildLogsWorker(), True)
     return worker
 
 

--- a/workers/chunkcleanupworker.py
+++ b/workers/chunkcleanupworker.py
@@ -34,7 +34,7 @@ class ChunkCleanupWorker(QueueWorker):
             raise JobException()
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -49,7 +49,6 @@ def create_gunicorn_worker():
     feature_flag = "SwiftStorage" in engines
     worker = GunicornWorker(
         __name__,
-        app,
         ChunkCleanupWorker(chunk_cleanup_queue, poll_period_seconds=POLL_PERIOD_SECONDS),
         feature_flag,
     )

--- a/workers/expiredappspecifictokenworker.py
+++ b/workers/expiredappspecifictokenworker.py
@@ -37,7 +37,7 @@ class ExpiredAppSpecificTokenWorker(Worker):
         return True
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -49,7 +49,7 @@ def create_gunicorn_worker():
     feature_flag = (features.APP_SPECIFIC_TOKENS) or (
         app.config.get("EXPIRED_APP_SPECIFIC_TOKEN_GC") is not None
     )
-    worker = GunicornWorker(__name__, app, ExpiredAppSpecificTokenWorker(), feature_flag)
+    worker = GunicornWorker(__name__, ExpiredAppSpecificTokenWorker(), feature_flag)
     return worker
 
 

--- a/workers/exportactionlogsworker.py
+++ b/workers/exportactionlogsworker.py
@@ -290,7 +290,7 @@ def _parse_time(specified_time):
         return None
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -302,7 +302,7 @@ def create_gunicorn_worker():
     log_worker = ExportActionLogsWorker(
         export_action_logs_queue, poll_period_seconds=POLL_PERIOD_SECONDS
     )
-    worker = GunicornWorker(__name__, app, log_worker, features.LOG_EXPORT)
+    worker = GunicornWorker(__name__, log_worker, features.LOG_EXPORT)
     return worker
 
 

--- a/workers/gc/gcworker.py
+++ b/workers/gc/gcworker.py
@@ -72,7 +72,7 @@ class GarbageCollectionWorker(Worker):
                 logger.debug("Could not acquire repo lock for garbage collection")
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -81,7 +81,7 @@ def create_gunicorn_worker():
 
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
-    worker = GunicornWorker(__name__, app, GarbageCollectionWorker(), features.GARBAGE_COLLECTION)
+    worker = GunicornWorker(__name__, GarbageCollectionWorker(), features.GARBAGE_COLLECTION)
     return worker
 
 

--- a/workers/globalpromstats/globalpromstats.py
+++ b/workers/globalpromstats/globalpromstats.py
@@ -65,7 +65,7 @@ class GlobalPrometheusStatsWorker(Worker):
             robot_rows.set(get_robot_count())
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -75,7 +75,7 @@ def create_gunicorn_worker():
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
     feature_flag = app.config.get("PROMETHEUS_PUSHGATEWAY_URL") is not None
-    worker = GunicornWorker(__name__, app, GlobalPrometheusStatsWorker(), feature_flag)
+    worker = GunicornWorker(__name__, GlobalPrometheusStatsWorker(), feature_flag)
     return worker
 
 

--- a/workers/gunicorn_worker.py
+++ b/workers/gunicorn_worker.py
@@ -1,25 +1,29 @@
+import logging
 import logging.config
-import threading
 from multiprocessing import Process
+from typing import Union, TYPE_CHECKING
 from util.log import logfile_path
+
+if TYPE_CHECKING:
+    from features import FeatureNameValue
+    from workers.worker import Worker
 
 
 class GunicornWorker:
     """
-    GunicornWorker allows a quay worker to run as a Gunicorn worker.
-    The Quay worker is launched as a sub-process and this class serves as a delegate
-    for the wsgi app.
+    GunicornWorker allows a Quay worker to run as a Gunicorn worker.
+    The Quay worker is launched as a sub-process.
 
     name:           the quay worker this class delegates for.
-    app:            a uwsgi framework application object.
     worker:         a quay worker type which implements a .start method.
     feature_flag:   a boolean value determine if the worker thread should be launched
     """
 
-    def __init__(self, name, app, worker, feature_flag):
+    def __init__(
+        self, name: str, worker: "Worker", feature_flag: Union[bool, "FeatureNameValue"]
+    ) -> None:
         logging.config.fileConfig(logfile_path(debug=False), disable_existing_loggers=False)
 
-        self.app = app
         self.name = name
         self.worker = worker
         self.feature_flag = feature_flag
@@ -28,7 +32,7 @@ class GunicornWorker:
         if self.feature_flag:
             self.logger.debug("starting {} thread".format(self.name))
             p = Process(target=self.worker.start)
-            p = p.start()
+            p.start()
 
-    def __call__(environ, start_response):
-        return self.app(environ, start_response)
+    def __call__(self, environ, start_response):
+        raise NotImplementedError()

--- a/workers/logrotateworker.py
+++ b/workers/logrotateworker.py
@@ -131,7 +131,7 @@ def _write_logs(filename, logs, log_archive):
         log_archive.store_file(tempfile, JSON_MIMETYPE, content_encoding="gzip", file_id=filename)
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -141,7 +141,7 @@ def create_gunicorn_worker():
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
     feature_flag = (features.ACTION_LOG_ROTATION) or (not None in [SAVE_PATH, SAVE_LOCATION])
-    worker = GunicornWorker(__name__, app, LogRotateWorker(), feature_flag)
+    worker = GunicornWorker(__name__, LogRotateWorker(), feature_flag)
     return worker
 
 

--- a/workers/manifestbackfillworker.py
+++ b/workers/manifestbackfillworker.py
@@ -86,7 +86,7 @@ class ManifestBackfillWorker(Worker):
         return True
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -95,9 +95,7 @@ def create_gunicorn_worker():
 
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
-    worker = GunicornWorker(
-        __name__, app, ManifestBackfillWorker(), features.MANIFEST_SIZE_BACKFILL
-    )
+    worker = GunicornWorker(__name__, ManifestBackfillWorker(), features.MANIFEST_SIZE_BACKFILL)
     return worker
 
 

--- a/workers/namespacegcworker.py
+++ b/workers/namespacegcworker.py
@@ -43,7 +43,7 @@ class NamespaceGCWorker(QueueWorker):
         gc_namespaces_purged.inc()
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -57,7 +57,7 @@ def create_gunicorn_worker():
         poll_period_seconds=POLL_PERIOD_SECONDS,
         reservation_seconds=NAMESPACE_GC_TIMEOUT,
     )
-    worker = GunicornWorker(__name__, app, gc_worker, features.NAMESPACE_GARBAGE_COLLECTION)
+    worker = GunicornWorker(__name__, gc_worker, features.NAMESPACE_GARBAGE_COLLECTION)
     return worker
 
 

--- a/workers/notificationworker/notificationworker.py
+++ b/workers/notificationworker/notificationworker.py
@@ -40,7 +40,7 @@ class NotificationWorker(QueueWorker):
                 raise exc
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -49,13 +49,10 @@ def create_gunicorn_worker():
 
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
-    from flask import Flask
-
     note_worker = NotificationWorker(
         notification_queue, poll_period_seconds=10, reservation_seconds=30, retry_after_seconds=30
     )
-    app = Flask(__name__)
-    worker = GunicornWorker(__name__, app, note_worker, True)
+    worker = GunicornWorker(__name__, note_worker, True)
     return worker
 
 

--- a/workers/queuecleanupworker.py
+++ b/workers/queuecleanupworker.py
@@ -38,7 +38,7 @@ class QueueCleanupWorker(Worker):
                     return
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -47,7 +47,7 @@ def create_gunicorn_worker():
 
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
-    worker = GunicornWorker(__name__, app, QueueCleanupWorker(), True)
+    worker = GunicornWorker(__name__, QueueCleanupWorker(), True)
     return worker
 
 

--- a/workers/repomirrorworker/repomirrorworker.py
+++ b/workers/repomirrorworker/repomirrorworker.py
@@ -38,7 +38,7 @@ class RepoMirrorWorker(Worker):
                 break
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -47,7 +47,7 @@ def create_gunicorn_worker():
 
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
-    worker = GunicornWorker(__name__, app, RepoMirrorWorker(), features.REPO_MIRROR)
+    worker = GunicornWorker(__name__, RepoMirrorWorker(), features.REPO_MIRROR)
     return worker
 
 

--- a/workers/repositoryactioncounter.py
+++ b/workers/repositoryactioncounter.py
@@ -105,7 +105,7 @@ class RepositoryActionCountWorker(Worker):
         return True
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -115,7 +115,7 @@ def create_gunicorn_worker():
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
     worker = GunicornWorker(
-        __name__, app, RepositoryActionCountWorker(), features.REPOSITORY_ACTION_COUNTER
+        __name__, RepositoryActionCountWorker(), features.REPOSITORY_ACTION_COUNTER
     )
     return worker
 

--- a/workers/repositorygcworker.py
+++ b/workers/repositorygcworker.py
@@ -48,7 +48,7 @@ class RepositoryGCWorker(QueueWorker):
             raise Exception("GC interrupted; will retry")
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -63,7 +63,7 @@ def create_gunicorn_worker():
         reservation_seconds=REPOSITORY_GC_TIMEOUT,
     )
 
-    worker = GunicornWorker(__name__, app, gc_worker, features.REPOSITORY_GARBAGE_COLLECTION)
+    worker = GunicornWorker(__name__, gc_worker, features.REPOSITORY_GARBAGE_COLLECTION)
     return worker
 
 

--- a/workers/securityscanningnotificationworker.py
+++ b/workers/securityscanningnotificationworker.py
@@ -132,7 +132,7 @@ class SecurityScanningNotificationWorker(QueueWorker):
             self.extend_processing(_PROCESSING_SECONDS_EXPIRATION, job_details)
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -145,7 +145,7 @@ def create_gunicorn_worker():
     note_worker = SecurityScanningNotificationWorker(
         secscan_notification_queue, poll_period_seconds=_POLL_PERIOD_SECONDS
     )
-    worker = GunicornWorker(__name__, app, note_worker, feature_flag)
+    worker = GunicornWorker(__name__, note_worker, feature_flag)
     return worker
 
 

--- a/workers/securityworker/securityworker.py
+++ b/workers/securityworker/securityworker.py
@@ -52,7 +52,7 @@ class SecurityWorker(Worker):
             self._model.perform_indexing_recent_manifests(batch_size)
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -62,7 +62,7 @@ def create_gunicorn_worker():
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
     app.register_blueprint(v2_bp, url_prefix="/v2")
-    worker = GunicornWorker(__name__, app, SecurityWorker(), features.SECURITY_SCANNER)
+    worker = GunicornWorker(__name__, SecurityWorker(), features.SECURITY_SCANNER)
     return worker
 
 

--- a/workers/servicekeyworker/servicekeyworker.py
+++ b/workers/servicekeyworker/servicekeyworker.py
@@ -56,7 +56,7 @@ class ServiceKeyWorker(Worker):
         instance_key_renewal_self.labels(True).inc()
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -65,7 +65,7 @@ def create_gunicorn_worker():
 
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
-    worker = GunicornWorker(__name__, app, ServiceKeyWorker(), True)
+    worker = GunicornWorker(__name__, ServiceKeyWorker(), True)
     return worker
 
 

--- a/workers/storagereplication.py
+++ b/workers/storagereplication.py
@@ -170,7 +170,7 @@ class StorageReplicationWorker(QueueWorker):
         )
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -193,7 +193,7 @@ def create_gunicorn_worker():
         poll_period_seconds=POLL_PERIOD_SECONDS,
         reservation_seconds=RESERVATION_SECONDS,
     )
-    worker = GunicornWorker(__name__, app, repl_worker, feature_flag)
+    worker = GunicornWorker(__name__, repl_worker, feature_flag)
     return worker
 
 

--- a/workers/teamsyncworker/teamsyncworker.py
+++ b/workers/teamsyncworker/teamsyncworker.py
@@ -30,7 +30,7 @@ class TeamSynchronizationWorker(Worker):
         sync_teams_to_groups(authentication, STALE_CUTOFF)
 
 
-def create_gunicorn_worker():
+def create_gunicorn_worker() -> GunicornWorker:
     """
     follows the gunicorn application factory pattern, enabling
     a quay worker to run as a gunicorn worker thread.
@@ -40,7 +40,7 @@ def create_gunicorn_worker():
     utilizing this method will enforce a 1:1 quay worker to gunicorn worker ratio.
     """
     feature_flag = (features.TEAM_SYNCING) and (authentication.federated_service)
-    worker = GunicornWorker(__name__, app, TeamSynchronizationWorker(), feature_flag)
+    worker = GunicornWorker(__name__, TeamSynchronizationWorker(), feature_flag)
     return worker
 
 


### PR DESCRIPTION
Quay uses GunicornWorker to run background workers in the development environment. It is not expected to serve any HTTP server.