### PR TITLE
Fix unit tests on macOS

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -117,7 +117,8 @@ def liveserver_app(flask_app, port):
 
     def _spawn_live_server():
         worker = lambda app, port: app.run(port=port, use_reloader=False)
-        shared["process"] = multiprocessing.Process(target=worker, args=(flask_app, port))
+        ctx = multiprocessing.get_context("fork")
+        shared["process"] = ctx.Process(target=worker, args=(flask_app, port))
         shared["process"].start()
 
         start_time = time.time()

--- a/test/registry/liveserverfixture.py
+++ b/test/registry/liveserverfixture.py
@@ -68,7 +68,8 @@ class liveFlaskServer(object):
             if started:
                 break
 
-            self._process = multiprocessing.Process(target=worker, args=(self.app, 0))
+            ctx = multiprocessing.get_context("fork")
+            self._process = ctx.Process(target=worker, args=(self.app, 0))
             self._process.start()
 
             # We must wait for the server to start listening, but give up


### PR DESCRIPTION
Tests that rely on multiprocessing to spawn liveserver fail on macOS:

    Can't pickle local object 'liveserver_app.<locals>._spawn_live_server.<locals>.<lambda>'

Changing the start method to "fork" addresses the problem.