### PR TITLE
builders: Add cacert's to build agent (PROJQUAY-3819)

### DIFF
--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -710,6 +710,16 @@ class KubernetesPodmanExecutor(KubernetesExecutor):
             else self.manager_hostname
         )
 
+        cert = self.executor_config.get("CA_CERT", self._ca_cert())
+        certs = [cert] if cert is not None else []
+        for extra_cert in self.executor_config.get("EXTRA_CA_CERTS", []):
+            try:
+                with open(os.path.join(OVERRIDE_CONFIG_DIRECTORY, extra_cert), "r") as f:
+                    certs.append(f.read())
+            except:
+                logger.warning("Failed to load extra CA cert for builder %s", extra_cert)
+        certs = "\n".join(certs)
+
         container = {
             "name": "builder",
             "imagePullPolicy": self.executor_config.get("IMAGE_PULL_POLICY", "Always"),
@@ -721,7 +731,8 @@ class KubernetesPodmanExecutor(KubernetesExecutor):
                 {"name": "REGISTRY_HOSTNAME", "value": self.registry_hostname},
                 {"name": "CONTAINER_RUNTIME", "value": "podman"},
                 {"name": "BULDAH_ISOLATION", "value": "chroot"},
-                {"name": "CA_CERT", "value": self.executor_config.get("CA_CERT", self._ca_cert())},
+                {"name": "CA_CERT", "value": certs},
+                {"name": "GIT_SSL_CAINFO", "value": "/certs/cacert.crt"},
                 {"name": "TLS_CERT_PATH", "value": "/certs/cacert.crt"},  # Used by build manager
                 {
                     "name": "SSL_CERT_FILE",

--- a/buildman/manager/test/test_executor.py
+++ b/buildman/manager/test/test_executor.py
@@ -1,0 +1,21 @@
+from buildman.manager.executor import KubernetesPodmanExecutor
+from unittest.mock import mock_open, patch
+from _init import OVERRIDE_CONFIG_DIRECTORY
+
+
+def test_podman_executor_adding_cacerts():
+    cert = "-----BEGIN CERTIFICATE-----certificate-----END CERTIFICATE-----"
+    additional_cert = "-----BEGIN CERTIFICATE-----additionalcertificate-----END CERTIFICATE-----"
+    executor_config = {"CA_CERT": cert, "EXTRA_CA_CERTS": ["extra_ca_cert_additional.crt"]}
+    with patch("builtins.open", mock_open(read_data=additional_cert)) as mock_file:
+        executor = KubernetesPodmanExecutor(
+            executor_config=executor_config,
+            registry_hostname="test.hostname",
+            manager_hostname="build.test.hostname",
+        )
+        spec = executor._build_job_containers("token", "builduid")
+        cert_env = [entry for entry in spec["env"] if entry["name"] == "CA_CERT"]
+        assert cert_env[0]["value"] == cert + "\n" + additional_cert
+        mock_file.assert_called_with(
+            OVERRIDE_CONFIG_DIRECTORY + "extra_ca_cert_additional.crt", "r"
+        )


### PR DESCRIPTION
Allows the quay-builder to use user provided certificates.