### PR TITLE
ui: add parent navigation link to repository view (PROJQUAY-3981)

### DIFF
--- a/static/css/core-ui.css
+++ b/static/css/core-ui.css
@@ -920,6 +920,21 @@ a:focus {
   font-family: FontAwesome;
 }
 
+.cor-title-link a.level-up-link  {
+  margin-right: 6px;
+  margin-left: 12px;
+}
+
+.cor-title-link a.level-up-link:before  {
+  content: "\f148";
+  color: white;
+  display: inline-block;
+  margin-right: 10px;
+  vertical-align: middle;
+  font-family: FontAwesome;
+  font-size: 22px;
+}
+
 .co-table {
   width: 100%;
 }

--- a/static/css/quay.css
+++ b/static/css/quay.css
@@ -3932,6 +3932,10 @@ i.mesos-icon {
   color: black;
 }
 
+.onprem .cor-title-link a.level-up-link:before {
+  color: black;
+}
+
 .onprem .co-fx-text-shadow span {
     text-shadow:none;
     color: black;

--- a/static/js/pages/repo-view.js
+++ b/static/js/pages/repo-view.js
@@ -194,5 +194,9 @@
     $scope.getImages = function(callback) {
       loadImages(callback);
     };
+
+    $scope.isOrganization = function(namespace) {
+      return !!UserService.getOrganization(namespace);
+    };
   }
 })();

--- a/static/partials/repo-view.html
+++ b/static/partials/repo-view.html
@@ -19,6 +19,12 @@
           <a class="back-link" href="/repository">
             Repositories
           </a>
+          <a class="level-up-link" href="/user/{{ namespace }}" ng-if="!isOrganization(namespace)">
+            Account
+          </a>
+          <a class="level-up-link" href="/organization/{{ namespace }}" ng-if="isOrganization(namespace)">
+            Organization
+          </a>
         </span>
         <span class="cor-title-content">
           <span class="repo-circle no-background hidden-xs" repo="viewScope.repository"></span>


### PR DESCRIPTION
This adds another link to the repository view that leads to the user account or organization containing the repository. Adds convenience to navigate one level up in the hierarchy of Quay's data model to explore other content in the same account or organization.

<img width="1571" alt="Screenshot 2022-06-18 at 12 39 40" src="https://user-images.githubusercontent.com/12664117/174434176-0408fcee-3f87-4a36-826c-6452275f6b7a.png">

<img width="1566" alt="Screenshot 2022-06-18 at 12 39 26" src="https://user-images.githubusercontent.com/12664117/174434181-7b8b31a6-1a2d-48d5-b2f1-3125b76cd198.png">
