### PR TITLE
Bump html5lib to remove warning about Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ greenlet==1.1.2
 grpcio==1.46.3
 gunicorn==20.1.0
 hashids==1.2.0
-html5lib==1.0.1
+html5lib==1.1
 idna==2.8
 importlib-metadata==1.4.0
 iso8601==0.1.12


### PR DESCRIPTION
Fix warning about deprecated import:

html5lib/_trie/_base.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working