### PR TITLE
chore: Add missing downstream dependency (PROJQUAY-4033)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -149,4 +149,5 @@ jsonpickle==1.2
 pip==21.1
 setuptools==50.3.0
 setuptools-scm[toml]==4.1.2
+typing-extensions==4.0.1
 wheel==0.35.1


### PR DESCRIPTION
* Resolves downstream build issue related to `azure-core`
```
2022-06-30 16:43:49,821 - atomic_reactor.plugins.imagebuilder - INFO - ERROR: Could not find a version that satisfies the requirement typing-extensions>=4.0.1 (from azure-core) (from versions: none)
2022-06-30 16:43:49,821 - atomic_reactor.plugins.imagebuilder - INFO - ERROR: No matching distribution found for typing-extensions>=4.0.1
```