### PR TITLE
chore: Add flit_core to deps (PROJQUAY-4033)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -144,6 +144,7 @@ zope.interface==5.4.0
 
 # Build dependencies
 Cython==3.0a9
+flit_core==3.7.1
 toml==0.10.2
 jsonpickle==1.2
 pip==21.1


### PR DESCRIPTION
* Required by `typing-extensions`
* Should resolve downstream error:
```
2022-06-30 19:19:13,357 - atomic_reactor.plugins.imagebuilder - INFO -   ERROR: Could not find a version that satisfies the requirement flit_core<4,>=3.4 (from versions: none)
2022-06-30 19:19:13,357 - atomic_reactor.plugins.imagebuilder - INFO -   ERROR: No matching distribution found for flit_core<4,>=3.4
```