### PR TITLE
secscan: Don't delete manifest security status on error (PROJQUAY-4060) 

### DIFF
--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -154,11 +154,6 @@ class V4SecurityScanner(SecurityScannerInterface):
         try:
             report = self._secscan_api.vulnerability_report(manifest_or_legacy_image.digest)
         except APIRequestFailure as arf:
-            try:
-                status.delete_instance()
-            except ReadOnlyModeException:
-                pass
-
             return SecurityInformationLookupResult.for_request_error(str(arf))
 
         if report is None:

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -106,7 +106,8 @@ def test_load_security_information_api_request_failure(initialized_db, set_secsc
     secscan._secscan_api.vulnerability_report.side_effect = APIRequestFailure()
 
     assert secscan.load_security_information(manifest).status == ScanLookupStatus.COULD_NOT_LOAD
-    assert not ManifestSecurityStatus.select().where(ManifestSecurityStatus.id == mss.id).exists()
+    # Assert that the ManifestSecurityStatus entry is not deleted.
+    assert ManifestSecurityStatus.select().where(ManifestSecurityStatus.id == mss.id).exists()
 
 
 def test_load_security_information_success(initialized_db, set_secscan_config):


### PR DESCRIPTION
Currently if Clair returns errors Quay will delete the security
status for that manifest, meaning it will revert to a "Queued"
status and needs to be reindexed. This in-turn means that the
functionality is not immediately recovered when Clair becomes
healthy. It is also generally a bad idea (except in specific
use-cases to have a data modification in a read path).

Signed-off-by: crozzy <joseph.crosland@gmail.com>