### PR TITLE
builders: Add cacert's to build agent (PROJQUAY-3819) (#1398)

### DIFF
--- a/buildman/manager/test/test_executor.py
+++ b/buildman/manager/test/test_executor.py
@@ -1,0 +1,21 @@
+from buildman.manager.executor import KubernetesPodmanExecutor
+from unittest.mock import mock_open, patch
+from _init import OVERRIDE_CONFIG_DIRECTORY
+
+
+def test_podman_executor_adding_cacerts():
+    cert = "-----BEGIN CERTIFICATE-----certificate-----END CERTIFICATE-----"
+    additional_cert = "-----BEGIN CERTIFICATE-----additionalcertificate-----END CERTIFICATE-----"
+    executor_config = {"CA_CERT": cert, "EXTRA_CA_CERTS": ["extra_ca_cert_additional.crt"]}
+    with patch("builtins.open", mock_open(read_data=additional_cert)) as mock_file:
+        executor = KubernetesPodmanExecutor(
+            executor_config=executor_config,
+            registry_hostname="test.hostname",
+            manager_hostname="build.test.hostname",
+        )
+        spec = executor._build_job_containers("token", "builduid")
+        cert_env = [entry for entry in spec["env"] if entry["name"] == "CA_CERT"]
+        assert cert_env[0]["value"] == cert + "\n" + additional_cert
+        mock_file.assert_called_with(
+            OVERRIDE_CONFIG_DIRECTORY + "extra_ca_cert_additional.crt", "r"
+        )

--- a/storage/test/test_azure.py
+++ b/storage/test/test_azure.py
@@ -83,7 +83,9 @@ def fake_azure_storage(files=None):
                     "status_code": 201,
                     "content": "{}",
                     "headers": {
-                        "Content-MD5": base64.b64encode(md5(files[filename][block_id]).digest()).decode("ascii"),
+                        "Content-MD5": base64.b64encode(
+                            md5(files[filename][block_id]).digest()
+                        ).decode("ascii"),
                         "ETag": "foo",
                         "x-ms-request-server-encrypted": "false",
                         "last-modified": "Wed, 21 Oct 2015 07:28:00 GMT",


### PR DESCRIPTION
Allows the quay-builder to use user provided certificates.