### PR TITLE
api: Update werkzeug to 1.0.0 and add valid CORS methods (PROJQUAY-4163)

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,7 +83,7 @@ if not is_testing:
 
 # Fix remote address handling for Flask.
 if app.config.get("PROXY_COUNT", 1):
-    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=app.config.get("PROXY_COUNT", 1))
+    app.wsgi_app = ProxyFix(app.wsgi_app)
 
 # Register additional experimental artifact types.
 # TODO: extract this into a real, dynamic registration system.

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -1033,7 +1033,7 @@ def config():
     return response
 
 
-@web.route("/csrf_token", methods=["GET"])
+@web.route("/csrf_token", methods=["GET", "OPTIONS"])
 @crossorigin(anonymous=False)
 def csrf_token():
     token = generate_csrf_token()

--- a/requirements.txt
+++ b/requirements.txt
@@ -134,7 +134,7 @@ urllib3==1.26.9
 webencodings==0.5.1
 WebOb==1.8.6
 websocket-client==0.57.0
-Werkzeug==0.16.1
+Werkzeug==1.0.0
 wrapt==1.13.3
 xhtml2pdf==0.2.4
 yapf==0.29.0

--- a/util/request.py
+++ b/util/request.py
@@ -24,6 +24,8 @@ def get_request_ip():
 
 
 def crossorigin(anonymous=True):
+    cors_methods = ["GET", "HEAD", "OPTIONS", "POST", "DELETE"]
+
     def decorate(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -42,7 +44,9 @@ def crossorigin(anonymous=True):
                 # for single origin requests, allow cookies
                 credentials = True
 
-            decorator = crossdomain(origin=cors_origin, headers=headers, credentials=credentials)
+            decorator = crossdomain(
+                origin=cors_origin, methods=cors_methods, headers=headers, credentials=credentials
+            )
             return decorator(func)(*args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
werkzeug 1.0.0 allows us to set samesite policy to "None" for CORS
requests from quay-ui