### PR TITLE
auth: allow rs384 in jwt (PROJQUAY-4148)

### DIFF
--- a/oauth/oidc.py
+++ b/oauth/oidc.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 OIDC_WELLKNOWN = ".well-known/openid-configuration"
 PUBLIC_KEY_CACHE_TTL = 3600  # 1 hour
-ALLOWED_ALGORITHMS = ["RS256"]
+ALLOWED_ALGORITHMS = ["RS256", "RS384"]
 JWT_CLOCK_SKEW_SECONDS = 30
 
 

--- a/util/security/jwtutil.py
+++ b/util/security/jwtutil.py
@@ -26,7 +26,7 @@ TOKEN_REGEX = re.compile(r"\ABearer (([a-zA-Z0-9+\-_/]+\.)+[a-zA-Z0-9+\-_/]+)\Z"
 
 # ALGORITHM_WHITELIST defines a whitelist of allowed algorithms to be used in JWTs. DO NOT ADD
 # `none` here!
-ALGORITHM_WHITELIST = ["rs256", "hs256"]
+ALGORITHM_WHITELIST = ["rs256", "hs256", "rs384"]
 
 
 class _StrictJWT(PyJWT):


### PR DESCRIPTION
Allow the use of RS384 for jwt and oidc.