### PR TITLE
ui: Remove trial from larger plans for quay.io (PROJQUAY-4197)

### DIFF
--- a/static/directives/plans-display.html
+++ b/static/directives/plans-display.html
@@ -95,10 +95,6 @@
               <i class="fa fa-angle-double-right"></i>
             </a>
           </div>
-
-          <ul class="plan-features single-feature">
-            <li><i class="fa fa-clock-o"></i>30-day free trial</li>
-          </ul>
         </div>
 
         <!-- Larger Plans -->
@@ -125,10 +121,6 @@
               <i class="fa fa-angle-double-right"></i>
             </a>
           </div>
-
-          <ul class="plan-features single-feature">
-            <li><i class="fa fa-clock-o"></i>30-day free trial</li>
-          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Remove the "30-day free trial" node from the bottom of plans