### PR TITLE
oci: Disable active_repo_tags_cache for tests (PROJQUAY-3872)

### DIFF
--- a/test/registry/conformance_tests.py
+++ b/test/registry/conformance_tests.py
@@ -25,7 +25,7 @@ def test_run_conformance(liveserver_session, app_reloader, registry_server_execu
     env["OCI_TEST_PUSH"] = "1"
     # TODO: support the content discovery once tags pagination is changed to support
     # the expected pagination parameter for next page.
-    # env["OCI_TEST_CONTENT_DISCOVERY"] = "1"
+    env["OCI_TEST_CONTENT_DISCOVERY"] = "1"
     # TODO: The Content Mangement API allows for deletion, etc
     # env["OCI_TEST_CONTENT_MANAGEMENT"] = "1"
 

--- a/test/testconfig.py
+++ b/test/testconfig.py
@@ -102,6 +102,9 @@ class TestConfig(DefaultConfig):
 
     DATA_MODEL_CACHE_CONFIG = {
         "engine": "inmemory",
+        # OCI Conformance tests don't expect results to be cached.
+        # If we implement cache invalidation, we can enable it back.
+        "active_repo_tags_cache_ttl": "0s",
     }
 
     FEATURE_REPO_MIRROR = True

--- a/util/expiresdict.py
+++ b/util/expiresdict.py
@@ -50,7 +50,7 @@ class ExpiresDict(object):
         # Otherwise the key has expired or was not found. Rebuild the cache and check it again.
         items = self._rebuild()
         found_item = items.get(key)
-        if found_item is None:
+        if found_item is None or found_item.expired:
             return default_value
 
         return found_item.value


### PR DESCRIPTION
The OCI Content Discovery tests requires Quay to immediately reflect tag changes in tag lists when a tag is created/deleted, so to make tests green we should disable active_repo_tags_cache.