### PR TITLE
mirror: Default mirror rollback to false (PROJQUAY-4296)

### DIFF
--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1014,6 +1014,11 @@ CONFIG_SCHEMA = {
             "description": "Replaces the SERVER_HOSTNAME as the destination for mirroring. Defaults to unset",
             "x-example": "openshift-quay-service",
         },
+        "REPO_MIRROR_ROLLBACK": {
+            "type": ["boolean", "null"],
+            "description": "Enables rolling repository back to previous state in the event the mirror fails. Defaults to false",
+            "x-example": "true",
+        },
         # Feature Flag: V1 push restriction.
         "V1_PUSH_WHITELIST": {
             "type": "array",

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -308,11 +308,29 @@ def test_successful_mirror_verbose_logs(run_skopeo_mock, initialized_db, app, mo
     assert [] == skopeo_calls
 
 
+@pytest.mark.parametrize(
+    "rollback_enabled, expected_delete_calls, expected_retarget_tag_calls",
+    [
+        (True, ["deleted", "updated", "created"], ["updated"]),
+        (False, ["deleted"], []),
+    ],
+)
 @disable_existing_mirrors
 @mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
 @mock.patch("workers.repomirrorworker.retarget_tag")
 @mock.patch("workers.repomirrorworker.delete_tag")
-def test_rollback(delete_tag_mock, retarget_tag_mock, run_skopeo_mock, initialized_db, app):
+@mock.patch("workers.repomirrorworker.app")
+def test_rollback(
+    mock_app,
+    delete_tag_mock,
+    retarget_tag_mock,
+    run_skopeo_mock,
+    expected_retarget_tag_calls,
+    expected_delete_calls,
+    rollback_enabled,
+    initialized_db,
+    app,
+):
     """
     Tags in the repo:
 
@@ -320,6 +338,12 @@ def test_rollback(delete_tag_mock, retarget_tag_mock, run_skopeo_mock, initializ
     "removed" - this tag will be removed during the mirror
     "created" - this tag will be created during the mirror
     """
+    mock_app.config = {
+        "REPO_MIRROR_ROLLBACK": rollback_enabled,
+        "REPO_MIRROR": True,
+        "REPO_MIRROR_SERVER_HOSTNAME": "localhost:5000",
+        "TESTING": True,
+    }
 
     mirror, repo = create_mirror_repo_robot(["updated", "created", "zzerror"])
     _create_tag(repo, "updated")
@@ -387,16 +411,6 @@ def test_rollback(delete_tag_mock, retarget_tag_mock, run_skopeo_mock, initializ
         },
     ]
 
-    retarget_tag_calls = [
-        "updated",
-    ]
-
-    delete_tag_calls = [
-        "deleted",
-        "updated",
-        "created",
-    ]
-
     def skopeo_test(args, proxy):
         try:
             skopeo_call = skopeo_calls.pop(0)
@@ -414,11 +428,11 @@ def test_rollback(delete_tag_mock, retarget_tag_mock, run_skopeo_mock, initializ
             raise e
 
     def retarget_tag_test(name, manifest, is_reversion=False):
-        assert retarget_tag_calls.pop(0) == name
+        assert expected_retarget_tag_calls.pop(0) == name
         assert is_reversion
 
     def delete_tag_test(repository_id, tag_name):
-        assert delete_tag_calls.pop(0) == tag_name
+        assert expected_delete_calls.pop(0) == tag_name
 
     run_skopeo_mock.side_effect = skopeo_test
     retarget_tag_mock.side_effect = retarget_tag_test
@@ -427,8 +441,8 @@ def test_rollback(delete_tag_mock, retarget_tag_mock, run_skopeo_mock, initializ
     worker._process_mirrors()
 
     assert [] == skopeo_calls
-    assert [] == retarget_tag_calls
-    assert [] == delete_tag_calls
+    assert [] == expected_retarget_tag_calls
+    assert [] == expected_delete_calls
 
 
 def test_remove_obsolete_tags(initialized_db):


### PR DESCRIPTION
Adds the `REPO_MIRROR_ROLLBACK` option to specify whether the mirror will rollback the state of the repo on failure of any one of the tags. Defaults to false. Adds additional `PARTIAL_SYNC` error status which logs the tags that failed to sync to the console.