### PR TITLE
feature: Enable IPv6 Listeners (PROJQUAY-272)

### DIFF
--- a/conf/nginx/nginx.conf.jnj
+++ b/conf/nginx/nginx.conf.jnj
@@ -30,6 +30,7 @@ http {
         include server-base.conf;
 
         listen 8443 ssl http2 default;
+        listen [::]:8443 ssl http2 default;
 
         ssl on;
 
@@ -54,6 +55,8 @@ http {
         include server-base.conf;
 
         listen 7443 ssl http2 default proxy_protocol;
+        listen [::]:7443 ssl http2 default proxy_protocol;
+        
         ssl on;
 
         # This header must be set only for HTTPS
@@ -75,6 +78,7 @@ http {
         ssl_certificate_key ../stack/ssl.key;
 
         listen 55443 ssl http2 default;
+        listen [::]:55443 ssl http2 default;
         ssl on;
 
         # Required for gRPC streaming of long running builds
@@ -108,6 +112,7 @@ http {
         ssl_certificate_key ../stack/ssl.key;
 
         listen 8443 ssl;
+        listen [::]:8443 ssl;
 
         ssl on;
 
@@ -126,6 +131,7 @@ http {
         include server-base.conf;
 
         listen 7443 ssl proxy_protocol;
+        listen [::]:7443 ssl proxy_protocol;
         ssl on;
 
         # This header must be set only for HTTPS
@@ -151,6 +157,7 @@ http {
         include server-base.conf;
 
         listen 8080 default;
+        listen [::]:8080 default;
 
         access_log /var/log/nginx/access.log lb_logs;
     }


### PR DESCRIPTION
* Adds IPv6 listeners to `nginx.conf`

Test by spinning up an instance and attempting to curl an IPv6 address and port:

```
$ curl http://localhost:8080/health/instance
{"data":{"services":{"auth":true,"database":true,"disk_space":true,"registry_gunicorn":true,"service_key":true,"web_gunicorn":true}},"status_code":200}

$ curl http://[::1]:8080/health/instance
{"data":{"services":{"auth":true,"database":true,"disk_space":true,"registry_gunicorn":true,"service_key":true,"web_gunicorn":true}},"status_code":200}
```