### PR TITLE
mirror: Rollback failed tags (PROJQUAY-4322)

### DIFF
--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -311,8 +311,8 @@ def test_successful_mirror_verbose_logs(run_skopeo_mock, initialized_db, app, mo
 @pytest.mark.parametrize(
     "rollback_enabled, expected_delete_calls, expected_retarget_tag_calls",
     [
-        (True, ["deleted", "updated", "created"], ["updated"]),
-        (False, ["deleted"], []),
+        (True, ["deleted", "zzerror", "updated", "created"], ["updated"]),
+        (False, ["deleted", "zzerror"], []),
     ],
 )
 @disable_existing_mirrors
@@ -421,6 +421,8 @@ def test_rollback(
                 _create_tag(repo, "updated")
             elif args[1] == "copy" and args[8].endswith(":created"):
                 _create_tag(repo, "created")
+            elif args[1] == "copy" and args[8].endswith(":zzerror"):
+                _create_tag(repo, "zzerror")
 
             return skopeo_call["results"]
         except Exception as e:


### PR DESCRIPTION
Currently Quay creates tags for Docker V2 schema 1 manifests in manifest lists. This makes it appear a tag was mirrored successfully when it had actually failed. This change rolls back those failed tags when the sync fails.