### PR TITLE
ui: Invalidate browser cache on new ui toggle (PROJQUAY-4423)

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -27,13 +27,13 @@ location /signin {
 location /angular {
     # Expire cookie and switch to old UI
     add_header Set-Cookie "patternfly=deleted; path=/; Expires=Thu, Jan 01 1970 00:00:00 UTC";
-    return 302 /;
+    return 302 /?$args;
 }
 
 location /react {
     # Set cookie and witch to new UI
     add_header Set-Cookie "patternfly=true; path=/; SameSite=Lax; HttpOnly;" always;
-    return 302 /;
+    return 302 /?$args;
 }
 
 location / {

--- a/static/js/directives/ui/new-ui-toggle/new-ui-toggle.component.ts
+++ b/static/js/directives/ui/new-ui-toggle/new-ui-toggle.component.ts
@@ -20,7 +20,11 @@ export class NewUiToggleComponent {
   private useNewUI($event): void {
     let protocol = window.location.protocol;
     let host = window.location.host;
-    window.location.replace(`${protocol}//${host}/react`);
+    let path = 'react';
+
+    // Add a random arg so nginx redirect to / doesn't get cached by browser
+    let randomArg = '?_=' + new Date().getTime();
+    window.location.replace(`${protocol}//${host}/${path}/${randomArg}`);
     $('#newBetaUIModal').modal('hide');
   }
 }


### PR DESCRIPTION
Second part of https://github.com/quay/quay-ui/pull/82

* Prevents browser from caching nginx redirect to `/` by passing query args in replace request. 