### PR TITLE
net: Add feature flags for IPv6 (PROJQUAY-131)

### DIFF
--- a/conf/init/nginx_conf_create.py
+++ b/conf/init/nginx_conf_create.py
@@ -75,6 +75,11 @@ def generate_nginx_config(config):
     ssl_protocols = config.get("SSL_PROTOCOLS", SSL_PROTOCOL_DEFAULTS)
     ssl_ciphers = config.get("SSL_CIPHERS", SSL_CIPHER_DEFAULTS)
 
+    # Enable IPv4 and/or IPv6. Valid values are IPv4, IPv6 or dual-stack.
+    ip_version = config.get("FEATURE_LISTEN_IP_VERSION", "IPv4")
+    use_ipv4 = True if ip_version.lower() != "ipv6" else False
+    use_ipv6 = True if ip_version.lower() in ["ipv6", "dual-stack"] else False
+
     write_config(
         os.path.join(QUAYCONF_DIR, "nginx/nginx.conf"),
         use_https=use_https,
@@ -82,6 +87,8 @@ def generate_nginx_config(config):
         v1_only_domain=v1_only_domain,
         ssl_protocols=ssl_protocols,
         ssl_ciphers=":".join(ssl_ciphers),
+        use_ipv4=use_ipv4,
+        use_ipv6=use_ipv6,
     )
 
 

--- a/conf/nginx/nginx.conf.jnj
+++ b/conf/nginx/nginx.conf.jnj
@@ -32,8 +32,12 @@ http {
 
         include server-base.conf;
 
+        {% if use_ipv4 %}
         listen 8443 ssl http2 default;
+        {% endif %}
+        {% if use_ipv6 %}
         listen [::]:8443 ssl http2 default;
+        {% endif %}
 
         ssl on;
 
@@ -57,8 +61,12 @@ http {
 
         include server-base.conf;
 
+        {% if use_ipv4 %}
         listen 7443 ssl http2 default proxy_protocol;
+        {% endif %}
+        {% if use_ipv6 %}
         listen [::]:7443 ssl http2 default proxy_protocol;
+        {% endif %}
         
         ssl on;
 
@@ -80,8 +88,12 @@ http {
         ssl_certificate ../stack/ssl.cert;
         ssl_certificate_key ../stack/ssl.key;
 
+        {% if use_ipv4 %}
         listen 55443 ssl http2 default;
+        {% endif %}
+        {% if use_ipv6 %}
         listen [::]:55443 ssl http2 default;
+        {% endif %}
         ssl on;
 
         # Required for gRPC streaming of long running builds
@@ -114,8 +126,12 @@ http {
         ssl_certificate ../stack/ssl.cert;
         ssl_certificate_key ../stack/ssl.key;
 
+        {% if use_ipv4 %}
         listen 8443 ssl;
+        {% endif %}
+        {% if use_ipv6 %}
         listen [::]:8443 ssl;
+        {% endif %}
 
         ssl on;
 
@@ -133,8 +149,12 @@ http {
 
         include server-base.conf;
 
+        {% if use_ipv4 %}
         listen 7443 ssl proxy_protocol;
+        {% endif %}
+        {% if use_ipv6 %}
         listen [::]:7443 ssl proxy_protocol;
+        {% endif %}
         ssl on;
 
         # This header must be set only for HTTPS
@@ -159,8 +179,12 @@ http {
     server {
         include server-base.conf;
 
+        {% if use_ipv4 %}
         listen 8080 default;
+        {% endif %}
+        {% if use_ipv6 %}
         listen [::]:8080 default;
+        {% endif %}
 
         access_log /var/log/nginx/access.log lb_logs;
     }

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1247,5 +1247,10 @@ CONFIG_SCHEMA = {
             "description": "Cross-Origin domain to allow requests from",
             "x-example": "localhost:9000",
         },
+        "FEATURE_LISTEN_IP_VERSION": {
+            "type": "string",
+            "description": "Enables IPv4, IPv6 or dual-stack networking. Defaults to `IPv4`.",
+            "x-example": "IPv4",
+        },
     },
 }


### PR DESCRIPTION
* Provides a toggle for enabling IPv6, helps resolve issue with nginx failing to start in an IPv4 only environment