### PR TITLE
dev: Update Clair for dev (PROJQUAY-4461)

### DIFF
--- a/docker-compose.static
+++ b/docker-compose.static
@@ -41,6 +41,7 @@ services:
       timeout: 9s
       retries: 3
       start_period: 10s
+    cpus: 2
 
   redis:
     user: nobody
@@ -77,13 +78,14 @@ services:
   clair:
     user: nobody
     container_name: quay-clair
-    image: quay.io/projectquay/clair:4.3.0
+    image: quay.io/projectquay/clair:4.4.0
     volumes:
       - "./local-dev/clair:/src/clair/"
     environment:
       CLAIR_CONF: "/src/clair/config.yaml"
       CLAIR_MODE: "combo"
     network_mode: "service:quay"
+    cpus: 2
     command:
       ["bash", "-c", "cd /src/clair/cmd/clair; go run -mod vendor ."]
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       timeout: 9s
       retries: 3
       start_period: 10s
+    cpus: 2
 
   redis:
     user: nobody
@@ -95,13 +96,14 @@ services:
   clair:
     user: nobody
     container_name: quay-clair
-    image: quay.io/projectquay/clair:4.3.0
+    image: quay.io/projectquay/clair:4.4.0
     volumes:
       - "./local-dev/clair:/src/clair/"
     environment:
       CLAIR_CONF: "/src/clair/config.yaml"
       CLAIR_MODE: "combo"
     network_mode: "service:quay"
+    cpus: 2
     command:
       ["bash", "-c", "cd /src/clair/cmd/clair; go run -mod vendor ."]
     depends_on:


### PR DESCRIPTION
* Updates Clair to 4.4.4
* Limits `clair` and `clair-db` to 2 CPU each
![image](https://user-images.githubusercontent.com/1656866/190159960-db440a36-4006-4a0a-9eb3-81f95eae6e73.png)
