### PR TITLE
Export Compliance: Fetching quay user data from federated login username (PROJQUAY-0000)

### DIFF
--- a/data/model/test/test_user.py
+++ b/data/model/test/test_user.py
@@ -15,6 +15,7 @@ from data.model.user import create_robot, lookup_robot, list_namespace_robots
 from data.model.user import get_pull_credentials, retrieve_robot_token, verify_robot
 from data.model.user import InvalidRobotException, delete_robot, get_matching_users
 from data.model.user import get_estimated_robot_count, RobotAccountToken, attach_federated_login
+from data.model.user import get_quay_user_from_federated_login_name
 from data.model.repository import create_repository
 from data.fields import Credential
 from data.queue import WorkQueue
@@ -235,3 +236,19 @@ def test_robot(initialized_db):
 
 def test_get_estimated_robot_count(initialized_db):
     assert get_estimated_robot_count() >= RobotAccountToken.select().count()
+
+
+def test_get_quay_user_from_federated_login_name(initialized_db):
+    username = "non-existant-user"
+    assert get_quay_user_from_federated_login_name(username) is None
+
+    devtable_username = "devtable"
+    # When quay.io username is same as SSO username
+    result = get_quay_user_from_federated_login_name(devtable_username)
+    assert result.username == devtable_username
+
+    freshuser_username = "freshuser"  # SSO username
+    public_username = "public"  # quayio username
+    # When quay.io username is different from SSO username
+    result = get_quay_user_from_federated_login_name(freshuser_username)
+    assert result.username == public_username

--- a/data/model/user.py
+++ b/data/model/user.py
@@ -1372,6 +1372,16 @@ def get_minimum_user_id():
     return User.select(fn.Min(User.id)).tuples().get()[0]
 
 
+def get_quay_user_from_federated_login_name(username):
+    results = FederatedLogin.select().where(FederatedLogin.metadata_json.contains(username))
+    user_id = None
+    for result in results:
+        if json.loads(result.metadata_json).get("service_username") == username:
+            user_id = result.user_id
+
+    return get_namespace_user_by_user_id(user_id) if user_id else None
+
+
 class LoginWrappedDBUser(UserMixin):
     def __init__(self, user_uuid, db_user=None):
         self._uuid = user_uuid

--- a/initdb.py
+++ b/initdb.py
@@ -63,6 +63,7 @@ from data.database import (
     UserOrganizationQuota,
     RepositorySize,
     ProxyCacheConfig,
+    FederatedLogin,
 )
 from data import model
 from data.decorators import is_deprecated_model
@@ -1277,6 +1278,30 @@ def populate_database(minimal=False):
     for to_count in Repository.select():
         model.repositoryactioncount.count_repository_actions(to_count, datetime.utcnow())
         model.repositoryactioncount.update_repository_score(to_count)
+
+    # Case 1: Where RH SSO username is same as quay.io username
+    FederatedLogin.create(
+        user=new_user_1,  # quay.io username
+        service=LoginService.get(name="quayrobot"),
+        service_ident="fake-id1",
+        metadata_json=json.dumps(
+            {
+                "service_username": new_user_1.username,  # login service username
+            }
+        ),
+    )
+
+    # Case 2: Where RH SSO username and quay.io username are different
+    FederatedLogin.create(
+        user=new_user_2,  # quay.io username
+        service=LoginService.get(name="quayrobot"),
+        service_ident="fake-id2",
+        metadata_json=json.dumps(
+            {
+                "service_username": new_user_3.username,  # login service username
+            }
+        ),
+    )
 
 
 WHITELISTED_EMPTY_MODELS = [


### PR DESCRIPTION
The function `get_quay_user_from_federated_login_name` is used by the Self Service Tool to fetch quay.io users based on RH SSO username. RH SSO username is stored as a JSON blob with key `service_username`.