### PR TITLE
superuser: Fix typo (PROJQUAY-3924)

### DIFF
--- a/data/users/__init__.py
+++ b/data/users/__init__.py
@@ -344,7 +344,7 @@ class SuperUserManager(object):
     def init_app(self, app, authentication):
         manager = None
         if authentication.federated_service:
-            manager = FederetedSuperUserManager(app, authentication)
+            manager = FederatedSuperUserManager(app, authentication)
         else:
             manager = ConfigSuperUserManager(app)
 


### PR DESCRIPTION
* Fixes issue with new `LDAP_SUPERUSER_FILTER` feature
```
<pre>Running init script &apos;/quay-registry/conf/init/nginx_conf_create.sh&apos;
Running init script &apos;/quay-registry/conf/init/runmigration.sh&apos;
Traceback (most recent call last):
  File &quot;/quay-registry/conf/init/data_migration.py&quot;, line 3, in &lt;module&gt;
    from app import app
  File &quot;/quay-registry/app.py&quot;, line 262, in &lt;module&gt;
    superusers = SuperUserManager(app, authentication)
  File &quot;/quay-registry/data/users/__init__.py&quot;, line 342, in __init__
    self.state = self.init_app(app, authentication)
  File &quot;/quay-registry/data/users/__init__.py&quot;, line 347, in init_app
    manager = FederetedSuperUserManager(app, authentication)
NameError: name &apos;FederetedSuperUserManager&apos; is not defined
</pre>
```