### PR TITLE
superuser: Fix super (PROJQUAY-3924)

### DIFF
--- a/data/users/__init__.py
+++ b/data/users/__init__.py
@@ -362,7 +362,7 @@ class FederatedSuperUserManager(ConfigSuperUserManager):
 
     def __init__(self, app, authentication):
         self.federated_users = authentication
-        super().__init__(self, app)
+        super().__init__(app)
 
     def is_superuser(self, username):
         """


### PR DESCRIPTION
* Fixes `super()` formatting for python 3. 
```
Running init script '/quay-registry/conf/init/nginx_conf_create.sh'
Running init script '/quay-registry/conf/init/runmigration.sh'
Traceback (most recent call last):
  File "/quay-registry/conf/init/data_migration.py", line 3, in <module>
    from app import app
  File "/quay-registry/app.py", line 262, in <module>
    superusers = SuperUserManager(app, authentication)
  File "/quay-registry/data/users/__init__.py", line 342, in __init__
    self.state = self.init_app(app, authentication)
  File "/quay-registry/data/users/__init__.py", line 347, in init_app
    manager = FederatedSuperUserManager(app, authentication)
  File "/quay-registry/data/users/__init__.py", line 365, in __init__
    super().__init__(self, app)
TypeError: __init__() takes 2 positional arguments but 3 were given
```