### PR TITLE
storage: return S3 url only for ip ranges in the same region (PROJQUAY-4498)

### DIFF
--- a/storage/test/test_cloudfront.py
+++ b/storage/test/test_cloudfront.py
@@ -14,6 +14,7 @@ from test.fixtures import *
 
 _TEST_CONTENT = os.urandom(1024)
 _TEST_BUCKET = "somebucket"
+_TEST_REGION = "us-east-1"
 _TEST_USER = "someuser"
 _TEST_PASSWORD = "somepassword"
 _TEST_PATH = "some/cool/path"
@@ -76,14 +77,18 @@ def test_direct_download(
             "test/data/test.pem",
             "some/path",
             _TEST_BUCKET,
+            _TEST_REGION,
             _TEST_USER,
             _TEST_PASSWORD,
         )
         engine.put_content(_TEST_PATH, _TEST_CONTENT)
         assert engine.exists(_TEST_PATH)
 
-        # Request a direct download URL for a request from a known AWS IP, and ensure we are returned an S3 URL.
-        assert "s3.amazonaws.com" in engine.get_direct_download_url(_TEST_PATH, test_aws_ip)
+        # Request a direct download URL for a request from a known AWS IP but not in the same region, returned CloudFront URL.
+        assert "cloudfrontdomain" in engine.get_direct_download_url(_TEST_PATH, test_aws_ip)
+
+        # Request a direct download URL for a request from a known AWS IP and in the same region, returned S3 URL.
+        assert "s3.amazonaws.com" in engine.get_direct_download_url(_TEST_PATH, "4.0.0.2")
 
         if ipranges_populated:
             # Request a direct download URL for a request from a non-AWS IP, and ensure we are returned a CloudFront URL.
@@ -109,6 +114,7 @@ def test_direct_download_no_ip(test_aws_ip, aws_ip_range_data, ipranges_populate
         "test/data/test.pem",
         "some/path",
         _TEST_BUCKET,
+        _TEST_REGION,
         _TEST_USER,
         _TEST_PASSWORD,
     )
@@ -132,6 +138,7 @@ def test_direct_download_with_username(test_aws_ip, aws_ip_range_data, ipranges_
         "test/data/test.pem",
         "some/path",
         _TEST_BUCKET,
+        _TEST_REGION,
         _TEST_USER,
         _TEST_PASSWORD,
     )

--- a/util/ipresolver/test/test_ipresolver.py
+++ b/util/ipresolver/test/test_ipresolver.py
@@ -26,6 +26,16 @@ def aws_ip_range_data():
                 "region": "GLOBAL",
                 "service": "EC2",
             },
+            {
+                "ip_prefix": "5.0.0.0/8",
+                "region": "af-south-1",
+                "service": "AMAZON",
+            },
+            {
+                "ip_prefix": "4.0.0.0/8",
+                "region": "us-east-1",
+                "service": "EC2",
+            },
         ],
     }
     return fake_range_doc
@@ -45,23 +55,48 @@ def test_ip_range_cache(aws_ip_range_data):
 def test_resolved(aws_ip_range_data, test_ip_range_cache, test_aws_ip, app):
     ipresolver = IPResolver(app)
     ipresolver.amazon_ranges = test_ip_range_cache["all_amazon"]
+
     ipresolver.sync_token = test_ip_range_cache["sync_token"]
 
     assert ipresolver.resolve_ip(test_aws_ip) == ResolvedLocation(
-        provider="aws", service=None, sync_token=123456789, country_iso_code=None
+        provider="aws",
+        service=None,
+        sync_token=123456789,
+        country_iso_code=None,
+        aws_region="GLOBAL",
     )
     assert ipresolver.resolve_ip("10.0.0.2") == ResolvedLocation(
-        provider="aws", service=None, sync_token=123456789, country_iso_code=None
+        provider="aws",
+        service=None,
+        sync_token=123456789,
+        country_iso_code=None,
+        aws_region="GLOBAL",
     )
     assert ipresolver.resolve_ip("6.0.0.2") == ResolvedLocation(
-        provider="aws", service=None, sync_token=123456789, country_iso_code="US"  # DoD assigned
+        provider="aws",
+        service=None,
+        sync_token=123456789,
+        country_iso_code="US",
+        aws_region="GLOBAL",  # DoD assigned
+    )
+    assert ipresolver.resolve_ip("4.0.0.2") == ResolvedLocation(
+        provider="aws",
+        service=None,
+        sync_token=123456789,
+        country_iso_code="US",
+        aws_region="us-east-1",
     )
     assert ipresolver.resolve_ip("56.0.0.2") == ResolvedLocation(
         provider="internet",
         service="US",
         sync_token=123456789,
         country_iso_code="US",  # USPS assigned
+        aws_region=None,
     )
     assert ipresolver.resolve_ip("127.0.0.1") == ResolvedLocation(
-        provider="internet", service=None, sync_token=123456789, country_iso_code=None
+        provider="internet",
+        service=None,
+        sync_token=123456789,
+        country_iso_code=None,
+        aws_region=None,
     )


### PR DESCRIPTION

This optimization ensures that we return the direct S3 URL for CloudFront storage only for requests from the same region. This ensures we don't get charged for cross-region traffic to S3