### PR TITLE
Clarify date format created by format_date

### DIFF
--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -126,7 +126,7 @@ def hide_if(value):
 
 def format_date(date):
     """
-    Output an RFC822 date format.
+    Output an RFC 2822 date format.
     """
     if date is None:
         return None


### PR DESCRIPTION
The format created by `email.utils.formatdate` is RFC 2822, not RFC 822.