### PR TITLE
secscan: Generate key to reduce vulnerabilities (PROJQUAY-4562)

### DIFF
--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -445,12 +445,24 @@ def features_for(report):
     Quay Security scanner response.
     """
     features = []
+    dedupe_vulns = {}
     for pkg_id, pkg in report["packages"].items():
         pkg_env = report["environments"][pkg_id][0]
-        pkg_vulns = [
-            report["vulnerabilities"][vuln_id]
-            for vuln_id in report["package_vulnerabilities"].get(pkg_id, [])
-        ]
+        pkg_vulns = []
+        # Quay doesn't care about vulnerabilities reported from different
+        # repos so dedupe them. Key = package_name + package_version + vuln_name.
+        for vuln_id in report["package_vulnerabilities"].get(pkg_id, []):
+            vuln_key = (
+                pkg["name"]
+                + "_"
+                + pkg["version"]
+                + "_"
+                + report["vulnerabilities"][vuln_id].get("name", "")
+            )
+            if not dedupe_vulns.get(vuln_key, False):
+                pkg_vulns.append(report["vulnerabilities"][vuln_id])
+            dedupe_vulns[vuln_key] = True
+
         enrichments = (
             {
                 key: sorted(val, key=lambda x: x["baseScore"], reverse=True)[0]

--- a/data/secscan_model/test/securityinformation_deduped.json
+++ b/data/secscan_model/test/securityinformation_deduped.json
@@ -1,0 +1,3764 @@
+{
+    "Layer": {
+        "Name": "sha256:1674a920ec5909881e0a7e46c27ac8a24858197e09904898586e3eb48684f446",
+        "ParentName": "",
+        "NamespaceName": "",
+        "IndexedByVersion": 4,
+        "Features": [
+            {
+                "Name": "acl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.2.53-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "alembic",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.3.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "aniso8601",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "apscheduler",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.6.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "attrs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "19.3.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "audit-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.0.7-2.el8.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "authlib",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.0.0a1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "aws-sam-translator",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.20.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "azure-core",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.8.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "azure-storage-blob",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "12.4.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "babel",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.9.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "basesystem",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "11-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "bash",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.4.20-4.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "bcrypt",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.1.7",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "beautifulsoup4",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "4.8.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "bintrees",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "bitmath",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.3.3.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "blinker",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "boto3",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.21.42",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "botocore",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.24.42",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "brotli",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.0.6-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "bzip2-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.0.6-26.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ca-certificates",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2021.2.50-80.0.el8_4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "cachetools",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "4.0.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "certifi",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2019.11.28",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "cffi",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.14.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "chardet",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.0.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "charset-normalizer",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.0.12",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "chkconfig",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.19.1-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "click",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "7.1.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "cnr-server",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.2.7.post1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "containers-common",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2:1-35.module+el8.6.0+15917+093ca6f8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "coreutils-single",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "8.30-12.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "cracklib",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.9.6-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "cracklib-dicts",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.9.6-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "criu",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.15-3.module+el8.6.0+15875+dc9a2b96",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "crypto-policies",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "20211116-1.gitae470d6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "crypto-policies-scripts",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "20211116-1.gitae470d6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "cryptography",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.3.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "cryptsetup-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.3.7-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "curl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "7.61.1-22.el8_6.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "cyrus-sasl-lib",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.1.27-6.el8_5",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "cython",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.0.0a9",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "datetime",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "4.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dbus",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:1.12.8-18.el8_6.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dbus-common",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:1.12.8-18.el8_6.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dbus-daemon",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:1.12.8-18.el8_6.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dbus-glib",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.110-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dbus-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:1.12.8-18.el8_6.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dbus-python",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.2.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dbus-tools",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:1.12.8-18.el8_6.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "debtcollector",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.22.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "decorator",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "4.4.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "decorator",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.2.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dejavu-fonts-common",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.35-7.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dejavu-sans-fonts",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.35-7.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "deprecated",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.2.7",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "device-mapper",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "8:1.02.181-3.el8_6.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "device-mapper-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "8:1.02.181-3.el8_6.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dmidecode",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:3.3-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dnf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.7.0-8.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dnf-data",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.7.0-8.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dnf-plugin-subscription-manager",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.28.29-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dnsmasq",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.79-21.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "dumb-init",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.2.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "elasticsearch",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "7.0.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "elasticsearch-dsl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "7.0.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "elfutils-default-yama-scope",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.186-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "elfutils-libelf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.186-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "elfutils-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.186-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ethtool",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.14",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "expat",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.2.5-8.el8_6.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "file-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "5.33-20.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "filesystem",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.8-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "findutils",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:4.6.0-20.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "flask",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.1.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "flask-cors",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.0.9",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "flask-login",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.4.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "flask-mail",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.9.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "flask-principal",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.4.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "flask-restful",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.3.9",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "fontconfig",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.13.1-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "fontpackages-filesystem",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.44-22.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "freetype",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.9.1-4.el8_3.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "furl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "fuse-common",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.3.0-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "fuse-overlayfs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.9-1.module+el8.6.0+15917+093ca6f8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "fuse3",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.3.0-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "fuse3-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.3.0-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "futures",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.1.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gawk",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.2.1-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gd",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.2.5-7.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gdb-gdbserver",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "8.2-18.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gdbm",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:1.18-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gdbm-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:1.18-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "geoip2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.0.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gevent",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "21.8.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "glib2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.56.4-158.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "glibc",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.28-189.5.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "glibc-common",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.28-189.5.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "glibc-minimal-langpack",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.28-189.5.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gmp",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:6.1.2-10.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gnupg2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.2.20-2.el8",
+                "Vulnerabilities": [
+                    {
+                        "Severity": "Medium",
+                        "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+                        "Link": "https://access.redhat.com/errata/RHSA-2022:6463 https://access.redhat.com/security/cve/CVE-2022-34903",
+                        "FixedBy": "0:2.2.20-3.el8_6",
+                        "Description": "The GNU Privacy Guard (GnuPG or GPG) is a tool for encrypting data and creating digital signatures, compliant with OpenPGP and S/MIME standards.\n\nSecurity Fix(es):\n\n* gpg: Signature spoofing via status line injection (CVE-2022-34903)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+                        "Name": "RHSA-2022:6463: gnupg2 security update (Moderate)",
+                        "Metadata": {
+                            "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+                            "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+                            "RepoLink": null,
+                            "DistroName": "Red Hat Enterprise Linux Server",
+                            "DistroVersion": "8",
+                            "NVD": {
+                                "CVSSv3": {
+                                    "Vectors": "",
+                                    "Score": ""
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "Name": "gnutls",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.6.16-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gobject-introspection",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.56.1-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gpg-pubkey",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "fd431d51-4ae0493b",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gpg-pubkey",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "d4082792-5b32db75",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gpgme",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.13.1-11.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "greenlet",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.1.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "grep",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.1-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "groff-base",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.22.3-18.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "grpcio",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.30.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gunicorn",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "20.1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "gzip",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.9-13.el8_5",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "hashids",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.2.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "html5lib",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.0.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "idna",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.5",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "idna",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ima-evm-utils",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.3.2-12.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "importlib-metadata",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.4.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "info",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "6.5-7.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "iniparse",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "iptables-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.8.4-22.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "iso8601",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.1.12",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "isodate",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.6.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "itsdangerous",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jansson",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.14-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jasmine-core",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:55d1c0fb65e634002b0c983896141d5f7fe976672630e402d451e1478d8a7588",
+                "Version": "2.8.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jasmine-core",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:55d1c0fb65e634002b0c983896141d5f7fe976672630e402d451e1478d8a7588",
+                "Version": "3.0.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jbigkit-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.1-14.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jinja2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.11.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jmespath",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.9.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "json-c",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.13.1-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "json-glib",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.4.4-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jsonpath-rw",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.4.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jsonpickle",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jsonpointer",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "jsonschema",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.2.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "kafka-python",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.4.7",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "keystoneauth1",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.18.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "keyutils-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.5.10-9.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "kmod",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "25-19.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "kmod-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "25-19.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "krb5-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.18.2-14.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "langpacks-en",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.0-12.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libX11",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.6.8-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libX11-common",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.6.8-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libXau",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.0.9-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libXpm",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.5.12-8.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libacl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.2.53-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libarchive",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.3.3-3.el8_5",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libassuan",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.5.1-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libattr",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.4.48-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libblkid",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.32.1-35.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libcap",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.48-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libcap-ng",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.7.11-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libcom_err",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.45.6-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libcomps",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.1.18",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libcomps",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.1.18-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libcurl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "7.61.1-22.el8_6.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libdb",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "5.3.28-42.el8_4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libdb-utils",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "5.3.28-42.el8_4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libdnf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.63.0-8.1.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libevent",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.1.8-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libfdisk",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.32.1-35.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libffi",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.1-23.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libgcc",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "8.5.0-10.1.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libgcrypt",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.8.5-7.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libgpg-error",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.31-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libibverbs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "37.2-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libidn2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.2.0-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libjpeg-turbo",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.5.3-12.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libksba",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.3.5-7.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libmnl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.0.4-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libmodulemd",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.13.0-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libmount",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.32.1-35.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libnet",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.1.6-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libnftnl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.1.5-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libnghttp2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.33.0-3.el8_2.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libnl3",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.5.0-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libnsl2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.2.0-2.20180605git4a062cf.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libpcap",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "14:1.9.1-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libpkgconf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.4.2-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libpng",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2:1.6.34-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libpq",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "13.5-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libpq-devel",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "13.5-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libpsl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.20.2-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libpwquality",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.4.4-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "librepo",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.14.2-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libreport-filesystem",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.9.5-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "librhsm",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.0.3-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libseccomp",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.5.2-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libselinux",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.9-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libsemanage",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.9-8.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libsepol",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.9-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libsigsegv",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.11-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libslirp",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4.4.0-1.module+el8.6.0+15875+dc9a2b96",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libsmartcols",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.32.1-35.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libsolv",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.7.20-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libssh",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.9.6-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libssh-config",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.9.6-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libstdc++",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "8.5.0-10.1.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libtasn1",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.13-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libtiff",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4.0.9-21.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libtirpc",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.1.4-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libunistring",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.9.9-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libusbx",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.0.23-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libuser",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.62-24.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libutempter",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.1.6-14.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libuuid",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.32.1-35.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libverto",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.3.0-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libwebp",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.0.0-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libxcb",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.13.1-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libxcrypt",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.1.1-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libxml2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.9.7-13.el8_6.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libxslt",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.1.32-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libyaml",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.1.7-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "libzstd",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.4.4-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "lua-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "5.3.4-12.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "lz4-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.8.3-3.el8_4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "mako",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.1.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "markupsafe",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.1.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "maxminddb",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.5.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "memcached",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "0:1.5.22-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "mixpanel",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "4.5.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "mpfr",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.1.6-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "msgpack",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.6.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "msrest",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.6.21",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ncurses",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "6.1-9.20180224.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ncurses-base",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "6.1-9.20180224.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ncurses-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "6.1-9.20180224.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ndg-httpsclient",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.5.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "netaddr",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.7.19",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "netifaces",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.10.9",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nettle",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.4.1-7.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nftables",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:0.9.3-25.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nginx",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nginx-all-modules",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nginx-filesystem",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nginx-mod-http-image-filter",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nginx-mod-http-perl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nginx-mod-http-xslt-filter",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nginx-mod-mail",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "nginx-mod-stream",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "npth",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.5-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "oauthlib",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "openldap",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.4.46-18.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "openssl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.1.1k-7.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "openssl-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:1.1.1k-7.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "orderedmultidict",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.0.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "os-service-types",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.7.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "oslo.config",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "7.0.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "oslo.i18n",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.25.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "oslo.serialization",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.29.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "oslo.utils",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "4.12.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "p11-kit",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.23.22-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "p11-kit-trust",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.23.22-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "packaging",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "21.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pam",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.3.1-16.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "passwd",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.80-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pbr",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "5.4.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pcre",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "8.42-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pcre2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "10.32-3.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "peewee",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.13.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Carp",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.42-396.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Data-Dumper",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.167-399.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Digest",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.17-395.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Digest-MD5",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.55-396.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Encode",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4:2.97-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Errno",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "0:1.28-421.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Exporter",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "5.72-396.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-File-Path",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.15-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-File-Temp",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "0.230.600-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Getopt-Long",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:2.50-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-HTTP-Tiny",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "0.074-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-IO",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "0:1.38-421.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-IO-Socket-IP",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "0.39-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-IO-Socket-SSL",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2.066-4.module+el8.3.0+6446+594cad75",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-MIME-Base64",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.15-396.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Mozilla-CA",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "20160104-7.module+el8.3.0+6498+9eecfe51",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Net-SSLeay",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.88-2.module+el8.6.0+13392+f0897f98",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-PathTools",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.74-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Pod-Escapes",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.07-395.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Pod-Perldoc",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.28-396.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Pod-Simple",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:3.35-395.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Pod-Usage",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4:1.69-395.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Scalar-List-Utils",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3:1.49-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Socket",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4:2.027-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Storable",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:3.11-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Term-ANSIColor",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4.06-396.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Term-Cap",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.17-395.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Text-ParseWords",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.30-395.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Text-Tabs+Wrap",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2013.0523-395.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Time-Local",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.280-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-URI",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.73-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-Unicode-Normalize",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.25-396.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-constant",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.33-396.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-interpreter",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4:5.26.3-421.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-libnet",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.11-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4:5.26.3-421.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-macros",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4:5.26.3-421.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-parent",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:0.237-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-podlators",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "4.11-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-threads",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:2.21-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "perl-threads-shared",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.58-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pillow",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "9.0.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pip",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "19.3.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pip",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "21.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pkgconf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.4.2-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pkgconf-m4",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.4.2-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pkgconf-pkg-config",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.4.2-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "platform-python",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.6.8-45.el8",
+                "Vulnerabilities": [
+                    {
+                        "Severity": "Medium",
+                        "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+                        "Link": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+                        "FixedBy": "0:3.6.8-47.el8_6",
+                        "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+                        "Name": "RHSA-2022:6457: python3 security update (Moderate)",
+                        "Metadata": {
+                            "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+                            "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+                            "RepoLink": null,
+                            "DistroName": "Red Hat Enterprise Linux Server",
+                            "DistroVersion": "8",
+                            "NVD": {
+                                "CVSSv3": {
+                                    "Vectors": "",
+                                    "Score": ""
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "Name": "platform-python-setuptools",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "39.2.0-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ply",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.11",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "popt",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.18-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "prometheus-client",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.7.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "protobuf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.15.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "protobuf-c",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.3.0-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "psutil",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "5.9.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "psycopg2-binary",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.9.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "publicsuffix-list-dafsa",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "20180723-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "py-bitbucket",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pyasn1",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.4.8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pyasn1-modules",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.2.8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pycparser",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.20",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pygithub",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.45",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pyinotify",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.9.6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pyjwt",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.4.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pymemcache",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.0.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pymysql",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.9.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pyopenssl",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "19.1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pyparsing",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.4.6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pypdf2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.27.6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pyrsistent",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.18.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pysocks",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.6.8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-dateutil",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.6.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-dateutil",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.8.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-editor",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.0.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-etcd",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.3.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-gitlab",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.0.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-keystoneclient",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.22.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-ldap",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.4.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-magic",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.4.15",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-redis-lock",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.7.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python-swiftclient",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.8.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-chardet",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.0.4-7.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-cloud-what",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.28.29-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-dateutil",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1:2.6.1-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-dbus",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.2.4-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-decorator",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.2.1-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-dmidecode",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.12.2-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-dnf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.7.0-8.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-dnf-plugins-core",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.0.21-11.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-ethtool",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.14-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-gobject-base",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.28.3-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-gpg",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.13.1-11.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-hawkey",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.63.0-8.1.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-idna",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.5-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-iniparse",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.4-31.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-inotify",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.9.6-13.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-libcomps",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.1.18-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-libdnf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "0.63.0-8.1.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-librepo",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.14.2-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.6.8-45.el8",
+                "Vulnerabilities": [
+                    {
+                        "Severity": "Medium",
+                        "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+                        "Link": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+                        "FixedBy": "0:3.6.8-47.el8_6",
+                        "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+                        "Name": "RHSA-2022:6457: python3 security update (Moderate)",
+                        "Metadata": {
+                            "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+                            "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+                            "RepoLink": null,
+                            "DistroName": "Red Hat Enterprise Linux Server",
+                            "DistroVersion": "8",
+                            "NVD": {
+                                "CVSSv3": {
+                                    "Vectors": "",
+                                    "Score": ""
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            {
+                "Name": "python3-libxml2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.9.7-13.el8_6.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-pip-wheel",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "9.0.3-22.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-pysocks",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.6.8-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-requests",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.20.0-2.1.el8_1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-rpm",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.14.3-23.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-setuptools-wheel",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "39.2.0-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-six",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.11.0-8.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-subscription-manager-rhsm",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.28.29-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-syspurpose",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.28.29-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python3-urllib3",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.24.2-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python38",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.8.12-1.module+el8.6.0+12642+c3710b74",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python38-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "3.8.12-1.module+el8.6.0+12642+c3710b74",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python38-pip",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "19.3.1-5.module+el8.6.0+13002+70cfc74a",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python38-pip-wheel",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "19.3.1-5.module+el8.6.0+13002+70cfc74a",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python38-setuptools",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "41.6.0-5.module+el8.5.0+12205+a865257a",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "python38-setuptools-wheel",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "41.6.0-5.module+el8.5.0+12205+a865257a",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pytz",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2019.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "pyyaml",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "5.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "raven",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "6.10.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "readline",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "7.0-10.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "recaptcha2",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "redhat-release",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "8.6-0.1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "redis",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.5.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "redis-py-cluster",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.1.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "rehash",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.0.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "reportlab",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "3.5.55",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "requests",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.20.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "requests",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.27.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "requests-aws4auth",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.9",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "requests-file",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.4.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "requests-oauthlib",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.3.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "rfc3986",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.3.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "rootfiles",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "8.1-22.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "rpm",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.14.3-23.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "rpm-build-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.14.3-23.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "rpm-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.14.3-23.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "runc",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1:1.1.3-2.module+el8.6.0+15917+093ca6f8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "s3transfer",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.5.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "sed",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.5-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "semantic-version",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.8.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "setup",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.12.2-6.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "setuptools",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "50.3.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "setuptools",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "39.2.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "setuptools",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "41.6.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "setuptools-scm",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "4.1.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "shadow-utils",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2:4.6-16.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "six",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.14.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "six",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.11.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "skopeo",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "2:1.8.0-2.module+el8.6.0+15917+093ca6f8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "slirp4netns",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "Version": "1.2.0-2.module+el8.6.0+15917+093ca6f8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "soupsieve",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.9.5",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "sqlalchemy",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.4.31",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "sqlite-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "3.26.0-15.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "stevedore",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.31.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "stringscore",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "stripe",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.42.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "subscription-manager",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.28.29",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "subscription-manager",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.28.29-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "subscription-manager-rhsm-certificates",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.28.29-3.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "supervisor",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "4.1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "supervisor-logging",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.0.9",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "supervisor-stdout",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.1.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "syspurpose",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.28.29",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "systemd",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "239-58.el8_6.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "systemd-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "239-58.el8_6.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "systemd-pam",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "239-58.el8_6.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "tar",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2:1.30-5.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "text-unidecode",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "tldextract",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.2.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "toml",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.10.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "toposort",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.5",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "tpm2-tss",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.3.2-4.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "tzdata",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2022c-1.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "tzlocal",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.0.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ubi8",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:0d51f270409c5c21859f12eee7aa77d3969ac3033b7129a2a87648b741ee66ee",
+                "Version": "8.6-903.1661794351",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "ubi8-container",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:0d51f270409c5c21859f12eee7aa77d3969ac3033b7129a2a87648b741ee66ee",
+                "Version": "8.6-903.1661794351",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "urllib3",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.26.9",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "urllib3",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.24.2",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "usermode",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.113-2.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "util-linux",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.32.1-35.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "vim-minimal",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2:8.0.1763-19.el8_6.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "virt-what",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.18-13.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "webencodings",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.5.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "webob",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.8.6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "websocket-client",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.57.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "werkzeug",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.16.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "wheel",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.35.1",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "which",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "2.21-17.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "wrapt",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "1.13.3",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "xhtml2pdf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.2.4",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "xz-libs",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "5.2.4-4.el8_6",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "yapf",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "0.29.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "yum",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "4.7.0-8.el8",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "zipp",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "2.1.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "zlib",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "Version": "1.2.11-18.el8_5",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "zope.event",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "4.5.0",
+                "Vulnerabilities": []
+            },
+            {
+                "Name": "zope.interface",
+                "VersionFormat": "",
+                "NamespaceName": "",
+                "AddedBy": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "Version": "5.4.0",
+                "Vulnerabilities": []
+            }
+        ]
+    }
+}

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -3,6 +3,7 @@ import mock
 import pytest
 import os
 import json
+import logging
 
 from datetime import datetime, timedelta
 
@@ -491,6 +492,37 @@ def test_features_for():
     generated = SecurityInformation(
         Layer(
             "sha256:b05ac1eeec8635442fa5d3e55d6ef4ad287b9c66055a552c2fd309c334563b0a",
+            "",
+            "",
+            4,
+            features_for(vuln_report),
+        )
+    ).to_dict()
+
+    # Sort the Features' list so that the following assertion holds even if they are out of order
+    # (Ordering of the dicts' key iteration is different from Python 2 to 3)
+    expected["Layer"]["Features"].sort(key=lambda d: d["Name"])
+    generated["Layer"]["Features"].sort(key=lambda d: d["Name"])
+
+    assert generated == expected
+
+
+def test_features_for_duplicates():
+    vuln_report_filename = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "vulnerabilityreport_duplicates.json"
+    )
+    security_info_filename = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "securityinformation_deduped.json"
+    )
+    with open(vuln_report_filename) as vuln_report_file:
+        vuln_report = json.load(vuln_report_file)
+
+    with open(security_info_filename) as security_info_file:
+        expected = json.load(security_info_file)
+
+    generated = SecurityInformation(
+        Layer(
+            vuln_report["manifest_hash"],
             "",
             "",
             4,

--- a/data/secscan_model/test/vulnerabilityreport_duplicates.json
+++ b/data/secscan_model/test/vulnerabilityreport_duplicates.json
@@ -1,0 +1,13366 @@
+{
+    "manifest_hash": "sha256:1674a920ec5909881e0a7e46c27ac8a24858197e09904898586e3eb48684f446",
+    "packages": {
+        "120": {
+            "id": "120",
+            "name": "mpfr",
+            "version": "3.1.6-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "119",
+                "name": "mpfr",
+                "version": "3.1.6-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "936": {
+            "id": "936",
+            "name": "dejavu-sans-fonts",
+            "version": "2.35-7.el8",
+            "kind": "binary",
+            "source": {
+                "id": "643",
+                "name": "dejavu-fonts",
+                "version": "2.35-7.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "426": {
+            "id": "426",
+            "name": "perl-Unicode-Normalize",
+            "version": "1.25-396.el8",
+            "kind": "binary",
+            "source": {
+                "id": "425",
+                "name": "perl-Unicode-Normalize",
+                "version": "1.25-396.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "958": {
+            "id": "958",
+            "name": "libtiff",
+            "version": "4.0.9-21.el8",
+            "kind": "binary",
+            "source": {
+                "id": "957",
+                "name": "libtiff",
+                "version": "4.0.9-21.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "956": {
+            "id": "956",
+            "name": "libpq",
+            "version": "13.5-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "481",
+                "name": "libpq",
+                "version": "13.5-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "654": {
+            "id": "654",
+            "name": "libX11-common",
+            "version": "1.6.8-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "653",
+                "name": "libX11",
+                "version": "1.6.8-5.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1100": {
+            "id": "1100",
+            "name": "futures",
+            "version": "3.1.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.1.1.0.0.0.0.0.0"
+        },
+        "1268": {
+            "id": "1268",
+            "name": "text-unidecode",
+            "version": "1.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.3.0.0.0.0.0.0.0"
+        },
+        "338": {
+            "id": "338",
+            "name": "python3-iniparse",
+            "version": "0.4-31.el8",
+            "kind": "binary",
+            "source": {
+                "id": "337",
+                "name": "python-iniparse",
+                "version": "0.4-31.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1168": {
+            "id": "1168",
+            "name": "packaging",
+            "version": "21.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.21.3.0.0.0.0.0.0.0"
+        },
+        "116": {
+            "id": "116",
+            "name": "gzip",
+            "version": "1.9-13.el8_5",
+            "kind": "binary",
+            "source": {
+                "id": "115",
+                "name": "gzip",
+                "version": "1.9-13.el8_5",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "176": {
+            "id": "176",
+            "name": "kmod-libs",
+            "version": "25-19.el8",
+            "kind": "binary",
+            "source": {
+                "id": "175",
+                "name": "kmod",
+                "version": "25-19.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1016": {
+            "id": "1016",
+            "name": "flask-mail",
+            "version": "0.9.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.9.1.0.0.0.0.0.0"
+        },
+        "1002": {
+            "id": "1002",
+            "name": "babel",
+            "version": "2.9.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.9.1.0.0.0.0.0.0"
+        },
+        "1074": {
+            "id": "1074",
+            "name": "certifi",
+            "version": "2019.11.28",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2019.11.28.0.0.0.0.0.0"
+        },
+        "140": {
+            "id": "140",
+            "name": "python3-libs",
+            "version": "3.6.8-45.el8",
+            "kind": "binary",
+            "source": {
+                "id": "139",
+                "name": "python3",
+                "version": "3.6.8-45.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "374": {
+            "id": "374",
+            "name": "libarchive",
+            "version": "3.3.3-3.el8_5",
+            "kind": "binary",
+            "source": {
+                "id": "373",
+                "name": "libarchive",
+                "version": "3.3.3-3.el8_5",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1216": {
+            "id": "1216",
+            "name": "python-redis-lock",
+            "version": "3.7.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.7.0.0.0.0.0.0.0"
+        },
+        "1172": {
+            "id": "1172",
+            "name": "peewee",
+            "version": "3.13.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.13.1.0.0.0.0.0.0"
+        },
+        "336": {
+            "id": "336",
+            "name": "json-glib",
+            "version": "1.4.4-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "335",
+                "name": "json-glib",
+                "version": "1.4.4-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "182": {
+            "id": "182",
+            "name": "dbus-common",
+            "version": "1:1.12.8-18.el8_6.1",
+            "kind": "binary",
+            "source": {
+                "id": "181",
+                "name": "dbus",
+                "version": "1.12.8-18.el8_6.1",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1194": {
+            "id": "1194",
+            "name": "pycparser",
+            "version": "2.20",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.20.0.0.0.0.0.0.0"
+        },
+        "694": {
+            "id": "694",
+            "name": "perl-Text-ParseWords",
+            "version": "3.30-395.el8",
+            "kind": "binary",
+            "source": {
+                "id": "693",
+                "name": "perl-Text-ParseWords",
+                "version": "3.30-395.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1042": {
+            "id": "1042",
+            "name": "webob",
+            "version": "1.8.6",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.8.6.0.0.0.0.0.0"
+        },
+        "1012": {
+            "id": "1012",
+            "name": "flask-cors",
+            "version": "3.0.9",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.0.9.0.0.0.0.0.0"
+        },
+        "1056": {
+            "id": "1056",
+            "name": "azure-storage-blob",
+            "version": "12.4.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.12.4.0.0.0.0.0.0.0"
+        },
+        "64": {
+            "id": "64",
+            "name": "sqlite-libs",
+            "version": "3.26.0-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "63",
+                "name": "sqlite",
+                "version": "3.26.0-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "110": {
+            "id": "110",
+            "name": "libsemanage",
+            "version": "2.9-8.el8",
+            "kind": "binary",
+            "source": {
+                "id": "109",
+                "name": "libsemanage",
+                "version": "2.9-8.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "978": {
+            "id": "978",
+            "name": "perl-Term-ANSIColor",
+            "version": "4.06-396.el8",
+            "kind": "binary",
+            "source": {
+                "id": "977",
+                "name": "perl-Term-ANSIColor",
+                "version": "4.06-396.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "388": {
+            "id": "388",
+            "name": "rpm",
+            "version": "4.14.3-23.el8",
+            "kind": "binary",
+            "source": {
+                "id": "201",
+                "name": "rpm",
+                "version": "4.14.3-23.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "144": {
+            "id": "144",
+            "name": "python3-six",
+            "version": "1.11.0-8.el8",
+            "kind": "binary",
+            "source": {
+                "id": "143",
+                "name": "python-six",
+                "version": "1.11.0-8.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "34": {
+            "id": "34",
+            "name": "libcomps",
+            "version": "0.1.18",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.1.18.0.0.0.0.0.0"
+        },
+        "278": {
+            "id": "278",
+            "name": "libidn2",
+            "version": "2.2.0-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "277",
+                "name": "libidn2",
+                "version": "2.2.0-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "470": {
+            "id": "470",
+            "name": "criu",
+            "version": "3.15-3.module+el8.6.0+15875+dc9a2b96",
+            "kind": "binary",
+            "source": {
+                "id": "469",
+                "name": "criu",
+                "version": "3.15-3.module+el8.6.0+15875+dc9a2b96",
+                "kind": "source",
+                "module": "container-tools:rhel8"
+            },
+            "module": "container-tools:rhel8",
+            "arch": "x86_64"
+        },
+        "152": {
+            "id": "152",
+            "name": "dbus-glib",
+            "version": "0.110-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "151",
+                "name": "dbus-glib",
+                "version": "0.110-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "948": {
+            "id": "948",
+            "name": "libX11",
+            "version": "1.6.8-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "653",
+                "name": "libX11",
+                "version": "1.6.8-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "282": {
+            "id": "282",
+            "name": "audit-libs",
+            "version": "3.0.7-2.el8.2",
+            "kind": "binary",
+            "source": {
+                "id": "281",
+                "name": "audit",
+                "version": "3.0.7-2.el8.2",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "650": {
+            "id": "650",
+            "name": "slirp4netns",
+            "version": "1.2.0-2.module+el8.6.0+15917+093ca6f8",
+            "kind": "binary",
+            "source": {
+                "id": "649",
+                "name": "slirp4netns",
+                "version": "1.2.0-2.module+el8.6.0+15917+093ca6f8",
+                "kind": "source",
+                "module": "container-tools:rhel8"
+            },
+            "module": "container-tools:rhel8",
+            "arch": "x86_64"
+        },
+        "680": {
+            "id": "680",
+            "name": "perl-Net-SSLeay",
+            "version": "1.88-2.module+el8.6.0+13392+f0897f98",
+            "kind": "binary",
+            "source": {
+                "id": "679",
+                "name": "perl-Net-SSLeay",
+                "version": "1.88-2.module+el8.6.0+13392+f0897f98",
+                "kind": "source",
+                "module": "perl-IO-Socket-SSL:2.066"
+            },
+            "module": "perl-IO-Socket-SSL:2.066",
+            "arch": "x86_64"
+        },
+        "406": {
+            "id": "406",
+            "name": "gdb-gdbserver",
+            "version": "8.2-18.el8",
+            "kind": "binary",
+            "source": {
+                "id": "405",
+                "name": "gdb",
+                "version": "8.2-18.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "648": {
+            "id": "648",
+            "name": "nginx-filesystem",
+            "version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+            "kind": "binary",
+            "source": {
+                "id": "437",
+                "name": "nginx",
+                "version": "1.14.1-9.module+el8.0.0+4108+af250afe",
+                "kind": "source",
+                "module": "nginx:1.14"
+            },
+            "module": "nginx:1.14",
+            "arch": "noarch"
+        },
+        "280": {
+            "id": "280",
+            "name": "file-libs",
+            "version": "5.33-20.el8",
+            "kind": "binary",
+            "source": {
+                "id": "279",
+                "name": "file",
+                "version": "5.33-20.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "130": {
+            "id": "130",
+            "name": "gawk",
+            "version": "4.2.1-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "129",
+                "name": "gawk",
+                "version": "4.2.1-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "132": {
+            "id": "132",
+            "name": "libnsl2",
+            "version": "1.2.0-2.20180605git4a062cf.el8",
+            "kind": "binary",
+            "source": {
+                "id": "131",
+                "name": "libnsl2",
+                "version": "1.2.0-2.20180605git4a062cf.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "272": {
+            "id": "272",
+            "name": "libsmartcols",
+            "version": "2.32.1-35.el8",
+            "kind": "binary",
+            "source": {
+                "id": "81",
+                "name": "util-linux",
+                "version": "2.32.1-35.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "196": {
+            "id": "196",
+            "name": "libssh",
+            "version": "0.9.6-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "195",
+                "name": "libssh",
+                "version": "0.9.6-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "36": {
+            "id": "36",
+            "name": "subscription-manager",
+            "version": "1.28.29",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.28.29.0.0.0.0.0.0"
+        },
+        "208": {
+            "id": "208",
+            "name": "rpm-build-libs",
+            "version": "4.14.3-23.el8",
+            "kind": "binary",
+            "source": {
+                "id": "201",
+                "name": "rpm",
+                "version": "4.14.3-23.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "986": {
+            "id": "986",
+            "name": "perl-Pod-Usage",
+            "version": "4:1.69-395.el8",
+            "kind": "binary",
+            "source": {
+                "id": "985",
+                "name": "perl-Pod-Usage",
+                "version": "1.69-395.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "186": {
+            "id": "186",
+            "name": "dbus",
+            "version": "1:1.12.8-18.el8_6.1",
+            "kind": "binary",
+            "source": {
+                "id": "181",
+                "name": "dbus",
+                "version": "1.12.8-18.el8_6.1",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1282": {
+            "id": "1282",
+            "name": "websocket-client",
+            "version": "0.57.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.57.0.0.0.0.0.0.0"
+        },
+        "216": {
+            "id": "216",
+            "name": "dnf-plugin-subscription-manager",
+            "version": "1.28.29-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "173",
+                "name": "subscription-manager",
+                "version": "1.28.29-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "206": {
+            "id": "206",
+            "name": "python3-libdnf",
+            "version": "0.63.0-8.1.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "205",
+                "name": "libdnf",
+                "version": "0.63.0-8.1.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1066": {
+            "id": "1066",
+            "name": "blinker",
+            "version": "1.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.4.0.0.0.0.0.0.0"
+        },
+        "162": {
+            "id": "162",
+            "name": "libdb-utils",
+            "version": "5.3.28-42.el8_4",
+            "kind": "binary",
+            "source": {
+                "id": "161",
+                "name": "libdb",
+                "version": "5.3.28-42.el8_4",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "236": {
+            "id": "236",
+            "name": "basesystem",
+            "version": "11-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "235",
+                "name": "basesystem",
+                "version": "11-5.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1020": {
+            "id": "1020",
+            "name": "flask-restful",
+            "version": "0.3.9",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.3.9.0.0.0.0.0.0"
+        },
+        "1158": {
+            "id": "1158",
+            "name": "os-service-types",
+            "version": "1.7.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.7.0.0.0.0.0.0.0"
+        },
+        "1106": {
+            "id": "1106",
+            "name": "greenlet",
+            "version": "1.1.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.1.2.0.0.0.0.0.0"
+        },
+        "430": {
+            "id": "430",
+            "name": "perl-PathTools",
+            "version": "3.74-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "429",
+                "name": "perl-PathTools",
+                "version": "3.74-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "108": {
+            "id": "108",
+            "name": "libusbx",
+            "version": "1.0.23-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "107",
+                "name": "libusbx",
+                "version": "1.0.23-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "384": {
+            "id": "384",
+            "name": "libcurl",
+            "version": "7.61.1-22.el8_6.4",
+            "kind": "binary",
+            "source": {
+                "id": "199",
+                "name": "curl",
+                "version": "7.61.1-22.el8_6.4",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "318": {
+            "id": "318",
+            "name": "libverto",
+            "version": "0.3.0-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "317",
+                "name": "libverto",
+                "version": "0.3.0-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "998": {
+            "id": "998",
+            "name": "apscheduler",
+            "version": "3.6.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.6.3.0.0.0.0.0.0"
+        },
+        "1006": {
+            "id": "1006",
+            "name": "datetime",
+            "version": "4.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.3.0.0.0.0.0.0.0"
+        },
+        "194": {
+            "id": "194",
+            "name": "python3-gpg",
+            "version": "1.13.1-11.el8",
+            "kind": "binary",
+            "source": {
+                "id": "193",
+                "name": "gpgme",
+                "version": "1.13.1-11.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "106": {
+            "id": "106",
+            "name": "ca-certificates",
+            "version": "2021.2.50-80.0.el8_4",
+            "kind": "binary",
+            "source": {
+                "id": "105",
+                "name": "ca-certificates",
+                "version": "2021.2.50-80.0.el8_4",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "74": {
+            "id": "74",
+            "name": "libffi",
+            "version": "3.1-23.el8",
+            "kind": "binary",
+            "source": {
+                "id": "73",
+                "name": "libffi",
+                "version": "3.1-23.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1238": {
+            "id": "1238",
+            "name": "requests-file",
+            "version": "1.4.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.4.3.0.0.0.0.0.0"
+        },
+        "754": {
+            "id": "754",
+            "name": "libpcap",
+            "version": "14:1.9.1-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "753",
+                "name": "libpcap",
+                "version": "1.9.1-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "158": {
+            "id": "158",
+            "name": "openldap",
+            "version": "2.4.46-18.el8",
+            "kind": "binary",
+            "source": {
+                "id": "157",
+                "name": "openldap",
+                "version": "2.4.46-18.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "946": {
+            "id": "946",
+            "name": "libXau",
+            "version": "1.0.9-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "945",
+                "name": "libXau",
+                "version": "1.0.9-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "656": {
+            "id": "656",
+            "name": "libxcb",
+            "version": "1.13.1-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "655",
+                "name": "libxcb",
+                "version": "1.13.1-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "340": {
+            "id": "340",
+            "name": "python3-dbus",
+            "version": "1.2.4-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "339",
+                "name": "dbus-python",
+                "version": "1.2.4-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "154": {
+            "id": "154",
+            "name": "gobject-introspection",
+            "version": "1.56.1-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "153",
+                "name": "gobject-introspection",
+                "version": "1.56.1-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "200": {
+            "id": "200",
+            "name": "curl",
+            "version": "7.61.1-22.el8_6.4",
+            "kind": "binary",
+            "source": {
+                "id": "199",
+                "name": "curl",
+                "version": "7.61.1-22.el8_6.4",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "190": {
+            "id": "190",
+            "name": "libyaml",
+            "version": "0.1.7-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "189",
+                "name": "libyaml",
+                "version": "0.1.7-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "258": {
+            "id": "258",
+            "name": "elfutils-libelf",
+            "version": "0.186-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "179",
+                "name": "elfutils",
+                "version": "0.186-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1188": {
+            "id": "1188",
+            "name": "py-bitbucket",
+            "version": "0.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.2.0.0.0.0.0.0.0"
+        },
+        "242": {
+            "id": "242",
+            "name": "glibc-minimal-langpack",
+            "version": "2.28-189.5.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "55",
+                "name": "glibc",
+                "version": "2.28-189.5.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "354": {
+            "id": "354",
+            "name": "python3-chardet",
+            "version": "3.0.4-7.el8",
+            "kind": "binary",
+            "source": {
+                "id": "353",
+                "name": "python-chardet",
+                "version": "3.0.4-7.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1226": {
+            "id": "1226",
+            "name": "redis",
+            "version": "3.5.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.5.3.0.0.0.0.0.0"
+        },
+        "260": {
+            "id": "260",
+            "name": "libcom_err",
+            "version": "1.45.6-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "259",
+                "name": "e2fsprogs",
+                "version": "1.45.6-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "178": {
+            "id": "178",
+            "name": "device-mapper-libs",
+            "version": "8:1.02.181-3.el8_6.2",
+            "kind": "binary",
+            "source": {
+                "id": "177",
+                "name": "lvm2",
+                "version": "2.03.14-3.el8_6.2",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "446": {
+            "id": "446",
+            "name": "nginx",
+            "version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+            "kind": "binary",
+            "source": {
+                "id": "437",
+                "name": "nginx",
+                "version": "1.14.1-9.module+el8.0.0+4108+af250afe",
+                "kind": "source",
+                "module": "nginx:1.14"
+            },
+            "module": "nginx:1.14",
+            "arch": "x86_64"
+        },
+        "262": {
+            "id": "262",
+            "name": "libuuid",
+            "version": "2.32.1-35.el8",
+            "kind": "binary",
+            "source": {
+                "id": "81",
+                "name": "util-linux",
+                "version": "2.32.1-35.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1050": {
+            "id": "1050",
+            "name": "attrs",
+            "version": "19.3.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.19.3.0.0.0.0.0.0.0"
+        },
+        "684": {
+            "id": "684",
+            "name": "perl-Mozilla-CA",
+            "version": "20160104-7.module+el8.3.0+6498+9eecfe51",
+            "kind": "binary",
+            "source": {
+                "id": "683",
+                "name": "perl-Mozilla-CA",
+                "version": "20160104-7.module+el8.3.0+6498+9eecfe51",
+                "kind": "source",
+                "module": "perl-libwww-perl:6.34"
+            },
+            "module": "perl-libwww-perl:6.34",
+            "arch": "noarch"
+        },
+        "330": {
+            "id": "330",
+            "name": "pam",
+            "version": "1.3.1-16.el8",
+            "kind": "binary",
+            "source": {
+                "id": "329",
+                "name": "pam",
+                "version": "1.3.1-16.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "682": {
+            "id": "682",
+            "name": "perl-Pod-Escapes",
+            "version": "1:1.07-395.el8",
+            "kind": "binary",
+            "source": {
+                "id": "681",
+                "name": "perl-Pod-Escapes",
+                "version": "1.07-395.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "646": {
+            "id": "646",
+            "name": "fontconfig",
+            "version": "2.13.1-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "645",
+                "name": "fontconfig",
+                "version": "2.13.1-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "938": {
+            "id": "938",
+            "name": "libnftnl",
+            "version": "1.1.5-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "937",
+                "name": "libnftnl",
+                "version": "1.1.5-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "738": {
+            "id": "738",
+            "name": "nginx-mod-http-image-filter",
+            "version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+            "kind": "binary",
+            "source": {
+                "id": "437",
+                "name": "nginx",
+                "version": "1.14.1-9.module+el8.0.0+4108+af250afe",
+                "kind": "source",
+                "module": "nginx:1.14"
+            },
+            "module": "nginx:1.14",
+            "arch": "x86_64"
+        },
+        "1166": {
+            "id": "1166",
+            "name": "oslo.utils",
+            "version": "4.12.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.12.2.0.0.0.0.0.0"
+        },
+        "962": {
+            "id": "962",
+            "name": "fuse-common",
+            "version": "3.3.0-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "637",
+                "name": "fuse",
+                "version": "2.9.7-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "240": {
+            "id": "240",
+            "name": "libselinux",
+            "version": "2.9-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "239",
+                "name": "libselinux",
+                "version": "2.9-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1200": {
+            "id": "1200",
+            "name": "pyrsistent",
+            "version": "0.18.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.18.0.0.0.0.0.0.0"
+        },
+        "42": {
+            "id": "42",
+            "name": "tzdata",
+            "version": "2022c-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "41",
+                "name": "tzdata",
+                "version": "2022c-1.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1036": {
+            "id": "1036",
+            "name": "pypdf2",
+            "version": "1.27.6",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.27.6.0.0.0.0.0.0"
+        },
+        "1224": {
+            "id": "1224",
+            "name": "recaptcha2",
+            "version": "0.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.1.0.0.0.0.0.0.0"
+        },
+        "126": {
+            "id": "126",
+            "name": "libnghttp2",
+            "version": "1.33.0-3.el8_2.1",
+            "kind": "binary",
+            "source": {
+                "id": "125",
+                "name": "nghttp2",
+                "version": "1.33.0-3.el8_2.1",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "692": {
+            "id": "692",
+            "name": "perl-podlators",
+            "version": "4.11-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "691",
+                "name": "perl-podlators",
+                "version": "4.11-1.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "378": {
+            "id": "378",
+            "name": "npth",
+            "version": "1.5-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "377",
+                "name": "npth",
+                "version": "1.5-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "76": {
+            "id": "76",
+            "name": "expat",
+            "version": "2.2.5-8.el8_6.2",
+            "kind": "binary",
+            "source": {
+                "id": "75",
+                "name": "expat",
+                "version": "2.2.5-8.el8_6.2",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "46": {
+            "id": "46",
+            "name": "redhat-release",
+            "version": "8.6-0.1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "45",
+                "name": "redhat-release",
+                "version": "8.6-0.1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "286": {
+            "id": "286",
+            "name": "keyutils-libs",
+            "version": "1.5.10-9.el8",
+            "kind": "binary",
+            "source": {
+                "id": "285",
+                "name": "keyutils",
+                "version": "1.5.10-9.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "244": {
+            "id": "244",
+            "name": "glibc",
+            "version": "2.28-189.5.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "55",
+                "name": "glibc",
+                "version": "2.28-189.5.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1170": {
+            "id": "1170",
+            "name": "pbr",
+            "version": "5.4.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.5.4.4.0.0.0.0.0.0"
+        },
+        "26": {
+            "id": "26",
+            "name": "syspurpose",
+            "version": "1.28.29",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.28.29.0.0.0.0.0.0"
+        },
+        "32": {
+            "id": "32",
+            "name": "ethtool",
+            "version": "0.14",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.14.0.0.0.0.0.0.0"
+        },
+        "1164": {
+            "id": "1164",
+            "name": "oslo.serialization",
+            "version": "2.29.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.29.2.0.0.0.0.0.0"
+        },
+        "30": {
+            "id": "30",
+            "name": "dbus-python",
+            "version": "1.2.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.2.4.0.0.0.0.0.0"
+        },
+        "394": {
+            "id": "394",
+            "name": "python3-hawkey",
+            "version": "0.63.0-8.1.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "205",
+                "name": "libdnf",
+                "version": "0.63.0-8.1.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "478": {
+            "id": "478",
+            "name": "memcached",
+            "version": "0:1.5.22-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "477",
+                "name": "memcached",
+                "version": "1.5.22-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "750": {
+            "id": "750",
+            "name": "jansson",
+            "version": "2.14-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "749",
+                "name": "jansson",
+                "version": "2.14-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "292": {
+            "id": "292",
+            "name": "dbus-libs",
+            "version": "1:1.12.8-18.el8_6.1",
+            "kind": "binary",
+            "source": {
+                "id": "181",
+                "name": "dbus",
+                "version": "1.12.8-18.el8_6.1",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "412": {
+            "id": "412",
+            "name": "gpg-pubkey",
+            "version": "fd431d51-4ae0493b",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            }
+        },
+        "326": {
+            "id": "326",
+            "name": "platform-python",
+            "version": "3.6.8-45.el8",
+            "kind": "binary",
+            "source": {
+                "id": "139",
+                "name": "python3",
+                "version": "3.6.8-45.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "288": {
+            "id": "288",
+            "name": "p11-kit-trust",
+            "version": "0.23.22-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "87",
+                "name": "p11-kit",
+                "version": "0.23.22-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "970": {
+            "id": "970",
+            "name": "perl-libnet",
+            "version": "3.11-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "969",
+                "name": "perl-libnet",
+                "version": "3.11-3.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1278": {
+            "id": "1278",
+            "name": "urllib3",
+            "version": "1.26.9",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.26.9.0.0.0.0.0.0"
+        },
+        "1150": {
+            "id": "1150",
+            "name": "netaddr",
+            "version": "0.7.19",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.7.19.0.0.0.0.0.0"
+        },
+        "306": {
+            "id": "306",
+            "name": "acl",
+            "version": "2.2.53-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "79",
+                "name": "acl",
+                "version": "2.2.53-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "174": {
+            "id": "174",
+            "name": "python3-cloud-what",
+            "version": "1.28.29-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "173",
+                "name": "subscription-manager",
+                "version": "1.28.29-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "334": {
+            "id": "334",
+            "name": "gnutls",
+            "version": "3.6.16-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "333",
+                "name": "gnutls",
+                "version": "3.6.16-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1108": {
+            "id": "1108",
+            "name": "grpcio",
+            "version": "1.30.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.30.0.0.0.0.0.0.0"
+        },
+        "102": {
+            "id": "102",
+            "name": "pcre",
+            "version": "8.42-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "101",
+                "name": "pcre",
+                "version": "8.42-6.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "410": {
+            "id": "410",
+            "name": "langpacks-en",
+            "version": "1.0-12.el8",
+            "kind": "binary",
+            "source": {
+                "id": "409",
+                "name": "langpacks",
+                "version": "1.0-12.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "968": {
+            "id": "968",
+            "name": "perl-Digest-MD5",
+            "version": "2.55-396.el8",
+            "kind": "binary",
+            "source": {
+                "id": "967",
+                "name": "perl-Digest-MD5",
+                "version": "2.55-396.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "674": {
+            "id": "674",
+            "name": "libxslt",
+            "version": "1.1.32-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "673",
+                "name": "libxslt",
+                "version": "1.1.32-6.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "98": {
+            "id": "98",
+            "name": "gdbm-libs",
+            "version": "1:1.18-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "97",
+                "name": "gdbm",
+                "version": "1.18-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "714": {
+            "id": "714",
+            "name": "perl-Text-Tabs+Wrap",
+            "version": "2013.0523-395.el8",
+            "kind": "binary",
+            "source": {
+                "id": "713",
+                "name": "perl-Text-Tabs+Wrap",
+                "version": "2013.0523-395.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "222": {
+            "id": "222",
+            "name": "findutils",
+            "version": "1:4.6.0-20.el8",
+            "kind": "binary",
+            "source": {
+                "id": "221",
+                "name": "findutils",
+                "version": "4.6.0-20.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "392": {
+            "id": "392",
+            "name": "libdnf",
+            "version": "0.63.0-8.1.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "205",
+                "name": "libdnf",
+                "version": "0.63.0-8.1.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1244": {
+            "id": "1244",
+            "name": "s3transfer",
+            "version": "0.5.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.5.1.0.0.0.0.0.0"
+        },
+        "1152": {
+            "id": "1152",
+            "name": "netifaces",
+            "version": "0.10.9",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.10.9.0.0.0.0.0.0"
+        },
+        "92": {
+            "id": "92",
+            "name": "libgcrypt",
+            "version": "1.8.5-7.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "91",
+                "name": "libgcrypt",
+                "version": "1.8.5-7.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "134": {
+            "id": "134",
+            "name": "crypto-policies",
+            "version": "20211116-1.gitae470d6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "133",
+                "name": "crypto-policies",
+                "version": "20211116-1.gitae470d6.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "438": {
+            "id": "438",
+            "name": "nginx-mod-stream",
+            "version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+            "kind": "binary",
+            "source": {
+                "id": "437",
+                "name": "nginx",
+                "version": "1.14.1-9.module+el8.0.0+4108+af250afe",
+                "kind": "source",
+                "module": "nginx:1.14"
+            },
+            "module": "nginx:1.14",
+            "arch": "x86_64"
+        },
+        "690": {
+            "id": "690",
+            "name": "perl-File-Temp",
+            "version": "0.230.600-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "689",
+                "name": "perl-File-Temp",
+                "version": "0.230.600-1.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "360": {
+            "id": "360",
+            "name": "python3-requests",
+            "version": "2.20.0-2.1.el8_1",
+            "kind": "binary",
+            "source": {
+                "id": "359",
+                "name": "python-requests",
+                "version": "2.20.0-2.1.el8_1",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1010": {
+            "id": "1010",
+            "name": "flask",
+            "version": "1.1.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.1.1.0.0.0.0.0.0"
+        },
+        "1208": {
+            "id": "1208",
+            "name": "python-gitlab",
+            "version": "2.0.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.0.0.0.0.0.0.0.0"
+        },
+        "396": {
+            "id": "396",
+            "name": "python3-rpm",
+            "version": "4.14.3-23.el8",
+            "kind": "binary",
+            "source": {
+                "id": "201",
+                "name": "rpm",
+                "version": "4.14.3-23.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "342": {
+            "id": "342",
+            "name": "python3-gobject-base",
+            "version": "3.28.3-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "341",
+                "name": "pygobject3",
+                "version": "3.28.3-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1122": {
+            "id": "1122",
+            "name": "isodate",
+            "version": "0.6.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.6.0.0.0.0.0.0.0"
+        },
+        "356": {
+            "id": "356",
+            "name": "python3-idna",
+            "version": "2.5-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "355",
+                "name": "python-idna",
+                "version": "2.5-5.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "28": {
+            "id": "28",
+            "name": "urllib3",
+            "version": "1.24.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.24.2.0.0.0.0.0.0"
+        },
+        "698": {
+            "id": "698",
+            "name": "perl-Getopt-Long",
+            "version": "1:2.50-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "697",
+                "name": "perl-Getopt-Long",
+                "version": "2.50-4.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "706": {
+            "id": "706",
+            "name": "perl-Scalar-List-Utils",
+            "version": "3:1.49-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "705",
+                "name": "perl-Scalar-List-Utils",
+                "version": "1.49-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "980": {
+            "id": "980",
+            "name": "perl-Term-Cap",
+            "version": "1.17-395.el8",
+            "kind": "binary",
+            "source": {
+                "id": "979",
+                "name": "perl-Term-Cap",
+                "version": "1.17-395.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1148": {
+            "id": "1148",
+            "name": "ndg-httpsclient",
+            "version": "0.5.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.5.1.0.0.0.0.0.0"
+        },
+        "82": {
+            "id": "82",
+            "name": "libblkid",
+            "version": "2.32.1-35.el8",
+            "kind": "binary",
+            "source": {
+                "id": "81",
+                "name": "util-linux",
+                "version": "2.32.1-35.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1080": {
+            "id": "1080",
+            "name": "charset-normalizer",
+            "version": "2.0.12",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.0.12.0.0.0.0.0.0"
+        },
+        "1014": {
+            "id": "1014",
+            "name": "flask-login",
+            "version": "0.4.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.4.1.0.0.0.0.0.0"
+        },
+        "1134": {
+            "id": "1134",
+            "name": "jsonschema",
+            "version": "3.2.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.2.0.0.0.0.0.0.0"
+        },
+        "192": {
+            "id": "192",
+            "name": "gnupg2",
+            "version": "2.2.20-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "191",
+                "name": "gnupg2",
+                "version": "2.2.20-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "408": {
+            "id": "408",
+            "name": "vim-minimal",
+            "version": "2:8.0.1763-19.el8_6.4",
+            "kind": "binary",
+            "source": {
+                "id": "407",
+                "name": "vim",
+                "version": "8.0.1763-19.el8_6.4",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1062": {
+            "id": "1062",
+            "name": "bintrees",
+            "version": "2.1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.1.0.0.0.0.0.0.0"
+        },
+        "1030": {
+            "id": "1030",
+            "name": "pygithub",
+            "version": "1.45",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.45.0.0.0.0.0.0.0"
+        },
+        "422": {
+            "id": "422",
+            "name": "perl-threads",
+            "version": "1:2.21-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "421",
+                "name": "perl-threads",
+                "version": "2.21-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "702": {
+            "id": "702",
+            "name": "perl-parent",
+            "version": "1:0.237-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "701",
+                "name": "perl-parent",
+                "version": "0.237-1.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "314": {
+            "id": "314",
+            "name": "libnl3",
+            "version": "3.5.0-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "313",
+                "name": "libnl3",
+                "version": "3.5.0-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "114": {
+            "id": "114",
+            "name": "libfdisk",
+            "version": "2.32.1-35.el8",
+            "kind": "binary",
+            "source": {
+                "id": "81",
+                "name": "util-linux",
+                "version": "2.32.1-35.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "376": {
+            "id": "376",
+            "name": "ima-evm-utils",
+            "version": "1.3.2-12.el8",
+            "kind": "binary",
+            "source": {
+                "id": "375",
+                "name": "ima-evm-utils",
+                "version": "1.3.2-12.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "54": {
+            "id": "54",
+            "name": "ncurses-libs",
+            "version": "6.1-9.20180224.el8",
+            "kind": "binary",
+            "source": {
+                "id": "53",
+                "name": "ncurses",
+                "version": "6.1-9.20180224.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "232": {
+            "id": "232",
+            "name": "subscription-manager-rhsm-certificates",
+            "version": "1.28.29-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "173",
+                "name": "subscription-manager",
+                "version": "1.28.29-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "224": {
+            "id": "224",
+            "name": "rootfiles",
+            "version": "8.1-22.el8",
+            "kind": "binary",
+            "source": {
+                "id": "223",
+                "name": "rootfiles",
+                "version": "8.1-22.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1286": {
+            "id": "1286",
+            "name": "wrapt",
+            "version": "1.13.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.13.3.0.0.0.0.0.0"
+        },
+        "16": {
+            "id": "16",
+            "name": "pyinotify",
+            "version": "0.9.6",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.9.6.0.0.0.0.0.0"
+        },
+        "700": {
+            "id": "700",
+            "name": "perl-Errno",
+            "version": "0:1.28-421.el8",
+            "kind": "binary",
+            "source": {
+                "id": "417",
+                "name": "perl",
+                "version": "5.26.3-421.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "992": {
+            "id": "992",
+            "name": "perl-Encode",
+            "version": "4:2.97-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "991",
+                "name": "perl-Encode",
+                "version": "2.97-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "44": {
+            "id": "44",
+            "name": "python3-pip-wheel",
+            "version": "9.0.3-22.el8",
+            "kind": "binary",
+            "source": {
+                "id": "43",
+                "name": "python-pip",
+                "version": "9.0.3-22.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1082": {
+            "id": "1082",
+            "name": "click",
+            "version": "7.1.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.7.1.2.0.0.0.0.0.0"
+        },
+        "666": {
+            "id": "666",
+            "name": "jbigkit-libs",
+            "version": "2.1-14.el8",
+            "kind": "binary",
+            "source": {
+                "id": "665",
+                "name": "jbigkit",
+                "version": "2.1-14.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1272": {
+            "id": "1272",
+            "name": "toml",
+            "version": "0.10.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.10.2.0.0.0.0.0.0"
+        },
+        "974": {
+            "id": "974",
+            "name": "perl-Time-Local",
+            "version": "1:1.280-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "973",
+                "name": "perl-Time-Local",
+                "version": "1.280-1.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1284": {
+            "id": "1284",
+            "name": "wheel",
+            "version": "0.35.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.35.1.0.0.0.0.0.0"
+        },
+        "1156": {
+            "id": "1156",
+            "name": "orderedmultidict",
+            "version": "1.0.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.0.1.0.0.0.0.0.0"
+        },
+        "1144": {
+            "id": "1144",
+            "name": "msgpack",
+            "version": "0.6.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.6.2.0.0.0.0.0.0"
+        },
+        "184": {
+            "id": "184",
+            "name": "systemd-pam",
+            "version": "239-58.el8_6.4",
+            "kind": "binary",
+            "source": {
+                "id": "103",
+                "name": "systemd",
+                "version": "239-58.el8_6.4",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "246": {
+            "id": "246",
+            "name": "libsepol",
+            "version": "2.9-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "245",
+                "name": "libsepol",
+                "version": "2.9-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "220": {
+            "id": "220",
+            "name": "tar",
+            "version": "2:1.30-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "219",
+                "name": "tar",
+                "version": "1.30-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "678": {
+            "id": "678",
+            "name": "perl-Data-Dumper",
+            "version": "2.167-399.el8",
+            "kind": "binary",
+            "source": {
+                "id": "677",
+                "name": "perl-Data-Dumper",
+                "version": "2.167-399.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "976": {
+            "id": "976",
+            "name": "perl-IO-Socket-IP",
+            "version": "0.39-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "975",
+                "name": "perl-IO-Socket-IP",
+                "version": "0.39-5.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "18": {
+            "id": "18",
+            "name": "python-dateutil",
+            "version": "2.6.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.6.1.0.0.0.0.0.0"
+        },
+        "950": {
+            "id": "950",
+            "name": "libnet",
+            "version": "1.1.6-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "949",
+                "name": "libnet",
+                "version": "1.1.6-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1274": {
+            "id": "1274",
+            "name": "toposort",
+            "version": "1.5",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.5.0.0.0.0.0.0.0"
+        },
+        "1266": {
+            "id": "1266",
+            "name": "supervisor-stdout",
+            "version": "0.1.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.1.1.0.0.0.0.0.0"
+        },
+        "766": {
+            "id": "766",
+            "name": "libevent",
+            "version": "2.1.8-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "765",
+                "name": "libevent",
+                "version": "2.1.8-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "382": {
+            "id": "382",
+            "name": "libssh-config",
+            "version": "0.9.6-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "195",
+                "name": "libssh",
+                "version": "0.9.6-3.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "60": {
+            "id": "60",
+            "name": "zlib",
+            "version": "1.2.11-18.el8_5",
+            "kind": "binary",
+            "source": {
+                "id": "59",
+                "name": "zlib",
+                "version": "1.2.11-18.el8_5",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "686": {
+            "id": "686",
+            "name": "perl-IO-Socket-SSL",
+            "version": "2.066-4.module+el8.3.0+6446+594cad75",
+            "kind": "binary",
+            "source": {
+                "id": "685",
+                "name": "perl-IO-Socket-SSL",
+                "version": "2.066-4.module+el8.3.0+6446+594cad75",
+                "kind": "source",
+                "module": "perl-IO-Socket-SSL:2.066"
+            },
+            "module": "perl-IO-Socket-SSL:2.066",
+            "arch": "noarch"
+        },
+        "2": {
+            "id": "2",
+            "name": "ubi8-container",
+            "version": "8.6-903.1661794351",
+            "kind": "source",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "rhctag:8.6.0.0.0.0.0.0.0.0",
+            "arch": "x86_64"
+        },
+        "960": {
+            "id": "960",
+            "name": "kmod",
+            "version": "25-19.el8",
+            "kind": "binary",
+            "source": {
+                "id": "175",
+                "name": "kmod",
+                "version": "25-19.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1058": {
+            "id": "1058",
+            "name": "bcrypt",
+            "version": "3.1.7",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.1.7.0.0.0.0.0.0"
+        },
+        "316": {
+            "id": "316",
+            "name": "libsigsegv",
+            "version": "2.11-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "315",
+                "name": "libsigsegv",
+                "version": "2.11-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "48": {
+            "id": "48",
+            "name": "filesystem",
+            "version": "3.8-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "47",
+                "name": "filesystem",
+                "version": "3.8-6.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1248": {
+            "id": "1248",
+            "name": "setuptools",
+            "version": "50.3.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.50.3.0.0.0.0.0.0.0"
+        },
+        "1240": {
+            "id": "1240",
+            "name": "requests-oauthlib",
+            "version": "1.3.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.3.0.0.0.0.0.0.0"
+        },
+        "1262": {
+            "id": "1262",
+            "name": "supervisor",
+            "version": "4.1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.1.0.0.0.0.0.0.0"
+        },
+        "944": {
+            "id": "944",
+            "name": "libwebp",
+            "version": "1.0.0-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "943",
+                "name": "libwebp",
+                "version": "1.0.0-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "758": {
+            "id": "758",
+            "name": "nftables",
+            "version": "1:0.9.3-25.el8",
+            "kind": "binary",
+            "source": {
+                "id": "757",
+                "name": "nftables",
+                "version": "0.9.3-25.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1024": {
+            "id": "1024",
+            "name": "mako",
+            "version": "1.1.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.1.1.0.0.0.0.0.0"
+        },
+        "1202": {
+            "id": "1202",
+            "name": "python-dateutil",
+            "version": "2.8.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.8.1.0.0.0.0.0.0"
+        },
+        "1104": {
+            "id": "1104",
+            "name": "gevent",
+            "version": "21.8.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.21.8.0.0.0.0.0.0.0"
+        },
+        "20": {
+            "id": "20",
+            "name": "requests",
+            "version": "2.20.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.20.0.0.0.0.0.0.0"
+        },
+        "668": {
+            "id": "668",
+            "name": "gd",
+            "version": "2.2.5-7.el8",
+            "kind": "binary",
+            "source": {
+                "id": "667",
+                "name": "gd",
+                "version": "2.2.5-7.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1068": {
+            "id": "1068",
+            "name": "boto3",
+            "version": "1.21.42",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.21.42.0.0.0.0.0.0"
+        },
+        "746": {
+            "id": "746",
+            "name": "pkgconf",
+            "version": "1.4.2-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "453",
+                "name": "pkgconf",
+                "version": "1.4.2-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "954": {
+            "id": "954",
+            "name": "python38-setuptools",
+            "version": "41.6.0-5.module+el8.5.0+12205+a865257a",
+            "kind": "binary",
+            "source": {
+                "id": "659",
+                "name": "python3x-setuptools",
+                "version": "41.6.0-5.module+el8.5.0+12205+a865257a",
+                "kind": "source",
+                "module": "python38:3.8"
+            },
+            "module": "python38:3.8",
+            "arch": "noarch"
+        },
+        "722": {
+            "id": "722",
+            "name": "perl-constant",
+            "version": "1.33-396.el8",
+            "kind": "binary",
+            "source": {
+                "id": "721",
+                "name": "perl-constant",
+                "version": "1.33-396.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "952": {
+            "id": "952",
+            "name": "python38-libs",
+            "version": "3.8.12-1.module+el8.6.0+12642+c3710b74",
+            "kind": "binary",
+            "source": {
+                "id": "661",
+                "name": "python38",
+                "version": "3.8.12-1.module+el8.6.0+12642+c3710b74",
+                "kind": "source",
+                "module": "python38:3.8"
+            },
+            "module": "python38:3.8",
+            "arch": "x86_64"
+        },
+        "1052": {
+            "id": "1052",
+            "name": "aws-sam-translator",
+            "version": "1.20.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.20.1.0.0.0.0.0.0"
+        },
+        "364": {
+            "id": "364",
+            "name": "device-mapper",
+            "version": "8:1.02.181-3.el8_6.2",
+            "kind": "binary",
+            "source": {
+                "id": "177",
+                "name": "lvm2",
+                "version": "2.03.14-3.el8_6.2",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "68": {
+            "id": "68",
+            "name": "libxcrypt",
+            "version": "4.1.1-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "67",
+                "name": "libxcrypt",
+                "version": "4.1.1-6.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "398": {
+            "id": "398",
+            "name": "libreport-filesystem",
+            "version": "2.9.5-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "397",
+                "name": "libreport",
+                "version": "2.9.5-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "168": {
+            "id": "168",
+            "name": "python3-decorator",
+            "version": "4.2.1-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "167",
+                "name": "python-decorator",
+                "version": "4.2.1-2.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "6": {
+            "id": "6",
+            "name": "pysocks",
+            "version": "1.6.8",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.6.8.0.0.0.0.0.0"
+        },
+        "332": {
+            "id": "332",
+            "name": "util-linux",
+            "version": "2.32.1-35.el8",
+            "kind": "binary",
+            "source": {
+                "id": "81",
+                "name": "util-linux",
+                "version": "2.32.1-35.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "386": {
+            "id": "386",
+            "name": "python3-librepo",
+            "version": "1.14.2-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "197",
+                "name": "librepo",
+                "version": "1.14.2-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1198": {
+            "id": "1198",
+            "name": "pyparsing",
+            "version": "2.4.6",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.4.6.0.0.0.0.0.0"
+        },
+        "774": {
+            "id": "774",
+            "name": "dnsmasq",
+            "version": "2.79-21.el8",
+            "kind": "binary",
+            "source": {
+                "id": "773",
+                "name": "dnsmasq",
+                "version": "2.79-21.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "984": {
+            "id": "984",
+            "name": "perl-Pod-Perldoc",
+            "version": "3.28-396.el8",
+            "kind": "binary",
+            "source": {
+                "id": "983",
+                "name": "perl-Pod-Perldoc",
+                "version": "3.28-396.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "12": {
+            "id": "12",
+            "name": "idna",
+            "version": "2.5",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.5.0.0.0.0.0.0.0"
+        },
+        "1192": {
+            "id": "1192",
+            "name": "pyasn1-modules",
+            "version": "0.2.8",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.2.8.0.0.0.0.0.0"
+        },
+        "1034": {
+            "id": "1034",
+            "name": "pymysql",
+            "version": "0.9.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.9.3.0.0.0.0.0.0"
+        },
+        "670": {
+            "id": "670",
+            "name": "ncurses",
+            "version": "6.1-9.20180224.el8",
+            "kind": "binary",
+            "source": {
+                "id": "53",
+                "name": "ncurses",
+                "version": "6.1-9.20180224.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "210": {
+            "id": "210",
+            "name": "python3-subscription-manager-rhsm",
+            "version": "1.28.29-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "173",
+                "name": "subscription-manager",
+                "version": "1.28.29-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "302": {
+            "id": "302",
+            "name": "which",
+            "version": "2.21-17.el8",
+            "kind": "binary",
+            "source": {
+                "id": "301",
+                "name": "which",
+                "version": "2.21-17.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1098": {
+            "id": "1098",
+            "name": "furl",
+            "version": "2.1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.1.0.0.0.0.0.0.0"
+        },
+        "454": {
+            "id": "454",
+            "name": "libpkgconf",
+            "version": "1.4.2-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "453",
+                "name": "pkgconf",
+                "version": "1.4.2-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "172": {
+            "id": "172",
+            "name": "python3-urllib3",
+            "version": "1.24.2-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "171",
+                "name": "python-urllib3",
+                "version": "1.24.2-5.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1022": {
+            "id": "1022",
+            "name": "jinja2",
+            "version": "2.11.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.11.3.0.0.0.0.0.0"
+        },
+        "418": {
+            "id": "418",
+            "name": "perl-macros",
+            "version": "4:5.26.3-421.el8",
+            "kind": "binary",
+            "source": {
+                "id": "417",
+                "name": "perl",
+                "version": "5.26.3-421.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "112": {
+            "id": "112",
+            "name": "libutempter",
+            "version": "1.1.6-14.el8",
+            "kind": "binary",
+            "source": {
+                "id": "111",
+                "name": "libutempter",
+                "version": "1.1.6-14.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1142": {
+            "id": "1142",
+            "name": "mixpanel",
+            "version": "4.5.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.5.0.0.0.0.0.0.0"
+        },
+        "264": {
+            "id": "264",
+            "name": "readline",
+            "version": "7.0-10.el8",
+            "kind": "binary",
+            "source": {
+                "id": "263",
+                "name": "readline",
+                "version": "7.0-10.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1028": {
+            "id": "1028",
+            "name": "pillow",
+            "version": "9.0.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.9.0.1.0.0.0.0.0.0"
+        },
+        "118": {
+            "id": "118",
+            "name": "cracklib-dicts",
+            "version": "2.9.6-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "117",
+                "name": "cracklib",
+                "version": "2.9.6-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "930": {
+            "id": "930",
+            "name": "libpng",
+            "version": "2:1.6.34-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "929",
+                "name": "libpng",
+                "version": "1.6.34-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1280": {
+            "id": "1280",
+            "name": "webencodings",
+            "version": "0.5.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.5.1.0.0.0.0.0.0"
+        },
+        "88": {
+            "id": "88",
+            "name": "p11-kit",
+            "version": "0.23.22-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "87",
+                "name": "p11-kit",
+                "version": "0.23.22-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1138": {
+            "id": "1138",
+            "name": "keystoneauth1",
+            "version": "3.18.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.18.0.0.0.0.0.0.0"
+        },
+        "730": {
+            "id": "730",
+            "name": "nginx-mod-http-xslt-filter",
+            "version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+            "kind": "binary",
+            "source": {
+                "id": "437",
+                "name": "nginx",
+                "version": "1.14.1-9.module+el8.0.0+4108+af250afe",
+                "kind": "source",
+                "module": "nginx:1.14"
+            },
+            "module": "nginx:1.14",
+            "arch": "x86_64"
+        },
+        "1218": {
+            "id": "1218",
+            "name": "python-swiftclient",
+            "version": "3.8.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.8.1.0.0.0.0.0.0"
+        },
+        "1212": {
+            "id": "1212",
+            "name": "python-ldap",
+            "version": "3.4.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.4.0.0.0.0.0.0.0"
+        },
+        "344": {
+            "id": "344",
+            "name": "cyrus-sasl-lib",
+            "version": "2.1.27-6.el8_5",
+            "kind": "binary",
+            "source": {
+                "id": "343",
+                "name": "cyrus-sasl",
+                "version": "2.1.27-6.el8_5",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1116": {
+            "id": "1116",
+            "name": "idna",
+            "version": "2.8",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.8.0.0.0.0.0.0.0"
+        },
+        "474": {
+            "id": "474",
+            "name": "containers-common",
+            "version": "2:1-35.module+el8.6.0+15917+093ca6f8",
+            "kind": "binary",
+            "source": {
+                "id": "473",
+                "name": "containers-common",
+                "version": "1-35.module+el8.6.0+15917+093ca6f8",
+                "kind": "source",
+                "module": "container-tools:rhel8"
+            },
+            "module": "container-tools:rhel8",
+            "arch": "x86_64"
+        },
+        "52": {
+            "id": "52",
+            "name": "pcre2",
+            "version": "10.32-3.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "51",
+                "name": "pcre2",
+                "version": "10.32-3.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1176": {
+            "id": "1176",
+            "name": "ply",
+            "version": "3.11",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.11.0.0.0.0.0.0.0"
+        },
+        "122": {
+            "id": "122",
+            "name": "libcomps",
+            "version": "0.1.18-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "121",
+                "name": "libcomps",
+                "version": "0.1.18-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1110": {
+            "id": "1110",
+            "name": "gunicorn",
+            "version": "20.1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.20.1.0.0.0.0.0.0.0"
+        },
+        "296": {
+            "id": "296",
+            "name": "gdbm",
+            "version": "1:1.18-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "97",
+                "name": "gdbm",
+                "version": "1.18-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "942": {
+            "id": "942",
+            "name": "python38-pip-wheel",
+            "version": "19.3.1-5.module+el8.6.0+13002+70cfc74a",
+            "kind": "binary",
+            "source": {
+                "id": "663",
+                "name": "python3x-pip",
+                "version": "19.3.1-5.module+el8.6.0+13002+70cfc74a",
+                "kind": "source",
+                "module": "python38:3.8"
+            },
+            "module": "python38:3.8",
+            "arch": "noarch"
+        },
+        "230": {
+            "id": "230",
+            "name": "python3-setuptools-wheel",
+            "version": "39.2.0-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "137",
+                "name": "python-setuptools",
+                "version": "39.2.0-6.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "310": {
+            "id": "310",
+            "name": "libksba",
+            "version": "1.3.5-7.el8",
+            "kind": "binary",
+            "source": {
+                "id": "309",
+                "name": "libksba",
+                "version": "1.3.5-7.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1086": {
+            "id": "1086",
+            "name": "cryptography",
+            "version": "3.3.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.3.2.0.0.0.0.0.0"
+        },
+        "390": {
+            "id": "390",
+            "name": "libmodulemd",
+            "version": "2.13.0-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "389",
+                "name": "libmodulemd",
+                "version": "2.13.0-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1032": {
+            "id": "1032",
+            "name": "pyjwt",
+            "version": "2.4.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.4.0.0.0.0.0.0.0"
+        },
+        "254": {
+            "id": "254",
+            "name": "libcap",
+            "version": "2.48-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "253",
+                "name": "libcap",
+                "version": "2.48-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "660": {
+            "id": "660",
+            "name": "python38-setuptools-wheel",
+            "version": "41.6.0-5.module+el8.5.0+12205+a865257a",
+            "kind": "binary",
+            "source": {
+                "id": "659",
+                "name": "python3x-setuptools",
+                "version": "41.6.0-5.module+el8.5.0+12205+a865257a",
+                "kind": "source",
+                "module": "python38:3.8"
+            },
+            "module": "python38:3.8",
+            "arch": "noarch"
+        },
+        "1162": {
+            "id": "1162",
+            "name": "oslo.i18n",
+            "version": "3.25.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.25.1.0.0.0.0.0.0"
+        },
+        "1026": {
+            "id": "1026",
+            "name": "markupsafe",
+            "version": "1.1.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.1.1.0.0.0.0.0.0"
+        },
+        "160": {
+            "id": "160",
+            "name": "passwd",
+            "version": "0.80-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "159",
+                "name": "passwd",
+                "version": "0.80-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "4": {
+            "id": "4",
+            "name": "ubi8",
+            "version": "8.6-903.1661794351",
+            "kind": "binary",
+            "source": {
+                "id": "2",
+                "name": "ubi8-container",
+                "version": "8.6-903.1661794351",
+                "kind": "source",
+                "arch": "x86_64"
+            },
+            "normalized_version": "rhctag:8.6.0.0.0.0.0.0.0.0",
+            "arch": "x86_64"
+        },
+        "8": {
+            "id": "8",
+            "name": "chardet",
+            "version": "3.0.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.0.4.0.0.0.0.0.0"
+        },
+        "442": {
+            "id": "442",
+            "name": "nginx-mod-http-perl",
+            "version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+            "kind": "binary",
+            "source": {
+                "id": "437",
+                "name": "nginx",
+                "version": "1.14.1-9.module+el8.0.0+4108+af250afe",
+                "kind": "source",
+                "module": "nginx:1.14"
+            },
+            "module": "nginx:1.14",
+            "arch": "x86_64"
+        },
+        "100": {
+            "id": "100",
+            "name": "libtasn1",
+            "version": "4.13-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "99",
+                "name": "libtasn1",
+                "version": "4.13-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "266": {
+            "id": "266",
+            "name": "libattr",
+            "version": "2.4.48-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "265",
+                "name": "attr",
+                "version": "2.4.48-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "124": {
+            "id": "124",
+            "name": "brotli",
+            "version": "1.0.6-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "123",
+                "name": "brotli",
+                "version": "1.0.6-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "274": {
+            "id": "274",
+            "name": "libstdc++",
+            "version": "8.5.0-10.1.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "227",
+                "name": "gcc",
+                "version": "8.5.0-10.1.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "188": {
+            "id": "188",
+            "name": "tpm2-tss",
+            "version": "2.3.2-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "187",
+                "name": "tpm2-tss",
+                "version": "2.3.2-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "228": {
+            "id": "228",
+            "name": "libgcc",
+            "version": "8.5.0-10.1.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "227",
+                "name": "gcc",
+                "version": "8.5.0-10.1.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "348": {
+            "id": "348",
+            "name": "usermode",
+            "version": "1.113-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "347",
+                "name": "usermode",
+                "version": "1.113-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "328": {
+            "id": "328",
+            "name": "libdb",
+            "version": "5.3.28-42.el8_4",
+            "kind": "binary",
+            "source": {
+                "id": "161",
+                "name": "libdb",
+                "version": "5.3.28-42.el8_4",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1090": {
+            "id": "1090",
+            "name": "decorator",
+            "version": "4.4.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.4.1.0.0.0.0.0.0"
+        },
+        "1160": {
+            "id": "1160",
+            "name": "oslo.config",
+            "version": "7.0.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.7.0.0.0.0.0.0.0.0"
+        },
+        "138": {
+            "id": "138",
+            "name": "platform-python-setuptools",
+            "version": "39.2.0-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "137",
+                "name": "python-setuptools",
+                "version": "39.2.0-6.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "928": {
+            "id": "928",
+            "name": "libjpeg-turbo",
+            "version": "1.5.3-12.el8",
+            "kind": "binary",
+            "source": {
+                "id": "927",
+                "name": "libjpeg-turbo",
+                "version": "1.5.3-12.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1210": {
+            "id": "1210",
+            "name": "python-keystoneclient",
+            "version": "3.22.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.22.0.0.0.0.0.0.0"
+        },
+        "252": {
+            "id": "252",
+            "name": "libxml2",
+            "version": "2.9.7-13.el8_6.1",
+            "kind": "binary",
+            "source": {
+                "id": "251",
+                "name": "libxml2",
+                "version": "2.9.7-13.el8_6.1",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1154": {
+            "id": "1154",
+            "name": "oauthlib",
+            "version": "3.1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.1.0.0.0.0.0.0.0"
+        },
+        "1140": {
+            "id": "1140",
+            "name": "maxminddb",
+            "version": "1.5.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.5.2.0.0.0.0.0.0"
+        },
+        "380": {
+            "id": "380",
+            "name": "gpgme",
+            "version": "1.13.1-11.el8",
+            "kind": "binary",
+            "source": {
+                "id": "193",
+                "name": "gpgme",
+                "version": "1.13.1-11.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "214": {
+            "id": "214",
+            "name": "dnf",
+            "version": "4.7.0-8.el8",
+            "kind": "binary",
+            "source": {
+                "id": "211",
+                "name": "dnf",
+                "version": "4.7.0-8.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "370": {
+            "id": "370",
+            "name": "dbus-daemon",
+            "version": "1:1.12.8-18.el8_6.1",
+            "kind": "binary",
+            "source": {
+                "id": "181",
+                "name": "dbus",
+                "version": "1.12.8-18.el8_6.1",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1102": {
+            "id": "1102",
+            "name": "geoip2",
+            "version": "3.0.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.0.0.0.0.0.0.0.0"
+        },
+        "1124": {
+            "id": "1124",
+            "name": "itsdangerous",
+            "version": "1.1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.1.0.0.0.0.0.0.0"
+        },
+        "982": {
+            "id": "982",
+            "name": "perl-HTTP-Tiny",
+            "version": "0.074-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "981",
+                "name": "perl-HTTP-Tiny",
+                "version": "0.074-1.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "934": {
+            "id": "934",
+            "name": "fontpackages-filesystem",
+            "version": "1.44-22.el8",
+            "kind": "binary",
+            "source": {
+                "id": "933",
+                "name": "fontpackages",
+                "version": "1.44-22.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1242": {
+            "id": "1242",
+            "name": "rfc3986",
+            "version": "1.3.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.3.2.0.0.0.0.0.0"
+        },
+        "1120": {
+            "id": "1120",
+            "name": "iso8601",
+            "version": "0.1.12",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.1.12.0.0.0.0.0.0"
+        },
+        "1128": {
+            "id": "1128",
+            "name": "jsonpath-rw",
+            "version": "1.4.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.4.0.0.0.0.0.0.0"
+        },
+        "256": {
+            "id": "256",
+            "name": "libzstd",
+            "version": "1.4.4-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "255",
+                "name": "zstd",
+                "version": "1.4.4-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "688": {
+            "id": "688",
+            "name": "perl-Pod-Simple",
+            "version": "1:3.35-395.el8",
+            "kind": "binary",
+            "source": {
+                "id": "687",
+                "name": "perl-Pod-Simple",
+                "version": "3.35-395.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "652": {
+            "id": "652",
+            "name": "protobuf-c",
+            "version": "1.3.0-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "651",
+                "name": "protobuf-c",
+                "version": "1.3.0-6.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "352": {
+            "id": "352",
+            "name": "python3-libxml2",
+            "version": "2.9.7-13.el8_6.1",
+            "kind": "binary",
+            "source": {
+                "id": "251",
+                "name": "libxml2",
+                "version": "2.9.7-13.el8_6.1",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "350": {
+            "id": "350",
+            "name": "python3-ethtool",
+            "version": "0.14-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "349",
+                "name": "python-ethtool",
+                "version": "0.14-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "234": {
+            "id": "234",
+            "name": "setup",
+            "version": "2.12.2-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "233",
+                "name": "setup",
+                "version": "2.12.2-6.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1292": {
+            "id": "1292",
+            "name": "zipp",
+            "version": "2.1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.1.0.0.0.0.0.0.0"
+        },
+        "1184": {
+            "id": "1184",
+            "name": "psycopg2-binary",
+            "version": "2.9.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.9.3.0.0.0.0.0.0"
+        },
+        "1046": {
+            "id": "1046",
+            "name": "alembic",
+            "version": "1.3.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.3.3.0.0.0.0.0.0"
+        },
+        "662": {
+            "id": "662",
+            "name": "python38",
+            "version": "3.8.12-1.module+el8.6.0+12642+c3710b74",
+            "kind": "binary",
+            "source": {
+                "id": "661",
+                "name": "python38",
+                "version": "3.8.12-1.module+el8.6.0+12642+c3710b74",
+                "kind": "source",
+                "module": "python38:3.8"
+            },
+            "module": "python38:3.8",
+            "arch": "x86_64"
+        },
+        "1246": {
+            "id": "1246",
+            "name": "semantic-version",
+            "version": "2.8.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.8.4.0.0.0.0.0.0"
+        },
+        "994": {
+            "id": "994",
+            "name": "perl-Carp",
+            "version": "1.42-396.el8",
+            "kind": "binary",
+            "source": {
+                "id": "993",
+                "name": "perl-Carp",
+                "version": "1.42-396.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1054": {
+            "id": "1054",
+            "name": "azure-core",
+            "version": "1.8.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.8.0.0.0.0.0.0.0"
+        },
+        "932": {
+            "id": "932",
+            "name": "openssl",
+            "version": "1:1.1.1k-7.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "319",
+                "name": "openssl",
+                "version": "1.1.1k-7.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "304": {
+            "id": "304",
+            "name": "cracklib",
+            "version": "2.9.6-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "117",
+                "name": "cracklib",
+                "version": "2.9.6-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "146": {
+            "id": "146",
+            "name": "python3-dateutil",
+            "version": "1:2.6.1-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "145",
+                "name": "python-dateutil",
+                "version": "2.6.1-6.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "58": {
+            "id": "58",
+            "name": "bash",
+            "version": "4.4.20-4.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "57",
+                "name": "bash",
+                "version": "4.4.20-4.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "96": {
+            "id": "96",
+            "name": "lz4-libs",
+            "version": "1.8.3-3.el8_4",
+            "kind": "binary",
+            "source": {
+                "id": "95",
+                "name": "lz4",
+                "version": "1.8.3-3.el8_4",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "482": {
+            "id": "482",
+            "name": "libpq-devel",
+            "version": "13.5-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "481",
+                "name": "libpq",
+                "version": "13.5-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "734": {
+            "id": "734",
+            "name": "nginx-mod-mail",
+            "version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+            "kind": "binary",
+            "source": {
+                "id": "437",
+                "name": "nginx",
+                "version": "1.14.1-9.module+el8.0.0+4108+af250afe",
+                "kind": "source",
+                "module": "nginx:1.14"
+            },
+            "module": "nginx:1.14",
+            "arch": "x86_64"
+        },
+        "742": {
+            "id": "742",
+            "name": "pkgconf-m4",
+            "version": "1.4.2-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "453",
+                "name": "pkgconf",
+                "version": "1.4.2-1.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "38": {
+            "id": "38",
+            "name": "pip",
+            "version": "19.3.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.19.3.1.0.0.0.0.0.0"
+        },
+        "1146": {
+            "id": "1146",
+            "name": "msrest",
+            "version": "0.6.21",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.6.21.0.0.0.0.0.0"
+        },
+        "268": {
+            "id": "268",
+            "name": "coreutils-single",
+            "version": "8.30-12.el8",
+            "kind": "binary",
+            "source": {
+                "id": "267",
+                "name": "coreutils",
+                "version": "8.30-12.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "104": {
+            "id": "104",
+            "name": "systemd-libs",
+            "version": "239-58.el8_6.4",
+            "kind": "binary",
+            "source": {
+                "id": "103",
+                "name": "systemd",
+                "version": "239-58.el8_6.4",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "22": {
+            "id": "22",
+            "name": "setuptools",
+            "version": "39.2.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.39.2.0.0.0.0.0.0.0"
+        },
+        "458": {
+            "id": "458",
+            "name": "pkgconf-pkg-config",
+            "version": "1.4.2-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "453",
+                "name": "pkgconf",
+                "version": "1.4.2-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1136": {
+            "id": "1136",
+            "name": "kafka-python",
+            "version": "1.4.7",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.4.7.0.0.0.0.0.0"
+        },
+        "964": {
+            "id": "964",
+            "name": "fuse-overlayfs",
+            "version": "1.9-1.module+el8.6.0+15917+093ca6f8",
+            "kind": "binary",
+            "source": {
+                "id": "963",
+                "name": "fuse-overlayfs",
+                "version": "1.9-1.module+el8.6.0+15917+093ca6f8",
+                "kind": "source",
+                "module": "container-tools:rhel8"
+            },
+            "module": "container-tools:rhel8",
+            "arch": "x86_64"
+        },
+        "1064": {
+            "id": "1064",
+            "name": "bitmath",
+            "version": "1.3.3.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.3.3.1.0.0.0.0.0"
+        },
+        "150": {
+            "id": "150",
+            "name": "librhsm",
+            "version": "0.0.3-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "149",
+                "name": "librhsm",
+                "version": "0.0.3-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1182": {
+            "id": "1182",
+            "name": "psutil",
+            "version": "5.9.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.5.9.0.0.0.0.0.0.0"
+        },
+        "80": {
+            "id": "80",
+            "name": "libacl",
+            "version": "2.2.53-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "79",
+                "name": "acl",
+                "version": "2.2.53-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1038": {
+            "id": "1038",
+            "name": "pyyaml",
+            "version": "5.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.5.4.0.0.0.0.0.0.0"
+        },
+        "1190": {
+            "id": "1190",
+            "name": "pyasn1",
+            "version": "0.4.8",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.4.8.0.0.0.0.0.0"
+        },
+        "462": {
+            "id": "462",
+            "name": "libibverbs",
+            "version": "37.2-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "461",
+                "name": "rdma-core",
+                "version": "37.2-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "434": {
+            "id": "434",
+            "name": "perl-IO",
+            "version": "0:1.38-421.el8",
+            "kind": "binary",
+            "source": {
+                "id": "417",
+                "name": "perl",
+                "version": "5.26.3-421.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "128": {
+            "id": "128",
+            "name": "libseccomp",
+            "version": "2.5.2-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "127",
+                "name": "libseccomp",
+                "version": "2.5.2-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "402": {
+            "id": "402",
+            "name": "python3-dnf-plugins-core",
+            "version": "4.0.21-11.el8",
+            "kind": "binary",
+            "source": {
+                "id": "401",
+                "name": "dnf-plugins-core",
+                "version": "4.0.21-11.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "940": {
+            "id": "940",
+            "name": "libslirp",
+            "version": "4.4.0-1.module+el8.6.0+15875+dc9a2b96",
+            "kind": "binary",
+            "source": {
+                "id": "939",
+                "name": "libslirp",
+                "version": "4.4.0-1.module+el8.6.0+15875+dc9a2b96",
+                "kind": "source",
+                "module": "container-tools:rhel8"
+            },
+            "module": "container-tools:rhel8",
+            "arch": "x86_64"
+        },
+        "198": {
+            "id": "198",
+            "name": "librepo",
+            "version": "1.14.2-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "197",
+                "name": "librepo",
+                "version": "1.14.2-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1294": {
+            "id": "1294",
+            "name": "zope.event",
+            "version": "4.5.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.5.0.0.0.0.0.0.0"
+        },
+        "672": {
+            "id": "672",
+            "name": "fuse3",
+            "version": "3.3.0-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "637",
+                "name": "fuse",
+                "version": "2.9.7-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "136": {
+            "id": "136",
+            "name": "libtirpc",
+            "version": "1.1.4-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "135",
+                "name": "libtirpc",
+                "version": "1.1.4-6.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "94": {
+            "id": "94",
+            "name": "libcap-ng",
+            "version": "0.7.11-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "93",
+                "name": "libcap-ng",
+                "version": "0.7.11-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "148": {
+            "id": "148",
+            "name": "glib2",
+            "version": "2.56.4-158.el8",
+            "kind": "binary",
+            "source": {
+                "id": "147",
+                "name": "glib2",
+                "version": "2.56.4-158.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1296": {
+            "id": "1296",
+            "name": "zope.interface",
+            "version": "5.4.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.5.4.0.0.0.0.0.0.0"
+        },
+        "300": {
+            "id": "300",
+            "name": "libpsl",
+            "version": "0.20.2-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "299",
+                "name": "libpsl",
+                "version": "0.20.2-6.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1094": {
+            "id": "1094",
+            "name": "elasticsearch",
+            "version": "7.0.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.7.0.4.0.0.0.0.0.0"
+        },
+        "164": {
+            "id": "164",
+            "name": "python3-libcomps",
+            "version": "0.1.18-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "121",
+                "name": "libcomps",
+                "version": "0.1.18-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "204": {
+            "id": "204",
+            "name": "libsolv",
+            "version": "0.7.20-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "203",
+                "name": "libsolv",
+                "version": "0.7.20-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "966": {
+            "id": "966",
+            "name": "groff-base",
+            "version": "1.22.3-18.el8",
+            "kind": "binary",
+            "source": {
+                "id": "965",
+                "name": "groff",
+                "version": "1.22.3-18.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1092": {
+            "id": "1092",
+            "name": "dumb-init",
+            "version": "1.2.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.2.2.0.0.0.0.0.0"
+        },
+        "156": {
+            "id": "156",
+            "name": "virt-what",
+            "version": "1.18-13.el8",
+            "kind": "binary",
+            "source": {
+                "id": "155",
+                "name": "virt-what",
+                "version": "1.18-13.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "762": {
+            "id": "762",
+            "name": "runc",
+            "version": "1:1.1.3-2.module+el8.6.0+15917+093ca6f8",
+            "kind": "binary",
+            "source": {
+                "id": "761",
+                "name": "runc",
+                "version": "1.1.3-2.module+el8.6.0+15917+093ca6f8",
+                "kind": "source",
+                "module": "container-tools:rhel8"
+            },
+            "module": "container-tools:rhel8",
+            "arch": "x86_64"
+        },
+        "324": {
+            "id": "324",
+            "name": "crypto-policies-scripts",
+            "version": "20211116-1.gitae470d6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "133",
+                "name": "crypto-policies",
+                "version": "20211116-1.gitae470d6.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "676": {
+            "id": "676",
+            "name": "perl-Digest",
+            "version": "1.17-395.el8",
+            "kind": "binary",
+            "source": {
+                "id": "675",
+                "name": "perl-Digest",
+                "version": "1.17-395.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1250": {
+            "id": "1250",
+            "name": "setuptools-scm",
+            "version": "4.1.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.1.2.0.0.0.0.0.0"
+        },
+        "718": {
+            "id": "718",
+            "name": "perl-File-Path",
+            "version": "2.15-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "717",
+                "name": "perl-File-Path",
+                "version": "2.15-2.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1040": {
+            "id": "1040",
+            "name": "sqlalchemy",
+            "version": "1.4.31",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.4.31.0.0.0.0.0.0"
+        },
+        "226": {
+            "id": "226",
+            "name": "gpg-pubkey",
+            "version": "d4082792-5b32db75",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            }
+        },
+        "202": {
+            "id": "202",
+            "name": "rpm-libs",
+            "version": "4.14.3-23.el8",
+            "kind": "binary",
+            "source": {
+                "id": "201",
+                "name": "rpm",
+                "version": "4.14.3-23.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1222": {
+            "id": "1222",
+            "name": "raven",
+            "version": "6.10.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.6.10.0.0.0.0.0.0.0"
+        },
+        "180": {
+            "id": "180",
+            "name": "elfutils-default-yama-scope",
+            "version": "0.186-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "179",
+                "name": "elfutils",
+                "version": "0.186-1.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1084": {
+            "id": "1084",
+            "name": "cnr-server",
+            "version": "0.2.7.post1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.2.7.0.0.0.0.1.0"
+        },
+        "658": {
+            "id": "658",
+            "name": "libXpm",
+            "version": "3.5.12-8.el8",
+            "kind": "binary",
+            "source": {
+                "id": "657",
+                "name": "libXpm",
+                "version": "3.5.12-8.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1232": {
+            "id": "1232",
+            "name": "reportlab",
+            "version": "3.5.55",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.5.55.0.0.0.0.0.0"
+        },
+        "1214": {
+            "id": "1214",
+            "name": "python-magic",
+            "version": "0.4.15",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.4.15.0.0.0.0.0.0"
+        },
+        "1264": {
+            "id": "1264",
+            "name": "supervisor-logging",
+            "version": "0.0.9",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.0.9.0.0.0.0.0.0"
+        },
+        "66": {
+            "id": "66",
+            "name": "info",
+            "version": "6.5-7.el8",
+            "kind": "binary",
+            "source": {
+                "id": "65",
+                "name": "texinfo",
+                "version": "6.5-7.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1004": {
+            "id": "1004",
+            "name": "cython",
+            "version": "3.0.0a9",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.0.0.0.0.-3.9.0.0"
+        },
+        "1196": {
+            "id": "1196",
+            "name": "pymemcache",
+            "version": "3.0.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.0.0.0.0.0.0.0.0"
+        },
+        "308": {
+            "id": "308",
+            "name": "nettle",
+            "version": "3.4.1-7.el8",
+            "kind": "binary",
+            "source": {
+                "id": "307",
+                "name": "nettle",
+                "version": "3.4.1-7.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1252": {
+            "id": "1252",
+            "name": "six",
+            "version": "1.14.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.14.0.0.0.0.0.0.0"
+        },
+        "726": {
+            "id": "726",
+            "name": "perl-interpreter",
+            "version": "4:5.26.3-421.el8",
+            "kind": "binary",
+            "source": {
+                "id": "417",
+                "name": "perl",
+                "version": "5.26.3-421.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "642": {
+            "id": "642",
+            "name": "libmnl",
+            "version": "1.0.4-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "641",
+                "name": "libmnl",
+                "version": "1.0.4-6.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1230": {
+            "id": "1230",
+            "name": "rehash",
+            "version": "1.0.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.0.0.0.0.0.0.0.0"
+        },
+        "1008": {
+            "id": "1008",
+            "name": "deprecated",
+            "version": "1.2.7",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.2.7.0.0.0.0.0.0"
+        },
+        "1186": {
+            "id": "1186",
+            "name": "pyopenssl",
+            "version": "19.1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.19.1.0.0.0.0.0.0.0"
+        },
+        "1258": {
+            "id": "1258",
+            "name": "stringscore",
+            "version": "0.1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.1.0.0.0.0.0.0.0"
+        },
+        "276": {
+            "id": "276",
+            "name": "chkconfig",
+            "version": "1.19.1-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "275",
+                "name": "chkconfig",
+                "version": "1.19.1-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "170": {
+            "id": "170",
+            "name": "python3-inotify",
+            "version": "0.9.6-13.el8",
+            "kind": "binary",
+            "source": {
+                "id": "169",
+                "name": "python-inotify",
+                "version": "0.9.6-13.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "366": {
+            "id": "366",
+            "name": "cryptsetup-libs",
+            "version": "2.3.7-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "365",
+                "name": "cryptsetup",
+                "version": "2.3.7-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "466": {
+            "id": "466",
+            "name": "iptables-libs",
+            "version": "1.8.4-22.el8",
+            "kind": "binary",
+            "source": {
+                "id": "465",
+                "name": "iptables",
+                "version": "1.8.4-22.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1114": {
+            "id": "1114",
+            "name": "html5lib",
+            "version": "1.0.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.0.1.0.0.0.0.0.0"
+        },
+        "996": {
+            "id": "996",
+            "name": "perl-libs",
+            "version": "4:5.26.3-421.el8",
+            "kind": "binary",
+            "source": {
+                "id": "417",
+                "name": "perl",
+                "version": "5.26.3-421.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "704": {
+            "id": "704",
+            "name": "perl-Exporter",
+            "version": "5.72-396.el8",
+            "kind": "binary",
+            "source": {
+                "id": "703",
+                "name": "perl-Exporter",
+                "version": "5.72-396.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1072": {
+            "id": "1072",
+            "name": "cachetools",
+            "version": "4.0.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.0.0.0.0.0.0.0.0"
+        },
+        "86": {
+            "id": "86",
+            "name": "lua-libs",
+            "version": "5.3.4-12.el8",
+            "kind": "binary",
+            "source": {
+                "id": "85",
+                "name": "lua",
+                "version": "5.3.4-12.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1178": {
+            "id": "1178",
+            "name": "prometheus-client",
+            "version": "0.7.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.7.1.0.0.0.0.0.0"
+        },
+        "1276": {
+            "id": "1276",
+            "name": "tzlocal",
+            "version": "2.0.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.0.0.0.0.0.0.0.0"
+        },
+        "1228": {
+            "id": "1228",
+            "name": "redis-py-cluster",
+            "version": "2.1.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.1.3.0.0.0.0.0.0"
+        },
+        "1126": {
+            "id": "1126",
+            "name": "jmespath",
+            "version": "0.9.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.9.4.0.0.0.0.0.0"
+        },
+        "1220": {
+            "id": "1220",
+            "name": "pytz",
+            "version": "2019.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2019.3.0.0.0.0.0.0.0"
+        },
+        "62": {
+            "id": "62",
+            "name": "bzip2-libs",
+            "version": "1.0.6-26.el8",
+            "kind": "binary",
+            "source": {
+                "id": "61",
+                "name": "bzip2",
+                "version": "1.0.6-26.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "166": {
+            "id": "166",
+            "name": "python3-dmidecode",
+            "version": "3.12.2-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "165",
+                "name": "python-dmidecode",
+                "version": "3.12.2-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "248": {
+            "id": "248",
+            "name": "xz-libs",
+            "version": "5.2.4-4.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "247",
+                "name": "xz",
+                "version": "5.2.4-4.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1236": {
+            "id": "1236",
+            "name": "requests-aws4auth",
+            "version": "0.9",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.9.0.0.0.0.0.0.0"
+        },
+        "1288": {
+            "id": "1288",
+            "name": "xhtml2pdf",
+            "version": "0.2.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.2.4.0.0.0.0.0.0"
+        },
+        "1256": {
+            "id": "1256",
+            "name": "stevedore",
+            "version": "1.31.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.31.0.0.0.0.0.0.0"
+        },
+        "346": {
+            "id": "346",
+            "name": "libuser",
+            "version": "0.62-24.el8",
+            "kind": "binary",
+            "source": {
+                "id": "345",
+                "name": "libuser",
+                "version": "0.62-24.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1270": {
+            "id": "1270",
+            "name": "tldextract",
+            "version": "2.2.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.2.2.0.0.0.0.0.0"
+        },
+        "238": {
+            "id": "238",
+            "name": "ncurses-base",
+            "version": "6.1-9.20180224.el8",
+            "kind": "binary",
+            "source": {
+                "id": "53",
+                "name": "ncurses",
+                "version": "6.1-9.20180224.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1180": {
+            "id": "1180",
+            "name": "protobuf",
+            "version": "3.15.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.15.0.0.0.0.0.0.0"
+        },
+        "1018": {
+            "id": "1018",
+            "name": "flask-principal",
+            "version": "0.4.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.4.0.0.0.0.0.0.0"
+        },
+        "1204": {
+            "id": "1204",
+            "name": "python-editor",
+            "version": "1.0.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.0.4.0.0.0.0.0.0"
+        },
+        "372": {
+            "id": "372",
+            "name": "systemd",
+            "version": "239-58.el8_6.4",
+            "kind": "binary",
+            "source": {
+                "id": "103",
+                "name": "systemd",
+                "version": "239-58.el8_6.4",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "358": {
+            "id": "358",
+            "name": "python3-pysocks",
+            "version": "1.6.8-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "357",
+                "name": "python-pysocks",
+                "version": "1.6.8-3.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "24": {
+            "id": "24",
+            "name": "six",
+            "version": "1.11.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.11.0.0.0.0.0.0.0"
+        },
+        "1174": {
+            "id": "1174",
+            "name": "pip",
+            "version": "21.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.21.1.0.0.0.0.0.0.0"
+        },
+        "1088": {
+            "id": "1088",
+            "name": "debtcollector",
+            "version": "1.22.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.22.0.0.0.0.0.0.0"
+        },
+        "250": {
+            "id": "250",
+            "name": "libgpg-error",
+            "version": "1.31-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "249",
+                "name": "libgpg-error",
+                "version": "1.31-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "90": {
+            "id": "90",
+            "name": "libunistring",
+            "version": "0.9.9-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "89",
+                "name": "libunistring",
+                "version": "0.9.9-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1000": {
+            "id": "1000",
+            "name": "authlib",
+            "version": "1.0.0a1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.0.0.0.0.-3.1.0.0"
+        },
+        "988": {
+            "id": "988",
+            "name": "perl-MIME-Base64",
+            "version": "3.15-396.el8",
+            "kind": "binary",
+            "source": {
+                "id": "987",
+                "name": "perl-MIME-Base64",
+                "version": "3.15-396.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1112": {
+            "id": "1112",
+            "name": "hashids",
+            "version": "1.2.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.2.0.0.0.0.0.0.0"
+        },
+        "312": {
+            "id": "312",
+            "name": "dmidecode",
+            "version": "1:3.3-4.el8",
+            "kind": "binary",
+            "source": {
+                "id": "311",
+                "name": "dmidecode",
+                "version": "3.3-4.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "400": {
+            "id": "400",
+            "name": "python3-dnf",
+            "version": "4.7.0-8.el8",
+            "kind": "binary",
+            "source": {
+                "id": "211",
+                "name": "dnf",
+                "version": "4.7.0-8.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "322": {
+            "id": "322",
+            "name": "krb5-libs",
+            "version": "1.18.2-14.el8",
+            "kind": "binary",
+            "source": {
+                "id": "321",
+                "name": "krb5",
+                "version": "1.18.2-14.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "298": {
+            "id": "298",
+            "name": "shadow-utils",
+            "version": "2:4.6-16.el8",
+            "kind": "binary",
+            "source": {
+                "id": "297",
+                "name": "shadow-utils",
+                "version": "4.6-16.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1060": {
+            "id": "1060",
+            "name": "beautifulsoup4",
+            "version": "4.8.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.8.2.0.0.0.0.0.0"
+        },
+        "1070": {
+            "id": "1070",
+            "name": "botocore",
+            "version": "1.24.42",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.24.42.0.0.0.0.0.0"
+        },
+        "284": {
+            "id": "284",
+            "name": "libassuan",
+            "version": "2.5.1-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "283",
+                "name": "libassuan",
+                "version": "2.5.1-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "664": {
+            "id": "664",
+            "name": "python38-pip",
+            "version": "19.3.1-5.module+el8.6.0+13002+70cfc74a",
+            "kind": "binary",
+            "source": {
+                "id": "663",
+                "name": "python3x-pip",
+                "version": "19.3.1-5.module+el8.6.0+13002+70cfc74a",
+                "kind": "source",
+                "module": "python38:3.8"
+            },
+            "module": "python38:3.8",
+            "arch": "noarch"
+        },
+        "320": {
+            "id": "320",
+            "name": "openssl-libs",
+            "version": "1:1.1.1k-7.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "319",
+                "name": "openssl",
+                "version": "1.1.1k-7.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "10": {
+            "id": "10",
+            "name": "decorator",
+            "version": "4.2.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.4.2.1.0.0.0.0.0.0"
+        },
+        "1044": {
+            "id": "1044",
+            "name": "werkzeug",
+            "version": "0.16.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.16.1.0.0.0.0.0.0"
+        },
+        "972": {
+            "id": "972",
+            "name": "perl-URI",
+            "version": "1.73-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "971",
+                "name": "perl-URI",
+                "version": "1.73-3.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "414": {
+            "id": "414",
+            "name": "jasmine-core",
+            "version": "2.8.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.8.0.0.0.0.0.0.0"
+        },
+        "1290": {
+            "id": "1290",
+            "name": "yapf",
+            "version": "0.29.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.29.0.0.0.0.0.0.0"
+        },
+        "78": {
+            "id": "78",
+            "name": "gmp",
+            "version": "1:6.1.2-10.el8",
+            "kind": "binary",
+            "source": {
+                "id": "77",
+                "name": "gmp",
+                "version": "6.1.2-10.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "72": {
+            "id": "72",
+            "name": "json-c",
+            "version": "0.13.1-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "71",
+                "name": "json-c",
+                "version": "0.13.1-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "990": {
+            "id": "990",
+            "name": "perl-Socket",
+            "version": "4:2.027-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "989",
+                "name": "perl-Socket",
+                "version": "2.027-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "84": {
+            "id": "84",
+            "name": "sed",
+            "version": "4.5-5.el8",
+            "kind": "binary",
+            "source": {
+                "id": "83",
+                "name": "sed",
+                "version": "4.5-5.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "368": {
+            "id": "368",
+            "name": "elfutils-libs",
+            "version": "0.186-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "179",
+                "name": "elfutils",
+                "version": "0.186-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "770": {
+            "id": "770",
+            "name": "skopeo",
+            "version": "2:1.8.0-2.module+el8.6.0+15917+093ca6f8",
+            "kind": "binary",
+            "source": {
+                "id": "769",
+                "name": "skopeo",
+                "version": "1.8.0-2.module+el8.6.0+15917+093ca6f8",
+                "kind": "source",
+                "module": "container-tools:rhel8"
+            },
+            "module": "container-tools:rhel8",
+            "arch": "x86_64"
+        },
+        "696": {
+            "id": "696",
+            "name": "perl-Storable",
+            "version": "1:3.11-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "695",
+                "name": "perl-Storable",
+                "version": "3.11-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "56": {
+            "id": "56",
+            "name": "glibc-common",
+            "version": "2.28-189.5.el8_6",
+            "kind": "binary",
+            "source": {
+                "id": "55",
+                "name": "glibc",
+                "version": "2.28-189.5.el8_6",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "218": {
+            "id": "218",
+            "name": "yum",
+            "version": "4.7.0-8.el8",
+            "kind": "binary",
+            "source": {
+                "id": "211",
+                "name": "dnf",
+                "version": "4.7.0-8.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1130": {
+            "id": "1130",
+            "name": "jsonpickle",
+            "version": "1.2",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.2.0.0.0.0.0.0.0"
+        },
+        "1132": {
+            "id": "1132",
+            "name": "jsonpointer",
+            "version": "2.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.0.0.0.0.0.0.0.0"
+        },
+        "1118": {
+            "id": "1118",
+            "name": "importlib-metadata",
+            "version": "1.4.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.4.0.0.0.0.0.0.0"
+        },
+        "1096": {
+            "id": "1096",
+            "name": "elasticsearch-dsl",
+            "version": "7.0.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.7.0.0.0.0.0.0.0.0"
+        },
+        "416": {
+            "id": "416",
+            "name": "jasmine-core",
+            "version": "3.0.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.3.0.0.0.0.0.0.0.0"
+        },
+        "40": {
+            "id": "40",
+            "name": "setuptools",
+            "version": "41.6.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.41.6.0.0.0.0.0.0.0"
+        },
+        "212": {
+            "id": "212",
+            "name": "dnf-data",
+            "version": "4.7.0-8.el8",
+            "kind": "binary",
+            "source": {
+                "id": "211",
+                "name": "dnf",
+                "version": "4.7.0-8.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1234": {
+            "id": "1234",
+            "name": "requests",
+            "version": "2.27.1",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.27.1.0.0.0.0.0.0"
+        },
+        "290": {
+            "id": "290",
+            "name": "grep",
+            "version": "3.1-6.el8",
+            "kind": "binary",
+            "source": {
+                "id": "289",
+                "name": "grep",
+                "version": "3.1-6.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "640": {
+            "id": "640",
+            "name": "freetype",
+            "version": "2.9.1-4.el8_3.1",
+            "kind": "binary",
+            "source": {
+                "id": "639",
+                "name": "freetype",
+                "version": "2.9.1-4.el8_3.1",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "70": {
+            "id": "70",
+            "name": "popt",
+            "version": "1.18-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "69",
+                "name": "popt",
+                "version": "1.18-1.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "710": {
+            "id": "710",
+            "name": "perl-threads-shared",
+            "version": "1.58-2.el8",
+            "kind": "binary",
+            "source": {
+                "id": "709",
+                "name": "perl-threads-shared",
+                "version": "1.58-2.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "404": {
+            "id": "404",
+            "name": "subscription-manager",
+            "version": "1.28.29-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "173",
+                "name": "subscription-manager",
+                "version": "1.28.29-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "450": {
+            "id": "450",
+            "name": "nginx-all-modules",
+            "version": "1:1.14.1-9.module+el8.0.0+4108+af250afe",
+            "kind": "binary",
+            "source": {
+                "id": "437",
+                "name": "nginx",
+                "version": "1.14.1-9.module+el8.0.0+4108+af250afe",
+                "kind": "source",
+                "module": "nginx:1.14"
+            },
+            "module": "nginx:1.14",
+            "arch": "noarch"
+        },
+        "50": {
+            "id": "50",
+            "name": "publicsuffix-list-dafsa",
+            "version": "20180723-1.el8",
+            "kind": "binary",
+            "source": {
+                "id": "49",
+                "name": "publicsuffix-list",
+                "version": "20180723-1.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "142": {
+            "id": "142",
+            "name": "libpwquality",
+            "version": "1.4.4-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "141",
+                "name": "libpwquality",
+                "version": "1.4.4-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "638": {
+            "id": "638",
+            "name": "fuse3-libs",
+            "version": "3.3.0-15.el8",
+            "kind": "binary",
+            "source": {
+                "id": "637",
+                "name": "fuse",
+                "version": "2.9.7-15.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "1206": {
+            "id": "1206",
+            "name": "python-etcd",
+            "version": "0.3.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.3.3.0.0.0.0.0.0"
+        },
+        "270": {
+            "id": "270",
+            "name": "libmount",
+            "version": "2.32.1-35.el8",
+            "kind": "binary",
+            "source": {
+                "id": "81",
+                "name": "util-linux",
+                "version": "2.32.1-35.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "14": {
+            "id": "14",
+            "name": "iniparse",
+            "version": "0.4",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.0.4.0.0.0.0.0.0.0"
+        },
+        "1076": {
+            "id": "1076",
+            "name": "cffi",
+            "version": "1.14.3",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.14.3.0.0.0.0.0.0"
+        },
+        "1260": {
+            "id": "1260",
+            "name": "stripe",
+            "version": "2.42.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.2.42.0.0.0.0.0.0.0"
+        },
+        "1048": {
+            "id": "1048",
+            "name": "aniso8601",
+            "version": "1.0",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.0.0.0.0.0.0.0.0"
+        },
+        "644": {
+            "id": "644",
+            "name": "dejavu-fonts-common",
+            "version": "2.35-7.el8",
+            "kind": "binary",
+            "source": {
+                "id": "643",
+                "name": "dejavu-fonts",
+                "version": "2.35-7.el8",
+                "kind": "source"
+            },
+            "arch": "noarch"
+        },
+        "1254": {
+            "id": "1254",
+            "name": "soupsieve",
+            "version": "1.9.5",
+            "kind": "binary",
+            "source": {
+                "id": "1",
+                "name": "",
+                "version": ""
+            },
+            "normalized_version": "pep440:0.1.9.5.0.0.0.0.0.0"
+        },
+        "294": {
+            "id": "294",
+            "name": "dbus-tools",
+            "version": "1:1.12.8-18.el8_6.1",
+            "kind": "binary",
+            "source": {
+                "id": "181",
+                "name": "dbus",
+                "version": "1.12.8-18.el8_6.1",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        },
+        "362": {
+            "id": "362",
+            "name": "python3-syspurpose",
+            "version": "1.28.29-3.el8",
+            "kind": "binary",
+            "source": {
+                "id": "173",
+                "name": "subscription-manager",
+                "version": "1.28.29-3.el8",
+                "kind": "source"
+            },
+            "arch": "x86_64"
+        }
+    },
+    "distributions": {
+        "1": {
+            "id": "1",
+            "did": "rhel",
+            "name": "Red Hat Enterprise Linux Server",
+            "version": "8",
+            "version_code_name": "",
+            "version_id": "8",
+            "arch": "",
+            "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+            "pretty_name": "Red Hat Enterprise Linux Server 8"
+        }
+    },
+    "repository": {
+        "1": {
+            "id": "1",
+            "name": "pypi",
+            "uri": "https://pypi.org/simple"
+        },
+        "2": {
+            "id": "2",
+            "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+            "key": "rhel-cpe-repository",
+            "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:baseos:*:*:*:*:*"
+        },
+        "3": {
+            "id": "3",
+            "name": "cpe:/o:redhat:rhel:8.3::baseos",
+            "key": "rhel-cpe-repository",
+            "cpe": "cpe:2.3:o:redhat:rhel:8.3:*:baseos:*:*:*:*:*"
+        },
+        "4": {
+            "id": "4",
+            "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+            "key": "rhel-cpe-repository",
+            "cpe": "cpe:2.3:a:redhat:enterprise_linux:8:*:appstream:*:*:*:*:*"
+        },
+        "5": {
+            "id": "5",
+            "name": "cpe:/a:redhat:rhel:8.3::appstream",
+            "key": "rhel-cpe-repository",
+            "cpe": "cpe:2.3:a:redhat:rhel:8.3:*:appstream:*:*:*:*:*"
+        },
+        "8": {
+            "id": "8",
+            "name": "Red Hat Container Catalog",
+            "uri": "https://catalog.redhat.com/software/containers/explore"
+        }
+    },
+    "environments": {
+        "80": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1096": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "96": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "24": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1052": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1024": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "114": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "44": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "218": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "714": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "82": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "250": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1286": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "300": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "396": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1158": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "458": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1030": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1252": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "644": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1202": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "680": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "36": [
+            {
+                "package_db": "python:usr/lib64/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1166": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1292": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1276": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "56": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "18": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "224": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "650": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "268": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1012": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "42": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "700": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "280": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "658": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1046": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "144": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "272": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1160": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1126": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1054": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1048": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "244": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "324": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "84": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "192": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1220": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "38": [
+            {
+                "package_db": "python:usr/lib/python3.8/site-packages",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1050": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1214": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "970": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "340": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1176": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1168": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1140": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "678": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "376": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "162": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "172": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "214": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1124": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "446": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1072": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1066": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "202": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "124": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1208": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "254": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "964": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "258": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1260": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "672": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "238": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "758": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1248": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1258": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "92": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1290": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "992": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1104": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "180": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "730": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "52": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "408": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "366": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "640": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "662": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "454": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "176": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "966": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1034": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1110": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "328": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "94": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "754": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1138": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "226": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "112": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "652": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "378": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "934": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "194": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "330": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "288": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "342": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "418": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "140": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1264": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1132": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1152": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "102": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "958": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "940": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1204": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "746": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "422": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1090": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1094": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "10": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "286": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1182": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "320": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "462": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "358": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1130": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1246": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "30": [
+            {
+                "package_db": "python:usr/lib64/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "368": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "212": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1198": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "34": [
+            {
+                "package_db": "python:usr/lib64/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "160": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "956": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "648": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "938": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "260": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "204": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "948": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1088": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "12": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "100": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "32": [
+            {
+                "package_db": "python:usr/lib64/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "190": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "116": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1224": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "264": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1188": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1212": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1206": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "990": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1102": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "984": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "26": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "282": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "184": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "210": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "400": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "48": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "186": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "20": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "426": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "292": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "952": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "156": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1232": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1134": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "154": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "322": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1082": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "308": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "976": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "108": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "946": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "654": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1240": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "312": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "236": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1000": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1178": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "62": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "710": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1068": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "276": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1266": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "196": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "750": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "138": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1136": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1272": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1076": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "770": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "986": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1002": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "78": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1144": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1128": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "414": [
+            {
+                "package_db": "python:quay-registry/config_app/node_modules/jasmine/node_modules/jasmine-core",
+                "introduced_in": "sha256:55d1c0fb65e634002b0c983896141d5f7fe976672630e402d451e1478d8a7588",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "684": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "394": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "932": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1236": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "438": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1086": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "734": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1184": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "278": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "690": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "344": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "90": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "242": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1026": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "642": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1062": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "88": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "738": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "298": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1070": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "352": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "110": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "362": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "270": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "942": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "372": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "722": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "774": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "336": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1156": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "950": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "936": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "356": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "262": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "178": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1016": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "404": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "296": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "132": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "656": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "928": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "166": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "384": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "158": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "450": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1190": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "252": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "76": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "198": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "334": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "170": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "122": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "50": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1116": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "294": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "944": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "766": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1238": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1060": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "274": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1084": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1172": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1294": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1216": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1288": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "692": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "674": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "318": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "46": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1268": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "406": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "996": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "314": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "120": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1092": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "370": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "72": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "290": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1064": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "442": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1296": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1242": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "70": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "222": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "68": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1154": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1036": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1106": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "266": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "696": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1032": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1098": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "98": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "234": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "968": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "150": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1222": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "332": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1228": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "74": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1162": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "670": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1186": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1218": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1244": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "718": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "174": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "380": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1022": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1044": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "64": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "398": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "410": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "694": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1008": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "58": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1010": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1274": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1210": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1038": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "646": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "664": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "4": [
+            {
+                "package_db": "root/buildinfo/Dockerfile-ubi8-8.6-903.1661794351",
+                "introduced_in": "sha256:0d51f270409c5c21859f12eee7aa77d3969ac3033b7129a2a87648b741ee66ee",
+                "distribution_id": "",
+                "repository_ids": [
+                    "8"
+                ]
+            }
+        ],
+        "1282": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "54": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "390": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "216": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1250": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "6": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1170": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "22": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "698": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1164": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "16": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "392": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "310": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1004": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "232": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "726": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "388": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "954": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "988": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1058": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1194": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1150": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "142": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "8": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "994": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1148": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "676": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "306": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1284": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "982": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "128": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "930": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "346": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1180": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "152": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1200": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "962": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "666": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1262": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "316": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "364": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "188": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "86": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "208": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1278": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "668": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1014": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1254": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "742": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "474": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "478": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "284": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1042": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "348": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "240": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "304": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1080": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1114": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "66": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1270": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1196": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "148": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "14": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "40": [
+            {
+                "package_db": "python:usr/lib/python3.8/site-packages",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "972": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1100": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "702": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "248": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1028": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1256": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1230": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "206": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "246": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "382": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "256": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1146": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1226": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "704": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "106": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1018": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1120": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "660": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "182": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "466": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "374": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1142": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "470": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "168": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1108": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "326": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "402": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1234": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "482": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "686": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "228": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "220": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "338": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "104": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "978": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "416": [
+            {
+                "package_db": "python:quay-registry/config_app/node_modules/jasmine-core",
+                "introduced_in": "sha256:55d1c0fb65e634002b0c983896141d5f7fe976672630e402d451e1478d8a7588",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "126": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "412": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1192": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "230": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1040": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1174": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "688": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1006": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "354": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "638": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "974": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "980": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1056": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "682": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1280": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "386": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "60": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "130": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "762": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "118": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "136": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "146": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "28": [
+            {
+                "package_db": "python:usr/lib/python3.6/site-packages",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "164": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "960": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "430": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "706": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "998": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1074": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "350": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "2": [
+            {
+                "package_db": "root/buildinfo/Dockerfile-ubi8-8.6-903.1661794351",
+                "introduced_in": "sha256:0d51f270409c5c21859f12eee7aa77d3969ac3033b7129a2a87648b741ee66ee",
+                "distribution_id": "",
+                "repository_ids": [
+                    "8"
+                ]
+            }
+        ],
+        "1020": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "434": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:3aba94eed52924a9707c3be29817a11f7efc8fac7fe75e0c91e48e242f988ccf",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1112": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "1122": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "360": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "302": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "1118": [
+            {
+                "package_db": "python:app/lib/python3.8/site-packages",
+                "introduced_in": "sha256:439e6bc4f7490f382f233003f10ca643d121659230990a4ae9cdff6a94d8c382",
+                "distribution_id": "",
+                "repository_ids": [
+                    "1"
+                ]
+            }
+        ],
+        "200": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ],
+        "134": [
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "1",
+                "repository_ids": [
+                    "2",
+                    "3",
+                    "4",
+                    "5"
+                ]
+            },
+            {
+                "package_db": "bdb:var/lib/rpm",
+                "introduced_in": "sha256:480a8b2c25e9343725938879adac8ebb1c01cfde85975f023ca7aa95bfe7e0da",
+                "distribution_id": "",
+                "repository_ids": null
+            }
+        ]
+    },
+    "vulnerabilities": {
+        "1701641": {
+            "id": "1701641",
+            "updater": "RHEL8-rhel-8-including-unpatched",
+            "name": "RHSA-2022:6457: python3 security update (Moderate)",
+            "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "issued": "2022-09-13T00:00:00Z",
+            "links": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+            "severity": "Moderate",
+            "normalized_severity": "Medium",
+            "package": {
+                "id": "",
+                "name": "python3-libs",
+                "version": "",
+                "kind": "binary",
+                "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+            },
+            "distribution": {
+                "id": "",
+                "did": "rhel",
+                "name": "Red Hat Enterprise Linux Server",
+                "version": "8",
+                "version_code_name": "",
+                "version_id": "8",
+                "arch": "",
+                "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+                "pretty_name": "Red Hat Enterprise Linux Server 8"
+            },
+            "repository": {
+                "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+                "key": "rhel-cpe-repository"
+            },
+            "fixed_in_version": "0:3.6.8-47.el8_6",
+            "arch_op": "pattern match"
+        },
+        "1701542": {
+            "id": "1701542",
+            "updater": "RHEL8-rhel-8-including-unpatched",
+            "name": "RHSA-2022:6457: python3 security update (Moderate)",
+            "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "issued": "2022-09-13T00:00:00Z",
+            "links": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+            "severity": "Moderate",
+            "normalized_severity": "Medium",
+            "package": {
+                "id": "",
+                "name": "platform-python",
+                "version": "",
+                "kind": "binary",
+                "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+            },
+            "distribution": {
+                "id": "",
+                "did": "rhel",
+                "name": "Red Hat Enterprise Linux Server",
+                "version": "8",
+                "version_code_name": "",
+                "version_id": "8",
+                "arch": "",
+                "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+                "pretty_name": "Red Hat Enterprise Linux Server 8"
+            },
+            "repository": {
+                "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+                "key": "rhel-cpe-repository"
+            },
+            "fixed_in_version": "0:3.6.8-47.el8_6",
+            "arch_op": "pattern match"
+        },
+        "1701515": {
+            "id": "1701515",
+            "updater": "RHEL8-rhel-8-including-unpatched",
+            "name": "RHSA-2022:6457: python3 security update (Moderate)",
+            "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "issued": "2022-09-13T00:00:00Z",
+            "links": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+            "severity": "Moderate",
+            "normalized_severity": "Medium",
+            "package": {
+                "id": "",
+                "name": "platform-python",
+                "version": "",
+                "kind": "binary",
+                "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+            },
+            "distribution": {
+                "id": "",
+                "did": "rhel",
+                "name": "Red Hat Enterprise Linux Server",
+                "version": "8",
+                "version_code_name": "",
+                "version_id": "8",
+                "arch": "",
+                "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+                "pretty_name": "Red Hat Enterprise Linux Server 8"
+            },
+            "repository": {
+                "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+                "key": "rhel-cpe-repository"
+            },
+            "fixed_in_version": "0:3.6.8-47.el8_6",
+            "arch_op": "pattern match"
+        },
+        "1702987": {
+            "id": "1702987",
+            "updater": "RHEL8-rhel-8-including-unpatched",
+            "name": "RHSA-2022:6463: gnupg2 security update (Moderate)",
+            "description": "The GNU Privacy Guard (GnuPG or GPG) is a tool for encrypting data and creating digital signatures, compliant with OpenPGP and S/MIME standards.\n\nSecurity Fix(es):\n\n* gpg: Signature spoofing via status line injection (CVE-2022-34903)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "issued": "2022-09-13T00:00:00Z",
+            "links": "https://access.redhat.com/errata/RHSA-2022:6463 https://access.redhat.com/security/cve/CVE-2022-34903",
+            "severity": "Moderate",
+            "normalized_severity": "Medium",
+            "package": {
+                "id": "",
+                "name": "gnupg2",
+                "version": "",
+                "kind": "binary",
+                "arch": "aarch64|ppc64le|s390x|x86_64"
+            },
+            "distribution": {
+                "id": "",
+                "did": "rhel",
+                "name": "Red Hat Enterprise Linux Server",
+                "version": "8",
+                "version_code_name": "",
+                "version_id": "8",
+                "arch": "",
+                "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+                "pretty_name": "Red Hat Enterprise Linux Server 8"
+            },
+            "repository": {
+                "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+                "key": "rhel-cpe-repository"
+            },
+            "fixed_in_version": "0:2.2.20-3.el8_6",
+            "arch_op": "pattern match"
+        },
+        "1702960": {
+            "id": "1702960",
+            "updater": "RHEL8-rhel-8-including-unpatched",
+            "name": "RHSA-2022:6463: gnupg2 security update (Moderate)",
+            "description": "The GNU Privacy Guard (GnuPG or GPG) is a tool for encrypting data and creating digital signatures, compliant with OpenPGP and S/MIME standards.\n\nSecurity Fix(es):\n\n* gpg: Signature spoofing via status line injection (CVE-2022-34903)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "issued": "2022-09-13T00:00:00Z",
+            "links": "https://access.redhat.com/errata/RHSA-2022:6463 https://access.redhat.com/security/cve/CVE-2022-34903",
+            "severity": "Moderate",
+            "normalized_severity": "Medium",
+            "package": {
+                "id": "",
+                "name": "gnupg2",
+                "version": "",
+                "kind": "binary",
+                "arch": "aarch64|ppc64le|s390x|x86_64"
+            },
+            "distribution": {
+                "id": "",
+                "did": "rhel",
+                "name": "Red Hat Enterprise Linux Server",
+                "version": "8",
+                "version_code_name": "",
+                "version_id": "8",
+                "arch": "",
+                "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+                "pretty_name": "Red Hat Enterprise Linux Server 8"
+            },
+            "repository": {
+                "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+                "key": "rhel-cpe-repository"
+            },
+            "fixed_in_version": "0:2.2.20-3.el8_6",
+            "arch_op": "pattern match"
+        },
+        "1701668": {
+            "id": "1701668",
+            "updater": "RHEL8-rhel-8-including-unpatched",
+            "name": "RHSA-2022:6457: python3 security update (Moderate)",
+            "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "issued": "2022-09-13T00:00:00Z",
+            "links": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+            "severity": "Moderate",
+            "normalized_severity": "Medium",
+            "package": {
+                "id": "",
+                "name": "python3-libs",
+                "version": "",
+                "kind": "binary",
+                "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+            },
+            "distribution": {
+                "id": "",
+                "did": "rhel",
+                "name": "Red Hat Enterprise Linux Server",
+                "version": "8",
+                "version_code_name": "",
+                "version_id": "8",
+                "arch": "",
+                "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+                "pretty_name": "Red Hat Enterprise Linux Server 8"
+            },
+            "repository": {
+                "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+                "key": "rhel-cpe-repository"
+            },
+            "fixed_in_version": "0:3.6.8-47.el8_6",
+            "arch_op": "pattern match"
+        }
+    },
+    "package_vulnerabilities": {
+        "192": [
+            "1702987",
+            "1702960"
+        ],
+        "140": [
+            "1701668",
+            "1701641"
+        ],
+        "326": [
+            "1701542",
+            "1701515"
+        ]
+    }
+}


### PR DESCRIPTION
Currently Quay is displaying the Clair response with no interpretation meaning when Clair reports on vulns per repo they appear to be duplicated (RHEL based images with multiple repos and packages existing in more than one). The correct way to fix this is via an interpretation layer in Quay, this change is a stop-gap to improve readability for the user.

Signed-off-by: crozzy <joseph.crosland@gmail.com>