### PR TITLE
Quay: Exporting image.oci package to Quay module (PROJQUAY-0000)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         "util.metrics",
         "image",
         "image.docker",
+        "image.oci",
         "image.docker.schema2",
         "image.shared",
         "digest",


### PR DESCRIPTION
This PR fixes -  `ModuleNotFoundError: No module named 'image.oci'` in the Quay module used in Service tool. 