### PR TITLE
users: add restricted users' filter (PROJQUAY-1245)

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ from data.model.user import LoginWrappedDBUser
 from data.queue import WorkQueue
 from data.userevent import UserEventsBuilderModule
 from data.userfiles import Userfiles
-from data.users import UserAuthentication, SuperUserManager
+from data.users import UserAuthentication, UserManager
 from data.registry_model import registry_model
 from data.secscan_model import secscan_model
 from image.oci import register_artifact_type
@@ -62,7 +62,6 @@ from util.saas.exceptionlog import Sentry
 from util.names import urn_generator
 from util.config import URLSchemeAndHostname
 from util.config.configutil import generate_secret_key
-from util.config.superusermanager import RestrictedUserManager
 from util.label_validator import LabelValidator
 from util.metrics.prometheus import PrometheusPlugin
 from util.repomirror.api import RepoMirrorAPI
@@ -260,8 +259,7 @@ sentry = Sentry(app)
 build_logs = BuildLogs(app)
 authentication = UserAuthentication(app, config_provider, OVERRIDE_CONFIG_DIRECTORY)
 userevents = UserEventsBuilderModule(app)
-superusers = SuperUserManager(app, authentication)
-restricted_users = RestrictedUserManager(app)
+usermanager = UserManager(app, authentication)
 instance_keys = InstanceKeys(app)
 label_validator = LabelValidator(app)
 build_canceller = BuildCanceller(app)

--- a/auth/permissions.py
+++ b/auth/permissions.py
@@ -7,7 +7,7 @@ from functools import partial
 from flask_principal import identity_loaded, Permission, Identity, identity_changed
 
 
-from app import app, superusers
+from app import app, usermanager
 from auth import scopes
 from data import model
 
@@ -25,6 +25,9 @@ _TeamNeed = partial(_TeamTypeNeed, "orgteam")
 _UserTypeNeed = namedtuple("_UserTypeNeed", ["type", "username", "role"])
 _UserNeed = partial(_UserTypeNeed, "user")
 _SuperUserNeed = partial(namedtuple("_SuperUserNeed", ["type"]), "superuser")
+_GlobalReadOnlySuperUserNeed = partial(
+    namedtuple("_GlobalReadlOnlySuperuserNeed", ["type"]), "globalreadonlysuperuser"
+)
 
 
 REPO_ROLES = [None, "read", "write", "admin"]
@@ -147,9 +150,13 @@ class QuayDeferredPermissionUser(Identity):
 
         if (
             scopes.SUPERUSER in self._scope_set or scopes.DIRECT_LOGIN in self._scope_set
-        ) and superusers.is_superuser(user_object.username):
+        ) and usermanager.is_superuser(user_object.username):
             logger.debug("Adding superuser to user: %s", user_object.username)
             self.provides.add(_SuperUserNeed())
+
+        if usermanager.is_global_readonly_superuser(user_object.username):
+            logger.debug("Adding global readonly superuser to user: %s", user_object.username)
+            self.provides.add(_GlobalReadOnlySuperUserNeed())
 
     def _populate_namespace_wide_provides(self, user_object, namespace_filter):
         """
@@ -311,6 +318,12 @@ class SuperUserPermission(QuayPermission):
     def __init__(self):
         need = _SuperUserNeed()
         super(SuperUserPermission, self).__init__(need)
+
+
+class GlobalReadOnlySuperUserPermission(QuayPermission):
+    def __init__(self):
+        need = _GlobalReadOnlySuperUserNeed()
+        super(GlobalReadOnlySuperUserPermission, self).__init__(need)
 
 
 class UserAdminPermission(QuayPermission):

--- a/config.py
+++ b/config.py
@@ -293,6 +293,11 @@ class DefaultConfig(ImmutableConfig):
     # Super user config. Note: This MUST BE an empty list for the default config.
     SUPER_USERS: List[str] = []
 
+    # Global readonly user.
+    # WARNING: THIS WILL GIVE USERS OF THIS LIST READ ACCESS TO ALL REPOS,
+    # REGARDLESS OF WHETHER THEY ARE PUBLIC OR NOT
+    GLOBAL_READONLY_SUPER_USERS: List[str] = []
+
     # Feature Flag: Whether sessions are permanent.
     FEATURE_PERMANENT_SESSIONS = True
 
@@ -834,5 +839,3 @@ class DefaultConfig(ImmutableConfig):
 
     FEATURE_RESTRICTED_USERS = False
     RESTRICTED_USERS_WHITELIST: List[str] = []
-    RESTRICTED_USER_INCLUDE_ROBOTS = True
-    RESTRICTED_USER_READ_ONLY = False

--- a/data/users/apptoken.py
+++ b/data/users/apptoken.py
@@ -76,3 +76,9 @@ class AppTokenInternalAuth(object):
 
     def has_superusers(self):
         raise NotImplementedError()
+
+    def is_restricted_user(self, username):
+        raise NotImplementedError()
+
+    def has_restricted_users(self):
+        raise NotImplementedError()

--- a/data/users/database.py
+++ b/data/users/database.py
@@ -91,3 +91,9 @@ class DatabaseUsers(object):
 
     def has_superusers(self):
         raise NotImplementedError()
+
+    def is_restricted_user(self, username):
+        raise NotImplementedError()
+
+    def has_restricted_users(self):
+        raise NotImplementedError()

--- a/data/users/externaljwt.py
+++ b/data/users/externaljwt.py
@@ -155,3 +155,9 @@ class ExternalJWTAuthN(FederatedUsers):
 
     def has_superusers(self):
         raise NotImplementedError()
+
+    def is_restricted_user(self, username):
+        raise NotImplementedError()
+
+    def has_restricted_users(self):
+        raise NotImplementedError()

--- a/data/users/federated.py
+++ b/data/users/federated.py
@@ -138,6 +138,12 @@ class FederatedUsers(object):
     def has_superusers(self):
         raise NotImplementedError()
 
+    def is_restricted_user(self, username):
+        raise NotImplementedError()
+
+    def has_restricted_users(self):
+        raise NotImplementedError()
+
     def _get_and_link_federated_user_info(self, username, email, internal_create=False):
         db_user = model.user.verify_federated_login(self._federated_service, username)
         if not db_user:

--- a/data/users/keystone.py
+++ b/data/users/keystone.py
@@ -354,3 +354,12 @@ class KeystoneV3Users(FederatedUsers):
 
     def is_superuser(self, username):
         raise NotImplementedError()
+
+    def has_superusers(self, username):
+        raise NotImplementedError()
+
+    def is_restricted_user(self, username):
+        raise NotImplementedError()
+
+    def has_restricted_users(self):
+        raise NotImplementedError()

--- a/endpoints/api/build.py
+++ b/endpoints/api/build.py
@@ -42,6 +42,7 @@ from endpoints.api import (
     abort,
     disallow_for_app_repositories,
     disallow_for_non_normal_repositories,
+    disallow_for_user_namespace,
 )
 from endpoints.building import (
     start_build,
@@ -260,6 +261,7 @@ class RepositoryBuildList(RepositoryParamResource):
     @nickname("requestRepoBuild")
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @validate_json_request("RepositoryBuildRequest")
     def post(self, namespace, repository):
         """
@@ -415,6 +417,7 @@ class RepositoryBuildResource(RepositoryParamResource):
     @nickname("cancelRepoBuild")
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     def delete(self, namespace, repository, build_uuid):
         """
         Cancels a repository build.

--- a/endpoints/api/manifest.py
+++ b/endpoints/api/manifest.py
@@ -28,6 +28,7 @@ from endpoints.api import (
     disallow_for_app_repositories,
     format_date,
     disallow_for_non_normal_repositories,
+    disallow_for_user_namespace,
 )
 from endpoints.exception import NotFound
 from util.validation import VALID_LABEL_KEY_REGEX
@@ -184,6 +185,7 @@ class RepositoryManifestLabels(RepositoryParamResource):
     @nickname("addManifestLabel")
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @validate_json_request("AddLabel")
     def post(self, namespace_name, repository_name, manifestref):
         """
@@ -282,6 +284,7 @@ class ManageRepositoryManifestLabel(RepositoryParamResource):
     @nickname("deleteManifestLabel")
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     def delete(self, namespace_name, repository_name, manifestref, labelid):
         """
         Deletes an existing label from a manifest.

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -17,6 +17,7 @@ from app import (
     namespace_gc_queue,
     ip_resolver,
     app,
+    usermanager,
 )
 from endpoints.api import (
     allow_if_superuser,
@@ -160,6 +161,9 @@ class OrganizationList(ApiResource):
         user = get_authenticated_user()
         org_data = request.get_json()
         existing = None
+
+        if features.RESTRICTED_USERS and usermanager.is_restricted_user(user.username):
+            raise Unauthorized()
 
         try:
             existing = model.organization.get_organization(org_data["name"])

--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -217,7 +217,7 @@ class OrgRobot(ApiResource):
         Returns the organization's robot with the specified name.
         """
         permission = AdministerOrganizationPermission(orgname)
-        if permission.can():
+        if permission.can() or allow_if_superuser():
             robot = model.get_org_robot(robot_shortname, orgname)
             return robot.to_dict(include_metadata=True, include_token=True)
 
@@ -232,7 +232,7 @@ class OrgRobot(ApiResource):
         Create a new robot in the organization.
         """
         permission = AdministerOrganizationPermission(orgname)
-        if permission.can():
+        if permission.can() or allow_if_superuser():
             create_data = request.get_json() or {}
             robot = model.create_org_robot(
                 robot_shortname,
@@ -260,7 +260,7 @@ class OrgRobot(ApiResource):
         Delete an existing organization robot.
         """
         permission = AdministerOrganizationPermission(orgname)
-        if permission.can():
+        if permission.can() or allow_if_superuser():
             robot_username = format_robot_username(orgname, robot_shortname)
             if not model.robot_has_mirror(robot_username):
                 model.delete_robot(robot_username)
@@ -360,7 +360,7 @@ class RegenerateOrgRobot(ApiResource):
         Regenerates the token for an organization robot.
         """
         permission = AdministerOrganizationPermission(orgname)
-        if permission.can():
+        if permission.can() or allow_if_superuser():
             robot = model.regenerate_org_robot_token(robot_shortname, orgname)
             log_action("regenerate_robot_token", orgname, {"robot": robot_shortname})
             return robot.to_dict(include_token=True)

--- a/endpoints/api/superuser.py
+++ b/endpoints/api/superuser.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives import serialization
 
 import features
 
-from app import app, avatar, superusers, authentication, config_provider
+from app import app, avatar, usermanager, authentication, config_provider
 from auth import scopes
 from auth.auth_context import get_authenticated_user
 from auth.permissions import SuperUserPermission
@@ -158,7 +158,7 @@ def user_view(user, password=None):
         "email": user.email,
         "verified": user.verified,
         "avatar": avatar.get_data_for_user(user),
-        "super_user": superusers.is_superuser(user.username),
+        "super_user": usermanager.is_superuser(user.username),
         "enabled": user.enabled,
     }
 
@@ -449,7 +449,7 @@ class SuperUserSendRecoveryEmail(ApiResource):
             if user is None:
                 raise NotFound()
 
-            if superusers.is_superuser(username):
+            if usermanager.is_superuser(username):
                 raise InvalidRequest("Cannot send a recovery email for a superuser")
 
             code = pre_oci_model.create_reset_password_email_code(user.email)
@@ -517,7 +517,7 @@ class SuperUserManagement(ApiResource):
             if user is None:
                 raise NotFound()
 
-            if superusers.is_superuser(username):
+            if usermanager.is_superuser(username):
                 raise InvalidRequest("Cannot delete a superuser")
 
             pre_oci_model.mark_user_for_deletion(username)
@@ -539,7 +539,7 @@ class SuperUserManagement(ApiResource):
             if user is None:
                 raise NotFound()
 
-            if superusers.is_superuser(username):
+            if usermanager.is_superuser(username):
                 raise InvalidRequest("Cannot update a superuser")
 
             user_data = request.get_json()
@@ -606,7 +606,7 @@ class SuperUserTakeOwnership(ApiResource):
         """
         if SuperUserPermission().can():
             # Disallow for superusers.
-            if superusers.is_superuser(namespace):
+            if usermanager.is_superuser(namespace):
                 raise InvalidRequest("Cannot take ownership of a superuser")
 
             authed_user = get_authenticated_user()

--- a/endpoints/api/superuser_models_interface.py
+++ b/endpoints/api/superuser_models_interface.py
@@ -8,7 +8,7 @@ from six import add_metaclass
 from tzlocal import get_localzone
 
 import features
-from app import avatar, superusers
+from app import avatar, usermanager
 from buildtrigger.basehandler import BuildTriggerHandler
 from data import model
 from endpoints.api import format_date
@@ -242,7 +242,7 @@ class User(namedtuple("User", ["username", "email", "verified", "enabled", "robo
             "email": self.email,
             "verified": self.verified,
             "avatar": avatar.get_data_for_user(self),
-            "super_user": superusers.is_superuser(self.username),
+            "super_user": usermanager.is_superuser(self.username),
             "enabled": self.enabled,
         }
         if features.QUOTA_MANAGEMENT and self.quotas is not None:

--- a/endpoints/api/tag.py
+++ b/endpoints/api/tag.py
@@ -23,6 +23,7 @@ from endpoints.api import (
     disallow_for_app_repositories,
     format_date,
     disallow_for_non_normal_repositories,
+    disallow_for_user_namespace,
 )
 from endpoints.exception import NotFound, InvalidRequest
 from util.names import TAG_ERROR, TAG_REGEX
@@ -125,6 +126,7 @@ class RepositoryTag(RepositoryParamResource):
     @require_repo_write()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("changeTag")
     @validate_json_request("ChangeTag")
     def put(self, namespace, repository, tag):
@@ -219,6 +221,7 @@ class RepositoryTag(RepositoryParamResource):
     @require_repo_write(allow_for_superuser=True)
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("deleteFullTag")
     def delete(self, namespace, repository, tag):
         """
@@ -270,6 +273,7 @@ class RestoreTag(RepositoryParamResource):
     @require_repo_write()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("restoreTag")
     @validate_json_request("RestoreTag")
     def post(self, namespace, repository, tag):

--- a/endpoints/api/test/test_security.py
+++ b/endpoints/api/test/test_security.py
@@ -5944,7 +5944,7 @@ def test_team_sync_security(is_superuser, allow_nonsuperuser, method, expected, 
     def is_superuser_method(_):
         return is_superuser
 
-    with patch("auth.permissions.superusers.is_superuser", is_superuser_method):
+    with patch("auth.permissions.usermanager.is_superuser", is_superuser_method):
         with toggle_feature("NONSUPERUSER_TEAM_SYNCING_SETUP", allow_nonsuperuser):
             with client_with_identity("devtable", client) as cl:
                 expect_success = is_superuser or allow_nonsuperuser

--- a/endpoints/api/trigger.py
+++ b/endpoints/api/trigger.py
@@ -34,6 +34,7 @@ from endpoints.api import (
     abort,
     disallow_for_app_repositories,
     disallow_for_non_normal_repositories,
+    disallow_for_user_namespace,
 )
 from endpoints.api.build import build_status_view, trigger_view, RepositoryBuildStatus
 from endpoints.api.trigger_analyzer import TriggerAnalyzer
@@ -115,6 +116,7 @@ class BuildTrigger(RepositoryParamResource):
     @require_repo_admin()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("updateBuildTrigger")
     @validate_json_request("UpdateTrigger")
     def put(self, namespace_name, repo_name, trigger_uuid):
@@ -146,6 +148,7 @@ class BuildTrigger(RepositoryParamResource):
     @require_repo_admin()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("deleteBuildTrigger")
     def delete(self, namespace_name, repo_name, trigger_uuid):
         """
@@ -195,6 +198,7 @@ class BuildTriggerSubdirs(RepositoryParamResource):
     @require_repo_admin()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("listBuildTriggerSubdirs")
     @validate_json_request("BuildTriggerSubdirRequest")
     def post(self, namespace_name, repo_name, trigger_uuid):
@@ -262,6 +266,7 @@ class BuildTriggerActivate(RepositoryParamResource):
     @require_repo_admin()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("activateBuildTrigger")
     @validate_json_request("BuildTriggerActivateRequest")
     def post(self, namespace_name, repo_name, trigger_uuid):
@@ -373,6 +378,7 @@ class BuildTriggerAnalyze(RepositoryParamResource):
     @require_repo_admin()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("analyzeBuildTrigger")
     @validate_json_request("BuildTriggerAnalyzeRequest")
     def post(self, namespace_name, repo_name, trigger_uuid):
@@ -443,6 +449,7 @@ class ActivateBuildTrigger(RepositoryParamResource):
     @require_repo_admin()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("manuallyStartBuildTrigger")
     @validate_json_request("RunParameters")
     def post(self, namespace_name, repo_name, trigger_uuid):
@@ -516,6 +523,7 @@ class BuildTriggerFieldValues(RepositoryParamResource):
     @require_repo_admin()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("listTriggerFieldValues")
     def post(self, namespace_name, repo_name, trigger_uuid, field_name):
         """
@@ -561,6 +569,7 @@ class BuildTriggerSources(RepositoryParamResource):
     @require_repo_admin()
     @disallow_for_app_repositories
     @disallow_for_non_normal_repositories
+    @disallow_for_user_namespace
     @nickname("listTriggerBuildSources")
     @validate_json_request("BuildTriggerSourcesRequest")
     def post(self, namespace_name, repo_name, trigger_uuid):

--- a/endpoints/decorators.py
+++ b/endpoints/decorators.py
@@ -10,7 +10,7 @@ from flask import abort, request, make_response
 
 import features
 
-from app import app, ip_resolver, model_cache, restricted_users
+from app import app, ip_resolver, model_cache, usermanager
 from auth.auth_context import get_authenticated_context, get_authenticated_user
 from data.database import RepositoryState
 from data.model import InvalidProxyCacheConfigException
@@ -195,35 +195,6 @@ def check_readonly(func):
         raise ReadOnlyModeException()
 
     return wrapper
-
-
-def check_restricted_user_readonly(error_class=None):
-    def __check_restricted_user_readonly(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            if request.method == "GET":
-                return func(*args, **kwargs)
-
-            if features.RESTRICTED_USERS and app.config.get("RESTRICTED_USER_READ_ONLY"):
-                if hasattr(func, "__restricted_user_readonly_call_allowed"):
-                    return func(*args, **kwargs)
-
-                user = get_authenticated_user()
-                # Subsequent auth checks should handle anon after this one if user not set
-                if user is None:
-                    return func(*args, **kwargs)
-
-                if restricted_users.is_restricted(user.username):
-                    if error_class:
-                        raise error_class()
-
-                    abort(403, message="Restricted user: %s" % user.username)
-
-            return func(*args, **kwargs)
-
-        return wrapper
-
-    return __check_restricted_user_readonly
 
 
 def route_show_if(value):

--- a/endpoints/v2/blob.py
+++ b/endpoints/v2/blob.py
@@ -239,9 +239,7 @@ def _try_to_mount_blob(repository_ref, mount_blob_digest):
 @disallow_for_account_recovery_mode
 @parse_repository_name()
 @process_registry_jwt_auth(scopes=["pull", "push"])
-@require_repo_write(
-    allow_for_superuser=True, disallow_for_restricted_users=app.config["RESTRICTED_USER_READ_ONLY"]
-)
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
 @anon_protect
 @check_readonly
 def start_blob_upload(namespace_name, repo_name):
@@ -312,9 +310,7 @@ def start_blob_upload(namespace_name, repo_name):
 @disallow_for_account_recovery_mode
 @parse_repository_name()
 @process_registry_jwt_auth(scopes=["pull"])
-@require_repo_write(
-    allow_for_superuser=True, disallow_for_restricted_users=app.config["RESTRICTED_USER_READ_ONLY"]
-)
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
 @anon_protect
 def fetch_existing_upload(namespace_name, repo_name, upload_uuid):
     repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
@@ -342,9 +338,7 @@ def fetch_existing_upload(namespace_name, repo_name, upload_uuid):
 @disallow_for_account_recovery_mode
 @parse_repository_name()
 @process_registry_jwt_auth(scopes=["pull", "push"])
-@require_repo_write(
-    allow_for_superuser=True, disallow_for_restricted_users=app.config["RESTRICTED_USER_READ_ONLY"]
-)
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
 @anon_protect
 @check_readonly
 def upload_chunk(namespace_name, repo_name, upload_uuid):
@@ -384,9 +378,7 @@ def upload_chunk(namespace_name, repo_name, upload_uuid):
 @disallow_for_account_recovery_mode
 @parse_repository_name()
 @process_registry_jwt_auth(scopes=["pull", "push"])
-@require_repo_write(
-    allow_for_superuser=True, disallow_for_restricted_users=app.config["RESTRICTED_USER_READ_ONLY"]
-)
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
 @anon_protect
 @check_readonly
 def monolithic_upload_or_last_chunk(namespace_name, repo_name, upload_uuid):
@@ -435,9 +427,7 @@ def monolithic_upload_or_last_chunk(namespace_name, repo_name, upload_uuid):
 @disallow_for_account_recovery_mode
 @parse_repository_name()
 @process_registry_jwt_auth(scopes=["pull", "push"])
-@require_repo_write(
-    allow_for_superuser=True, disallow_for_restricted_users=app.config["RESTRICTED_USER_READ_ONLY"]
-)
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
 @anon_protect
 @check_readonly
 def cancel_upload(namespace_name, repo_name, upload_uuid):
@@ -459,9 +449,7 @@ def cancel_upload(namespace_name, repo_name, upload_uuid):
 @disallow_for_account_recovery_mode
 @parse_repository_name()
 @process_registry_jwt_auth(scopes=["pull", "push"])
-@require_repo_write(
-    allow_for_superuser=True, disallow_for_restricted_users=app.config["RESTRICTED_USER_READ_ONLY"]
-)
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
 @anon_protect
 @check_readonly
 def delete_digest(namespace_name, repo_name, digest):

--- a/endpoints/v2/manifest.py
+++ b/endpoints/v2/manifest.py
@@ -248,9 +248,7 @@ def _doesnt_accept_schema_v1():
 @parse_repository_name()
 @_reject_manifest2_schema2
 @process_registry_jwt_auth(scopes=["pull", "push"])
-@require_repo_write(
-    allow_for_superuser=True, disallow_for_restricted_users=app.config["RESTRICTED_USER_READ_ONLY"]
-)
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
 @anon_protect
 @check_readonly
 def write_manifest_by_tagname(namespace_name, repo_name, manifest_ref):
@@ -263,9 +261,7 @@ def write_manifest_by_tagname(namespace_name, repo_name, manifest_ref):
 @parse_repository_name()
 @_reject_manifest2_schema2
 @process_registry_jwt_auth(scopes=["pull", "push"])
-@require_repo_write(
-    allow_for_superuser=True, disallow_for_restricted_users=app.config["RESTRICTED_USER_READ_ONLY"]
-)
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
 @anon_protect
 @check_readonly
 def write_manifest_by_digest(namespace_name, repo_name, manifest_ref):
@@ -328,9 +324,7 @@ def _parse_manifest(content_type, request_data):
 @disallow_for_account_recovery_mode
 @parse_repository_name()
 @process_registry_jwt_auth(scopes=["pull", "push"])
-@require_repo_write(
-    allow_for_superuser=True, disallow_for_restricted_users=app.config["RESTRICTED_USER_READ_ONLY"]
-)
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
 @anon_protect
 @check_readonly
 def delete_manifest_by_digest(namespace_name, repo_name, manifest_ref):

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1252,6 +1252,14 @@ CONFIG_SCHEMA = {
             "description": "Enables IPv4, IPv6 or dual-stack networking. Defaults to `IPv4`.",
             "x-example": "IPv4",
         },
+        "GLOBAL_READONLY_SUPER_USERS": {
+            "type": "array",
+            "description": "Quay usernames of those super users to be granted global readonly privileges",
+            "uniqueItems": True,
+            "items": {
+                "type": "string",
+            },
+        },
         "FEATURE_SUPERUSERS_FULL_ACCESS": {
             "type": "boolean",
             "description": "Grant superusers full access to repositories, registry-wide",
@@ -1269,18 +1277,8 @@ CONFIG_SCHEMA = {
         },
         "RESTRICTED_USERS_WHITELIST": {
             "type": "array",
-            "description": "Whitelisted users to exclude when FEATURE_RESTRICTED_READ_ONLY_USERS is enabled",
+            "description": "Whitelisted users to exclude when FEATURE_RESTRICTED_USERS is enabled",
             "x-example": ["devtable"],
-        },
-        "RESTRICTED_USER_INCLUDE_ROBOTS": {
-            "type": "boolean",
-            "description": "Whether to include restrict namespace robots when restricting users",
-            "x-example": True,
-        },
-        "RESTRICTED_USER_READ_ONLY": {
-            "type": "boolean",
-            "description": "Whether to restrict restricted users to read-only operations when FEATURE_RESTRICTED_USERS is enabled",
-            "x-example": False,
         },
     },
 }

--- a/util/config/superusermanager.py
+++ b/util/config/superusermanager.py
@@ -16,7 +16,7 @@ class UserManager(object):
         self._array.value = usernames_str.encode("utf8")
 
 
-class SuperUserManager(UserManager):
+class ConfigUserManager(UserManager):
     """
     In-memory helper class for quickly accessing (and updating) the valid set of super users.
 
@@ -24,44 +24,87 @@ class SuperUserManager(UserManager):
     """
 
     def __init__(self, app):
-        super().__init__(app, SUPER_USERS_CONFIG)
+        super_usernames = app.config.get(SUPER_USERS_CONFIG, [])
+        super_usernames_str = ",".join(super_usernames)
 
-    def is_superuser(self, username):
+        self._super_max_length = len(super_usernames_str) + MAX_USERNAME_LENGTH + 1
+        self._superusers_array = Array("c", self._super_max_length, lock=True)
+        self._superusers_array.value = super_usernames_str.encode("utf8")
+
+        restricted_usernames_whitelist = app.config.get(RESTRICTED_USERS_WHITELIST_CONFIG, [])
+        restricted_usernames_whitelist_str = ",".join(restricted_usernames_whitelist)
+
+        self._restricted_max_length = (
+            len(restricted_usernames_whitelist_str) + MAX_USERNAME_LENGTH + 1
+        )
+        self._restricted_users_array = Array("c", self._restricted_max_length, lock=True)
+        self._restricted_users_array.value = restricted_usernames_whitelist_str.encode("utf8")
+
+        global_readonly_usernames = app.config.get("GLOBAL_READONLY_SUPER_USERS", [])
+        global_readonly_usernames_str = ",".join(global_readonly_usernames)
+
+        self._global_readonly_max_length = (
+            len(global_readonly_usernames_str) + MAX_USERNAME_LENGTH + 1
+        )
+        self._global_readonly_array = Array("c", self._global_readonly_max_length, lock=True)
+        self._global_readonly_array.value = global_readonly_usernames_str.encode("utf8")
+
+    def is_superuser(self, username: str) -> bool:
         """
         Returns if the given username represents a super user.
         """
-        usernames = self._array.value.decode("utf8").split(",")
+        usernames = self._superusers_array.value.decode("utf8").split(",")
         return username in usernames
 
-    def register_superuser(self, username):
+    def register_superuser(self, username: str) -> None:
         """
         Registers a new username as a super user for the duration of the container.
 
         Note that this does *not* change any underlying config files.
         """
-        usernames = self._array.value.decode("utf8").split(",")
+        usernames = self._superusers_array.value.decode("utf8").split(",")
         usernames.append(username)
         new_string = ",".join(usernames)
 
         if len(new_string) <= self._max_length:
-            self._array.value = new_string.encode("utf8")
+            self._superusers_array.value = new_string.encode("utf8")
         else:
             raise Exception("Maximum superuser count reached. Please report this to support.")
 
-    def has_superusers(self):
+    def has_superusers(self) -> bool:
         """
         Returns whether there are any superusers defined.
         """
-        return bool(self._array.value)
+        return bool(self._superusers_array.value)
 
+    def is_restricted_user(self, username: str, include_robots: bool = True) -> bool:
+        if not self._restricted_users_array.value:
+            return False
 
-class RestrictedUserManager(UserManager):
-    def __init__(self, app):
-        super().__init__(app, RESTRICTED_USERS_WHITELIST_CONFIG)
-
-    def is_restricted(self, username, include_robots=True):
         if include_robots:
-            username = username.split("+", 1)[0]
+            username = username.split("+")[0]
 
-        usernames = self._array.value.decode("utf8").split(",")
+        usernames = self._restricted_users_array.value.decode("utf8").split(",")
         return not (username in usernames)
+
+    def has_restricted_users(self) -> bool:
+        """
+        Returns whether there are any restricted users defined.
+        """
+        if not self._restricted_users_array.value:
+            return False
+
+        return bool(self._restricted_users_array.value)
+
+    def is_global_readonly_superuser(self, username: str) -> bool:
+        """
+        Returns if the given username represents a super user.
+        """
+        usernames = self._global_readonly_array.value.decode("utf8").split(",")
+        return username in usernames
+
+    def has_global_readonly_superusers(self) -> bool:
+        """
+        Returns if the given username represents a super user.
+        """
+        return bool(self._global_readonly_array.value)

--- a/util/config/test/test_superusermanager.py
+++ b/util/config/test/test_superusermanager.py
@@ -1,0 +1,60 @@
+import pytest
+from dataclasses import dataclass
+
+from util.config.superusermanager import ConfigUserManager
+from test.fixtures import *
+
+
+@pytest.mark.parametrize(
+    "config, username, expected",
+    [
+        ({"RESTRICTED_USERS_WHITELIST": []}, "devtable", False),
+        ({"RESTRICTED_USERS_WHITELIST": ["devtable"]}, "devtable", False),
+        ({"RESTRICTED_USERS_WHITELIST": ["someotheruser"]}, "devtable", True),
+    ],
+)
+def test_restricted_user_whitelist(config, username, expected):
+    app.config = config
+
+    configusermanager = ConfigUserManager(app)
+
+    assert configusermanager.is_restricted_user(username) == expected
+    if expected:
+        assert configusermanager.has_restricted_users()
+
+
+@pytest.mark.parametrize(
+    "config, username, expected",
+    [
+        ({"SUPER_USERS": []}, "devtable", False),
+        ({"SUPER_USERS": ["devtable"]}, "devtable", True),
+        ({"SUPER_USERS": ["someotheruser"]}, "devtable", False),
+    ],
+)
+def test_superuser_list(config, username, expected):
+    app.config = config
+
+    configusermanager = ConfigUserManager(app)
+
+    assert configusermanager.is_superuser(username) == expected
+    if expected:
+        assert configusermanager.has_superusers()
+
+
+@pytest.mark.parametrize(
+    "config, username, expected",
+    [
+        ({"GLOBAL_READONLY_SUPER_USERS": []}, "devtable", False),
+        ({"GLOBAL_READONLY_SUPER_USERS": ["devtable"]}, "devtable", True),
+        ({"GLOBAL_READONLY_SUPER_USERS": ["someotheruser"]}, "devtable", False),
+        ({"SUPER_USERS": ["devtable"]}, "devtable", False),
+    ],
+)
+def test_global_readonly_superuser_list(config, username, expected):
+    app.config = config
+
+    configusermanager = ConfigUserManager(app)
+
+    assert configusermanager.is_global_readonly_superuser(username) == expected
+    if expected:
+        assert configusermanager.has_global_readonly_superusers()


### PR DESCRIPTION
 Similar to LDAP_SUPERUSER_FILTER, add a specific filter to define
    restricted users, based on the LDAP_USER_FILTER
    - restrict writes on restricted users' own namespace. Normal
    permissions applies on organization membership
    - add global readonly superuser GLOBAL_READONLY_SUPER_USERS (PROJQUAY-2604)
    - Removes RESTRICTED_USER_INCLUDE_ROBOTS, FEATURE_RESTRICTED_READ_ONLY_USERS