### PR TITLE
ui: Fix font size in superuser page (PROJQUAY-4407)

### DIFF
--- a/static/css/directives/ui/new-ui-toggle.css
+++ b/static/css/directives/ui/new-ui-toggle.css
@@ -1,4 +1,4 @@
-.active, .inactive {
+.new-ui-active, .new-ui-inactive {
     font-size: 30px;
     cursor: pointer;
 }
@@ -7,11 +7,11 @@
     border-bottom: none !important;
 }
 
-i.active {
+i.new-ui-active {
     color: #438fda;
 }
 
-i.inactive {
+i.new-ui-inactive {
     color: #777;
 }
 

--- a/static/js/directives/ui/new-ui-toggle/new-ui-toggle.component.html
+++ b/static/js/directives/ui/new-ui-toggle/new-ui-toggle.component.html
@@ -4,7 +4,7 @@
       <span>Current UI</span>
     </div>
     <div class="col-md-3 right-padding-0 align-items-center">
-      <i class="fa fa-toggle-on" ng-class="$ctrl.newUIIsActive ? 'active':'fa-rotate-180 inactive'" ng-click="$ctrl.handleToogleClick($event)" />
+      <i class="fa fa-toggle-on" ng-class="$ctrl.newUIIsActive ? 'new-ui-active':'fa-rotate-180 new-ui-inactive'" ng-click="$ctrl.handleToogleClick($event)" />
     </div>
     <div class="col-md-4 right-padding-0 align-items-center">
       <span>New UI</span>&nbsp


### PR DESCRIPTION
Recent CSS changes caused the font size in the superuser panel to increase. The `active` and `inactive` CSS classes were added and overrode the existing `active` and `inactive` definitions.