### PR TITLE
chore: Add server side assembly of chunked metadata for RADOSGW driver (PROJQUAY-4592)

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -967,6 +967,7 @@ class RadosGWStorage(_CloudStorage):
 
         return super(RadosGWStorage, self).get_direct_upload_url(path, mime_type, requires_cors)
 
+
 class RHOCSStorage(RadosGWStorage):
     """
     RHOCSStorage implements storage explicitly via RHOCS.

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -967,16 +967,6 @@ class RadosGWStorage(_CloudStorage):
 
         return super(RadosGWStorage, self).get_direct_upload_url(path, mime_type, requires_cors)
 
-    def complete_chunked_upload(self, uuid, final_path, storage_metadata):
-        self._initialize_cloud_conn()
-
-        # RadosGW does not support multipart copying from keys, so we are forced to join
-        # it all locally and then reupload.
-        # See https://github.com/ceph/ceph/pull/5139
-        chunk_list = self._chunk_list_from_metadata(storage_metadata)
-        self._client_side_chunk_join(final_path, chunk_list)
-
-
 class RHOCSStorage(RadosGWStorage):
     """
     RHOCSStorage implements storage explicitly via RHOCS.


### PR DESCRIPTION
RadosGW did not support multipart copying from keys so we needed to do a local join and reupload of the whole blob. This creates issues for very big blobs where timeouts can occur. Since the issue was fixed in 2015. on the Rados side, we no longer need this part of legacy code.

See [here](https://github.com/ceph/ceph/pull/5139) for more information.