### PR TITLE
deps: Update bs4 (PROJQUAY-4605)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ azure-core==1.23.1
 azure-storage-blob==12.4.0
 Babel==2.9.1
 bcrypt==3.1.7
-beautifulsoup4==4.8.2
+beautifulsoup4==4.11.1
 bintrees==2.1.0
 bitmath==1.3.3.1
 blinker==1.4


### PR DESCRIPTION
* Updates `beautifulsoup4` to latest version to bypass `error in beautifulsoup4 setup command: use_2to3 is invalid` error during downstream build
* Error most likely stems from `setuptools` update in https://github.com/quay/quay/pull/1558
* [Newer version](https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/revision/606) of `beautifulsoup4` removes `use_2to3` from `setup.py` 