### PR TITLE
config: Add conftest mediatypes to default Quay configuration (PROJQUAY-4614)

### DIFF
--- a/config.py
+++ b/config.py
@@ -777,6 +777,10 @@ class DefaultConfig(ImmutableConfig):
         "application/vnd.oci.source.image.config.v1+json": [
             "application/vnd.oci.image.layer.v1.tar+gzip"
         ],
+        "application/vnd.unknown.config.v1+json": [
+            "application/vnd.cncf.openpolicyagent.policy.layer.v1+rego",
+            "application/vnd.cncf.openpolicyagent.data.layer.v1+json ",
+        ],
     }
 
     # Feature Flag: Whether to allow Helm OCI content types.


### PR DESCRIPTION
Allow conftest policies to be stored on Quay