### PR TITLE
Restore create release id

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -66,7 +66,8 @@ jobs:
         with:
           name: release
       - name: Create Release
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@v1.11.1
+        id: create_release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           bodyFile: ${{steps.download.outputs.download-path}}/changelog


### PR DESCRIPTION
* Bumps `ncipollo/release-action` to latest version
* Adds id to `create_release` to allow extraction of output