### PR TITLE
scripts: push to ecr backup when building quay.io (PROJQUAY-3273)

### DIFF
--- a/scripts/app_sre_build_deploy_rhel7.sh
+++ b/scripts/app_sre_build_deploy_rhel7.sh
@@ -7,8 +7,9 @@ set -exv
 CURRENT_DIR=$(dirname $0)
 
 BASE_IMG="quay-py3"
-QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
 IMG="${BASE_IMG}:latest"
+BACKUP_BASE_IMG="quayio-py3-backup"
+BACKUP_IMAGE="${BACKUP_URL}/${BACKUP_BASE_IMG}"
 
 GIT_HASH=`git rev-parse --short=7 HEAD`
 
@@ -18,12 +19,11 @@ BUILD_CMD="docker build" IMG="$IMG" make app-sre-docker-build
 # save the image as a tar archive
 docker save ${IMG} -o ${BASE_IMG}
 
-# push the image
-skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+# push image to backup repository
+skopeo copy --dest-creds "${BACKUP_USER}:${BACKUP_TOKEN}" \
     "docker-archive:${BASE_IMG}" \
-    "docker://${QUAY_IMAGE}:latest"
+    "docker://${BACKUP_IMAGE}:latest"
 
-skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+skopeo copy --dest-creds "${BACKUP_USER}:${BACKUP_TOKEN}" \
     "docker-archive:${BASE_IMG}" \
-    "docker://${QUAY_IMAGE}:${GIT_HASH}"
-
+    "docker://${BACKUP_IMAGE}:${GIT_HASH}"

--- a/scripts/app_sre_post_deploy_rhel7.sh
+++ b/scripts/app_sre_post_deploy_rhel7.sh
@@ -6,19 +6,18 @@ set -exv
 
 BASE_IMG="quay-py3"
 IMG="${BASE_IMG}:latest"
-BACKUP_BASE_IMG="quayio-py3-backup"
-BACKUP_IMAGE="${BACKUP_URL}/${BACKUP_BASE_IMG}"
+QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
 
 GIT_HASH=`git rev-parse --short=7 HEAD`
 
-# push the image to backup repository
-skopeo copy --dest-creds "${BACKUP_USER}:${BACKUP_TOKEN}" \
+# push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
     "docker-archive:${BASE_IMG}" \
-    "docker://${BACKUP_IMAGE}:latest"
+    "docker://${QUAY_IMAGE}:latest"
 
-skopeo copy --dest-creds "${BACKUP_USER}:${BACKUP_TOKEN}" \
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
     "docker-archive:${BASE_IMG}" \
-    "docker://${BACKUP_IMAGE}:${GIT_HASH}"
+    "docker://${QUAY_IMAGE}:${GIT_HASH}"
 
 # remove the archived image
 rm ${BASE_IMG}


### PR DESCRIPTION
Change order to push to ecr first when deploying quay.io - fixes the problem of needing a newer build when deploying quay.io but cannot get it because quay.io itself is down.