### PR TITLE
Update auth flow to add "access_token" response field (PROJQUAY-4431)

### DIFF
--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -197,6 +197,10 @@ class Proxy:
 
         resp_json = resp.json()
         token = resp_json.get("token")
+        if token is None:
+            # For OAuth2.0 compatability, "access_token" can also used and is equivalent to "token" "
+            # https://docs.docker.com/registry/spec/auth/token/#token-response-fields
+            token = resp_json.get("access_token")
 
         # our cached token will expire a few seconds (TOKEN_RENEWAL_THRESHOLD)
         # before the actual token expiration.


### PR DESCRIPTION
Azure registry uses OAuth 2.0 for registry authentication which will also accept token under the name `access_token`. The change adds this field

Signed-off-by: harishsurf <hgovinda@redhat.com>