### PR TITLE
config: Remove whitespace from config (PROJQUAY-4666)

### DIFF
--- a/config.py
+++ b/config.py
@@ -779,7 +779,7 @@ class DefaultConfig(ImmutableConfig):
         ],
         "application/vnd.unknown.config.v1+json": [
             "application/vnd.cncf.openpolicyagent.policy.layer.v1+rego",
-            "application/vnd.cncf.openpolicyagent.data.layer.v1+json ",
+            "application/vnd.cncf.openpolicyagent.data.layer.v1+json",
         ],
     }
 


### PR DESCRIPTION
White space in the mediatype config is preventing conftest policies containing data from being pushed.