### PR TITLE
arch: Map aarch64 to arm64 in ARCH variable (PROJQUAY-4679)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ ENV OS=linux
 ARG PUSHGATEWAY_VERSION=1.0.0
 RUN set -ex\
 	; ARCH=$(uname -m) ; echo $ARCH \
-	; if [ "$ARCH" == "x86_64" ] ; then ARCH="amd64" ; elif [ "$ARCH" == "arm_64" ] ; then ARCH="arm64" ; fi \
+	; if [ "$ARCH" == "x86_64" ] ; then ARCH="amd64" ; elif [ "$ARCH" == "aarch64" ] ; then ARCH="arm64" ; fi \
 	; curl -fsSL "https://github.com/prometheus/pushgateway/releases/download/v${PUSHGATEWAY_VERSION}/pushgateway-${PUSHGATEWAY_VERSION}.${OS}-${ARCH}.tar.gz"\
 	| tar xz "pushgateway-${PUSHGATEWAY_VERSION}.${OS}-${ARCH}/pushgateway"\
 	; install "pushgateway-${PUSHGATEWAY_VERSION}.${OS}-${ARCH}/pushgateway" /usr/local/bin/pushgateway\


### PR DESCRIPTION
Building the image on Fedora arm64 fails without this change.

`uname -m` prints `aarch64` on my machine. I have never seen `arm_64` (with an underscore) anywhere before.