### PR TITLE
proxy: Modify registry auth url for proxy cache validation (PROJQUAY-4585)

### DIFF
--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -992,7 +992,7 @@ class ProxyCacheConfigValidation(ApiResource):
             existing = model.organization.get_organization(orgname)
             config.organization = existing
 
-            proxy = Proxy(config, "something-totally-fake", True)
+            proxy = Proxy(config, validation=True)
             response = proxy.get(f"{proxy.base_url}/v2/")
             if response.status_code == 200:
                 return "Valid", 202


### PR DESCRIPTION
When authenticating against a registry, if the `www-authenticate` header doesn't specify a `service` parameter, it should be excluded from the registry auth url.

Eg:
```
$  curl -I -L https://registry.ci.openshift.org/v2/
HTTP/2 401
content-type: application/json; charset=utf-8
docker-distribution-api-version: registry/2.0
www-authenticate: Bearer realm="https://registry.ci.openshift.org/openshift/token"
```

the `www-authenticate` header doesn't specify a `service` parameter. Prior to this change, the malformed url request failed with a `401`
```
$ curl https://registry.ci.openshift.org/openshift/token\?service\=None\&scope\=repository:something-totally-fake:pull
{"details":"repository name \"something-totally-fake\" invalid: it must be of the format \u003cproject\u003e/\u003cname\u003e"} 
```

Signed-off-by: harishsurf <hgovinda@redhat.com>