### PR TITLE
auth: Adding wraps to user namespace decorator (PROJQUAY-4694)

### DIFF
--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -269,6 +269,7 @@ class RepositoryParamResource(ApiResource):
 
 
 def disallow_for_user_namespace(func):
+    @wraps(func)
     def wrapped(self, namespace_name, repository_name, *args, **kwargs):
         if features.RESTRICTED_USERS:
             user = get_authenticated_user()


### PR DESCRIPTION
Missing wraps decorator on disallow_for_user_namespace prevents some API endpoints from being discovered on the frontend.