### PR TITLE
UI: Fix redirection to user/org page (PROJQUAY-4667)

### DIFF
--- a/static/js/pages/repo-view.js
+++ b/static/js/pages/repo-view.js
@@ -194,9 +194,5 @@
     $scope.getImages = function(callback) {
       loadImages(callback);
     };
-
-    $scope.isOrganization = function(namespace) {
-      return !!UserService.getOrganization(namespace);
-    };
   }
 })();

--- a/static/partials/repo-view.html
+++ b/static/partials/repo-view.html
@@ -19,10 +19,10 @@
           <a class="back-link" href="/repository">
             Repositories
           </a>
-          <a class="level-up-link" href="/user/{{ namespace }}" ng-if="!isOrganization(namespace)">
+          <a class="level-up-link" href="/user/{{ namespace }}" ng-if="!viewScope.repository.is_organization">
             Account
           </a>
-          <a class="level-up-link" href="/organization/{{ namespace }}" ng-if="isOrganization(namespace)">
+          <a class="level-up-link" href="/organization/{{ namespace }}" ng-if="viewScope.repository.is_organization">
             Organization
           </a>
         </span>
@@ -137,5 +137,5 @@
       </cor-tab-panel>
     </div>
   </div>
-  
+
 </div>


### PR DESCRIPTION
The previous implementation of org check uses `UserService.getOrganization` which checks for logged in users orgs and returns true only if org matches to users orgs as [here](https://github.com/quay/quay/blob/master/static/js/services/user-service.js#L99-L113)
This PR fixes to use the `is_organization` flag returned by the repository response which is irrespective of user belonging to the org. 

Before:
<img width="1916" alt="Screen Shot 2022-11-09 at 10 36 37 AM" src="https://user-images.githubusercontent.com/11522230/200873555-4d900123-fac5-42fc-a646-23b3c5a919a7.png">
After:
<img width="1916" alt="Screen Shot 2022-11-09 at 10 36 12 AM" src="https://user-images.githubusercontent.com/11522230/200873581-c9e6fbd5-44c7-4b0b-a511-af02c6182dfa.png">

Here `Fedora123` org is created by a different user but admin has superuser perms and can view it.