### PR TITLE
users: fix create repo on push on orgs for restricted users (PROJQUAY-4732)

### DIFF
--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -108,7 +108,7 @@ class UserRobot(ApiResource):
         robot = model.get_user_robot(robot_shortname, parent)
         return robot.to_dict(include_metadata=True, include_token=True)
 
-    @require_user_admin()
+    @require_user_admin(disallow_for_restricted_users=True)
     @nickname("createUserRobot")
     @max_json_size(ROBOT_MAX_SIZE)
     @validate_json_request("CreateRobot", optional=True)
@@ -135,7 +135,7 @@ class UserRobot(ApiResource):
         )
         return robot.to_dict(include_metadata=True, include_token=True), 201
 
-    @require_user_admin()
+    @require_user_admin(disallow_for_restricted_users=True)
     @nickname("deleteUserRobot")
     def delete(self, robot_shortname):
         """
@@ -330,7 +330,7 @@ class RegenerateUserRobot(ApiResource):
     Resource for regenerate an organization's robot's token.
     """
 
-    @require_user_admin()
+    @require_user_admin(disallow_for_restricted_users=True)
     @nickname("regenerateUserRobotToken")
     def post(self, robot_shortname):
         """

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -262,6 +262,7 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
                 else:
                     logger.debug("No permission to modify repository %s/%s", namespace, reponame)
 
+            # TODO(kleesc): this is getting hard to follow. Should clean this up at some point.
             elif (
                 features.RESTRICTED_USERS
                 and user is not None
@@ -292,7 +293,11 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
                             raise Unsupported(message="Cannot create organization")
 
                 if CreateRepositoryPermission(namespace).can() and user is not None:
-                    if features.RESTRICTED_USERS and usermanager.is_restricted_user(user.username):
+                    if (
+                        features.RESTRICTED_USERS
+                        and usermanager.is_restricted_user(user.username)
+                        and user.username == namespace
+                    ):
                         logger.debug(
                             "Restricted users cannot create repository %s/%s", namespace, reponame
                         )


### PR DESCRIPTION
Also addresses [PROJQUAY-4732](https://issues.redhat.com//browse/PROJQUAY-4732), disabling robot creation on account's namespaces when FEATURE_RESTRICTED_USER is set.