### PR TITLE
conf: Update nginx config (PROJQUAY-4554)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -39,7 +39,7 @@ jobs:
         flake8 --ignore=C901,E203,E262,E265,E266,E402,E501,E712,E713,E722,E731,E741,F401,F403,F405,F811,F821,F841,W503
         # Run full scan for visibility purposes.
         flake8 --exit-zero
-    
+
     - name: Check Requirements are pinned
       run: |
         # Read each line of requirement.txt and flag if any line doesn't contain ==, @, newline, or #
@@ -152,8 +152,8 @@ jobs:
     - name: tox
       run: tox -e py39-registry
 
-  docker:
-    name: Docker Build
+  docker-amd64:
+    name: Docker Build amd64
     runs-on: ubuntu-latest
     steps:
 
@@ -168,13 +168,71 @@ jobs:
     - name: Docker Build (linux/amd64)
       env:
        DOCKER_BUILDKIT: 1
-      run: docker build --platform=linux/amd64 .
+      run: docker build --platform=linux/amd64 -t localhost/quay-local:latest .
 
-#    Commenting because of recurring failure with arm
-#    - name: Docker Build (linux/arm64)
-#      env:
-#       DOCKER_BUILDKIT: 1
-#      run: docker build --platform=linux/arm64 .
+    - name: Start Quay
+      run: |
+        docker-compose up -d redis quay-db
+        docker exec -t quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
+        DOCKER_USER="1001:0" docker-compose up -d --no-build quay
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Clone Quay UI Repository
+      uses: actions/checkout@v3
+      with:
+        repository: quay/quay-ui
+        path: './quay-ui'
+
+    - name: Seed Database
+      run: cd quay-ui && npm run quay:seed
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest requests
+
+    - name: Integration Test
+      run:  |
+        docker restart quay-quay
+        sleep 30
+        make integration-test
+
+  docker-arm64:
+    name: Docker Build arm64
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Docker Build (linux/arm64)
+      env:
+        DOCKER_BUILDKIT: 1
+      run: docker build --platform=linux/arm64 .
+
+  docker-ppc64le:
+    name: Docker Build ppc64le
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
 
     - name: Docker Build (linux/ppc64le)
       env:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,11 @@ e2e-test:
 	-m 'e2e' --timeout=3600 --verbose -x --ignore=buildman/ \
 	./
 
+integration-test:
+	TEST=true PYTHONPATH="." py.test \
+	--verbose --ignore=buildman/ \
+	test/integration/*
+
 registry-test:
 	TEST=true PYTHONPATH="." py.test  \
 	--cov="." --cov-report=html --cov-report=term-missing \

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -37,20 +37,13 @@ location /react {
 }
 
 location / {
-    # Only show old UI
-    if ($host ~* "quay.io") {
-        proxy_pass   http://web_app_server;
-        break;
-    }
-
     root {{static_dir}}/patternfly/;
     index index.html;
 
     # Show new UI if patternfly cookie is set
     if ($cookie_patternfly) {
         # catch new static paths and direct to /index.html
-        # TODO: figure out how to match on $uri
-        rewrite ^(/organizations|/repositories) /index.html break; 
+        rewrite ^(/organization|/repository|/tag) /index.html break;
     }
 
     # Show old UI if patternfly cookie is not set
@@ -60,11 +53,12 @@ location / {
 }
 
 # Capture traffic that needs to go to web_app, see /web.py
-location ~* ^(/oauth1|/oauth2|/webhooks|/keys|/.well-known) {
+location ~* ^(/config|/csrf_token|/oauth1|/oauth2|/webhooks|/keys|/.well-known) {
     proxy_pass   http://web_app_server;
 }
 
-location ~* ^(/csrf_token|/config)$ {
+# Capture old UI paths that aren't present in new UI
+location ~* ^(/user/(.*)|/search) {
     proxy_pass   http://web_app_server;
 }
 

--- a/static/js/quay-routes.module.ts
+++ b/static/js/quay-routes.module.ts
@@ -102,7 +102,7 @@ function provideRoutes($routeProvider: ng.route.IRouteProvider,
     .route('/organization/:orgname/billing/invoices', 'invoices')
 
     // View User
-    .route('/user/:username', 'user-view')
+    .route('/user/:username/', 'user-view')
 
     // View User Billing
     .route('/user/:username/billing', 'billing')

--- a/test/integration/test_nginx.py
+++ b/test/integration/test_nginx.py
@@ -1,0 +1,19 @@
+import requests
+import pytest
+
+host = "http://localhost:8080"
+
+
+@pytest.mark.parametrize(
+    "path, status",
+    [
+        ("/repository/", 200),
+        ("/repository/projectquay/clair-jwt", 200),
+        ("/organization/projectquay/", 200),
+        ("/user/user1/?tab=settings", 200),
+        ("/search?q=", 200),
+    ],
+)
+def test_nginx_ok(path, status):
+    r = requests.head(f"{host}{path}", allow_redirects=False)
+    assert r.status_code == status


### PR DESCRIPTION
* Adds new Make target, `integration-test`
  * Requires running `npm run quay:seed` from `quay-ui` repo
* The following legacy paths should now work when loaded in the new UI
  * `/user/<user>/`
    * There's no corresponding path in the new UI so this redirect back to the old UI and requires a refresh to retoggle the new UI
  * `/search`
    * There's no corresponding path in the new UI so this redirect back to the old UI and requires a refresh to retoggle the new UI
  * `/organization/<org>/`
  * `/repository/`
  * `/repository/<org>/<repo>`
* Splits out docker builds based on architecture and adds an integration test to `amd64` builds
  
```
$ make integration-test
TEST=true PYTHONPATH="." py.test \
	--verbose --ignore=buildman/ \
	test/integration/*
Test session starts (platform: darwin, Python 3.9.15, pytest 7.1.2, pytest-sugar 0.9.5)
cachedir: .pytest_cache
rootdir: /Users/doconnor/git/forks/quay/quay, configfile: tox.ini
plugins: grpc-0.8.0, xdist-2.5.0, forked-1.4.0, sugar-0.9.5, timeout-2.1.0, cov-3.0.0, flask-1.2.0
collecting ...
 test/integration/test_nginx.py::test_nginx_ok[/repository/-200] ✓                                                                   20% ██
 test/integration/test_nginx.py::test_nginx_ok[/repository/projectquay/clair-jwt-200] ✓                                              40% ████
 test/integration/test_nginx.py::test_nginx_ok[/organization/projectquay/-200] ✓                                                     60% ██████
 test/integration/test_nginx.py::test_nginx_ok[/user/user1/?tab=settings-200] ✓                                                      80% ████████
 test/integration/test_nginx.py::test_nginx_ok[/search?q=-200] ✓                                                                    100% ██████████

Results (0.34s):
       5 passed
```