### PR TITLE
Revert "chore: Add server side assembly of chunked metadata for RADOSGW driver (PROJQUAY-4592)

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -967,6 +967,15 @@ class RadosGWStorage(_CloudStorage):
 
         return super(RadosGWStorage, self).get_direct_upload_url(path, mime_type, requires_cors)
 
+    def complete_chunked_upload(self, uuid, final_path, storage_metadata):
+        self._initialize_cloud_conn()
+
+        # RadosGW does not support multipart copying from keys, so we are forced to join
+        # it all locally and then reupload.
+        # See https://github.com/ceph/ceph/pull/5139
+        chunk_list = self._chunk_list_from_metadata(storage_metadata)
+        self._client_side_chunk_join(final_path, chunk_list)
+
 
 class RHOCSStorage(RadosGWStorage):
     """


### PR DESCRIPTION
This reverts commit cdb52ed023c8222f2eeb95a1c71c403a06655ed8. Noobaa has issues assembling big blobs from keys so this needs to be reverted to resolve a problem of pushing big blobs to the registry.