### PR TITLE
build(deps): reduce CVEs in dependencies and runtime environment (PROJQUAY-4777)

### DIFF
--- a/.github/workflows/oci-distribution-spec.yaml
+++ b/.github/workflows/oci-distribution-spec.yaml
@@ -102,7 +102,7 @@ jobs:
         # https://access.redhat.com/documentation/en-us/red_hat_quay/3.8/html/deploy_red_hat_quay_-_high_availability/deploying_red_hat_quay
         docker run \
           --detach \
-          --health-cmd="curl -f http://localhost:8080/health/instance" \
+          --health-cmd="curl -fsS http://localhost:8080/health/instance" \
           --health-interval=10s \
           --health-retries=5 \
           --health-timeout=5s \

--- a/.github/workflows/oci-distribution-spec.yaml
+++ b/.github/workflows/oci-distribution-spec.yaml
@@ -112,14 +112,15 @@ jobs:
           --volume=/tmp/config:/conf/stack:Z \
           localhost/quay
 
-        for i in 1 2 3 4 5 6 7 8 9 10; do
+        for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
           status=$(docker inspect -f '{{.State.Health.Status}}' quay)
           printf "[%s] status: %s\n" "$(date -u +'%F %T')" "$status"
           if [ "$status" == "healthy" ]; then
             break
           fi
-          sleep 5
+          sleep 10
         done
+        docker inspect --format='{{json .State.Health}}' quay
 
         docker exec -i quay python <<EOF
         from app import app

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV QUAYRUN /quay-registry/conf
 ENV QUAYPATH $QUAYDIR
 ENV PYTHONUSERBASE /app
 ENV PYTHONPATH $QUAYPATH
+ENV TZ UTC
 RUN set -ex\
 	; microdnf -y module enable nginx:1.20 \
 	; microdnf -y module enable python39:3.9 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PYTHONPATH $QUAYPATH
 RUN set -ex\
 	; microdnf -y module enable nginx:1.20 \
 	; microdnf -y module enable python39:3.9 \
-        ; microdnf update -y \
+	; microdnf update -y \
 	; microdnf -y --setopt=tsflags=nodocs install \
 		dnsmasq \
 		memcached \
@@ -26,8 +26,8 @@ RUN set -ex\
 		python39 \
 		python3-gpg \
 		skopeo \
-                findutils \
-        ; microdnf remove platform-python-pip python39-pip \
+        findutils \
+    ; microdnf remove platform-python-pip python39-pip \
 	; microdnf -y clean all && rm -rf /var/cache/yum
 
 # Config-editor builds the javascript for the configtool.
@@ -39,7 +39,7 @@ ARG CONFIGTOOL_VERSION=v0.1.12
 RUN curl -fsSL "https://github.com/quay/config-tool/archive/${CONFIGTOOL_VERSION}.tar.gz"\
 	| tar xz --strip-components=4 --exclude='*.go'
 RUN set -ex\
-	; npm install --quiet --no-progress --ignore-engines\
+	; npm install --quiet --no-progress --ignore-engines \
 	; npm run --quiet build\
 	; rm -Rf node_modules\
 	;
@@ -48,19 +48,19 @@ RUN set -ex\
 FROM base AS build-python
 ENV PYTHONDONTWRITEBYTECODE 1
 RUN set -ex\
-	; microdnf -y --setopt=tsflags=nodocs install\
-		gcc-c++\
-		git\
-		openldap-devel\
-		python39-devel\
-		libffi-devel\
+	; microdnf -y --setopt=tsflags=nodocs install \
+		gcc-c++ \
+		git \
+		openldap-devel \
+		python39-devel \
+		libffi-devel \
         openssl-devel \
         diffutils \
         file \
         make \
         libjpeg-turbo \
         libjpeg-turbo-devel \
-		wget\
+		wget \
 	; microdnf -y clean all
 WORKDIR /build
 RUN python3 -m ensurepip --upgrade

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,8 @@ certifi==2022.12.7
 cffi==1.14.3
 chardet==3.0.4
 charset-normalizer==2.0.12
-click==7.1.2
+click==8.0.0
+cnr-server @ git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b
 cryptography==3.3.2
 DateTime==4.3
 debtcollector==1.22.0
@@ -145,7 +146,7 @@ zope.interface==5.4.0
 Cython==3.0.0a9
 flit_core==3.7.1
 toml==0.10.2
-jsonpickle==1.2
+jsonpickle==1.4.2
 pip==22.2.1
 setuptools==65.5.1
 setuptools-scm[toml]==4.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -149,4 +149,4 @@ pip==22.2.1
 setuptools==65.5.1
 setuptools-scm[toml]==4.1.2
 typing_extensions==4.0.1
-wheel==0.38.1
+wheel==0.38.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ cffi==1.14.3
 chardet==3.0.4
 charset-normalizer==2.0.12
 click==8.0.0
-cnr-server @ git+https://github.com/quay/appr.git@58c88e4952e95935c0dd72d4a24b0c44f2249f5b
 cryptography==3.3.2
 DateTime==4.3
 debtcollector==1.22.0
@@ -146,7 +145,6 @@ zope.interface==5.4.0
 Cython==3.0.0a9
 flit_core==3.7.1
 toml==0.10.2
-jsonpickle==1.4.2
 pip==22.2.1
 setuptools==65.5.1
 setuptools-scm[toml]==4.1.2


### PR DESCRIPTION
- switch to ubi-minimal to get rid of subscription-manager and associated old urllib3 versions
- remove older pip version part of python39 appstream
- bump python dependencies

Signed-off-by: dmesser <dmesser@redhat.com>