### PR TITLE
users: default to true if LDAP_RESTRICTED_USER_FILTER is not set (PROJQUAY-4776)

### DIFF
--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -505,6 +505,9 @@ class LDAPUsers(FederatedUsers):
         if not username_or_email:
             return False
 
+        if self._ldap_restricted_user_filter is None:
+            return True
+
         logger.debug("Looking up LDAP restricted user username or email %s", username_or_email)
         (found_user, err_msg) = self._ldap_single_user_search(
             username_or_email,
@@ -518,6 +521,9 @@ class LDAPUsers(FederatedUsers):
         return True
 
     def has_restricted_users(self) -> bool:
+        if self._ldap_restricted_user_filter is None and self.at_least_one_user_exists():
+            return True
+
         has_restricted_users, _ = self.at_least_one_user_exists(filter_restricted_users=True)
         return has_restricted_users
 

--- a/test/test_ldap.py
+++ b/test/test_ldap.py
@@ -870,10 +870,10 @@ class TestLDAP(unittest.TestCase):
                 is_superuser = ldap.is_superuser(user.username)
                 is_restricted_user = ldap.is_restricted_user(user.username)
                 self.assertFalse(is_superuser)
-                self.assertFalse(is_restricted_user)
+                self.assertTrue(is_restricted_user)
 
             self.assertFalse(ldap.has_superusers())
-            self.assertFalse(ldap.has_restricted_users())
+            self.assertTrue(ldap.has_restricted_users())
 
     def test_at_least_one_user_exists_filtered(self):
         base_dn = ["dc=quay", "dc=io"]


### PR DESCRIPTION
When LDAP is used and FEATURE_RESTRICTED_USERS is set, if LDAP_RESTRICTED_USER_FILTER is set, then, by default, all ldap users are restricted.