### PR TITLE
cors: Adding missing method type (PROJQUAY-4800)

### DIFF
--- a/util/request.py
+++ b/util/request.py
@@ -24,7 +24,7 @@ def get_request_ip():
 
 
 def crossorigin(anonymous=True):
-    cors_methods = ["GET", "HEAD", "OPTIONS", "POST", "DELETE"]
+    cors_methods = ["GET", "HEAD", "OPTIONS", "POST", "DELETE", "PUT"]
 
     def decorate(func):
         @wraps(func)


### PR DESCRIPTION
The PUT method has not been added to the list of cors methods, causing PUT requests to fail.