### PR TITLE
ui: Add cookie consent for quay.io (PROJQUAY-4555)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -149,10 +149,19 @@ mixpanel.init("{{ mixpanel_key }}", { track_pageview : false, debug: {{ is_debug
           <li quay-require="['BILLING']">
             <span class="quay-service-status"></span>
           </li>
+          {% if feature_set.get('FEATURE_UI_V2') and config_set['SERVER_HOSTNAME'] == ('quay.io') or config_set['SERVER_HOSTNAME'] == ('stage.quay.io') %}
+          <li>
+            <span id="teconsent" style="line-height: 1.1;"></span>
+          </li>
+          {% endif %}
           <li>{{ version_number }}</li>
         </ul>
       </div>
     </nav>
+
+    {% if feature_set.get('FEATURE_UI_V2') and config_set['SERVER_HOSTNAME'] == ('quay.io') or config_set['SERVER_HOSTNAME'] == ('stage.quay.io') %}
+    <div id="consent_blackbar" style="position: fixed;bottom: 0;width: 100%;z-index: 5;padding: 10px;"></div>
+    {% endif %}
 
     <!-- Modal message dialog -->
     <div class="modal fade" id="couldnotloadModal" data-backdrop="static">


### PR DESCRIPTION
* Adds cookie consent for `stage.quay.io` and `quay.io` 

Should be visible in a private tab. 

![Screenshot 2022-12-06 at 2 46 08 PM](https://user-images.githubusercontent.com/1656866/206015657-a8c3ce2b-5b93-4ac9-9331-b9d4e3d6c0c0.png)
![Screenshot 2022-12-06 at 2 45 51 PM](https://user-images.githubusercontent.com/1656866/206015661-a0b143f7-d462-4f69-b7ad-2221c130f89c.png)
