### PR TITLE
chore: remove jsonpickle from dependencies (PROJQUAY-4865)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -146,7 +146,6 @@ zope.interface==5.4.0
 Cython==3.0.0a9
 flit_core==3.7.1
 toml==0.10.2
-jsonpickle==1.2
 pip==22.2.1
 setuptools==65.5.1
 setuptools-scm[toml]==4.1.2


### PR DESCRIPTION
jsonpickle was required by aws-xray-sdk that we don't use anymore.