### PR TITLE
chore: remove yapf (PROJQUAY-4865)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,18 +151,6 @@ clean:
 	rm -rf screenshots
 
 
-yapf-all:
-	yapf -r . -p -i
-
-
-yapf-diff:
-	if [ $(MODIFIED_FILES_COUNT) -ne 0 ]; then yapf -d -p $(MODIFIED_FILES) ; fi
-
-
-yapf-test:
-	if [ `yapf -d -p $(MODIFIED_FILES) | wc -l` -gt 0 ] ; then false ; else true ;fi
-
-
 generate-proto-py:
 	python -m grpc_tools.protoc -Ibuildman/buildman_pb --python_out=buildman/buildman_pb --grpc_python_out=buildman/buildman_pb buildman.proto
 

--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -640,11 +640,6 @@
         "project": "xmltodict"
     }, 
     {
-        "format": "Python", 
-        "license": "Apache Software License 2.0", 
-        "project": "yapf"
-    }, 
-    {
         "format": "JavaScript", 
         "license": "ISC", 
         "project": "abbrev"

--- a/requirements.txt
+++ b/requirements.txt
@@ -137,7 +137,6 @@ websocket-client==0.57.0
 Werkzeug==1.0.0
 wrapt==1.13.3
 xhtml2pdf==0.2.4
-yapf==0.29.0
 zipp==2.1.0
 zope.event==4.5.0
 zope.interface==5.4.0


### PR DESCRIPTION
Yapf is a formatter for Python files that is no longer used by Quay. It was replaced by black.