### PR TITLE
deploy: add podAntiAffinity to deployment (PROJQUAY-3684)

### DIFF
--- a/deploy/openshift/quay-py3-app.yaml
+++ b/deploy/openshift/quay-py3-app.yaml
@@ -154,6 +154,17 @@ objects:
           secret:
             secretName: ${{QUAY_APP_CONFIG_SECRET}}
         serviceAccountName: ${{NAME}}
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: ${{QUAY_APP_COMPONENT_LABEL_KEY}}
+                      operator: In
+                      values:
+                      - ${{QUAY_APP_COMPONENT_LABEL_VALUE}}
+                  topologyKey: kubernetes.io/hostname
         containers:
         - name: syslog-cloudwatch-bridge
           image:  ${SYSLOG_IMAGE}:${SYSLOG_IMAGE_TAG}
@@ -464,5 +475,3 @@ parameters:
     value: "200"
   - name: IGNORE_VALIDATION
     value: "false"
-
-


### PR DESCRIPTION
Adds pod anti-affinity in `quay-py3-app.yaml` according to https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity

Trying to address alert received for quay.io where pod anti-affinity is not set for deployment.