### PR TITLE
chore: Use GitHub Actions cache for Docker Build jobs (PROJQUAY-4970)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -154,7 +154,7 @@ jobs:
 
   docker-amd64:
     name: Docker Build amd64
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - uses: actions/checkout@v3
@@ -229,7 +229,7 @@ jobs:
 
   docker-arm64:
     name: Docker Build arm64
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - uses: actions/checkout@v3
@@ -247,7 +247,7 @@ jobs:
 
   docker-ppc64le:
     name: Docker Build ppc64le
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - uses: actions/checkout@v3

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -232,36 +232,36 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
 
-    - uses: actions/checkout@v3
-
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Docker Build (linux/arm64)
-      env:
-        DOCKER_BUILDKIT: 1
-      run: docker build --platform=linux/arm64 .
+    - name: Build image (linux/arm64)
+      uses: docker/build-push-action@v3
+      with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/arm64
 
   docker-ppc64le:
     name: Docker Build ppc64le
     runs-on: ubuntu-22.04
     steps:
 
-    - uses: actions/checkout@v3
-
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Docker Build (linux/ppc64le)
-      env:
-       DOCKER_BUILDKIT: 1
-      run: docker build --platform=linux/ppc64le .
+    - name: Build image (linux/ppc64le)
+      uses: docker/build-push-action@v3
+      with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/ppc64le
 
   mysql:
     name: E2E MySQL Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,19 +89,15 @@ FROM registry.access.redhat.com/ubi8/nodejs-10 AS build-static
 WORKDIR /opt/app-root/src
 COPY --chown=1001:0 static/  ./static/
 COPY --chown=1001:0 *.json *.js  ./
-RUN set -ex\
-	; npm install --quiet --no-progress --ignore-engines\
-	; npm run --quiet build\
-	;
+RUN npm clean-install
+RUN npm run --quiet build
 
 # Build React UI
 FROM registry.access.redhat.com/ubi8/nodejs-16:latest as build-ui
 WORKDIR /opt/app-root
 COPY --chown=1001:0 web .
-
-RUN set -ex &&\
-	npm install --quiet --no-progress --ignore-engines
-RUN	npm run --quiet build
+RUN npm clean-install
+RUN npm run --quiet build
 
 # Pushgateway grabs pushgateway.
 FROM registry.access.redhat.com/ubi8/ubi:latest AS pushgateway

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,16 +87,18 @@ RUN set -ex\
 # Build-static downloads the static javascript.
 FROM registry.access.redhat.com/ubi8/nodejs-10 AS build-static
 WORKDIR /opt/app-root/src
+COPY --chown=1001:0 package.json package-lock.json  ./
+RUN npm clean-install
 COPY --chown=1001:0 static/  ./static/
 COPY --chown=1001:0 *.json *.js  ./
-RUN npm clean-install
 RUN npm run --quiet build
 
 # Build React UI
 FROM registry.access.redhat.com/ubi8/nodejs-16:latest as build-ui
 WORKDIR /opt/app-root
-COPY --chown=1001:0 web .
+COPY --chown=1001:0 web/package.json web/package-lock.json  ./
 RUN npm clean-install
+COPY --chown=1001:0 web .
 RUN npm run --quiet build
 
 # Pushgateway grabs pushgateway.


### PR DESCRIPTION
It takes >2 hours to build a Quay image for linux/arm64 by GitHub Actions. Caching should help us speed things up a bit.