### PR TITLE
deploy: add weight to anti-affinity (PROJQUAY-3684)

### DIFF
--- a/deploy/openshift/quay-py3-app.yaml
+++ b/deploy/openshift/quay-py3-app.yaml
@@ -157,7 +157,8 @@ objects:
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
-              - podAffinityTerm:
+              - weight: 1
+                podAffinityTerm:
                   labelSelector:
                     matchExpressions:
                     - key: ${{QUAY_APP_COMPONENT_LABEL_KEY}}

--- a/deploy/openshift/quay-py3-cloudflare-app.yaml
+++ b/deploy/openshift/quay-py3-cloudflare-app.yaml
@@ -154,6 +154,18 @@ objects:
           secret:
             secretName: ${{QUAY_APP_CONFIG_SECRET}}
         serviceAccountName: ${{NAME}}
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: ${{QUAY_APP_COMPONENT_LABEL_KEY}}
+                      operator: In
+                      values:
+                      - ${{QUAY_APP_COMPONENT_LABEL_VALUE}}
+                  topologyKey: kubernetes.io/hostname
         containers:
         - name: syslog-cloudwatch-bridge
           image:  ${SYSLOG_IMAGE}:${SYSLOG_IMAGE_TAG}


### PR DESCRIPTION
fixing error on deploy:
`spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight: Invalid value: 0: must be in the range 1-100`