### PR TITLE
deploy: decrease query max points (PROJQUAY-4974)

### DIFF
--- a/deploy/dashboards/grafana-dashboard-quay-slo.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-quay-slo.configmap.yaml
@@ -27,7 +27,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "iteration": 1673983948682,
+      "iteration": 1674054659078,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -2476,6 +2476,7 @@ data:
           "legend": {
             "show": true
           },
+          "maxDataPoints": 15,
           "pluginVersion": "9.0.3",
           "reverseYBuckets": false,
           "targets": [
@@ -2511,6 +2512,95 @@ data:
             "show": true
           },
           "yBucketBound": "auto"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 6,
+            "y": 97
+          },
+          "id": 77,
+          "maxDataPoints": 100,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.5, sum(rate(quay_secscan_result_duration_bucket[$rate])) by(le))",
+              "refId": "A"
+            }
+          ],
+          "title": "Median Secscan Latency",
+          "type": "timeseries"
         }
       ],
       "refresh": false,
@@ -2681,7 +2771,7 @@ data:
       "timezone": "",
       "title": "Quay SLO",
       "uid": "quay-slo",
-      "version": 6,
+      "version": 7,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
limits the number of data points returned by secscan_result_duration query to 15 this is to fix error in grafana where secscan latency shows a 502 or "query processing would load too many samples into memory in query execution"