### PR TITLE
chore: Bump futures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ Flask-Mail==0.9.1
 Flask-Principal==0.4.0
 Flask-RESTful==0.3.9
 furl==2.1.0
-futures==3.1.1
+futures==3.4.0
 geoip2==3.0.0
 gevent==21.8.0
 greenlet==1.1.2


### PR DESCRIPTION
The release 3.1.1 is yanked, we should use a newer version.