### PR TITLE
chore: Remove appr dependencies (PROJQUAY-4992)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,13 +29,11 @@ dumb-init==1.2.2
 elasticsearch==7.6.0
 elasticsearch-dsl==7.0.0
 Flask==1.1.1
-Flask-Cors==3.0.9
 Flask-Login==0.4.1
 Flask-Mail==0.9.1
 Flask-Principal==0.4.0
 Flask-RESTful==0.3.9
 furl==2.1.0
-futures==3.1.1
 geoip2==3.0.0
 gevent==21.8.0
 greenlet==1.1.2
@@ -61,7 +59,6 @@ maxminddb==1.5.2
 mixpanel==4.5.0
 msgpack==0.6.2
 msrest==0.6.21
-ndg-httpsclient==0.5.1
 netaddr==0.7.19
 netifaces==0.10.9
 oauthlib==3.2.1
@@ -94,7 +91,6 @@ PyPDF2 @ https://files.pythonhosted.org/packages/3d/48/0966606e08dd93a77e8398037
 pyrsistent==0.18.0
 python-dateutil==2.8.1
 python-editor==1.0.4
-python-etcd @ git+https://github.com/DevTable/python-etcd.git@f1168cb02a2a8c83bec1108c6fcd8615ef463b14
 python-gitlab==2.0.0
 python-keystoneclient==3.22.0
 python-ldap==3.4.0


### PR DESCRIPTION
A follow-up of #1718. We can remove dependencies that are not needed anymore.