### PR TITLE
config: clean upload folder by default (PROJQUAY-4395)

### DIFF
--- a/config.py
+++ b/config.py
@@ -804,7 +804,7 @@ class DefaultConfig(ImmutableConfig):
     FEATURE_EXTENDED_REPOSITORY_NAMES = True
 
     # Automatically clean stale blobs leftover in the uploads storage folder from cancelled uploads
-    CLEAN_BLOB_UPLOAD_FOLDER = False
+    CLEAN_BLOB_UPLOAD_FOLDER = True
 
     # Add quota management configuration, caching, and validation
     FEATURE_QUOTA_MANAGEMENT = False


### PR DESCRIPTION
If quay doesn't clean up temporary files under `uploads` folder by default, that means it is very possible for customer to pay more money for storage usage.  A lot of  important customers are money-sensitive,  so it doesn't make sense to set CLEAN_BLOB_UPLOAD_FOLDER as false by default.