### PR TITLE
storage: Add MultiCDN storage provider (PROJQUAY-5048)

### DIFF
--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -1,3 +1,4 @@
+from storage.multicdnstorage import MultiCDNStorage
 from storage.cloudflarestorage import CloudFlareS3Storage
 from storage.local import LocalStorage
 from storage.cloud import (
@@ -9,24 +10,16 @@ from storage.cloud import (
 )
 from storage.fakestorage import FakeStorage
 from storage.distributedstorage import DistributedStorage
+from storage.storagecontext import StorageContext
+from storage.storagedriverclasses import STORAGE_DRIVER_CLASSES
 from storage.swift import SwiftStorage
 from storage.azurestorage import AzureStorage
 from storage.downloadproxy import DownloadProxy
-from util.ipresolver import NoopIPResolver
 
 TYPE_LOCAL_STORAGE = "LocalStorage"
 
-STORAGE_DRIVER_CLASSES = {
-    "LocalStorage": LocalStorage,
-    "S3Storage": S3Storage,
-    "GoogleCloudStorage": GoogleCloudStorage,
-    "RadosGWStorage": RadosGWStorage,
-    "SwiftStorage": SwiftStorage,
-    "CloudFrontedS3Storage": CloudFrontedS3Storage,
-    "AzureStorage": AzureStorage,
-    "RHOCSStorage": RHOCSStorage,
-    "CloudFlareStorage": CloudFlareS3Storage,
-}
+# Adding multi-CDN storage provider here to avoid circular import
+STORAGE_DRIVER_CLASSES["MultiCDNStorage"] = MultiCDNStorage
 
 
 def get_storage_driver(location, chunk_cleanup_queue, config_provider, ip_resolver, storage_params):
@@ -39,14 +32,6 @@ def get_storage_driver(location, chunk_cleanup_queue, config_provider, ip_resolv
     driver_class = STORAGE_DRIVER_CLASSES.get(driver, FakeStorage)
     context = StorageContext(location, chunk_cleanup_queue, config_provider, ip_resolver)
     return driver_class(context, **parameters)
-
-
-class StorageContext(object):
-    def __init__(self, location, chunk_cleanup_queue, config_provider, ip_resolver):
-        self.location = location
-        self.chunk_cleanup_queue = chunk_cleanup_queue
-        self.config_provider = config_provider
-        self.ip_resolver = ip_resolver or NoopIPResolver()
 
 
 class Storage(object):

--- a/storage/basestorage.py
+++ b/storage/basestorage.py
@@ -7,6 +7,10 @@ from util.registry.filelike import READ_UNTIL_END
 logger = logging.getLogger(__name__)
 
 
+class InvalidConfigurationException(Exception):
+    pass
+
+
 class StoragePaths(object):
     shared_images = "sharedimages"
 

--- a/storage/multicdnstorage.py
+++ b/storage/multicdnstorage.py
@@ -1,0 +1,195 @@
+import logging
+from typing import Dict
+
+from storage.basestorage import BaseStorageV2, InvalidConfigurationException
+from util.ipresolver import GEOIP_CONTINENT_CODES
+
+logger = logging.getLogger(__name__)
+
+from storage.storagecontext import StorageContext
+from storage.storagedriverclasses import STORAGE_DRIVER_CLASSES
+
+VALID_RULE_KEYS = ["namespace", "continent", "target"]
+
+
+class MultiCDNStorage(BaseStorageV2):
+    """
+    Implements a Pseudo storage provider which supports
+    multiple CDN based storage providers under it.
+
+    Based on rules defined in the config, this provider
+    can select the correct CDN to serve the request
+
+    Currently supported sub providers:
+        - CloudFrontedS3Storage
+        - CloudFlareS3Storage
+
+    Currently supported rules:
+        - namespace (could be an org or a user)
+        - continent (Source IP continent. Possible values based on GeoIP Database continent codes)
+
+    Example Config:
+        - MultiCDNStorage
+        - providers:
+            TargetName1:
+                - ProviderName1
+                - porviderConfig1
+            Targetname2:
+                - ProviderName2
+                - ProviderConfig2
+          default_provider: TargetName1
+          rules:
+          - namespace: test
+            continent: APAC
+            target: TargetName2
+
+    Rules are evaluated in the order they are defined. For a match, all fields of the rule have to match
+    exactly. Partial matches are not supported. Once a rule is matched, we short-circuit the matching process
+    and use the provider in the matched rule
+    """
+
+    def __init__(self, context, providers: dict, default_provider: str, rules: list):
+        super().__init__()
+
+        self.context: StorageContext = context
+        self._validate_config(providers, default_provider, rules)
+        self.providers = self._init_providers(providers)
+        self.default_provider = self.providers.get(default_provider)
+        self.rules = rules
+
+    def _validate_config(self, providers, default_provider, rules):
+        # validate providers config
+        if not providers or not isinstance(providers, dict) or len(providers.keys()) == 0:
+            raise InvalidConfigurationException(
+                "providers should be a dict of storage providers with their configs"
+            )
+
+        # default target must always exist and should be valid
+        if not default_provider:
+            raise InvalidConfigurationException("default provider not provided")
+
+        if default_provider not in providers.keys():
+            raise InvalidConfigurationException(
+                "Default provider not found in configured providers"
+            )
+
+        for provider_target in providers:
+            config = providers.get(provider_target)
+            if len(config) != 2:
+                raise InvalidConfigurationException(
+                    f"Provider {provider_target} invalid. Should contain provider name and config as list"
+                )
+
+        # Validate rules
+        for rule in rules:
+            rule_config_keys = rule.keys()
+            for config_key in rule_config_keys:
+                if config_key not in VALID_RULE_KEYS:
+                    raise InvalidConfigurationException(
+                        f"{rule} Invalid: {config_key} bad rule key. Should be one of {VALID_RULE_KEYS}"
+                    )
+
+            if not rule.get("target"):
+                raise InvalidConfigurationException(
+                    f"target not configured for rule {rule}: Add one of the provders as target in the config"
+                )
+
+            if rule["target"] not in providers.keys():
+                raise InvalidConfigurationException(
+                    f'{rule} Invalid: {rule["target"]} not in the configured targets {providers.keys()}'
+                )
+
+            if rule.get("continent") and rule["continent"] not in GEOIP_CONTINENT_CODES:
+                raise InvalidConfigurationException(
+                    f'{rule} Invalid: {rule["continent"]} not a valid continent. Should be on of {GEOIP_CONTINENT_CODES}'
+                )
+
+    def _init_providers(self, providers_config):
+        providers = {}
+        for target_name in providers_config:
+            [provider_name, provider_config] = providers_config.get(target_name)
+            provider_class = STORAGE_DRIVER_CLASSES[provider_name]
+            providers[target_name] = provider_class(self.context, **provider_config)
+
+        return providers
+
+    def match_rule(self, rule, continent=None, namespace=None):
+        if rule.get("namespace") and namespace != rule.get("namespace"):
+            return False
+
+        if rule.get("continent") and continent != rule.get("continent"):
+            return False
+
+        return True
+
+    def find_matching_provider(self, namespace, request_ip):
+        resolved_ip = self.context.ip_resolver.resolve_ip(request_ip)
+        continent = resolved_ip.continent if resolved_ip and resolved_ip.continent else None
+
+        provider = None
+        for rule in self.rules:
+            if self.match_rule(rule, continent, namespace):
+                target_name = rule.get("target")
+                provider = self.providers.get(target_name)
+                break
+
+        if not provider:
+            provider = self.default_provider
+
+        return provider
+
+    def get_direct_download_url(
+        self, path, request_ip=None, expires_in=60, requires_cors=False, head=False, **kwargs
+    ):
+        namespace = kwargs.get("namespace", None)
+        provider = self.find_matching_provider(namespace, request_ip)
+        return provider.get_direct_download_url(
+            path, request_ip, expires_in, requires_cors, head, **kwargs
+        )
+
+    def initiate_chunked_upload(self):
+        return self.default_provider.initiate_chunked_upload()
+
+    def stream_upload_chunk(self, uuid, offset, length, in_fp, storage_metadata, content_type=None):
+        return self.default_provider.stream_upload_chunk(
+            uuid, offset, length, in_fp, storage_metadata, content_type
+        )
+
+    def complete_chunked_upload(self, uuid, final_path, storage_metadata):
+        return self.default_provider.complete_chunked_upload(uuid, final_path, storage_metadata)
+
+    def cancel_chunked_upload(self, uuid, storage_metadata):
+        return self.default_provider.cancel_chunked_upload(uuid, storage_metadata)
+
+    def get_content(self, path):
+        """
+        Used internally to get the manifest from storage
+        """
+        return self.default_provider.get_content(path)
+
+    def put_content(self, path, content):
+        return self.default_provider.put_content(path, content)
+
+    def stream_read(self, path):
+        return self.default_provider.stream_read(path)
+
+    def stream_read_file(self, path):
+        return self.default_provider.stream_read_file(path)
+
+    def stream_write(self, path, fp, content_type=None, content_encoding=None):
+        return self.default_provider.stream_write(path, fp, content_type, content_encoding)
+
+    def exists(self, path):
+        return self.default_provider.exists(path)
+
+    def remove(self, path):
+        return self.default_provider.remove(path)
+
+    def get_checksum(self, path):
+        return self.default_provider.get_checksum(path)
+
+    def clean_partial_uploads(self, deletion_date_threshold):
+        return self.default_provider.clean_partial_uploads(deletion_date_threshold)
+
+    def copy_to(self, destination, path):
+        self.default_provider.copy_to(destination, path)

--- a/storage/storagecontext.py
+++ b/storage/storagecontext.py
@@ -1,0 +1,9 @@
+from util.ipresolver import NoopIPResolver
+
+
+class StorageContext(object):
+    def __init__(self, location, chunk_cleanup_queue, config_provider, ip_resolver):
+        self.location = location
+        self.chunk_cleanup_queue = chunk_cleanup_queue
+        self.config_provider = config_provider
+        self.ip_resolver = ip_resolver or NoopIPResolver()

--- a/storage/storagedriverclasses.py
+++ b/storage/storagedriverclasses.py
@@ -1,0 +1,23 @@
+from storage.local import LocalStorage
+from storage.cloud import (
+    S3Storage,
+    GoogleCloudStorage,
+    RadosGWStorage,
+    RHOCSStorage,
+    CloudFrontedS3Storage,
+)
+from storage.swift import SwiftStorage
+from storage.azurestorage import AzureStorage
+from storage.cloudflarestorage import CloudFlareS3Storage
+
+STORAGE_DRIVER_CLASSES = {
+    "LocalStorage": LocalStorage,
+    "S3Storage": S3Storage,
+    "GoogleCloudStorage": GoogleCloudStorage,
+    "RadosGWStorage": RadosGWStorage,
+    "SwiftStorage": SwiftStorage,
+    "CloudFrontedS3Storage": CloudFrontedS3Storage,
+    "AzureStorage": AzureStorage,
+    "RHOCSStorage": RHOCSStorage,
+    "CloudFlareStorage": CloudFlareS3Storage,
+}

--- a/util/ipresolver/__init__.py
+++ b/util/ipresolver/__init__.py
@@ -19,10 +19,14 @@ from typing import Dict
 from util.abchelpers import nooper
 
 ResolvedLocation = namedtuple(
-    "ResolvedLocation", ["provider", "service", "sync_token", "country_iso_code", "aws_region"]
+    "ResolvedLocation",
+    ["provider", "service", "sync_token", "country_iso_code", "aws_region", "continent"],
 )
 
 AWS_SERVICES = {"EC2", "CODEBUILD"}
+
+# https://support.maxmind.com/hc/en-us/articles/4414877149467-IP-Geolocation-Data#h_01FRRGRYTGZB29ERDBZCX3MR8Q
+GEOIP_CONTINENT_CODES = ["AF", "AN", "AS", "EU", "NA", "OC", "SA"]
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +149,7 @@ class IPResolver(IPResolverInterface):
         try:
             parsed_ip = IPAddress(ip_address)
         except AddrFormatError:
-            return ResolvedLocation("invalid_ip", None, self.sync_token, None, None)
+            return ResolvedLocation("invalid_ip", None, self.sync_token, None, None, None)
 
         # Try geoip classification
         try:
@@ -164,12 +168,18 @@ class IPResolver(IPResolverInterface):
                     self.sync_token,
                     geoinfo.country.iso_code,
                     None,
+                    geoinfo.continent.code,
                 )
 
-            return ResolvedLocation("internet", None, self.sync_token, None, None)
+            return ResolvedLocation("internet", None, self.sync_token, None, None, None)
 
         return ResolvedLocation(
-            "aws", None, self.sync_token, geoinfo.country.iso_code if geoinfo else None, aws_region
+            "aws",
+            None,
+            self.sync_token,
+            geoinfo.country.iso_code if geoinfo else None,
+            aws_region,
+            geoinfo.continent.code if geoinfo else None,
         )
 
     def get_aws_ip_region(self, ip_address: IPAddress):
@@ -196,3 +206,6 @@ class IPResolver(IPResolverInterface):
                 all_amazon[region].add(IPNetwork(service_description["ip_prefix"]))
 
         return all_amazon
+
+    def get_ip_region(self, ip):
+        pass


### PR DESCRIPTION
This storage provider can route to different underlying sub-providers based on a critiera. Currently supported filters are source_ip and namespace.

Example Config:

```    
    - MultiCDNStorage
    - providers:
        TargetName1:
            - ProviderName1
            - porviderConfig1
        Targetname2:
            - ProviderName2
            - ProviderConfig2
      default_provider: TargetName1
      rules:
      - namespace: test
        continent: APAC
        target: TargetName2
```