### PR TITLE
storage: add option to validate all configured storages (PROJQUAY-5074)

### DIFF
--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -93,6 +93,7 @@ class Storage(object):
             default_locations,
             download_proxy,
             app.config.get("REGISTRY_STATE") == "readonly",
+            validate_endtoend=app.config.get("DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND", False),
         )
 
         # register extension with app


### PR DESCRIPTION
Add config option to validate all configured storages, and not just the first preferred one during healthcheck.