### PR TITLE
tox: allow /bin/sh (PROJQUAY-5092)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,7 @@ setenv =
     MARKERS="not e2e"
 docker = mysql
 whitelist_internals = /bin/sh
+allowlist_externals = /bin/sh
 # TODO(kleesc): Re-enable buildman tests after buildman rewrite
 commands =
     python --version
@@ -79,6 +80,7 @@ setenv =
     MARKERS="not e2e"
 docker = postgres
 whitelist_internals = /bin/sh
+allowlist_externals = /bin/sh
 # TODO(kleesc): Re-enable buildman tests after buildman rewrite
 commands =
     python --version


### PR DESCRIPTION
add `allowlist_externals = /bin/sh` to psql and mysql e2e tests