### PR TITLE
security: Change error messages in UI during LDAP login (PROJQUAY-4845)

### DIFF
--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -287,7 +287,7 @@ class LDAPUsers(FederatedUsers):
 
         # Make sure we have at least one result.
         if len(with_dns) < 1:
-            return (None, "Username not found")
+            return (None, "Invalid username or password.")
 
         # If we have found a single pair, then return it.
         if len(with_dns) == 1:
@@ -417,7 +417,7 @@ class LDAPUsers(FederatedUsers):
         """
         # Make sure that even if the server supports anonymous binds, we don't allow it
         if not password:
-            return (None, "Anonymous binding not allowed")
+            return (None, "Anonymous binding not allowed.")
 
         (found_user, err_msg) = self._ldap_single_user_search(username_or_email)
         if found_user is None:
@@ -434,7 +434,7 @@ class LDAPUsers(FederatedUsers):
         except ldap.REFERRAL as re:
             referral_dn = self._get_ldap_referral_dn(re)
             if not referral_dn:
-                return (None, "Invalid username")
+                return (None, "Invalid username or password.")
 
             try:
                 with LDAPConnection(
@@ -443,11 +443,11 @@ class LDAPUsers(FederatedUsers):
                     pass
             except ldap.INVALID_CREDENTIALS:
                 logger.debug("Invalid LDAP credentials")
-                return (None, "Invalid password")
+                return (None, "Invalid username or password.")
 
         except ldap.INVALID_CREDENTIALS:
             logger.debug("Invalid LDAP credentials")
-            return (None, "Invalid password")
+            return (None, "Invalid username or password.")
 
         return self._build_user_information(found_response)
 

--- a/data/users/federated.py
+++ b/data/users/federated.py
@@ -95,11 +95,11 @@ class FederatedUsers(object):
         """
         db_user = model.user.get_user(username)
         if not db_user:
-            return (None, "Invalid user")
+            return (None, "Invalid username or password.")
 
         federated_login = model.user.lookup_federated_login(db_user, self._federated_service)
         if not federated_login:
-            return (None, "Invalid user")
+            return (None, "Invalid username or password.")
 
         (credentials, err_msg) = self.verify_credentials(federated_login.service_ident, password)
         if credentials is None:

--- a/test/test_ldap.py
+++ b/test/test_ldap.py
@@ -413,6 +413,7 @@ class TestLDAP(unittest.TestCase):
             # Verify we cannot confirm the user.
             (response, err_msg) = ldap.confirm_existing_user("someuser", "invalidpass")
             self.assertIsNone(response)
+            self.assertEqual(err_msg, "Invalid username or password.")
 
     def test_missing_mail(self):
         with mock_ldap() as ldap:

--- a/test/test_ldap.py
+++ b/test/test_ldap.py
@@ -367,19 +367,19 @@ class TestLDAP(unittest.TestCase):
             # Verify we cannot confirm the user.
             (response, err_msg) = ldap.confirm_existing_user("someuser", "")
             self.assertIsNone(response)
-            self.assertEqual(err_msg, "Invalid user")
+            self.assertEqual(err_msg, "Invalid username or password.")
 
     def test_login_whitespace_password(self):
         with mock_ldap() as ldap:
             # Verify we cannot login.
             (response, err_msg) = ldap.verify_and_link_user("someuser", "    ")
             self.assertIsNone(response)
-            self.assertEqual(err_msg, "Invalid password")
+            self.assertEqual(err_msg, "Invalid username or password.")
 
             # Verify we cannot confirm the user.
             (response, err_msg) = ldap.confirm_existing_user("someuser", "    ")
             self.assertIsNone(response)
-            self.assertEqual(err_msg, "Invalid user")
+            self.assertEqual(err_msg, "Invalid username or password.")
 
     def test_login_secondary(self):
         with mock_ldap() as ldap:
@@ -396,24 +396,23 @@ class TestLDAP(unittest.TestCase):
             # Verify we cannot login with a wildcard.
             (response, err_msg) = ldap.verify_and_link_user("some*", "somepass")
             self.assertIsNone(response)
-            self.assertEqual(err_msg, "Username not found")
+            self.assertEqual(err_msg, "Invalid username or password.")
 
             # Verify we cannot confirm the user.
             (response, err_msg) = ldap.confirm_existing_user("some*", "somepass")
             self.assertIsNone(response)
-            self.assertEqual(err_msg, "Invalid user")
+            self.assertEqual(err_msg, "Invalid username or password.")
 
     def test_invalid_password(self):
         with mock_ldap() as ldap:
             # Verify we cannot login with an invalid password.
             (response, err_msg) = ldap.verify_and_link_user("someuser", "invalidpass")
             self.assertIsNone(response)
-            self.assertEqual(err_msg, "Invalid password")
+            self.assertEqual(err_msg, "Invalid username or password.")
 
             # Verify we cannot confirm the user.
             (response, err_msg) = ldap.confirm_existing_user("someuser", "invalidpass")
             self.assertIsNone(response)
-            self.assertEqual(err_msg, "Invalid user")
 
     def test_missing_mail(self):
         with mock_ldap() as ldap:

--- a/test/test_ldap.py
+++ b/test/test_ldap.py
@@ -362,7 +362,7 @@ class TestLDAP(unittest.TestCase):
             # Verify we cannot login.
             (response, err_msg) = ldap.verify_and_link_user("someuser", "")
             self.assertIsNone(response)
-            self.assertEqual(err_msg, "Anonymous binding not allowed")
+            self.assertEqual(err_msg, "Anonymous binding not allowed.")
 
             # Verify we cannot confirm the user.
             (response, err_msg) = ldap.confirm_existing_user("someuser", "")


### PR DESCRIPTION
Previously, on installations where LDAP is used, we were telling users whether the username or password was failing when login attempts were made. This might pose a security risk, a malicious user could, via the returned message, identify which users have access to Quay and which don't. 

With this change, we return a general message saying the user used wrong credentials instead of providing any details.