### PR TITLE
deploy: add annotation (PROJQUAY-3680)

### DIFF
--- a/deploy/openshift/quay-py3-app.yaml
+++ b/deploy/openshift/quay-py3-app.yaml
@@ -129,6 +129,8 @@ objects:
     name: quay-py3-app
     labels:
       ${{QUAY_APP_COMPONENT_LABEL_KEY}}: ${{QUAY_APP_COMPONENT_LABEL_VALUE}}
+    annotations:
+      ${{QUAY_DISABLE_MIN_REPLICAS_CHECK}}: ${{QUAY_DISABLE_MIN_REPLICAS_REASON}}
   spec:
     replicas: ${{QUAY_APP_DEPLOYMENT_REPLICAS}}
     minReadySeconds: ${{QUAY_APP_DEPLOYMENT_MIN_READY_SECONDS}}

--- a/deploy/openshift/quay-py3-cloudflare-app.yaml
+++ b/deploy/openshift/quay-py3-cloudflare-app.yaml
@@ -129,6 +129,8 @@ objects:
     name: quay-py3-cloudflare-app
     labels:
       ${{QUAY_APP_COMPONENT_LABEL_KEY}}: ${{QUAY_APP_COMPONENT_LABEL_VALUE}}
+    annotations:
+      ${{QUAY_DISABLE_MIN_REPLICAS_CHECK}}: ${{QUAY_DISABLE_MIN_REPLICAS_REASON}}
   spec:
     replicas: ${{QUAY_APP_DEPLOYMENT_REPLICAS}}
     minReadySeconds: ${{QUAY_APP_DEPLOYMENT_MIN_READY_SECONDS}}


### PR DESCRIPTION
Add annotation for disabling `min_replicas` check in staging. Annotation is being applied to the pods, but not the deployments.