### PR TITLE
chore: Bump pyOpenSSL and cryptography (PROJQUAY-5120)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,12 +62,19 @@ RUN set -ex\
         libjpeg-turbo \
         libjpeg-turbo-devel \
 		wget \
+		rust-toolset \
 	; microdnf -y clean all
 WORKDIR /build
 RUN python3 -m ensurepip --upgrade
 COPY requirements.txt .
 # Note that it installs into PYTHONUSERBASE because of the '--user'
 # flag.
+
+# When cross-compiling the container, cargo uncontrollably consumes memory and
+# gets killed by the OOM Killer when it fetches dependencies. The workaround is
+# to use the git executable.
+# See https://github.com/rust-lang/cargo/issues/10583 for details.
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 
 # Added GRPC & Gevent support for IBMZ
 # wget has been added to reduce the build time

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ cffi==1.14.3
 chardet==3.0.4
 charset-normalizer==2.0.12
 click==8.0.0
-cryptography==3.3.2
+cryptography==39.0.1
 DateTime==4.3
 debtcollector==1.22.0
 decorator==4.4.1
@@ -85,7 +85,7 @@ PyGithub==1.45
 PyJWT==2.4.0
 pymemcache==3.0.0
 PyMySQL==0.9.3
-pyOpenSSL==19.1.0
+pyOpenSSL==23.0.0
 pyparsing==2.4.6
 PyPDF2 @ https://files.pythonhosted.org/packages/3d/48/0966606e08dd93a77e839803789151ff81ac27ec6767957af8afb9588501/PyPDF2-1.27.6.tar.gz#egg=PyPDF2&cachito_hash=sha256:3a3c0585678279b93a4c0fa31fb6f6217cfbdac3f6d3dcd1dfc9888579f3e858 # Generated from PyPi download link + sha256
 pyrsistent==0.18.0


### PR DESCRIPTION
See https://github.com/quay/quay/pull/1748 for details.