### PR TITLE
builders: Update scope for gitlab to include write access (PROJQUAY-5181)

### DIFF
--- a/static/js/services/trigger-service.js
+++ b/static/js/services/trigger-service.js
@@ -84,7 +84,7 @@ angular.module('quay').factory('TriggerService', ['UtilService', '$sanitize', 'K
       'get_redirect_url': function(namespace, repository) {
         var redirect_uri = KeyService['gitlabRedirectUri'] + '/trigger';
         var client_id = KeyService['gitlabTriggerClientId'];
-        var scopes = "read_repository openid profile email"
+        var scopes = "api write_repository openid"
 
         var authorize_url = new UtilService.UrlBuilder(KeyService['gitlabTriggerAuthorizeUrl']);
         authorize_url.setQueryParameter('client_id', client_id);


### PR DESCRIPTION
api write_repository is required to create a webhook on the repo