### PR TITLE
repomirror: Add default value for REPO_MIRROR_ROLLBACK to config (PROJQUAY-4296)

### DIFF
--- a/config.py
+++ b/config.py
@@ -512,6 +512,10 @@ class DefaultConfig(ImmutableConfig):
     # Replaces the SERVER_HOSTNAME as the destination for mirroring.
     REPO_MIRROR_SERVER_HOSTNAME: Optional[str] = None
 
+    # Enables rolling repository back to previous state in the event the mirror fails.
+    # Defaults to false, to allow partial mirroring of upstream repositories.
+    REPO_MIRROR_ROLLBACK = False
+
     # "Secret" key for generating encrypted paging tokens. Only needed to be secret to
     # hide the ID range for production (in which this value is overridden). Should *not*
     # be relied upon for secure encryption otherwise.


### PR DESCRIPTION
We forgot to add the default value to `config.py` when we enabled this change. This PR adds the default value along with the flag description.