### PR TITLE
Add config support for IPv6 (PROJQUAY-272)

### DIFF
--- a/config.py
+++ b/config.py
@@ -825,3 +825,8 @@ class DefaultConfig(ImmutableConfig):
 
     # Origin to allow for CORS requests
     CORS_ORIGIN = "*"
+
+    # Enables IPv4, IPv6 or dual-stack listening mode.
+    # Valid options are IPv4, IPv6 or dual-stack.
+    # Defaults to IPv4
+    FEATURE_LISTEN_IP_VERSION = "IPv4"

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -117,6 +117,7 @@ CONFIG_SCHEMA = {
         "DISTRIBUTED_STORAGE_PREFERENCE",
         "DEFAULT_TAG_EXPIRATION",
         "TAG_EXPIRATION_OPTIONS",
+        "FEATURE_LISTEN_IP_VERSION"
     ],
     "properties": {
         "REGISTRY_STATE": {
@@ -1241,6 +1242,11 @@ CONFIG_SCHEMA = {
             "type": "string",
             "description": "Cross-Origin domain to allow requests from",
             "x-example": "localhost:9000",
+        },
+        "FEATURE_LISTEN_IP_VERSION": {
+            "type": "string",
+            "description": "Enables IPv4/IPv6 or dual-stack listening modes. Valid options are IPv4, IPv6 or dual-stack. Defaults to IPv4.",
+            "x-example": "IPv4",
         },
     },
 }


### PR DESCRIPTION
This PR adds config support for choosing the IP stack that Quay will run on. The property is marked as required. Defaults to IPv4, unless specified otherwise.