### PR TITLE
chore: Downgrade cryptography to 3.3.2 (PROJQUAY-5120)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ cffi==1.14.3
 chardet==3.0.4
 charset-normalizer==2.0.12
 click==8.0.0
-cryptography==39.0.1
+cryptography==3.3.2
 DateTime==4.3
 debtcollector==1.22.0
 decorator==4.4.1
@@ -85,7 +85,7 @@ PyGithub==1.45
 PyJWT==2.4.0
 pymemcache==3.0.0
 PyMySQL==0.9.3
-pyOpenSSL==23.0.0
+pyOpenSSL==21.0.0
 pyparsing==2.4.6
 PyPDF2 @ https://files.pythonhosted.org/packages/3d/48/0966606e08dd93a77e839803789151ff81ac27ec6767957af8afb9588501/PyPDF2-1.27.6.tar.gz#egg=PyPDF2&cachito_hash=sha256:3a3c0585678279b93a4c0fa31fb6f6217cfbdac3f6d3dcd1dfc9888579f3e858 # Generated from PyPi download link + sha256
 pyrsistent==0.18.0


### PR DESCRIPTION
Quay downstream build system cannot build new versions of the package `cryptography` as they use Rust. Unless downstream is fixed, we should use the latest available version that does not depend on Rust.