### PR TITLE
ldap: Don't convert dashes to underscores in usernames (PROJQUAY-5253)

### DIFF
--- a/util/validation.py
+++ b/util/validation.py
@@ -18,7 +18,7 @@ VALID_LABEL_KEY_REGEX = r"^[a-z0-9](([a-z0-9]|[-.](?![.-]))*[a-z0-9])?$"
 VALID_USERNAME_REGEX = r"^([a-z0-9]+(?:[._-][a-z0-9]+)*)$"
 VALID_SERVICE_KEY_NAME_REGEX = r"^[\s a-zA-Z0-9\-_:/]*$"
 
-INVALID_USERNAME_CHARACTERS = r"[^a-z0-9_]"
+INVALID_USERNAME_CHARACTERS = r"[^a-z0-9_-]"
 
 
 def validate_label_key(label_key):


### PR DESCRIPTION
When `FEATURE_USER_CONFIRMATION` is set to true and an LDAP username that has dashes inside is used, Quay will automatically change dashes to underscores. This breaks `LDAP_RESTRICTED_USER_FILTER`  since namespaces in Quay do not have to be the same as LDAP namespaces. The change can only impact ancient Docker versions prior to version 1.5 where support for dashes in namespaces has been introduced.