### PR TITLE
locking: change log severity (PROJQUAY-5221)

### DIFF
--- a/util/locking.py
+++ b/util/locking.py
@@ -74,7 +74,7 @@ class GlobalLock(object):
             logger.debug("Acquired lock %s", self._lock_name)
             return True
         except RedisError as re:
-            logger.debug("Could not connect to Redis for lock %s: %s", self._lock_name, re)
+            logger.warn("Could not connect to Redis for lock %s: %s", self._lock_name, re)
             return False
         except:
             logger.debug("Could not acquire lock %s", self._lock_name)


### PR DESCRIPTION
When a worker fails to acquire the lock, make sure a log message is sent as a warning for better visibility when troubleshooting.