### PR TITLE
logs: Add audit logs for login/logout to Quay (PROJQUAY-2344)

### DIFF
--- a/data/migrations/versions/0246c2d0e750_add_login_logout_logentrykind.py
+++ b/data/migrations/versions/0246c2d0e750_add_login_logout_logentrykind.py
@@ -1,0 +1,33 @@
+"""add login logout logentrykind
+
+Revision ID: 0246c2d0e750
+Revises: b2d1e4b95fc2
+Create Date: 2023-04-11 14:40:57.391686
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "0246c2d0e750"
+down_revision = "b2d1e4b95fc2"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.bulk_insert(
+        tables.logentrykind,
+        [
+            {"name": "login_success"},
+            {"name": "logout_success"},
+        ],
+    )
+
+
+def downgrade(op, tables, tester):
+    op.execute(
+        tables.logentrykind.delete().where(
+            tables.logentrykind.name
+            == op.inline_literal("login_success") | tables.logentrykind.name
+            == op.inline_literal("logout_success")
+        )
+    )

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -660,6 +660,10 @@ def conduct_signin(username_or_email, password, invite_code=None):
 
         success, headers = common_login(found_user.uuid)
         if success:
+            log_action(
+                "login_success",
+                found_user.username,
+            )
             return {"success": True}, 200, headers
         else:
             needs_email_verification = True
@@ -860,8 +864,9 @@ class Signout(ApiResource):
         """
         Request that the current user be signed out.
         """
+        user = get_authenticated_user()
         # Invalidate all sessions for the user.
-        model.user.invalidate_all_sessions(get_authenticated_user())
+        model.user.invalidate_all_sessions(user)
 
         # Clear out the user's identity.
         identity_changed.send(app, identity=AnonymousIdentity())
@@ -869,6 +874,8 @@ class Signout(ApiResource):
         # Remove the user's session cookie.
         logout_user()
 
+        if user:
+            log_action("logout_success", user.username)
         return {"success": True}
 
 

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -23,6 +23,7 @@ from auth.signedgrant import generate_signed_token
 from data import model
 from data.registry_model import registry_model
 from data.registry_model.manifestbuilder import create_manifest_builder, lookup_manifest_builder
+from endpoints.api import log_action
 from endpoints.decorators import (
     anon_protect,
     anon_allowed,
@@ -136,6 +137,7 @@ def create_user():
 
     if result.has_nonrobot_user:
         # Mark that the user was logged in.
+        log_action("login_success", username)
         event = userevents.get_event(username)
         event.publish_event_data("docker-cli", {"action": "login"})
 

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -21,6 +21,7 @@ from data.database import RepositoryState
 from data.registry_model import registry_model
 from data.registry_model.datatypes import RepositoryReference
 from data.model.repo_mirror import get_mirroring_robot
+from endpoints.api import log_action
 from endpoints.decorators import anon_protect
 from endpoints.v2 import v2_bp
 from endpoints.v2.errors import (
@@ -126,8 +127,11 @@ def generate_registry_jwt(auth_result):
         }
 
     # Send the user event.
-    if get_authenticated_user() is not None:
-        event = userevents.get_event(get_authenticated_user().username)
+    user = get_authenticated_user()
+    if user is not None:
+        if user_event_data["action"] == "login":
+            log_action("login_success", user.username)
+        event = userevents.get_event(user.username)
         event.publish_event_data("docker-cli", user_event_data)
 
     # Build the signed JWT.

--- a/initdb.py
+++ b/initdb.py
@@ -432,6 +432,9 @@ def initialize_database():
     LogEntryKind.create(name="start_build_trigger")
     LogEntryKind.create(name="cancel_build")
 
+    LogEntryKind.create(name="login_success")
+    LogEntryKind.create(name="logout_success")
+
     ImageStorageLocation.create(name="local_eu")
     ImageStorageLocation.create(name="local_us")
 


### PR DESCRIPTION
Adds audit events for : 
- login/ logout of quay UI
- login via docker/podman CLI

Note: No call is made to docker registry API during a logout from CLI, hence no audit events are logged
Testing: verified that the above audit events are generated via a local splunk instance