### PR TITLE
chore: Ensure use of HTTP 1.1 when proxying storage (PROJQUAY-5140)

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -79,11 +79,14 @@ location ~ ^/_storage_proxy/([^/]+)/([^/]+)/([^/]+)/(.+) {
     auth_request /_storage_proxy_auth;
 
     proxy_pass $2://$3/$4$is_args$args;
+    proxy_http_version 1.1;
 
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $3;
     proxy_set_header Authorization "";
+    proxy_ssl_name $3;
+    proxy_ssl_server_name on;
 
     add_header Host $3;
 


### PR DESCRIPTION
We were not enforcing the use of `HTTP 1.1` when storage proxy was concerned. This causes problems in certain complex scenarios.