### PR TITLE
logs: Add audit logs for organization and user namespace activities (PROJQUAY-3482)

### DIFF
--- a/data/migrations/versions/a648ab200ab7_add_org_auditing.py
+++ b/data/migrations/versions/a648ab200ab7_add_org_auditing.py
@@ -28,6 +28,10 @@ def upgrade(op, tables, tester):
             {"name": "user_enable"},
             {"name": "user_change_email"},
             {"name": "user_change_password"},
+            {"name": "user_change_invoicing"},
+            {"name": "user_change_tag_expiration"},
+            {"name": "user_change_metadata"},
+            {"name": "user_generate_client_key"}
         ],
     )
 
@@ -47,6 +51,11 @@ def downgrade(op, tables, tester):
             == op.inline_literal("user_disable") | tables.logentrykind.name 
             == op.inline_literal("user_enable") | tables.logentrykind.name 
             == op.inline_literal("user_change_email") | tables.logentrykind.name 
-            == op.inline_literal("user_change_password")
+            == op.inline_literal("user_change_password") | tables.logentrykind.name 
+            == op.inline_literal("user_change_name") | tables.logentrykind.name 
+            == op.inline_literal("user_change_invoicing") | tables.logentrykind.name 
+            == op.inline_literal("user_change_tag_expiration") | tables.logentrykind.name 
+            == op.inline_literal("user_change_metadata") | tables.logentrykind.name 
+            == op.inline_literal("user_generate_client_key")
         )
     )

--- a/data/migrations/versions/a648ab200ab7_add_org_auditing.py
+++ b/data/migrations/versions/a648ab200ab7_add_org_auditing.py
@@ -8,8 +8,9 @@ Create Date: 2023-04-27 18:00:59.985970
 
 # revision identifiers, used by Alembic.
 import sqlalchemy as sa
-revision = 'a648ab200ab7'
-down_revision = 'b2d1e4b95fc2'
+
+revision = "a648ab200ab7"
+down_revision = "b2d1e4b95fc2"
 
 
 def upgrade(op, tables, tester):
@@ -31,7 +32,7 @@ def upgrade(op, tables, tester):
             {"name": "user_change_invoicing"},
             {"name": "user_change_tag_expiration"},
             {"name": "user_change_metadata"},
-            {"name": "user_generate_client_key"}
+            {"name": "user_generate_client_key"},
         ],
     )
 
@@ -46,16 +47,16 @@ def downgrade(op, tables, tester):
             == op.inline_literal("org_change_invoicing") | tables.logentrykind.name
             == op.inline_literal("org_change_tag_expiration") | tables.logentrykind.name
             == op.inline_literal("org_change_name") | tables.logentrykind.name
-            == op.inline_literal("user_create") | tables.logentrykind.name 
-            == op.inline_literal("user_delete") | tables.logentrykind.name 
-            == op.inline_literal("user_disable") | tables.logentrykind.name 
-            == op.inline_literal("user_enable") | tables.logentrykind.name 
-            == op.inline_literal("user_change_email") | tables.logentrykind.name 
-            == op.inline_literal("user_change_password") | tables.logentrykind.name 
-            == op.inline_literal("user_change_name") | tables.logentrykind.name 
-            == op.inline_literal("user_change_invoicing") | tables.logentrykind.name 
-            == op.inline_literal("user_change_tag_expiration") | tables.logentrykind.name 
-            == op.inline_literal("user_change_metadata") | tables.logentrykind.name 
+            == op.inline_literal("user_create") | tables.logentrykind.name
+            == op.inline_literal("user_delete") | tables.logentrykind.name
+            == op.inline_literal("user_disable") | tables.logentrykind.name
+            == op.inline_literal("user_enable") | tables.logentrykind.name
+            == op.inline_literal("user_change_email") | tables.logentrykind.name
+            == op.inline_literal("user_change_password") | tables.logentrykind.name
+            == op.inline_literal("user_change_name") | tables.logentrykind.name
+            == op.inline_literal("user_change_invoicing") | tables.logentrykind.name
+            == op.inline_literal("user_change_tag_expiration") | tables.logentrykind.name
+            == op.inline_literal("user_change_metadata") | tables.logentrykind.name
             == op.inline_literal("user_generate_client_key")
         )
     )

--- a/data/migrations/versions/a648ab200ab7_add_org_auditing.py
+++ b/data/migrations/versions/a648ab200ab7_add_org_auditing.py
@@ -7,10 +7,9 @@ Create Date: 2023-04-27 18:00:59.985970
 """
 
 # revision identifiers, used by Alembic.
+import sqlalchemy as sa
 revision = 'a648ab200ab7'
 down_revision = 'b2d1e4b95fc2'
-
-import sqlalchemy as sa
 
 
 def upgrade(op, tables, tester):
@@ -22,6 +21,13 @@ def upgrade(op, tables, tester):
             {"name": "org_change_email"},
             {"name": "org_change_invoicing"},
             {"name": "org_change_tag_expiration"},
+            {"name": "org_change_name"},
+            {"name": "user_create"},
+            {"name": "user_delete"},
+            {"name": "user_disable"},
+            {"name": "user_enable"},
+            {"name": "user_change_email"},
+            {"name": "user_change_password"},
         ],
     )
 
@@ -34,6 +40,13 @@ def downgrade(op, tables, tester):
             == op.inline_literal("org_delete") | tables.logentrykind.name
             == op.inline_literal("org_change_email") | tables.logentrykind.name
             == op.inline_literal("org_change_invoicing") | tables.logentrykind.name
-            == op.inline_literal("org_change_tag_expiration")
+            == op.inline_literal("org_change_tag_expiration") | tables.logentrykind.name
+            == op.inline_literal("org_change_name") | tables.logentrykind.name
+            == op.inline_literal("user_create") | tables.logentrykind.name 
+            == op.inline_literal("user_delete") | tables.logentrykind.name 
+            == op.inline_literal("user_disable") | tables.logentrykind.name 
+            == op.inline_literal("user_enable") | tables.logentrykind.name 
+            == op.inline_literal("user_change_email") | tables.logentrykind.name 
+            == op.inline_literal("user_change_password")
         )
     )

--- a/data/migrations/versions/a648ab200ab7_add_org_auditing.py
+++ b/data/migrations/versions/a648ab200ab7_add_org_auditing.py
@@ -29,6 +29,7 @@ def upgrade(op, tables, tester):
             {"name": "user_enable"},
             {"name": "user_change_email"},
             {"name": "user_change_password"},
+            {"name": "user_change_name"},
             {"name": "user_change_invoicing"},
             {"name": "user_change_tag_expiration"},
             {"name": "user_change_metadata"},

--- a/data/migrations/versions/a648ab200ab7_add_org_auditing.py
+++ b/data/migrations/versions/a648ab200ab7_add_org_auditing.py
@@ -1,0 +1,39 @@
+"""add org auditing
+
+Revision ID: a648ab200ab7
+Revises: b2d1e4b95fc2
+Create Date: 2023-04-27 18:00:59.985970
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a648ab200ab7'
+down_revision = 'b2d1e4b95fc2'
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.bulk_insert(
+        tables.logentrykind,
+        [
+            {"name": "org_create"},
+            {"name": "org_delete"},
+            {"name": "org_change_email"},
+            {"name": "org_change_invoicing"},
+            {"name": "org_change_tag_expiration"},
+        ],
+    )
+
+
+def downgrade(op, tables, tester):
+    op.execute(
+        tables.logentrykind.delete().where(
+            tables.logentrykind.name
+            == op.inline_literal("org_create") | tables.logentrykind.name
+            == op.inline_literal("org_delete") | tables.logentrykind.name
+            == op.inline_literal("org_change_email") | tables.logentrykind.name
+            == op.inline_literal("org_change_invoicing") | tables.logentrykind.name
+            == op.inline_literal("org_change_tag_expiration")
+        )
+    )

--- a/data/migrations/versions/a648ab200ab7_add_org_auditing.py
+++ b/data/migrations/versions/a648ab200ab7_add_org_auditing.py
@@ -1,7 +1,7 @@
 """add org auditing
 
 Revision ID: a648ab200ab7
-Revises: b2d1e4b95fc2
+Revises: f0875fbc7c7a
 Create Date: 2023-04-27 18:00:59.985970
 
 """

--- a/data/migrations/versions/a648ab200ab7_add_org_auditing.py
+++ b/data/migrations/versions/a648ab200ab7_add_org_auditing.py
@@ -10,7 +10,7 @@ Create Date: 2023-04-27 18:00:59.985970
 import sqlalchemy as sa
 
 revision = "a648ab200ab7"
-down_revision = "b2d1e4b95fc2"
+down_revision = "f0875fbc7c7a"
 
 
 def upgrade(op, tables, tester):

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -642,7 +642,7 @@ def tags_containing_legacy_image(image):
         .join(Image)
         .where(Tag.repository == image.repository_id)
         .where(Image.repository == image.repository_id)
-        .where((Image.id == image.id) | (Image.ancestors ** ancestors_str))
+        .where((Image.id == image.id) | (Image.ancestors**ancestors_str))
     )
     return filter_to_alive_tags(tags)
 

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -186,14 +186,16 @@ def list_repository_tag_history(
     )
     try:
         if filter_tag_name is not None:
-            operation, value = filter_tag_name.split(':', 1)
-            if operation == 'like':
+            operation, value = filter_tag_name.split(":", 1)
+            if operation == "like":
                 query = query.where(Tag.name.contains(value))
-            elif operation == 'eq':
+            elif operation == "eq":
                 query = query.where(Tag.name == value)
     except ValueError:
-        raise ValueError("Unsupported syntax for filter_tag_name. Expected <operation>:<tag_name> where <operation>"
-                         "can be 'like' or 'eq'.")
+        raise ValueError(
+            "Unsupported syntax for filter_tag_name. Expected <operation>:<tag_name> where <operation>"
+            "can be 'like' or 'eq'."
+        )
 
     if specific_tag_name is not None:
         query = query.where(Tag.name == specific_tag_name)
@@ -640,7 +642,7 @@ def tags_containing_legacy_image(image):
         .join(Image)
         .where(Tag.repository == image.repository_id)
         .where(Image.repository == image.repository_id)
-        .where((Image.id == image.id) | (Image.ancestors**ancestors_str))
+        .where((Image.id == image.id) | (Image.ancestors ** ancestors_str))
     )
     return filter_to_alive_tags(tags)
 

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -284,7 +284,13 @@ class OCIModel(RegistryDataInterface):
         into service.
         """
         tags, has_more = oci.tag.list_repository_tag_history(
-            repository_ref._db_id, page, size, specific_tag_name, active_tags_only, since_time_ms, filter_tag_name,
+            repository_ref._db_id,
+            page,
+            size,
+            specific_tag_name,
+            active_tags_only,
+            since_time_ms,
+            filter_tag_name,
         )
 
         # TODO: Remove this once the layers compressed sizes have been fully backfilled.

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -200,7 +200,11 @@ class OrganizationList(ApiResource):
                 email_required=features.MAILING,
                 is_possible_abuser=is_possible_abuser,
             )
-            log_action("org_create", org_data["name"], {"email": org_data.get("email"), "namespace": org_data["name"]})
+            log_action(
+                "org_create",
+                org_data["name"],
+                {"email": org_data.get("email"), "namespace": org_data["name"]},
+            )
             return "Created", 201
         except model.DataModelException as ex:
             raise request_error(exception=ex)
@@ -275,7 +279,11 @@ class Organization(ApiResource):
             if "invoice_email" in org_data:
                 logger.debug("Changing invoice_email for organization: %s", org.username)
                 model.user.change_send_invoice_email(org, org_data["invoice_email"])
-                log_action("org_change_invoicing", orgname, {"invoice_email": org_data["invoice_email"], "namespace": orgname})
+                log_action(
+                    "org_change_invoicing",
+                    orgname,
+                    {"invoice_email": org_data["invoice_email"], "namespace": orgname},
+                )
 
             if (
                 "invoice_email_address" in org_data
@@ -284,25 +292,37 @@ class Organization(ApiResource):
                 new_email = org_data["invoice_email_address"]
                 logger.debug("Changing invoice email address for organization: %s", org.username)
                 model.user.change_invoice_email_address(org, new_email)
-                log_action("org_change_invoicing", orgname, {"invoice_email_address": new_email, "namespace": orgname})
+                log_action(
+                    "org_change_invoicing",
+                    orgname,
+                    {"invoice_email_address": new_email, "namespace": orgname},
+                )
 
             if "email" in org_data and org_data["email"] != org.email:
                 new_email = org_data["email"]
                 old_email = org.email
-                
+
                 if model.user.find_user_by_email(new_email):
                     raise request_error(message="E-mail address already used")
 
                 logger.debug("Changing email address for organization: %s", org.username)
                 model.user.update_email(org, new_email)
-                log_action("org_change_email", orgname, {"email": new_email, "namespace": orgname, "old_email": old_email})
+                log_action(
+                    "org_change_email",
+                    orgname,
+                    {"email": new_email, "namespace": orgname, "old_email": old_email},
+                )
 
             if features.CHANGE_TAG_EXPIRATION and "tag_expiration_s" in org_data:
                 logger.debug(
                     "Changing organization tag expiration to: %ss", org_data["tag_expiration_s"]
                 )
                 model.user.change_user_tag_expiration(org, org_data["tag_expiration_s"])
-                log_action("org_change_tag_expiration", orgname, {"tag_expiration": org_data["tag_expiration_s"], "namespace": orgname})
+                log_action(
+                    "org_change_tag_expiration",
+                    orgname,
+                    {"tag_expiration": org_data["tag_expiration_s"], "namespace": orgname},
+                )
 
             teams = model.team.get_teams_within_org(org)
             return org_view(org, teams)
@@ -322,7 +342,9 @@ class Organization(ApiResource):
             except model.InvalidOrganizationException:
                 raise NotFound()
 
-            log_action("org_delete", orgname,  {"namespace": orgname}) # we need to do this before the deletion, as the org will be gone after
+            log_action(
+                "org_delete", orgname, {"namespace": orgname}
+            )  # we need to do this before the deletion, as the org will be gone after
             model.user.mark_namespace_for_deletion(org, all_queues, namespace_gc_queue)
             return "", 204
 

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -200,7 +200,7 @@ class OrganizationList(ApiResource):
                 email_required=features.MAILING,
                 is_possible_abuser=is_possible_abuser,
             )
-            log_action("org_create", org_data["name"], {"email": org_data.get("email")})
+            log_action("org_create", org_data["name"], {"email": org_data.get("email"), "namespace": org_data["name"]})
             return "Created", 201
         except model.DataModelException as ex:
             raise request_error(exception=ex)
@@ -275,7 +275,7 @@ class Organization(ApiResource):
             if "invoice_email" in org_data:
                 logger.debug("Changing invoice_email for organization: %s", org.username)
                 model.user.change_send_invoice_email(org, org_data["invoice_email"])
-                log_action("org_change_invoicing", orgname, {"invoice_email": org_data["invoice_email"]})
+                log_action("org_change_invoicing", orgname, {"invoice_email": org_data["invoice_email"], "namespace": orgname})
 
             if (
                 "invoice_email_address" in org_data
@@ -284,7 +284,7 @@ class Organization(ApiResource):
                 new_email = org_data["invoice_email_address"]
                 logger.debug("Changing invoice email address for organization: %s", org.username)
                 model.user.change_invoice_email_address(org, new_email)
-                log_action("org_change_invoicing", orgname, {"invoice_email_address": new_email})
+                log_action("org_change_invoicing", orgname, {"invoice_email_address": new_email, "namespace": orgname})
 
             if "email" in org_data and org_data["email"] != org.email:
                 new_email = org_data["email"]
@@ -293,14 +293,14 @@ class Organization(ApiResource):
 
                 logger.debug("Changing email address for organization: %s", org.username)
                 model.user.update_email(org, new_email)
-                log_action("org_change_email", orgname, {"email": new_email})
+                log_action("org_change_email", orgname, {"email": new_email, "namespace": orgname})
 
             if features.CHANGE_TAG_EXPIRATION and "tag_expiration_s" in org_data:
                 logger.debug(
                     "Changing organization tag expiration to: %ss", org_data["tag_expiration_s"]
                 )
                 model.user.change_user_tag_expiration(org, org_data["tag_expiration_s"])
-                log_action("org_change_tag_expiration", orgname, {"tag_expiration": org_data["tag_expiration_s"]})
+                log_action("org_change_tag_expiration", orgname, {"tag_expiration": org_data["tag_expiration_s"], "namespace": orgname})
 
             teams = model.team.get_teams_within_org(org)
             return org_view(org, teams)
@@ -320,7 +320,7 @@ class Organization(ApiResource):
             except model.InvalidOrganizationException:
                 raise NotFound()
 
-            log_action("org_delete", orgname) # we need to do this before the deletion, as the org will be gone after
+            log_action("org_delete", orgname,  {"namespace": orgname}) # we need to do this before the deletion, as the org will be gone after
             model.user.mark_namespace_for_deletion(org, all_queues, namespace_gc_queue)
             return "", 204
 

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -288,12 +288,14 @@ class Organization(ApiResource):
 
             if "email" in org_data and org_data["email"] != org.email:
                 new_email = org_data["email"]
+                old_email = org.email
+                
                 if model.user.find_user_by_email(new_email):
                     raise request_error(message="E-mail address already used")
 
                 logger.debug("Changing email address for organization: %s", org.username)
                 model.user.update_email(org, new_email)
-                log_action("org_change_email", orgname, {"email": new_email, "namespace": orgname})
+                log_action("org_change_email", orgname, {"email": new_email, "namespace": orgname, "old_email": old_email})
 
             if features.CHANGE_TAG_EXPIRATION and "tag_expiration_s" in org_data:
                 logger.debug(

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -320,8 +320,8 @@ class Organization(ApiResource):
             except model.InvalidOrganizationException:
                 raise NotFound()
 
+            log_action("org_delete", orgname) # we need to do this before the deletion, as the org will be gone after
             model.user.mark_namespace_for_deletion(org, all_queues, namespace_gc_queue)
-            log_action("org_delete", orgname)
             return "", 204
 
         raise Unauthorized()

--- a/endpoints/api/superuser.py
+++ b/endpoints/api/superuser.py
@@ -12,7 +12,6 @@ from random import SystemRandom
 from flask import request, make_response, jsonify
 
 from cryptography.hazmat.primitives import serialization
-import auth
 
 import features
 

--- a/endpoints/api/superuser.py
+++ b/endpoints/api/superuser.py
@@ -409,6 +409,11 @@ class SuperUserList(ApiResource):
             install_user, confirmation_code = pre_oci_model.create_install_user(
                 username, password, email
             )
+
+            authed_user = get_authenticated_user()
+
+            log_action("user_create", username, {"email": email, "username": username, "superuser": authed_user.username})
+
             if features.MAILING:
                 send_confirmation_email(
                     install_user.username, install_user.email, confirmation_code
@@ -520,6 +525,8 @@ class SuperUserManagement(ApiResource):
             if usermanager.is_superuser(username):
                 raise InvalidRequest("Cannot delete a superuser")
 
+            log_action("user_delete", username, {"username": username})
+                       
             pre_oci_model.mark_user_for_deletion(username)
             return "", 204
 
@@ -542,11 +549,16 @@ class SuperUserManagement(ApiResource):
             if usermanager.is_superuser(username):
                 raise InvalidRequest("Cannot update a superuser")
 
+
+            authed_user = get_authenticated_user()
+
             user_data = request.get_json()
             if "password" in user_data:
                 # Ensure that we are using database auth.
                 if app.config["AUTHENTICATION_TYPE"] != "Database":
                     raise InvalidRequest("Cannot change password in non-database auth")
+
+                log_action("user_change_password", username, {"username": username, "superuser": authed_user.username})
 
                 pre_oci_model.change_password(username, user_data["password"])
 
@@ -555,11 +567,22 @@ class SuperUserManagement(ApiResource):
                 if app.config["AUTHENTICATION_TYPE"] not in ["Database", "AppToken"]:
                     raise InvalidRequest("Cannot change e-mail in non-database auth")
 
+                log_action("user_change_email", username, {"username": username, "email": user_data["email"], "superuser": authed_user.username})
+
                 pre_oci_model.update_email(username, user_data["email"], auto_verify=True)
 
             if "enabled" in user_data:
                 # Disable/enable the user.
-                pre_oci_model.update_enabled(username, bool(user_data["enabled"]))
+                enabled = bool(user_data["enabled"])
+
+                authed_user = get_authenticated_user()
+
+                if(enabled):
+                    log_action("user_enable", username, {"username": username, "superuser": authed_user.username})
+                else:
+                    log_action("user_disable", username, {"username": username, "superuser": authed_user.username})
+
+                pre_oci_model.update_enabled(username, enabled)
 
             if "superuser" in user_data:
                 config_object = config_provider.get_config()
@@ -676,8 +699,11 @@ class SuperUserOrganizationManagement(ApiResource):
         """
         if SuperUserPermission().can():
             org_data = request.get_json()
-            old_name = org_data["name"] if "name" in org_data else None
-            org = pre_oci_model.change_organization_name(name, old_name)
+            new_name = org_data["name"] if "name" in org_data else None
+
+            log_action("org_change_name", name, {"old_name": name, "new_name": new_name})
+            
+            org = pre_oci_model.change_organization_name(name, new_name)
             return org.to_dict()
 
         raise Unauthorized()

--- a/endpoints/api/superuser.py
+++ b/endpoints/api/superuser.py
@@ -413,7 +413,11 @@ class SuperUserList(ApiResource):
 
             authed_user = get_authenticated_user()
 
-            log_action("user_create", username, {"email": email, "username": username, "superuser": authed_user.username})
+            log_action(
+                "user_create",
+                username,
+                {"email": email, "username": username, "superuser": authed_user.username},
+            )
 
             if features.MAILING:
                 send_confirmation_email(
@@ -527,7 +531,7 @@ class SuperUserManagement(ApiResource):
                 raise InvalidRequest("Cannot delete a superuser")
 
             log_action("user_delete", username, {"username": username})
-                       
+
             pre_oci_model.mark_user_for_deletion(username)
             return "", 204
 
@@ -550,7 +554,6 @@ class SuperUserManagement(ApiResource):
             if usermanager.is_superuser(username):
                 raise InvalidRequest("Cannot update a superuser")
 
-
             authed_user = get_authenticated_user()
 
             user_data = request.get_json()
@@ -559,7 +562,11 @@ class SuperUserManagement(ApiResource):
                 if app.config["AUTHENTICATION_TYPE"] != "Database":
                     raise InvalidRequest("Cannot change password in non-database auth")
 
-                log_action("user_change_password", username, {"username": username, "superuser": authed_user.username})
+                log_action(
+                    "user_change_password",
+                    username,
+                    {"username": username, "superuser": authed_user.username},
+                )
 
                 pre_oci_model.change_password(username, user_data["password"])
 
@@ -573,7 +580,11 @@ class SuperUserManagement(ApiResource):
 
                 pre_oci_model.update_email(username, user_data["email"], auto_verify=True)
 
-                log_action("user_change_email", username, {"old_email": old_email, "email": new_email, "superuser": authed_user.username})
+                log_action(
+                    "user_change_email",
+                    username,
+                    {"old_email": old_email, "email": new_email, "superuser": authed_user.username},
+                )
 
             if "enabled" in user_data:
                 # Disable/enable the user.
@@ -581,10 +592,18 @@ class SuperUserManagement(ApiResource):
 
                 authed_user = get_authenticated_user()
 
-                if(enabled):
-                    log_action("user_enable", username, {"username": username, "superuser": authed_user.username})
+                if enabled:
+                    log_action(
+                        "user_enable",
+                        username,
+                        {"username": username, "superuser": authed_user.username},
+                    )
                 else:
-                    log_action("user_disable", username, {"username": username, "superuser": authed_user.username})
+                    log_action(
+                        "user_disable",
+                        username,
+                        {"username": username, "superuser": authed_user.username},
+                    )
 
                 pre_oci_model.update_enabled(username, enabled)
 
@@ -707,8 +726,12 @@ class SuperUserOrganizationManagement(ApiResource):
 
             authed_user = get_authenticated_user()
 
-            log_action("org_change_name", name, {"old_name": name, "new_name": new_name, "superuser": authed_user.username})
-            
+            log_action(
+                "org_change_name",
+                name,
+                {"old_name": name, "new_name": new_name, "superuser": authed_user.username},
+            )
+
             org = pre_oci_model.change_organization_name(name, new_name)
             return org.to_dict()
 

--- a/endpoints/api/tag.py
+++ b/endpoints/api/tag.py
@@ -69,8 +69,13 @@ class ListRepositoryTags(RepositoryParamResource):
     @disallow_for_app_repositories
     @parse_args()
     @query_param("specificTag", "Filters the tags to the specific tag.", type=str, default="")
-    @query_param("filter_tag_name", "Syntax: <op>:<name> Filters the tag names based on the operation."
-                                    "<op> can be 'like' or 'eq'.", type=str, default="")
+    @query_param(
+        "filter_tag_name",
+        "Syntax: <op>:<name> Filters the tag names based on the operation."
+        "<op> can be 'like' or 'eq'.",
+        type=str,
+        default="",
+    )
     @query_param(
         "limit", "Limit to the number of results to return per page. Max 100.", type=int, default=50
     )

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -501,7 +501,7 @@ class User(ApiResource):
                         raise request_error(message="Username is already in use")
 
                     user = model.user.change_username(user.id, new_username)
-                    log_action("user_change_username", new_username, {"old_username": old_username})
+                    log_action("user_change_name", new_username, {"old_username": old_username})
                 elif confirm_username:
                     model.user.remove_user_prompt(user, "confirm_username")
 

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -422,19 +422,31 @@ class User(ApiResource):
             if "invoice_email" in user_data:
                 logger.debug("Changing invoice_email for user: %s", user.username)
                 model.user.change_send_invoice_email(user, user_data["invoice_email"])
-                log_action("user_change_invoicing", user.username, {"invoice_email": user_data["invoice_email"]})
+                log_action(
+                    "user_change_invoicing",
+                    user.username,
+                    {"invoice_email": user_data["invoice_email"]},
+                )
 
             if features.CHANGE_TAG_EXPIRATION and "tag_expiration_s" in user_data:
                 logger.debug("Changing user tag expiration to: %ss", user_data["tag_expiration_s"])
                 model.user.change_user_tag_expiration(user, user_data["tag_expiration_s"])
-                log_action("user_change_tag_expiration", user.username, {"tag_expiration": user_data["tag_expiration_s"]})
+                log_action(
+                    "user_change_tag_expiration",
+                    user.username,
+                    {"tag_expiration": user_data["tag_expiration_s"]},
+                )
 
             if (
                 "invoice_email_address" in user_data
                 and user_data["invoice_email_address"] != user.invoice_email_address
             ):
                 model.user.change_invoice_email_address(user, user_data["invoice_email_address"])
-                log_action("user_change_invoicing", user.username, {"invoice_email_address": user_data["invoice_email_address"]})
+                log_action(
+                    "user_change_invoicing",
+                    user.username,
+                    {"invoice_email_address": user_data["invoice_email_address"]},
+                )
 
             if "email" in user_data and user_data["email"] != user.email:
                 new_email = user_data["email"]
@@ -453,7 +465,11 @@ class User(ApiResource):
                     send_change_email(user.username, user_data["email"], confirmation_code)
                 else:
                     model.user.update_email(user, new_email, auto_verify=not features.MAILING)
-                    log_action("user_change_email", user.username, {"email": new_email, "old_email": old_email})
+                    log_action(
+                        "user_change_email",
+                        user.username,
+                        {"email": new_email, "old_email": old_email},
+                    )
 
             if features.USER_METADATA:
                 metadata = {}
@@ -556,7 +572,11 @@ class User(ApiResource):
                 prompts=prompts,
             )
 
-            log_action("user_create", user_data["username"], {"email": user_data.get("email"), "username": user_data["username"]})
+            log_action(
+                "user_create",
+                user_data["username"],
+                {"email": user_data.get("email"), "username": user_data["username"]},
+            )
 
             email_address_confirmed = handle_invite_code(invite_code, new_user)
             if features.MAILING and not email_address_confirmed:
@@ -582,7 +602,6 @@ class User(ApiResource):
         """
         if app.config["AUTHENTICATION_TYPE"] != "Database":
             abort(404)
-
 
         authed_user = get_authenticated_user()
 

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -405,10 +405,11 @@ class User(ApiResource):
         try:
             if "password" in user_data:
                 logger.debug("Changing password for user: %s", user.username)
-                log_action("account_change_password", user.username)
 
                 # Change the user's password.
                 model.user.change_password(user, user_data["password"])
+
+                log_action("account_change_password", user.username)
 
                 # Login again to reset their session cookie.
                 success, headers = common_login(user.uuid)
@@ -421,19 +422,23 @@ class User(ApiResource):
             if "invoice_email" in user_data:
                 logger.debug("Changing invoice_email for user: %s", user.username)
                 model.user.change_send_invoice_email(user, user_data["invoice_email"])
+                log_action("user_change_invoicing", user.username, {"invoice_email": user_data["invoice_email"]})
 
             if features.CHANGE_TAG_EXPIRATION and "tag_expiration_s" in user_data:
                 logger.debug("Changing user tag expiration to: %ss", user_data["tag_expiration_s"])
                 model.user.change_user_tag_expiration(user, user_data["tag_expiration_s"])
+                log_action("user_change_tag_expiration", user.username, {"tag_expiration": user_data["tag_expiration_s"]})
 
             if (
                 "invoice_email_address" in user_data
                 and user_data["invoice_email_address"] != user.invoice_email_address
             ):
                 model.user.change_invoice_email_address(user, user_data["invoice_email_address"])
+                log_action("user_change_invoicing", user.username, {"invoice_email_address": user_data["invoice_email_address"]})
 
             if "email" in user_data and user_data["email"] != user.email:
                 new_email = user_data["email"]
+                old_email = user.email
                 if model.user.find_user_by_email(new_email):
                     # Email already used.
                     raise request_error(message="E-mail address already used")
@@ -448,6 +453,7 @@ class User(ApiResource):
                     send_change_email(user.username, user_data["email"], confirmation_code)
                 else:
                     model.user.update_email(user, new_email, auto_verify=not features.MAILING)
+                    log_action("user_change_email", user.username, {"email": new_email, "old_email": old_email})
 
             if features.USER_METADATA:
                 metadata = {}
@@ -458,12 +464,14 @@ class User(ApiResource):
 
                 if len(metadata) > 0:
                     model.user.update_user_metadata(user, metadata)
+                    log_action("user_change_metadata", user.username, metadata)
 
             # Check for username rename. A username can be renamed if the feature is enabled OR the user
             # currently has a confirm_username prompt.
             if "username" in user_data:
                 confirm_username = model.user.has_user_prompt(user, "confirm_username")
                 new_username = user_data.get("username")
+                old_username = user.username
                 previous_username = user.username
 
                 rename_allowed = features.USER_RENAME or (
@@ -477,6 +485,7 @@ class User(ApiResource):
                         raise request_error(message="Username is already in use")
 
                     user = model.user.change_username(user.id, new_username)
+                    log_action("user_change_username", new_username, {"old_username": old_username})
                 elif confirm_username:
                     model.user.remove_user_prompt(user, "confirm_username")
 
@@ -547,6 +556,8 @@ class User(ApiResource):
                 prompts=prompts,
             )
 
+            log_action("user_create", user_data["username"], {"email": user_data.get("email"), "username": user_data["username"]})
+
             email_address_confirmed = handle_invite_code(invite_code, new_user)
             if features.MAILING and not email_address_confirmed:
                 confirmation_code = model.user.create_confirm_email_code(new_user)
@@ -572,9 +583,17 @@ class User(ApiResource):
         if app.config["AUTHENTICATION_TYPE"] != "Database":
             abort(404)
 
+
+        authed_user = get_authenticated_user()
+
         model.user.mark_namespace_for_deletion(
             get_authenticated_user(), all_queues, namespace_gc_queue
         )
+
+        deleted_user = model.user.get_user_by_id(authed_user.id)
+
+        log_action("user_delete", deleted_user.username, {"username": authed_user.username})
+
         return "", 204
 
 
@@ -644,6 +663,8 @@ class ClientKey(ApiResource):
         (result, error_message) = authentication.confirm_existing_user(username, password)
         if not result:
             raise request_error(message=error_message)
+
+        log_action("user_generate_client_key", username)
 
         return {"key": authentication.encrypt_user_password(password).decode("ascii")}
 

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -542,7 +542,9 @@ def confirm_email():
         user, new_email, old_email = model.user.confirm_user_email(code)
 
         if new_email and old_email:
-            log_action("user_change_email", user.username, {"email": new_email, "old_email": old_email})
+            log_action(
+                "user_change_email", user.username, {"email": new_email, "old_email": old_email}
+            )
     except model.DataModelException as ex:
         return index("", error_info=dict(reason="confirmerror", error_message=str(ex)))
 

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -20,6 +20,7 @@ from flask import (
 )
 
 from flask_login import current_user
+from endpoints.api import log_action
 
 import features
 
@@ -539,6 +540,9 @@ def confirm_email():
 
     try:
         user, new_email, old_email = model.user.confirm_user_email(code)
+
+        if new_email and old_email:
+            log_action("user_change_email", user.username, {"email": new_email, "old_email": old_email})
     except model.DataModelException as ex:
         return index("", error_info=dict(reason="confirmerror", error_message=str(ex)))
 

--- a/initdb.py
+++ b/initdb.py
@@ -360,6 +360,8 @@ def initialize_database():
 
     LogEntryKind.create(name="build_dockerfile")
 
+    LogEntryKind.create(name="org_create")
+    LogEntryKind.create(name="org_delete")
     LogEntryKind.create(name="org_create_team")
     LogEntryKind.create(name="org_delete_team")
     LogEntryKind.create(name="org_invite_team_member")
@@ -370,6 +372,9 @@ def initialize_database():
     LogEntryKind.create(name="org_remove_team_member")
     LogEntryKind.create(name="org_set_team_description")
     LogEntryKind.create(name="org_set_team_role")
+    LogEntryKind.create(name="org_change_email")
+    LogEntryKind.create(name="org_change_invoicing")
+    LogEntryKind.create(name="org_change_tag_expiration")
 
     LogEntryKind.create(name="create_prototype_permission")
     LogEntryKind.create(name="modify_prototype_permission")

--- a/initdb.py
+++ b/initdb.py
@@ -332,6 +332,13 @@ def initialize_database():
     AccessTokenKind.create(name="build-worker")
     AccessTokenKind.create(name="pushpull-token")
 
+    LogEntryKind.create(name="user_create")
+    LogEntryKind.create(name="user_delete")
+    LogEntryKind.create(name="user_disable")
+    LogEntryKind.create(name="user_enable")
+    LogEntryKind.create(name="user_change_email")
+    LogEntryKind.create(name="user_change_password")
+
     LogEntryKind.create(name="account_change_plan")
     LogEntryKind.create(name="account_change_cc")
     LogEntryKind.create(name="account_change_password")
@@ -375,6 +382,7 @@ def initialize_database():
     LogEntryKind.create(name="org_change_email")
     LogEntryKind.create(name="org_change_invoicing")
     LogEntryKind.create(name="org_change_tag_expiration")
+    LogEntryKind.create(name="org_change_name")
 
     LogEntryKind.create(name="create_prototype_permission")
     LogEntryKind.create(name="modify_prototype_permission")

--- a/initdb.py
+++ b/initdb.py
@@ -338,6 +338,11 @@ def initialize_database():
     LogEntryKind.create(name="user_enable")
     LogEntryKind.create(name="user_change_email")
     LogEntryKind.create(name="user_change_password")
+    LogEntryKind.create(name="user_change_name")
+    LogEntryKind.create(name="user_change_invoicing")
+    LogEntryKind.create(name="user_change_tag_expiration")
+    LogEntryKind.create(name="user_change_metadata")
+    LogEntryKind.create(name="user_generate_client_key")
 
     LogEntryKind.create(name="account_change_plan")
     LogEntryKind.create(name="account_change_cc")

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -63,6 +63,48 @@ angular.module('quay').directive('logsView', function () {
       };
 
       var logDescriptions = {
+        'user_create': function(metadata) {
+          if(metadata.superuser) {
+            return '[Superuser] {superuser} created user {username}';
+          } else {
+            return 'User {username} created';
+          }
+        },
+        'user_delete': function(metadata) {
+          if(metadata.superuser) {
+            return '[Superuser] {superuser} deleted user {username}';
+          } else {
+            return 'User {username} deleted';
+          }
+        },
+        'user_enable': function(metadata) {
+          if(metadata.superuser) {
+            return '[Superuser] {superuser} enabled user {username}';
+          } else {
+            return 'User {username} enabled';
+          }
+        },
+        'user_disable': function(metadata) {
+          if(metadata.superuser) {
+            return '[Superuser] {superuser} disabled user {username}';
+          } else {
+            return 'User {username} disabled';
+          }
+        },
+        'user_change_password': function(metadata) {
+          if(metadata.superuser) {
+            return '[Superuser] {superuser} changed password of user {username}';
+          } else {
+            return 'User {username} changed password';
+          }
+        },
+        'user_change_email': function(metadata) {
+          if(metadata.superuser) {
+            return '[Superuser] {superuser} changed email of user {username} to {email}';
+          } else {
+            return 'User {username} changed email to {email}';
+          }
+        },
         'account_change_plan': 'Change plan',
         'account_change_cc': 'Update credit card',
         'account_change_password': 'Change password',
@@ -251,8 +293,8 @@ angular.module('quay').directive('logsView', function () {
           }
           return 'Build from Dockerfile[[ for repository {namespace}/{repo}]]';
         },
-        'org_create': 'Create Organization {namespace}',
-        'org_delete': 'Delete Organization {namespace}',
+        'org_create': 'Organization {namespace} created',
+        'org_delete': 'Organization {namespace} deleted',
         'org_change_email': 'Change organization email {email}',
         'org_change_invoicing': function(metadata) {
           if (metadata.invoice_email) {
@@ -367,9 +409,9 @@ angular.module('quay').directive('logsView', function () {
 
         'take_ownership': function(metadata) {
           if (metadata.was_user) {
-            return '[Superuser ]{superuser} took ownership of user namespace {namespace}';
+            return '[Superuser] {superuser} took ownership of user namespace {namespace}';
           } else {
-            return '[Superuser ]{superuser} took ownership of organization {namespace}';
+            return '[Superuser] {superuser} took ownership of organization {namespace}';
           }
         },
 

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -251,6 +251,19 @@ angular.module('quay').directive('logsView', function () {
           }
           return 'Build from Dockerfile[[ for repository {namespace}/{repo}]]';
         },
+        'org_create': 'Create Organization {namespace}',
+        'org_delete': 'Delete Organization {namespace}',
+        'org_change_email': 'Change organization email {email}',
+        'org_change_invoicing': function(metadata) {
+          if (metadata.invoice_email) {
+            return 'Enabled email invoicing';
+          } else if(metadata.invoice_email_address) {
+            return 'Set email invoicing address to {invoice_email_address}';
+          } else {
+            return 'Disabled email invoicing';
+          }
+        },
+        'org_change_tag_expiration': 'Change time machine window to {tag_expiration}',
         'org_create_team': 'Create team {team}',
         'org_delete_team': 'Delete team {team}',
         'org_add_team_member': 'Add member {member} to team {team}',
@@ -424,6 +437,11 @@ angular.module('quay').directive('logsView', function () {
         'create_tag': 'Create Tag',
         'move_tag': 'Move Tag',
         'revert_tag':'Restore Tag',
+        'org_create': 'Create organization',
+        'org_delete': 'Delete organization',
+        'org_change_email': 'Change organization email',
+        'org_change_invoicing': 'Change organization invoicing',
+        'org_change_tag_expiration': 'Change time machine window',
         'org_create_team': 'Create team',
         'org_delete_team': 'Delete team',
         'org_add_team_member': 'Add team member',

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -65,46 +65,65 @@ angular.module('quay').directive('logsView', function () {
       var logDescriptions = {
         'user_create': function(metadata) {
           if(metadata.superuser) {
-            return '[Superuser] {superuser} created user {username}';
+            return 'Superuser {superuser} created user {username}';
           } else {
             return 'User {username} created';
           }
         },
         'user_delete': function(metadata) {
           if(metadata.superuser) {
-            return '[Superuser] {superuser} deleted user {username}';
+            return 'Superuser {superuser} deleted user {username}';
           } else {
             return 'User {username} deleted';
           }
         },
         'user_enable': function(metadata) {
           if(metadata.superuser) {
-            return '[Superuser] {superuser} enabled user {username}';
+            return 'Superuser {superuser} enabled user {username}';
           } else {
             return 'User {username} enabled';
           }
         },
         'user_disable': function(metadata) {
           if(metadata.superuser) {
-            return '[Superuser] {superuser} disabled user {username}';
+            return 'Superuser {superuser} disabled user {username}';
           } else {
             return 'User {username} disabled';
           }
         },
         'user_change_password': function(metadata) {
           if(metadata.superuser) {
-            return '[Superuser] {superuser} changed password of user {username}';
+            return 'Superuser {superuser} changed password of user {username}';
           } else {
             return 'User {username} changed password';
           }
         },
         'user_change_email': function(metadata) {
           if(metadata.superuser) {
-            return '[Superuser] {superuser} changed email of user {username} to {email}';
+            return 'Superuser {superuser} changed email from {old_email} to {email}';
           } else {
-            return 'User {username} changed email to {email}';
+            return 'Changed email from {old_email} to {email}';
           }
         },
+        'user_change_name': function(metadata) {
+          if(metadata.superuser) {
+            return 'Superuser {superuser} renamed user {old_username} to {username}';
+          } else {
+            return 'User {old_username} changed name to {username}';
+          }
+        },
+        'user_change_invoicing': function(metadata) {
+          if (metadata.invoice_email) {
+            return 'Enabled email invoicing';
+          } else if(metadata.invoice_email_address) {
+            return 'Set email invoicing address to {invoice_email_address}';
+          } else {
+            return 'Disabled email invoicing';
+          }
+        },
+        'user_generate_client_key': "Generated Docker CLI password",
+        'user_change_metadata': "User changed metadata",
+        'user_change_tag_expiration': "Change time machine window to {tag_expiration}",
         'account_change_plan': 'Change plan',
         'account_change_cc': 'Update credit card',
         'account_change_password': 'Change password',
@@ -295,7 +314,7 @@ angular.module('quay').directive('logsView', function () {
         },
         'org_create': 'Organization {namespace} created',
         'org_delete': 'Organization {namespace} deleted',
-        'org_change_email': 'Change organization email {email}',
+        'org_change_email': 'Change organization email from {old_email} to {email}',
         'org_change_invoicing': function(metadata) {
           if (metadata.invoice_email) {
             return 'Enabled email invoicing';
@@ -306,6 +325,13 @@ angular.module('quay').directive('logsView', function () {
           }
         },
         'org_change_tag_expiration': 'Change time machine window to {tag_expiration}',
+        'org_change_name': function(metadata) {
+          if (metadata.superuser) {
+            return 'Superuser {superuser} renamed organization from {old_name} to {new_name}';
+          } else {
+            return 'Organization renamed from {old_name} to {new_name}';
+          }
+        },
         'org_create_team': 'Create team {team}',
         'org_delete_team': 'Delete team {team}',
         'org_add_team_member': 'Add member {member} to team {team}',
@@ -409,9 +435,9 @@ angular.module('quay').directive('logsView', function () {
 
         'take_ownership': function(metadata) {
           if (metadata.was_user) {
-            return '[Superuser] {superuser} took ownership of user namespace {namespace}';
+            return 'Superuser {superuser} took ownership of user namespace {namespace}';
           } else {
-            return '[Superuser] {superuser} took ownership of organization {namespace}';
+            return 'Superuser {superuser} took ownership of organization {namespace}';
           }
         },
 
@@ -456,6 +482,17 @@ angular.module('quay').directive('logsView', function () {
 };
 
       var logKinds = {
+        'user_create': 'Create user',
+        'user_delete': 'Delete user',
+        'user_disable': 'Disable user',
+        'user_enable': 'Enable user',
+        'user_change_password': 'Change user password',
+        'user_change_email': 'Change user email',
+        'user_change_name': 'Change user name',
+        'user_change_invoicing': 'Change user invoicing',
+        'user_change_tag_expiration': 'Change time machine window',
+        'user_change_metadata': 'Change user metadata',
+        'user_generate_client_key': 'Generate Docker CLI password',
         'account_change_plan': 'Change plan',
         'account_change_cc': 'Update credit card',
         'account_change_password': 'Change password',
@@ -484,6 +521,7 @@ angular.module('quay').directive('logsView', function () {
         'org_change_email': 'Change organization email',
         'org_change_invoicing': 'Change organization invoicing',
         'org_change_tag_expiration': 'Change time machine window',
+        'org_change_name': 'Change organization name',
         'org_create_team': 'Create team',
         'org_delete_team': 'Delete team',
         'org_add_team_member': 'Add team member',

--- a/static/js/services/string-builder-service.js
+++ b/static/js/services/string-builder-service.js
@@ -26,7 +26,8 @@ angular.module('quay').factory('StringBuilderService', ['$sce', 'UtilService', f
     'original_image': 'archive',
     'client_id': 'chain',
     'manifest_digest': 'link',
-    'tag_expiration': 'clock-o'
+    'tag_expiration': 'clock-o',
+    'namespace': 'sitemap',
   };
 
   var allowMarkdown = {

--- a/static/js/services/string-builder-service.js
+++ b/static/js/services/string-builder-service.js
@@ -9,6 +9,7 @@ angular.module('quay').factory('StringBuilderService', ['$sce', 'UtilService', f
     'username': 'user',
     'user': 'user',
     'email': 'envelope',
+    'invoice_email_address': 'envelope',
     'activating_username': 'user',
     'delegate_user': 'user',
     'delegate_team': 'group',
@@ -24,7 +25,8 @@ angular.module('quay').factory('StringBuilderService', ['$sce', 'UtilService', f
     'image': 'archive',
     'original_image': 'archive',
     'client_id': 'chain',
-    'manifest_digest': 'link'
+    'manifest_digest': 'link',
+    'tag_expiration': 'clock-o'
   };
 
   var allowMarkdown = {
@@ -60,6 +62,32 @@ angular.module('quay').factory('StringBuilderService', ['$sce', 'UtilService', f
 
     'old_expiration_date': function(value) {
       return moment.unix(value).format('LLL');
+    },
+
+    'tag_expiration': function(value) {
+      const duration = moment.duration(value, 'seconds');
+      const weeks = Math.floor(duration.asWeeks());
+      const days = Math.floor(duration.asDays()) % 7;
+      const hours = duration.hours();
+      const minutes = duration.minutes();
+      const remainingSeconds = duration.seconds();
+      const parts = [];
+      if (weeks) {
+        parts.push(`${weeks}w`);
+      }
+      if (days) {
+        parts.push(`${days}d`);
+      }
+      if (hours) {
+        parts.push(`${hours}h`);
+      }
+      if (minutes) {
+        parts.push(`${minutes}m`);
+      }
+      if (remainingSeconds) {
+        parts.push(`${remainingSeconds}s`);
+      }
+      return parts.length ? parts.join(' ') : '0s';
     }
   };
 

--- a/static/js/services/string-builder-service.js
+++ b/static/js/services/string-builder-service.js
@@ -7,8 +7,11 @@ angular.module('quay').factory('StringBuilderService', ['$sce', 'UtilService', f
   var fieldIcons = {
     'inviter': 'user',
     'username': 'user',
+    'old_username': 'user',
+    'superuser': 'user-secret',
     'user': 'user',
     'email': 'envelope',
+    'old_email': 'envelope',
     'invoice_email_address': 'envelope',
     'activating_username': 'user',
     'delegate_user': 'user',
@@ -27,7 +30,12 @@ angular.module('quay').factory('StringBuilderService', ['$sce', 'UtilService', f
     'client_id': 'chain',
     'manifest_digest': 'link',
     'tag_expiration': 'clock-o',
+    'expiration_date': 'calendar',
+    'old_expiration_date': 'calendar',
     'namespace': 'sitemap',
+    'old_name': 'sitemap',
+    'new_name': 'sitemap',
+    'app_specific_token_title': 'key'
   };
 
   var allowMarkdown = {


### PR DESCRIPTION
This adds several new action log event types, entries and corresponding UI support for the following activities:

- user/organization creation
- user/organization deletion
- user enable / disable via superuser
- organization rename via superuser
- change of an user/organization's email address, invoicing and time machine settings
- change of a users's password
- user creation via registration
- user Docker CLI password generation

Changes have been tested and verified with the table-based log model as well as the log list view UI.

<img width="1134" alt="Screenshot 2023-04-28 at 10 45 28" src="https://user-images.githubusercontent.com/12664117/235351785-ff571ce8-9740-4c81-8928-5aa94368da61.png">
<img width="1397" alt="Screenshot 2023-04-28 at 12 20 53" src="https://user-images.githubusercontent.com/12664117/235351787-70f4e0f5-d4cf-49ae-a808-5deacf29d1d3.png">
<img width="1248" alt="Screenshot 2023-04-29 at 22 12 11" src="https://user-images.githubusercontent.com/12664117/235351789-124745f7-885f-4c74-b2e9-eade5f554df9.png">