### PR TITLE
logs: add audit log events for login/logout to Quay (PROJQUAY-2344)

### DIFF
--- a/config.py
+++ b/config.py
@@ -436,6 +436,9 @@ class DefaultConfig(ImmutableConfig):
     LOG_ARCHIVE_LOCATION = "local_us"
     LOG_ARCHIVE_PATH = "logarchive/"
 
+    # Action logs configuration for advanced events
+    ACTION_LOG_AUDIT_LOGINS = True
+
     # Action logs archive
     ACTION_LOG_ARCHIVE_LOCATION: Optional[str] = "local_us"
     ACTION_LOG_ARCHIVE_PATH: Optional[str] = "actionlogarchive/"

--- a/data/migrations/versions/0246c2d0e750_add_login_logout_logentrykind.py
+++ b/data/migrations/versions/0246c2d0e750_add_login_logout_logentrykind.py
@@ -1,0 +1,33 @@
+"""add login logout logentrykind
+
+Revision ID: 0246c2d0e750
+Revises: a648ab200ab7
+Create Date: 2023-05-4 09:44:57.391686
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "0246c2d0e750"
+down_revision = "a648ab200ab7"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.bulk_insert(
+        tables.logentrykind,
+        [
+            {"name": "login_success"},
+            {"name": "logout_success"},
+        ],
+    )
+
+
+def downgrade(op, tables, tester):
+    op.execute(
+        tables.logentrykind.delete().where(
+            tables.logentrykind.name
+            == op.inline_literal("login_success") | tables.logentrykind.name
+            == op.inline_literal("logout_success")
+        )
+    )

--- a/data/migrations/versions/0246c2d0e750_add_login_logout_logentrykind.py
+++ b/data/migrations/versions/0246c2d0e750_add_login_logout_logentrykind.py
@@ -1,14 +1,14 @@
 """add login logout logentrykind
 
 Revision ID: 0246c2d0e750
-Revises: a648ab200ab7
+Revises: 43fea47d641f
 Create Date: 2023-05-4 09:44:57.391686
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "0246c2d0e750"
-down_revision = "a648ab200ab7"
+down_revision = "43fea47d641f"
 
 import sqlalchemy as sa
 

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -713,7 +713,6 @@ def conduct_signin(username_or_email, password, invite_code=None):
                 found_user.username,
                 {
                     "type": "quayauth",
-                    "ip": get_request_ip(),
                     "useragent": request.user_agent.string,
                 },
             )

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -711,7 +711,11 @@ def conduct_signin(username_or_email, password, invite_code=None):
             log_action(
                 "login_success",
                 found_user.username,
-                {"type": "quayauth", "ip": get_request_ip(), "useragent": request.user_agent.string}
+                {
+                    "type": "quayauth",
+                    "ip": get_request_ip(),
+                    "useragent": request.user_agent.string,
+                },
             )
             return {"success": True}, 200, headers
         else:

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -708,14 +708,15 @@ def conduct_signin(username_or_email, password, invite_code=None):
 
         success, headers = common_login(found_user.uuid)
         if success:
-            log_action(
-                "login_success",
-                found_user.username,
-                {
-                    "type": "quayauth",
-                    "useragent": request.user_agent.string,
-                },
-            )
+            if app.config.get("ACTION_LOG_AUDIT_LOGINS"):
+                log_action(
+                    "login_success",
+                    found_user.username,
+                    {
+                        "type": "quayauth",
+                        "useragent": request.user_agent.string,
+                    },
+                )
             return {"success": True}, 200, headers
         else:
             needs_email_verification = True

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -708,6 +708,11 @@ def conduct_signin(username_or_email, password, invite_code=None):
 
         success, headers = common_login(found_user.uuid)
         if success:
+            log_action(
+                "login_success",
+                found_user.username,
+                {"type": "quayauth", "ip": get_request_ip(), "useragent": request.user_agent.string}
+            )
             return {"success": True}, 200, headers
         else:
             needs_email_verification = True
@@ -909,8 +914,9 @@ class Signout(ApiResource):
         """
         Request that the current user be signed out.
         """
+        user = get_authenticated_user()
         # Invalidate all sessions for the user.
-        model.user.invalidate_all_sessions(get_authenticated_user())
+        model.user.invalidate_all_sessions(user)
 
         # Clear out the user's identity.
         identity_changed.send(app, identity=AnonymousIdentity())
@@ -918,6 +924,8 @@ class Signout(ApiResource):
         # Remove the user's session cookie.
         logout_user()
 
+        if user:
+            log_action("logout_success", user.username)
         return {"success": True}
 
 

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -37,7 +37,6 @@ from notifications import spawn_notification
 from util.audit import track_and_log
 from util.http import abort
 from util.names import REPOSITORY_NAME_REGEX
-from util.request import get_request_ip
 
 logger = logging.getLogger(__name__)
 

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -140,10 +140,10 @@ def create_user():
         # Mark that the user was logged in.
         log_action(
             "login_success",
-            username,
+            result.authed_user.username,
             {"type": "quayauth", "ip": get_request_ip(), "useragent": request.user_agent.string},
         )
-        event = userevents.get_event(username)
+        event = userevents.get_event(result.authed_user.username)
         event.publish_event_data("docker-cli", {"action": "login"})
 
     return success

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -138,7 +138,11 @@ def create_user():
 
     if result.has_nonrobot_user:
         # Mark that the user was logged in.
-        log_action("login_success", username, {"type": "quayauth", "ip": get_request_ip(), "useragent": request.user_agent.string})
+        log_action(
+            "login_success",
+            username,
+            {"type": "quayauth", "ip": get_request_ip(), "useragent": request.user_agent.string},
+        )
         event = userevents.get_event(username)
         event.publish_event_data("docker-cli", {"action": "login"})
 

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -23,6 +23,7 @@ from auth.signedgrant import generate_signed_token
 from data import model
 from data.registry_model import registry_model
 from data.registry_model.manifestbuilder import create_manifest_builder, lookup_manifest_builder
+from endpoints.api import log_action
 from endpoints.decorators import (
     anon_protect,
     anon_allowed,
@@ -36,6 +37,7 @@ from notifications import spawn_notification
 from util.audit import track_and_log
 from util.http import abort
 from util.names import REPOSITORY_NAME_REGEX
+from util.request import get_request_ip
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +138,7 @@ def create_user():
 
     if result.has_nonrobot_user:
         # Mark that the user was logged in.
+        log_action("login_success", username, {"type": "quayauth", "ip": get_request_ip(), "useragent": request.user_agent.string})
         event = userevents.get_event(username)
         event.publish_event_data("docker-cli", {"action": "login"})
 

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -143,7 +143,7 @@ def create_user():
             result.authed_user.username,
             {"type": "quayauth", "ip": get_request_ip(), "useragent": request.user_agent.string},
         )
-        event = userevents.get_event(result.authed_user.username)
+        event = userevents.get_event(username)
         event.publish_event_data("docker-cli", {"action": "login"})
 
     return success

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -7,7 +7,7 @@ from functools import wraps
 from flask import request, make_response, jsonify, session
 
 import features
-from app import userevents, storage, docker_v2_signing_key
+from app import app, userevents, storage, docker_v2_signing_key
 from auth.auth_context import get_authenticated_context, get_authenticated_user
 from auth.credentials import validate_credentials, CredentialKind
 from auth.decorators import process_auth
@@ -137,11 +137,12 @@ def create_user():
 
     if result.has_nonrobot_user:
         # Mark that the user was logged in.
-        log_action(
-            "login_success",
-            result.authed_user.username,
-            {"type": "quayauth", "useragent": request.user_agent.string},
-        )
+        if app.config.get("ACTION_LOG_AUDIT_LOGINS"):
+            log_action(
+                "login_success",
+                result.authed_user.username,
+                {"type": "quayauth", "useragent": request.user_agent.string},
+            )
         event = userevents.get_event(username)
         event.publish_event_data("docker-cli", {"action": "login"})
 

--- a/endpoints/v1/index.py
+++ b/endpoints/v1/index.py
@@ -141,7 +141,7 @@ def create_user():
         log_action(
             "login_success",
             result.authed_user.username,
-            {"type": "quayauth", "ip": get_request_ip(), "useragent": request.user_agent.string},
+            {"type": "quayauth", "useragent": request.user_agent.string},
         )
         event = userevents.get_event(username)
         event.publish_event_data("docker-cli", {"action": "login"})

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -134,7 +134,7 @@ def generate_registry_jwt(auth_result):
             log_action(
                 "login_success",
                 user.username,
-                {"type": "v2auth", "ip": get_request_ip(), "useragent": request.user_agent.string},
+                {"type": "v2auth", "useragent": request.user_agent.string},
             )
         event = userevents.get_event(user.username)
         event.publish_event_data("docker-cli", user_event_data)

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -135,7 +135,7 @@ def generate_registry_jwt(auth_result):
     # Send the user event.
     user = get_authenticated_user()
     if user is not None:
-        if is_login_event:
+        if is_login_event and app.config.get("ACTION_LOG_AUDIT_LOGINS"):
             metadata = {}
             context = get_authenticated_context()
 

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -136,10 +136,27 @@ def generate_registry_jwt(auth_result):
     user = get_authenticated_user()
     if user is not None:
         if is_login_event:
+            metadata = {}
+            context = get_authenticated_context()
+
+            if context.appspecifictoken is not None:
+                metadata["kind"] = "app_specific_token"
+                metadata["app_specific_token_title"] = context.appspecifictoken.title
+
+            if context.robot is not None:
+                metadata["kind"] = "robot"
+                metadata["robot"] = context.robot.username
+
+            if context.user is not None:
+                metadata["kind"] = "user"
+
+            metadata["type"] = "v2auth"
+            metadata["useragent"] = request.user_agent.string
+
             log_action(
                 "login_success",
                 user.username if not user.robot else parse_robot_username(user.username)[0],
-                {"type": "v2auth", "useragent": request.user_agent.string},
+                metadata=metadata,
             )
         event = userevents.get_event(user.username)
         event.publish_event_data("docker-cli", user_event_data)

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -134,7 +134,7 @@ def generate_registry_jwt(auth_result):
         if user_event_data["action"] == "login":
             log_action(
                 "login_success",
-                user.username if not user.robot else parse_robot_username(user.username)[0] ,
+                user.username if not user.robot else parse_robot_username(user.username)[0],
                 {"type": "v2auth", "useragent": request.user_agent.string},
             )
         event = userevents.get_event(user.username)

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -131,7 +131,11 @@ def generate_registry_jwt(auth_result):
     user = get_authenticated_user()
     if user is not None:
         if user_event_data["action"] == "login":
-            log_action("login_success", user.username, {"type": "v2auth", "ip": get_request_ip() , "useragent": request.user_agent.string})
+            log_action(
+                "login_success",
+                user.username,
+                {"type": "v2auth", "ip": get_request_ip(), "useragent": request.user_agent.string},
+            )
         event = userevents.get_event(user.username)
         event.publish_event_data("docker-cli", user_event_data)
 

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -128,10 +128,14 @@ def generate_registry_jwt(auth_result):
             "repository": scope_results[0].repository,
         }
 
+    # determine if this is solely a login event
+    # need to use scope_params here since scope_results could be empty in case of lack of permissions
+    is_login_event = user_event_data["action"] == "login" and len(scope_params) == 0
+
     # Send the user event.
     user = get_authenticated_user()
     if user is not None:
-        if user_event_data["action"] == "login":
+        if is_login_event:
             log_action(
                 "login_success",
                 user.username if not user.robot else parse_robot_username(user.username)[0],

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -37,6 +37,7 @@ from util.names import (
     parse_namespace_repository,
     REPOSITORY_NAME_REGEX,
     REPOSITORY_NAME_EXTENDED_REGEX,
+    parse_robot_username,
 )
 from util.request import get_request_ip
 from util.security.registry_jwt import (
@@ -133,7 +134,7 @@ def generate_registry_jwt(auth_result):
         if user_event_data["action"] == "login":
             log_action(
                 "login_success",
-                user.username,
+                user.username if not user.robot else parse_robot_username(user.username)[0] ,
                 {"type": "v2auth", "useragent": request.user_agent.string},
             )
         event = userevents.get_event(user.username)

--- a/initdb.py
+++ b/initdb.py
@@ -450,6 +450,9 @@ def initialize_database():
     LogEntryKind.create(name="start_build_trigger")
     LogEntryKind.create(name="cancel_build")
 
+    LogEntryKind.create(name="login_success")
+    LogEntryKind.create(name="logout_success")
+
     ImageStorageLocation.create(name="local_eu")
     ImageStorageLocation.create(name="local_us")
 

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -480,12 +480,12 @@ angular.module('quay').directive('logsView', function () {
         },
         'cancel_build': 'Cancel build {build_uuid}',
         'login_success': function(metadata) {
-          var useragent_short = metadata.useragent.substring(0, 20)+ '...';
+          metadata["useragent"] = metadata.useragent.substring(0, 64)+ '...';
 
           if (metadata.type == 'v2auth') {
-            return 'Login to registry[[ with user-agent {useragent_short}]]';
+            return 'Login to registry[[ with user-agent {useragent}]]';
           } else {
-            return 'Login to Quay[[ with user-agent {useragent_short}]]';
+            return 'Login to Quay[[ with user-agent {useragent}]]';
           }
         },
         'logout_success': 'Logout from Quay',

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -584,6 +584,7 @@ angular.module('quay').directive('logsView', function () {
         'delete_proxy_cache_config': 'Delete Proxy Cache Config',
         'start_build_trigger': 'Manual build trigger',
         'cancel_build': 'Cancel build',
+        'login_success': 'Login success',
 
         // Note: these are deprecated.
         'add_repo_webhook': 'Add webhook',

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -480,10 +480,12 @@ angular.module('quay').directive('logsView', function () {
         },
         'cancel_build': 'Cancel build {build_uuid}',
         'login_success': function(metadata) {
+          var useragent_short = metadata.useragent.substring(0, 20)+ '...';
+
           if (metadata.type == 'v2auth') {
-            return 'Login to registry[[ from IP {ip} and user-agent {useragent}]]';
+            return 'Login to registry[[ with user-agent {useragent_short}]]';
           } else {
-            return 'Login to Quay[[ from IP {ip} and user-agent {useragent}]]';
+            return 'Login to Quay[[ with user-agent {useragent_short}]]';
           }
         },
         'logout_success': 'Logout from Quay',

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -478,7 +478,15 @@ angular.module('quay').directive('logsView', function () {
             metadata['service'], metadata['config']);
           return 'Manually start build from trigger[[ - ' + triggerDescription + ']]';
         },
-        'cancel_build': 'Cancel build {build_uuid}'
+        'cancel_build': 'Cancel build {build_uuid}',
+        'login_success': function(metadata) {
+          if (metadata.type == 'v2auth') {
+            return 'Login to registry[[ from IP {ip} and user-agent {useragent}]]';
+          } else {
+            return 'Login to Quay[[ from IP {ip} and user-agent {useragent}]]';
+          }
+        },
+        'logout_success': 'Logout from Quay',
 };
 
       var logKinds = {

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -483,7 +483,16 @@ angular.module('quay').directive('logsView', function () {
           metadata["useragent"] = metadata.useragent.substring(0, 64)+ '...';
 
           if (metadata.type == 'v2auth') {
-            return 'Login to registry[[ with user-agent {useragent}]]';
+            var message = 'Login to registry[[ with';
+            
+            if (metadata.kind == 'app_specific_token') {
+              message += ' app-specific token {app_specific_token_title} and';
+            } 
+            else if (metadata.kind == 'robot') {
+              message += ' robot {robot} and';
+            }
+
+            return message + ' user-agent {useragent}]]'
           } else {
             return 'Login to Quay[[ with user-agent {useragent}]]';
           }

--- a/static/js/services/string-builder-service.js
+++ b/static/js/services/string-builder-service.js
@@ -35,7 +35,8 @@ angular.module('quay').factory('StringBuilderService', ['$sce', 'UtilService', f
     'namespace': 'sitemap',
     'old_name': 'sitemap',
     'new_name': 'sitemap',
-    'app_specific_token_title': 'key'
+    'app_specific_token_title': 'key',
+    'useragent': 'user-secret',
   };
 
   var allowMarkdown = {

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -342,6 +342,11 @@ CONFIG_SCHEMA = {
             "description": "Path under storage in which to place user-uploaded files",
             "x-example": "userfiles",
         },
+        "ACTION_LOG_AUDIT_LOGINS": {
+            "type": "string",
+            "description": "Whether to log all registry API and Quay API/UI logins event to the action log. Defaults to True",
+            "x-example": False,
+        },
         "ACTION_LOG_ARCHIVE_LOCATION": {
             "type": "string",
             "description": "If action log archiving is enabled, the storage engine in which to place the "

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -5389,7 +5389,7 @@ COPY public.accesstokenkind (id, name) FROM stdin;
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-43fea47d641f
+0246c2d0e750
 \.
 
 
@@ -6011,6 +6011,8 @@ COPY public.logentrykind (id, name) FROM stdin;
 94	user_change_tag_expiration
 95	user_change_metadata
 96	user_generate_client_key
+97	login_success
+98	logout_success
 \.
 
 
@@ -7771,7 +7773,7 @@ SELECT pg_catalog.setval('public.logentry_id_seq', 1, false);
 -- Name: logentrykind_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.logentrykind_id_seq', 96, true);
+SELECT pg_catalog.setval('public.logentrykind_id_seq', 98, true);
 
 
 --


### PR DESCRIPTION
Based on @harishsurf 's work in #1822 this is adding audit events for :

- login/ logout of quay (e.g. via the Web UI)
- login via registry docker v2/OCI protocol (e.g. via docker/podman CLI)  with metadata covering robots and app-specific tokens

It also adds visualization in the current log view UI. The behavior is on by default and can be controlled by the `ACTION_LOG_AUDIT_LOGINS` config flag.

Note: No call is made to docker registry API during a logout from docker/podman CLI, hence no audit events are logged
Testing: verified with a local instance and database audit logging

<img width="1240" alt="Screenshot 2023-05-14 at 22 33 03" src="https://github.com/quay/quay/assets/12664117/fd8ef227-ac82-42f9-ac56-374368576ccb">

<img width="1233" alt="Screenshot 2023-05-05 at 18 47 17" src="https://user-images.githubusercontent.com/12664117/236518457-b4aabe2f-6ddb-487c-a140-7d178590e210.png">
