### PR TITLE
quota: excluding robots from quota total (PROJQUAY-5469)

### DIFF
--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -86,6 +86,7 @@ def config_services():
         "manifestbackfillworker": {"autostart": "false"},
         "securityscanningnotificationworker": {"autostart": "false"},
         "config-editor": {"autostart": "true"},
+        "quotatotalworker": {"autostart": "true"},
     }
 
 

--- a/config.py
+++ b/config.py
@@ -798,7 +798,7 @@ class DefaultConfig(ImmutableConfig):
     QUOTA_TOTAL_DELAY_SECONDS = 60
 
     # Enables the quota backfill worker
-    QUOTA_BACKFILL = True
+    QUOTA_BACKFILL = False
 
     # Feature Flag: Enables Quay to act as a pull through cache for upstream registries
     FEATURE_PROXY_CACHE = False

--- a/data/registry_model/quota.py
+++ b/data/registry_model/quota.py
@@ -38,7 +38,7 @@ def update_sizes(repository_id: int, manifest_id: int, blobs: dict, operation: s
         return
 
     namespace_id = get_namespace_id_from_repository(repository_id)
-    if not_eligible_namespace(namespace_id):
+    if not eligible_namespace(namespace_id):
         return
 
     # Addition - if the blob already referenced it's already been counted
@@ -287,17 +287,11 @@ def is_blob_alive(namespace_id: int, tag_id: int, blob_id: int):
     )
 
 
-def not_eligible_namespace(namespace_id):
+def eligible_namespace(namespace_id):
     """
-    Returns whether the namespace is eligible to have a quota size
+    Returns true if the namespace is eligible to have a quota size
     """
-    namespace = None
-    try:
-        namespace = User.select().where(User.id == namespace_id).get()
-    except User.DoesNotExist:
-        return True
-
-    return not namespace.enabled or namespace.robot
+    return User.select(1).where(User.id == namespace_id, User.enabled, ~User.robot).exists()
 
 
 def run_backfill(namespace_id: int):

--- a/data/registry_model/quota.py
+++ b/data/registry_model/quota.py
@@ -286,16 +286,17 @@ def is_blob_alive(namespace_id: int, tag_id: int, blob_id: int):
         .exists()
     )
 
+
 def not_eligible_namespace(namespace_id):
     """
     Returns whether the namespace is eligible to have a quota size
     """
     namespace = None
     try:
-        namespace = User.select().where(User.id==namespace_id).get()
+        namespace = User.select().where(User.id == namespace_id).get()
     except User.DoesNotExist:
         return True
-    
+
     return not namespace.enabled or namespace.robot
 
 
@@ -327,9 +328,12 @@ def run_backfill(namespace_id: int):
 
         # Check to make sure the repository hasn't been deleted since the time passed
         latest_repository = lookup_repository(repository.id)
-        if latest_repository is None or latest_repository.state == RepositoryState.MARKED_FOR_DELETION:
+        if (
+            latest_repository is None
+            or latest_repository.state == RepositoryState.MARKED_FOR_DELETION
+        ):
             return
-        
+
         repository_size = get_repository_size(repository.id)
         repository_size_exists = repository_size is not None
         if not repository_size_exists or (

--- a/workers/quotatotalworker.py
+++ b/workers/quotatotalworker.py
@@ -36,6 +36,7 @@ class QuotaTotalWorker(Worker):
             .where(
                 ~fn.EXISTS(subq),
                 User.enabled == True,
+                User.robot == False,
             )
             .limit(BATCH_SIZE)
         ):

--- a/workers/test/test_quotatotalworker.py
+++ b/workers/test/test_quotatotalworker.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 from data.model.organization import create_organization
-from data.model.user import get_user
+from data.model.user import create_robot, get_user
 from data.registry_model.quota import update_namespacesize
 from test.fixtures import *
 from workers.quotatotalworker import QuotaTotalWorker
@@ -11,6 +11,7 @@ ORG_NAME = "orgdoesnotexist"
 def test_namespace_discovery(initialized_db):
     user = get_user("devtable")
     orgdoesnotexist = create_organization("orgdoesnotexist", "orgdoesnotexist@devtable.com", user)
+    create_robot("testrobot", orgdoesnotexist) # Robot accounts should not have total calculated
     orgbackfillreset = create_organization(
         "orgbackfillreset", "orgbackfillreset@devtable.com", user
     )
@@ -25,6 +26,7 @@ def test_namespace_discovery(initialized_db):
         orgalreadycounted.id,
         {"size_bytes": 0, "backfill_start_ms": 0, "backfill_complete": True},
     )
+
     expected_calls = [orgdoesnotexist.id, orgbackfillreset.id]
     with patch("workers.quotatotalworker.run_backfill", MagicMock()) as mock_run_backfill:
 

--- a/workers/test/test_quotatotalworker.py
+++ b/workers/test/test_quotatotalworker.py
@@ -11,7 +11,7 @@ ORG_NAME = "orgdoesnotexist"
 def test_namespace_discovery(initialized_db):
     user = get_user("devtable")
     orgdoesnotexist = create_organization("orgdoesnotexist", "orgdoesnotexist@devtable.com", user)
-    create_robot("testrobot", orgdoesnotexist) # Robot accounts should not have total calculated
+    create_robot("testrobot", orgdoesnotexist)  # Robot accounts should not have total calculated
     orgbackfillreset = create_organization(
         "orgbackfillreset", "orgbackfillreset@devtable.com", user
     )


### PR DESCRIPTION
Add's checks to make sure the total being calculated isn't for a robot account.
Add's the `quotatotalworker` to the list of workers for the config tool.