### PR TITLE
api: allow manifests to be pulled by digest (PROJQUAY-5467)

### DIFF
--- a/data/model/oci/manifest.py
+++ b/data/model/oci/manifest.py
@@ -245,6 +245,7 @@ def get_or_create_manifest(
     raise_on_error=False,
     retriever=None,
     hidden=True,
+    tag_with_digest=None,
 ):
     """
     Returns a CreatedManifest for the manifest in the specified repository with the matching digest
@@ -277,6 +278,7 @@ def get_or_create_manifest(
         raise_on_error=raise_on_error,
         retriever=retriever,
         hidden=hidden,
+        tag_with_digest=tag_with_digest,
     )
     if created_manifest is not None:
         reset_child_manifest_expiration(repository_id, created_manifest.manifest)
@@ -292,6 +294,7 @@ def _create_manifest(
     raise_on_error=False,
     retriever=None,
     hidden=True,
+    tag_with_digest=None,
 ):
     # Validate the manifest.
     retriever = retriever or RepositoryContentRetriever.for_repository(repository_id, storage)
@@ -403,7 +406,12 @@ def _create_manifest(
             # its safe to elide the temp tag operation. If we ever change GC code to collect *all* manifests
             # in a repository for GC, then we will have to reevaluate this optimization at that time.
             if not for_tagging:
-                create_temporary_tag_if_necessary(manifest, temp_tag_expiration_sec, hidden=hidden)
+                create_temporary_tag_if_necessary(
+                    manifest,
+                    temp_tag_expiration_sec,
+                    hidden=hidden,
+                    tag_with_digest=tag_with_digest,
+                )
 
         # Define the labels for the manifest (if any).
         # TODO: Once the old data model is gone, turn this into a batch operation and make the label

--- a/data/model/oci/manifest.py
+++ b/data/model/oci/manifest.py
@@ -244,6 +244,7 @@ def get_or_create_manifest(
     for_tagging=False,
     raise_on_error=False,
     retriever=None,
+    hidden=True,
 ):
     """
     Returns a CreatedManifest for the manifest in the specified repository with the matching digest
@@ -275,6 +276,7 @@ def get_or_create_manifest(
         for_tagging=for_tagging,
         raise_on_error=raise_on_error,
         retriever=retriever,
+        hidden=hidden,
     )
     if created_manifest is not None:
         reset_child_manifest_expiration(repository_id, created_manifest.manifest)
@@ -289,6 +291,7 @@ def _create_manifest(
     for_tagging=False,
     raise_on_error=False,
     retriever=None,
+    hidden=True,
 ):
     # Validate the manifest.
     retriever = retriever or RepositoryContentRetriever.for_repository(repository_id, storage)
@@ -400,7 +403,7 @@ def _create_manifest(
             # its safe to elide the temp tag operation. If we ever change GC code to collect *all* manifests
             # in a repository for GC, then we will have to reevaluate this optimization at that time.
             if not for_tagging:
-                create_temporary_tag_if_necessary(manifest, temp_tag_expiration_sec)
+                create_temporary_tag_if_necessary(manifest, temp_tag_expiration_sec, hidden=hidden)
 
         # Define the labels for the manifest (if any).
         # TODO: Once the old data model is gone, turn this into a batch operation and make the label

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -330,7 +330,7 @@ def get_expired_tag(repository_id, tag_name):
         return None
 
 
-def create_temporary_tag_if_necessary(manifest, expiration_sec):
+def create_temporary_tag_if_necessary(manifest, expiration_sec, hidden=True):
     """
     Creates a temporary tag pointing to the given manifest, with the given expiration in seconds,
     unless there is an existing tag that will keep the manifest around.
@@ -361,7 +361,7 @@ def create_temporary_tag_if_necessary(manifest, expiration_sec):
             lifetime_start_ms=now_ms,
             lifetime_end_ms=end_ms,
             reversion=False,
-            hidden=True,
+            hidden=hidden,
             manifest=manifest,
             tag_kind=Tag.tag_kind.get_id("tag"),
         )

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -330,12 +330,15 @@ def get_expired_tag(repository_id, tag_name):
         return None
 
 
-def create_temporary_tag_if_necessary(manifest, expiration_sec, hidden=True):
+def create_temporary_tag_if_necessary(manifest, expiration_sec, hidden=True, tag_with_digest=None):
     """
     Creates a temporary tag pointing to the given manifest, with the given expiration in seconds,
     unless there is an existing tag that will keep the manifest around.
     """
-    tag_name = "$temp-%s" % str(uuid.uuid4())
+    if tag_with_digest:
+        tag_name = tag_with_digest
+    else:
+        tag_name = "$temp-%s" % str(uuid.uuid4())
     now_ms = get_epoch_timestamp_ms()
     end_ms = now_ms + (expiration_sec * 1000)
 

--- a/data/registry_model/interface.py
+++ b/data/registry_model/interface.py
@@ -61,6 +61,7 @@ class RegistryDataInterface(object):
         repository_ref,
         manifest_digest,
         allow_dead=False,
+        allow_hidden=False,
         require_available=False,
         raise_on_error=False,
     ):

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -658,7 +658,13 @@ class OCIModel(RegistryDataInterface):
         )
 
     def create_manifest_with_temp_tag(
-        self, repository_ref, manifest_interface_instance, expiration_sec, storage, hidden=True
+        self,
+        repository_ref,
+        manifest_interface_instance,
+        expiration_sec,
+        storage,
+        hidden=True,
+        tag_with_digest=None,
     ):
         """
         Creates a manifest under the repository and sets a temporary tag to point to it.
@@ -674,6 +680,7 @@ class OCIModel(RegistryDataInterface):
                 storage,
                 temp_tag_expiration_sec=expiration_sec,
                 hidden=hidden,
+                tag_with_digest=tag_with_digest,
             )
             if created_manifest is None:
                 return None

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -147,6 +147,7 @@ class OCIModel(RegistryDataInterface):
         repository_ref,
         manifest_digest,
         allow_dead=False,
+        allow_hidden=False,
         require_available=False,
         raise_on_error=False,
     ):
@@ -158,6 +159,7 @@ class OCIModel(RegistryDataInterface):
             repository_ref._db_id,
             manifest_digest,
             allow_dead=allow_dead,
+            allow_hidden=allow_hidden,
             require_available=require_available,
         )
         if manifest is None:
@@ -663,8 +665,6 @@ class OCIModel(RegistryDataInterface):
         manifest_interface_instance,
         expiration_sec,
         storage,
-        hidden=True,
-        tag_with_digest=None,
     ):
         """
         Creates a manifest under the repository and sets a temporary tag to point to it.
@@ -679,8 +679,6 @@ class OCIModel(RegistryDataInterface):
                 manifest_interface_instance,
                 storage,
                 temp_tag_expiration_sec=expiration_sec,
-                hidden=hidden,
-                tag_with_digest=tag_with_digest,
             )
             if created_manifest is None:
                 return None

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -658,7 +658,7 @@ class OCIModel(RegistryDataInterface):
         )
 
     def create_manifest_with_temp_tag(
-        self, repository_ref, manifest_interface_instance, expiration_sec, storage
+        self, repository_ref, manifest_interface_instance, expiration_sec, storage, hidden=True
     ):
         """
         Creates a manifest under the repository and sets a temporary tag to point to it.
@@ -673,6 +673,7 @@ class OCIModel(RegistryDataInterface):
                 manifest_interface_instance,
                 storage,
                 temp_tag_expiration_sec=expiration_sec,
+                hidden=hidden,
             )
             if created_manifest is None:
                 return None

--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -231,6 +231,7 @@ class ProxyModel(OCIModel):
         repository_ref,
         manifest_digest,
         allow_dead=False,
+        allow_hidden=False,
         require_available=False,
         raise_on_error=True,
     ):

--- a/endpoints/v2/manifest.py
+++ b/endpoints/v2/manifest.py
@@ -142,7 +142,9 @@ def fetch_manifest_by_digest(namespace_name, repo_name, manifest_ref, registry_m
 
     try:
         manifest = registry_model.lookup_manifest_by_digest(
-            repository_ref, manifest_ref, raise_on_error=True
+            repository_ref,
+            manifest_ref,
+            raise_on_error=True,
         )
     except ManifestDoesNotExist as e:
         image_pulls.labels("v2", "manifest", 404).inc()
@@ -284,7 +286,7 @@ def write_manifest_by_digest(namespace_name, repo_name, manifest_ref):
 
     expiration_sec = app.config["PUSH_TEMP_TAG_EXPIRATION_SEC"]
     manifest = registry_model.create_manifest_with_temp_tag(
-        repository_ref, parsed, expiration_sec, storage
+        repository_ref, parsed, expiration_sec, storage, hidden=False
     )
 
     if manifest is None:

--- a/endpoints/v2/manifest.py
+++ b/endpoints/v2/manifest.py
@@ -286,7 +286,7 @@ def write_manifest_by_digest(namespace_name, repo_name, manifest_ref):
 
     expiration_sec = app.config["PUSH_TEMP_TAG_EXPIRATION_SEC"]
     manifest = registry_model.create_manifest_with_temp_tag(
-        repository_ref, parsed, expiration_sec, storage, hidden=False
+        repository_ref, parsed, expiration_sec, storage, hidden=False, tag_with_digest=parsed.digest
     )
 
     if manifest is None:

--- a/endpoints/v2/manifest.py
+++ b/endpoints/v2/manifest.py
@@ -145,6 +145,7 @@ def fetch_manifest_by_digest(namespace_name, repo_name, manifest_ref, registry_m
             repository_ref,
             manifest_ref,
             raise_on_error=True,
+            allow_hidden=True,
         )
     except ManifestDoesNotExist as e:
         image_pulls.labels("v2", "manifest", 404).inc()
@@ -286,7 +287,10 @@ def write_manifest_by_digest(namespace_name, repo_name, manifest_ref):
 
     expiration_sec = app.config["PUSH_TEMP_TAG_EXPIRATION_SEC"]
     manifest = registry_model.create_manifest_with_temp_tag(
-        repository_ref, parsed, expiration_sec, storage, hidden=False, tag_with_digest=parsed.digest
+        repository_ref,
+        parsed,
+        expiration_sec,
+        storage,
     )
 
     if manifest is None:

--- a/test/registry/protocol_fixtures.py
+++ b/test/registry/protocol_fixtures.py
@@ -229,6 +229,22 @@ def unicode_emoji_images():
 
 
 @pytest.fixture(scope="session")
+def openpolicyagent_policy():
+    """
+    Returns basic OPA policy image for push and pull testing
+    """
+    image_bytes = layer_bytes_for_contents(b"some contents")
+    return [
+        Image(
+            id="someid",
+            bytes=image_bytes,
+            parent_id=None,
+            config={"mediaType": "application/vnd.cncf.openpolicyagent.policy.layer.v1+rego"},
+        ),
+    ]
+
+
+@pytest.fixture(scope="session")
 def jwk():
     return jwklib.JsonWebKey.generate_key("RSA", 2048, is_private=True)
 

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -221,8 +221,7 @@ def test_basic_push_by_manifest_digest(
         options=options,
     )
 
-    # If this is not schema 1, then verify we cannot pull.
-    expected_failure = None if manifest_protocol.schema == "schema1" else Failures.UNKNOWN_TAG
+    expected_failure = None
 
     # Pull the repository by digests to verify.
     digests = [str(manifest.digest) for manifest in list(result.manifests.values())]
@@ -3068,4 +3067,34 @@ def test_malformed_schema2_config(v22_protocol, basic_images, liveserver_session
         credentials=credentials,
         options=options,
         expected_failure=Failures.INVALID_MANIFEST,
+    )
+
+
+def test_conftest_policy_push(manifest_protocol, openpolicyagent_policy, liveserver_session):
+    credentials = ("devtable", "password")
+
+    options = ProtocolOptions()
+    options.push_by_manifest_digest = True
+
+    # Push policy by digest
+    result = manifest_protocol.push(
+        liveserver_session,
+        "devtable",
+        "newrepo",
+        "latest",
+        openpolicyagent_policy,
+        credentials=credentials,
+        options=options,
+    )
+
+    # Pull the policy by digests to verify.
+    digests = [str(manifest.digest) for manifest in list(result.manifests.values())]
+    manifest_protocol.pull(
+        liveserver_session,
+        "devtable",
+        "newrepo",
+        digests,
+        openpolicyagent_policy,
+        credentials=credentials,
+        expected_failure=None,
     )


### PR DESCRIPTION
Prevent manifests pushed by digest from being hidden. Lets newer versions of conftest push to quay, since it expects to be able to pull the policy by digest when performing a push.