### PR TITLE
superuser(auth)!: ensure superusers are not restricted (PROJQUAY-5196)

### DIFF
--- a/data/users/__init__.py
+++ b/data/users/__init__.py
@@ -340,6 +340,10 @@ class UserAuthentication(object):
         return self.state.has_superusers()
 
     def is_restricted_user(self, username):
+        # do not restrict superusers
+        if self.is_superuser(username):
+            return False
+
         return self.state.is_restricted_user(username)
 
     def has_restricted_users(self):
@@ -368,6 +372,10 @@ class UserManager(object):
 
     def is_restricted_user(self, username):
         if not features.RESTRICTED_USERS:
+            return False
+
+        # do not restrict superusers
+        if self.is_superuser(username):
             return False
 
         return self.state.is_restricted_user(username)
@@ -399,6 +407,10 @@ class FederatedUserManager(ConfigUserManager):
         """
         Returns if the given username represents a restricted user.
         """
+        # do not restrict superusers
+        if self.is_superuser(username):
+            return False
+
         if include_robots:
             username = username.split("+", 1)[0]
 

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -503,7 +503,7 @@ class LDAPUsers(FederatedUsers):
 
     def is_restricted_user(self, username_or_email: str) -> bool:
         # do not restrict superusers
-        if self.is_superuser(username):
+        if self.is_superuser(username_or_email):
             return False
 
         if not username_or_email:

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -502,6 +502,10 @@ class LDAPUsers(FederatedUsers):
         return has_superusers
 
     def is_restricted_user(self, username_or_email: str) -> bool:
+        # do not restrict superusers
+        if self.is_superuser(username):
+            return False
+
         if not username_or_email:
             return False
 

--- a/util/config/superusermanager.py
+++ b/util/config/superusermanager.py
@@ -81,6 +81,10 @@ class ConfigUserManager(UserManager):
         return bool(self._superusers_array.value)
 
     def is_restricted_user(self, username: str, include_robots: bool = True) -> bool:
+        # do not restrict superusers
+        if self.is_superuser(username):
+            return False
+
         if include_robots:
             username = username.split("+")[0]
 


### PR DESCRIPTION
BREAKING CHANGE: superusers will not be restricted applying this change

After discussing https://issues.redhat.com/browse/PROJQUAY-5196 with various Team members and the PM, the `FEATURE_RESTRICTED_USERS` limits superuser accounts which is considered being a bug.

I tried adapting the code accordingly and unfortunately with various authentication mechanism and temporary extend of superuser lists, I had to adapt all `is_restricted_user` methods instead of having this inherited by a parent Class.

Code is untested and needs to follow the default QE process.
Adaption to unittests might be necessary as well.