### PR TITLE
quota: moving resetting of child manifest temporary tags to delete endpoint (PROJQUAY-5512)

### DIFF
--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -469,6 +469,7 @@ def _delete_tag(tag, now_ms):
         if updated != 1:
             return None
 
+        reset_child_manifest_expiration(tag.repository, tag.manifest)
         return tag
 
 
@@ -762,15 +763,27 @@ def remove_tag_from_timemachine(
                 increment = increment + 1
 
     if include_submanifests:
-        with db_transaction():
-            # pylint: disable-next=not-an-iterable
-            for child_manifest in get_child_manifests(repo_id, manifest_id):
-                Tag.update(lifetime_end_ms=now_ms - time_machine_ms - increment).where(
-                    Tag.repository == repo_id,
-                    Tag.manifest == child_manifest.child_manifest,
-                    Tag.hidden == True,
-                    Tag.lifetime_end_ms > now_ms - time_machine_ms - increment,
-                ).execute()
-                increment = increment + 1
+        reset_child_manifest_expiration(repo_id, manifest_id, now_ms - time_machine_ms)
 
     return updated
+
+
+def reset_child_manifest_expiration(repository_id, manifest, expiration=None):
+    """
+    Resets the expirations of temporary tags targeting the child manifests.
+    """
+    if not config.app_config.get("RESET_CHILD_MANIFEST_EXPIRATION", True):
+        return
+
+    with db_transaction():
+        # pylint: disable-next=not-an-iterable
+        for child_manifest in get_child_manifests(repository_id, manifest):
+            expiry_ms = get_epoch_timestamp_ms() if expiration is None else expiration
+            Tag.update(lifetime_end_ms=expiry_ms).where(
+                Tag.repository == repository_id,
+                Tag.manifest == child_manifest.child_manifest,
+                Tag.lifetime_end_ms > expiry_ms,
+                Tag.name.startswith("$temp-"),
+                Tag.hidden == True,
+            ).execute()
+

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -786,4 +786,3 @@ def reset_child_manifest_expiration(repository_id, manifest, expiration=None):
                 Tag.name.startswith("$temp-"),
                 Tag.hidden == True,
             ).execute()
-

--- a/data/model/oci/test/test_oci_manifest.py
+++ b/data/model/oci/test/test_oci_manifest.py
@@ -309,14 +309,6 @@ def test_get_or_create_manifest_list(initialized_db):
     assert v1_manifest.digest in child_manifests
     assert v2_manifest.digest in child_manifests
 
-    # Ensure the expiry of the child manifest tags have been reset
-    tags = list(Tag.select().where(Tag.manifest << list(child_manifests.values())))
-    assert len(tags) > 0
-    for tag in tags:
-        assert tag.hidden
-        assert tag.name.startswith("$temp-")
-        assert tag.lifetime_end_ms < get_epoch_timestamp_ms()
-
     assert child_manifests[v1_manifest.digest].media_type.name == v1_manifest.media_type
     assert child_manifests[v2_manifest.digest].media_type.name == v2_manifest.media_type
 

--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -656,8 +656,8 @@ class TestRegistryProxyModelLookupManifestByDigest:
 
         assert updated_tag.id == manifest_tag.id
         assert updated_list_tag.id == manifest_list_tag.id
-        assert updated_tag.lifetime_end_ms < get_epoch_timestamp_ms()
-        assert updated_list_tag.lifetime_end_ms > get_epoch_timestamp_ms()
+        assert updated_tag.lifetime_end_ms > manifest_tag.lifetime_end_ms
+        assert updated_list_tag.lifetime_end_ms > manifest_list_tag.lifetime_end_ms
 
     def test_renew_manifest_list_tag_when_upstream_manifest_changed(
         self, create_repo, proxy_manifest_response


### PR DESCRIPTION
The tagged JIRA contains most of the details. Moves the resetting of child manifest temporary tags to happen on deletion instead of on push/pull. Resetting child manifest temporary tags caused issues in other portions of the code like proxy cache where temporary tags were deleted too early. 