### PR TITLE
quota: removing QUOTA_TOTAL_DELAY_SECONDS option (PROJQUAY-5503)

### DIFF
--- a/config.py
+++ b/config.py
@@ -795,10 +795,6 @@ class DefaultConfig(ImmutableConfig):
     FEATURE_QUOTA_MANAGEMENT = False
     # default value for all organizations to reject by default. 0 = no configuration
     DEFAULT_SYSTEM_REJECT_QUOTA_BYTES = 0
-    # Time delay for starting the quota backfill. Rolling deployments can cause incorrect
-    # totals, so this field should be set to a time longer than it takes for the rolling
-    # deployment to complete
-    QUOTA_TOTAL_DELAY_SECONDS = 60
 
     # Enables the quota backfill worker
     QUOTA_BACKFILL = False

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1254,11 +1254,6 @@ CONFIG_SCHEMA = {
             "description": "Enables system default quota reject byte allowance for all organizations",
             "x-example": False,
         },
-        "QUOTA_TOTAL_DELAY_SECONDS": {
-            "type": "int",
-            "description": "The time to delay the Quota backfill operation. Must be set longer than the time required to complete the deployment.",
-            "x-example": 30,
-        },
         "QUOTA_BACKFILL": {
             "type": "boolean",
             "description": "Enables the quota backfill worker to calculate the size of pre-existing blobs",

--- a/workers/quotatotalworker.py
+++ b/workers/quotatotalworker.py
@@ -64,14 +64,6 @@ if __name__ == "__main__":
         while True:
             time.sleep(100000)
 
-    if app.config.get("QUOTA_TOTAL_DELAY_SECONDS", None) is not None:
-        logger.debug(
-            "Delaying quota backfill for %s seconds.",
-            str(app.config.get("QUOTA_TOTAL_DELAY_SECONDS", 0)),
-        )
-        time.sleep(app.config.get("QUOTA_TOTAL_DELAY_SECONDS", 0))
-        logger.debug("Delay complete, starting quotatotalworker...")
-
     GlobalLock.configure(app.config)
     logging.config.fileConfig(logfile_path(debug=False), disable_existing_loggers=False)
     worker = QuotaTotalWorker()


### PR DESCRIPTION
Initially introduced as a solution to the race conditions of the running total on first deployment. It delays the backfill until the deployment has finished to prevent the running total from running at the same time as the deployment. Has the potential to be incorrectly used and result in incorrect totals if set to low.