### PR TITLE
proxy: Allow anonymous pulls from registries (PROJQUAY-5273)

### DIFF
--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -1036,6 +1036,8 @@ class ProxyCacheConfigValidation(ApiResource):
             response = proxy.get(f"{proxy.base_url}/v2/")
             if response.status_code == 200:
                 return "Valid", 202
+            if response.status_code == 401:
+                return "Anonymous", 202
         except UpstreamRegistryError as e:
             raise request_error(
                 message="Failed login to remote registry. Please verify entered details and try again."

--- a/static/js/directives/ui/proxy-cache-view.js
+++ b/static/js/directives/ui/proxy-cache-view.js
@@ -38,8 +38,9 @@ angular.module('quay').directive('proxyCacheView', function () {
                     });
             }
 
-            var displayError = function(message = 'Could not update details') {
-                let errorDisplay = ApiService.errorDisplay(message, () => {});
+            var displayError = function (message = 'Could not update details') {
+                let errorDisplay = ApiService.errorDisplay(message, () => {
+                });
                 return errorDisplay;
             }
 
@@ -47,19 +48,18 @@ angular.module('quay').directive('proxyCacheView', function () {
                 let params = {'orgname': $scope.currentConfig.org_name};
 
                 // validate payload
-                ApiService.validateProxyCacheConfig($scope.currentConfig, params).then(function(response) {
-                    if (response == "Valid") {
+                ApiService.validateProxyCacheConfig($scope.currentConfig, params).then(function (response) {
+                    if (response === "Valid" || response === "Anonymous") {
                         // save payload
                         ApiService.createProxyCacheConfig($scope.currentConfig, params).then((resp) => {
                             fetchProxyConfig();
                             alertSaveSuccessMessage();
-                        },  displayError());
+                        }, displayError());
                     }
-                },  displayError("Validation Error"));
-
+                }, displayError("Validation Error"));
             }
 
-            var alertSaveSuccessMessage = function() {
+            var alertSaveSuccessMessage = function () {
                 $timeout(function () {
                     $scope.alertSaveSuccess = true;
                 }, 1);
@@ -68,7 +68,7 @@ angular.module('quay').directive('proxyCacheView', function () {
                 }, 5000);
             };
 
-            var alertRemoveSuccessMessage = function() {
+            var alertRemoveSuccessMessage = function () {
                 $timeout(function () {
                     $scope.alertRemoveSuccess = true;
                 }, 1);


### PR DESCRIPTION
Currently anonymous pulls from registries are blocked since some registries like `gcr.io` require a `repo/image name` as part of `scope` to get a token or they return a `401`.  Since the `reponame` is not known at the time of initial proxy cache configuration, this change allows `401` as an accepted response to allow proxy config to be saved