### PR TITLE
proxy: allowing expiring tags with timemachine set to 0 (PROJQUAY-5558)

### DIFF
--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -698,6 +698,9 @@ def get_legacy_images_for_tags(tags):
 
 
 def get_tags_within_timemachine_window(repo_id, tag_name, manifest_id, timemaching_window_ms):
+    if timemaching_window_ms == 0:
+        return []
+
     now_ms = get_epoch_timestamp_ms()
     return (
         Tag.select(Tag.id)
@@ -722,9 +725,6 @@ def remove_tag_from_timemachine(
     except User.DoesNotExist:
         return False
 
-    if namespace.removed_tag_expiration_s == 0:
-        return False
-
     time_machine_ms = namespace.removed_tag_expiration_s * 1000
     now_ms = get_epoch_timestamp_ms()
 
@@ -742,13 +742,15 @@ def remove_tag_from_timemachine(
         # Expire the tag past the time machine window and set hidden=true to
         # prevent it from appearing in tag history
         updated = (
-            Tag.update(lifetime_end_ms=now_ms - time_machine_ms, hidden=True)
+            Tag.update(lifetime_end_ms=now_ms - time_machine_ms)
             .where(Tag.id == alive_tag)
             .where(Tag.lifetime_end_ms == alive_tag.lifetime_end_ms)
             .execute()
         )
         if updated != 1:
             return False
+        else:
+            updated = True
     else:
         # Update all tags with matching name and manifest with a expiry outside the time machine
         # window
@@ -756,13 +758,13 @@ def remove_tag_from_timemachine(
             for tag in get_tags_within_timemachine_window(
                 repo_id, tag_name, manifest_id, time_machine_ms
             ):
-                Tag.update(lifetime_end_ms=now_ms - time_machine_ms - increment, hidden=True).where(
+                Tag.update(lifetime_end_ms=now_ms - time_machine_ms - increment).where(
                     Tag.id == tag
                 ).execute()
                 updated = True
                 increment = increment + 1
 
-    if include_submanifests:
+    if updated and include_submanifests:
         reset_child_manifest_expiration(repo_id, manifest_id, now_ms - time_machine_ms)
 
     return updated

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -598,7 +598,7 @@ def test_remove_tag_from_timemachine(initialized_db):
     results, _ = list_repository_tag_history(repo, 1, 100, specific_tag_name="latest")
     for tag in results:
         assert tag.lifetime_end_ms < get_epoch_timestamp_ms() - expiration_window
-        assert tag.hidden
+        assert not tag.hidden
 
 
 def test_remove_tag_from_timemachine_alive(initialized_db):
@@ -616,7 +616,7 @@ def test_remove_tag_from_timemachine_alive(initialized_db):
 
     tag = Tag.select().where(Tag.id == tag.id).get()
     assert tag.lifetime_end_ms < get_epoch_timestamp_ms() - expiration_window
-    assert tag.hidden
+    assert not tag.hidden
 
 
 def test_remove_tag_from_timemachine_submanifests(initialized_db):
@@ -636,7 +636,7 @@ def test_remove_tag_from_timemachine_submanifests(initialized_db):
 
     updated_tag = Tag.select().where(Tag.id == created_tag.id).get()
     assert updated_tag.lifetime_end_ms < get_epoch_timestamp_ms() - expiration_window
-    assert updated_tag.hidden
+    assert not updated_tag.hidden
 
     child_manifests = [
         cm.child_manifest

--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -257,6 +257,8 @@ class ProxyModel(OCIModel):
             return wrapped_manifest
 
         db_tag = oci.tag.get_tag_by_manifest_id(repository_ref.id, wrapped_manifest.id)
+
+        # If no tag exists for this manifest, create a temporary tag to keep it alive
         if db_tag is None:
             try:
                 manifest = (

--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -257,19 +257,6 @@ class ProxyModel(OCIModel):
             return wrapped_manifest
 
         db_tag = oci.tag.get_tag_by_manifest_id(repository_ref.id, wrapped_manifest.id)
-
-        # If no tag exists for this manifest, create a temporary tag to keep it alive
-        if db_tag is None:
-            try:
-                manifest = (
-                    ManifestTable.select().where(ManifestTable.id == wrapped_manifest.id).get()
-                )
-            except ManifestDoesNotExist as e:
-                raise ManifestDoesNotExist(str(e))
-            db_tag = oci.tag.create_temporary_tag_if_necessary(
-                manifest, self._config.expiration_s or None
-            )
-
         existing_tag = Tag.for_tag(
             db_tag, self._legacy_image_id_handler, manifest_row=db_tag.manifest
         )


### PR DESCRIPTION
Adds the following changes:
- Allows `remove_tag_from_timemachine` to expire tags even if the time machine window is set to 0, immediately marking them for deletion. This allows the quota proxy pruner to expire tags with the same method call. This wasn't required for normal push/pulls as the user would just call the `DELETE /tag` endpoint.
- Remove `hidden = true` when expiring tags. For proxy Quay will attempt to lookup the tag referenced by the manifest in order to extend it's `lifetime_end_ms`. Hiding this tag prevents that logic from running correctly.
