### PR TITLE
[redhat-3.7] superuser: lowering page limit (PROJQUAY-5178)

### DIFF
--- a/static/js/directives/ui/manage-user-tab.js
+++ b/static/js/directives/ui/manage-user-tab.js
@@ -88,7 +88,7 @@ angular.module('quay').directive('manageUserTab', function () {
 
       var loadPaginatedUsers = function(nextPageToken = null) {
         $scope.backgroundLoadingUsers = true;
-        var params = nextPageToken != null ? {limit: 100, next_page: nextPageToken} : {limit: 100};
+        var params = nextPageToken != null ? {limit: 50, next_page: nextPageToken} : {limit: 50};
         ApiService.listAllUsers(null, params).then(function(resp) {
           $scope.users = [...$scope.users, ...resp['users']];
           if(resp["next_page"] != null){

--- a/static/js/pages/superuser.js
+++ b/static/js/pages/superuser.js
@@ -142,7 +142,7 @@
 
     var loadPaginatedOrganizations = function(nextPageToken = null) {
       $scope.backgroundLoadingOrgs = true;
-      var params = nextPageToken != null ? {limit: 100, next_page: nextPageToken} : {limit: 100};
+      var params = nextPageToken != null ? {limit: 50, next_page: nextPageToken} : {limit: 50};
       ApiService.listAllOrganizationsAsResource(params).get(function(resp) {
         $scope.organizations = [...$scope.organizations, ...resp['organizations']];
         if(resp["next_page"] != null){


### PR DESCRIPTION
Need to merge [1923](https://github.com/quay/quay/pull/1923/files) before this PR.

Lowering the page limit allows for more operations to be done per requested user. Specifically in the scenario where for each user a LDAP lookup is done to check whether the user in the list is a superuser or not. This allows time for the request to complete and load the user list without error.