### PR TITLE
audit: ignore errors due to read-only mode in audit logs (PROJQUAY-5598)

### DIFF
--- a/data/logs_model/table_logs_model.py
+++ b/data/logs_model/table_logs_model.py
@@ -240,6 +240,7 @@ class TableLogsModel(SharedModel, ActionLogsDataInterface):
                 timestamp=timestamp,
             )
         except ReadOnlyModeException:
+            logger.debug("Skipping log action '%s' in read-only mode" % kind_name)
             pass
 
     def yield_logs_for_export(

--- a/data/logs_model/table_logs_model.py
+++ b/data/logs_model/table_logs_model.py
@@ -18,6 +18,7 @@ from data.logs_model.interface import (
 from data.logs_model.datatypes import Log, AggregatedLogCount, LogEntriesPage
 from data.logs_model.shared import SharedModel, InvalidLogsDateRangeError
 from data.model.log import get_stale_logs, get_stale_logs_start_id, delete_stale_logs
+from data.readreplica import ReadOnlyModeException
 
 logger = logging.getLogger(__name__)
 
@@ -228,15 +229,18 @@ class TableLogsModel(SharedModel, ActionLogsDataInterface):
             assert namespace_name is not None
             repository = model.repository.get_repository(namespace_name, repository_name)
 
-        model.log.log_action(
-            kind_name,
-            namespace_name,
-            performer=performer,
-            repository=repository,
-            ip=ip,
-            metadata=metadata or {},
-            timestamp=timestamp,
-        )
+        try:
+            model.log.log_action(
+                kind_name,
+                namespace_name,
+                performer=performer,
+                repository=repository,
+                ip=ip,
+                metadata=metadata or {},
+                timestamp=timestamp,
+            )
+        except ReadOnlyModeException:
+            pass
 
     def yield_logs_for_export(
         self,

--- a/util/audit.py
+++ b/util/audit.py
@@ -87,16 +87,14 @@ def track_and_log(event_name, repo_obj, analytics_name=None, analytics_sample=1,
 
     # Log the action to the database.
     logger.debug("Logging the %s to logs system", event_name)
-    try:
-        logs_model.log_action(
-            event_name,
-            namespace_name,
-            performer=get_authenticated_user(),
-            ip=get_request_ip(),
-            metadata=metadata,
-            repository=repo_obj,
-            is_free_namespace=is_free_namespace,
-        )
-        logger.debug("Track and log of %s complete", event_name)
-    except ReadOnlyModeException:
-        pass
+
+    logs_model.log_action(
+        event_name,
+        namespace_name,
+        performer=get_authenticated_user(),
+        ip=get_request_ip(),
+        metadata=metadata,
+        repository=repo_obj,
+        is_free_namespace=is_free_namespace,
+    )
+    logger.debug("Track and log of %s complete", event_name)


### PR DESCRIPTION
This addresses https://issues.redhat.com/browse/PROJQUAY-5598

When the registry is in read-only mode, all writes to the database are suspended. Subsequently all log audit entry attempts will fail if the log model is based on the database. To avoid dealing with related exceptions from the database / model layer across the code base this PR adds handling at the relevant table logs model directly. This doesn't effect other log models where the log storage is an external system (ElasticSearch, Splunk, Document, etc)

Signed-off-by: dmesser <dmesser@redhat.com>