### PR TITLE
db: change removed_tag_expiration_s  to bigint (PROJQUAY-2462)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -675,7 +675,7 @@ class User(BaseModel):
     invoice_email = BooleanField(default=False)
     invalid_login_attempts = IntegerField(default=0)
     last_invalid_login = DateTimeField(default=datetime.utcnow)
-    removed_tag_expiration_s = IntegerField(default=1209600)  # Two weeks
+    removed_tag_expiration_s = BigIntegerField(default=1209600)  # Two weeks
     enabled = BooleanField(default=True)
     invoice_email_address = CharField(null=True, index=True)
 

--- a/data/migrations/versions/46980ea2dde5_change_removed_tag_expiration_s_to_.py
+++ b/data/migrations/versions/46980ea2dde5_change_removed_tag_expiration_s_to_.py
@@ -1,0 +1,23 @@
+"""change removed_tag_expiration_s to BIGINT
+
+Revision ID: 46980ea2dde5
+Revises: 8cf90670bf38
+Create Date: 2023-06-04 11:14:26.150812
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "46980ea2dde5"
+down_revision = "8cf90670bf38"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    # Alter the column to use BIGINT data type
+    op.alter_column("user", "removed_tag_expiration_s", type_=sa.BigInteger)
+
+
+def downgrade(op, tables, tester):
+    # Alter the column to use INT data type, this might fail if there are already values that are bigger than INT but we do not intend to support downgrades anyway
+    op.alter_column("user", "removed_tag_expiration_s", type_=sa.Integer)

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -4497,7 +4497,7 @@ CREATE TABLE public."user" (
     invoice_email boolean NOT NULL,
     invalid_login_attempts integer DEFAULT 0 NOT NULL,
     last_invalid_login timestamp without time zone NOT NULL,
-    removed_tag_expiration_s integer DEFAULT 1209600 NOT NULL,
+    removed_tag_expiration_s bigint DEFAULT 1209600 NOT NULL,
     enabled boolean DEFAULT true NOT NULL,
     invoice_email_address character varying(255),
     company character varying(255),
@@ -5437,7 +5437,7 @@ COPY public.accesstokenkind (id, name) FROM stdin;
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-ab5a24478052
+46980ea2dde5
 \.
 
 
@@ -6061,6 +6061,7 @@ COPY public.logentrykind (id, name) FROM stdin;
 96	user_generate_client_key
 97	login_success
 98	logout_success
+99	permanently_delete_tag
 \.
 
 
@@ -7829,7 +7830,7 @@ SELECT pg_catalog.setval('public.logentry_id_seq', 1, false);
 -- Name: logentrykind_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.logentrykind_id_seq', 98, true);
+SELECT pg_catalog.setval('public.logentrykind_id_seq', 99, true);
 
 
 --


### PR DESCRIPTION
This addresses https://issues.redhat.com/browse/PROJQUAY-2462.

In this case we see garbage collection stopping due to too large values in the removed_tag_expiration_s column of the user table. This column is currently set to integer which is fine for most use cases, but becomes problematic with garbage collection since we multiply this value by 1000. The maximum allowed number for a signed integer is [(1/2)*2^32]-1 or 2147483647, any number over this value will lead to errors. For example 4 weeks of time machine window will lead to this field overflowing.


Signed-off-by: dmesser <dmesser@redhat.com>