### PR TITLE
db: handle readonly mode when updating repo size cache (PROJQUAY-4854)

### DIFF
--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -1,7 +1,6 @@
 import logging
 import random
 import json
-from typing_extensions import ReadOnly
 import uuid
 
 from enum import Enum

--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import json
+from typing_extensions import ReadOnly
 import uuid
 
 from enum import Enum
@@ -52,6 +53,7 @@ from data.database import (
     Tag,
     get_epoch_timestamp_ms,
 )
+from data.readreplica import ReadOnlyModeException
 from data.text import prefix_search
 from util.itertoolrecipes import take
 
@@ -781,6 +783,8 @@ def force_cache_repo_size(repo_id: int):
             # If that's the case, it should be safe to just ignore the IntegrityError,
             # as the RepositorySize should have been created with the correct value.
             logger.warning("RepositorySize for repo id %s already exists", repo_id)
-            return size
+            pass
+        except ReadOnlyModeException:
+            pass
 
     return size


### PR DESCRIPTION
This addresses https://issues.redhat.com/browse/PROJQUAY-4854. The code path is hit by the UI and will cause errors when trying to review repositories. In this implementation of repository size calculation a cache is maintained and updated when repos are listed. The cache update will cause errors when trying to hit the database with the registry in read-only mode.