### PR TITLE
chore: updated s390x builder

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -66,29 +66,6 @@ jobs:
           echo $ZVSI_HOST
           echo "IP=${ZVSI_HOST}" >> $GITHUB_OUTPUT
           
-      - name: Setup Docker on ZVSI
-        uses: appleboy/ssh-action@master
-        with:
-            host: ${{ steps.ZVSI.outputs.IP }}
-            username: ${{ secrets.ZVSI_SSH_USER }}
-            key: ${{ secrets.ZVSI_PR_KEY }}
-            script: |
-              #update
-              arch
-              apt-get update
-              
-              #Setup Docker
-              apt-get install ca-certificates curl gnupg
-              install -m 0755 -d /etc/apt/keyrings
-              curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-              chmod a+r /etc/apt/keyrings/docker.gpg
-              echo \
-              "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-              "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-              tee /etc/apt/sources.list.d/docker.list > /dev/null
-              apt-get update
-              apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
-            
       - name: Setup SSH config for builders
         env:
           BUILDER_AARCH64_SSH_CONFIG: ${{ secrets.BUILDER_AARCH64_SSH_CONFIG }}

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -70,7 +70,7 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
             host: ${{ steps.ZVSI.outputs.IP }}
-            username: ${{ secrets.SSH_USER }}
+            username: ${{ secrets.ZVSI_SSH_USER }}
             key: ${{ secrets.ZVSI_PR_KEY }}
             script: |
               #update
@@ -99,7 +99,6 @@ jobs:
           BUILDER_PPC64LE_SSH_KNOWN_HOSTS: ${{ secrets.BUILDER_PPC64LE_SSH_KNOWN_HOSTS }}
           BUILDER_S390X_SSH_HOST: ${{ steps.ZVSI.outputs.IP }}
           BUILDER_S390X_SSH_KEY: ${{ secrets.ZVSI_PR_KEY }}
-          
         run: |
           mkdir ~/.ssh
           chmod 700 ~/.ssh
@@ -171,10 +170,12 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}
       
       - name: Post Build-and-publish-s390x
+        if: ${{ steps.ZVSI.conclusion == 'success' && always() }}
         run: |
           #Delete the created ZVSI
           ibmcloud is instance-delete $ZVSI_INSTANCE_NAME --force
-          sleep 15
-            
+          sleep 20
+          
           #Release the created FP
           ibmcloud is floating-ip-release $ZVSI_FP_NAME --force
+

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -19,6 +19,16 @@ jobs:
       REGISTRY: quay.io/projectquay
       REPO_NAME: ${{ github.event.repository.name }}
       TAG_SUFFIX: -unstable
+      ZVSI_FP_NAME: quay-floating
+      ZVSI_KEY_NAME: quay-key
+      ZVSI_INSTANCE_NAME: quay-zvsi
+      ZVSI_VPC: r018-b72c601c-c1d9-42cf-af66-c0f6da4ab982
+      ZVSI_ZONE_NAME: eu-gb-2
+      ZVSI_PROFILE_NAME: bz2-4x16
+      ZVSI_SUBNET: 0797-88f93aad-3acd-4c8e-be10-8dc6d41bc9b9
+      ZVSI_IMAGE: r018-b774babd-711c-415c-8c62-aae0d6c824dc 
+      ZVSI_KEY: r018-ee997015-b88c-4500-874c-71f2175a8284
+      ZVSI_RG_ID: 2e818eb391df4774977812b50ff0e8c9
     runs-on: 'ubuntu-latest'
     steps:
       - name: Check out the repo
@@ -29,11 +39,56 @@ jobs:
         if: startsWith('env.BRANCH_PREFIX', env.GITHUB_REF)
         run: |
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=version::${BRANCH_NAME/${{ env.BRANCH_PREFIX }}/}"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
+          echo "version=${BRANCH_NAME/${{ env.BRANCH_PREFIX }}/}" >> $GITHUB_OUTPUT
+      
+      - name: Install IBMCLI
+        run: curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+          
+      - name: IBM Cloud Login
+        run: ibmcloud login -q --apikey ${{ secrets.IBMCLOUD_API_KEY }} -r eu-gb 
+          
+      - name: Install VPC CLI plug-in
+        run: ibmcloud plugin install vpc-infrastructure
+          
+      - name: Creation of ZVSI
+        id: ZVSI
+        run: |
+          #creation of zvsi
+          ibmcloud is instance-create $ZVSI_INSTANCE_NAME $ZVSI_VPC $ZVSI_ZONE_NAME $ZVSI_PROFILE_NAME $ZVSI_SUBNET --image $ZVSI_IMAGE --keys $ZVSI_KEY --resource-group-id $ZVSI_RG_ID
+          #Reserving a floating ip to the ZVSI
+          ibmcloud is floating-ip-reserve $ZVSI_FP_NAME --zone $ZVSI_ZONE_NAME --resource-group-id $ZVSI_RG_ID --in $ZVSI_INSTANCE_NAME
+          #Bouding the Floating ip to the ZVSI
+          ibmcloud is floating-ip-update $ZVSI_FP_NAME --nic primary --in $ZVSI_INSTANCE_NAME
+          sleep 20
+            
+          #Saving the Floating IP to login ZVSI
+          ZVSI_HOST=$(ibmcloud is floating-ip $ZVSI_FP_NAME | awk '/Address/{print $2}')
+          echo $ZVSI_HOST
+          echo "IP=${ZVSI_HOST}" >> $GITHUB_OUTPUT
+          
+      - name: Setup Docker on ZVSI
+        uses: appleboy/ssh-action@master
+        with:
+            host: ${{ steps.ZVSI.outputs.IP }}
+            username: ${{ secrets.SSH_USER }}
+            key: ${{ secrets.ZVSI_PR_KEY }}
+            script: |
+              #update
+              arch
+              apt-get update
+              
+              #Setup Docker
+              apt-get install ca-certificates curl gnupg
+              install -m 0755 -d /etc/apt/keyrings
+              curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+              chmod a+r /etc/apt/keyrings/docker.gpg
+              echo \
+              "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+              "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+              tee /etc/apt/sources.list.d/docker.list > /dev/null
+              apt-get update
+              apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+            
       - name: Setup SSH config for builders
         env:
           BUILDER_AARCH64_SSH_CONFIG: ${{ secrets.BUILDER_AARCH64_SSH_CONFIG }}
@@ -42,6 +97,9 @@ jobs:
           BUILDER_PPC64LE_SSH_CONFIG: ${{ secrets.BUILDER_PPC64LE_SSH_CONFIG }}
           BUILDER_PPC64LE_SSH_KEY: ${{ secrets.BUILDER_PPC64LE_SSH_KEY }}
           BUILDER_PPC64LE_SSH_KNOWN_HOSTS: ${{ secrets.BUILDER_PPC64LE_SSH_KNOWN_HOSTS }}
+          BUILDER_S390X_SSH_HOST: ${{ steps.ZVSI.outputs.IP }}
+          BUILDER_S390X_SSH_KEY: ${{ secrets.ZVSI_PR_KEY }}
+          
         run: |
           mkdir ~/.ssh
           chmod 700 ~/.ssh
@@ -53,7 +111,11 @@ jobs:
           touch ~/.ssh/id_builder_ppc64le
           chmod 600 ~/.ssh/id_builder_ppc64le
           echo "$BUILDER_PPC64LE_SSH_KEY" >~/.ssh/id_builder_ppc64le
-
+          
+          touch ~/.ssh/id_builder_s390x
+          chmod 600 ~/.ssh/id_builder_s390x
+          echo "$BUILDER_S390X_SSH_KEY" > ~/.ssh/id_builder_s390x
+          
           touch ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
           cat >~/.ssh/known_hosts <<END
@@ -71,18 +133,26 @@ jobs:
           Host builder-ppc64le
             IdentityFile "~/.ssh/id_builder_ppc64le"
           $BUILDER_PPC64LE_SSH_CONFIG
+          
+          Host builder-s390x
+            StrictHostKeyChecking no
+            HostName $BUILDER_S390X_SSH_HOST
+            User root
+            IdentityFile "~/.ssh/id_builder_s390x"
           END
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          platforms: linux/amd64,linux/s390x
+          platforms: linux/amd64
           append: |
             - endpoint: ssh://builder-aarch64
               platforms: linux/arm64
             - endpoint: ssh://builder-ppc64le
               platforms: linux/ppc64le
-
+            - endpoint: ssh://builder-s390x
+              platforms: linux/s390x
+              
       - name: Login to Quay.io
         uses: docker/login-action@v1
         with:
@@ -99,4 +169,12 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}
-
+      
+      - name: Post Build-and-publish-s390x
+        run: |
+          #Delete the created ZVSI
+          ibmcloud is instance-delete $ZVSI_INSTANCE_NAME --force
+          sleep 15
+            
+          #Release the created FP
+          ibmcloud is floating-ip-release $ZVSI_FP_NAME --force

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -26,7 +26,7 @@ jobs:
       ZVSI_ZONE_NAME: eu-gb-2
       ZVSI_PROFILE_NAME: bz2-4x16
       ZVSI_SUBNET: 0797-88f93aad-3acd-4c8e-be10-8dc6d41bc9b9
-      ZVSI_IMAGE: r018-b774babd-711c-415c-8c62-aae0d6c824dc 
+      ZVSI_IMAGE: r018-acadf3d4-f340-4e13-add0-49ce45e8a778
       ZVSI_KEY: r018-ee997015-b88c-4500-874c-71f2175a8284
       ZVSI_RG_ID: 2e818eb391df4774977812b50ff0e8c9
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
# Description
Updated builder for IBM/Z 

## Tests that have been done

-  Verified the Building and publishing docker build through [workflow](https://github.com/ksdeekshith/quay/actions/runs/5174142121/jobs/9320128036) 

## Changes that have been done

-  Updated **set-output** command, which is being deprecated, to **GITHUB_OUTPUT**
-  Removed **QEMU**
-  Added on-the-fly **creation of ZVSI for s390x builder** and **deletion post build-and-publish-s390x**