### PR TITLE
data: Fix error getting tag while calculating scan results SLO (PROJQUAY-5600)

### DIFF
--- a/data/registry_model/datatypes.py
+++ b/data/registry_model/datatypes.py
@@ -353,7 +353,10 @@ class Manifest(
         """
         When the manifest was created
         """
-        result = TagTable.get(TagTable.manifest_id == self.id).lifetime_start_ms
+        try:
+            result = TagTable.get(TagTable.manifest_id == self.id).lifetime_start_ms
+        except TagTable.DoesNotExist:
+            return None
         return result
 
     @property

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -400,9 +400,12 @@ class V4SecurityScanner(SecurityScannerInterface):
                 index_status = IndexStatus.COMPLETED
                 # record time to get results if manifest has just been uploaded
                 if not manifest.has_been_scanned:
-                    dur_ms = get_epoch_timestamp_ms() - manifest.created_at
-                    dur_sec = dur_ms / 1000
-                    secscan_result_duration.observe(dur_sec)
+                    created_at = manifest.created_at
+
+                    if created_at is not None:
+                        dur_ms = get_epoch_timestamp_ms() - created_at
+                        dur_sec = dur_ms / 1000
+                        secscan_result_duration.observe(dur_sec)
 
                     if features.SECURITY_SCANNER_NOTIFY_ON_NEW_INDEX:
                         try:


### PR DESCRIPTION
Catch possible exception thrown when looking up tag `lifetime_start_ms` and set `created_at` property for a manifest to None.

If `created_at` is None, don't calculate indexing SLI for manifest.