### PR TITLE
fix: Accept schema 2 images as OCI index children (PROJQUAY-4826)

### DIFF
--- a/image/oci/index.py
+++ b/image/oci/index.py
@@ -47,6 +47,8 @@ from image.docker.schema2 import (
     DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE,
     DOCKER_SCHEMA2_MANIFESTLIST_CONTENT_TYPE,
 )
+from image.docker.schema2.manifest import DockerSchema2Manifest
+from image.docker.schema2.list import DockerSchema2ManifestList
 from image.oci import OCI_IMAGE_INDEX_CONTENT_TYPE, OCI_IMAGE_MANIFEST_CONTENT_TYPE
 from image.oci.descriptor import get_descriptor_schema
 from image.oci.manifest import OCIManifest
@@ -262,6 +264,8 @@ class OCIIndex(ManifestListInterface):
         """
         manifests = self._parsed[INDEX_MANIFESTS_KEY]
         supported_types = {}
+        supported_types[DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE] = DockerSchema2Manifest
+        supported_types[DOCKER_SCHEMA2_MANIFESTLIST_CONTENT_TYPE] = DockerSchema2ManifestList
         supported_types[OCI_IMAGE_MANIFEST_CONTENT_TYPE] = OCIManifest
         supported_types[OCI_IMAGE_INDEX_CONTENT_TYPE] = OCIIndex
         return [

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -2271,7 +2271,15 @@ def test_push_pull_manifest_list_back_compat(
     )
 
 
-@pytest.mark.parametrize("schema_version", [1, 2, "oci"])
+@pytest.mark.parametrize(
+    "schema_version, first_manifest_schema_version, second_manifest_schema_version",
+    [
+        (1, 1, 2),
+        (2, 2, 2),
+        ("oci", "oci", "oci"),
+        ("oci", 2, 2),
+    ],
+)
 def test_push_pull_manifest_list(
     v22_protocol,
     basic_images,
@@ -2279,6 +2287,8 @@ def test_push_pull_manifest_list(
     liveserver_session,
     app_reloader,
     schema_version,
+    first_manifest_schema_version,
+    second_manifest_schema_version,
     data_model,
 ):
     """Test: Push a new tag with a manifest list containing two manifests, one (possibly) legacy
@@ -2294,15 +2304,18 @@ def test_push_pull_manifest_list(
         "devtable", "newrepo", "latest", basic_images, blobs, options
     )
 
-    if schema_version == "oci":
-        first_manifest = v22_protocol.build_oci(basic_images, blobs, options)
-        second_manifest = v22_protocol.build_oci(different_images, blobs, options)
-    else:
-        first_manifest = signed.unsigned()
-        if schema_version == 2:
-            first_manifest = v22_protocol.build_schema2(basic_images, blobs, options)
+    def _build_manifest(layers, schema_version):
+        if schema_version == "oci":
+            return v22_protocol.build_oci(layers, blobs, options)
+        elif schema_version == 2:
+            return v22_protocol.build_schema2(layers, blobs, options)
+        elif schema_version == 1:
+            return signed.unsigned()
+        else:
+            raise ValueError("invalid schema version")
 
-        second_manifest = v22_protocol.build_schema2(different_images, blobs, options)
+    first_manifest = _build_manifest(basic_images, first_manifest_schema_version)
+    second_manifest = _build_manifest(different_images, second_manifest_schema_version)
 
     # Create and push the manifest list.
     builder = OCIIndexBuilder() if schema_version == "oci" else DockerSchema2ManifestListBuilder()


### PR DESCRIPTION
This change fixes [PROJQUAY-4826](https://issues.redhat.com/browse/PROJQUAY-4826).