### PR TITLE
geo-rep: Initialize features from config in util script (PROJQUAY-5627)

### DIFF
--- a/util/removelocation.py
+++ b/util/removelocation.py
@@ -1,11 +1,11 @@
 import logging
-import features
 import sys
 import argparse
 from data.database import (
     ImageStoragePlacement,
     ImageStorageLocation,
 )
+from app import features
 
 # This is a util function used to clean up a removed location from the database
 # This must be ran AFTER the location is removed from the config.yaml file, so that


### PR DESCRIPTION
- Features must be initialized in order to check if storage replication is enabled, so we need to import and intialize the config from inside the util script