### PR TITLE
[redhat-3.9] chore: Use buildx v0.11.0-rc2

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -76,6 +76,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
+          version: v0.11.0-rc2
           platforms: linux/amd64,linux/s390x
           append: |
             - endpoint: ssh://builder-aarch64


### PR DESCRIPTION
Manual backport of #1960.