### PR TITLE
api: allow robot token creation with a pre-defined token (PROJQUAY-5414)

### DIFF
--- a/data/model/user.py
+++ b/data/model/user.py
@@ -321,7 +321,7 @@ def update_enabled(user, set_enabled):
     user.save()
 
 
-def create_robot(robot_shortname, parent, description="", unstructured_metadata=None):
+def create_robot(robot_shortname, parent, description="", unstructured_metadata=None, token=None):
     (username_valid, username_issue) = validate_username(robot_shortname)
     if not username_valid:
         raise InvalidRobotException(
@@ -343,7 +343,7 @@ def create_robot(robot_shortname, parent, description="", unstructured_metadata=
     try:
         with db_transaction():
             created = User.create(username=username, email=str(uuid.uuid4()), robot=True)
-            token = random_string_generator(length=64)()
+            token = token if token else random_string_generator(length=64)()
             RobotAccountToken.create(robot_account=created, token=token, fully_migrated=True)
             FederatedLogin.create(
                 user=created, service=service, service_ident="robot:%s" % created.id

--- a/data/model/user.py
+++ b/data/model/user.py
@@ -66,7 +66,8 @@ from util.validation import (
     validate_username,
     validate_email,
     validate_password,
-    INVALID_PASSWORD_MESSAGE, validate_robot_token,
+    INVALID_PASSWORD_MESSAGE,
+    validate_robot_token,
 )
 
 logger = logging.getLogger(__name__)

--- a/data/model/user.py
+++ b/data/model/user.py
@@ -66,7 +66,7 @@ from util.validation import (
     validate_username,
     validate_email,
     validate_password,
-    INVALID_PASSWORD_MESSAGE,
+    INVALID_PASSWORD_MESSAGE, validate_robot_token,
 )
 
 logger = logging.getLogger(__name__)
@@ -327,6 +327,9 @@ def create_robot(robot_shortname, parent, description="", unstructured_metadata=
         raise InvalidRobotException(
             "The name for the robot '%s' is invalid: %s" % (robot_shortname, username_issue)
         )
+
+    if token and not validate_robot_token(token):
+        raise InvalidRobotException("Invalid token for robot")
 
     username = format_robot_username(parent.username, robot_shortname)
 

--- a/util/validation.py
+++ b/util/validation.py
@@ -57,6 +57,7 @@ def validate_password(password):
         return False
     return len(password) > 7
 
+
 def validate_robot_token(token):
     if len(token) != 64:
         return False

--- a/util/validation.py
+++ b/util/validation.py
@@ -57,6 +57,16 @@ def validate_password(password):
         return False
     return len(password) > 7
 
+def validate_robot_token(token):
+    if len(token) != 64:
+        return False
+
+    for t in token:
+        if t not in string.ascii_uppercase + string.digits:
+            return False
+
+    return True
+
 
 def _gen_filler_chars(num_filler_chars):
     if num_filler_chars == 0:


### PR DESCRIPTION
This is for usecases where we want to explicitly create a robot token with a pre-defined token in case of migration events when we migrate from one quay to another, we can re-use the same robot token to avoid resetting it in all places it is used