### PR TITLE
ui: Add custom TOS support

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,6 +48,7 @@ CLIENT_WHITELIST = [
     "QUOTA_BACKFILL",
     "PERMANENTLY_DELETE_TAGS",
     "UI_V2_FEEDBACK_FORM",
+    "TERMS_OF_SERVICE",
 ]
 
 
@@ -845,3 +846,6 @@ class DefaultConfig(ImmutableConfig):
     ENTITLEMENT_RECONCILIATION_MARKETPLACE_ENDPOINT = ""
 
     FEATURE_RH_MARKETPLACE = False
+
+    # Set up custom TOS for on-premise installations
+    TERMS_OF_SERVICE =  ""

--- a/endpoints/api/discovery.py
+++ b/endpoints/api/discovery.py
@@ -40,7 +40,11 @@ TYPE_CONVERTER = {
 
 PREFERRED_URL_SCHEME = app.config["PREFERRED_URL_SCHEME"]
 SERVER_HOSTNAME = app.config["SERVER_HOSTNAME"]
-
+if SERVER_HOSTNAME == "quay.io" or SERVER_HOSTNAME == "stage.quay.io":
+    TERMS_OF_SERVICE = "https://quay.io/tos"
+else:
+    TERMS_OF_SERVICE = app.config["TERMS_OF_SERVICE"]
+CONTACT_EMAIL = app.config["MAIL_DEFAULT_SENDER"]
 
 def fully_qualified_name(method_view_class):
     return "%s.%s" % (method_view_class.__module__, method_view_class.__name__)
@@ -321,8 +325,8 @@ def swagger_route_data(include_internal=False, compact=False):
                 "with Quay repositories, users, and organizations. You can find out more "
                 'at <a href="https://quay.io">Quay</a>.'
             ),
-            "termsOfService": "https://quay.io/tos",
-            "contact": {"email": "support@quay.io"},
+            "termsOfService": TERMS_OF_SERVICE,
+            "contact": {"email": CONTACT_EMAIL},
         },
         "securityDefinitions": {
             "oauth2_implicit": {

--- a/templates/base.html
+++ b/templates/base.html
@@ -138,6 +138,12 @@ mixpanel.init("{{ mixpanel_key }}", { track_pageview : false, debug: {{ is_debug
           {% if config_set['BRANDING']['footer_img'] %}
           <li><a href="{{ config_set['BRANDING']['footer_url'] }}" ng-safenewtab><img src="{{ config_set['BRANDING']['footer_img'] }}"></a></li>
           {% endif %}
+          {% if config_set['SERVER_HOSTNAME'] == ('quay.io') or config_set['SERVER_HOSTNAME'] == ('stage.quay.io') %}
+          <li><a href="https://quay.io/tos/" ng-safenewtab>Terms of Service</a></li>
+          {% endif %}
+          {% if config_set['TERMS_OF_SERVICE'] %}
+          <li><a href="{{ config_set['TERMS_OF_SERVICE'] }}" ng-safenewtab>Terms of Service</a></li>
+          {% endif %}
           <li><a href="{{ config_set['DOCUMENTATION_ROOT'] }}" ng-safenewtab>Documentation</a></li>
           <li quay-require="['BILLING']"><a href="https://www.openshift.com/legal/terms" target="_blank">Terms</a></li>
           <li quay-require="['BILLING']"><a href="https://www.redhat.com/en/about/privacy-policy" target="_blank">Privacy</a></li>

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1383,5 +1383,11 @@ CONFIG_SCHEMA = {
             "description": "Endpoint for internal RH marketplace API",
             "x-example": "https://internal-rh-marketplace-endpoint",
         },
+        # Custom terms of service
+        "TERMS_OF_SERVICE": {
+            "type": "string",
+            "description": "Enable customizing of terms of service for on-prem installations",
+            "x-example": "https://quay.io/tos",
+        },
     },
 }


### PR DESCRIPTION
Enable adding of a custom TOS in the Quay footer for on-premise installations via the optional `TERMS_OF_SERVICE` config flag. If the flag is not defined, the TOS field will not be visible when the page is rendered. Also changes the behaviour of the discovery endpoint to include custom terms of service instead of pointing to Quay.io terms of service for all installations.