### PR TITLE
federationuser(ldap): adding keepalive settings for LDAP connections (PROJQUAY-5137)

### DIFF
--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -20,6 +20,7 @@ _DEFAULT_KEEPALIVE_IDLE = 10
 _DEFAULT_KEEPALIVE_INTERVAL = 5
 _DEFAULT_KEEPALIVE_PROBES = 3
 
+
 class LDAPConnectionBuilder(object):
     def __init__(
         self,


### PR DESCRIPTION
Adding keepalive setting for LDAP connection in complex network scenarios.

introducing variables for 
* _DEFAULT_KEEPALIVE_IDLE
* _DEFAULT_KEEPALIVE_INTERVAL
* _DEFAULT_KEEPALIVE_PROBES

setting the corresponding LDAP options. 
The LDAP restart option ensures on issues that the connection will be re-established.
