### PR TITLE
Revert "chore: Bump dependencies that cause syntax warnings (PROJQUAY-5650)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ maxminddb==1.5.2
 mixpanel==4.5.0
 msgpack==0.6.2
 msrest==0.6.21
-netaddr==0.8.0
+netaddr==0.7.19
 netifaces==0.10.9
 oauthlib==3.2.2
 orderedmultidict==1.0.1
@@ -125,7 +125,7 @@ supervisor-stdout @ git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d
 text-unidecode==1.3
 tldextract==2.2.2
 toposort==1.5
-tzlocal==5.0.1
+tzlocal==2.0.0
 urllib3==1.26.9
 webencodings==0.5.1
 WebOb==1.8.6


### PR DESCRIPTION
Reverts quay/quay#1976

New tzlocal causes issues like this:
```
notificationworker stderr |   File "/quay-registry/workers/worker.py", line 60, in __init__
notificationworker stderr |     self._sched = BackgroundScheduler()
notificationworker stderr |   File "/app/lib/python3.9/site-packages/apscheduler/schedulers/base.py", line 87, in __init__
notificationworker stderr |     self.configure(gconfig, **options)
notificationworker stderr |   File "/app/lib/python3.9/site-packages/apscheduler/schedulers/base.py", line 126, in configure
notificationworker stderr |     self._configure(config)
notificationworker stderr |   File "/app/lib/python3.9/site-packages/apscheduler/schedulers/background.py", line 29, in _configure
notificationworker stderr |     super(BackgroundScheduler, self)._configure(config)
notificationworker stderr |   File "/app/lib/python3.9/site-packages/apscheduler/schedulers/base.py", line 697, in _configure
notificationworker stderr |     self.timezone = astimezone(config.pop('timezone', None)) or get_localzone()
notificationworker stderr |   File "/app/lib/python3.9/site-packages/tzlocal/unix.py", line 218, in get_localzone
notificationworker stderr |     _cache_tz = _get_localzone()
notificationworker stderr |   File "/app/lib/python3.9/site-packages/tzlocal/unix.py", line 175, in _get_localzone
notificationworker stderr |     tzenv = utils._tz_from_env()
notificationworker stderr |   File "/app/lib/python3.9/site-packages/tzlocal/utils.py", line 109, in _tz_from_env
notificationworker stderr |     raise zoneinfo.ZoneInfoNotFoundError(
notificationworker stderr | zoneinfo._common.ZoneInfoNotFoundError: 'tzlocal() does not support non-zoneinfo timezones like UTC. \nPlease use a timezone in the form of Continent/City'
```