### PR TITLE
Update CI-nightly.yaml

### DIFF
--- a/.github/workflows/CI-nightly.yaml
+++ b/.github/workflows/CI-nightly.yaml
@@ -6,6 +6,7 @@ on:
     inputs: {}
 jobs:
   unit:
+    if: github.repository == 'quay/quay'
     name: Run all Test
     runs-on: ubuntu-20.04
     env:


### PR DESCRIPTION
Nightly CI job is executing on forked repo at scheduled time.

Added check to not schedule the job on forked repo 



