### PR TITLE
config: Enable notifications for new indexes by default (PROJQUAY-5682)

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,10 +1,10 @@
-from typing import Optional, Dict, Any, List, Union, Tuple
+import os.path
+from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
-import os.path
 import requests
 
-from _init import ROOT_DIR, CONF_DIR
+from _init import CONF_DIR, ROOT_DIR
 
 
 def build_requests_session():
@@ -827,7 +827,7 @@ class DefaultConfig(ImmutableConfig):
     CORS_ORIGIN = "*"
 
     # Feature Flag: Enables notifications about vulnerabilities to be sent for new pushes
-    FEATURE_SECURITY_SCANNER_NOTIFY_ON_NEW_INDEX = False
+    FEATURE_SECURITY_SCANNER_NOTIFY_ON_NEW_INDEX = True
 
     FEATURE_SUPERUSERS_FULL_ACCESS = False
     FEATURE_SUPERUSERS_ORG_CREATION_ONLY = False

--- a/data/secscan_model/test/test_secscan_interface.py
+++ b/data/secscan_model/test/test_secscan_interface.py
@@ -1,20 +1,24 @@
-import pytest
-
-from mock import patch, Mock
-
-from data.secscan_model.datatypes import ScanLookupStatus, SecurityInformationLookupResult
-from data.secscan_model.secscan_v4_model import (
-    V4SecurityScanner,
-    IndexReportState,
-    ScanToken as V4ScanToken,
-)
-from data.secscan_model import secscan_model
-from data.registry_model import registry_model
-from data.database import ManifestSecurityStatus, IndexerVersion, IndexStatus, ManifestLegacyImage
-
 from test.fixtures import *
 
+import pytest
+from mock import Mock, patch
+
 from app import app, instance_keys, storage
+from data.database import (
+    IndexerVersion,
+    IndexStatus,
+    ManifestLegacyImage,
+    ManifestSecurityStatus,
+)
+from data.registry_model import registry_model
+from data.secscan_model import secscan_model
+from data.secscan_model.datatypes import (
+    ScanLookupStatus,
+    SecurityInformationLookupResult,
+)
+from data.secscan_model.secscan_v4_model import IndexReportState
+from data.secscan_model.secscan_v4_model import ScanToken as V4ScanToken
+from data.secscan_model.secscan_v4_model import V4SecurityScanner
 
 
 @pytest.mark.parametrize(
@@ -64,6 +68,7 @@ def test_perform_indexing(next_token, expected_next_token, expected_error, initi
 
     def secscan_api(*args, **kwargs):
         api = Mock()
+        api.vulnerability_report.return_value = {"vulnerabilities": []}
         api.state.return_value = {"state": "abc"}
         api.index.return_value = ({"err": None, "state": IndexReportState.Index_Finished}, "abc")
 

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1356,7 +1356,7 @@ CONFIG_SCHEMA = {
         "FEATURE_SECURITY_SCANNER_NOTIFY_ON_NEW_INDEX": {
             "type": "boolean",
             "description": "Whether to allow sending notifications about vulnerabilities for new pushes",
-            "x-example": False,
+            "x-example": True,
         },
         "RESET_CHILD_MANIFEST_EXPIRATION": {
             "type": "boolean",


### PR DESCRIPTION
Change the default from `False` to `True` for
`FEATURE_SECURITY_SCANNING_NOTIFY_ON_NEW_INDEX`.

Since this flag addresses a bug, it should be enabled by default.