### PR TITLE
secsan: Add tags field to event data on new vulnerability notifications (PROJQUAY-5681)

### DIFF
--- a/notifications/notificationevent.py
+++ b/notifications/notificationevent.py
@@ -247,7 +247,7 @@ class VulnerabilityFoundEvent(NotificationEvent):
             return msg % (
                 event_data[vuln_key][priority_key],
                 event_data["repository"],
-                len(event_data["tags"]),
+                len(event_data.get("tags")),
             )
 
 


### PR DESCRIPTION
Add tag field to event data for vulnerability notifications on new image pushes.

Missing tag field caused an exception for slack notifications, should allow slack notifications to fire for new images.

![Screenshot 2023-06-29 at 11 49 55 AM](https://github.com/quay/quay/assets/47163063/581cd836-1821-4d1c-a159-44db344d3bad)
