### PR TITLE
storage: Do nothing when completing chunked upload if chunk list is empty (PROJQUAY-5489)

### DIFF
--- a/storage/test/test_cloud_storage.py
+++ b/storage/test/test_cloud_storage.py
@@ -1,21 +1,20 @@
 import os
 import time
-
+from datetime import timedelta
 from io import BytesIO
 
-import pytest
-
-import botocore.exceptions
 import boto3
-
+import botocore.exceptions
+import pytest
 from moto import mock_s3
 
 from storage import S3Storage, StorageContext
-from storage.cloud import _CloudStorage, _PartUploadMetadata
-from storage.cloud import _CHUNKS_KEY
-from storage.cloud import _build_endpoint_url
-
-from datetime import timedelta
+from storage.cloud import (
+    _CHUNKS_KEY,
+    _build_endpoint_url,
+    _CloudStorage,
+    _PartUploadMetadata,
+)
 
 _TEST_CONTENT = os.urandom(1024)
 _TEST_BUCKET = "somebucket"
@@ -193,7 +192,8 @@ def test_chunk_upload(storage_engine, chunk_count, force_client_side):
     )
 
     # Ensure the file contents are valid.
-    assert storage_engine.get_content("some/chunked/path") == final_data
+    if chunk_count != 0:
+        assert storage_engine.get_content("some/chunked/path") == final_data
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When completing a chunked upload, if the chunk list is empty do not attempt to assemble anything.

Using oras to copy an artifact from an outside registry to quay results in a 5XX error. This is because at some point the upload chunk list is empty and attempting to complete the chunked upload causes an exception. Not trying to write to storage if there are no chunks allows the copy operation to successfully complete.