### PR TITLE
Pagination: Fixing paginate for /api/v1/superuser/logs API

### DIFF
--- a/data/model/modelutil.py
+++ b/data/model/modelutil.py
@@ -55,7 +55,11 @@ def paginate(
 
     offset_val = page_token.get("offset_val", 0) if page_token else 0
     return paginate_query(
-        query, limit=limit, sort_field_name=sort_field_name, page_number=page_number, offset_val=offset_val
+        query,
+        limit=limit,
+        sort_field_name=sort_field_name,
+        page_number=page_number,
+        offset_val=offset_val,
     )
 
 
@@ -85,9 +89,12 @@ def paginate_query(query, limit=50, sort_field_name=None, page_number=None, offs
         start_index = getattr(results[limit], sort_field_name or "id")
         is_datetime = False
         if isinstance(start_index, datetime):
-            # since multiple entries can have same datetime, returning id which has unique constraint.
             start_index = start_index.isoformat() + "Z"
-            use_offset = getattr(results[limit], sort_field_name) == getattr(results[limit-1], sort_field_name)
+            # datetime does not have a unique constraint, so multiple entries can have the same datetime.
+            # using offset to fetch next page items with same datetime.
+            use_offset = getattr(results[limit], sort_field_name) == getattr(
+                results[limit - 1], sort_field_name
+            )
             offset_val = limit + offset_val if use_offset else 0
             is_datetime = True
 

--- a/data/model/modelutil.py
+++ b/data/model/modelutil.py
@@ -84,7 +84,6 @@ def paginate_query(query, limit=50, sort_field_name=None, page_number=None, offs
     """
     results = list(query)
     page_token = None
-    offset_val = 0
     if len(results) > limit:
         start_index = getattr(results[limit], sort_field_name or "id")
         is_datetime = False

--- a/data/model/modelutil.py
+++ b/data/model/modelutil.py
@@ -53,7 +53,7 @@ def paginate(
     if page_number is not None and max_page is not None and page_number > max_page:
         return [], None
 
-    offset_val = page_token.get("offset_val") if page_token else 0
+    offset_val = page_token.get("offset_val", 0) if page_token else 0
     return paginate_query(
         query, limit=limit, sort_field_name=sort_field_name, page_number=page_number, offset_val=offset_val
     )
@@ -67,6 +67,8 @@ def pagination_start(page_token=None):
     """
     if page_token is not None:
         start_index = page_token.get("start_index")
+        if page_token.get("is_datetime"):
+            start_index = dateutil.parser.parse(start_index)
         return start_index
     return None
 


### PR DESCRIPTION
Superuser logs are sorted on datetime field. The next page token contains the value of the start_index of the datetime field for the next page. datetime column on the LogEntry table is not unique, so in some cases,  multiple entries can have the same datetime field. 
For example, logs have a page limit of 20 entries. If 25 entries have the same datetime - d1, the start_index of the next page is again d1. With the current logic, the same query is run for the next page too. This PR addresses such issues and adds an offset in such cases where (the first 20 entries of page 1 and 1 or more entries of page 2 have the same datetime).