### PR TITLE
chore: Use stable Cython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ tinycss2==1.2.1
 tqdm==4.65.0
 
 # Build dependencies
-Cython==3.0.0a9
+Cython==0.29.36
 flit_core==3.7.1
 toml==0.10.2
 pip==22.2.1


### PR DESCRIPTION
Cython is required to build PyYAML from sources, and it depends on Cython<3.0.