### PR TITLE
api: Adding ignore timezone flag when parsing datetime (PROJQUAY-5360)

### DIFF
--- a/data/model/modelutil.py
+++ b/data/model/modelutil.py
@@ -71,8 +71,6 @@ def pagination_start(page_token=None):
     """
     if page_token is not None:
         start_index = page_token.get("start_index")
-        if page_token.get("is_datetime"):
-            start_index = dateutil.parser.parse(start_index)
         return start_index
     return None
 

--- a/data/model/modelutil.py
+++ b/data/model/modelutil.py
@@ -103,4 +103,5 @@ def paginate_query(query, limit=50, sort_field_name=None, page_number=None, offs
             "is_datetime": is_datetime,
             "offset_val": offset_val,
         }
+
     return results[0:limit], page_token

--- a/data/model/modelutil.py
+++ b/data/model/modelutil.py
@@ -71,6 +71,8 @@ def pagination_start(page_token=None):
     """
     if page_token is not None:
         start_index = page_token.get("start_index")
+        if page_token.get("is_datetime"):
+            start_index = dateutil.parser.parse(start_index, ignoretz=True)
         return start_index
     return None
 
@@ -101,5 +103,4 @@ def paginate_query(query, limit=50, sort_field_name=None, page_number=None, offs
             "is_datetime": is_datetime,
             "offset_val": offset_val,
         }
-
     return results[0:limit], page_token


### PR DESCRIPTION
When the database time is altered or explicitly set, the dateutil library adds the offset - `±HH:MM` to the set datetime. This is not identified by the query language and hence gets ignored when the query is complied. `ignoretz` flag in the [parse function](https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parse) when set to `True` does not add this offset to the datetime and thus the start_index from the page_token is identified and complied. 