### PR TITLE
chore: Add config for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - dmage
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    assignees:
+      - dmage


### PR DESCRIPTION
This PR enables dependabot for this repository. It updates dependencies to the latest versions (even when there are no CVEs). Example of PRs - https://github.com/dmage/quay/pulls?q=is%3Apr+author%3Aapp%2Fdependabot