### PR TITLE
chore: Add build dependencies for lxml 4.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN set -ex\
         libjpeg-turbo-devel \
 		wget \
 		rust-toolset \
+		libxml2-devel \
+		libxslt-devel \
 	; microdnf -y clean all
 WORKDIR /build
 RUN python3 -m ensurepip --upgrade


### PR DESCRIPTION
Follow-up to fix build errors caused by #2000.

```
Collecting lxml==4.9.2
  Downloading https://.../packages/lxml/4.9.2/lxml-4.9.2.tar.gz (3.7 MB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      Building lxml version 4.9.2.
      Building without Cython.
      Error: Please make sure the libxml2 and libxslt development packages are installed.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```