### PR TITLE
chore: Add build dependency for reportlab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN set -ex\
 		rust-toolset \
 		libxml2-devel \
 		libxslt-devel \
+		freetype-devel \
 	; microdnf -y clean all
 WORKDIR /build
 RUN python3 -m ensurepip --upgrade


### PR DESCRIPTION
Without the freetype-devel package installed, the build process fails:

```
Collecting reportlab==3.6.13
  Downloading https://.../packages/reportlab/3.6.13/reportlab-3.6.13.tar.gz (4.0 MB)
  Preparing metadata (setup.py): started
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      ##### setup-python-3.9.16-linux-x86_64: ================================================
      ##### setup-python-3.9.16-linux-x86_64: Attempting build of _rl_accel
      ##### setup-python-3.9.16-linux-x86_64: extensions from 'src/rl_addons/rl_accel'
      ##### setup-python-3.9.16-linux-x86_64: ================================================
      ##### setup-python-3.9.16-linux-x86_64: ===================================================
      ##### setup-python-3.9.16-linux-x86_64: Attempting build of _renderPM
      ##### setup-python-3.9.16-linux-x86_64: extensions from 'src/rl_addons/renderPM'
      ##### setup-python-3.9.16-linux-x86_64: ===================================================
      ##### setup-python-3.9.16-linux-x86_64: will use package libart 2.3.21
      !!!!! cannot find ft2build.h
      [end of output]
```