### PR TITLE
chore: fix build of PyYAML on linux/ppc64le

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,9 @@ RUN ARCH=$(uname -m) ; echo $ARCH; \
 	fi
 
 RUN set -ex\
-    ; python3 -m pip install --no-cache-dir --progress-bar off --user $(grep -e '^pip=' -e '^wheel=' -e '^setuptools=' ./requirements.txt) \
+	; python3 -m pip install --no-cache-dir --progress-bar off --user $(grep -e '^pip=' -e '^wheel=' -e '^setuptools=' ./requirements.txt) \
+	; python3 -m pip install --no-cache-dir --progress-bar off --user Cython==3.0.0a9 \
+	; python3 -m pip install --no-cache-dir --progress-bar off --user --no-build-isolation PyYAML==5.4.1 \
 	; python3 -m pip install --no-cache-dir --progress-bar off --user --requirement requirements.txt \
 	;
 RUN set -ex\


### PR DESCRIPTION
PyYAML 5.4.1 is the latest (at the moment) version that can be installed with Cython 3.0 (3.0b9).

As gevent requires Cython 3.0+, we cannot use PyYAML 6.0 that depends on Cython 0.x (<3.0).

As PyYAML 5.4.1 doesn't restrict the version of Cython that can be used to build it, pip selects Cython 3.0 when it creates an isolated build environment and fails to build PyYAML. To fix that, we preinstall build dependencies and disable the build isolation for PyYAML.