### PR TITLE
chore: Remove reference to Image table from the backfill replication script (PROJQUAY-5929)

### DIFF
--- a/util/backfillreplication.py
+++ b/util/backfillreplication.py
@@ -3,7 +3,6 @@ import features
 
 from app import storage, image_replication_queue
 from data.database import (
-    Image,
     ImageStorage,
     Repository,
     User,


### PR DESCRIPTION
The `image` table is deprecated and also not used in the backfill replication script. This PR removes the reference left from the previous PR.