### PR TITLE
quota: disabling quotatotalworker when running config editor (PROJQUAY-5925)

### DIFF
--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -87,8 +87,8 @@ def config_services():
         "manifestbackfillworker": {"autostart": "false"},
         "securityscanningnotificationworker": {"autostart": "false"},
         "config-editor": {"autostart": "true"},
-        "quotatotalworker": {"autostart": "true"},
-        "quotaregistrysizeworker": {"autostart": "true"},
+        "quotatotalworker": {"autostart": "false"},
+        "quotaregistrysizeworker": {"autostart": "false"},
     }
 
 


### PR DESCRIPTION
Quota worker incorrectly runs during config editor start up.