### PR TITLE
chore: fix nightly test failures

### DIFF
--- a/.github/workflows/CI-nightly.yaml
+++ b/.github/workflows/CI-nightly.yaml
@@ -110,7 +110,7 @@ jobs:
         export DEBIAN_FRONTEND=noninteractive;
         apt-get -y update;
         apt-get -y install libgpgme-dev libldap2-dev libsasl2-dev swig python3.9-dev python3-pip findutils git;
-        apt-get -y install libffi-dev libssl-dev libjpeg-dev;
+        apt-get -y install libffi-dev libssl-dev libjpeg-dev libxml2-dev libxslt-dev;
         git clone ${GH_REPOSITORY} build;
         cd build  && git checkout ${GH_REF};
         cat requirements-dev.txt | grep tox | xargs pip install;
@@ -135,7 +135,7 @@ jobs:
         script: |
           apt-get update -y
           apt-get -y install build-essential libgpgme-dev libldap2-dev libsasl2-dev swig python3.9-dev python3-pip findutils git
-          apt-get -y install libffi-dev libssl-dev libjpeg-dev libpq-dev
+          apt-get -y install libffi-dev libssl-dev libjpeg-dev libpq-dev libxml2-dev libxslt-dev
           git clone ${GH_REPOSITORY} build
           cd build  && git checkout ${GH_REF}
           GRPC_LATEST=$(grep "grpcio" requirements.txt |cut -d "=" -f 3)


### PR DESCRIPTION
Nightly tests for ppc64le and Z are failing with the below errors. Need to install required packages.

```err:   × python setup.py egg_info did not run successfully.
err:   │ exit code: 1
err:   ╰─> [5 lines of output]
err:       /tmp/pip-install-nylqgj2z/lxml_f64d41d75f61487f8b32a0164c470fee/setup.py:67: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
err:         import pkg_resources
err:       Building lxml version 4.9.2.
err:       Building without Cython.
err:       Error: Please make sure the libxml2 and libxslt development packages are installed.
err:       [end of output]```