### PR TITLE
chore: fix ppc64le nightly test run

### DIFF
--- a/.github/workflows/CI-nightly.yaml
+++ b/.github/workflows/CI-nightly.yaml
@@ -98,7 +98,7 @@ jobs:
         docker context create ${{ matrix.platform }} --description "Node ${{ matrix.platform }}" --docker "host=ssh://builder-${{ matrix.platform }}"
         docker context use ${{ matrix.platform }}
     - name: Install dependencies and run tests on all arch except s390x
-      if: matrix.platform  != 's390x'
+      if: matrix.platform != 's390x'
       run: >-
         docker run
         --rm
@@ -106,14 +106,16 @@ jobs:
         -e GH_REPOSITORY
         -e GH_REF
         ubuntu:20.04
-        /bin/bash -c '
+        /bin/bash -ec '
         export DEBIAN_FRONTEND=noninteractive;
         apt-get -y update;
         apt-get -y install libgpgme-dev libldap2-dev libsasl2-dev swig python3.9-dev python3-pip findutils git;
         apt-get -y install libffi-dev libssl-dev libjpeg-dev libxml2-dev libxslt-dev;
+        apt-get -y install rustc cargo pkg-config;
         git clone ${GH_REPOSITORY} build;
         cd build  && git checkout ${GH_REF};
         cat requirements-dev.txt | grep tox | xargs pip install;
+        sed -i "s/PyYAML==5.4.1/PyYAML==6.0.1/" requirements.txt;
         tox -e py39-unit;
         tox -e py39-e2e;
         tox -e py39-registry;'


### PR DESCRIPTION
Use PyYAML==6.0.1 which requires Cython<3.0 just for running tests.

Preinstall rustc cargo pkg-config required for building cryptography on ppc64le.