### PR TITLE
chore: fix s390x nightly ci

### DIFF
--- a/.github/workflows/CI-nightly.yaml
+++ b/.github/workflows/CI-nightly.yaml
@@ -138,6 +138,7 @@ jobs:
           apt-get update -y
           apt-get -y install build-essential libgpgme-dev libldap2-dev libsasl2-dev swig python3.9-dev python3-pip findutils git
           apt-get -y install libffi-dev libssl-dev libjpeg-dev libpq-dev libxml2-dev libxslt-dev
+          apt-get -y install rustc cargo pkg-config
           git clone ${GH_REPOSITORY} build
           cd build  && git checkout ${GH_REF}
           GRPC_LATEST=$(grep "grpcio" requirements.txt |cut -d "=" -f 3)


### PR DESCRIPTION
```
 Failed to build cryptography

error: can't find Rust compiler
```
ref: https://github.com/quay/quay/actions/runs/5915637333/job/16042083379