### PR TITLE
deploy: Add a startup probe to the py3 deployment (PROJQUAY-522)

### DIFF
--- a/deploy/openshift/quay-py3-app.yaml
+++ b/deploy/openshift/quay-py3-app.yaml
@@ -246,6 +246,7 @@ objects:
               - -k
               - https://localhost:8443/health/instance
             failureThreshold: ${{QUAY_APP_STARTUP_PROBE_FAILURE_THRESHOLD}}
+            timeoutSeconds: ${{QUAY_APP_STARTUP_PROBE_TIMEOUT_SECONDS}}
             periodSeconds: ${{QUAY_APP_STARTUP_PROBE_PERIOD_SECONDS}}
           livenessProbe:
             exec:
@@ -388,10 +389,13 @@ parameters:
     displayName: quay app deployment max unavailable
   - name: QUAY_APP_STARTUP_PROBE_FAILURE_THRESHOLD
     value: "20"
-    displayName: quay app liveness probe initial delay seconds
+    displayName: quay app startup probe initial delay seconds
+  - name: QUAY_APP_STARTUP_PROBE_TIMEOUT_SECONDS
+    value: "60"
+    displayName: quay app startup probe timeout seconds
   - name: QUAY_APP_STARTUP_PROBE_PERIOD_SECONDS
     value: "60"
-    displayName: quay app liveness probe initial delay seconds
+    displayName: quay app startup probe initial delay seconds
   - name: QUAY_APP_LIVENESS_PROBE_INITIAL_DELAY_SECONDS
     value: "15"
     displayName: quay app liveness probe initial delay seconds

--- a/deploy/openshift/quay-py3-app.yaml
+++ b/deploy/openshift/quay-py3-app.yaml
@@ -227,6 +227,7 @@ objects:
             initialDelaySeconds: ${{QUAY_SYSLOG_LIVENESS_PROBE_INITIAL_DELAY_SECONDS}}
             periodSeconds: ${{QUAY_SYSLOG_LIVENESS_PROBE_PERIOD_SECONDS}}
             timeoutSeconds: ${{QUAY_SYSLOG_LIVENESS_PROBE_TIMEOUT_SECONDS}}
+
         - name: quay-app
           image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: ${{IMAGE_PULL_POLICY}}
@@ -238,6 +239,14 @@ objects:
           volumeMounts:
           - name: configvolume
             mountPath: /conf/stack
+          startupProbe:
+            exec:
+              command:
+              - curl
+              - -k
+              - https://localhost:8443/health/instance
+            failureThreshold: ${{QUAY_APP_STARTUP_PROBE_FAILURE_THRESHOLD}}
+            periodSeconds: ${{QUAY_APP_STARTUP_PROBE_PERIOD_SECONDS}}
           livenessProbe:
             exec:
               command:
@@ -377,6 +386,12 @@ parameters:
   - name: QUAY_APP_DEPLOYMENT_MAX_UNAVAILABLE
     value: "0"
     displayName: quay app deployment max unavailable
+  - name: QUAY_APP_STARTUP_PROBE_FAILURE_THRESHOLD
+    value: "20"
+    displayName: quay app liveness probe initial delay seconds
+  - name: QUAY_APP_STARTUP_PROBE_PERIOD_SECONDS
+    value: "60"
+    displayName: quay app liveness probe initial delay seconds
   - name: QUAY_APP_LIVENESS_PROBE_INITIAL_DELAY_SECONDS
     value: "15"
     displayName: quay app liveness probe initial delay seconds


### PR DESCRIPTION
This is for cases where we have a long running
migraiton and we don't want to kill the pod mid migration