### PR TITLE
init(postgresclientcerts): add Postgresql client certificate authentication (PROJQUAY-2417)

### DIFF
--- a/conf/init/client_certs.sh
+++ b/conf/init/client_certs.sh
@@ -8,7 +8,7 @@ if [ -d /run/secrets/postgresql ]; then
 		[ -e /run/secrets/postgresql/tls.crt ] && \
 			cp /run/secrets/postgresql/tls.crt ${CERTDIR}/postgresql.crt
 		[ -e /run/secrets/postgresql/tls.key ] && \
-			cp /run/secrets/postgresql/tls.key ${CERTDIR}/postgresql.key 
+			cp /run/secrets/postgresql/tls.key ${CERTDIR}/postgresql.key
 		# SSL key needs to be restricted mode 0600
 		[ -e ${CERTDIR}/postgresql.key ] && \
 			chmod 0600 ${CERTDIR}/postgresql.key

--- a/conf/init/client_certs.sh
+++ b/conf/init/client_certs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+CERTDIR=${CERTDIR:-"/.postgresql"}
+
+# only execute if we have the secrets for client certificates
+if [ -d /run/secrets/postgresql ]; then
+	if [ -d ${CERTDIR} ]; then
+		[ -e /run/secrets/postgresql/tls.crt ] && \
+			cp /run/secrets/postgresql/tls.crt ${CERTDIR}/postgresql.crt
+		[ -e /run/secrets/postgresql/tls.key ] && \
+			cp /run/secrets/postgresql/tls.key ${CERTDIR}/postgresql.key 
+		# SSL key needs to be restricted mode 0600
+		[ -e ${CERTDIR}/postgresql.key ] && \
+			chmod 0600 ${CERTDIR}/postgresql.key
+		[ -e /run/secrets/postgresql/ca.crt ] && \
+			cp /run/secrets/postgresql/ca.crt ${CERTDIR}/root.crt
+		[ -e /run/secrets/postgresql/ca.crl ] && \
+			cp /run/secrets/postgresql/ca.crl ${CERTDIR}/root.crl
+	else
+		# inidicate that we didn't succeed with creating the expected SSL store
+		echo "cannot create ${CERTDIR}"
+		exit 1
+	fi
+fi
+exit 0

--- a/quay-entrypoint.sh
+++ b/quay-entrypoint.sh
@@ -70,6 +70,7 @@ case "$QUAYENTRY" in
         export OPERATOR_ENDPOINT="${OPERATOR_ENDPOINT}"
 
         "${QUAYPATH}/conf/init/certs_install.sh" || exit
+        "${QUAYPATH}/conf/init/client_certs.sh" || exit
         "${QUAYPATH}/conf/init/supervisord_conf_create.sh" config || exit
         exec supervisord -c "${QUAYCONF}/supervisord.conf" 2>&1
         ;;


### PR DESCRIPTION
add init script to prep Postgres Client certificates with proper permission if secret is populated through quay-operator PR (https://github.com/quay/quay-operator/pull/796)

This PR depends on successful merge of:

PR config-tool (https://github.com/quay/config-tool/pull/214)
PR quay-operator (https://github.com/quay/quay-operator/pull/796)
to work as expected.