### PR TITLE
api: order tags by name instead of ID (PROJQUAY-2806)

### DIFF
--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -135,10 +135,10 @@ def lookup_alive_tags_shallow(repository_id, start_pagination_id=None, limit=Non
 
     *only* contain their ID and name. Also note that the Tags are returned ordered by ID.
     """
-    query = Tag.select(Tag.id, Tag.name).where(Tag.repository == repository_id).order_by(Tag.id)
+    query = Tag.select(Tag.id, Tag.name).where(Tag.repository == repository_id).order_by(Tag.name)
 
     if start_pagination_id is not None:
-        query = query.where(Tag.id >= start_pagination_id)
+        query = query.offset(start_pagination_id)
 
     if limit is not None:
         query = query.limit(limit)

--- a/endpoints/v2/__init__.py
+++ b/endpoints/v2/__init__.py
@@ -101,11 +101,12 @@ def paginate(
             if page_info is not None:
                 start_id = page_info.get("start_id", None)
 
-            def callback(results, response):
+            def callback(results, response, offset=None):
                 if len(results) <= limit:
                     return
 
-                next_page_token = encrypt_page_token({"start_id": max([obj.id for obj in results])})
+                start_id = max([obj.id for obj in results]) if not offset else offset
+                next_page_token = encrypt_page_token({"start_id": start_id})
 
                 link_url = os.path.join(
                     get_app_url(), url_for(request.endpoint, **request.view_args)

--- a/endpoints/v2/tag.py
+++ b/endpoints/v2/tag.py
@@ -37,5 +37,5 @@ def list_all_tags(namespace_name, repo_name, start_id, limit, pagination_callbac
         }
     )
 
-    pagination_callback(tags, response)
+    pagination_callback(tags, response, offset=start_id + limit)
     return response


### PR DESCRIPTION
as per the spec, tag list should return values in lexical order