### PR TITLE
documentation: Change tag template link location for build triggers (PROJQUAY-6044)

### DIFF
--- a/buildtrigger/basehandler.py
+++ b/buildtrigger/basehandler.py
@@ -98,7 +98,7 @@ METADATA_SCHEMA = {
     "properties": {
         "commit": {
             "type": "string",
-            "description": "first 7 characters of the SHA-1 identifier for a git commit",
+            "description": "Full SHA-1 identifier of the commit",
             "pattern": "^([A-Fa-f0-9]{7,})$",
         },
         "parsed_ref": {
@@ -138,7 +138,7 @@ METADATA_SCHEMA = {
             "properties": {
                 "short_sha": {
                     "type": "string",
-                    "description": "The short SHA for this git commit",
+                    "description": "The short SHA for this git commit (7 characters)",
                 },
                 "url": {
                     "type": "string",

--- a/static/js/services/documentation/documentation.service.impl.ts
+++ b/static/js/services/documentation/documentation.service.impl.ts
@@ -18,7 +18,7 @@ export class DocumentationServiceImpl implements DocumentationService {
         return `html/use_red_hat_quay/repository_notifications#${p['event']}`;
       },
       'notifications': 'html/use_red_hat_quay/repository_notifications',
-      'builds.tag-templating': 'https://github.com/quay/quay/blob/master/buildtrigger/basehandler.py#L81'
+      'builds.tag-templating': 'https://access.redhat.com/solutions/7033393'
     };
   }
 


### PR DESCRIPTION
The documentation link on the build trigger tag template screen is currently pointing to the location of the `schema` directly in the code. 

This is not really useful or user friendly. This will repoint that documentation link to the KCS article written for this purpose.