### PR TITLE
secscan: add support for new enrichment type (PROJQUAY-5981)

### DIFF
--- a/data/secscan_model/test/securityinformation_with_rhcc_enrichments.json
+++ b/data/secscan_model/test/securityinformation_with_rhcc_enrichments.json
@@ -1,0 +1,6995 @@
+
+{
+  "Layer": {
+    "Name": "sha256:33f40783cb6ac656b56a6c64208f38ef17ab8023171321551be2cd14876a1418",
+    "ParentName": "",
+    "NamespaceName": "",
+    "IndexedByVersion": 4,
+    "Features": [
+      {
+        "Name": "acl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.2.53-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "alsa-lib",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.2.5-4.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "audit-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.0-0.17.20191104git1c2f876.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "avahi-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.7-20.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "basesystem",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "11-5.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "bash",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.4.20-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "brotli",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.0.6-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "bzip2-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.0.6-26.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "ca-certificates",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2021.2.50-80.0.el8_4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "chkconfig",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.19.1-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.amazon.opendistroforelasticsearch:opendistro_security",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.10.1.2-redhat-00006",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.carrotsearch:hppc",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.7.1.redhat-00002",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.eclipsesource.minimal-json:minimal-json",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.9.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.fasterxml.jackson.core:jackson-annotations",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.10.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.fasterxml.jackson.core:jackson-annotations",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.10.5.redhat-00002",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.fasterxml.jackson.core:jackson-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.10.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.fasterxml.jackson.core:jackson-databind",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.10.5.1",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-42004 https://github.com/FasterXML/jackson-databind/issues/3582 https://github.com/FasterXML/jackson-databind/commit/063183589218fec19a9293ed2f17ec53ea80ba88 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50490 https://github.com/FasterXML/jackson-databind https://lists.debian.org/debian-lts-announce/2022/11/msg00035.html https://security.gentoo.org/glsa/202210-21 https://security.netapp.com/advisory/ntap-20221118-0008/ https://www.debian.org/security/2022/dsa-5283",
+            "FixedBy": "2.12.7.1",
+            "Description": "Uncontrolled Resource Consumption in FasterXML jackson-databind",
+            "Name": "GHSA-rgv9-q543-rqg4",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-42003 https://github.com/FasterXML/jackson-databind/issues/3590 https://github.com/FasterXML/jackson-databind/issues/3627 https://github.com/FasterXML/jackson-databind/commit/0e37a39502439ecbaa1a5b5188387c01bf7f7fa1 https://github.com/FasterXML/jackson-databind/commit/7ba9ac5b87a9d6ac0d2815158ecbeb315ad4dcdc https://github.com/FasterXML/jackson-databind/commit/cd090979b7ea78c75e4de8a4aed04f7e9fa8deea https://github.com/FasterXML/jackson-databind/commit/d499f2e7bbc5ebd63af11e1f5cf1989fa323aa45 https://github.com/FasterXML/jackson-databind/commit/d78d00ee7b5245b93103fef3187f70543d67ca33 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=51020 https://github.com/FasterXML/jackson-databind https://github.com/FasterXML/jackson-databind/blob/2.13/release-notes/VERSION-2.x https://github.com/FasterXML/jackson-databind/commits/jackson-databind-2.4.0-rc1?after=75b97b8519f0d50c62523ad85170d80a197a2c86+174&branch=jackson-databind-2.4.0-rc1&qualified_name=refs%2Ftags%2Fjackson-databind-2.4.0-rc1 https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.13.4.1...jackson-databind-2.13.4.2 https://lists.debian.org/debian-lts-announce/2022/11/msg00035.html https://security.gentoo.org/glsa/202210-21 https://security.netapp.com/advisory/ntap-20221124-0004/ https://www.debian.org/security/2022/dsa-5283",
+            "FixedBy": "2.12.7.1",
+            "Description": "Uncontrolled Resource Consumption in Jackson-databind",
+            "Name": "GHSA-jjjh-jjxp-wpff",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-36518 https://github.com/FasterXML/jackson-databind/issues/2816 https://github.com/FasterXML/jackson-databind/commit/fcfc4998ec23f0b1f7f8a9521c2b317b6c25892b https://github.com/FasterXML/jackson-databind https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12 https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13 https://lists.debian.org/debian-lts-announce/2022/05/msg00001.html https://lists.debian.org/debian-lts-announce/2022/11/msg00035.html https://security.netapp.com/advisory/ntap-20220506-0004/ https://www.debian.org/security/2022/dsa-5283 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "2.12.6.1",
+            "Description": "Deeply nested json in jackson-databind",
+            "Name": "GHSA-57j2-w4cx-62h2",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-46877 https://github.com/FasterXML/jackson-databind/issues/3328 https://github.com/FasterXML/jackson-databind/commit/3ccde7d938fea547e598fdefe9a82cff37fed5cb https://github.com/FasterXML/jackson-databind https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12.6 https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13.1 https://groups.google.com/g/jackson-user/c/OsBsirPM_Vw",
+            "FixedBy": "2.12.6",
+            "Description": "jackson-databind possible Denial of Service if using JDK serialization to serialize JsonNode",
+            "Name": "GHSA-3x8x-79m2-3w2w",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.10.5",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-28491 https://github.com/FasterXML/jackson-dataformats-binary/issues/186 https://github.com/FasterXML/jackson-dataformats-binary/commit/3d7de83423f8f68f8e9a0c8250084e11818544c7 https://github.com/FasterXML/jackson-dataformats-binary/commit/de072d314af8f5f269c8abec6930652af67bc8e6 https://github.com/FasterXML/jackson-dataformats-binary https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATAFORMAT-1047329 https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "2.11.4",
+            "Description": "Denial of Service (DoS) in Jackson Dataformat CBOR",
+            "Name": "GHSA-xmc8-26q4-qjhx",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "com.fasterxml.jackson.dataformat:jackson-dataformat-smile",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.10.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.10.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.fasterxml.woodstox:woodstox-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "5.0.3",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-40152 https://github.com/FasterXML/woodstox/issues/157 https://github.com/FasterXML/woodstox/issues/160 https://github.com/x-stream/xstream/issues/304 https://github.com/FasterXML/woodstox/pull/159 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47434 https://github.com/FasterXML/woodstox",
+            "FixedBy": "5.4.0",
+            "Description": "Denial of Service due to parser crash",
+            "Name": "GHSA-3f7h-mf4q-vrm4",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "com.flipkart.zjsonpatch:zjsonpatch",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.4.4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.github.spullara.mustache.java:compiler",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.9.3",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.github.wnameless:json-flattener",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.5.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.google.code.findbugs:jsr305",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.0.2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.google.errorprone:error_prone_annotations",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.1.3.redhat-00002",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.google.guava:guava",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "25.1.0.jre-redhat-00001",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2023-2976 https://github.com/google/guava/issues/2575 https://github.com/google/guava/issues/6532 https://github.com/google/guava/commit/feb83a1c8fd2e7670b244d5afd23cba5aca43284 https://github.com/google/guava https://github.com/google/guava/releases/tag/v32.0.0 https://security.netapp.com/advisory/ntap-20230818-0008/",
+            "FixedBy": "32.0.0",
+            "Description": "Guava vulnerable to insecure use of temporary directory",
+            "Name": "GHSA-7g45-4rm6-3mm3",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Low",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908 https://github.com/google/guava/issues/4011 https://github.com/google/guava/issues/4011#issuecomment-1578991974 https://github.com/google/guava/commit/feb83a1c8fd2e7670b244d5afd23cba5aca43284 https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40 https://github.com/google/guava https://lists.apache.org/thread.html/r007add131977f4f576c232b25e024249a3d16f66aad14a4b52819d21%40%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r007add131977f4f576c232b25e024249a3d16f66aad14a4b52819d21@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r037fed1d0ebde50c9caf8d99815db3093c344c3f651c5a49a09824ce@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r07ed3e4417ad043a27bee7bb33322e9bfc7d7e6d1719b8e3dfd95c14%40%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r07ed3e4417ad043a27bee7bb33322e9bfc7d7e6d1719b8e3dfd95c14@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r161b87f8037bbaff400194a63cd2016c9a69f5949f06dcc79beeab54%40%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r161b87f8037bbaff400194a63cd2016c9a69f5949f06dcc79beeab54@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r215b3d50f56faeb2f9383505f3e62faa9f549bb23e8a9848b78a968e%40%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r215b3d50f56faeb2f9383505f3e62faa9f549bb23e8a9848b78a968e@%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r294be9d31c0312d2c0837087204b5d4bf49d0552890e6eec716fa6a6%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r294be9d31c0312d2c0837087204b5d4bf49d0552890e6eec716fa6a6@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r2fe45d96eea8434b91592ca08109118f6308d60f6d0e21d52438cfb4%40%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r2fe45d96eea8434b91592ca08109118f6308d60f6d0e21d52438cfb4@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r3c3b33ee5bef0c67391d27a97cbfd89d44f328cf072b601b58d4e748%40%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r3c3b33ee5bef0c67391d27a97cbfd89d44f328cf072b601b58d4e748@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r3dd8881de891598d622227e9840dd7c2ef1d08abbb49e9690c7ae1bc%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/r3dd8881de891598d622227e9840dd7c2ef1d08abbb49e9690c7ae1bc@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/r4776f62dfae4a0006658542f43034a7fc199350e35a66d4e18164ee6%40%3Ccommits.cxf.apache.org%3E https://lists.apache.org/thread.html/r4776f62dfae4a0006658542f43034a7fc199350e35a66d4e18164ee6@%3Ccommits.cxf.apache.org%3E https://lists.apache.org/thread.html/r49549a8322f62cd3acfa4490d25bfba0be04f3f9ff4d14fe36199d27%40%3Cyarn-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/r49549a8322f62cd3acfa4490d25bfba0be04f3f9ff4d14fe36199d27@%3Cyarn-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/r58a8775205ab1839dba43054b09a9ab3b25b423a4170b2413c4067ac%40%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r58a8775205ab1839dba43054b09a9ab3b25b423a4170b2413c4067ac@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r5b3d93dfdfb7708e796e8762ab40edbde8ff8add48aba53e5ea26f44%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/r5b3d93dfdfb7708e796e8762ab40edbde8ff8add48aba53e5ea26f44@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/r5d61b98ceb7bba939a651de5900dbd67be3817db6bfcc41c6e04e199%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r5d61b98ceb7bba939a651de5900dbd67be3817db6bfcc41c6e04e199@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r6874dfe26eefc41b7c9a5e4a0487846fc4accf8c78ff948b24a1104a%40%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r6874dfe26eefc41b7c9a5e4a0487846fc4accf8c78ff948b24a1104a@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r68d86f4b06c808204f62bcb254fcb5b0432528ee8d37a07ef4bc8222%40%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r68d86f4b06c808204f62bcb254fcb5b0432528ee8d37a07ef4bc8222@%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r79e47ed555bdb1180e528420a7a2bb898541367a29a3bc6bbf0baf2c%40%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r79e47ed555bdb1180e528420a7a2bb898541367a29a3bc6bbf0baf2c@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r7b0e81d8367264d6cad98766a469d64d11248eb654417809bfdacf09%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r7b0e81d8367264d6cad98766a469d64d11248eb654417809bfdacf09@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r841c5e14e1b55281523ebcde661ece00b38a0569e00ef5e12bd5f6ba%40%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/r841c5e14e1b55281523ebcde661ece00b38a0569e00ef5e12bd5f6ba@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/ra7ab308481ee729f998691e8e3e02e93b1dedfc98f6b1cd3d86923b3%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/ra7ab308481ee729f998691e8e3e02e93b1dedfc98f6b1cd3d86923b3@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rb2364f4cf4d274eab5a7ecfaf64bf575cedf8b0173551997c749d322%40%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/rb2364f4cf4d274eab5a7ecfaf64bf575cedf8b0173551997c749d322@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/rb8c0f1b7589864396690fe42a91a71dea9412e86eec66dc85bbacaaf%40%3Ccommits.cxf.apache.org%3E https://lists.apache.org/thread.html/rb8c0f1b7589864396690fe42a91a71dea9412e86eec66dc85bbacaaf@%3Ccommits.cxf.apache.org%3E https://lists.apache.org/thread.html/rbc7642b9800249553f13457e46b813bea1aec99d2bc9106510e00ff3%40%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rbc7642b9800249553f13457e46b813bea1aec99d2bc9106510e00ff3@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc2dbc4633a6eea1fcbce6831876cfa17b73759a98c65326d1896cb1a%40%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc2dbc4633a6eea1fcbce6831876cfa17b73759a98c65326d1896cb1a@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc607bc52f3507b8b9c28c6a747c3122f51ac24afe80af2a670785b97%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rc607bc52f3507b8b9c28c6a747c3122f51ac24afe80af2a670785b97@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rcafc3a637d82bdc9a24036b2ddcad1e519dd0e6f848fcc3d606fd78f%40%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/rcafc3a637d82bdc9a24036b2ddcad1e519dd0e6f848fcc3d606fd78f@%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/rd01f5ff0164c468ec7abc96ff7646cea3cce6378da2e4aa29c6bcb95%40%3Cgithub.arrow.apache.org%3E https://lists.apache.org/thread.html/rd01f5ff0164c468ec7abc96ff7646cea3cce6378da2e4aa29c6bcb95@%3Cgithub.arrow.apache.org%3E https://lists.apache.org/thread.html/rd2704306ec729ccac726e50339b8a8f079515cc29ccb77713b16e7c5%40%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/rd2704306ec729ccac726e50339b8a8f079515cc29ccb77713b16e7c5@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/rd5d58088812cf8e677d99b07f73c654014c524c94e7fedbdee047604%40%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rd5d58088812cf8e677d99b07f73c654014c524c94e7fedbdee047604@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rd7e12d56d49d73e2b8549694974b07561b79b05455f7f781954231bf%40%3Cdev.pig.apache.org%3E https://lists.apache.org/thread.html/rd7e12d56d49d73e2b8549694974b07561b79b05455f7f781954231bf@%3Cdev.pig.apache.org%3E https://lists.apache.org/thread.html/re120f6b3d2f8222121080342c5801fdafca2f5188ceeb3b49c8a1d27%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/re120f6b3d2f8222121080342c5801fdafca2f5188ceeb3b49c8a1d27@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/reebbd63c25bc1a946caa419cec2be78079f8449d1af48e52d47c9e85%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/reebbd63c25bc1a946caa419cec2be78079f8449d1af48e52d47c9e85@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rf00b688ffa620c990597f829ff85fdbba8bf73ee7bfb34783e1f0d4e%40%3Cyarn-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/rf00b688ffa620c990597f829ff85fdbba8bf73ee7bfb34783e1f0d4e@%3Cyarn-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/rf9f0fa84b8ae1a285f0210bafec6de2a9eba083007d04640b82aa625%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rf9f0fa84b8ae1a285f0210bafec6de2a9eba083007d04640b82aa625@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rfc27e2727a20a574f39273e0432aa97486a332f9b3068f6ac1346594%40%3Cdev.myfaces.apache.org%3E https://lists.apache.org/thread.html/rfc27e2727a20a574f39273e0432aa97486a332f9b3068f6ac1346594@%3Cdev.myfaces.apache.org%3E https://security.netapp.com/advisory/ntap-20220210-0003/ https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415 https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+            "FixedBy": "32.0.0",
+            "Description": "Information Disclosure in Guava",
+            "Name": "GHSA-5mg8-w23w-74h3",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "com.google.j2objc:j2objc-annotations",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.1.0.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.jayway.jsonpath:json-path",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.4.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.maxmind.db:maxmind-db",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.2.2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.maxmind.geoip2:geoip2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.9.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.onelogin:java-saml",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.3.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.onelogin:java-saml-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.3.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "com.tdunning:t-digest",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "commons-cli:commons-cli",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.3.1.redhat-2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "commons-codec:commons-codec",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.10",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "commons-collections:commons-collections",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.2.2.redhat-2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "commons-lang:commons-lang",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "commons-logging:commons-logging",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "commons-logging:commons-logging",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.1.3",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "copy-jdk-configs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.0-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "coreutils-single",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "8.30-12.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "cracklib",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.9.6-15.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "cracklib-dicts",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.9.6-15.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "crypto-policies",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "20210617-1.gitc776d3e.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "crypto-policies-scripts",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "20210617-1.gitc776d3e.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "cryptsetup-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.3.3-4.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0370 https://access.redhat.com/security/cve/CVE-2021-4122",
+            "FixedBy": "0:2.3.3-4.el8_5.1",
+            "Description": "The cryptsetup packages provide a utility for setting up disk encryption using the dm-crypt kernel module.\n\nSecurity Fix(es):\n\n* cryptsetup: disable encryption via header rewrite (CVE-2021-4122)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0370: cryptsetup security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "cups-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1:2.2.6-40.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4864 https://access.redhat.com/security/cve/CVE-2023-32360",
+            "FixedBy": "1:2.2.6-51.el8_8.1",
+            "Description": "The Common UNIX Printing System (CUPS) provides a portable printing layer for Linux, UNIX, and similar operating systems.\n\nSecurity Fix(es):\n\n* cups: Information leak through Cups-Get-Document operation (CVE-2023-32360)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4864: cups security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5056 https://access.redhat.com/security/cve/CVE-2022-26691",
+            "FixedBy": "1:2.2.6-45.el8_6.2",
+            "Description": "The Common UNIX Printing System (CUPS) provides a portable printing layer for Linux, UNIX, and similar operating systems.\n\nSecurity Fix(es):\n\n* cups: authorization bypass when using \"local\" authorization (CVE-2022-26691)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* 30-second delays printing to Windows 2016 server via HTTPS (BZ#2073531)",
+            "Name": "RHSA-2022:5056: cups security and bug fix update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "curl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "7.61.1-22.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4523 https://access.redhat.com/security/cve/CVE-2023-27536 https://access.redhat.com/security/cve/CVE-2023-28321",
+            "FixedBy": "0:7.61.1-30.el8_8.3",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: GSS delegation too eager connection re-use (CVE-2023-27536)\n\n* curl: IDN wildcard match may lead to Improper Cerificate Validation (CVE-2023-28321)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4523: curl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3106 https://access.redhat.com/security/cve/CVE-2023-27535",
+            "FixedBy": "0:7.61.1-30.el8_8.2",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: FTP too eager connection reuse (CVE-2023-27535)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Cannot upload files to Jscape SFTP server: file gets created empty (BZ#2188029)",
+            "Name": "RHSA-2023:3106: curl security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Low",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:2963 https://access.redhat.com/security/cve/CVE-2022-35252 https://access.redhat.com/security/cve/CVE-2022-43552",
+            "FixedBy": "0:7.61.1-30.el8",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: Incorrect handling of control code characters in cookies (CVE-2022-35252)\n\n* curl: Use-after-free triggered by an HTTP proxy deny response (CVE-2022-43552)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.8 Release Notes linked from the References section.",
+            "Name": "RHSA-2023:2963: curl security and bug fix update (Low)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1140 https://access.redhat.com/security/cve/CVE-2023-23916",
+            "FixedBy": "0:7.61.1-25.el8_7.3",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP multi-header compression denial of service (CVE-2023-23916)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1140: curl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:6159 https://access.redhat.com/security/cve/CVE-2022-32206 https://access.redhat.com/security/cve/CVE-2022-32208",
+            "FixedBy": "0:7.61.1-22.el8_6.4",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP compression denial of service (CVE-2022-32206)\n\n* curl: FTP-KRB bad message verification (CVE-2022-32208)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:6159: curl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5313 https://access.redhat.com/security/cve/CVE-2022-22576 https://access.redhat.com/security/cve/CVE-2022-27774 https://access.redhat.com/security/cve/CVE-2022-27776 https://access.redhat.com/security/cve/CVE-2022-27782",
+            "FixedBy": "0:7.61.1-22.el8_6.3",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: OAUTH2 bearer bypass in connection re-use (CVE-2022-22576)\n\n* curl: credential leak on redirect (CVE-2022-27774)\n\n* curl: auth/cookie leak on redirect (CVE-2022-27776)\n\n* curl: TLS and SSH connection too eager reuse (CVE-2022-27782)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5313: curl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "cyrus-sasl-lib",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.1.27-5.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0658 https://access.redhat.com/security/cve/CVE-2022-24407",
+            "FixedBy": "0:2.1.27-6.el8_5",
+            "Description": "The cyrus-sasl packages contain the Cyrus implementation of Simple Authentication and Security Layer (SASL). SASL is a method for adding authentication support to connection-based protocols.\n\nSecurity Fix(es):\n\n* cyrus-sasl: failure to properly escape SQL input allows an attacker to execute arbitrary SQL commands (CVE-2022-24407)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0658: cyrus-sasl security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "dbus",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:1.12.8-14.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+            "FixedBy": "1:1.12.8-24.el8_8.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4498: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+            "FixedBy": "1:1.12.8-23.el8_7.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0096: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "dbus-common",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:1.12.8-14.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+            "FixedBy": "1:1.12.8-24.el8_8.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4498: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+            "FixedBy": "1:1.12.8-23.el8_7.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0096: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "dbus-daemon",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:1.12.8-14.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+            "FixedBy": "1:1.12.8-24.el8_8.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4498: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+            "FixedBy": "1:1.12.8-23.el8_7.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0096: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "dbus-glib",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.110-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "dbus-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:1.12.8-14.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+            "FixedBy": "1:1.12.8-24.el8_8.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4498: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+            "FixedBy": "1:1.12.8-23.el8_7.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0096: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "dbus-tools",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:1.12.8-14.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+            "FixedBy": "1:1.12.8-24.el8_8.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4498: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+            "FixedBy": "1:1.12.8-23.el8_7.1",
+            "Description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0096: dbus security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "device-mapper",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "8:1.02.177-10.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "device-mapper-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "8:1.02.177-10.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "dmidecode",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:3.2-10.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "dnf",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.7.0-4.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "dnf-data",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.7.0-4.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "dnf-plugin-subscription-manager",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.28.21-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+            "FixedBy": "0:1.28.36-3.el8_8",
+            "Description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4706: subscription-manager security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "elfutils-default-yama-scope",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.185-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "elfutils-libelf",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.185-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "elfutils-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.185-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "expat",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.2.5-4.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0103 https://access.redhat.com/security/cve/CVE-2022-43680",
+            "FixedBy": "0:2.2.5-10.el8_7.1",
+            "Description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: use-after free caused by overeager destruction of a shared DTD in\nXML_ExternalEntityParserCreate (CVE-2022-43680)\n\nFor more details about the security issue(s), including the impact, a CVSS\nscore, acknowledgments, and other related information, refer to the CVE page(s)\nlisted in the References section.",
+            "Name": "RHSA-2023:0103: expat security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:6878 https://access.redhat.com/security/cve/CVE-2022-40674",
+            "FixedBy": "0:2.2.5-8.el8_6.3",
+            "Description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: a use-after-free in the doContent function in xmlparse.c (CVE-2022-40674)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:6878: expat security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5314 https://access.redhat.com/security/cve/CVE-2022-25313 https://access.redhat.com/security/cve/CVE-2022-25314",
+            "FixedBy": "0:2.2.5-8.el8_6.2",
+            "Description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: stack exhaustion in doctype parsing (CVE-2022-25313)\n\n* expat: integer overflow in copyString() (CVE-2022-25314)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5314: expat security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0951 https://access.redhat.com/security/cve/CVE-2021-45960 https://access.redhat.com/security/cve/CVE-2021-46143 https://access.redhat.com/security/cve/CVE-2022-22822 https://access.redhat.com/security/cve/CVE-2022-22823 https://access.redhat.com/security/cve/CVE-2022-22824 https://access.redhat.com/security/cve/CVE-2022-22825 https://access.redhat.com/security/cve/CVE-2022-22826 https://access.redhat.com/security/cve/CVE-2022-22827 https://access.redhat.com/security/cve/CVE-2022-23852 https://access.redhat.com/security/cve/CVE-2022-25235 https://access.redhat.com/security/cve/CVE-2022-25236 https://access.redhat.com/security/cve/CVE-2022-25315",
+            "FixedBy": "0:2.2.5-4.el8_5.3",
+            "Description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: Malformed 2- and 3-byte UTF-8 sequences can lead to arbitrary code execution (CVE-2022-25235)\n\n* expat: Namespace-separator characters in \"xmlns[:prefix]\" attribute values can lead to arbitrary code execution (CVE-2022-25236)\n\n* expat: Integer overflow in storeRawNames() (CVE-2022-25315)\n\n* expat: Large number of prefixed XML attributes on a single tag can crash libexpat (CVE-2021-45960)\n\n* expat: Integer overflow in doProlog in xmlparse.c (CVE-2021-46143)\n\n* expat: Integer overflow in addBinding in xmlparse.c (CVE-2022-22822)\n\n* expat: Integer overflow in build_model in xmlparse.c (CVE-2022-22823)\n\n* expat: Integer overflow in defineAttribute in xmlparse.c (CVE-2022-22824)\n\n* expat: Integer overflow in lookup in xmlparse.c (CVE-2022-22825)\n\n* expat: Integer overflow in nextScaffoldPart in xmlparse.c (CVE-2022-22826)\n\n* expat: Integer overflow in storeAtts in xmlparse.c (CVE-2022-22827)\n\n* expat: Integer overflow in function XML_GetBuffer (CVE-2022-23852)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0951: expat security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "file-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "5.33-20.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "filesystem",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.8-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "findutils",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:4.6.0-20.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "freetype",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.9.1-4.el8_3.1",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7745 https://access.redhat.com/security/cve/CVE-2022-27404 https://access.redhat.com/security/cve/CVE-2022-27405 https://access.redhat.com/security/cve/CVE-2022-27406",
+            "FixedBy": "0:2.9.1-9.el8",
+            "Description": "FreeType is a free, high-quality, portable font engine that can open and manage font files. FreeType loads, hints, and renders individual glyphs efficiently.\n\nSecurity Fix(es):\n\n* FreeType: Buffer overflow in sfnt_init_face (CVE-2022-27404)\n\n* FreeType: Segmentation violation via FNT_Size_Request (CVE-2022-27405)\n\n* Freetype: Segmentation violation via FT_Request_Size (CVE-2022-27406)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+            "Name": "RHSA-2022:7745: freetype security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "gawk",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.2.1-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "gdb-gdbserver",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "8.2-16.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "gdbm",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:1.18-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "gdbm-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:1.18-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "glib2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.56.4-156.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7704 https://access.redhat.com/security/cve/CVE-2022-22624 https://access.redhat.com/security/cve/CVE-2022-22628 https://access.redhat.com/security/cve/CVE-2022-22629 https://access.redhat.com/security/cve/CVE-2022-22662 https://access.redhat.com/security/cve/CVE-2022-26700 https://access.redhat.com/security/cve/CVE-2022-26709 https://access.redhat.com/security/cve/CVE-2022-26710 https://access.redhat.com/security/cve/CVE-2022-26716 https://access.redhat.com/security/cve/CVE-2022-26717 https://access.redhat.com/security/cve/CVE-2022-26719 https://access.redhat.com/security/cve/CVE-2022-30293 https://access.redhat.com/security/cve/CVE-2022-32891",
+            "FixedBy": "0:2.56.4-159.el8",
+            "Description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform.\n\nGLib provides the core application building blocks for libraries and applications written in C. It provides the core object system used in GNOME, the main loop implementation, and a large set of utility functions for strings and common data structures.\n\nSecurity Fix(es):\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-22624)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-22628)\n\n* webkitgtk: Buffer overflow leading to arbitrary code execution (CVE-2022-22629)\n\n* webkitgtk: Cookie management issue leading to sensitive user information disclosure (CVE-2022-22662)\n\n* webkitgtk: Memory corruption issue leading to arbitrary code execution (CVE-2022-26700)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-26709)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-26710)\n\n* webkitgtk: Memory corruption issue leading to arbitrary code execution (CVE-2022-26716)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-26717)\n\n* webkitgtk: Memory corruption issue leading to arbitrary code execution (CVE-2022-26719)\n\n* webkitgtk: Heap buffer overflow in WebCore::TextureMapperLayer::setContentsLayer leading to arbitrary code execution (CVE-2022-30293)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+            "Name": "RHSA-2022:7704: webkit2gtk3 security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "glibc",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.28-164.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0896 https://access.redhat.com/security/cve/CVE-2021-3999 https://access.redhat.com/security/cve/CVE-2022-23218 https://access.redhat.com/security/cve/CVE-2022-23219",
+            "FixedBy": "0:2.28-164.el8_5.3",
+            "Description": "The glibc packages provide the standard C libraries (libc), POSIX thread libraries (libpthread), standard math libraries (libm), and the name service cache daemon (nscd) used by multiple programs on the system. Without these libraries, the Linux system cannot function correctly.\n\nSecurity Fix(es):\n\n* glibc: Off-by-one buffer overflow/underflow in getcwd() (CVE-2021-3999)\n\n* glibc: Stack-based buffer overflow in svcunix_create via long pathnames (CVE-2022-23218)\n\n* glibc: Stack-based buffer overflow in sunrpc clnt_create via a long pathname (CVE-2022-23219)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0896: glibc security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "glibc-common",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.28-164.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0896 https://access.redhat.com/security/cve/CVE-2021-3999 https://access.redhat.com/security/cve/CVE-2022-23218 https://access.redhat.com/security/cve/CVE-2022-23219",
+            "FixedBy": "0:2.28-164.el8_5.3",
+            "Description": "The glibc packages provide the standard C libraries (libc), POSIX thread libraries (libpthread), standard math libraries (libm), and the name service cache daemon (nscd) used by multiple programs on the system. Without these libraries, the Linux system cannot function correctly.\n\nSecurity Fix(es):\n\n* glibc: Off-by-one buffer overflow/underflow in getcwd() (CVE-2021-3999)\n\n* glibc: Stack-based buffer overflow in svcunix_create via long pathnames (CVE-2022-23218)\n\n* glibc: Stack-based buffer overflow in sunrpc clnt_create via a long pathname (CVE-2022-23219)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0896: glibc security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "glibc-minimal-langpack",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.28-164.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0896 https://access.redhat.com/security/cve/CVE-2021-3999 https://access.redhat.com/security/cve/CVE-2022-23218 https://access.redhat.com/security/cve/CVE-2022-23219",
+            "FixedBy": "0:2.28-164.el8_5.3",
+            "Description": "The glibc packages provide the standard C libraries (libc), POSIX thread libraries (libpthread), standard math libraries (libm), and the name service cache daemon (nscd) used by multiple programs on the system. Without these libraries, the Linux system cannot function correctly.\n\nSecurity Fix(es):\n\n* glibc: Off-by-one buffer overflow/underflow in getcwd() (CVE-2021-3999)\n\n* glibc: Stack-based buffer overflow in svcunix_create via long pathnames (CVE-2022-23218)\n\n* glibc: Stack-based buffer overflow in sunrpc clnt_create via a long pathname (CVE-2022-23219)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0896: glibc security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "gmp",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:6.1.2-10.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "gnupg2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.2.20-2.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:6463 https://access.redhat.com/security/cve/CVE-2022-34903",
+            "FixedBy": "0:2.2.20-3.el8_6",
+            "Description": "The GNU Privacy Guard (GnuPG or GPG) is a tool for encrypting data and creating digital signatures, compliant with OpenPGP and S/MIME standards.\n\nSecurity Fix(es):\n\n* gpg: Signature spoofing via status line injection (CVE-2022-34903)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:6463: gnupg2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "gnutls",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.6.16-4.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1569 https://access.redhat.com/security/cve/CVE-2023-0361",
+            "FixedBy": "0:3.6.16-6.el8_7",
+            "Description": "The gnutls packages provide the GNU Transport Layer Security (GnuTLS) library, which implements cryptographic algorithms and protocols such as SSL, TLS, and DTLS.\n\nSecurity Fix(es):\n\n* gnutls: timing side-channel in the TLS RSA key exchange code (CVE-2023-0361)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* trap invalid opcode ip:7feef81809fe sp:7fee997419c0 error:0 in libgnutls.so.30.28.2[7feef8040000+1dd000] (BZ#2131152)",
+            "Name": "RHSA-2023:1569: gnutls security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7105 https://access.redhat.com/security/cve/CVE-2022-2509",
+            "FixedBy": "0:3.6.16-5.el8_6",
+            "Description": "The gnutls packages provide the GNU Transport Layer Security (GnuTLS) library, which implements cryptographic algorithms and protocols such as SSL, TLS, and DTLS.\n\nSecurity Fix(es):\n\n* gnutls: Double free during gnutls_pkcs7_verify. (CVE-2022-2509)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:7105: gnutls security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "gobject-introspection",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.56.1-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "gpgme",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.13.1-9.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "graphite2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.3.10-10.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "grep",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.1-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "gzip",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.9-12.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:1537 https://access.redhat.com/security/cve/CVE-2022-1271",
+            "FixedBy": "0:1.9-13.el8_5",
+            "Description": "The gzip packages contain the gzip (GNU zip) data compression utility. gzip is used to compress regular files. It replaces them with files containing the .gz extension, while retaining ownership modes, access, and modification times.\n\nSecurity Fix(es):\n\n* gzip: arbitrary-file-write vulnerability (CVE-2022-1271)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:1537: gzip security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "harfbuzz",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.7.5-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "hostname",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.20-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "ima-evm-utils",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.3.2-12.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "info",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "6.5-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.dropwizard.metrics:metrics-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.1.2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.jsonwebtoken:jjwt-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.10.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.jsonwebtoken:jjwt-impl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.10.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.jsonwebtoken:jjwt-jackson",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.10.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.netty:netty-buffer",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.63.Final",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.netty:netty-buffer",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.32.Final",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.netty:netty-codec",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.63.Final",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-grg4-wf29-r9vv https://nvd.nist.gov/vuln/detail/CVE-2021-37136 https://github.com/netty/netty/commit/41d3d61a61608f2223bb364955ab2045dd5e4020 https://github.com/netty/netty https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java#L294 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java#L305 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java#L80 https://lists.apache.org/thread.html/r06a145c9bd41a7344da242cef07977b24abe3349161ede948e30913d@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5406eaf3b07577d233b9f07cfc8f26e28369e6bab5edfcab41f28abb@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5e05eba32476c580412f9fbdfc9b8782d5b40558018ac4ac07192a04@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r75490c61c2cb7b6ae2c81238fd52ae13636c60435abcd732d41531a0@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rd262f59b1586a108e320e5c966feeafbb1b8cdc96965debc7cc10b16@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rfb2bf8597e53364ccab212fbcbb2a4e9f0a9e1429b1dc08023c6868e@%3Cdev.tinkerpop.apache.org%3E https://lists.debian.org/debian-lts-announce/2023/01/msg00008.html https://security.netapp.com/advisory/ntap-20220210-0012/ https://www.debian.org/security/2023/dsa-5316 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "4.1.68.Final",
+            "Description": "Bzip2Decoder doesn't allow setting size restrictions for decompressed data",
+            "Name": "GHSA-grg4-wf29-r9vv",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-9vjp-v76f-g363 https://nvd.nist.gov/vuln/detail/CVE-2021-37137 https://github.com/netty/netty/commit/6da4956b31023ae967451e1d94ff51a746a9194f https://github.com/netty/netty https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java#L171 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java#L185 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java#L79 https://lists.apache.org/thread.html/r06a145c9bd41a7344da242cef07977b24abe3349161ede948e30913d@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5406eaf3b07577d233b9f07cfc8f26e28369e6bab5edfcab41f28abb@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5e05eba32476c580412f9fbdfc9b8782d5b40558018ac4ac07192a04@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r75490c61c2cb7b6ae2c81238fd52ae13636c60435abcd732d41531a0@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rd262f59b1586a108e320e5c966feeafbb1b8cdc96965debc7cc10b16@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rfb2bf8597e53364ccab212fbcbb2a4e9f0a9e1429b1dc08023c6868e@%3Cdev.tinkerpop.apache.org%3E https://lists.debian.org/debian-lts-announce/2023/01/msg00008.html https://security.netapp.com/advisory/ntap-20220210-0012/ https://www.debian.org/security/2023/dsa-5316 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "4.1.68.Final",
+            "Description": " SnappyFrameDecoder doesn't restrict chunk length any may buffer skippable chunks in an unnecessary way",
+            "Name": "GHSA-9vjp-v76f-g363",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "io.netty:netty-codec",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.32.Final",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-grg4-wf29-r9vv https://nvd.nist.gov/vuln/detail/CVE-2021-37136 https://github.com/netty/netty/commit/41d3d61a61608f2223bb364955ab2045dd5e4020 https://github.com/netty/netty https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java#L294 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java#L305 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java#L80 https://lists.apache.org/thread.html/r06a145c9bd41a7344da242cef07977b24abe3349161ede948e30913d@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5406eaf3b07577d233b9f07cfc8f26e28369e6bab5edfcab41f28abb@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5e05eba32476c580412f9fbdfc9b8782d5b40558018ac4ac07192a04@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r75490c61c2cb7b6ae2c81238fd52ae13636c60435abcd732d41531a0@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rd262f59b1586a108e320e5c966feeafbb1b8cdc96965debc7cc10b16@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rfb2bf8597e53364ccab212fbcbb2a4e9f0a9e1429b1dc08023c6868e@%3Cdev.tinkerpop.apache.org%3E https://lists.debian.org/debian-lts-announce/2023/01/msg00008.html https://security.netapp.com/advisory/ntap-20220210-0012/ https://www.debian.org/security/2023/dsa-5316 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "4.1.68.Final",
+            "Description": "Bzip2Decoder doesn't allow setting size restrictions for decompressed data",
+            "Name": "GHSA-grg4-wf29-r9vv",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-9vjp-v76f-g363 https://nvd.nist.gov/vuln/detail/CVE-2021-37137 https://github.com/netty/netty/commit/6da4956b31023ae967451e1d94ff51a746a9194f https://github.com/netty/netty https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java#L171 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java#L185 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java#L79 https://lists.apache.org/thread.html/r06a145c9bd41a7344da242cef07977b24abe3349161ede948e30913d@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5406eaf3b07577d233b9f07cfc8f26e28369e6bab5edfcab41f28abb@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5e05eba32476c580412f9fbdfc9b8782d5b40558018ac4ac07192a04@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r75490c61c2cb7b6ae2c81238fd52ae13636c60435abcd732d41531a0@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rd262f59b1586a108e320e5c966feeafbb1b8cdc96965debc7cc10b16@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rfb2bf8597e53364ccab212fbcbb2a4e9f0a9e1429b1dc08023c6868e@%3Cdev.tinkerpop.apache.org%3E https://lists.debian.org/debian-lts-announce/2023/01/msg00008.html https://security.netapp.com/advisory/ntap-20220210-0012/ https://www.debian.org/security/2023/dsa-5316 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "4.1.68.Final",
+            "Description": " SnappyFrameDecoder doesn't restrict chunk length any may buffer skippable chunks in an unnecessary way",
+            "Name": "GHSA-9vjp-v76f-g363",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "io.netty:netty-codec-http",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.32.Final",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-wx5j-54mm-rqqq https://nvd.nist.gov/vuln/detail/CVE-2021-43797 https://github.com/netty/netty/pull/11891 https://github.com/netty/netty/commit/07aa6b5938a8b6ed7a6586e066400e2643897323 https://github.com/netty/netty/ https://lists.debian.org/debian-lts-announce/2023/01/msg00008.html https://security.netapp.com/advisory/ntap-20220107-0003/ https://www.debian.org/security/2023/dsa-5316 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "4.1.71.Final",
+            "Description": "HTTP request smuggling in netty",
+            "Name": "GHSA-wx5j-54mm-rqqq",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Critical",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20444 https://github.com/netty/netty/issues/9866 https://github.com/netty/netty/pull/9871 https://github.com/netty/netty/pull/9871/files#diff-e26989b9171ef22c27c9f7d80689cfb059d568c9bd10e75970d96c02d0654878 https://access.redhat.com/errata/RHSA-2020:0497 https://access.redhat.com/errata/RHSA-2020:0567 https://access.redhat.com/errata/RHSA-2020:0601 https://access.redhat.com/errata/RHSA-2020:0605 https://access.redhat.com/errata/RHSA-2020:0606 https://access.redhat.com/errata/RHSA-2020:0804 https://access.redhat.com/errata/RHSA-2020:0805 https://access.redhat.com/errata/RHSA-2020:0806 https://access.redhat.com/errata/RHSA-2020:0811 https://github.com/netty/netty https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final https://lists.apache.org/thread.html/r059b042bca47be53ff8a51fd04d95eb01bb683f1afa209db136e8cb7@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r0aa8b28e76ec01c697b15e161e6797e88fc8d406ed762e253401106e@%3Ccommits.camel.apache.org%3E https://lists.apache.org/thread.html/r0c3d49bfdbc62fd3915676433cc5899c5506d06da1c552ef1b7923a5@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r0f5e72d5f69b4720dfe64fcbc2da9afae949ed1e9cbffa84bb7d92d7@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r1b103833cb5bc8466e24ff0ecc5e75b45a705334ab6a444e64e840a0@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/r1fcccf8bdb3531c28bc9aa605a6a1bea7e68cef6fc12e01faafb2fb5@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r205937c85817a911b0c72655c2377e7a2c9322d6ef6ce1b118d34d8d@%3Cdev.geode.apache.org%3E https://lists.apache.org/thread.html/r2f2989b7815d809ff3fda8ce330f553e5f133505afd04ffbc135f35f@%3Cissues.spark.apache.org%3E https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r34912a9b1a5c269a77b8be94ef6fb6d1e9b3c69129719dc00f01cf0b@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r36fcf538b28f2029e8b4f6b9a772f3b107913a78f09b095c5b153a62@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r489886fe72a98768eed665474cba13bad8d6fe0654f24987706636c5@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4c675b2d0cc2a5e506b11ee10d60a378859ee340aca052e4c7ef4749@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4d3f1d3e333d9c2b2f6e6ae8ed8750d4de03410ac294bcd12c7eefa3@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r640eb9b3213058a963e18291f903fc1584e577f60035f941e32f760a@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r6945f3c346b7af89bbd3526a7c9b705b1e3569070ebcd0964bcedd7d@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r70b1ff22ee80e8101805b9a473116dd33265709007d2deb6f8c80bf2@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r7790b9d99696d9eddce8a8c96f13bb68460984294ea6fea3800143e4@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r804895eedd72c9ec67898286eb185e04df852b0dd5fe53cf5b6138f9@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r832724df393a7ef25ca4c7c2eb83ad2d6c21c74569acda5233f9f1ec@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r8402d67fdfe9cf169f859d52a7670b28a08eff31e54b522cc1432532@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r86befa74c5cd1482c711134104aec339bf7ae879f2c4437d7ec477d4@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/r90030b0117490caed526e57271bf4d7f9b012091ac5083c895d16543@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r91e0fa345c86c128b75a4a791b4b503b53173ff4c13049ac7129d319@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r96e08f929234e8ba1ef4a93a0fd2870f535a1f9ab628fabc46115986@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra1a71b576a45426af5ee65255be9596ff3181a342f4ba73b800db78f@%3Cdev.geode.apache.org%3E https://lists.apache.org/thread.html/ra2ace4bcb5cf487f72cbcbfa0f8cc08e755ec2b93d7e69f276148b08@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra9fbfe7d4830ae675bf34c7c0f8c22fc8a4099f65706c1bc4f54c593@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/raaac04b7567c554786132144bea3dcb72568edd410c1e6f0101742e7@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rb3361f6c6a5f834ad3db5e998c352760d393c0891b8d3bea90baa836@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rc7eb5634b71d284483e58665b22bf274a69bd184d9bd7ede52015d91@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rcb2c59428f34d4757702f9ae739a8795bda7bea97b857e708a9c62c6@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rd8f72411fb75b98d366400ae789966373b5c3eb3f511e717caf3e49e@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rdb69125652311d0c41f6066ff44072a3642cf33a4b5e3c4f9c1ec9c2@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rdd5d243a5f8ed8b83c0104e321aa420e5e98792a95749e3c9a54c0b9@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/re0b78a3d0a4ba2cf9f4e14e1d05040bde9051d5c78071177186336c9@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/re78eaef7d01ad65c370df30e45c686fffff00b37f7bfd78b26a08762@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rf2bf8e2eb0a03227f5bc100b544113f8cafea01e887bb068e8d1fa41@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rf5b2dfb7401666a19915f8eaef3ba9f5c3386e2066fcd2ae66e16a2f@%3Cdev.flink.apache.org%3E https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rff210a24f3a924829790e69eaefa84820902b7b31f17c3bf2def9114@%3Ccommits.druid.apache.org%3E https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html https://lists.debian.org/debian-lts-announce/2020/09/msg00003.html https://lists.debian.org/debian-lts-announce/2020/09/msg00004.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TS6VX7OMXPDJIU5LRGUAHRK6MENAVJ46/ https://usn.ubuntu.com/4532-1/ https://www.debian.org/security/2021/dsa-4885",
+            "FixedBy": "4.1.44",
+            "Description": "HTTP Request Smuggling in Netty",
+            "Name": "GHSA-cqqj-4p63-rrmm",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2 https://nvd.nist.gov/vuln/detail/CVE-2021-21290 https://github.com/netty/netty/commit/c735357bf29d07856ad171c6611a2e1a0e0000ec https://github.com/netty/netty https://lists.apache.org/thread.html/r0053443ce19ff125981559f8c51cf66e3ab4350f47812b8cf0733a05@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/r02e467123d45006a1dda20a38349e9c74c3a4b53e2e07be0939ecb3f@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r0857b613604c696bf9743f0af047360baaded48b1c75cf6945a083c5@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r10308b625e49d4e9491d7e079606ca0df2f0a4d828f1ad1da64ba47b@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r1908a34b9cc7120e5c19968a116ddbcffea5e9deb76c2be4fa461904@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r2748097ea4b774292539cf3de6e3b267fc7a88d6c8ec40f4e2e87bd4@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/r2936730ef0a06e724b96539bc7eacfcd3628987c16b1b99c790e7b87@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r2fda4dab73097051977f2ab818f75e04fbcb15bb1003c8530eac1059@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r326ec431f06eab7cb7113a7a338e59731b8d556d05258457f12bac1b@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/r4efed2c501681cb2e8d629da16e48d9eac429624fd4c9a8c6b8e7020@%3Cdev.tinkerpop.apache.org%3E https://lists.apache.org/thread.html/r584cf871f188c406d8bd447ff4e2fd9817fca862436c064d0951a071@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r59bac5c09f7a4179b9e2460e8f41c278aaf3b9a21cc23678eb893e41@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r5bf303d7c04da78f276765da08559fdc62420f1df539b277ca31f63b@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r5c701840aa2845191721e39821445e1e8c59711e71942b7796a6ec29@%3Cusers.activemq.apache.org%3E https://lists.apache.org/thread.html/r5e4a540089760c8ecc2c411309d74264f1dad634ad93ad583ca16214@%3Ccommits.kafka.apache.org%3E https://lists.apache.org/thread.html/r5e66e286afb5506cdfe9bbf68a323e8d09614f6d1ddc806ed0224700@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r71dbb66747ff537640bb91eb0b2b24edef21ac07728097016f58b01f@%3Ccommits.kafka.apache.org%3E https://lists.apache.org/thread.html/r743149dcc8db1de473e6bff0b3ddf10140a7357bc2add75f7d1fbb12@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r790c2926efcd062067eb18fde2486527596d7275381cfaff2f7b3890@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/r7bb3cdc192e9a6f863d3ea05422f09fa1ae2b88d4663e63696ee7ef5@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r9924ef9357537722b28d04c98a189750b80694a19754e5057c34ca48@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/ra0fc2b4553dd7aaf75febb61052b7f1243ac3a180a71c01f29093013@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/ra503756ced78fdc2136bd33e87cb7553028645b261b1f5c6186a121e@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/rb06c1e766aa45ee422e8261a8249b561784186483e8f742ea627bda4@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/rb51d6202ff1a773f96eaa694b7da4ad3f44922c40b3d4e1a19c2f325@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rb592033a2462548d061a83ac9449c5ff66098751748fcd1e2d008233@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rc0087125cb15b4b78e44000f841cd37fefedfda942fd7ddf3ad1b528@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rc488f80094872ad925f0c73d283d4c00d32def81977438e27a3dc2bb@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/rcd163e421273e8dca1c71ea298dce3dd11b41d51c3a812e0394e6a5d@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rdba4f78ac55f803893a1a2265181595e79e3aa027e2e651dfba98c18@%3Cjira.kafka.apache.org%3E https://lists.debian.org/debian-lts-announce/2021/02/msg00016.html https://security.netapp.com/advisory/ntap-20220210-0011/ https://www.debian.org/security/2021/dsa-4885 https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+            "FixedBy": "4.1.59.Final",
+            "Description": "Local Information Disclosure Vulnerability in Netty on Unix-Like systems",
+            "Name": "GHSA-5mcr-gq6c-3hq2",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-269q-hmxg-m83q https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2 https://nvd.nist.gov/vuln/detail/CVE-2022-24823 https://github.com/netty/netty/commit/185f8b2756a36aaa4f973f1a2a025e7d981823f1 https://github.com/netty/netty https://security.netapp.com/advisory/ntap-20220616-0004/ https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "4.1.77.Final",
+            "Description": "Local Information Disclosure Vulnerability in io.netty:netty-codec-http",
+            "Name": "GHSA-269q-hmxg-m83q",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "io.netty:netty-codec-http",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.63.Final-redhat-00001",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-wx5j-54mm-rqqq https://nvd.nist.gov/vuln/detail/CVE-2021-43797 https://github.com/netty/netty/pull/11891 https://github.com/netty/netty/commit/07aa6b5938a8b6ed7a6586e066400e2643897323 https://github.com/netty/netty/ https://lists.debian.org/debian-lts-announce/2023/01/msg00008.html https://security.netapp.com/advisory/ntap-20220107-0003/ https://www.debian.org/security/2023/dsa-5316 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "4.1.71.Final",
+            "Description": "HTTP request smuggling in netty",
+            "Name": "GHSA-wx5j-54mm-rqqq",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-269q-hmxg-m83q https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2 https://nvd.nist.gov/vuln/detail/CVE-2022-24823 https://github.com/netty/netty/commit/185f8b2756a36aaa4f973f1a2a025e7d981823f1 https://github.com/netty/netty https://security.netapp.com/advisory/ntap-20220616-0004/ https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "4.1.77.Final",
+            "Description": "Local Information Disclosure Vulnerability in io.netty:netty-codec-http",
+            "Name": "GHSA-269q-hmxg-m83q",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "io.netty:netty-common",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.32.Final",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.netty:netty-common",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.63.Final",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.netty:netty-handler",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.63.Final",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-6mjq-h674-j845 https://nvd.nist.gov/vuln/detail/CVE-2023-34462 https://github.com/netty/netty/commit/535da17e45201ae4278c0479e6162bb4127d4c32 https://github.com/netty/netty",
+            "FixedBy": "4.1.94.Final",
+            "Description": "netty-handler SniHandler 16MB allocation",
+            "Name": "GHSA-6mjq-h674-j845",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "io.netty:netty-handler",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.32.Final",
+        "Vulnerabilities": [
+          {
+            "Severity": "Unknown",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2019-20445 https://github.com/netty/netty/issues/9861 https://github.com/netty/netty/pull/9865 https://access.redhat.com/errata/RHSA-2020:0497 https://access.redhat.com/errata/RHSA-2020:0567 https://access.redhat.com/errata/RHSA-2020:0601 https://access.redhat.com/errata/RHSA-2020:0605 https://access.redhat.com/errata/RHSA-2020:0606 https://access.redhat.com/errata/RHSA-2020:0804 https://access.redhat.com/errata/RHSA-2020:0805 https://access.redhat.com/errata/RHSA-2020:0806 https://access.redhat.com/errata/RHSA-2020:0811 https://github.com/netty/netty https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final https://lists.apache.org/thread.html/r030beff88aeb6d7a2d6cd21342bd18686153ce6e26a4171d0e035663@%3Cissues.flume.apache.org%3E https://lists.apache.org/thread.html/r1b103833cb5bc8466e24ff0ecc5e75b45a705334ab6a444e64e840a0@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/r1fcccf8bdb3531c28bc9aa605a6a1bea7e68cef6fc12e01faafb2fb5@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r205937c85817a911b0c72655c2377e7a2c9322d6ef6ce1b118d34d8d@%3Cdev.geode.apache.org%3E https://lists.apache.org/thread.html/r2f2989b7815d809ff3fda8ce330f553e5f133505afd04ffbc135f35f@%3Cissues.spark.apache.org%3E https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r36fcf538b28f2029e8b4f6b9a772f3b107913a78f09b095c5b153a62@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r46f93de62b1e199f3f9babb18128681677c53493546f532ed88c359d@%3Creviews.spark.apache.org%3E https://lists.apache.org/thread.html/r4d3f1d3e333d9c2b2f6e6ae8ed8750d4de03410ac294bcd12c7eefa3@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r4ff40646e9ccce13560458419accdfc227b8b6ca4ead3a8a91decc74@%3Cissues.flume.apache.org%3E https://lists.apache.org/thread.html/r640eb9b3213058a963e18291f903fc1584e577f60035f941e32f760a@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r6945f3c346b7af89bbd3526a7c9b705b1e3569070ebcd0964bcedd7d@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r70b1ff22ee80e8101805b9a473116dd33265709007d2deb6f8c80bf2@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r7790b9d99696d9eddce8a8c96f13bb68460984294ea6fea3800143e4@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r804895eedd72c9ec67898286eb185e04df852b0dd5fe53cf5b6138f9@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r81700644754e66ffea465c869cb477de25f8041e21598e8818fc2c45@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r832724df393a7ef25ca4c7c2eb83ad2d6c21c74569acda5233f9f1ec@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r96e08f929234e8ba1ef4a93a0fd2870f535a1f9ab628fabc46115986@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra1a71b576a45426af5ee65255be9596ff3181a342f4ba73b800db78f@%3Cdev.geode.apache.org%3E https://lists.apache.org/thread.html/ra2ace4bcb5cf487f72cbcbfa0f8cc08e755ec2b93d7e69f276148b08@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra9fbfe7d4830ae675bf34c7c0f8c22fc8a4099f65706c1bc4f54c593@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/raaac04b7567c554786132144bea3dcb72568edd410c1e6f0101742e7@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rb5c065e7bd701b0744f9f28ad769943f91745102716c1eb516325f11@%3Cissues.spark.apache.org%3E https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rbdb59c683d666130906a9c05a1d2b034c4cc08cda7ed41322bd54fe2@%3Cissues.flume.apache.org%3E https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rd8f72411fb75b98d366400ae789966373b5c3eb3f511e717caf3e49e@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rdb69125652311d0c41f6066ff44072a3642cf33a4b5e3c4f9c1ec9c2@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rf5b2dfb7401666a19915f8eaef3ba9f5c3386e2066fcd2ae66e16a2f@%3Cdev.flink.apache.org%3E https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rff210a24f3a924829790e69eaefa84820902b7b31f17c3bf2def9114@%3Ccommits.druid.apache.org%3E https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html https://lists.debian.org/debian-lts-announce/2020/09/msg00003.html https://lists.debian.org/debian-lts-announce/2020/09/msg00004.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TS6VX7OMXPDJIU5LRGUAHRK6MENAVJ46/ https://usn.ubuntu.com/4532-1/ https://www.debian.org/security/2021/dsa-4885",
+            "FixedBy": "4.1.45",
+            "Description": "HTTP Request Smuggling in Netty",
+            "Name": "GHSA-p2v9-g2qv-p635",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-11612 https://github.com/netty/netty/issues/6168 https://github.com/netty/netty/pull/9924 https://github.com/netty/netty/compare/netty-4.1.45.Final...netty-4.1.46.Final https://lists.apache.org/thread.html/r14446ed58208cb6d97b6faa6ebf145f1cf2c70c0886c0c133f4d3b6f@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r255ed239e65d0596812362adc474bee96caf7ba042c7ad2f3c62cec7@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r281882fdf9ea89aac02fd2f92786693a956aac2ce9840cce87c7df6b@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r2958e4d49ee046e1e561e44fdc114a0d2285927501880f15852a9b53@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r31424427cc6d7db46beac481bdeed9a823fc20bb1b9deede38557f71@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r3195127e46c87a680b5d1d3733470f83b886bfd3b890c50df718bed1@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r3ea4918d20d0c1fa26cac74cc7cda001d8990bc43473d062867ef70d@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4a7e4e23bd84ac24abf30ab5d5edf989c02b555e1eca6a2f28636692@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4f4a14d6a608db447b725ec2e96c26ac9664d83cd879aa21e2cfeb24@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r5030cd8ea5df1e64cf6a7b633eff145992fbca03e8bfc687cd2427ab@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r5a0b1f0b1c3bcd66f5177fbd6f6de2d0f8cae24a13ab2669f274251a@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r5b1ad61552591b747cd31b3a908d5ff2e8f2a8a6847583dd6b7b1ee7@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r69b23a94d4ae45394cabae012dd1f4a963996869c44c478eb1c61082@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r7641ee788e1eb1be4bb206a7d15f8a64ec6ef23e5ec6132d5a567695@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r7790b9d99696d9eddce8a8c96f13bb68460984294ea6fea3800143e4@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r7836bbdbe95c99d4d725199f0c169927d4e87ba57e4beeeb699c097a@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r832724df393a7ef25ca4c7c2eb83ad2d6c21c74569acda5233f9f1ec@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r866288c2ada00ce148b7307cdf869f15f24302b3eb2128af33830997@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r88e2b91560c065ed67e62adf8f401c417e4d70256d11ea447215a70c@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r8a654f11e1172b0effbfd6f8d5b6ca651ae4ac724a976923c268a42f@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r9addb580456807cd11d6f0c6b6373b7d7161d06d2278866c30c7febb@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r9c30b7fca4baedebcb46d6e0f90071b30cc4a0e074164d50122ec5ec@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra98e3a8541a09271f96478d5e22c7e3bd1afdf48641c8be25d62d9f9@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/raaac04b7567c554786132144bea3dcb72568edd410c1e6f0101742e7@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rd302ddb501fa02c5119120e5fc21df9a1c00e221c490edbe2d7ad365@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rdb69125652311d0c41f6066ff44072a3642cf33a4b5e3c4f9c1ec9c2@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/re1ea144e91f03175d661b2d3e97c7d74b912e019613fa90419cf63f4@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ref2c8a0cbb3b8271e5b9a06457ba78ad2028128627186531730f50ef@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ref3943adbc3a8813aee0e3a9dd919bacbb27f626be030a3c6d6c7f83@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rf5b2dfb7401666a19915f8eaef3ba9f5c3386e2066fcd2ae66e16a2f@%3Cdev.flink.apache.org%3E https://lists.apache.org/thread.html/rf803b65b4a57589d79cf2e83d8ece0539018d32864f932f63c972844@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rf9f8bcc4ca8d2788f77455ff594468404732a4497baebe319043f4d5@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rfd173eac20d5e5f581c8984b685c836dafea8eb2f7ff85f617704cf1@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rff8859c0d06b1688344b39097f9685c43b461cf2bc41f60f001704e9@%3Ccommits.zookeeper.apache.org%3E https://lists.debian.org/debian-lts-announce/2020/09/msg00003.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TS6VX7OMXPDJIU5LRGUAHRK6MENAVJ46/ https://security.netapp.com/advisory/ntap-20201223-0001/ https://www.debian.org/security/2021/dsa-4885 https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2021.html",
+            "FixedBy": "4.1.46",
+            "Description": "Denial of Service in Netty",
+            "Name": "GHSA-mm9x-g8pc-w292",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/netty/netty/security/advisories/GHSA-6mjq-h674-j845 https://nvd.nist.gov/vuln/detail/CVE-2023-34462 https://github.com/netty/netty/commit/535da17e45201ae4278c0479e6162bb4127d4c32 https://github.com/netty/netty",
+            "FixedBy": "4.1.94.Final",
+            "Description": "netty-handler SniHandler 16MB allocation",
+            "Name": "GHSA-6mjq-h674-j845",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "io.netty:netty-resolver",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.63.Final",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.netty:netty-resolver",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.32.Final",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.netty:netty-transport",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.32.Final",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.netty:netty-transport",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.63.Final",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.prometheus:simpleclient",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.6.0.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "io.prometheus:simpleclient_common",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.6.0.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "java-11-openjdk-headless",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1:11.0.13.0.8-3.el8_5",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4175 https://access.redhat.com/security/cve/CVE-2023-22006 https://access.redhat.com/security/cve/CVE-2023-22036 https://access.redhat.com/security/cve/CVE-2023-22041 https://access.redhat.com/security/cve/CVE-2023-22045 https://access.redhat.com/security/cve/CVE-2023-22049 https://access.redhat.com/security/cve/CVE-2023-25193",
+            "FixedBy": "1:11.0.20.0.8-2.el8",
+            "Description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: ZIP file parsing infinite loop (8302483) (CVE-2023-22036)\n\n* OpenJDK: weakness in AES implementation (8308682) (CVE-2023-22041)\n\n* OpenJDK: improper handling of slash characters in URI-to-path conversion (8305312) (CVE-2023-22049)\n\n* harfbuzz: OpenJDK: O(n^2) growth via consecutive marks (CVE-2023-25193)\n\n* OpenJDK: HTTP client insufficient file name validation (8302475) (CVE-2023-22006)\n\n* OpenJDK: array indexing integer overflow issue (8304468) (CVE-2023-22045)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* A virtual machine crash was observed in JDK 11.0.19 when executing the GregorianCalender.computeTime() method (JDK-8307683). It was found\nthat although the root cause of the crash is an old issue, a recent fix for a rare issue in the C2 compiler (JDK-8297951) made the crash much more likely. To mitigate this, the fix has been reverted in JDK 11.0.20 and will be reapplied once JDK-8307683 is resolved. (RHBZ#2222493)\n\n* Prepare for the next quarterly OpenJDK upstream release (2023-07, 11.0.20) [rhel-8] (BZ#2223101)",
+            "Name": "RHSA-2023:4175: java-11-openjdk security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1895 https://access.redhat.com/security/cve/CVE-2023-21930 https://access.redhat.com/security/cve/CVE-2023-21937 https://access.redhat.com/security/cve/CVE-2023-21938 https://access.redhat.com/security/cve/CVE-2023-21939 https://access.redhat.com/security/cve/CVE-2023-21954 https://access.redhat.com/security/cve/CVE-2023-21967 https://access.redhat.com/security/cve/CVE-2023-21968",
+            "FixedBy": "1:11.0.19.0.7-1.el8_7",
+            "Description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: improper connection handling during TLS handshake (8294474) (CVE-2023-21930)\n\n* OpenJDK: Swing HTML parsing issue (8296832) (CVE-2023-21939)\n\n* OpenJDK: incorrect enqueue of references in garbage collector (8298191) (CVE-2023-21954)\n\n* OpenJDK: certificate validation issue in TLS session negotiation (8298310) (CVE-2023-21967)\n\n* OpenJDK: missing string checks for NULL characters (8296622) (CVE-2023-21937)\n\n* OpenJDK: incorrect handling of NULL characters in ProcessBuilder (8295304) (CVE-2023-21938)\n\n* OpenJDK: missing check for slash characters in URI-to-path conversion (8298667) (CVE-2023-21968)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1895: java-11-openjdk security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0200 https://access.redhat.com/security/cve/CVE-2023-21835 https://access.redhat.com/security/cve/CVE-2023-21843",
+            "FixedBy": "1:11.0.18.0.10-2.el8_7",
+            "Description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: handshake DoS attack against DTLS connections (JSSE, 8287411) (CVE-2023-21835)\n\n* OpenJDK: soundbank URL remote loading (Sound, 8293742) (CVE-2023-21843)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Prepare for the next quarterly OpenJDK upstream release (2023-01, 11.0.18) [rhel-8] (BZ#2157797)",
+            "Name": "RHSA-2023:0200: java-11-openjdk security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7012 https://access.redhat.com/security/cve/CVE-2022-21618 https://access.redhat.com/security/cve/CVE-2022-21619 https://access.redhat.com/security/cve/CVE-2022-21624 https://access.redhat.com/security/cve/CVE-2022-21626 https://access.redhat.com/security/cve/CVE-2022-21628 https://access.redhat.com/security/cve/CVE-2022-39399",
+            "FixedBy": "1:11.0.17.0.8-2.el8_6",
+            "Description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: improper MultiByte conversion can lead to buffer overflow (JGSS, 8286077) (CVE-2022-21618)\n\n* OpenJDK: excessive memory allocation in X.509 certificate parsing (Security, 8286533) (CVE-2022-21626)\n\n* OpenJDK: HttpServer no connection count limit (Lightweight HTTP Server, 8286918) (CVE-2022-21628)\n\n* OpenJDK: improper handling of long NTLM client hostnames (Security, 8286526) (CVE-2022-21619)\n\n* OpenJDK: insufficient randomization of JNDI DNS port numbers (JNDI, 8286910) (CVE-2022-21624)\n\n* OpenJDK: missing SNI caching in HTTP/2 (Networking, 8289366) (CVE-2022-39399)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Prepare for the next quarterly OpenJDK upstream release (2022-10, 11.0.17) [rhel-8] (BZ#2131863)",
+            "Name": "RHSA-2022:7012: java-11-openjdk security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5683 https://access.redhat.com/security/cve/CVE-2022-21540 https://access.redhat.com/security/cve/CVE-2022-21541 https://access.redhat.com/security/cve/CVE-2022-34169",
+            "FixedBy": "1:11.0.16.0.8-1.el8_6",
+            "Description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nThe following packages have been upgraded to a later upstream version: java-11-openjdk (11.0.16.0.8). (BZ#2084649)\n\nSecurity Fix(es):\n\n* OpenJDK: integer truncation issue in Xalan-J (JAXP, 8285407) (CVE-2022-34169)\n\n* OpenJDK: class compilation issue (Hotspot, 8281859) (CVE-2022-21540)\n\n* OpenJDK: improper restriction of MethodHandle.invokeBasic() (Hotspot, 8281866) (CVE-2022-21541)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* rh1991003 patch breaks sun.security.pkcs11.wrapper.PKCS11.getInstance() [rhel-8, openjdk-11] (BZ#2099917)\n\n* Revert to disabling system security properties and FIPS mode support together [rhel-8, openjdk-11] (BZ#2108248)\n\n* SecretKey generate/import operations don't add the CKA_SIGN attribute in FIPS mode [rhel-8, openjdk-11] (BZ#2108251)",
+            "Name": "RHSA-2022:5683: java-11-openjdk security, bug fix, and enhancement update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:1442 https://access.redhat.com/security/cve/CVE-2022-21426 https://access.redhat.com/security/cve/CVE-2022-21434 https://access.redhat.com/security/cve/CVE-2022-21443 https://access.redhat.com/security/cve/CVE-2022-21476 https://access.redhat.com/security/cve/CVE-2022-21496",
+            "FixedBy": "1:11.0.15.0.9-2.el8_5",
+            "Description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: Defective secure validation in Apache Santuario (Libraries, 8278008) (CVE-2022-21476)\n\n* OpenJDK: Unbounded memory allocation when compiling crafted XPath expressions (JAXP, 8270504) (CVE-2022-21426)\n\n* OpenJDK: Improper object-to-string conversion in AnnotationInvocationHandler (Libraries, 8277672) (CVE-2022-21434)\n\n* OpenJDK: Missing check for negative ObjectIdentifier (Libraries, 8275151) (CVE-2022-21443)\n\n* OpenJDK: URI parsing inconsistencies (JNDI, 8278972) (CVE-2022-21496)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:1442: java-11-openjdk security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0185 https://access.redhat.com/security/cve/CVE-2022-21248 https://access.redhat.com/security/cve/CVE-2022-21277 https://access.redhat.com/security/cve/CVE-2022-21282 https://access.redhat.com/security/cve/CVE-2022-21283 https://access.redhat.com/security/cve/CVE-2022-21291 https://access.redhat.com/security/cve/CVE-2022-21293 https://access.redhat.com/security/cve/CVE-2022-21294 https://access.redhat.com/security/cve/CVE-2022-21296 https://access.redhat.com/security/cve/CVE-2022-21299 https://access.redhat.com/security/cve/CVE-2022-21305 https://access.redhat.com/security/cve/CVE-2022-21340 https://access.redhat.com/security/cve/CVE-2022-21341 https://access.redhat.com/security/cve/CVE-2022-21360 https://access.redhat.com/security/cve/CVE-2022-21365 https://access.redhat.com/security/cve/CVE-2022-21366",
+            "FixedBy": "1:11.0.14.0.9-2.el8_5",
+            "Description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: Incomplete deserialization class filtering in ObjectInputStream (Serialization, 8264934) (CVE-2022-21248)\n\n* OpenJDK: Incorrect reading of TIFF files in TIFFNullDecompressor (ImageIO, 8270952) (CVE-2022-21277)\n\n* OpenJDK: Insufficient URI checks in the XSLT TransformerImpl (JAXP, 8270492) (CVE-2022-21282)\n\n* OpenJDK: Unexpected exception thrown in regex Pattern (Libraries, 8268813) (CVE-2022-21283)\n\n* OpenJDK: Incorrect marking of writeable fields (Hotspot, 8270386) (CVE-2022-21291)\n\n* OpenJDK: Incomplete checks of StringBuffer and StringBuilder during deserialization (Libraries, 8270392) (CVE-2022-21293)\n\n* OpenJDK: Incorrect IdentityHashMap size checks during deserialization (Libraries, 8270416) (CVE-2022-21294)\n\n* OpenJDK: Incorrect access checks in XMLEntityManager (JAXP, 8270498) (CVE-2022-21296)\n\n* OpenJDK: Infinite loop related to incorrect handling of newlines in XMLEntityScanner (JAXP, 8270646) (CVE-2022-21299)\n\n* OpenJDK: Array indexing issues in LIRGenerator (Hotspot, 8272014) (CVE-2022-21305)\n\n* OpenJDK: Excessive resource use when reading JAR manifest attributes (Libraries, 8272026) (CVE-2022-21340)\n\n* OpenJDK: Insufficient checks when deserializing exceptions in ObjectInputStream (Serialization, 8272236) (CVE-2022-21341)\n\n* OpenJDK: Excessive memory allocation in BMPImageReader (ImageIO, 8273756) (CVE-2022-21360)\n\n* OpenJDK: Integer overflow in BMPImageReader (ImageIO, 8273838) (CVE-2022-21365)\n\n* OpenJDK: Excessive memory allocation in TIFF*Decompressor (ImageIO, 8274096) (CVE-2022-21366)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0185: java-11-openjdk security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "javapackages-filesystem",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "5.3.0-1.module+el8+2447+6f56d9a6",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "joda-time:joda-time",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.10.1.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "json-c",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.13.1-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "json-glib",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.4.4-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "kafka-clients-1.0.1.redhat",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "keyutils-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.5.10-9.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "kmod-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "25-18.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "krb5-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.18.2-14.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:8638 https://access.redhat.com/security/cve/CVE-2022-42898",
+            "FixedBy": "0:1.18.2-22.el8_7",
+            "Description": "Kerberos is a network authentication system, which can improve the security of your network by eliminating the insecure practice of sending passwords over the network in unencrypted form. It allows clients and servers to authenticate to each other with the help of a trusted third party, the Kerberos key distribution center (KDC).\n\nSecurity Fix(es):\n\n* krb5: integer overflow vulnerabilities in PAC parsing (CVE-2022-42898)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:8638: krb5 security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "langpacks-en",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.0-12.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "lcms2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.9-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libacl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.2.53-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libarchive",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.3.3-1.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Low",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3018 https://access.redhat.com/security/cve/CVE-2022-36227",
+            "FixedBy": "0:3.3.3-5.el8",
+            "Description": "The libarchive programming library can create and read several different streaming archive formats, including GNU tar, cpio, and ISO 9660 CD-ROM images. Libarchive is used notably in the bsdtar utility, scripting language bindings such as python-libarchive, and several popular desktop file managers.\n\nSecurity Fix(es):\n\n* libarchive: NULL pointer dereference in archive_write.c (CVE-2022-36227)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.8 Release Notes linked from the References section.",
+            "Name": "RHSA-2023:3018: libarchive security update (Low)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0892 https://access.redhat.com/security/cve/CVE-2021-23177 https://access.redhat.com/security/cve/CVE-2021-31566",
+            "FixedBy": "0:3.3.3-3.el8_5",
+            "Description": "The libarchive programming library can create and read several different streaming archive formats, including GNU tar, cpio, and ISO 9660 CD-ROM images. Libarchive is used notably in the bsdtar utility, scripting language bindings such as python-libarchive, and several popular desktop file managers.\n\nSecurity Fix(es):\n\n* libarchive: extracting a symlink with ACLs modifies ACLs of target (CVE-2021-23177)\n\n* libarchive: symbolic links incorrectly followed when changing modes, times, ACL and flags of a file while extracting an archive (CVE-2021-31566)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0892: libarchive security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libassuan",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.5.1-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libattr",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.4.48-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libblkid",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.32.1-28.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libcap",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.26-5.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4524 https://access.redhat.com/security/cve/CVE-2023-2602 https://access.redhat.com/security/cve/CVE-2023-2603",
+            "FixedBy": "0:2.48-5.el8_8",
+            "Description": "Libcap is a library for getting and setting POSIX.1e (formerly POSIX 6) draft 15 capabilities.\n\nSecurity Fix(es):\n\n* libcap: Integer Overflow in _libcap_strdup() (CVE-2023-2603)\n\n* libcap: Memory Leak on pthread_create() Error (CVE-2023-2602)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4524: libcap security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libcap-ng",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.7.11-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libcom_err",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.45.6-2.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7720 https://access.redhat.com/security/cve/CVE-2022-1304",
+            "FixedBy": "0:1.45.6-5.el8",
+            "Description": "The e2fsprogs packages provide a number of utilities for creating, checking, modifying, and correcting the ext2, ext3, and ext4 file systems.\n\nSecurity Fix(es):\n\n* e2fsprogs: out-of-bounds read/write via crafted filesystem (CVE-2022-1304)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+            "Name": "RHSA-2022:7720: e2fsprogs security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libcomps",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.1.16-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libcurl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "7.61.1-22.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4523 https://access.redhat.com/security/cve/CVE-2023-27536 https://access.redhat.com/security/cve/CVE-2023-28321",
+            "FixedBy": "0:7.61.1-30.el8_8.3",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: GSS delegation too eager connection re-use (CVE-2023-27536)\n\n* curl: IDN wildcard match may lead to Improper Cerificate Validation (CVE-2023-28321)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4523: curl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3106 https://access.redhat.com/security/cve/CVE-2023-27535",
+            "FixedBy": "0:7.61.1-30.el8_8.2",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: FTP too eager connection reuse (CVE-2023-27535)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Cannot upload files to Jscape SFTP server: file gets created empty (BZ#2188029)",
+            "Name": "RHSA-2023:3106: curl security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Low",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:2963 https://access.redhat.com/security/cve/CVE-2022-35252 https://access.redhat.com/security/cve/CVE-2022-43552",
+            "FixedBy": "0:7.61.1-30.el8",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: Incorrect handling of control code characters in cookies (CVE-2022-35252)\n\n* curl: Use-after-free triggered by an HTTP proxy deny response (CVE-2022-43552)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.8 Release Notes linked from the References section.",
+            "Name": "RHSA-2023:2963: curl security and bug fix update (Low)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1140 https://access.redhat.com/security/cve/CVE-2023-23916",
+            "FixedBy": "0:7.61.1-25.el8_7.3",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP multi-header compression denial of service (CVE-2023-23916)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1140: curl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:6159 https://access.redhat.com/security/cve/CVE-2022-32206 https://access.redhat.com/security/cve/CVE-2022-32208",
+            "FixedBy": "0:7.61.1-22.el8_6.4",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP compression denial of service (CVE-2022-32206)\n\n* curl: FTP-KRB bad message verification (CVE-2022-32208)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:6159: curl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5313 https://access.redhat.com/security/cve/CVE-2022-22576 https://access.redhat.com/security/cve/CVE-2022-27774 https://access.redhat.com/security/cve/CVE-2022-27776 https://access.redhat.com/security/cve/CVE-2022-27782",
+            "FixedBy": "0:7.61.1-22.el8_6.3",
+            "Description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: OAUTH2 bearer bypass in connection re-use (CVE-2022-22576)\n\n* curl: credential leak on redirect (CVE-2022-27774)\n\n* curl: auth/cookie leak on redirect (CVE-2022-27776)\n\n* curl: TLS and SSH connection too eager reuse (CVE-2022-27782)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5313: curl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libdb",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "5.3.28-42.el8_4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libdb-utils",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "5.3.28-42.el8_4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libdnf",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.63.0-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libfdisk",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.32.1-28.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libffi",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.1-22.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libgcc",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "8.5.0-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2021:4587 https://access.redhat.com/security/cve/CVE-2021-42574",
+            "FixedBy": "0:8.5.0-4.el8_5",
+            "Description": "The gcc packages provide compilers for C, C++, Java, Fortran, Objective C, and Ada 95 GNU, as well as related support libraries.\n\nSecurity Fix(es):\n\n* Developer environment: Unicode's bidirectional (BiDi) override characters can cause trojan source attacks (CVE-2021-42574)\n\nThe following changes were introduced in gcc in order to facilitate detection of BiDi Unicode characters:\n\nThis update implements a new warning option -Wbidirectional to warn about possibly dangerous bidirectional characters.\n\nThere are three levels of warning supported by gcc:\n\"-Wbidirectional=unpaired\", which warns about improperly terminated BiDi contexts. (This is the default.)\n\"-Wbidirectional=none\", which turns the warning off.\n\"-Wbidirectional=any\", which warns about any use of bidirectional characters.\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2021:4587: gcc security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libgcrypt",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.8.5-6.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5311 https://access.redhat.com/security/cve/CVE-2021-40528",
+            "FixedBy": "0:1.8.5-7.el8_6",
+            "Description": "The libgcrypt library provides general-purpose implementations of various cryptographic algorithms.\n\nSecurity Fix(es):\n\n* libgcrypt: ElGamal implementation allows plaintext recovery (CVE-2021-40528)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5311: libgcrypt security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libgpg-error",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.31-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libidn2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.2.0-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libjpeg-turbo",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.5.3-12.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libksba",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.3.5-7.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0625 https://access.redhat.com/security/cve/CVE-2022-47629",
+            "FixedBy": "0:1.3.5-9.el8_7",
+            "Description": "KSBA (pronounced Kasbah) is a library to make X.509 certificates as well as the CMS easily accessible by other applications. Both specifications are building blocks of S/MIME and TLS.\n\nSecurity Fix(es):\n\n* libksba: integer overflow to code executiona (CVE-2022-47629)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0625: libksba security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7089 https://access.redhat.com/security/cve/CVE-2022-3515",
+            "FixedBy": "0:1.3.5-8.el8_6",
+            "Description": "KSBA (pronounced Kasbah) is a library to make X.509 certificates as well as the CMS easily accessible by other applications.  Both specifications are building blocks of S/MIME and TLS.\n\nSecurity Fix(es):\n\n* libksba: integer overflow may lead to remote code execution (CVE-2022-3515)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:7089: libksba security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libmodulemd",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.13.0-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libmount",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.32.1-28.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libnghttp2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.33.0-3.el8_2.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libnl3",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.5.0-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libnsl2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.2.0-2.20180605git4a062cf.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libpng",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2:1.6.34-5.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libpsl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.20.2-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libpwquality",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.4.4-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "librepo",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.14.0-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libreport-filesystem",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.9.5-15.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "librhsm",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.0.3-4.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libseccomp",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.5.1-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libselinux",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.9-5.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libsemanage",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.9-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libsepol",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.9-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libsigsegv",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.11-5.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libsmartcols",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.32.1-28.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libsolv",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.7.19-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libssh",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.9.4-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3839 https://access.redhat.com/security/cve/CVE-2023-1667 https://access.redhat.com/security/cve/CVE-2023-2283",
+            "FixedBy": "0:0.9.6-10.el8_8",
+            "Description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nSecurity Fix(es):\n\n* libssh: NULL pointer dereference during rekeying with algorithm guessing (CVE-2023-1667)\n\n* libssh: authorization bypass in pki_verify_data_signature (CVE-2023-2283)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:3839: libssh security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Low",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:2031 https://access.redhat.com/security/cve/CVE-2021-3634",
+            "FixedBy": "0:0.9.6-3.el8",
+            "Description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nThe following packages have been upgraded to a later upstream version: libssh (0.9.6). (BZ#1896651)\n\nSecurity Fix(es):\n\n* libssh: possible heap-based buffer overflow when rekeying (CVE-2021-3634)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+            "Name": "RHSA-2022:2031: libssh security, bug fix, and enhancement update (Low)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libssh-config",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.9.4-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3839 https://access.redhat.com/security/cve/CVE-2023-1667 https://access.redhat.com/security/cve/CVE-2023-2283",
+            "FixedBy": "0:0.9.6-10.el8_8",
+            "Description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nSecurity Fix(es):\n\n* libssh: NULL pointer dereference during rekeying with algorithm guessing (CVE-2023-1667)\n\n* libssh: authorization bypass in pki_verify_data_signature (CVE-2023-2283)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:3839: libssh security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Low",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:2031 https://access.redhat.com/security/cve/CVE-2021-3634",
+            "FixedBy": "0:0.9.6-3.el8",
+            "Description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nThe following packages have been upgraded to a later upstream version: libssh (0.9.6). (BZ#1896651)\n\nSecurity Fix(es):\n\n* libssh: possible heap-based buffer overflow when rekeying (CVE-2021-3634)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+            "Name": "RHSA-2022:2031: libssh security, bug fix, and enhancement update (Low)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libstdc++",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "8.5.0-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2021:4587 https://access.redhat.com/security/cve/CVE-2021-42574",
+            "FixedBy": "0:8.5.0-4.el8_5",
+            "Description": "The gcc packages provide compilers for C, C++, Java, Fortran, Objective C, and Ada 95 GNU, as well as related support libraries.\n\nSecurity Fix(es):\n\n* Developer environment: Unicode's bidirectional (BiDi) override characters can cause trojan source attacks (CVE-2021-42574)\n\nThe following changes were introduced in gcc in order to facilitate detection of BiDi Unicode characters:\n\nThis update implements a new warning option -Wbidirectional to warn about possibly dangerous bidirectional characters.\n\nThere are three levels of warning supported by gcc:\n\"-Wbidirectional=unpaired\", which warns about improperly terminated BiDi contexts. (This is the default.)\n\"-Wbidirectional=none\", which turns the warning off.\n\"-Wbidirectional=any\", which warns about any use of bidirectional characters.\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2021:4587: gcc security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libtasn1",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.13-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0116 https://access.redhat.com/security/cve/CVE-2021-46848",
+            "FixedBy": "0:4.13-4.el8_7",
+            "Description": "A library that provides Abstract Syntax Notation One (ASN.1, as specified by the X.680 ITU-T recommendation) parsing and structures management, and Distinguished Encoding Rules (DER, as per X.690) encoding and decoding functions.\n\nSecurity Fix(es):\n\n* libtasn1: Out-of-bound access in ETYPE_OK (CVE-2021-46848)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0116: libtasn1 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libtirpc",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.1.4-5.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHBA-2022:2065 https://access.redhat.com/security/cve/CVE-2021-46828",
+            "FixedBy": "0:1.1.4-6.el8",
+            "Description": "For detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+            "Name": "RHBA-2022:2065: libtirpc bug fix and enhancement update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libunistring",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.9.9-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libusbx",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.0.23-4.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libuser",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.62-23.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libutempter",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.1.6-14.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libuuid",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.32.1-28.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libverto",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.3.0-5.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libxcrypt",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.1.1-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libxml2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.9.7-9.el8_4.2",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4529 https://access.redhat.com/security/cve/CVE-2023-28484 https://access.redhat.com/security/cve/CVE-2023-29469",
+            "FixedBy": "0:2.9.7-16.el8_8.1",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: NULL dereference in xmlSchemaFixupComplexType (CVE-2023-28484)\n\n* libxml2: Hashing of empty dict strings isn't deterministic (CVE-2023-29469)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4529: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0173 https://access.redhat.com/security/cve/CVE-2022-40303 https://access.redhat.com/security/cve/CVE-2022-40304",
+            "FixedBy": "0:2.9.7-15.el8_7.1",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows with XML_PARSE_HUGE (CVE-2022-40303)\n\n* libxml2: dict corruption caused by entity reference cycles (CVE-2022-40304)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0173: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7715 https://access.redhat.com/security/cve/CVE-2016-3709",
+            "FixedBy": "0:2.9.7-15.el8",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Incorrect server side include parsing can lead to XSS (CVE-2016-3709)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+            "Name": "RHSA-2022:7715: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5317 https://access.redhat.com/security/cve/CVE-2022-29824",
+            "FixedBy": "0:2.9.7-13.el8_6.1",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows in xmlBuf and xmlBuffer lead to out-of-bounds write (CVE-2022-29824)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5317: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0899 https://access.redhat.com/security/cve/CVE-2022-23308",
+            "FixedBy": "0:2.9.7-12.el8_5",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Use-after-free of ID and IDREF attributes (CVE-2022-23308)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0899: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "libyaml",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.1.7-5.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "libzstd",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.4.4-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "lksctp-tools",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.0.18-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "lua",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "5.3.4-12.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "lua-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "5.3.4-12.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "lz4-java",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "lz4-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.8.3-3.el8_4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "mpfr",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.1.6-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "ncurses-base",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "6.1-9.20180224.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "ncurses-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "6.1-9.20180224.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "net.minidev:accessors-smart",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "net.minidev:json-smart",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.3",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-27568 https://github.com/netplex/json-smart-v1/issues/7 https://github.com/netplex/json-smart-v2/issues/60 https://github.com/netplex/json-smart-v2/issues/62 https://github.com/netplex/json-smart-v2/pull/72 https://github.com/netplex/json-smart-v1/commit/768db58ee0e3e344fcdb574b7629765308a1d0af https://github.com/netplex/json-smart-v2 https://lists.apache.org/thread.html/rb6287f5aa628c8d9af52b5401ec6cc51b6fc28ab20d318943453e396@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/re237267da268c690df5e1c6ea6a38a7fc11617725e8049490f58a6fa@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rf70210b4d63191c0bfb2a0d5745e104484e71703bf5ad9cb01c980c6@%3Ccommits.druid.apache.org%3E https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html",
+            "FixedBy": "2.3.1",
+            "Description": "Improper Check for Unusual or Exceptional Conditions in json-smart",
+            "Name": "GHSA-v528-7hrm-frqp",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/oswaldobapvicjr/jsonmerge/security/advisories/GHSA-493p-pfq6-5258 https://nvd.nist.gov/vuln/detail/CVE-2023-1370 https://github.com/netplex/json-smart-v2/issues/137 https://github.com/netplex/json-smart-v2/commit/5b3205d051952d3100aa0db1535f6ba6226bd87a https://github.com/netplex/json-smart-v2/commit/e2791ae506a57491bc856b439d706c81e45adcf8 https://github.com/oswaldobapvicjr/jsonmerge https://research.jfrog.com/vulnerabilities/stack-exhaustion-in-json-smart-leads-to-denial-of-service-when-parsing-malformed-json-xray-427633/ https://security.snyk.io/vuln/SNYK-JAVA-NETMINIDEV-3369748 https://www.cve.org/CVERecord?id=CVE-2023-1370",
+            "FixedBy": "2.4.9",
+            "Description": "json-smart Uncontrolled Recursion vulnerabilty",
+            "Name": "GHSA-493p-pfq6-5258",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "net.sf.jopt-simple:jopt-simple",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "5.0.2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "net.shibboleth.utilities:java-support",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.3.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "nettle",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.4.1-7.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "npth",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.5-4.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "nspr",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.32.0-1.el8_4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "nss",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.67.0-7.el8_5",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+            "FixedBy": "0:3.79.0-11.el8_7",
+            "Description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1252: nss security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "nss-softokn",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.67.0-7.el8_5",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+            "FixedBy": "0:3.79.0-11.el8_7",
+            "Description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1252: nss security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "nss-softokn-freebl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.67.0-7.el8_5",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+            "FixedBy": "0:3.79.0-11.el8_7",
+            "Description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1252: nss security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "nss-sysinit",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.67.0-7.el8_5",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+            "FixedBy": "0:3.79.0-11.el8_7",
+            "Description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1252: nss security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "nss-util",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.67.0-7.el8_5",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+            "FixedBy": "0:3.79.0-11.el8_7",
+            "Description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1252: nss security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "openldap",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.4.46-18.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "openssl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1:1.1.1k-4.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1405 https://access.redhat.com/security/cve/CVE-2022-4304 https://access.redhat.com/security/cve/CVE-2022-4450 https://access.redhat.com/security/cve/CVE-2023-0215 https://access.redhat.com/security/cve/CVE-2023-0286",
+            "FixedBy": "1:1.1.1k-9.el8_7",
+            "Description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: X.400 address type confusion in X.509 GeneralName (CVE-2023-0286)\n\n* openssl: timing attack in RSA Decryption implementation (CVE-2022-4304)\n\n* openssl: double free after calling PEM_read_bio_ex (CVE-2022-4450)\n\n* openssl: use-after-free following BIO_new_NDEF (CVE-2023-0215)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1405: openssl security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5818 https://access.redhat.com/security/cve/CVE-2022-1292 https://access.redhat.com/security/cve/CVE-2022-2068 https://access.redhat.com/security/cve/CVE-2022-2097",
+            "FixedBy": "1:1.1.1k-7.el8_6",
+            "Description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: c_rehash script allows command injection (CVE-2022-1292)\n\n* openssl: the c_rehash script allows command injection (CVE-2022-2068)\n\n* openssl: AES OCB fails to encrypt some bytes (CVE-2022-2097)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5818: openssl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:1065 https://access.redhat.com/security/cve/CVE-2022-0778",
+            "FixedBy": "1:1.1.1k-6.el8_5",
+            "Description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Infinite loop in BN_mod_sqrt() reachable when parsing certificates (CVE-2022-0778)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:1065: openssl security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2021:5226 https://access.redhat.com/security/cve/CVE-2021-3712",
+            "FixedBy": "1:1.1.1k-5.el8_5",
+            "Description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Read buffer overruns processing ASN.1 strings (CVE-2021-3712)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2021:5226: openssl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "openssl-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:1.1.1k-4.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:1405 https://access.redhat.com/security/cve/CVE-2022-4304 https://access.redhat.com/security/cve/CVE-2022-4450 https://access.redhat.com/security/cve/CVE-2023-0215 https://access.redhat.com/security/cve/CVE-2023-0286",
+            "FixedBy": "1:1.1.1k-9.el8_7",
+            "Description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: X.400 address type confusion in X.509 GeneralName (CVE-2023-0286)\n\n* openssl: timing attack in RSA Decryption implementation (CVE-2022-4304)\n\n* openssl: double free after calling PEM_read_bio_ex (CVE-2022-4450)\n\n* openssl: use-after-free following BIO_new_NDEF (CVE-2023-0215)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:1405: openssl security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5818 https://access.redhat.com/security/cve/CVE-2022-1292 https://access.redhat.com/security/cve/CVE-2022-2068 https://access.redhat.com/security/cve/CVE-2022-2097",
+            "FixedBy": "1:1.1.1k-7.el8_6",
+            "Description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: c_rehash script allows command injection (CVE-2022-1292)\n\n* openssl: the c_rehash script allows command injection (CVE-2022-2068)\n\n* openssl: AES OCB fails to encrypt some bytes (CVE-2022-2097)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5818: openssl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:1065 https://access.redhat.com/security/cve/CVE-2022-0778",
+            "FixedBy": "1:1.1.1k-6.el8_5",
+            "Description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Infinite loop in BN_mod_sqrt() reachable when parsing certificates (CVE-2022-0778)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:1065: openssl security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2021:5226 https://access.redhat.com/security/cve/CVE-2021-3712",
+            "FixedBy": "1:1.1.1k-5.el8_5",
+            "Description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Read buffer overruns processing ASN.1 strings (CVE-2021-3712)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2021:5226: openssl security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.antlr:antlr4-runtime",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.5.3.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.antlr:antlr4-runtime",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.5.1.1-redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.commons:commons-lang3",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.commons:commons-text",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.cxf:cxf-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.2.2.redhat-1",
+        "Vulnerabilities": [
+          {
+            "Severity": "Critical",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-46364 https://cxf.apache.org/security-advisories.data/CVE-2022-46364.txt?version=1&modificationDate=1670944472739&api=v2",
+            "FixedBy": "3.4.10",
+            "Description": "Apache CXF Server-Side Request Forgery vulnerability",
+            "Name": "GHSA-x3x3-qwjq-8gj4",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Unknown",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-46363 https://github.com/apache/cxf https://lists.apache.org/thread/pdzo1qgyplf4y523tnnzrcm7hoco3l8c",
+            "FixedBy": "3.4.10",
+            "Description": "Apache CXF vulnerable to Exposure of Sensitive Information",
+            "Name": "GHSA-3w37-5p3p-jv92",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.apache.cxf:cxf-rt-rs-json-basic",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.2.2.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.cxf:cxf-rt-rs-security-jose",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.2.2.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.cxf:cxf-rt-security",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.2.2.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.httpcomponents:fluent-hc",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.5.3",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.httpcomponents:httpasyncclient",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.1.2",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.httpcomponents:httpclient",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.5.3",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13956 https://github.com/apache/httpcomponents-client https://lists.apache.org/thread.html/r03bbc318c81be21f5c8a9b85e34f2ecc741aa804a8e43b0ef2c37749@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/r043a75acdeb52b15dd5e9524cdadef4202e6a5228644206acf9363f9@%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/r06cf3ca5c8ceb94b39cd24a73d4e96153b485a7dac88444dd876accb@%3Cissues.drill.apache.org%3E https://lists.apache.org/thread.html/r0a75b8f0f72f3e18442dc56d33f3827b905f2fe5b7ba48997436f5d1@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r0bebe6f9808ac7bdf572873b4fa96a29c6398c90dab29f131f3ebffe@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r12cb62751b35bdcda0ae2a08b67877d665a1f4d41eee0fa7367169e0@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r132e4c6a560cfc519caa1aaee63bdd4036327610eadbd89f76dd5457@%3Cdev.creadur.apache.org%3E https://lists.apache.org/thread.html/r2835543ef0f91adcc47da72389b816e36936f584c7be584d2314fac3@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/r2a03dc210231d7e852ef73015f71792ac0fcaca6cccc024c522ef17d@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r2dc7930b43eadc78220d269b79e13ecd387e4bee52db67b2f47d4303@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/r34178ab6ef106bc940665fd3f4ba5026fac3603b3fa2aefafa0b619d@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r34efec51cb817397ccf9f86e25a75676d435ba5f83ee7b2eabdad707@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r3cecd59fba74404cbf4eb430135e1080897fb376f111406a78bed13a@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/r3f740e4c38bba1face49078aa5cbeeb558c27be601cc9712ad2dcd1e@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r4850b3fbaea02fde2886e461005e4af8d37c80a48b3ce2a6edca0e30@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r549ac8c159bf0c568c19670bedeb8d7c0074beded951d34b1c1d0d05@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r55b2a1d1e9b1ec9db792b93da8f0f99a4fd5a5310b02673359d9b4d1@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r5b55f65c123a7481104d663a915ec45a0d103e6aaa03f42ed1c07a89@%3Cdev.jackrabbit.apache.org%3E https://lists.apache.org/thread.html/r5de3d3808e7b5028df966e45115e006456c4e8931dc1e29036f17927@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r5fec9c1d67f928179adf484b01e7becd7c0a6fdfe3a08f92ea743b90@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r63296c45d5d84447babaf39bd1487329d8a80d8d563e67a4b6f3d8a7@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r69a94e2f302d1b778bdfefe90fcb4b8c50b226438c3c8c1d0de85a19@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r6a3cda38d050ebe13c1bc9a28d0a8ec38945095d07eca49046bcb89f@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r6d672b46622842e565e00f6ef6bef83eb55d8792aac2bee75bff9a2a@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/r6dab7da30f8bf075f79ee189e33b45a197502e2676481bb8787fc0d7%40%3Cdev.hc.apache.org%3E https://lists.apache.org/thread.html/r6eb2dae157dbc9af1f30d1f64e9c60d4ebef618f3dce4a0e32d6ea4d@%3Ccommits.drill.apache.org%3E https://lists.apache.org/thread.html/r70c429923100c5a4fae8e5bc71c8a2d39af3de4888f50a0ac3755e6f@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r87ddc09295c27f25471269ad0a79433a91224045988b88f0413a97ec@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/r8aa1e5c343b89aec5b69961471950e862f15246cb6392910161c389b@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/r9e52a6c72c8365000ecd035e48cc9fee5a677a150350d4420c46443d@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/ra539f20ef0fb0c27ee39945b5f56bf162e5c13d1c60f7344dab8de3b@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/ra8bc6b61c5df301a6fe5a716315528ecd17ccb8a7f907e24a47a1a5e@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rad6222134183046f3928f733bf680919e0c390739bfbfe6c90049673@%3Cissues.drill.apache.org%3E https://lists.apache.org/thread.html/rae14ae25ff4a60251e3ba2629c082c5ba3851dfd4d21218b99b56652@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rb33212dab7beccaf1ffef9b88610047c644f644c7a0ebdc44d77e381@%3Ccommits.turbine.apache.org%3E https://lists.apache.org/thread.html/rb4ba262d6f08ab9cf8b1ebbcd9b00b0368ffe90dad7ad7918b4b56fc@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/rb725052404fabffbe093c83b2c46f3f87e12c3193a82379afbc529f8@%3Csolr-user.lucene.apache.org%3E https://lists.apache.org/thread.html/rc0863892ccfd9fd0d0ae10091f24ee769fb39b8957fe4ebabfc11f17@%3Cdev.jackrabbit.apache.org%3E https://lists.apache.org/thread.html/rc3739e0ad4bcf1888c6925233bfc37dd71156bbc8416604833095c42@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/rc505fee574fe8d18f9b0c655a4d120b0ae21bb6a73b96003e1d9be35@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rc5c6ccb86d2afe46bbd4b71573f0448dc1f87bbcd5a0d8c7f8f904b2@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rc990e2462ec32b09523deafb2c73606208599e196fa2d7f50bdbc587@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/rcced7ed3237c29cd19c1e9bf465d0038b8b2e967b99fc283db7ca553@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/rcd9ad5dda60c82ab0d0c9bd3e9cb1dc740804451fc20c7f451ef5cc4@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rd5ab56beb2ac6879f6ab427bc4e5f7691aed8362d17b713f61779858@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/re504acd4d63b8df2a7353658f45c9a3137e5f80e41cf7de50058b2c1@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rea3dbf633dde5008d38bf6600a3738b9216e733e03f9ff7becf79625@%3Cissues.drill.apache.org%3E https://lists.apache.org/thread.html/ree942561f4620313c75982a4e5f3b74fe6f7062b073210779648eec2@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/reef569c2419705754a3acf42b5f19b2a158153cef0e448158bc54917@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/rf03228972e56cb4a03e6d9558188c2938078cf3ceb23a3fead87c9ca@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/rf43d17ed0d1fb4fb79036b582810ef60b18b1ef3add0d5dea825af1e@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rf4db88c22e1be9eb60c7dc623d0528642c045fb196a24774ac2fa3a3@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rf7ca60f78f05b772cc07d27e31bcd112f9910a05caf9095e38ee150f@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/rfb35f6db9ba1f1e061b63769a4eff5abadcc254ebfefc280e5a0dcf1@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/rfbedcb586a1e7dfce87ee03c720e583fc2ceeafa05f35c542cecc624@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rfc00884c7b7ca878297bffe45fcb742c362b00b26ba37070706d44c3@%3Cissues.hive.apache.org%3E https://security.netapp.com/advisory/ntap-20220210-0002/ https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+            "FixedBy": "4.5.13",
+            "Description": "Cross-site scripting in Apache HttpClient",
+            "Name": "GHSA-7r82-7xv7-xcpj",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.apache.httpcomponents:httpclient",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.5.2",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13956 https://github.com/apache/httpcomponents-client https://lists.apache.org/thread.html/r03bbc318c81be21f5c8a9b85e34f2ecc741aa804a8e43b0ef2c37749@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/r043a75acdeb52b15dd5e9524cdadef4202e6a5228644206acf9363f9@%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/r06cf3ca5c8ceb94b39cd24a73d4e96153b485a7dac88444dd876accb@%3Cissues.drill.apache.org%3E https://lists.apache.org/thread.html/r0a75b8f0f72f3e18442dc56d33f3827b905f2fe5b7ba48997436f5d1@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r0bebe6f9808ac7bdf572873b4fa96a29c6398c90dab29f131f3ebffe@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r12cb62751b35bdcda0ae2a08b67877d665a1f4d41eee0fa7367169e0@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r132e4c6a560cfc519caa1aaee63bdd4036327610eadbd89f76dd5457@%3Cdev.creadur.apache.org%3E https://lists.apache.org/thread.html/r2835543ef0f91adcc47da72389b816e36936f584c7be584d2314fac3@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/r2a03dc210231d7e852ef73015f71792ac0fcaca6cccc024c522ef17d@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r2dc7930b43eadc78220d269b79e13ecd387e4bee52db67b2f47d4303@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/r34178ab6ef106bc940665fd3f4ba5026fac3603b3fa2aefafa0b619d@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r34efec51cb817397ccf9f86e25a75676d435ba5f83ee7b2eabdad707@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r3cecd59fba74404cbf4eb430135e1080897fb376f111406a78bed13a@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/r3f740e4c38bba1face49078aa5cbeeb558c27be601cc9712ad2dcd1e@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r4850b3fbaea02fde2886e461005e4af8d37c80a48b3ce2a6edca0e30@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r549ac8c159bf0c568c19670bedeb8d7c0074beded951d34b1c1d0d05@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r55b2a1d1e9b1ec9db792b93da8f0f99a4fd5a5310b02673359d9b4d1@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r5b55f65c123a7481104d663a915ec45a0d103e6aaa03f42ed1c07a89@%3Cdev.jackrabbit.apache.org%3E https://lists.apache.org/thread.html/r5de3d3808e7b5028df966e45115e006456c4e8931dc1e29036f17927@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r5fec9c1d67f928179adf484b01e7becd7c0a6fdfe3a08f92ea743b90@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r63296c45d5d84447babaf39bd1487329d8a80d8d563e67a4b6f3d8a7@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r69a94e2f302d1b778bdfefe90fcb4b8c50b226438c3c8c1d0de85a19@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r6a3cda38d050ebe13c1bc9a28d0a8ec38945095d07eca49046bcb89f@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r6d672b46622842e565e00f6ef6bef83eb55d8792aac2bee75bff9a2a@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/r6dab7da30f8bf075f79ee189e33b45a197502e2676481bb8787fc0d7%40%3Cdev.hc.apache.org%3E https://lists.apache.org/thread.html/r6eb2dae157dbc9af1f30d1f64e9c60d4ebef618f3dce4a0e32d6ea4d@%3Ccommits.drill.apache.org%3E https://lists.apache.org/thread.html/r70c429923100c5a4fae8e5bc71c8a2d39af3de4888f50a0ac3755e6f@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r87ddc09295c27f25471269ad0a79433a91224045988b88f0413a97ec@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/r8aa1e5c343b89aec5b69961471950e862f15246cb6392910161c389b@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/r9e52a6c72c8365000ecd035e48cc9fee5a677a150350d4420c46443d@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/ra539f20ef0fb0c27ee39945b5f56bf162e5c13d1c60f7344dab8de3b@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/ra8bc6b61c5df301a6fe5a716315528ecd17ccb8a7f907e24a47a1a5e@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rad6222134183046f3928f733bf680919e0c390739bfbfe6c90049673@%3Cissues.drill.apache.org%3E https://lists.apache.org/thread.html/rae14ae25ff4a60251e3ba2629c082c5ba3851dfd4d21218b99b56652@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rb33212dab7beccaf1ffef9b88610047c644f644c7a0ebdc44d77e381@%3Ccommits.turbine.apache.org%3E https://lists.apache.org/thread.html/rb4ba262d6f08ab9cf8b1ebbcd9b00b0368ffe90dad7ad7918b4b56fc@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/rb725052404fabffbe093c83b2c46f3f87e12c3193a82379afbc529f8@%3Csolr-user.lucene.apache.org%3E https://lists.apache.org/thread.html/rc0863892ccfd9fd0d0ae10091f24ee769fb39b8957fe4ebabfc11f17@%3Cdev.jackrabbit.apache.org%3E https://lists.apache.org/thread.html/rc3739e0ad4bcf1888c6925233bfc37dd71156bbc8416604833095c42@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/rc505fee574fe8d18f9b0c655a4d120b0ae21bb6a73b96003e1d9be35@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rc5c6ccb86d2afe46bbd4b71573f0448dc1f87bbcd5a0d8c7f8f904b2@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rc990e2462ec32b09523deafb2c73606208599e196fa2d7f50bdbc587@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/rcced7ed3237c29cd19c1e9bf465d0038b8b2e967b99fc283db7ca553@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/rcd9ad5dda60c82ab0d0c9bd3e9cb1dc740804451fc20c7f451ef5cc4@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rd5ab56beb2ac6879f6ab427bc4e5f7691aed8362d17b713f61779858@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/re504acd4d63b8df2a7353658f45c9a3137e5f80e41cf7de50058b2c1@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rea3dbf633dde5008d38bf6600a3738b9216e733e03f9ff7becf79625@%3Cissues.drill.apache.org%3E https://lists.apache.org/thread.html/ree942561f4620313c75982a4e5f3b74fe6f7062b073210779648eec2@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/reef569c2419705754a3acf42b5f19b2a158153cef0e448158bc54917@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/rf03228972e56cb4a03e6d9558188c2938078cf3ceb23a3fead87c9ca@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/rf43d17ed0d1fb4fb79036b582810ef60b18b1ef3add0d5dea825af1e@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rf4db88c22e1be9eb60c7dc623d0528642c045fb196a24774ac2fa3a3@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rf7ca60f78f05b772cc07d27e31bcd112f9910a05caf9095e38ee150f@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/rfb35f6db9ba1f1e061b63769a4eff5abadcc254ebfefc280e5a0dcf1@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/rfbedcb586a1e7dfce87ee03c720e583fc2ceeafa05f35c542cecc624@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rfc00884c7b7ca878297bffe45fcb742c362b00b26ba37070706d44c3@%3Cissues.hive.apache.org%3E https://security.netapp.com/advisory/ntap-20220210-0002/ https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+            "FixedBy": "4.5.13",
+            "Description": "Cross-site scripting in Apache HttpClient",
+            "Name": "GHSA-7r82-7xv7-xcpj",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.apache.httpcomponents:httpclient-cache",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.5.3",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.httpcomponents:httpcore",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.4.6",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.httpcomponents:httpcore",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.4.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.httpcomponents:httpcore-nio",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.4.5",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.logging.log4j:log4j-1.2-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.11.1.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.logging.log4j:log4j-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.11.1.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.logging.log4j:log4j-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.11.1.redhat-00001",
+        "Vulnerabilities": [
+          {
+            "Severity": "Low",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-9488 https://issues.apache.org/jira/browse/LOG4J2-2819 https://lists.apache.org/thread.html/r0a2699f724156a558afd1abb6c044fb9132caa66dce861b82699722a@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r0df3d7a5acb98c57e64ab9266aa21eeee1d9b399addb96f9cf1cbe05@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r1fc73f0e16ec2fa249d3ad39a5194afb9cc5afb4c023dc0bab5a5881@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r22a56beb76dd8cf18e24fda9072f1e05990f49d6439662d3782a392f@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r2721aba31a8562639c4b937150897e24f78f747cdbda8641c0f659fe@%3Cusers.kafka.apache.org%3E https://lists.apache.org/thread.html/r2f209d271349bafd91537a558a279c08ebcff8fa3e547357d58833e6@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r33864a0fc171c1c4bf680645ebb6d4f8057899ab294a43e1e4fe9d04@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r393943de452406f0f6f4b3def9f8d3c071f96323c1f6ed1a098f7fe4@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/r3d1d00441c55144a4013adda74b051ae7864128ebcfb6ee9721a2eb3@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r4285398e5585a0456d3d9db021a4fce6e6fcf3ec027dfa13a450ec98@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r45916179811a32cbaa500f972de9098e6ee80ee81c7f134fce83e03a@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/r48bcd06049c1779ef709564544c3d8a32ae6ee5c3b7281a606ac4463@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r48efc7cb5aeb4e1f67aaa06fb4b5479a5635d12f07d0b93fc2d08809@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4d5dc9f3520071338d9ebc26f9f158a43ae28a91923d176b550a807b@%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/r4db540cafc5d7232c62e076051ef661d37d345015b2e59b3f81a932f@%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/r4ed1f49616a8603832d378cb9d13e7a8b9b27972bb46d946ccd8491f@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r5a68258e5ab12532dc179edae3d6e87037fa3b50ab9d63a90c432507@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r65578f3761a89bc164e8964acd5d913b9f8fd997967b195a89a97ca3@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r7641ee788e1eb1be4bb206a7d15f8a64ec6ef23e5ec6132d5a567695@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r7e5c10534ed06bf805473ac85e8412fe3908a8fa4cabf5027bf11220@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/r7e739f2961753af95e2a3a637828fb88bfca68e5d6b0221d483a9ee5@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r8c001b9a95c0bbec06f4457721edd94935a55932e64b82cc5582b846@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r8e96c340004b7898cad3204ea51280ef6e4b553a684e1452bf1b18b1@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r9776e71e3c67c5d13a91c1eba0dc025b48b802eb7561cc6956d6961c@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r9a79175c393d14d760a0ae3731b4a873230a16ef321aa9ca48a810cd@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra051e07a0eea4943fa104247e69596f094951f51512d42c924e86c75@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/ra632b329b2ae2324fabbad5da204c4ec2e171ff60348ec4ba698fd40@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/rbc45eb0f53fd6242af3e666c2189464f848a851d408289840cecc6e3@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rbc7642b9800249553f13457e46b813bea1aec99d2bc9106510e00ff3@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc2dbc4633a6eea1fcbce6831876cfa17b73759a98c65326d1896cb1a@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc6b81c013618d1de1b5d6b8c1088aaf87b4bacc10c2371f15a566701@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rd55f65c6822ff235eda435d31488cfbb9aa7055cdf47481ebee777cc@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rd5d58088812cf8e677d99b07f73c654014c524c94e7fedbdee047604@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rd8e87c4d69df335d0ba7d815b63be8bd8a6352f429765c52eb07ddac@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/re024d86dffa72ad800f2848d0c77ed93f0b78ee808350b477a6ed987@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/rec34b1cccf907898e7cb36051ffac3ccf1ea89d0b261a2a3b3fb267f@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rf1c2a81a08034c688b8f15cf58a4cfab322d00002ca46d20133bee20@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772@%3Cdev.mina.apache.org%3E https://lists.debian.org/debian-lts-announce/2021/12/msg00017.html https://security.netapp.com/advisory/ntap-20200504-0003/ https://www.debian.org/security/2021/dsa-5020 https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2021.html https://www.oracle.com/security-alerts/cpujul2020.html https://www.oracle.com/security-alerts/cpuoct2020.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+            "FixedBy": "2.13.2",
+            "Description": "Improper validation of certificate with host mismatch in Apache Log4j SMTP appender",
+            "Name": "GHSA-vwqq-5vrc-xw9h",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-45105 https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-501673.pdf https://lists.debian.org/debian-lts-announce/2021/12/msg00017.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EOKPQGV24RRBBI4TBZUDQMM4MEH7MXCY/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/SIG7FZULMNK2XF6FZRU4VWYDQXNMUGAJ/ https://logging.apache.org/log4j/2.x/security.html https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032 https://security.netapp.com/advisory/ntap-20211218-0001/ https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd https://www.debian.org/security/2021/dsa-5024 https://www.kb.cert.org/vuls/id/930724 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html https://www.zerodayinitiative.com/advisories/ZDI-21-1541/ http://www.openwall.com/lists/oss-security/2021/12/19/1",
+            "FixedBy": "2.12.3",
+            "Description": "Apache Log4j2 vulnerable to Improper Input Validation and Uncontrolled Recursion",
+            "Name": "GHSA-p6xc-xr62-6r2g",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Critical",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228 https://github.com/apache/logging-log4j2/pull/608 https://cert-portal.siemens.com/productcert/pdf/ssa-397453.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-661247.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-714170.pdf https://github.com/advisories/GHSA-7rjr-3q55-vv33 https://github.com/apache/logging-log4j2 https://github.com/cisagov/log4j-affected-db https://github.com/cisagov/log4j-affected-db/blob/develop/SOFTWARE-LIST.md https://github.com/nu11secur1ty/CVE-mitre/tree/main/CVE-2021-44228 https://github.com/tangxiaofeng7/apache-log4j-poc https://issues.apache.org/jira/browse/LOG4J2-3198 https://issues.apache.org/jira/browse/LOG4J2-3201 https://issues.apache.org/jira/browse/LOG4J2-3214 https://issues.apache.org/jira/browse/LOG4J2-3221 https://lists.debian.org/debian-lts-announce/2021/12/msg00007.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M5CSVUNV4HWZZXGOKNSK6L7RPM7BOKIB/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VU57UJDCFIASIO35GC55JMKSRXJMCDFM/ https://logging.apache.org/log4j/2.x/changes-report.html#a2.15.0 https://logging.apache.org/log4j/2.x/manual/lookups.html#JndiLookup https://logging.apache.org/log4j/2.x/manual/migration.html https://logging.apache.org/log4j/2.x/security.html https://msrc-blog.microsoft.com/2021/12/11/microsofts-response-to-cve-2021-44228-apache-log4j2/ https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032 https://security.netapp.com/advisory/ntap-20211210-0007/ https://support.apple.com/kb/HT213189 https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd https://twitter.com/kurtseifried/status/1469345530182455296 https://www.bentley.com/en/common-vulnerability-exposure/be-2022-0001 https://www.debian.org/security/2021/dsa-5020 https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html https://www.kb.cert.org/vuls/id/930724 https://www.nu11secur1ty.com/2021/12/cve-2021-44228.html https://www.oracle.com/security-alerts/alert-cve-2021-44228.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html http://packetstormsecurity.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html http://packetstormsecurity.com/files/165260/VMware-Security-Advisory-2021-0028.html http://packetstormsecurity.com/files/165261/Apache-Log4j2-2.14.1-Information-Disclosure.html http://packetstormsecurity.com/files/165270/Apache-Log4j2-2.14.1-Remote-Code-Execution.html http://packetstormsecurity.com/files/165281/Log4j2-Log4Shell-Regexes.html http://packetstormsecurity.com/files/165282/Log4j-Payload-Generator.html http://packetstormsecurity.com/files/165306/L4sh-Log4j-Remote-Code-Execution.html http://packetstormsecurity.com/files/165307/Log4j-Remote-Code-Execution-Word-Bypassing.html http://packetstormsecurity.com/files/165311/log4j-scan-Extensive-Scanner.html http://packetstormsecurity.com/files/165371/VMware-Security-Advisory-2021-0028.4.html http://packetstormsecurity.com/files/165532/Log4Shell-HTTP-Header-Injection.html http://packetstormsecurity.com/files/165642/VMware-vCenter-Server-Unauthenticated-Log4Shell-JNDI-Injection-Remote-Code-Execution.html http://packetstormsecurity.com/files/165673/UniFi-Network-Application-Unauthenticated-Log4Shell-Remote-Code-Execution.html http://packetstormsecurity.com/files/167794/Open-Xchange-App-Suite-7.10.x-Cross-Site-Scripting-Command-Injection.html http://packetstormsecurity.com/files/167917/MobileIron-Log4Shell-Remote-Command-Execution.html http://packetstormsecurity.com/files/171626/AD-Manager-Plus-7122-Remote-Code-Execution.html http://seclists.org/fulldisclosure/2022/Dec/2 http://seclists.org/fulldisclosure/2022/Jul/11 http://seclists.org/fulldisclosure/2022/Mar/23 http://www.openwall.com/lists/oss-security/2021/12/10/1 http://www.openwall.com/lists/oss-security/2021/12/10/2 http://www.openwall.com/lists/oss-security/2021/12/10/3 http://www.openwall.com/lists/oss-security/2021/12/13/1 http://www.openwall.com/lists/oss-security/2021/12/13/2 http://www.openwall.com/lists/oss-security/2021/12/14/4 http://www.openwall.com/lists/oss-security/2021/12/15/3",
+            "FixedBy": "2.12.2",
+            "Description": "Remote code injection in Log4j",
+            "Name": "GHSA-jfh8-c2jp-5v3q",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-44832 https://cert-portal.siemens.com/productcert/pdf/ssa-784507.pdf https://github.com/apache/logging-log4j2 https://issues.apache.org/jira/browse/LOG4J2-3293 https://lists.apache.org/thread/s1o5vlo78ypqxnzn6p8zf6t9shtq5143 https://lists.debian.org/debian-lts-announce/2021/12/msg00036.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EVV25FXL4FU5X6X5BSL7RLQ7T6F65MRA/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/T57MPJUW3MA6QGWZRTMCHHMMPQNVKGFC/ https://security.netapp.com/advisory/ntap-20220104-0001/ https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html http://www.openwall.com/lists/oss-security/2021/12/28/1",
+            "FixedBy": "2.12.4",
+            "Description": "Improper Input Validation and Injection in Apache Log4j2",
+            "Name": "GHSA-8489-44mv-ggj8",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Critical",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-45046 https://cert-portal.siemens.com/productcert/pdf/ssa-397453.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-661247.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-714170.pdf https://github.com/advisories/GHSA-jfh8-c2jp-5v3q https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/EOKPQGV24RRBBI4TBZUDQMM4MEH7MXCY/ https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/SIG7FZULMNK2XF6FZRU4VWYDQXNMUGAJ/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EOKPQGV24RRBBI4TBZUDQMM4MEH7MXCY/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/SIG7FZULMNK2XF6FZRU4VWYDQXNMUGAJ/ https://logging.apache.org/log4j/2.x/security.html https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032 https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd https://www.cve.org/CVERecord?id=CVE-2021-44228 https://www.debian.org/security/2021/dsa-5022 https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html https://www.kb.cert.org/vuls/id/930724 https://www.openwall.com/lists/oss-security/2021/12/14/4 https://www.oracle.com/security-alerts/alert-cve-2021-44228.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html http://www.openwall.com/lists/oss-security/2021/12/14/4 http://www.openwall.com/lists/oss-security/2021/12/15/3 http://www.openwall.com/lists/oss-security/2021/12/18/1",
+            "FixedBy": "2.12.2",
+            "Description": "Incomplete fix for Apache Log4j vulnerability",
+            "Name": "GHSA-7rjr-3q55-vv33",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.apache.logging.log4j:log4j-slf4j-impl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.11.1.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-analyzers-common",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-backward-codecs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-expressions",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-grouping",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-highlighter",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-join",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-memory",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-misc",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-queries",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-queryparser",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-sandbox",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-spatial",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-spatial-extras",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-spatial3d",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.lucene:lucene-suggest",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "7.7.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.apache.santuario:xmlsec",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.0.7",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2021-40690 https://lists.apache.org/thread.html/r3b3f5ba9b0de8c9c125077b71af06026d344a709a8ba67db81ee9faa@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r401ecb7274794f040cd757b259ebe3e8c463ae74f7961209ccad3c59@%3Cissues.cxf.apache.org%3E https://lists.apache.org/thread.html/r8848751b6a5dd78cc9e99d627e74fecfaffdfa1bb615dce827aad633%40%3Cdev.santuario.apache.org%3E https://lists.apache.org/thread.html/r8a5c0ce9014bd07303aec1e5eed55951704878016465d3dae00e0c28@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r9c100d53c84d54cf71975e3f0cfcc2856a8846554a04c99390156ce4@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/raf352f95c19c0c4051af3180752cb69acbea88d0d066ab176c6170e8@%3Cuser.poi.apache.org%3E https://lists.apache.org/thread.html/rbbbac0759b12472abd0c278d32b5e0867bb21934df8e14e5e641597c@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/rbdac116aef912b563da54f4c152222c0754e32fb2f785519ac5e059f@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/re294cfc61f509512874ea514d8d64fd276253d54ac378ffa7a4880c8@%3Ccommits.tomee.apache.org%3E https://lists.debian.org/debian-lts-announce/2021/09/msg00015.html https://security.netapp.com/advisory/ntap-20230818-0002/ https://www.debian.org/security/2021/dsa-5010 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+            "FixedBy": "2.1.7",
+            "Description": "Exposure of Sensitive Information to an Unauthorized Actor in Apache Santuario",
+            "Name": "GHSA-j8wc-gxx9-82hx",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2019-12400 https://access.redhat.com/errata/RHSA-2020:0804 https://access.redhat.com/errata/RHSA-2020:0805 https://access.redhat.com/errata/RHSA-2020:0806 https://access.redhat.com/errata/RHSA-2020:0811 https://lists.apache.org/thread.html/8e814b925bf580bc527d96ff51e72ffe5bdeaa4b8bf5b89498cab24c@%3Cdev.santuario.apache.org%3E https://lists.apache.org/thread.html/edaa7edb9c58e5f5bd0c950f2b6232b62b15f5c44ad803e8728308ce@%3Cdev.santuario.apache.org%3E https://lists.apache.org/thread.html/r107bffb06a5e27457fe9af7dfe3a233d0d36c6c2f5122f117eb7f626@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r1c07a561426ec5579073046ad7f4207cdcef452bb3100abaf908e0cd@%3Ccommits.santuario.apache.org%3E https://lists.apache.org/thread.html/rcdc0da94fe21b26493eae47ca987a290bdf90c721a7a42491fdd41d4@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/rf82be0a7c98cd3545e20817bb96ed05551ea0020acbaf9a469fef402@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/rf958cea96236de8829940109ae07e870aa3d59235345421e4924ff03@%3Ccommits.tomee.apache.org%3E https://security.netapp.com/advisory/ntap-20190910-0003/ https://www.oracle.com/security-alerts/cpuoct2021.html http://santuario.apache.org/secadv.data/CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2",
+            "FixedBy": "2.1.4",
+            "Description": "Improper input validation in Apache Santuario XML Security for Java",
+            "Name": "GHSA-4q98-wr72-h35w",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.apache.velocity:velocity",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.7",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-13936 https://github.com/apache/velocity-engine https://lists.apache.org/thread.html/r01043f584cbd47959fabe18fff64de940f81a65024bb8dddbda31d9a%40%3Cuser.velocity.apache.org%3E https://lists.apache.org/thread.html/r01043f584cbd47959fabe18fff64de940f81a65024bb8dddbda31d9a@%3Cuser.velocity.apache.org%3E https://lists.apache.org/thread.html/r0bc98e9cd080b4a13b905c571b9bed87e1a0878d44dbf21487c6cca4@%3Cdev.santuario.apache.org%3E https://lists.apache.org/thread.html/r17cb932fab14801b14e5b97a7f05192f4f366ef260c10d4a8dba8ac9@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/r293284c6806c73f51098001ea86a14271c39f72cd76af9e946d9d9ad@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/r39de20c7e9c808b1f96790875d33e58c9c0aabb44fd9227e7b3dc5da@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/r3ea4c4c908505b20a4c268330dfe7188b90c84dcf777728d02068ae6@%3Cannounce.apache.org%3E https://lists.apache.org/thread.html/r4cd59453b65d4ac290fcb3b71fdf32b4f1f8989025e89558deb5a245@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/r52a5129df402352adc34d052bab9234c8ef63596306506a89fdc7328@%3Cusers.activemq.apache.org%3E https://lists.apache.org/thread.html/r7f209b837217d2a0fe5977fb692e7f15d37fa5de8214bcdc4c21d9a7@%3Ccommits.turbine.apache.org%3E https://lists.apache.org/thread.html/r9dc2505651788ac668299774d9e7af4dc616be2f56fdc684d1170882@%3Cusers.activemq.apache.org%3E https://lists.apache.org/thread.html/rb042f3b0090e419cc9f5a3d32cf0baff283ccd6fcb1caea61915d6b6@%3Ccommits.velocity.apache.org%3E https://lists.apache.org/thread.html/rbee7270556f4172322936b5ecc9fabf0c09f00d4fa56c9de1963c340@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/rd2a89e17e8a9b451ce655f1a34117752ea1d18a22ce580d8baa824fd@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rd7e865c87f9043c21d9c1fd9d4df866061d9a08cfc322771160d8058@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/re641197d204765130618086238c73dd2ce5a3f94b33785b587d72726@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/re8e7482fe54d289fc0229e61cc64947b63b12c3c312e9f25bf6f3b8c@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/reab5978b54a9f4c078402161e30a89c42807b198814acadbe6c862c7@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/rf7d369de88dc88a1347006a3323b3746d849234db40a8edfd5ebc436@%3Cdev.ws.apache.org%3E https://lists.debian.org/debian-lts-announce/2021/03/msg00019.html https://security.gentoo.org/glsa/202107-52 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html http://www.openwall.com/lists/oss-security/2021/03/10/1",
+            "FixedBy": "lastAffected=1.7",
+            "Description": "Sandbox Bypass in Apache Velocity Engine",
+            "Name": "GHSA-59j4-wjwp-mw9m",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.apache.ws.xmlschema:xmlschema-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.2.3",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.bouncycastle:bcpg-jdk15on",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.61",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.bouncycastle:bcprov-jdk15on",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.61",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-15522 https://github.com/bcgit/bc-csharp/wiki/CVE-2020-15522 https://github.com/bcgit/bc-java/wiki/CVE-2020-15522 https://security.netapp.com/advisory/ntap-20210622-0007/ https://www.bouncycastle.org/releasenotes.html",
+            "FixedBy": "1.66",
+            "Description": "Timing based private key exposure in Bouncy Castle",
+            "Name": "GHSA-6xx3-rg99-gc3p",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.bouncycastle:bcprov-jdk15on",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.67.0.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.checkerframework:checker-qual",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.0.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.codehaus.mojo:animal-sniffer-annotations",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.14.0.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.codehaus.woodstox:stax2-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.1.4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.codelibs.elasticsearch.module:aggs-matrix-stats",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.codelibs.elasticsearch.module:lang-mustache",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.codelibs.elasticsearch.module:parent-join",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.codelibs.elasticsearch.module:rank-eval",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.codelibs.elasticsearch.module:transport-netty4",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.cryptacular:cryptacular",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.1.1",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2020-7226 https://github.com/vt-middleware/cryptacular/issues/52 https://github.com/apereo/cas/pull/4685 https://github.com/vt-middleware/cryptacular/pull/56 https://github.com/apereo/cas/commit/8810f2b6c71d73341d4dde6b09a18eb46cfd6d45 https://github.com/apereo/cas/commit/93b1c3e9d90e36a19d0fa0f6efb863c6f0235e75 https://github.com/apereo/cas/commit/a042808d6adbbf44753d52c55cac5f533e24101f https://github.com/vt-middleware/cryptacular/commit/311baf12252abf21947afd07bf0a0291ec3ec796 https://github.com/vt-middleware/cryptacular/commit/ec2fb65f2455c479376695e3d75d30c7f6884b3f https://github.com/vt-middleware/cryptacular https://github.com/vt-middleware/cryptacular/blob/fafccd07ab1214e3588a35afe3c361519129605f/src/main/java/org/cryptacular/CiphertextHeader.java#L153 https://github.com/vt-middleware/cryptacular/blob/master/src/main/java/org/cryptacular/CiphertextHeader.java#L153 https://lists.apache.org/thread.html/r0847c7eb78c8f9e87d5b841fbd5da52b2ad4b4345e04b51c30621d88@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r209de85beae4d257d27fc577e3a3e97039bdb4c2dc6f4a8e5a5a5811@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r2237a27040b57adc2fcc5570bd530ad2038e67fcb2a3ce65283d3143@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r380781f5b489cb3c818536cd3b3757e806bfe0bca188591e0051ac03@%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r4a62133ad01d5f963755021027a4cce23f76b8674a13860d2978c7c8@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r77c48cd851f60833df9a9c9c31f12243508e15d1b2a0961066d44fc6@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/rc36b75cabb4d700b48035d15ad8b8c2712bb32123572a1bdaec2510a@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/re04e4f8f0d095387fb6b0ff9016a0af8c93f42e1de93b09298bfa547@%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/re7f46c4cc29a4616e0aa669c84a0eb34832e83a8eef05189e2e59b44@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/rfa4647c58e375996e62a9094bffff6dc350ec311ba955b430e738945@%3Cdev.ws.apache.org%3E https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+            "FixedBy": "1.1.4",
+            "Description": "Denial of Service in Cryptacular",
+            "Name": "GHSA-x64g-4xx9-fh6x",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.elasticsearch.client:elasticsearch-rest-client",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.client:org.elasticsearch.client#rest;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin.ingest:openshift-ingest-plugin",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.0-redhat-00003",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin.prometheus:prometheus-exporter",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.2-redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:aggs-matrix-stats",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:analysis-common",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:ingest-common",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:ingest-geoip",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:ingest-user-agent",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:lang-expression",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:lang-mustache",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:lang-painless",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:mapper-extras",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:org.elasticsearch.plugin#spi;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:org.elasticsearch.plugin#tribe;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:parent-join",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:percolator",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:rank-eval",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:reindex",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:repository-url",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch.plugin:transport-netty4",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:elasticsearch-ssl-config",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:java-version-checker",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:jna",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "4.5.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:org.elasticsearch#cli;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:org.elasticsearch#core;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:org.elasticsearch#dissect;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:org.elasticsearch#grok;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:org.elasticsearch#launchers;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:org.elasticsearch#plugin-cli;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:org.elasticsearch#secure-sm;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:org.elasticsearch#server;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:org.elasticsearch#x-content;6.8.1.redhat-00012",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.elasticsearch:plugin-classloader",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.8.1.redhat-00012",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.hdrhistogram:HdrHistogram",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.1.9.redhat-00004",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.jctools:jctools-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.1.0",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.jctools:jctools-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.1.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.jruby.jcodings:jcodings",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.0.12",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.jruby.joni:joni",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2.1.6",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.ldaptive:ldaptive",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.2.3",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.locationtech.jts:jts-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.15.0.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.locationtech.spatial4j:spatial4j",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "0.7",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-messaging-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-profile-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-saml-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-saml-impl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-security-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-security-impl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-soap-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-soap-impl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-storage-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-xmlsec-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.opensaml:opensaml-xmlsec-impl",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.3.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.ow2.asm:asm",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "5.0.4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.ow2.asm:asm-commons",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "5.0.4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.ow2.asm:asm-debug-all",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "5.1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.ow2.asm:asm-tree",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "5.0.4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.slf4j:slf4j-api",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.7.25.redhat-00001",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "org.xerial.snappy:snappy-java",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.1.4.redhat-1",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/xerial/snappy-java/security/advisories/GHSA-qcwq-55hx-v3vh https://nvd.nist.gov/vuln/detail/CVE-2023-34455 https://github.com/xerial/snappy-java/commit/3bf67857fcf70d9eea56eed4af7c925671e8eaea https://github.com/xerial/snappy-java https://github.com/xerial/snappy-java/blob/05c39b2ca9b5b7b39611529cc302d3d796329611/src/main/java/org/xerial/snappy/SnappyInputStream.java#L388 https://github.com/xerial/snappy-java/blob/master/src/main/java/org/xerial/snappy/SnappyInputStream.java https://security.netapp.com/advisory/ntap-20230818-0009/",
+            "FixedBy": "1.1.10.1",
+            "Description": "snappy-java's unchecked chunk length leads to DoS",
+            "Name": "GHSA-qcwq-55hx-v3vh",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/xerial/snappy-java/security/advisories/GHSA-pqr6-cmr2-h8hf https://nvd.nist.gov/vuln/detail/CVE-2023-34453 https://github.com/xerial/snappy-java/commit/820e2e074c58748b41dbd547f4edba9e108ad905 https://github.com/xerial/snappy-java https://github.com/xerial/snappy-java/blob/05c39b2ca9b5b7b39611529cc302d3d796329611/src/main/java/org/xerial/snappy/BitShuffle.java#L107 https://github.com/xerial/snappy-java/blob/master/src/main/java/org/xerial/snappy/BitShuffle.java",
+            "FixedBy": "1.1.10.1",
+            "Description": "snappy-java's Integer Overflow vulnerability in shuffle leads to DoS",
+            "Name": "GHSA-pqr6-cmr2-h8hf",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/xerial/snappy-java/security/advisories/GHSA-fjpj-2g6w-x25r https://nvd.nist.gov/vuln/detail/CVE-2023-34454 https://github.com/xerial/snappy-java/commit/d0042551e4a3509a725038eb9b2ad1f683674d94 https://github.com/xerial/snappy-java https://github.com/xerial/snappy-java/blob/05c39b2ca9b5b7b39611529cc302d3d796329611/src/main/java/org/xerial/snappy/Snappy.java#L169 https://github.com/xerial/snappy-java/blob/05c39b2ca9b5b7b39611529cc302d3d796329611/src/main/java/org/xerial/snappy/Snappy.java#L422 https://github.com/xerial/snappy-java/blob/master/src/main/java/org/xerial/snappy/Snappy.java",
+            "FixedBy": "1.1.10.1",
+            "Description": "snappy-java's Integer Overflow vulnerability in compress leads to DoS",
+            "Name": "GHSA-fjpj-2g6w-x25r",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "org.yaml:snakeyaml",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "1.17",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-41854 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/commits/e230a1758842beec93d28eddfde568c21774780a https://bitbucket.org/snakeyaml/snakeyaml/issues/531/ https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50355 https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3DDXEXXWAZGF5AVHIPGFPXIWL6TSMKJE/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/7MKE4XWRXTH32757H7QJU4ACS67DYDCR/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KSPAJ5Y45A4ZDION2KN5RDWLHK4XKY2J/",
+            "FixedBy": "1.32",
+            "Description": "Snakeyaml vulnerable to Stack overflow leading to denial of service",
+            "Name": "GHSA-w37g-rhq8-7m4j",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2017-18640 https://bitbucket.org/asomov/snakeyaml https://bitbucket.org/asomov/snakeyaml/commits/da11ddbd91c1f8392ea932b37fa48110fa54ed8c https://bitbucket.org/asomov/snakeyaml/issues/377/allow-configuration-for-preventing-billion https://bitbucket.org/asomov/snakeyaml/wiki/Billion%20laughs%20attack https://bitbucket.org/asomov/snakeyaml/wiki/Changes https://bitbucket.org/snakeyaml/snakeyaml/issues/377 https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes https://lists.apache.org/thread.html/r1058e7646988394de6a3fd0857ea9b1ee0de14d7bb28fee5ff782457@%3Ccommits.atlas.apache.org%3E https://lists.apache.org/thread.html/r154090b871cf96d985b90864442d84eb027c72c94bc3f0a5727ba2d1@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r16ae4e529401b75a1f5aa462b272b31bf2a108236f882f06fddc14bc@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r1703a402f30c8a2ee409f8c6f393e95a63f8c952cc9ee5bf9dd586dc@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r182e9cf6f3fb22b9be0cac4ff0685199741d2ab6e9a4e27a3693c224@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r191ceadb1b883357384981848dfa5235cb02a90070c553afbaf9b3d9@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r1aab47b48a757c70e40fc0bcb1fcf1a3951afa6a17aee7cd66cf79f8@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/r1dfac8b6a7097bcb4979402bbb6e2f8c36d0d9001e3018717eb22b7e@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r1ffce2ed3017e9964f03ad2c539d69e49144fc8e9bf772d641612f98@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r20350031c60a77b45e0eded33e9b3e9cb0cbfc5e24e1c63bf264df12@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r22ac2aa053b7d9c6b75a49db78125c9316499668d0f4a044f3402e2f@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r2721aba31a8562639c4b937150897e24f78f747cdbda8641c0f659fe@%3Cusers.kafka.apache.org%3E https://lists.apache.org/thread.html/r28c9009a48d52cf448f8b02cd823da0f8601d2dff4d66f387a35f1e0@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r2a5b84fdf59042dc398497e914b5bb1aed77328320b1438144ae1953@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r2b05744c0c2867daa5d1a96832965b7d6220328b0ead06c22a6e7854@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r2db207a2431a5e9e95e899858ab1f5eabd9bcc790a6ca7193ae07e94@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r436988d2cfe8a770ae361c82b181c5b2bf48a249bad84d8a55a3b46e@%3Cdev.phoenix.apache.org%3E https://lists.apache.org/thread.html/r465d2553a31265b042cf5457ef649b71e0722ab89b6ea94a5d59529b@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r4c682fb8cf69dd14162439656a6ebdf42ea6ad0e4edba95907ea3f14@%3Ccommits.servicecomb.apache.org%3E https://lists.apache.org/thread.html/r4d7f37da1bc2df90a5a0f56eb7629b5ea131bfe11eeeb4b4c193f64a@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r5510f0125ba409fc1cabd098ab8b457741e5fa314cbd0e61e4339422@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r55d807f31e64a080c54455897c20b1667ec792e5915132c7b7750533@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r56805265475919252ba7fc10123f15b91097f3009bae86476624ca25@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r643ba53f002ae59068f9352fe1d82e1b6f375387ffb776f13efe8fda@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r666f29a7d0e1f98fa1425ca01efcfa86e6e3856e01d300828aa7c6ea@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r6c91e52b3cc9f4e64afe0f34f20507143fd1f756d12681a56a9b38da@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r6d54c2da792c74cc14b9b7665ea89e144c9e238ed478d37fd56292e6@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r72a3588d62b2de1361dc9648f5d355385735e47f7ba49d089b0e680d@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r7ce3de03facf7e7f3e24fc25d26d555818519dafdb20f29398a3414b@%3Cdev.phoenix.apache.org%3E https://lists.apache.org/thread.html/r8464b6ec951aace8c807bac9ea526d4f9e3116aa16d38be06f7c6524@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r8b57c57cffa01e418868a3c7535b987635ff1fb5ab534203bfa2d64a@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r900e020760c89f082df1c6e0d46320eba721e4e47bb9eb521e68cd95@%3Ccommits.servicecomb.apache.org%3E https://lists.apache.org/thread.html/raebd2019b3da8c2f90f31e8b203b45353f78770ca93bfe5376f5532e@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rb0e033d5ec8233360203431ad96580cf2ec56f47d9a425d894e279c2@%3Cpr.cassandra.apache.org%3E https://lists.apache.org/thread.html/rb34d8d3269ad47a1400f5a1a2d8310e13a80b6576ebd7f512144198d@%3Ccommon-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/rb5c33d0069c927fae16084f0605895b98d231d7c48527bcb822ac48c@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rb7b28ac741e32dd5edb2c22485d635275bead7290b056ee56baf8ce0@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/rbaa1f513d903c89a08267c91d86811fa5bcc82e0596b6142c5cea7ea@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rc3211c71f7e0973a1825d1988a3921288c06cd9d793eae97ecd34948@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rcb2a7037366c58bac6aec6ce3df843a11ef97ae4eb049f05f410eaa5@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/rcb4b61dbe2ed1c7a88781a9aff5a9e7342cc7ed026aec0418ee67596@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rce5c93bba6e815fb62ad38e28ca1943b3019af1eddeb06507ad4e11a@%3Ccommits.atlas.apache.org%3E https://lists.apache.org/thread.html/rd582c64f66c354240290072f340505f5d026ca944ec417226bb0272e@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rdd34c0479587e32a656d976649409487d51ca0d296b3e26b6b89c3f5@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/re791a854001ec1f79cd4f47328b270e7a1d9d7056debb8f16d962722@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/re851bbfbedd47c690b6e01942acb98ee08bd00df1a94910b905bc8cd@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/reb1751562ee5146d3aca654a2df76a2c13d8036645ce69946f9c219e@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/recfe569f4f260328b0036f1c82b2956e864d519ab941a5e75d0d832d@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rf95bebee6dfcc55067cebe8482bd31e6f481d9f74ba8e03f860c3ec7@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rfe0aab6c3bebbd9cbfdedb65ff3fdf420714bcb8acdfd346077e1263@%3Ccommon-commits.hadoop.apache.org%3E https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CKN7VGIKTYBCAKYBRG55QHXAY5UDZ7HA/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PTVJC54XGX26UJVVYCXZ7D25X3R5T2G6/ https://mvnrepository.com/artifact/org.yaml/snakeyaml/1.25/usages https://security.gentoo.org/glsa/202305-28 https://www.oracle.com/security-alerts/cpuApr2021.html",
+            "FixedBy": "1.26",
+            "Description": "SnakeYAML Entity Expansion during load operation",
+            "Name": "GHSA-rvwf-54qp-4r6v",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://github.com/google/security-research/security/advisories/GHSA-mjmj-j48q-9wg2 https://nvd.nist.gov/vuln/detail/CVE-2022-1471 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/commits/5014df1a36f50aca54405bb8433bc99a8847f758 https://bitbucket.org/snakeyaml/snakeyaml/commits/acc44099f5f4af26ff86b4e4e4cc1c874e2dc5c4 https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in#comment-64581479 https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in#comment-64634374 https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in#comment-64876314 https://bitbucket.org/snakeyaml/snakeyaml/wiki/CVE-2022-1471 https://github.com/mbechler/marshalsec https://groups.google.com/g/kubernetes-security-announce/c/mwrakFaEdnc https://security.netapp.com/advisory/ntap-20230818-0015/ https://snyk.io/blog/unsafe-deserialization-snakeyaml-java-cve-2022-1471/ https://www.github.com/mbechler/marshalsec/blob/master/marshalsec.pdf?raw=true",
+            "FixedBy": "2.0",
+            "Description": "SnakeYaml Constructor Deserialization Remote Code Execution",
+            "Name": "GHSA-mjmj-j48q-9wg2",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-38750 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/issues/526/stackoverflow-oss-fuzz-47027 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47027 https://lists.debian.org/debian-lts-announce/2022/10/msg00001.html https://security.gentoo.org/glsa/202305-28",
+            "FixedBy": "1.31",
+            "Description": "snakeYAML before 1.31 vulnerable to Denial of Service due to Out-of-bounds Write",
+            "Name": "GHSA-hhhw-99gj-p3c3",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-38749 https://arxiv.org/pdf/2306.05534.pdf https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/issues/525/got-stackoverflowerror-for-many-open https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47024 https://lists.debian.org/debian-lts-announce/2022/10/msg00001.html https://security.gentoo.org/glsa/202305-28",
+            "FixedBy": "1.31",
+            "Description": "snakeYAML before 1.31 vulnerable to Denial of Service due to Out-of-bounds Write",
+            "Name": "GHSA-c4r9-r8fh-9vj2",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-38752 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/issues/531/stackoverflow-oss-fuzz-47081 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47081 https://security.gentoo.org/glsa/202305-28",
+            "FixedBy": "1.32",
+            "Description": "snakeYAML before 1.32 vulnerable to Denial of Service due to Out-of-bounds Write",
+            "Name": "GHSA-9w3m-gqgf-c4p9",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-38751 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/issues/530/stackoverflow-oss-fuzz-47039 https://bitbucket.org/snakeyaml/snakeyaml/src/master/src/test/java/org/yaml/snakeyaml/issues/issue530/Fuzzy47039Test.java https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47039 https://lists.debian.org/debian-lts-announce/2022/10/msg00001.html https://security.gentoo.org/glsa/202305-28",
+            "FixedBy": "1.31",
+            "Description": "snakeYAML before 1.31 vulnerable to Denial of Service due to Out-of-bounds Write",
+            "Name": "GHSA-98wm-3w3q-mw94",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "osv/maven",
+            "Link": "https://nvd.nist.gov/vuln/detail/CVE-2022-25857 https://github.com/snakeyaml/snakeyaml/commit/fc300780da21f4bb92c148bc90257201220cf174 https://bitbucket.org/snakeyaml/snakeyaml/commits/fc300780da21f4bb92c148bc90257201220cf174 https://bitbucket.org/snakeyaml/snakeyaml/issues/525 https://github.com/snakeyaml/snakeyaml https://lists.debian.org/debian-lts-announce/2022/10/msg00001.html https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-2806360",
+            "FixedBy": "1.31",
+            "Description": "Uncontrolled Resource Consumption in snakeyaml",
+            "Name": "GHSA-3mc7-4q67-w48m",
+            "Metadata": {
+              "UpdatedBy": "osv/maven",
+              "RepoName": "maven",
+              "RepoLink": "https://repo1.maven.apache.org/maven2",
+              "DistroName": "",
+              "DistroVersion": "",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "p11-kit",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.23.22-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "p11-kit-trust",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.23.22-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "pam",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.3.1-15.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "passwd",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.80-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "pcre",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "8.42-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "pcre2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "10.32-2.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5809 https://access.redhat.com/security/cve/CVE-2022-1586",
+            "FixedBy": "0:10.32-3.el8_6",
+            "Description": "The pcre2 package contains a new generation of the Perl Compatible Regular Expression libraries for implementing regular expression pattern matching using the same syntax and semantics as Perl. \n\nSecurity Fix(es):\n\n* pcre2: Out-of-bounds read in compile_xclass_matchingpath in pcre2_jit_compile.c (CVE-2022-1586)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5809: pcre2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "platform-python",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.6.8-41.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3591 https://access.redhat.com/security/cve/CVE-2023-24329",
+            "FixedBy": "0:3.6.8-51.el8_8.1",
+            "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: urllib.parse url blocklisting bypass (CVE-2023-24329)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:3591: python3 security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0833 https://access.redhat.com/security/cve/CVE-2020-10735 https://access.redhat.com/security/cve/CVE-2021-28861 https://access.redhat.com/security/cve/CVE-2022-45061",
+            "FixedBy": "0:3.6.8-48.el8_7.1",
+            "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: int() type in PyLong_FromString() does not limit amount of digits converting text to int leading to DoS (CVE-2020-10735)\n\n* python: open redirection vulnerability in lib/http/server.py may lead to information disclosure (CVE-2021-28861)\n\n* Python: CPU denial of service via inefficient IDNA decoder (CVE-2022-45061)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0833: python3 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+            "FixedBy": "0:3.6.8-47.el8_6",
+            "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:6457: python3 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:1986 https://access.redhat.com/security/cve/CVE-2021-3737 https://access.redhat.com/security/cve/CVE-2021-4189",
+            "FixedBy": "0:3.6.8-45.el8",
+            "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python: ftplib should not use the host from the PASV response (CVE-2021-4189)\n\n* python: urllib: HTTP client possible infinite loop on a 100 Continue response (CVE-2021-3737)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+            "Name": "RHSA-2022:1986: python3 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "platform-python-pip",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "9.0.3-20.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "platform-python-setuptools",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "39.2.0-6.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0835 https://access.redhat.com/security/cve/CVE-2022-40897",
+            "FixedBy": "0:39.2.0-6.el8_7.1",
+            "Description": "The python-setuptools package provides a collection of enhancements to Python distribution utilities allowing convenient building and distribution of Python packages.\n\nSecurity Fix(es):\n\n* pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py (CVE-2022-40897)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0835: python-setuptools security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "popt",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.18-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "publicsuffix-list-dafsa",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "20180723-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-chardet",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.0.4-7.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-cloud-what",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.28.21-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+            "FixedBy": "0:1.28.36-3.el8_8",
+            "Description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4706: subscription-manager security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "python3-dateutil",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1:2.6.1-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-dbus",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.2.4-15.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-decorator",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.2.1-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-dmidecode",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.12.2-15.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-dnf",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.7.0-4.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-dnf-plugins-core",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.0.21-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-ethtool",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.14-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-gobject-base",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.28.3-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-gpg",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.13.1-9.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-hawkey",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.63.0-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-idna",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.5-5.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-iniparse",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.4-31.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-inotify",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.9.6-13.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-libcomps",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.1.16-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-libdnf",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "0.63.0-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-librepo",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.14.0-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.6.8-41.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3591 https://access.redhat.com/security/cve/CVE-2023-24329",
+            "FixedBy": "0:3.6.8-51.el8_8.1",
+            "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: urllib.parse url blocklisting bypass (CVE-2023-24329)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:3591: python3 security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0833 https://access.redhat.com/security/cve/CVE-2020-10735 https://access.redhat.com/security/cve/CVE-2021-28861 https://access.redhat.com/security/cve/CVE-2022-45061",
+            "FixedBy": "0:3.6.8-48.el8_7.1",
+            "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: int() type in PyLong_FromString() does not limit amount of digits converting text to int leading to DoS (CVE-2020-10735)\n\n* python: open redirection vulnerability in lib/http/server.py may lead to information disclosure (CVE-2021-28861)\n\n* Python: CPU denial of service via inefficient IDNA decoder (CVE-2022-45061)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0833: python3 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+            "FixedBy": "0:3.6.8-47.el8_6",
+            "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:6457: python3 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:1986 https://access.redhat.com/security/cve/CVE-2021-3737 https://access.redhat.com/security/cve/CVE-2021-4189",
+            "FixedBy": "0:3.6.8-45.el8",
+            "Description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python: ftplib should not use the host from the PASV response (CVE-2021-4189)\n\n* python: urllib: HTTP client possible infinite loop on a 100 Continue response (CVE-2021-3737)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+            "Name": "RHSA-2022:1986: python3 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "python3-libxml2",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.9.7-9.el8_4.2",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4529 https://access.redhat.com/security/cve/CVE-2023-28484 https://access.redhat.com/security/cve/CVE-2023-29469",
+            "FixedBy": "0:2.9.7-16.el8_8.1",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: NULL dereference in xmlSchemaFixupComplexType (CVE-2023-28484)\n\n* libxml2: Hashing of empty dict strings isn't deterministic (CVE-2023-29469)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4529: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0173 https://access.redhat.com/security/cve/CVE-2022-40303 https://access.redhat.com/security/cve/CVE-2022-40304",
+            "FixedBy": "0:2.9.7-15.el8_7.1",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows with XML_PARSE_HUGE (CVE-2022-40303)\n\n* libxml2: dict corruption caused by entity reference cycles (CVE-2022-40304)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0173: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7715 https://access.redhat.com/security/cve/CVE-2016-3709",
+            "FixedBy": "0:2.9.7-15.el8",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Incorrect server side include parsing can lead to XSS (CVE-2016-3709)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+            "Name": "RHSA-2022:7715: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5317 https://access.redhat.com/security/cve/CVE-2022-29824",
+            "FixedBy": "0:2.9.7-13.el8_6.1",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows in xmlBuf and xmlBuffer lead to out-of-bounds write (CVE-2022-29824)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5317: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0899 https://access.redhat.com/security/cve/CVE-2022-23308",
+            "FixedBy": "0:2.9.7-12.el8_5",
+            "Description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Use-after-free of ID and IDREF attributes (CVE-2022-23308)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0899: libxml2 security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "python3-pip",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "9.0.3-20.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-pip-wheel",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "9.0.3-20.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-pysocks",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.6.8-3.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-pyyaml",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.12-12.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-requests",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.20.0-2.1.el8_1",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4520 https://access.redhat.com/security/cve/CVE-2023-32681",
+            "FixedBy": "0:2.20.0-3.el8_8",
+            "Description": "The python-requests package contains a library designed to make HTTP requests easy for developers.\n\nSecurity Fix(es):\n\n* python-requests: Unintended leak of Proxy-Authorization header (CVE-2023-32681)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4520: python-requests security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "python3-rpm",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.14.3-19.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+            "FixedBy": "0:4.14.3-19.el8_5.2",
+            "Description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0368: rpm security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "python3-setuptools",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "39.2.0-6.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0835 https://access.redhat.com/security/cve/CVE-2022-40897",
+            "FixedBy": "0:39.2.0-6.el8_7.1",
+            "Description": "The python-setuptools package provides a collection of enhancements to Python distribution utilities allowing convenient building and distribution of Python packages.\n\nSecurity Fix(es):\n\n* pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py (CVE-2022-40897)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0835: python-setuptools security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "python3-setuptools-wheel",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "39.2.0-6.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0835 https://access.redhat.com/security/cve/CVE-2022-40897",
+            "FixedBy": "0:39.2.0-6.el8_7.1",
+            "Description": "The python-setuptools package provides a collection of enhancements to Python distribution utilities allowing convenient building and distribution of Python packages.\n\nSecurity Fix(es):\n\n* pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py (CVE-2022-40897)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0835: python-setuptools security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "python3-six",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.11.0-8.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python3-subscription-manager-rhsm",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.28.21-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+            "FixedBy": "0:1.28.36-3.el8_8",
+            "Description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4706: subscription-manager security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "python3-syspurpose",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.28.21-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+            "FixedBy": "0:1.28.36-3.el8_8",
+            "Description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4706: subscription-manager security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "python3-urllib3",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.24.2-5.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "python36",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.6.8-38.module+el8.5.0+12207+5c5719bc",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "readline",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "7.0-10.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "redhat-release",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "8.5-0.8.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "rootfiles",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "8.1-22.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "rpm",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.14.3-19.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+            "FixedBy": "0:4.14.3-19.el8_5.2",
+            "Description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0368: rpm security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "rpm-build-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.14.3-19.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+            "FixedBy": "0:4.14.3-19.el8_5.2",
+            "Description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0368: rpm security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "rpm-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.14.3-19.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+            "FixedBy": "0:4.14.3-19.el8_5.2",
+            "Description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0368: rpm security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "sed",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.5-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "setup",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.12.2-6.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "shadow-utils",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2:4.6-14.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "sqlite-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "3.26.0-15.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3840 https://access.redhat.com/security/cve/CVE-2020-24736",
+            "FixedBy": "0:3.26.0-18.el8_8",
+            "Description": "SQLite is a C library that implements an SQL database engine. A large subset of SQL92 is supported. A complete database is stored in a single disk file. The API is designed for convenience and ease of use. Applications that link against SQLite can enjoy the power and flexibility of an SQL database without the administrative hassles of supporting a separate database server.\n\nSecurity Fix(es):\n\n* sqlite: Crash due to misuse of window functions. (CVE-2020-24736)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:3840: sqlite security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0110 https://access.redhat.com/security/cve/CVE-2022-35737",
+            "FixedBy": "0:3.26.0-17.el8_7",
+            "Description": "SQLite is a C library that implements an SQL database engine. A large subset of SQL92 is supported. A complete database is stored in a single disk file. The API is designed for convenience and ease of use. Applications that link against SQLite can enjoy the power and flexibility of an SQL database without the administrative hassles of supporting a separate database server.\n\nSecurity Fix(es):\n\n* sqlite: an array-bounds overflow if billions of bytes are used in a string argument to a C API (CVE-2022-35737)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0110: sqlite security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7108 https://access.redhat.com/security/cve/CVE-2020-35525 https://access.redhat.com/security/cve/CVE-2020-35527",
+            "FixedBy": "0:3.26.0-16.el8_6",
+            "Description": "SQLite is a C library that implements an SQL database engine. A large subset of SQL92 is supported. A complete database is stored in a single disk file. The API is designed for convenience and ease of use. Applications that link against SQLite can enjoy the power and flexibility of an SQL database without the administrative hassles of supporting a separate database server.\n\nSecurity Fix(es):\n\n* sqlite: Out of bounds access during table rename (CVE-2020-35527)\n\n* sqlite: Null pointer derreference in src/select.c (CVE-2020-35525)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:7108: sqlite security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "subscription-manager",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.28.21-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+            "FixedBy": "0:1.28.36-3.el8_8",
+            "Description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4706: subscription-manager security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "subscription-manager-rhsm-certificates",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.28.21-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+            "FixedBy": "0:1.28.36-3.el8_8",
+            "Description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:4706: subscription-manager security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "systemd",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "239-51.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3837 https://access.redhat.com/security/cve/CVE-2023-26604",
+            "FixedBy": "0:239-74.el8_8.2",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: privilege escalation via the less pager (CVE-2023-26604)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd-pstore crashes when attempting to move standalone files out of /sys/fs/pstore (BZ#2190153)",
+            "Name": "RHSA-2023:3837: systemd security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0837 https://access.redhat.com/security/cve/CVE-2022-4415",
+            "FixedBy": "0:239-68.el8_7.4",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: local information leak due to systemd-coredump not respecting fs.suid_dumpable kernel setting (CVE-2022-4415)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd doesn't record messages to the journal during boot (BZ#2164049)",
+            "Name": "RHSA-2023:0837: systemd security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0100 https://access.redhat.com/security/cve/CVE-2022-3821",
+            "FixedBy": "0:239-68.el8_7.1",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: buffer overrun in format_timespan() function (CVE-2022-3821)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* ShutdownWatchdogSec value is not taken into account on reboot (BZ#2127170)",
+            "Name": "RHSA-2023:0100: systemd security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:6206 https://access.redhat.com/security/cve/CVE-2022-2526",
+            "FixedBy": "0:239-58.el8_6.4",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd-resolved: use-after-free when dealing with DnsStream in resolved-dns-stream.c (CVE-2022-2526)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:6206: systemd security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "systemd-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "239-51.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3837 https://access.redhat.com/security/cve/CVE-2023-26604",
+            "FixedBy": "0:239-74.el8_8.2",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: privilege escalation via the less pager (CVE-2023-26604)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd-pstore crashes when attempting to move standalone files out of /sys/fs/pstore (BZ#2190153)",
+            "Name": "RHSA-2023:3837: systemd security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0837 https://access.redhat.com/security/cve/CVE-2022-4415",
+            "FixedBy": "0:239-68.el8_7.4",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: local information leak due to systemd-coredump not respecting fs.suid_dumpable kernel setting (CVE-2022-4415)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd doesn't record messages to the journal during boot (BZ#2164049)",
+            "Name": "RHSA-2023:0837: systemd security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0100 https://access.redhat.com/security/cve/CVE-2022-3821",
+            "FixedBy": "0:239-68.el8_7.1",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: buffer overrun in format_timespan() function (CVE-2022-3821)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* ShutdownWatchdogSec value is not taken into account on reboot (BZ#2127170)",
+            "Name": "RHSA-2023:0100: systemd security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:6206 https://access.redhat.com/security/cve/CVE-2022-2526",
+            "FixedBy": "0:239-58.el8_6.4",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd-resolved: use-after-free when dealing with DnsStream in resolved-dns-stream.c (CVE-2022-2526)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:6206: systemd security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "systemd-pam",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "239-51.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:3837 https://access.redhat.com/security/cve/CVE-2023-26604",
+            "FixedBy": "0:239-74.el8_8.2",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: privilege escalation via the less pager (CVE-2023-26604)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd-pstore crashes when attempting to move standalone files out of /sys/fs/pstore (BZ#2190153)",
+            "Name": "RHSA-2023:3837: systemd security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0837 https://access.redhat.com/security/cve/CVE-2022-4415",
+            "FixedBy": "0:239-68.el8_7.4",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: local information leak due to systemd-coredump not respecting fs.suid_dumpable kernel setting (CVE-2022-4415)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd doesn't record messages to the journal during boot (BZ#2164049)",
+            "Name": "RHSA-2023:0837: systemd security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0100 https://access.redhat.com/security/cve/CVE-2022-3821",
+            "FixedBy": "0:239-68.el8_7.1",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: buffer overrun in format_timespan() function (CVE-2022-3821)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* ShutdownWatchdogSec value is not taken into account on reboot (BZ#2127170)",
+            "Name": "RHSA-2023:0100: systemd security and bug fix update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:6206 https://access.redhat.com/security/cve/CVE-2022-2526",
+            "FixedBy": "0:239-58.el8_6.4",
+            "Description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd-resolved: use-after-free when dealing with DnsStream in resolved-dns-stream.c (CVE-2022-2526)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:6206: systemd security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "tar",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2:1.30-5.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2023:0842 https://access.redhat.com/security/cve/CVE-2022-48303",
+            "FixedBy": "2:1.30-6.el8_7.1",
+            "Description": "The GNU tar program can save multiple files in an archive and restore files from an archive.\n\nSecurity Fix(es):\n\n* tar: heap buffer overflow at from_header() in list.c via specially crafted checksum (CVE-2022-48303)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2023:0842: tar security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "test-package-with-vuln",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:63f9f4c31162a6a5dacd999a0dc65007e15b2ca6b2d9360a1234c27de12e7f38",
+        "Version": "1.1.0.redhat-1",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "tpm2-tss",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.3.2-4.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "tzdata",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2021e-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "tzdata-java",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "2021e-1.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "ubi8",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:63f9f4c31162a6a5dacd999a0dc65007e15b2ca6b2d9360a1234c27de12e7f38",
+        "Version": "8.5-200",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "ubi8-container",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:63f9f4c31162a6a5dacd999a0dc65007e15b2ca6b2d9360a1234c27de12e7f38",
+        "Version": "8.5-200",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "unzip",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "6.0-45.el8_4",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "usermode",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.113-2.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "util-linux",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.32.1-28.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "vim-minimal",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2:8.0.1763-16.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5813 https://access.redhat.com/security/cve/CVE-2022-1785 https://access.redhat.com/security/cve/CVE-2022-1897 https://access.redhat.com/security/cve/CVE-2022-1927",
+            "FixedBy": "2:8.0.1763-19.el8_6.4",
+            "Description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: Out-of-bounds Write (CVE-2022-1785)\n\n* vim: out-of-bounds write in vim_regsub_both() in regexp.c (CVE-2022-1897)\n\n* vim: buffer over-read in utf_ptr2char() in mbyte.c (CVE-2022-1927)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5813: vim security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:5319 https://access.redhat.com/security/cve/CVE-2022-1621 https://access.redhat.com/security/cve/CVE-2022-1629",
+            "FixedBy": "2:8.0.1763-19.el8_6.2",
+            "Description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: heap buffer overflow (CVE-2022-1621)\n\n* vim: buffer over-read (CVE-2022-1629)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:5319: vim security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:1552 https://access.redhat.com/security/cve/CVE-2022-1154",
+            "FixedBy": "2:8.0.1763-16.el8_5.13",
+            "Description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: use after free in utf_ptr2char (CVE-2022-1154)",
+            "Name": "RHSA-2022:1552: vim security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0894 https://access.redhat.com/security/cve/CVE-2022-0261 https://access.redhat.com/security/cve/CVE-2022-0318 https://access.redhat.com/security/cve/CVE-2022-0359 https://access.redhat.com/security/cve/CVE-2022-0361 https://access.redhat.com/security/cve/CVE-2022-0392 https://access.redhat.com/security/cve/CVE-2022-0413",
+            "FixedBy": "2:8.0.1763-16.el8_5.12",
+            "Description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: Heap-based buffer overflow in block_insert() in src/ops.c (CVE-2022-0261)\n\n* vim: Heap-based buffer overflow in utf_head_off() in mbyte.c (CVE-2022-0318)\n\n* vim: Heap-based buffer overflow in init_ccline() in ex_getln.c (CVE-2022-0359)\n\n* vim: Illegal memory access when copying lines in visual mode leads to heap buffer overflow (CVE-2022-0361)\n\n* vim: Heap-based buffer overflow in getexmodeline() in ex_getln.c (CVE-2022-0392)\n\n* vim: Use after free in src/ex_cmds.c (CVE-2022-0413)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0894: vim security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:0366 https://access.redhat.com/security/cve/CVE-2021-3872 https://access.redhat.com/security/cve/CVE-2021-3984 https://access.redhat.com/security/cve/CVE-2021-4019 https://access.redhat.com/security/cve/CVE-2021-4192 https://access.redhat.com/security/cve/CVE-2021-4193",
+            "FixedBy": "2:8.0.1763-16.el8_5.4",
+            "Description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: heap-based buffer overflow in win_redr_status() in drawscreen.c (CVE-2021-3872)\n\n* vim: illegal memory access in find_start_brace() in cindent.c when C-indenting (CVE-2021-3984)\n\n* vim: heap-based buffer overflow in find_help_tags() in help.c (CVE-2021-4019)\n\n* vim: use-after-free in win_linetabsize() (CVE-2021-4192)\n\n* vim: out-of-bound read in getvcol() (CVE-2021-4193)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:0366: vim security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "virt-what",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.18-12.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "which",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "2.21-16.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "xz-libs",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "5.2.4-3.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:4991 https://access.redhat.com/security/cve/CVE-2022-1271",
+            "FixedBy": "0:5.2.4-4.el8_6",
+            "Description": "XZ Utils is an integrated collection of user-space file compression utilities based on the Lempel-Ziv-Markov chain algorithm (LZMA), which performs lossless data compression. The algorithm provides a high compression ratio while keeping the decompression time short.\n\nSecurity Fix(es):\n\n* gzip: arbitrary-file-write vulnerability (CVE-2022-1271)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:4991: xz security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Name": "yum",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "4.7.0-4.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "zip",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "Version": "3.0-23.el8",
+        "Vulnerabilities": []
+      },
+      {
+        "Name": "zlib",
+        "VersionFormat": "",
+        "NamespaceName": "",
+        "AddedBy": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "Version": "1.2.11-17.el8",
+        "Vulnerabilities": [
+          {
+            "Severity": "Medium",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:7106 https://access.redhat.com/security/cve/CVE-2022-37434",
+            "FixedBy": "0:1.2.11-19.el8_6",
+            "Description": "The zlib packages provide a general-purpose lossless data compression library that is used by many different programs.\n\nSecurity Fix(es):\n\n* zlib: a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field (CVE-2022-37434)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:7106: zlib security update (Moderate)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          },
+          {
+            "Severity": "High",
+            "NamespaceName": "RHEL8-rhel-8-including-unpatched",
+            "Link": "https://access.redhat.com/errata/RHSA-2022:1642 https://access.redhat.com/security/cve/CVE-2018-25032",
+            "FixedBy": "0:1.2.11-18.el8_5",
+            "Description": "The zlib packages provide a general-purpose lossless data compression library that is used by many different programs.\n\nSecurity Fix(es):\n\n* zlib: A flaw found in zlib when compressing (not decompressing) certain inputs (CVE-2018-25032)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+            "Name": "RHSA-2022:1642: zlib security update (Important)",
+            "Metadata": {
+              "UpdatedBy": "RHEL8-rhel-8-including-unpatched",
+              "RepoName": "cpe:/o:redhat:enterprise_linux:8::baseos",
+              "RepoLink": null,
+              "DistroName": "Red Hat Enterprise Linux Server",
+              "DistroVersion": "8",
+              "NVD": {
+                "CVSSv3": {
+                  "Vectors": "",
+                  "Score": ""
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/secscan_model/test/vulnerabilityreport_with_rhcc_enrichments.json
+++ b/data/secscan_model/test/vulnerabilityreport_with_rhcc_enrichments.json
@@ -1,0 +1,21401 @@
+{
+  "manifest_hash": "sha256:33f40783cb6ac656b56a6c64208f38ef17ab8023171321551be2cd14876a1418",
+  "packages": {
+    "316": {
+      "id": "316",
+      "name": "python3-requests",
+      "version": "2.20.0-2.1.el8_1",
+      "kind": "binary",
+      "source": {
+        "id": "315",
+        "name": "python-requests",
+        "version": "2.20.0-2.1.el8_1",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "52": {
+      "id": "52",
+      "name": "libgcrypt",
+      "version": "1.8.5-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "51",
+        "name": "libgcrypt",
+        "version": "1.8.5-6.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "928": {
+      "id": "928",
+      "name": "org.elasticsearch.plugin:parent-join",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "784": {
+      "id": "784",
+      "name": "python36",
+      "version": "3.6.8-38.module+el8.5.0+12207+5c5719bc",
+      "kind": "binary",
+      "source": {
+        "id": "783",
+        "name": "python36",
+        "version": "3.6.8-38.module+el8.5.0+12207+5c5719bc",
+        "kind": "source",
+        "module": "python36:3.6"
+      },
+      "module": "python36:3.6",
+      "arch": "x86_64"
+    },
+    "1032": {
+      "id": "1032",
+      "name": "com.google.j2objc:j2objc-annotations",
+      "version": "1.1.0.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "134": {
+      "id": "134",
+      "name": "kmod-libs",
+      "version": "25-18.el8",
+      "kind": "binary",
+      "source": {
+        "id": "133",
+        "name": "kmod",
+        "version": "25-18.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1044": {
+      "id": "1044",
+      "name": "io.jsonwebtoken:jjwt-api",
+      "version": "0.10.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1060": {
+      "id": "1060",
+      "name": "org.codelibs.elasticsearch.module:lang-mustache",
+      "version": "6.8.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "950": {
+      "id": "950",
+      "name": "org.elasticsearch.plugin:reindex",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "338": {
+      "id": "338",
+      "name": "libmodulemd",
+      "version": "2.13.0-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "337",
+        "name": "libmodulemd",
+        "version": "2.13.0-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "18": {
+      "id": "18",
+      "name": "bash",
+      "version": "4.4.20-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "17",
+        "name": "bash",
+        "version": "4.4.20-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "278": {
+      "id": "278",
+      "name": "krb5-libs",
+      "version": "1.18.2-14.el8",
+      "kind": "binary",
+      "source": {
+        "id": "277",
+        "name": "krb5",
+        "version": "1.18.2-14.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "840": {
+      "id": "840",
+      "name": "org.apache.logging.log4j:log4j-core",
+      "version": "2.11.1.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "834": {
+      "id": "834",
+      "name": "org.locationtech.jts:jts-core",
+      "version": "1.15.0.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "352": {
+      "id": "352",
+      "name": "systemd-pam",
+      "version": "239-51.el8",
+      "kind": "binary",
+      "source": {
+        "id": "63",
+        "name": "systemd",
+        "version": "239-51.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1024": {
+      "id": "1024",
+      "name": "org.apache.httpcomponents:httpclient",
+      "version": "4.5.3",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "100": {
+      "id": "100",
+      "name": "libdb",
+      "version": "5.3.28-42.el8_4",
+      "kind": "binary",
+      "source": {
+        "id": "99",
+        "name": "libdb",
+        "version": "5.3.28-42.el8_4",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "216": {
+      "id": "216",
+      "name": "elfutils-libelf",
+      "version": "0.185-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "165",
+        "name": "elfutils",
+        "version": "0.185-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "850": {
+      "id": "850",
+      "name": "org.apache.lucene:lucene-highlighter",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "994": {
+      "id": "994",
+      "name": "org.apache.commons:commons-lang3",
+      "version": "3.4",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "944": {
+      "id": "944",
+      "name": "org.apache.httpcomponents:httpclient",
+      "version": "4.5.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "50": {
+      "id": "50",
+      "name": "libunistring",
+      "version": "0.9.9-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "49",
+        "name": "libunistring",
+        "version": "0.9.9-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1138": {
+      "id": "1138",
+      "name": "org.elasticsearch.plugin.prometheus:prometheus-exporter",
+      "version": "6.8.1.2-redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1112": {
+      "id": "1112",
+      "name": "org.opensaml:opensaml-xmlsec-impl",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1046": {
+      "id": "1046",
+      "name": "io.jsonwebtoken:jjwt-impl",
+      "version": "0.10.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "196": {
+      "id": "196",
+      "name": "ncurses-base",
+      "version": "6.1-9.20180224.el8",
+      "kind": "binary",
+      "source": {
+        "id": "13",
+        "name": "ncurses",
+        "version": "6.1-9.20180224.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "896": {
+      "id": "896",
+      "name": "org.jruby.jcodings:jcodings",
+      "version": "1.0.12",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "774": {
+      "id": "774",
+      "name": "nss-softokn-freebl",
+      "version": "3.67.0-7.el8_5",
+      "kind": "binary",
+      "source": {
+        "id": "557",
+        "name": "nss",
+        "version": "3.67.0-7.el8_5",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "910": {
+      "id": "910",
+      "name": "org.elasticsearch.plugin:lang-expression",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "912": {
+      "id": "912",
+      "name": "org.apache.lucene:lucene-expressions",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1040": {
+      "id": "1040",
+      "name": "com.onelogin:java-saml-core",
+      "version": "2.3.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1092": {
+      "id": "1092",
+      "name": "org.opensaml:opensaml-messaging-api",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "8": {
+      "id": "8",
+      "name": "filesystem",
+      "version": "3.8-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "7",
+        "name": "filesystem",
+        "version": "3.8-6.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1062": {
+      "id": "1062",
+      "name": "org.ldaptive:ldaptive",
+      "version": "1.2.3",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "288": {
+      "id": "288",
+      "name": "python3-six",
+      "version": "1.11.0-8.el8",
+      "kind": "binary",
+      "source": {
+        "id": "287",
+        "name": "python-six",
+        "version": "1.11.0-8.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "1042": {
+      "id": "1042",
+      "name": "net.shibboleth.utilities:java-support",
+      "version": "7.3.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "870": {
+      "id": "870",
+      "name": "org.apache.lucene:lucene-suggest",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "934": {
+      "id": "934",
+      "name": "commons-codec:commons-codec",
+      "version": "1.10",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "570": {
+      "id": "570",
+      "name": "lksctp-tools",
+      "version": "1.0.18-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "569",
+        "name": "lksctp-tools",
+        "version": "1.0.18-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "36": {
+      "id": "36",
+      "name": "libuuid",
+      "version": "2.32.1-28.el8",
+      "kind": "binary",
+      "source": {
+        "id": "35",
+        "name": "util-linux",
+        "version": "2.32.1-28.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "826": {
+      "id": "826",
+      "name": "org.elasticsearch:java-version-checker",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1028": {
+      "id": "1028",
+      "name": "org.apache.httpcomponents:httpcore",
+      "version": "4.4.6",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1064": {
+      "id": "1064",
+      "name": "org.apache.logging.log4j:log4j-slf4j-impl",
+      "version": "2.11.1.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "346": {
+      "id": "346",
+      "name": "dbus-daemon",
+      "version": "1:1.12.8-14.el8",
+      "kind": "binary",
+      "source": {
+        "id": "159",
+        "name": "dbus",
+        "version": "1.12.8-14.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "916": {
+      "id": "916",
+      "name": "org.elasticsearch.plugin:lang-mustache",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "824": {
+      "id": "824",
+      "name": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml",
+      "version": "2.10.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "948": {
+      "id": "948",
+      "name": "org.apache.httpcomponents:httpcore-nio",
+      "version": "4.4.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "264": {
+      "id": "264",
+      "name": "mpfr",
+      "version": "3.1.6-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "263",
+        "name": "mpfr",
+        "version": "3.1.6-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "820": {
+      "id": "820",
+      "name": "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+      "version": "2.10.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "70": {
+      "id": "70",
+      "name": "libsemanage",
+      "version": "2.9-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "69",
+        "name": "libsemanage",
+        "version": "2.9-6.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1026": {
+      "id": "1026",
+      "name": "org.apache.httpcomponents:httpclient-cache",
+      "version": "4.5.3",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1010": {
+      "id": "1010",
+      "name": "org.apache.cxf:cxf-rt-security",
+      "version": "3.2.2.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "922": {
+      "id": "922",
+      "name": "org.elasticsearch.plugin:org.elasticsearch.plugin#spi;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1250": {
+      "id": "1250",
+      "name": "com.maxmind.db:maxmind-db",
+      "version": "1.2.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "184": {
+      "id": "184",
+      "name": "rootfiles",
+      "version": "8.1-22.el8",
+      "kind": "binary",
+      "source": {
+        "id": "183",
+        "name": "rootfiles",
+        "version": "8.1-22.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "1038": {
+      "id": "1038",
+      "name": "com.onelogin:java-saml",
+      "version": "2.3.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "334": {
+      "id": "334",
+      "name": "python3-librepo",
+      "version": "1.14.0-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "147",
+        "name": "librepo",
+        "version": "1.14.0-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "178": {
+      "id": "178",
+      "name": "yum",
+      "version": "4.7.0-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "171",
+        "name": "dnf",
+        "version": "4.7.0-4.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "362": {
+      "id": "362",
+      "name": "subscription-manager",
+      "version": "1.28.21-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "131",
+        "name": "subscription-manager",
+        "version": "1.28.21-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "306": {
+      "id": "306",
+      "name": "python3-ethtool",
+      "version": "0.14-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "305",
+        "name": "python-ethtool",
+        "version": "0.14-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "274": {
+      "id": "274",
+      "name": "gawk",
+      "version": "4.2.1-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "273",
+        "name": "gawk",
+        "version": "4.2.1-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1122": {
+      "id": "1122",
+      "name": "org.codehaus.woodstox:stax2-api",
+      "version": "3.1.4",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "236": {
+      "id": "236",
+      "name": "libidn2",
+      "version": "2.2.0-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "235",
+        "name": "libidn2",
+        "version": "2.2.0-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "804": {
+      "id": "804",
+      "name": "org.elasticsearch:org.elasticsearch#server;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "224": {
+      "id": "224",
+      "name": "libattr",
+      "version": "2.4.48-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "223",
+        "name": "attr",
+        "version": "2.4.48-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1076": {
+      "id": "1076",
+      "name": "io.netty:netty-codec-http",
+      "version": "4.1.32.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1242": {
+      "id": "1242",
+      "name": "com.maxmind.geoip2:geoip2",
+      "version": "2.9.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "872": {
+      "id": "872",
+      "name": "org.elasticsearch:plugin-classloader",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "222": {
+      "id": "222",
+      "name": "readline",
+      "version": "7.0-10.el8",
+      "kind": "binary",
+      "source": {
+        "id": "221",
+        "name": "readline",
+        "version": "7.0-10.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "772": {
+      "id": "772",
+      "name": "nspr",
+      "version": "4.32.0-1.el8_4",
+      "kind": "binary",
+      "source": {
+        "id": "771",
+        "name": "nspr",
+        "version": "4.32.0-1.el8_4",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "292": {
+      "id": "292",
+      "name": "glib2",
+      "version": "2.56.4-156.el8",
+      "kind": "binary",
+      "source": {
+        "id": "291",
+        "name": "glib2",
+        "version": "2.56.4-156.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "130": {
+      "id": "130",
+      "name": "python3-urllib3",
+      "version": "1.24.2-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "129",
+        "name": "python-urllib3",
+        "version": "1.24.2-5.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "260": {
+      "id": "260",
+      "name": "gzip",
+      "version": "1.9-12.el8",
+      "kind": "binary",
+      "source": {
+        "id": "259",
+        "name": "gzip",
+        "version": "1.9-12.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "956": {
+      "id": "956",
+      "name": "io.netty:netty-codec",
+      "version": "4.1.63.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "40": {
+      "id": "40",
+      "name": "libacl",
+      "version": "2.2.53-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "39",
+        "name": "acl",
+        "version": "2.2.53-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "204": {
+      "id": "204",
+      "name": "libsepol",
+      "version": "2.9-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "203",
+        "name": "libsepol",
+        "version": "2.9-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1130": {
+      "id": "1130",
+      "name": "org.apache.ws.xmlschema:xmlschema-core",
+      "version": "2.2.3",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "252": {
+      "id": "252",
+      "name": "dbus-tools",
+      "version": "1:1.12.8-14.el8",
+      "kind": "binary",
+      "source": {
+        "id": "159",
+        "name": "dbus",
+        "version": "1.12.8-14.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "94": {
+      "id": "94",
+      "name": "openssl-libs",
+      "version": "1:1.1.1k-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "93",
+        "name": "openssl",
+        "version": "1.1.1k-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "276": {
+      "id": "276",
+      "name": "libnsl2",
+      "version": "1.2.0-2.20180605git4a062cf.el8",
+      "kind": "binary",
+      "source": {
+        "id": "275",
+        "name": "libnsl2",
+        "version": "1.2.0-2.20180605git4a062cf.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "30": {
+      "id": "30",
+      "name": "popt",
+      "version": "1.18-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "29",
+        "name": "popt",
+        "version": "1.18-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "28": {
+      "id": "28",
+      "name": "libxcrypt",
+      "version": "4.1.1-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "27",
+        "name": "libxcrypt",
+        "version": "4.1.1-6.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "976": {
+      "id": "976",
+      "name": "org.codelibs.elasticsearch.module:aggs-matrix-stats",
+      "version": "6.8.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "324": {
+      "id": "324",
+      "name": "npth",
+      "version": "1.5-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "323",
+        "name": "npth",
+        "version": "1.5-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "984": {
+      "id": "984",
+      "name": "org.checkerframework:checker-qual",
+      "version": "2.0.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1052": {
+      "id": "1052",
+      "name": "com.jayway.jsonpath:json-path",
+      "version": "2.4.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "190": {
+      "id": "190",
+      "name": "subscription-manager-rhsm-certificates",
+      "version": "1.28.21-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "131",
+        "name": "subscription-manager",
+        "version": "1.28.21-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1034": {
+      "id": "1034",
+      "name": "com.fasterxml.jackson.core:jackson-annotations",
+      "version": "2.10.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "250": {
+      "id": "250",
+      "name": "dbus-libs",
+      "version": "1:1.12.8-14.el8",
+      "kind": "binary",
+      "source": {
+        "id": "159",
+        "name": "dbus",
+        "version": "1.12.8-14.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "974": {
+      "id": "974",
+      "name": "net.minidev:accessors-smart",
+      "version": "1.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "210": {
+      "id": "210",
+      "name": "libxml2",
+      "version": "2.9.7-9.el8_4.2",
+      "kind": "binary",
+      "source": {
+        "id": "209",
+        "name": "libxml2",
+        "version": "2.9.7-9.el8_4.2",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "892": {
+      "id": "892",
+      "name": "org.elasticsearch:org.elasticsearch#grok;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "310": {
+      "id": "310",
+      "name": "python3-chardet",
+      "version": "3.0.4-7.el8",
+      "kind": "binary",
+      "source": {
+        "id": "309",
+        "name": "python-chardet",
+        "version": "3.0.4-7.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "1050": {
+      "id": "1050",
+      "name": "com.github.wnameless:json-flattener",
+      "version": "0.5.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1110": {
+      "id": "1110",
+      "name": "org.opensaml:opensaml-xmlsec-api",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "876": {
+      "id": "876",
+      "name": "org.locationtech.spatial4j:spatial4j",
+      "version": "0.7",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "972": {
+      "id": "972",
+      "name": "org.elasticsearch.plugin:org.elasticsearch.plugin#tribe;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1086": {
+      "id": "1086",
+      "name": "io.netty:netty-transport",
+      "version": "4.1.32.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "266": {
+      "id": "266",
+      "name": "libcomps",
+      "version": "0.1.16-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "121",
+        "name": "libcomps",
+        "version": "0.1.16-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1140": {
+      "id": "1140",
+      "name": "io.prometheus:simpleclient",
+      "version": "0.6.0.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1142": {
+      "id": "1142",
+      "name": "io.prometheus:simpleclient_common",
+      "version": "0.6.0.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "990": {
+      "id": "990",
+      "name": "commons-collections:commons-collections",
+      "version": "3.2.2.redhat-2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "188": {
+      "id": "188",
+      "name": "python3-setuptools-wheel",
+      "version": "39.2.0-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "187",
+        "name": "python-setuptools",
+        "version": "39.2.0-6.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "808": {
+      "id": "808",
+      "name": "org.elasticsearch:org.elasticsearch#core;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "864": {
+      "id": "864",
+      "name": "org.apache.lucene:lucene-spatial",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "168": {
+      "id": "168",
+      "name": "systemd",
+      "version": "239-51.el8",
+      "kind": "binary",
+      "source": {
+        "id": "63",
+        "name": "systemd",
+        "version": "239-51.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "576": {
+      "id": "576",
+      "name": "libjpeg-turbo",
+      "version": "1.5.3-12.el8",
+      "kind": "binary",
+      "source": {
+        "id": "575",
+        "name": "libjpeg-turbo",
+        "version": "1.5.3-12.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "256": {
+      "id": "256",
+      "name": "shadow-utils",
+      "version": "2:4.6-14.el8",
+      "kind": "binary",
+      "source": {
+        "id": "255",
+        "name": "shadow-utils",
+        "version": "4.6-14.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "312": {
+      "id": "312",
+      "name": "python3-idna",
+      "version": "2.5-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "311",
+        "name": "python-idna",
+        "version": "2.5-5.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "72": {
+      "id": "72",
+      "name": "libutempter",
+      "version": "1.1.6-14.el8",
+      "kind": "binary",
+      "source": {
+        "id": "71",
+        "name": "libutempter",
+        "version": "1.1.6-14.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "986": {
+      "id": "986",
+      "name": "commons-cli:commons-cli",
+      "version": "1.3.1.redhat-2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "152": {
+      "id": "152",
+      "name": "rpm-libs",
+      "version": "4.14.3-19.el8",
+      "kind": "binary",
+      "source": {
+        "id": "151",
+        "name": "rpm",
+        "version": "4.14.3-19.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "966": {
+      "id": "966",
+      "name": "io.netty:netty-resolver",
+      "version": "4.1.63.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "890": {
+      "id": "890",
+      "name": "org.elasticsearch:org.elasticsearch#dissect;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "300": {
+      "id": "300",
+      "name": "cyrus-sasl-lib",
+      "version": "2.1.27-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "299",
+        "name": "cyrus-sasl",
+        "version": "2.1.27-5.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "218": {
+      "id": "218",
+      "name": "json-c",
+      "version": "0.13.1-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "217",
+        "name": "json-c",
+        "version": "0.13.1-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "794": {
+      "id": "794",
+      "name": "harfbuzz",
+      "version": "1.7.5-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "793",
+        "name": "harfbuzz",
+        "version": "1.7.5-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "158": {
+      "id": "158",
+      "name": "libreport-filesystem",
+      "version": "2.9.5-15.el8",
+      "kind": "binary",
+      "source": {
+        "id": "157",
+        "name": "libreport",
+        "version": "2.9.5-15.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "238": {
+      "id": "238",
+      "name": "file-libs",
+      "version": "5.33-20.el8",
+      "kind": "binary",
+      "source": {
+        "id": "237",
+        "name": "file",
+        "version": "5.33-20.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "846": {
+      "id": "846",
+      "name": "org.apache.lucene:lucene-core",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "108": {
+      "id": "108",
+      "name": "json-glib",
+      "version": "1.4.4-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "107",
+        "name": "json-glib",
+        "version": "1.4.4-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "76": {
+      "id": "76",
+      "name": "cracklib",
+      "version": "2.9.6-15.el8",
+      "kind": "binary",
+      "source": {
+        "id": "75",
+        "name": "cracklib",
+        "version": "2.9.6-15.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "962": {
+      "id": "962",
+      "name": "org.jctools:jctools-core",
+      "version": "3.1.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "964": {
+      "id": "964",
+      "name": "io.netty:netty-handler",
+      "version": "4.1.63.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "172": {
+      "id": "172",
+      "name": "python3-dnf",
+      "version": "4.7.0-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "171",
+        "name": "dnf",
+        "version": "4.7.0-4.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "856": {
+      "id": "856",
+      "name": "org.apache.lucene:lucene-misc",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "582": {
+      "id": "582",
+      "name": "java-11-openjdk-headless",
+      "version": "1:11.0.13.0.8-3.el8_5",
+      "kind": "binary",
+      "source": {
+        "id": "581",
+        "name": "java-11-openjdk",
+        "version": "11.0.13.0.8-3.el8_5",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "796": {
+      "id": "796",
+      "name": "javapackages-filesystem",
+      "version": "5.3.0-1.module+el8+2447+6f56d9a6",
+      "kind": "binary",
+      "source": {
+        "id": "795",
+        "name": "javapackages-tools",
+        "version": "5.3.0-1.module+el8+2447+6f56d9a6",
+        "kind": "source",
+        "module": "javapackages-runtime:201801"
+      },
+      "module": "javapackages-runtime:201801",
+      "arch": "noarch"
+    },
+    "332": {
+      "id": "332",
+      "name": "libcurl",
+      "version": "7.61.1-22.el8",
+      "kind": "binary",
+      "source": {
+        "id": "149",
+        "name": "curl",
+        "version": "7.61.1-22.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "568": {
+      "id": "568",
+      "name": "python3-pip",
+      "version": "9.0.3-20.el8",
+      "kind": "binary",
+      "source": {
+        "id": "3",
+        "name": "python-pip",
+        "version": "9.0.3-20.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "296": {
+      "id": "296",
+      "name": "dbus-glib",
+      "version": "0.110-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "295",
+        "name": "dbus-glib",
+        "version": "0.110-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1078": {
+      "id": "1078",
+      "name": "io.netty:netty-common",
+      "version": "4.1.32.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "138": {
+      "id": "138",
+      "name": "libyaml",
+      "version": "0.1.7-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "137",
+        "name": "libyaml",
+        "version": "0.1.7-5.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "342": {
+      "id": "342",
+      "name": "python3-hawkey",
+      "version": "0.63.0-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "155",
+        "name": "libdnf",
+        "version": "0.63.0-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "20": {
+      "id": "20",
+      "name": "zlib",
+      "version": "1.2.11-17.el8",
+      "kind": "binary",
+      "source": {
+        "id": "19",
+        "name": "zlib",
+        "version": "1.2.11-17.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "34": {
+      "id": "34",
+      "name": "libcom_err",
+      "version": "1.45.6-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "33",
+        "name": "e2fsprogs",
+        "version": "1.45.6-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "286": {
+      "id": "286",
+      "name": "libpwquality",
+      "version": "1.4.4-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "285",
+        "name": "libpwquality",
+        "version": "1.4.4-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1016": {
+      "id": "1016",
+      "name": "com.google.errorprone:error_prone_annotations",
+      "version": "2.1.3.redhat-00002",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "258": {
+      "id": "258",
+      "name": "libpsl",
+      "version": "0.20.2-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "257",
+        "name": "libpsl",
+        "version": "0.20.2-6.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "62": {
+      "id": "62",
+      "name": "pcre",
+      "version": "8.42-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "61",
+        "name": "pcre",
+        "version": "8.42-6.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "84": {
+      "id": "84",
+      "name": "dmidecode",
+      "version": "1:3.2-10.el8",
+      "kind": "binary",
+      "source": {
+        "id": "83",
+        "name": "dmidecode",
+        "version": "3.2-10.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1114": {
+      "id": "1114",
+      "name": "org.codelibs.elasticsearch.module:parent-join",
+      "version": "6.8.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "194": {
+      "id": "194",
+      "name": "basesystem",
+      "version": "11-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "193",
+        "name": "basesystem",
+        "version": "11-5.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "350": {
+      "id": "350",
+      "name": "elfutils-default-yama-scope",
+      "version": "0.185-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "165",
+        "name": "elfutils",
+        "version": "0.185-1.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "564": {
+      "id": "564",
+      "name": "unzip",
+      "version": "6.0-45.el8_4",
+      "kind": "binary",
+      "source": {
+        "id": "563",
+        "name": "unzip",
+        "version": "6.0-45.el8_4",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "328": {
+      "id": "328",
+      "name": "which",
+      "version": "2.21-16.el8",
+      "kind": "binary",
+      "source": {
+        "id": "327",
+        "name": "which",
+        "version": "2.21-16.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "202": {
+      "id": "202",
+      "name": "glibc",
+      "version": "2.28-164.el8",
+      "kind": "binary",
+      "source": {
+        "id": "15",
+        "name": "glibc",
+        "version": "2.28-164.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "254": {
+      "id": "254",
+      "name": "gdbm",
+      "version": "1:1.18-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "57",
+        "name": "gdbm",
+        "version": "1.18-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1104": {
+      "id": "1104",
+      "name": "org.opensaml:opensaml-soap-api",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "170": {
+      "id": "170",
+      "name": "rpm-build-libs",
+      "version": "4.14.3-19.el8",
+      "kind": "binary",
+      "source": {
+        "id": "151",
+        "name": "rpm",
+        "version": "4.14.3-19.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "344": {
+      "id": "344",
+      "name": "dnf-data",
+      "version": "4.7.0-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "171",
+        "name": "dnf",
+        "version": "4.7.0-4.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "2": {
+      "id": "2",
+      "name": "tzdata",
+      "version": "2021e-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "1",
+        "name": "tzdata",
+        "version": "2021e-1.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "282": {
+      "id": "282",
+      "name": "platform-python-setuptools",
+      "version": "39.2.0-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "187",
+        "name": "python-setuptools",
+        "version": "39.2.0-6.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "884": {
+      "id": "884",
+      "name": "org.elasticsearch:org.elasticsearch#plugin-cli;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "330": {
+      "id": "330",
+      "name": "libssh-config",
+      "version": "0.9.4-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "145",
+        "name": "libssh",
+        "version": "0.9.4-3.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "786": {
+      "id": "786",
+      "name": "libpng",
+      "version": "2:1.6.34-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "785",
+        "name": "libpng",
+        "version": "1.6.34-5.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "14": {
+      "id": "14",
+      "name": "ncurses-libs",
+      "version": "6.1-9.20180224.el8",
+      "kind": "binary",
+      "source": {
+        "id": "13",
+        "name": "ncurses",
+        "version": "6.1-9.20180224.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1126": {
+      "id": "1126",
+      "name": "org.apache.velocity:velocity",
+      "version": "1.7",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1106": {
+      "id": "1106",
+      "name": "org.opensaml:opensaml-soap-impl",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "830": {
+      "id": "830",
+      "name": "joda-time:joda-time",
+      "version": "2.10.1.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "118": {
+      "id": "118",
+      "name": "passwd",
+      "version": "0.80-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "117",
+        "name": "passwd",
+        "version": "0.80-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "160": {
+      "id": "160",
+      "name": "dbus-common",
+      "version": "1:1.12.8-14.el8",
+      "kind": "binary",
+      "source": {
+        "id": "159",
+        "name": "dbus",
+        "version": "1.12.8-14.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "368": {
+      "id": "368",
+      "name": "langpacks-en",
+      "version": "1.0-12.el8",
+      "kind": "binary",
+      "source": {
+        "id": "367",
+        "name": "langpacks",
+        "version": "1.0-12.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "1132": {
+      "id": "1132",
+      "name": "org.apache.santuario:xmlsec",
+      "version": "2.0.7",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "98": {
+      "id": "98",
+      "name": "platform-python",
+      "version": "3.6.8-41.el8",
+      "kind": "binary",
+      "source": {
+        "id": "97",
+        "name": "python3",
+        "version": "3.6.8-41.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1102": {
+      "id": "1102",
+      "name": "org.opensaml:opensaml-security-impl",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "958": {
+      "id": "958",
+      "name": "io.netty:netty-codec-http",
+      "version": "4.1.63.Final-redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "242": {
+      "id": "242",
+      "name": "libassuan",
+      "version": "2.5.1-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "241",
+        "name": "libassuan",
+        "version": "2.5.1-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "54": {
+      "id": "54",
+      "name": "libcap-ng",
+      "version": "0.7.11-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "53",
+        "name": "libcap-ng",
+        "version": "0.7.11-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "920": {
+      "id": "920",
+      "name": "org.ow2.asm:asm-debug-all",
+      "version": "5.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1116": {
+      "id": "1116",
+      "name": "org.codelibs.elasticsearch.module:rank-eval",
+      "version": "6.8.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1082": {
+      "id": "1082",
+      "name": "io.netty:netty-handler",
+      "version": "4.1.32.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "80": {
+      "id": "80",
+      "name": "nettle",
+      "version": "3.4.1-7.el8",
+      "kind": "binary",
+      "source": {
+        "id": "79",
+        "name": "nettle",
+        "version": "3.4.1-7.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "354": {
+      "id": "354",
+      "name": "dbus",
+      "version": "1:1.12.8-14.el8",
+      "kind": "binary",
+      "source": {
+        "id": "159",
+        "name": "dbus",
+        "version": "1.12.8-14.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "940": {
+      "id": "940",
+      "name": "org.elasticsearch:elasticsearch-ssl-config",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "970": {
+      "id": "970",
+      "name": "org.elasticsearch.plugin:transport-netty4",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "148": {
+      "id": "148",
+      "name": "librepo",
+      "version": "1.14.0-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "147",
+        "name": "librepo",
+        "version": "1.14.0-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "586": {
+      "id": "586",
+      "name": "python3-pyyaml",
+      "version": "3.12-12.el8",
+      "kind": "binary",
+      "source": {
+        "id": "585",
+        "name": "PyYAML",
+        "version": "3.12-12.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "16": {
+      "id": "16",
+      "name": "glibc-common",
+      "version": "2.28-164.el8",
+      "kind": "binary",
+      "source": {
+        "id": "15",
+        "name": "glibc",
+        "version": "2.28-164.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "272": {
+      "id": "272",
+      "name": "libseccomp",
+      "version": "2.5.1-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "271",
+        "name": "libseccomp",
+        "version": "2.5.1-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "776": {
+      "id": "776",
+      "name": "nss-sysinit",
+      "version": "3.67.0-7.el8_5",
+      "kind": "binary",
+      "source": {
+        "id": "557",
+        "name": "nss",
+        "version": "3.67.0-7.el8_5",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "308": {
+      "id": "308",
+      "name": "python3-libxml2",
+      "version": "2.9.7-9.el8_4.2",
+      "kind": "binary",
+      "source": {
+        "id": "209",
+        "name": "libxml2",
+        "version": "2.9.7-9.el8_4.2",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "814": {
+      "id": "814",
+      "name": "org.elasticsearch:org.elasticsearch#x-content;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "960": {
+      "id": "960",
+      "name": "io.netty:netty-common",
+      "version": "4.1.63.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "580": {
+      "id": "580",
+      "name": "lcms2",
+      "version": "2.9-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "579",
+        "name": "lcms2",
+        "version": "2.9-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "92": {
+      "id": "92",
+      "name": "libtirpc",
+      "version": "1.1.4-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "91",
+        "name": "libtirpc",
+        "version": "1.1.4-5.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1100": {
+      "id": "1100",
+      "name": "org.opensaml:opensaml-security-api",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "106": {
+      "id": "106",
+      "name": "gnutls",
+      "version": "3.6.16-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "105",
+        "name": "gnutls",
+        "version": "3.6.16-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "854": {
+      "id": "854",
+      "name": "org.apache.lucene:lucene-memory",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "96": {
+      "id": "96",
+      "name": "crypto-policies-scripts",
+      "version": "20210617-1.gitc776d3e.el8",
+      "kind": "binary",
+      "source": {
+        "id": "95",
+        "name": "crypto-policies",
+        "version": "20210617-1.gitc776d3e.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "844": {
+      "id": "844",
+      "name": "org.apache.lucene:lucene-backward-codecs",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "112": {
+      "id": "112",
+      "name": "python3-dbus",
+      "version": "1.2.4-15.el8",
+      "kind": "binary",
+      "source": {
+        "id": "111",
+        "name": "dbus-python",
+        "version": "1.2.4-15.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "68": {
+      "id": "68",
+      "name": "libusbx",
+      "version": "1.0.23-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "67",
+        "name": "libusbx",
+        "version": "1.0.23-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "918": {
+      "id": "918",
+      "name": "org.antlr:antlr4-runtime",
+      "version": "4.5.3.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "166": {
+      "id": "166",
+      "name": "elfutils-libs",
+      "version": "0.185-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "165",
+        "name": "elfutils",
+        "version": "0.185-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "46": {
+      "id": "46",
+      "name": "libstdc++",
+      "version": "8.5.0-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "45",
+        "name": "gcc",
+        "version": "8.5.0-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "230": {
+      "id": "230",
+      "name": "libsmartcols",
+      "version": "2.32.1-28.el8",
+      "kind": "binary",
+      "source": {
+        "id": "35",
+        "name": "util-linux",
+        "version": "2.32.1-28.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "914": {
+      "id": "914",
+      "name": "com.github.spullara.mustache.java:compiler",
+      "version": "0.9.3",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "90": {
+      "id": "90",
+      "name": "libverto",
+      "version": "0.3.0-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "89",
+        "name": "libverto",
+        "version": "0.3.0-5.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "22": {
+      "id": "22",
+      "name": "bzip2-libs",
+      "version": "1.0.6-26.el8",
+      "kind": "binary",
+      "source": {
+        "id": "21",
+        "name": "bzip2",
+        "version": "1.0.6-26.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1048": {
+      "id": "1048",
+      "name": "io.jsonwebtoken:jjwt-jackson",
+      "version": "0.10.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "146": {
+      "id": "146",
+      "name": "libssh",
+      "version": "0.9.4-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "145",
+        "name": "libssh",
+        "version": "0.9.4-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "58": {
+      "id": "58",
+      "name": "gdbm-libs",
+      "version": "1:1.18-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "57",
+        "name": "gdbm",
+        "version": "1.18-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1096": {
+      "id": "1096",
+      "name": "org.opensaml:opensaml-saml-api",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "44": {
+      "id": "44",
+      "name": "sed",
+      "version": "4.5-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "43",
+        "name": "sed",
+        "version": "4.5-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "132": {
+      "id": "132",
+      "name": "python3-cloud-what",
+      "version": "1.28.21-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "131",
+        "name": "subscription-manager",
+        "version": "1.28.21-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1056": {
+      "id": "1056",
+      "name": "com.google.code.findbugs:jsr305",
+      "version": "3.0.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "868": {
+      "id": "868",
+      "name": "org.apache.lucene:lucene-spatial3d",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "64": {
+      "id": "64",
+      "name": "systemd-libs",
+      "version": "239-51.el8",
+      "kind": "binary",
+      "source": {
+        "id": "63",
+        "name": "systemd",
+        "version": "239-51.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "348": {
+      "id": "348",
+      "name": "device-mapper-libs",
+      "version": "8:1.02.177-10.el8",
+      "kind": "binary",
+      "source": {
+        "id": "161",
+        "name": "lvm2",
+        "version": "2.03.12-10.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "886": {
+      "id": "886",
+      "name": "org.elasticsearch.plugin:aggs-matrix-stats",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1118": {
+      "id": "1118",
+      "name": "org.slf4j:slf4j-api",
+      "version": "1.7.25.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1066": {
+      "id": "1066",
+      "name": "lz4-java",
+      "version": "0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "810": {
+      "id": "810",
+      "name": "org.elasticsearch:org.elasticsearch#launchers;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "164": {
+      "id": "164",
+      "name": "cryptsetup-libs",
+      "version": "2.3.3-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "163",
+        "name": "cryptsetup",
+        "version": "2.3.3-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "38": {
+      "id": "38",
+      "name": "gmp",
+      "version": "1:6.1.2-10.el8",
+      "kind": "binary",
+      "source": {
+        "id": "37",
+        "name": "gmp",
+        "version": "6.1.2-10.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1074": {
+      "id": "1074",
+      "name": "io.netty:netty-codec",
+      "version": "4.1.32.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1120": {
+      "id": "1120",
+      "name": "org.xerial.snappy:snappy-java",
+      "version": "1.1.4.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "862": {
+      "id": "862",
+      "name": "org.apache.lucene:lucene-sandbox",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "212": {
+      "id": "212",
+      "name": "libcap",
+      "version": "2.26-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "211",
+        "name": "libcap",
+        "version": "2.26-5.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "162": {
+      "id": "162",
+      "name": "device-mapper",
+      "version": "8:1.02.177-10.el8",
+      "kind": "binary",
+      "source": {
+        "id": "161",
+        "name": "lvm2",
+        "version": "2.03.12-10.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "828": {
+      "id": "828",
+      "name": "org.elasticsearch:jna",
+      "version": "4.5.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "998": {
+      "id": "998",
+      "name": "org.apache.commons:commons-text",
+      "version": "1.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "572": {
+      "id": "572",
+      "name": "freetype",
+      "version": "2.9.1-4.el8_3.1",
+      "kind": "binary",
+      "source": {
+        "id": "571",
+        "name": "freetype",
+        "version": "2.9.1-4.el8_3.1",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "358": {
+      "id": "358",
+      "name": "dnf",
+      "version": "4.7.0-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "171",
+        "name": "dnf",
+        "version": "4.7.0-4.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "206": {
+      "id": "206",
+      "name": "xz-libs",
+      "version": "5.2.4-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "205",
+        "name": "xz",
+        "version": "5.2.4-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "938": {
+      "id": "938",
+      "name": "org.elasticsearch.client:org.elasticsearch.client#rest;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "904": {
+      "id": "904",
+      "name": "org.ow2.asm:asm",
+      "version": "5.0.4",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "86": {
+      "id": "86",
+      "name": "libnl3",
+      "version": "3.5.0-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "85",
+        "name": "libnl3",
+        "version": "3.5.0-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1244": {
+      "id": "1244",
+      "name": "org.elasticsearch.plugin:ingest-geoip",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1006": {
+      "id": "1006",
+      "name": "org.apache.cxf:cxf-rt-rs-json-basic",
+      "version": "3.2.2.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "208": {
+      "id": "208",
+      "name": "libgpg-error",
+      "version": "1.31-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "207",
+        "name": "libgpg-error",
+        "version": "1.31-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "372": {
+      "id": "372",
+      "name": "ubi8",
+      "version": "8.5-200",
+      "kind": "binary",
+      "source": {
+        "id": "370",
+        "name": "ubi8-container",
+        "version": "8.5-200",
+        "kind": "source",
+        "arch": "x86_64"
+      },
+      "normalized_version": "rhctag:8.5.0.0.0.0.0.0.0.0",
+      "arch": "x86_64"
+    },
+    "270": {
+      "id": "270",
+      "name": "libnghttp2",
+      "version": "1.33.0-3.el8_2.1",
+      "kind": "binary",
+      "source": {
+        "id": "269",
+        "name": "nghttp2",
+        "version": "1.33.0-3.el8_2.1",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "228": {
+      "id": "228",
+      "name": "libmount",
+      "version": "2.32.1-28.el8",
+      "kind": "binary",
+      "source": {
+        "id": "35",
+        "name": "util-linux",
+        "version": "2.32.1-28.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "290": {
+      "id": "290",
+      "name": "python3-dateutil",
+      "version": "1:2.6.1-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "289",
+        "name": "python-dateutil",
+        "version": "2.6.1-6.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "566": {
+      "id": "566",
+      "name": "cups-libs",
+      "version": "1:2.2.6-40.el8",
+      "kind": "binary",
+      "source": {
+        "id": "565",
+        "name": "cups",
+        "version": "2.2.6-40.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "240": {
+      "id": "240",
+      "name": "audit-libs",
+      "version": "3.0-0.17.20191104git1c2f876.el8",
+      "kind": "binary",
+      "source": {
+        "id": "239",
+        "name": "audit",
+        "version": "3.0-0.17.20191104git1c2f876.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1054": {
+      "id": "1054",
+      "name": "net.minidev:json-smart",
+      "version": "2.3",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1008": {
+      "id": "1008",
+      "name": "org.apache.cxf:cxf-rt-rs-security-jose",
+      "version": "3.2.2.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "102": {
+      "id": "102",
+      "name": "pam",
+      "version": "1.3.1-15.el8",
+      "kind": "binary",
+      "source": {
+        "id": "101",
+        "name": "pam",
+        "version": "1.3.1-15.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "226": {
+      "id": "226",
+      "name": "coreutils-single",
+      "version": "8.30-12.el8",
+      "kind": "binary",
+      "source": {
+        "id": "225",
+        "name": "coreutils",
+        "version": "8.30-12.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "578": {
+      "id": "578",
+      "name": "graphite2",
+      "version": "1.3.10-10.el8",
+      "kind": "binary",
+      "source": {
+        "id": "577",
+        "name": "graphite2",
+        "version": "1.3.10-10.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "942": {
+      "id": "942",
+      "name": "org.apache.httpcomponents:httpasyncclient",
+      "version": "4.1.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "806": {
+      "id": "806",
+      "name": "org.elasticsearch:org.elasticsearch#cli;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "268": {
+      "id": "268",
+      "name": "brotli",
+      "version": "1.0.6-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "267",
+        "name": "brotli",
+        "version": "1.0.6-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "366": {
+      "id": "366",
+      "name": "vim-minimal",
+      "version": "2:8.0.1763-16.el8",
+      "kind": "binary",
+      "source": {
+        "id": "365",
+        "name": "vim",
+        "version": "8.0.1763-16.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "360": {
+      "id": "360",
+      "name": "dnf-plugin-subscription-manager",
+      "version": "1.28.21-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "131",
+        "name": "subscription-manager",
+        "version": "1.28.21-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "926": {
+      "id": "926",
+      "name": "org.elasticsearch.plugin:mapper-extras",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "110": {
+      "id": "110",
+      "name": "python3-iniparse",
+      "version": "0.4-31.el8",
+      "kind": "binary",
+      "source": {
+        "id": "109",
+        "name": "python-iniparse",
+        "version": "0.4-31.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "954": {
+      "id": "954",
+      "name": "io.netty:netty-buffer",
+      "version": "4.1.63.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "326": {
+      "id": "326",
+      "name": "gpgme",
+      "version": "1.13.1-9.el8",
+      "kind": "binary",
+      "source": {
+        "id": "141",
+        "name": "gpgme",
+        "version": "1.13.1-9.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "562": {
+      "id": "562",
+      "name": "nss",
+      "version": "3.67.0-7.el8_5",
+      "kind": "binary",
+      "source": {
+        "id": "557",
+        "name": "nss",
+        "version": "3.67.0-7.el8_5",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "176": {
+      "id": "176",
+      "name": "python3-subscription-manager-rhsm",
+      "version": "1.28.21-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "131",
+        "name": "subscription-manager",
+        "version": "1.28.21-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1084": {
+      "id": "1084",
+      "name": "io.netty:netty-resolver",
+      "version": "4.1.32.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "874": {
+      "id": "874",
+      "name": "org.yaml:snakeyaml",
+      "version": "1.17",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "198": {
+      "id": "198",
+      "name": "libselinux",
+      "version": "2.9-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "197",
+        "name": "libselinux",
+        "version": "2.9-5.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "82": {
+      "id": "82",
+      "name": "libksba",
+      "version": "1.3.5-7.el8",
+      "kind": "binary",
+      "source": {
+        "id": "81",
+        "name": "libksba",
+        "version": "1.3.5-7.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "946": {
+      "id": "946",
+      "name": "org.apache.httpcomponents:httpcore",
+      "version": "4.4.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "122": {
+      "id": "122",
+      "name": "python3-libcomps",
+      "version": "0.1.16-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "121",
+        "name": "libcomps",
+        "version": "0.1.16-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "558": {
+      "id": "558",
+      "name": "nss-util",
+      "version": "3.67.0-7.el8_5",
+      "kind": "binary",
+      "source": {
+        "id": "557",
+        "name": "nss",
+        "version": "3.67.0-7.el8_5",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "930": {
+      "id": "930",
+      "name": "org.elasticsearch.plugin:percolator",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "124": {
+      "id": "124",
+      "name": "python3-dmidecode",
+      "version": "3.12.2-15.el8",
+      "kind": "binary",
+      "source": {
+        "id": "123",
+        "name": "python-dmidecode",
+        "version": "3.12.2-15.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "842": {
+      "id": "842",
+      "name": "org.apache.lucene:lucene-analyzers-common",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1002": {
+      "id": "1002",
+      "name": "org.cryptacular:cryptacular",
+      "version": "1.1.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "978": {
+      "id": "978",
+      "name": "org.codehaus.mojo:animal-sniffer-annotations",
+      "version": "1.14.0.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "320": {
+      "id": "320",
+      "name": "libarchive",
+      "version": "3.3.3-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "319",
+        "name": "libarchive",
+        "version": "3.3.3-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "802": {
+      "id": "802",
+      "name": "org.hdrhistogram:HdrHistogram",
+      "version": "2.1.9.redhat-00004",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "156": {
+      "id": "156",
+      "name": "python3-libdnf",
+      "version": "0.63.0-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "155",
+        "name": "libdnf",
+        "version": "0.63.0-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "6": {
+      "id": "6",
+      "name": "redhat-release",
+      "version": "8.5-0.8.el8",
+      "kind": "binary",
+      "source": {
+        "id": "5",
+        "name": "redhat-release",
+        "version": "8.5-0.8.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "10": {
+      "id": "10",
+      "name": "publicsuffix-list-dafsa",
+      "version": "20180723-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "9",
+        "name": "publicsuffix-list",
+        "version": "20180723-1.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "1070": {
+      "id": "1070",
+      "name": "com.eclipsesource.minimal-json:minimal-json",
+      "version": "0.9.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1012": {
+      "id": "1012",
+      "name": "org.elasticsearch.client:elasticsearch-rest-client",
+      "version": "6.8.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "370": {
+      "id": "370",
+      "name": "ubi8-container",
+      "version": "8.5-200",
+      "kind": "source",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      },
+      "normalized_version": "rhctag:8.5.0.0.0.0.0.0.0.0",
+      "arch": "x86_64"
+    },
+    "314": {
+      "id": "314",
+      "name": "python3-pysocks",
+      "version": "1.6.8-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "313",
+        "name": "python-pysocks",
+        "version": "1.6.8-3.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "246": {
+      "id": "246",
+      "name": "p11-kit-trust",
+      "version": "0.23.22-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "47",
+        "name": "p11-kit",
+        "version": "0.23.22-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "24": {
+      "id": "24",
+      "name": "sqlite-libs",
+      "version": "3.26.0-15.el8",
+      "kind": "binary",
+      "source": {
+        "id": "23",
+        "name": "sqlite",
+        "version": "3.26.0-15.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "304": {
+      "id": "304",
+      "name": "usermode",
+      "version": "1.113-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "303",
+        "name": "usermode",
+        "version": "1.113-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "574": {
+      "id": "574",
+      "name": "lua",
+      "version": "5.3.4-12.el8",
+      "kind": "binary",
+      "source": {
+        "id": "231",
+        "name": "lua",
+        "version": "5.3.4-12.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "866": {
+      "id": "866",
+      "name": "org.apache.lucene:lucene-spatial-extras",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "144": {
+      "id": "144",
+      "name": "virt-what",
+      "version": "1.18-12.el8",
+      "kind": "binary",
+      "source": {
+        "id": "143",
+        "name": "virt-what",
+        "version": "1.18-12.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "78": {
+      "id": "78",
+      "name": "acl",
+      "version": "2.2.53-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "39",
+        "name": "acl",
+        "version": "2.2.53-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "322": {
+      "id": "322",
+      "name": "ima-evm-utils",
+      "version": "1.3.2-12.el8",
+      "kind": "binary",
+      "source": {
+        "id": "321",
+        "name": "ima-evm-utils",
+        "version": "1.3.2-12.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "26": {
+      "id": "26",
+      "name": "info",
+      "version": "6.5-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "25",
+        "name": "texinfo",
+        "version": "6.5-6.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "924": {
+      "id": "924",
+      "name": "org.elasticsearch.plugin:lang-painless",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "318": {
+      "id": "318",
+      "name": "python3-syspurpose",
+      "version": "1.28.21-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "131",
+        "name": "subscription-manager",
+        "version": "1.28.21-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "248": {
+      "id": "248",
+      "name": "grep",
+      "version": "3.1-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "247",
+        "name": "grep",
+        "version": "3.1-6.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "336": {
+      "id": "336",
+      "name": "rpm",
+      "version": "4.14.3-19.el8",
+      "kind": "binary",
+      "source": {
+        "id": "151",
+        "name": "rpm",
+        "version": "4.14.3-19.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1088": {
+      "id": "1088",
+      "name": "com.amazon.opendistroforelasticsearch:opendistro_security",
+      "version": "0.10.1.2-redhat-00006",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "882": {
+      "id": "882",
+      "name": "org.bouncycastle:bcprov-jdk15on",
+      "version": "1.61",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "906": {
+      "id": "906",
+      "name": "org.ow2.asm:asm-commons",
+      "version": "5.0.4",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "116": {
+      "id": "116",
+      "name": "openldap",
+      "version": "2.4.46-18.el8",
+      "kind": "binary",
+      "source": {
+        "id": "115",
+        "name": "openldap",
+        "version": "2.4.46-18.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "996": {
+      "id": "996",
+      "name": "commons-logging:commons-logging",
+      "version": "1.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1020": {
+      "id": "1020",
+      "name": "com.google.guava:guava",
+      "version": "25.1.0.jre-redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "66": {
+      "id": "66",
+      "name": "ca-certificates",
+      "version": "2021.2.50-80.0.el8_4",
+      "kind": "binary",
+      "source": {
+        "id": "65",
+        "name": "ca-certificates",
+        "version": "2021.2.50-80.0.el8_4",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "982": {
+      "id": "982",
+      "name": "org.bouncycastle:bcprov-jdk15on",
+      "version": "1.67.0.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "56": {
+      "id": "56",
+      "name": "lz4-libs",
+      "version": "1.8.3-3.el8_4",
+      "kind": "binary",
+      "source": {
+        "id": "55",
+        "name": "lz4",
+        "version": "1.8.3-3.el8_4",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "908": {
+      "id": "908",
+      "name": "org.ow2.asm:asm-tree",
+      "version": "5.0.4",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "120": {
+      "id": "120",
+      "name": "libdb-utils",
+      "version": "5.3.28-42.el8_4",
+      "kind": "binary",
+      "source": {
+        "id": "99",
+        "name": "libdb",
+        "version": "5.3.28-42.el8_4",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "136": {
+      "id": "136",
+      "name": "tpm2-tss",
+      "version": "2.3.2-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "135",
+        "name": "tpm2-tss",
+        "version": "2.3.2-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "778": {
+      "id": "778",
+      "name": "platform-python-pip",
+      "version": "9.0.3-20.el8",
+      "kind": "binary",
+      "source": {
+        "id": "3",
+        "name": "python-pip",
+        "version": "9.0.3-20.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "1128": {
+      "id": "1128",
+      "name": "com.fasterxml.woodstox:woodstox-core",
+      "version": "5.0.3",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "262": {
+      "id": "262",
+      "name": "cracklib-dicts",
+      "version": "2.9.6-15.el8",
+      "kind": "binary",
+      "source": {
+        "id": "75",
+        "name": "cracklib",
+        "version": "2.9.6-15.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "126": {
+      "id": "126",
+      "name": "python3-decorator",
+      "version": "4.2.1-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "125",
+        "name": "python-decorator",
+        "version": "4.2.1-2.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "798": {
+      "id": "798",
+      "name": "zip",
+      "version": "3.0-23.el8",
+      "kind": "binary",
+      "source": {
+        "id": "797",
+        "name": "zip",
+        "version": "3.0-23.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "220": {
+      "id": "220",
+      "name": "libffi",
+      "version": "3.1-22.el8",
+      "kind": "binary",
+      "source": {
+        "id": "219",
+        "name": "libffi",
+        "version": "3.1-22.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "140": {
+      "id": "140",
+      "name": "gnupg2",
+      "version": "2.2.20-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "139",
+        "name": "gnupg2",
+        "version": "2.2.20-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1068": {
+      "id": "1068",
+      "name": "io.dropwizard.metrics:metrics-core",
+      "version": "3.1.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "900": {
+      "id": "900",
+      "name": "org.elasticsearch.plugin:ingest-user-agent",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "128": {
+      "id": "128",
+      "name": "python3-inotify",
+      "version": "0.9.6-13.el8",
+      "kind": "binary",
+      "source": {
+        "id": "127",
+        "name": "python-inotify",
+        "version": "0.9.6-13.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "32": {
+      "id": "32",
+      "name": "expat",
+      "version": "2.2.5-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "31",
+        "name": "expat",
+        "version": "2.2.5-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "936": {
+      "id": "936",
+      "name": "commons-logging:commons-logging",
+      "version": "1.1.3",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "836": {
+      "id": "836",
+      "name": "org.apache.logging.log4j:log4j-1.2-api",
+      "version": "2.11.1.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "302": {
+      "id": "302",
+      "name": "libuser",
+      "version": "0.62-23.el8",
+      "kind": "binary",
+      "source": {
+        "id": "301",
+        "name": "libuser",
+        "version": "0.62-23.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "114": {
+      "id": "114",
+      "name": "python3-gobject-base",
+      "version": "3.28.3-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "113",
+        "name": "pygobject3",
+        "version": "3.28.3-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "182": {
+      "id": "182",
+      "name": "findutils",
+      "version": "1:4.6.0-20.el8",
+      "kind": "binary",
+      "source": {
+        "id": "181",
+        "name": "findutils",
+        "version": "4.6.0-20.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1246": {
+      "id": "1246",
+      "name": "com.fasterxml.jackson.core:jackson-annotations",
+      "version": "2.10.5.redhat-00002",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "782": {
+      "id": "782",
+      "name": "python3-setuptools",
+      "version": "39.2.0-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "187",
+        "name": "python-setuptools",
+        "version": "39.2.0-6.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "150": {
+      "id": "150",
+      "name": "curl",
+      "version": "7.61.1-22.el8",
+      "kind": "binary",
+      "source": {
+        "id": "149",
+        "name": "curl",
+        "version": "7.61.1-22.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "894": {
+      "id": "894",
+      "name": "org.elasticsearch.plugin:ingest-common",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "852": {
+      "id": "852",
+      "name": "org.apache.lucene:lucene-join",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "858": {
+      "id": "858",
+      "name": "org.apache.lucene:lucene-queries",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "284": {
+      "id": "284",
+      "name": "python3-libs",
+      "version": "3.6.8-41.el8",
+      "kind": "binary",
+      "source": {
+        "id": "97",
+        "name": "python3",
+        "version": "3.6.8-41.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "356": {
+      "id": "356",
+      "name": "python3-rpm",
+      "version": "4.14.3-19.el8",
+      "kind": "binary",
+      "source": {
+        "id": "151",
+        "name": "rpm",
+        "version": "4.14.3-19.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1108": {
+      "id": "1108",
+      "name": "org.opensaml:opensaml-storage-api",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "186": {
+      "id": "186",
+      "name": "libgcc",
+      "version": "8.5.0-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "45",
+        "name": "gcc",
+        "version": "8.5.0-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "192": {
+      "id": "192",
+      "name": "setup",
+      "version": "2.12.2-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "191",
+        "name": "setup",
+        "version": "2.12.2-6.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "880": {
+      "id": "880",
+      "name": "org.bouncycastle:bcpg-jdk15on",
+      "version": "1.61",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "48": {
+      "id": "48",
+      "name": "p11-kit",
+      "version": "0.23.22-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "47",
+        "name": "p11-kit",
+        "version": "0.23.22-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "780": {
+      "id": "780",
+      "name": "avahi-libs",
+      "version": "0.7-20.el8",
+      "kind": "binary",
+      "source": {
+        "id": "779",
+        "name": "avahi",
+        "version": "0.7-20.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1018": {
+      "id": "1018",
+      "name": "org.apache.httpcomponents:fluent-hc",
+      "version": "4.5.3",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "860": {
+      "id": "860",
+      "name": "org.apache.lucene:lucene-queryparser",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "560": {
+      "id": "560",
+      "name": "nss-softokn",
+      "version": "3.67.0-7.el8_5",
+      "kind": "binary",
+      "source": {
+        "id": "557",
+        "name": "nss",
+        "version": "3.67.0-7.el8_5",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "142": {
+      "id": "142",
+      "name": "python3-gpg",
+      "version": "1.13.1-9.el8",
+      "kind": "binary",
+      "source": {
+        "id": "141",
+        "name": "gpgme",
+        "version": "1.13.1-9.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1094": {
+      "id": "1094",
+      "name": "org.opensaml:opensaml-profile-api",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1072": {
+      "id": "1072",
+      "name": "io.netty:netty-buffer",
+      "version": "4.1.32.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "244": {
+      "id": "244",
+      "name": "keyutils-libs",
+      "version": "1.5.10-9.el8",
+      "kind": "binary",
+      "source": {
+        "id": "243",
+        "name": "keyutils",
+        "version": "1.5.10-9.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "60": {
+      "id": "60",
+      "name": "libtasn1",
+      "version": "4.13-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "59",
+        "name": "libtasn1",
+        "version": "4.13-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "280": {
+      "id": "280",
+      "name": "crypto-policies",
+      "version": "20210617-1.gitc776d3e.el8",
+      "kind": "binary",
+      "source": {
+        "id": "95",
+        "name": "crypto-policies",
+        "version": "20210617-1.gitc776d3e.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "234": {
+      "id": "234",
+      "name": "chkconfig",
+      "version": "1.19.1-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "233",
+        "name": "chkconfig",
+        "version": "1.19.1-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1090": {
+      "id": "1090",
+      "name": "org.opensaml:opensaml-core",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "838": {
+      "id": "838",
+      "name": "org.apache.logging.log4j:log4j-api",
+      "version": "2.11.1.redhat-00001",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1080": {
+      "id": "1080",
+      "name": "org.jctools:jctools-core",
+      "version": "2.1.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "200": {
+      "id": "200",
+      "name": "glibc-minimal-langpack",
+      "version": "2.28-164.el8",
+      "kind": "binary",
+      "source": {
+        "id": "15",
+        "name": "glibc",
+        "version": "2.28-164.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1036": {
+      "id": "1036",
+      "name": "com.fasterxml.jackson.core:jackson-databind",
+      "version": "2.10.5.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "790": {
+      "id": "790",
+      "name": "copy-jdk-configs",
+      "version": "4.0-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "789",
+        "name": "copy-jdk-configs",
+        "version": "4.0-2.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "1134": {
+      "id": "1134",
+      "name": "com.flipkart.zjsonpatch:zjsonpatch",
+      "version": "0.4.4",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "154": {
+      "id": "154",
+      "name": "libsolv",
+      "version": "0.7.19-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "153",
+        "name": "libsolv",
+        "version": "0.7.19-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "298": {
+      "id": "298",
+      "name": "gobject-introspection",
+      "version": "1.56.1-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "297",
+        "name": "gobject-introspection",
+        "version": "1.56.1-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "584": {
+      "id": "584",
+      "name": "openssl",
+      "version": "1:1.1.1k-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "93",
+        "name": "openssl",
+        "version": "1.1.1k-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "812": {
+      "id": "812",
+      "name": "org.elasticsearch:org.elasticsearch#secure-sm;6.8.1.redhat-00012",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "952": {
+      "id": "952",
+      "name": "org.elasticsearch.plugin:repository-url",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "364": {
+      "id": "364",
+      "name": "gdb-gdbserver",
+      "version": "8.2-16.el8",
+      "kind": "binary",
+      "source": {
+        "id": "363",
+        "name": "gdb",
+        "version": "8.2-16.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "232": {
+      "id": "232",
+      "name": "lua-libs",
+      "version": "5.3.4-12.el8",
+      "kind": "binary",
+      "source": {
+        "id": "231",
+        "name": "lua",
+        "version": "5.3.4-12.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "992": {
+      "id": "992",
+      "name": "commons-lang:commons-lang",
+      "version": "2.4",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "180": {
+      "id": "180",
+      "name": "tar",
+      "version": "2:1.30-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "179",
+        "name": "tar",
+        "version": "1.30-5.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "4": {
+      "id": "4",
+      "name": "python3-pip-wheel",
+      "version": "9.0.3-20.el8",
+      "kind": "binary",
+      "source": {
+        "id": "3",
+        "name": "python-pip",
+        "version": "9.0.3-20.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "902": {
+      "id": "902",
+      "name": "org.antlr:antlr4-runtime",
+      "version": "4.5.1.1-redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1136": {
+      "id": "1136",
+      "name": "org.elasticsearch.plugin.ingest:openshift-ingest-plugin",
+      "version": "6.8.1.0-redhat-00003",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "74": {
+      "id": "74",
+      "name": "libfdisk",
+      "version": "2.32.1-28.el8",
+      "kind": "binary",
+      "source": {
+        "id": "35",
+        "name": "util-linux",
+        "version": "2.32.1-28.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "800": {
+      "id": "800",
+      "name": "hostname",
+      "version": "3.20-6.el8",
+      "kind": "binary",
+      "source": {
+        "id": "799",
+        "name": "hostname",
+        "version": "3.20-6.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "88": {
+      "id": "88",
+      "name": "libsigsegv",
+      "version": "2.11-5.el8",
+      "kind": "binary",
+      "source": {
+        "id": "87",
+        "name": "libsigsegv",
+        "version": "2.11-5.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "214": {
+      "id": "214",
+      "name": "libzstd",
+      "version": "1.4.4-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "213",
+        "name": "zstd",
+        "version": "1.4.4-1.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "12": {
+      "id": "12",
+      "name": "pcre2",
+      "version": "10.32-2.el8",
+      "kind": "binary",
+      "source": {
+        "id": "11",
+        "name": "pcre2",
+        "version": "10.32-2.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "932": {
+      "id": "932",
+      "name": "org.elasticsearch.plugin:rank-eval",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "898": {
+      "id": "898",
+      "name": "org.jruby.joni:joni",
+      "version": "2.1.6",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "816": {
+      "id": "816",
+      "name": "com.carrotsearch:hppc",
+      "version": "0.7.1.redhat-00002",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "878": {
+      "id": "878",
+      "name": "com.tdunning:t-digest",
+      "version": "3.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "822": {
+      "id": "822",
+      "name": "com.fasterxml.jackson.dataformat:jackson-dataformat-smile",
+      "version": "2.10.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "968": {
+      "id": "968",
+      "name": "io.netty:netty-transport",
+      "version": "4.1.63.Final",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "42": {
+      "id": "42",
+      "name": "libblkid",
+      "version": "2.32.1-28.el8",
+      "kind": "binary",
+      "source": {
+        "id": "35",
+        "name": "util-linux",
+        "version": "2.32.1-28.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "818": {
+      "id": "818",
+      "name": "com.fasterxml.jackson.core:jackson-core",
+      "version": "2.10.5",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1014": {
+      "id": "1014",
+      "name": "org.elasticsearch.client:elasticsearch-rest-high-level-client",
+      "version": "6.8.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "104": {
+      "id": "104",
+      "name": "util-linux",
+      "version": "2.32.1-28.el8",
+      "kind": "binary",
+      "source": {
+        "id": "35",
+        "name": "util-linux",
+        "version": "2.32.1-28.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "792": {
+      "id": "792",
+      "name": "tzdata-java",
+      "version": "2021e-1.el8",
+      "kind": "binary",
+      "source": {
+        "id": "1",
+        "name": "tzdata",
+        "version": "2021e-1.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "888": {
+      "id": "888",
+      "name": "org.elasticsearch.plugin:analysis-common",
+      "version": "6.8.1.redhat-00012",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1004": {
+      "id": "1004",
+      "name": "org.apache.cxf:cxf-core",
+      "version": "3.2.2.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "848": {
+      "id": "848",
+      "name": "org.apache.lucene:lucene-grouping",
+      "version": "7.7.0",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "788": {
+      "id": "788",
+      "name": "alsa-lib",
+      "version": "1.2.5-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "787",
+        "name": "alsa-lib",
+        "version": "1.2.5-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "1058": {
+      "id": "1058",
+      "name": "kafka-clients-1.0.1.redhat",
+      "version": "7",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1124": {
+      "id": "1124",
+      "name": "org.codelibs.elasticsearch.module:transport-netty4",
+      "version": "6.8.1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "294": {
+      "id": "294",
+      "name": "librhsm",
+      "version": "0.0.3-4.el8",
+      "kind": "binary",
+      "source": {
+        "id": "293",
+        "name": "librhsm",
+        "version": "0.0.3-4.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "340": {
+      "id": "340",
+      "name": "libdnf",
+      "version": "0.63.0-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "155",
+        "name": "libdnf",
+        "version": "0.63.0-3.el8",
+        "kind": "source"
+      },
+      "arch": "x86_64"
+    },
+    "174": {
+      "id": "174",
+      "name": "python3-dnf-plugins-core",
+      "version": "4.0.21-3.el8",
+      "kind": "binary",
+      "source": {
+        "id": "173",
+        "name": "dnf-plugins-core",
+        "version": "4.0.21-3.el8",
+        "kind": "source"
+      },
+      "arch": "noarch"
+    },
+    "832": {
+      "id": "832",
+      "name": "net.sf.jopt-simple:jopt-simple",
+      "version": "5.0.2",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1098": {
+      "id": "1098",
+      "name": "org.opensaml:opensaml-saml-impl",
+      "version": "3.3.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    },
+    "1000": {
+      "id": "1000",
+      "name": "test-package-with-vuln",
+      "version": "1.1.0.redhat-1",
+      "kind": "binary",
+      "source": {
+        "id": "369",
+        "name": "",
+        "version": ""
+      }
+    }
+  },
+  "distributions": {
+    "1": {
+      "id": "1",
+      "did": "rhel",
+      "name": "Red Hat Enterprise Linux Server",
+      "version": "8",
+      "version_code_name": "",
+      "version_id": "8",
+      "arch": "",
+      "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+      "pretty_name": "Red Hat Enterprise Linux Server 8"
+    }
+  },
+  "repository": {
+    "2": {
+      "id": "2",
+      "name": "cpe:/o:redhat:rhel:8.3::baseos",
+      "key": "rhel-cpe-repository",
+      "cpe": "cpe:2.3:o:redhat:rhel:8.3:*:baseos:*:*:*:*:*"
+    },
+    "3": {
+      "id": "3",
+      "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+      "key": "rhel-cpe-repository",
+      "cpe": "cpe:2.3:a:redhat:enterprise_linux:8:*:appstream:*:*:*:*:*"
+    },
+    "4": {
+      "id": "4",
+      "name": "cpe:/a:redhat:rhel:8.3::appstream",
+      "key": "rhel-cpe-repository",
+      "cpe": "cpe:2.3:a:redhat:rhel:8.3:*:appstream:*:*:*:*:*"
+    },
+    "5": {
+      "id": "5",
+      "name": "Red Hat Container Catalog",
+      "uri": "https://catalog.redhat.com/software/containers/explore"
+    },
+    "10": {
+      "id": "10",
+      "name": "maven",
+      "uri": "https://repo1.maven.apache.org/maven2"
+    },
+    "1": {
+      "id": "1",
+      "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+      "key": "rhel-cpe-repository",
+      "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:baseos:*:*:*:*:*"
+    }
+  },
+  "environments": {
+    "16": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "162": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1090": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-core-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "18": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "832": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/jopt-simple-5.0.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1110": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-xmlsec-api-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "796": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "968": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/transport-netty4/netty-transport-4.1.63.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "772": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "204": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1064": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/log4j-slf4j-impl-2.11.1.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "850": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-highlighter-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1118": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/slf4j-api-1.7.25.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "134": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "844": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-backward-codecs-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "62": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "902": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-expression/antlr4-runtime-4.5.1.1-redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "828": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/jna-4.5.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "332": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1136": [
+      {
+        "package_db": "jar:usr/share/elasticsearch/plugins/openshift-ingest-plugin/openshift-ingest-plugin-6.8.1.0-redhat-00003.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1038": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/java-saml-2.3.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "972": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/tribe/tribe-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "2": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "792": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "824": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/jackson-dataformat-yaml-2.10.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "776": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "846": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-core-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "814": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/elasticsearch-x-content-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "44": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1124": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/transport-netty4-client-6.8.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "874": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/snakeyaml-1.17.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "276": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1034": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/jackson-annotations-2.10.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "48": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "146": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "168": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "918": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-painless/antlr4-runtime-4.5.3.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "304": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "324": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "330": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "982": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/bcprov-jdk15on-1.67.0.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "152": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "314": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "876": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/spatial4j-0.7.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "76": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "264": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "166": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "912": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-expression/lucene-expressions-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "808": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/elasticsearch-core-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "214": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "188": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1088": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opendistro_security-0.10.1.2-redhat-00006.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "10": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "252": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "212": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "926": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/mapper-extras/mapper-extras-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "934": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/reindex/commons-codec-1.10.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1140": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/prometheus-exporter/simpleclient-0.6.0.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "216": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "572": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "68": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "900": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-user-agent/ingest-user-agent-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "880": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/tools/plugin-cli/bcpg-jdk15on-1.61.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "316": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "370": [
+      {
+        "package_db": "root/buildinfo/Dockerfile-ubi8-8.5-200",
+        "introduced_in": "sha256:63f9f4c31162a6a5dacd999a0dc65007e15b2ca6b2d9360a1234c27de12e7f38",
+        "distribution_id": "",
+        "repository_ids": [
+          "5"
+        ]
+      }
+    ],
+    "1000": [
+      {
+        "package_db": "root/somewhere",
+        "introduced_in": "sha256:63f9f4c31162a6a5dacd999a0dc65007e15b2ca6b2d9360a1234c27de12e7f38",
+        "distribution_id": "",
+        "repository_ids": [
+          "5"
+        ]
+      }
+    ],
+    "786": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "576": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1050": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/json-flattener-0.5.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "882": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/tools/plugin-cli/bcprov-jdk15on-1.61.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "336": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1242": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-geoip/geoip2-2.9.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "108": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "888": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/analysis-common/analysis-common-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "114": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1112": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-xmlsec-impl-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "878": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/t-digest-3.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "92": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1036": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-geoip/jackson-databind-2.10.5.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "958": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/transport-netty4/netty-codec-http-4.1.63.Final-redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "798": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "24": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "996": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/commons-logging-1.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "960": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/transport-netty4/netty-common-4.1.63.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "806": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/elasticsearch-cli-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1132": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/xmlsec-2.0.7.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "338": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "34": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "350": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "8": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "966": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/transport-netty4/netty-resolver-4.1.63.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1102": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-security-impl-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "894": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-common/ingest-common-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1104": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-soap-api-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "14": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "228": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "366": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "28": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "986": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/commons-cli-1.3.1.redhat-2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "328": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "286": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1044": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/jjwt-api-0.10.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "942": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/reindex/httpasyncclient-4.1.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1058": [
+      {
+        "package_db": "file:usr/share/elasticsearch/plugins/opendistro_security/kafka-clients-1.0.1.redhat-7.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "778": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "54": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "994": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/commons-lang3-3.4.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "284": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "206": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "50": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "292": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "774": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1026": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/httpclient-cache-4.5.3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "38": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1070": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/minimal-json-0.9.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "928": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/parent-join/parent-join-client-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "580": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1074": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/netty-codec-4.1.32.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "278": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "340": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "160": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "322": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "852": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-join-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "872": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/plugin-classloader-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "222": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1042": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/java-support-7.3.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1086": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/netty-transport-4.1.32.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "916": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-mustache/lang-mustache-client-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "42": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "280": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "256": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "804": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/elasticsearch-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "224": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "104": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "56": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "306": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "98": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "294": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1138": [
+      {
+        "package_db": "jar:usr/share/elasticsearch/plugins/prometheus-exporter/prometheus-exporter-6.8.1.2-redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "990": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/commons-collections-3.2.2.redhat-2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "870": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-suggest-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "318": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "298": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1244": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-geoip/ingest-geoip-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "4": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1054": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/json-smart-2.3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "320": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "52": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "950": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/reindex/reindex-client-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "194": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "584": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "364": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "862": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-sandbox-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "142": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "128": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "174": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "820": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/jackson-dataformat-cbor-2.10.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "956": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/transport-netty4/netty-codec-4.1.63.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1096": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-saml-api-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "156": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "208": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1100": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-security-api-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "272": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "578": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "920": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-painless/asm-debug-all-5.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "908": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-expression/asm-tree-5.0.4.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1076": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/netty-codec-http-4.1.32.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "218": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "310": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1012": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/elasticsearch-rest-client-6.8.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "932": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/rank-eval/rank-eval-client-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "182": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "118": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "74": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "802": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/HdrHistogram-2.1.9.redhat-00004.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "362": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "106": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "32": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "558": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "36": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1016": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/error_prone_annotations-2.1.3.redhat-00002.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "346": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "372": [
+      {
+        "package_db": "root/buildinfo/Dockerfile-ubi8-8.5-200",
+        "introduced_in": "sha256:63f9f4c31162a6a5dacd999a0dc65007e15b2ca6b2d9360a1234c27de12e7f38",
+        "distribution_id": "",
+        "repository_ids": [
+          "5"
+        ]
+      }
+    ],
+    "96": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1028": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/httpcore-4.4.6.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "154": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "344": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1006": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/cxf-rt-rs-json-basic-3.2.2.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "190": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "906": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-expression/asm-commons-5.0.4.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "132": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "274": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "6": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "896": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-common/jcodings-1.0.12.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "826": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/java-version-checker-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "22": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "86": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "100": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "192": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1126": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/velocity-1.7.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "184": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "26": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "854": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-memory-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1114": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/parent-join-client-6.8.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "866": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-spatial-extras-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "64": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1120": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/snappy-java-1.1.4.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "116": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1068": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/metrics-core-3.1.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "914": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-mustache/compiler-0.9.3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "936": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/reindex/commons-logging-1.1.3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "948": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/reindex/httpcore-nio-4.4.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1014": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/elasticsearch-rest-high-level-client-6.8.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "70": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1084": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/netty-resolver-4.1.32.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "102": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "810": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/elasticsearch-launchers-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "898": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-common/joni-2.1.6.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1134": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/zjsonpatch-0.4.4.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "308": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1106": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-soap-impl-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "150": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "20": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "574": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "790": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1072": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/netty-buffer-4.1.32.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "890": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-common/elasticsearch-dissect-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "892": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-common/elasticsearch-grok-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "970": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/transport-netty4/transport-netty4-client-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1128": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/woodstox-core-5.0.3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "88": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "856": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-misc-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1056": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/jsr305-3.0.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "356": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "282": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "910": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-expression/lang-expression-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "72": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "976": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/aggs-matrix-stats-client-6.8.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "830": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/joda-time-2.10.1.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "930": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/percolator/percolator-client-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "12": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "954": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/transport-netty4/netty-buffer-4.1.63.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "266": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "962": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/transport-netty4/netty-common-4.1.63.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "800": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "126": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1108": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-storage-api-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1004": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/cxf-core-3.2.2.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "840": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/log4j-core-2.11.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1250": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-geoip/maxmind-db-1.2.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "30": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "210": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "198": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "80": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "180": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "78": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1052": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/json-path-2.4.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "812": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/elasticsearch-secure-sm-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "60": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1094": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-profile-api-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "938": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/reindex/elasticsearch-rest-client-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "940": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/reindex/elasticsearch-ssl-config-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "258": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "140": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "250": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "836": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/log4j-1.2-api-2.11.1.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "178": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "84": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "978": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/animal-sniffer-annotations-1.14.0.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "268": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "784": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "568": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "46": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "288": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1078": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/netty-common-4.1.32.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "170": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "94": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "232": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "82": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "244": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "164": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "834": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/jts-core-1.15.0.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1142": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/prometheus-exporter/simpleclient_common-0.6.0.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "570": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1046": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/jjwt-impl-0.10.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1122": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/stax2-api-3.1.4.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "358": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "300": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1060": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/lang-mustache-client-6.8.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1246": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/ingest-geoip/jackson-annotations-2.10.5.redhat-00002.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "246": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "238": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "186": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "302": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "848": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-grouping-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "202": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "144": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "984": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/checker-qual-2.0.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1066": [
+      {
+        "package_db": "jar:usr/share/elasticsearch/plugins/opendistro_security/lz4-java-1.4.0.redhat-3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1024": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/httpclient-4.5.3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "230": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "342": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1082": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/netty-handler-4.1.32.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "858": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-queries-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "260": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "992": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/commons-lang-2.4.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "998": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/commons-text-1.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "352": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "240": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "58": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "120": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "924": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-painless/lang-painless-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "974": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/accessors-smart-1.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "922": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-painless/elasticsearch-scripting-painless-spi-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "838": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/log4j-api-2.11.1.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1018": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/fluent-hc-4.5.3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "148": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1002": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/cryptacular-1.1.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "296": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "348": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "196": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1098": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-saml-impl-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "248": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "816": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/hppc-0.7.1.redhat-00002.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "560": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "138": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "964": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/transport-netty4/netty-handler-4.1.63.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "326": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "868": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-spatial3d-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "40": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1130": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/xmlschema-core-2.2.3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "842": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-analyzers-common-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "818": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/jackson-core-2.10.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "822": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/jackson-dataformat-smile-2.10.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "112": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "884": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/tools/plugin-cli/elasticsearch-plugin-cli-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1092": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/opensaml-messaging-api-3.3.0.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "788": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "270": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "354": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "290": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1116": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/rank-eval-client-6.8.1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "176": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1062": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/ldaptive-1.2.3.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "944": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/reindex/httpclient-4.5.2.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1080": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/netty-common-4.1.32.Final.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "860": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-queryparser-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "220": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "794": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "122": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "886": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/aggs-matrix-stats/aggs-matrix-stats-client-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "564": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "172": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "226": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "90": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "236": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "904": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/lang-expression/asm-5.0.4.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "1010": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/cxf-rt-security-3.2.2.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "136": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "952": [
+      {
+        "package_db": "jar:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/repository-url/repository-url-6.8.1.redhat-00012.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "782": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "864": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/lib/lucene-spatial-7.7.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "946": [
+      {
+        "package_db": "maven:var/tmp/elasticsearch-6.8.1.redhat-00012/modules/reindex/httpcore-4.4.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "110": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "586": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1020": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/guava-25.1.0.jre-redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "562": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "582": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "234": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "312": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1040": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/java-saml-core-2.3.0.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "254": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "124": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "66": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "242": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "130": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1048": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/jjwt-jackson-0.10.5.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "368": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "360": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "334": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "200": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "566": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "780": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1008": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/cxf-rt-rs-security-jose-3.2.2.redhat-1.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "158": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ],
+    "1032": [
+      {
+        "package_db": "maven:usr/share/elasticsearch/plugins/opendistro_security/j2objc-annotations-1.1.0.redhat-00001.jar",
+        "introduced_in": "sha256:1d36a59122cc81b205d83b525b9a8baaf1b20035e8cb4e8610125eb5d87d50c9",
+        "distribution_id": "",
+        "repository_ids": [
+          "10"
+        ]
+      }
+    ],
+    "262": [
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "1",
+        "repository_ids": [
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      {
+        "package_db": "bdb:var/lib/rpm",
+        "introduced_in": "sha256:ce3c6836540f978b55c511d236429e26b7a45f5a6f1204ab8d4378afaf77332f",
+        "distribution_id": "",
+        "repository_ids": null
+      }
+    ]
+  },
+  "vulnerabilities": {
+    "3690333": {
+      "id": "3690333",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0894: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: Heap-based buffer overflow in block_insert() in src/ops.c (CVE-2022-0261)\n\n* vim: Heap-based buffer overflow in utf_head_off() in mbyte.c (CVE-2022-0318)\n\n* vim: Heap-based buffer overflow in init_ccline() in ex_getln.c (CVE-2022-0359)\n\n* vim: Illegal memory access when copying lines in visual mode leads to heap buffer overflow (CVE-2022-0361)\n\n* vim: Heap-based buffer overflow in getexmodeline() in ex_getln.c (CVE-2022-0392)\n\n* vim: Use after free in src/ex_cmds.c (CVE-2022-0413)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0894 https://access.redhat.com/security/cve/CVE-2022-0261 https://access.redhat.com/security/cve/CVE-2022-0318 https://access.redhat.com/security/cve/CVE-2022-0359 https://access.redhat.com/security/cve/CVE-2022-0361 https://access.redhat.com/security/cve/CVE-2022-0392 https://access.redhat.com/security/cve/CVE-2022-0413",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-16.el8_5.12",
+      "arch_op": "pattern match"
+    },
+    "4209498": {
+      "id": "4209498",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:8638: krb5 security update (Important)",
+      "description": "Kerberos is a network authentication system, which can improve the security of your network by eliminating the insecure practice of sending passwords over the network in unencrypted form. It allows clients and servers to authenticate to each other with the help of a trusted third party, the Kerberos key distribution center (KDC).\n\nSecurity Fix(es):\n\n* krb5: integer overflow vulnerabilities in PAC parsing (CVE-2022-42898)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-11-28T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:8638 https://access.redhat.com/security/cve/CVE-2022-42898",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "krb5-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.18.2-22.el8_7",
+      "arch_op": "pattern match"
+    },
+    "3920785": {
+      "id": "3920785",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5317: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows in xmlBuf and xmlBuffer lead to out-of-bounds write (CVE-2022-29824)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5317 https://access.redhat.com/security/cve/CVE-2022-29824",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-13.el8_6.1",
+      "arch_op": "pattern match"
+    },
+    "137459": {
+      "id": "137459",
+      "updater": "osv/maven",
+      "name": "GHSA-3x8x-79m2-3w2w",
+      "description": "jackson-databind possible Denial of Service if using JDK serialization to serialize JsonNode",
+      "issued": "2023-03-19T00:30:25Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2021-46877 https://github.com/FasterXML/jackson-databind/issues/3328 https://github.com/FasterXML/jackson-databind/commit/3ccde7d938fea547e598fdefe9a82cff37fed5cb https://github.com/FasterXML/jackson-databind https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12.6 https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13.1 https://groups.google.com/g/jackson-user/c/OsBsirPM_Vw",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "com.fasterxml.jackson.core:jackson-databind",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.12.6&introduced=2.10.0"
+    },
+    "4308422": {
+      "id": "4308422",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0835: python-setuptools security update (Moderate)",
+      "description": "The python-setuptools package provides a collection of enhancements to Python distribution utilities allowing convenient building and distribution of Python packages.\n\nSecurity Fix(es):\n\n* pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py (CVE-2022-40897)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0835 https://access.redhat.com/security/cve/CVE-2022-40897",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-setuptools-wheel",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:39.2.0-6.el8_7.1"
+    },
+    "4046865": {
+      "id": "4046865",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6878: expat security update (Important)",
+      "description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: a use-after-free in the doContent function in xmlparse.c (CVE-2022-40674)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-11T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6878 https://access.redhat.com/security/cve/CVE-2022-40674",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "expat",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.5-8.el8_6.3",
+      "arch_op": "pattern match"
+    },
+    "137797": {
+      "id": "137797",
+      "updater": "osv/maven",
+      "name": "GHSA-493p-pfq6-5258",
+      "description": "json-smart Uncontrolled Recursion vulnerabilty",
+      "issued": "2023-03-23T20:32:03Z",
+      "links": "https://github.com/oswaldobapvicjr/jsonmerge/security/advisories/GHSA-493p-pfq6-5258 https://nvd.nist.gov/vuln/detail/CVE-2023-1370 https://github.com/netplex/json-smart-v2/issues/137 https://github.com/netplex/json-smart-v2/commit/5b3205d051952d3100aa0db1535f6ba6226bd87a https://github.com/netplex/json-smart-v2/commit/e2791ae506a57491bc856b439d706c81e45adcf8 https://github.com/oswaldobapvicjr/jsonmerge https://research.jfrog.com/vulnerabilities/stack-exhaustion-in-json-smart-leads-to-denial-of-service-when-parsing-malformed-json-xray-427633/ https://security.snyk.io/vuln/SNYK-JAVA-NETMINIDEV-3369748 https://www.cve.org/CVERecord?id=CVE-2023-1370",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "net.minidev:json-smart",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.4.9"
+    },
+    "3641368": {
+      "id": "3641368",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0658: cyrus-sasl security update (Important)",
+      "description": "The cyrus-sasl packages contain the Cyrus implementation of Simple Authentication and Security Layer (SASL). SASL is a method for adding authentication support to connection-based protocols.\n\nSecurity Fix(es):\n\n* cyrus-sasl: failure to properly escape SQL input allows an attacker to execute arbitrary SQL commands (CVE-2022-24407)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-23T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0658 https://access.redhat.com/security/cve/CVE-2022-24407",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "cyrus-sasl-lib",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.1.27-6.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4435315": {
+      "id": "4435315",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:2963: curl security and bug fix update (Low)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: Incorrect handling of control code characters in cookies (CVE-2022-35252)\n\n* curl: Use-after-free triggered by an HTTP proxy deny response (CVE-2022-43552)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.8 Release Notes linked from the References section.",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:2963 https://access.redhat.com/security/cve/CVE-2022-35252 https://access.redhat.com/security/cve/CVE-2022-43552",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8",
+      "arch_op": "pattern match"
+    },
+    "149795": {
+      "id": "149795",
+      "updater": "osv/maven",
+      "name": "GHSA-jjjh-jjxp-wpff",
+      "description": "Uncontrolled Resource Consumption in Jackson-databind",
+      "issued": "2022-10-03T00:00:31Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-42003 https://github.com/FasterXML/jackson-databind/issues/3590 https://github.com/FasterXML/jackson-databind/issues/3627 https://github.com/FasterXML/jackson-databind/commit/0e37a39502439ecbaa1a5b5188387c01bf7f7fa1 https://github.com/FasterXML/jackson-databind/commit/7ba9ac5b87a9d6ac0d2815158ecbeb315ad4dcdc https://github.com/FasterXML/jackson-databind/commit/cd090979b7ea78c75e4de8a4aed04f7e9fa8deea https://github.com/FasterXML/jackson-databind/commit/d499f2e7bbc5ebd63af11e1f5cf1989fa323aa45 https://github.com/FasterXML/jackson-databind/commit/d78d00ee7b5245b93103fef3187f70543d67ca33 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=51020 https://github.com/FasterXML/jackson-databind https://github.com/FasterXML/jackson-databind/blob/2.13/release-notes/VERSION-2.x https://github.com/FasterXML/jackson-databind/commits/jackson-databind-2.4.0-rc1?after=75b97b8519f0d50c62523ad85170d80a197a2c86+174&branch=jackson-databind-2.4.0-rc1&qualified_name=refs%2Ftags%2Fjackson-databind-2.4.0-rc1 https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.13.4.1...jackson-databind-2.13.4.2 https://lists.debian.org/debian-lts-announce/2022/11/msg00035.html https://security.gentoo.org/glsa/202210-21 https://security.netapp.com/advisory/ntap-20221124-0004/ https://www.debian.org/security/2022/dsa-5283",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "com.fasterxml.jackson.core:jackson-databind",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.12.7.1&introduced=2.4.0-rc1"
+    },
+    "4575276": {
+      "id": "4575276",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4175: java-11-openjdk security and bug fix update (Moderate)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: ZIP file parsing infinite loop (8302483) (CVE-2023-22036)\n\n* OpenJDK: weakness in AES implementation (8308682) (CVE-2023-22041)\n\n* OpenJDK: improper handling of slash characters in URI-to-path conversion (8305312) (CVE-2023-22049)\n\n* harfbuzz: OpenJDK: O(n^2) growth via consecutive marks (CVE-2023-25193)\n\n* OpenJDK: HTTP client insufficient file name validation (8302475) (CVE-2023-22006)\n\n* OpenJDK: array indexing integer overflow issue (8304468) (CVE-2023-22045)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* A virtual machine crash was observed in JDK 11.0.19 when executing the GregorianCalender.computeTime() method (JDK-8307683). It was found\nthat although the root cause of the crash is an old issue, a recent fix for a rare issue in the C2 compiler (JDK-8297951) made the crash much more likely. To mitigate this, the fix has been reverted in JDK 11.0.20 and will be reapplied once JDK-8307683 is resolved. (RHBZ#2222493)\n\n* Prepare for the next quarterly OpenJDK upstream release (2023-07, 11.0.20) [rhel-8] (BZ#2223101)",
+      "issued": "2023-07-20T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4175 https://access.redhat.com/security/cve/CVE-2023-22006 https://access.redhat.com/security/cve/CVE-2023-22036 https://access.redhat.com/security/cve/CVE-2023-22041 https://access.redhat.com/security/cve/CVE-2023-22045 https://access.redhat.com/security/cve/CVE-2023-22049 https://access.redhat.com/security/cve/CVE-2023-25193",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.20.0.8-2.el8",
+      "arch_op": "pattern match"
+    },
+    "4320940": {
+      "id": "4320940",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1140: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP multi-header compression denial of service (CVE-2023-23916)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1140 https://access.redhat.com/security/cve/CVE-2023-23916",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-25.el8_7.3",
+      "arch_op": "pattern match"
+    },
+    "140254": {
+      "id": "140254",
+      "updater": "osv/maven",
+      "name": "GHSA-6xx3-rg99-gc3p",
+      "description": "Timing based private key exposure in Bouncy Castle",
+      "issued": "2021-08-13T15:22:31Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2020-15522 https://github.com/bcgit/bc-csharp/wiki/CVE-2020-15522 https://github.com/bcgit/bc-java/wiki/CVE-2020-15522 https://security.netapp.com/advisory/ntap-20210622-0007/ https://www.bouncycastle.org/releasenotes.html",
+      "severity": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.bouncycastle:bcprov-jdk15on",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.66"
+    },
+    "4055140": {
+      "id": "4055140",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7089: libksba security update (Important)",
+      "description": "KSBA (pronounced Kasbah) is a library to make X.509 certificates as well as the CMS easily accessible by other applications.  Both specifications are building blocks of S/MIME and TLS.\n\nSecurity Fix(es):\n\n* libksba: integer overflow may lead to remote code execution (CVE-2022-3515)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-24T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7089 https://access.redhat.com/security/cve/CVE-2022-3515",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "libksba",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.3.5-8.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3716723": {
+      "id": "3716723",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1065: openssl security update (Important)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Infinite loop in BN_mod_sqrt() reachable when parsing certificates (CVE-2022-0778)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-28T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1065 https://access.redhat.com/security/cve/CVE-2022-0778",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "openssl-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-6.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4588813": {
+      "id": "4588813",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4520: python-requests security update (Moderate)",
+      "description": "The python-requests package contains a library designed to make HTTP requests easy for developers.\n\nSecurity Fix(es):\n\n* python-requests: Unintended leak of Proxy-Authorization header (CVE-2023-32681)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4520 https://access.redhat.com/security/cve/CVE-2023-32681",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-requests",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.20.0-3.el8_8"
+    },
+    "4236413": {
+      "id": "4236413",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-common",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1"
+    },
+    "3716799": {
+      "id": "3716799",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1065: openssl security update (Important)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Infinite loop in BN_mod_sqrt() reachable when parsing certificates (CVE-2022-0778)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-28T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1065 https://access.redhat.com/security/cve/CVE-2022-0778",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "openssl-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-6.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4284065": {
+      "id": "4284065",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0103: expat security update (Moderate)",
+      "description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: use-after free caused by overeager destruction of a shared DTD in\nXML_ExternalEntityParserCreate (CVE-2022-43680)\n\nFor more details about the security issue(s), including the impact, a CVSS\nscore, acknowledgments, and other related information, refer to the CVE page(s)\nlisted in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0103 https://access.redhat.com/security/cve/CVE-2022-43680",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "expat",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.5-10.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "3712453": {
+      "id": "3712453",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0896: glibc security update (Moderate)",
+      "description": "The glibc packages provide the standard C libraries (libc), POSIX thread libraries (libpthread), standard math libraries (libm), and the name service cache daemon (nscd) used by multiple programs on the system. Without these libraries, the Linux system cannot function correctly.\n\nSecurity Fix(es):\n\n* glibc: Off-by-one buffer overflow/underflow in getcwd() (CVE-2021-3999)\n\n* glibc: Stack-based buffer overflow in svcunix_create via long pathnames (CVE-2022-23218)\n\n* glibc: Stack-based buffer overflow in sunrpc clnt_create via a long pathname (CVE-2022-23219)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0896 https://access.redhat.com/security/cve/CVE-2021-3999 https://access.redhat.com/security/cve/CVE-2022-23218 https://access.redhat.com/security/cve/CVE-2022-23219",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "glibc-minimal-langpack",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.28-164.el8_5.3",
+      "arch_op": "pattern match"
+    },
+    "148367": {
+      "id": "148367",
+      "updater": "osv/maven",
+      "name": "GHSA-hhhw-99gj-p3c3",
+      "description": "snakeYAML before 1.31 vulnerable to Denial of Service due to Out-of-bounds Write",
+      "issued": "2022-09-06T00:00:27Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-38750 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/issues/526/stackoverflow-oss-fuzz-47027 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47027 https://lists.debian.org/debian-lts-announce/2022/10/msg00001.html https://security.gentoo.org/glsa/202305-28",
+      "severity": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.yaml:snakeyaml",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.31"
+    },
+    "4590620": {
+      "id": "4590620",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4529: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: NULL dereference in xmlSchemaFixupComplexType (CVE-2023-28484)\n\n* libxml2: Hashing of empty dict strings isn't deterministic (CVE-2023-29469)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4529 https://access.redhat.com/security/cve/CVE-2023-28484 https://access.redhat.com/security/cve/CVE-2023-29469",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-16.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "141290": {
+      "id": "141290",
+      "updater": "osv/maven",
+      "name": "GHSA-8489-44mv-ggj8",
+      "description": "Improper Input Validation and Injection in Apache Log4j2",
+      "issued": "2022-01-04T16:14:20Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2021-44832 https://cert-portal.siemens.com/productcert/pdf/ssa-784507.pdf https://github.com/apache/logging-log4j2 https://issues.apache.org/jira/browse/LOG4J2-3293 https://lists.apache.org/thread/s1o5vlo78ypqxnzn6p8zf6t9shtq5143 https://lists.debian.org/debian-lts-announce/2021/12/msg00036.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EVV25FXL4FU5X6X5BSL7RLQ7T6F65MRA/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/T57MPJUW3MA6QGWZRTMCHHMMPQNVKGFC/ https://security.netapp.com/advisory/ntap-20220104-0001/ https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html http://www.openwall.com/lists/oss-security/2021/12/28/1",
+      "severity": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.apache.logging.log4j:log4j-core",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.12.4&introduced=2.4"
+    },
+    "4559245": {
+      "id": "4559245",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3839: libssh security update (Moderate)",
+      "description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nSecurity Fix(es):\n\n* libssh: NULL pointer dereference during rekeying with algorithm guessing (CVE-2023-1667)\n\n* libssh: authorization bypass in pki_verify_data_signature (CVE-2023-2283)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3839 https://access.redhat.com/security/cve/CVE-2023-1667 https://access.redhat.com/security/cve/CVE-2023-2283",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libssh",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:0.9.6-10.el8_8",
+      "arch_op": "pattern match"
+    },
+    "3553907": {
+      "id": "3553907",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2021:4587: gcc security update (Moderate)",
+      "description": "The gcc packages provide compilers for C, C++, Java, Fortran, Objective C, and Ada 95 GNU, as well as related support libraries.\n\nSecurity Fix(es):\n\n* Developer environment: Unicode's bidirectional (BiDi) override characters can cause trojan source attacks (CVE-2021-42574)\n\nThe following changes were introduced in gcc in order to facilitate detection of BiDi Unicode characters:\n\nThis update implements a new warning option -Wbidirectional to warn about possibly dangerous bidirectional characters.\n\nThere are three levels of warning supported by gcc:\n\"-Wbidirectional=unpaired\", which warns about improperly terminated BiDi contexts. (This is the default.)\n\"-Wbidirectional=none\", which turns the warning off.\n\"-Wbidirectional=any\", which warns about any use of bidirectional characters.\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2021-11-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2021:4587 https://access.redhat.com/security/cve/CVE-2021-42574",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libstdc++",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:8.5.0-4.el8_5",
+      "arch_op": "pattern match"
+    },
+    "2108904": {
+      "id": "2108904",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHBA-2022:2065: libtirpc bug fix and enhancement update (Moderate)",
+      "description": "For detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHBA-2022:2065 https://access.redhat.com/security/cve/CVE-2021-46828",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libtirpc",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.1.4-6.el8",
+      "arch_op": "pattern match"
+    },
+    "4321514": {
+      "id": "4321514",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss-softokn",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "136158": {
+      "id": "136158",
+      "updater": "osv/maven",
+      "name": "GHSA-269q-hmxg-m83q",
+      "description": "Local Information Disclosure Vulnerability in io.netty:netty-codec-http",
+      "issued": "2022-05-10T08:46:50Z",
+      "links": "https://github.com/netty/netty/security/advisories/GHSA-269q-hmxg-m83q https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2 https://nvd.nist.gov/vuln/detail/CVE-2022-24823 https://github.com/netty/netty/commit/185f8b2756a36aaa4f973f1a2a025e7d981823f1 https://github.com/netty/netty https://security.netapp.com/advisory/ntap-20220616-0004/ https://www.oracle.com/security-alerts/cpujul2022.html",
+      "severity": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "io.netty:netty-codec-http",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.1.77.Final"
+    },
+    "3872785": {
+      "id": "3872785",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1986: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python: ftplib should not use the host from the PASV response (CVE-2021-4189)\n\n* python: urllib: HTTP client possible infinite loop on a 100 Continue response (CVE-2021-3737)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1986 https://access.redhat.com/security/cve/CVE-2021-3737 https://access.redhat.com/security/cve/CVE-2021-4189",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-45.el8",
+      "arch_op": "pattern match"
+    },
+    "4441833": {
+      "id": "4441833",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3018: libarchive security update (Low)",
+      "description": "The libarchive programming library can create and read several different streaming archive formats, including GNU tar, cpio, and ISO 9660 CD-ROM images. Libarchive is used notably in the bsdtar utility, scripting language bindings such as python-libarchive, and several popular desktop file managers.\n\nSecurity Fix(es):\n\n* libarchive: NULL pointer dereference in archive_write.c (CVE-2022-36227)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.8 Release Notes linked from the References section.",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3018 https://access.redhat.com/security/cve/CVE-2022-36227",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "libarchive",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.3.3-5.el8",
+      "arch_op": "pattern match"
+    },
+    "4585484": {
+      "id": "4585484",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4209612": {
+      "id": "4209612",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:8638: krb5 security update (Important)",
+      "description": "Kerberos is a network authentication system, which can improve the security of your network by eliminating the insecure practice of sending passwords over the network in unencrypted form. It allows clients and servers to authenticate to each other with the help of a trusted third party, the Kerberos key distribution center (KDC).\n\nSecurity Fix(es):\n\n* krb5: integer overflow vulnerabilities in PAC parsing (CVE-2022-42898)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-11-28T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:8638 https://access.redhat.com/security/cve/CVE-2022-42898",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "krb5-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.18.2-22.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4558700": {
+      "id": "4558700",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: privilege escalation via the less pager (CVE-2023-26604)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd-pstore crashes when attempting to move standalone files out of /sys/fs/pstore (BZ#2190153)",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3837 https://access.redhat.com/security/cve/CVE-2023-26604",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-74.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "4589268": {
+      "id": "4589268",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4524: libcap security update (Moderate)",
+      "description": "Libcap is a library for getting and setting POSIX.1e (formerly POSIX 6) draft 15 capabilities.\n\nSecurity Fix(es):\n\n* libcap: Integer Overflow in _libcap_strdup() (CVE-2023-2603)\n\n* libcap: Memory Leak on pthread_create() Error (CVE-2023-2602)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4524 https://access.redhat.com/security/cve/CVE-2023-2602 https://access.redhat.com/security/cve/CVE-2023-2603",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcap",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.48-5.el8_8",
+      "arch_op": "pattern match"
+    },
+    "143317": {
+      "id": "143317",
+      "updater": "osv/maven",
+      "name": "GHSA-9vjp-v76f-g363",
+      "description": " SnappyFrameDecoder doesn't restrict chunk length any may buffer skippable chunks in an unnecessary way",
+      "issued": "2021-09-09T17:11:31Z",
+      "links": "https://github.com/netty/netty/security/advisories/GHSA-9vjp-v76f-g363 https://nvd.nist.gov/vuln/detail/CVE-2021-37137 https://github.com/netty/netty/commit/6da4956b31023ae967451e1d94ff51a746a9194f https://github.com/netty/netty https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java#L171 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java#L185 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java#L79 https://lists.apache.org/thread.html/r06a145c9bd41a7344da242cef07977b24abe3349161ede948e30913d@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5406eaf3b07577d233b9f07cfc8f26e28369e6bab5edfcab41f28abb@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5e05eba32476c580412f9fbdfc9b8782d5b40558018ac4ac07192a04@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r75490c61c2cb7b6ae2c81238fd52ae13636c60435abcd732d41531a0@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rd262f59b1586a108e320e5c966feeafbb1b8cdc96965debc7cc10b16@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rfb2bf8597e53364ccab212fbcbb2a4e9f0a9e1429b1dc08023c6868e@%3Cdev.tinkerpop.apache.org%3E https://lists.debian.org/debian-lts-announce/2023/01/msg00008.html https://security.netapp.com/advisory/ntap-20220210-0012/ https://www.debian.org/security/2023/dsa-5316 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "io.netty:netty-codec",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.1.68.Final&introduced=4.0.0"
+    },
+    "4015788": {
+      "id": "4015788",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6206: systemd security update (Important)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd-resolved: use-after-free when dealing with DnsStream in resolved-dns-stream.c (CVE-2022-2526)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-29T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6206 https://access.redhat.com/security/cve/CVE-2022-2526",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "systemd",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-58.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "137268": {
+      "id": "137268",
+      "updater": "osv/maven",
+      "name": "GHSA-3mc7-4q67-w48m",
+      "description": "Uncontrolled Resource Consumption in snakeyaml",
+      "issued": "2022-08-31T00:00:24Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-25857 https://github.com/snakeyaml/snakeyaml/commit/fc300780da21f4bb92c148bc90257201220cf174 https://bitbucket.org/snakeyaml/snakeyaml/commits/fc300780da21f4bb92c148bc90257201220cf174 https://bitbucket.org/snakeyaml/snakeyaml/issues/525 https://github.com/snakeyaml/snakeyaml https://lists.debian.org/debian-lts-announce/2022/10/msg00001.html https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-2806360",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "org.yaml:snakeyaml",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.31"
+    },
+    "4236232": {
+      "id": "4236232",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4016581": {
+      "id": "4016581",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6206: systemd security update (Important)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd-resolved: use-after-free when dealing with DnsStream in resolved-dns-stream.c (CVE-2022-2526)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-29T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6206 https://access.redhat.com/security/cve/CVE-2022-2526",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "systemd-pam",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-58.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "4028688": {
+      "id": "4028688",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6457: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-09-13T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "platform-python",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-47.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4191348": {
+      "id": "4191348",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7715: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Incorrect server side include parsing can lead to XSS (CVE-2016-3709)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7715 https://access.redhat.com/security/cve/CVE-2016-3709",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-15.el8",
+      "arch_op": "pattern match"
+    },
+    "4585108": {
+      "id": "4585108",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-common",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1"
+    },
+    "3921127": {
+      "id": "3921127",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5319: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: heap buffer overflow (CVE-2022-1621)\n\n* vim: buffer over-read (CVE-2022-1629)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5319 https://access.redhat.com/security/cve/CVE-2022-1621 https://access.redhat.com/security/cve/CVE-2022-1629",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-19.el8_6.2",
+      "arch_op": "pattern match"
+    },
+    "3879114": {
+      "id": "3879114",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:2031: libssh security, bug fix, and enhancement update (Low)",
+      "description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nThe following packages have been upgraded to a later upstream version: libssh (0.9.6). (BZ#1896651)\n\nSecurity Fix(es):\n\n* libssh: possible heap-based buffer overflow when rekeying (CVE-2021-3634)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:2031 https://access.redhat.com/security/cve/CVE-2021-3634",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "libssh",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:0.9.6-3.el8",
+      "arch_op": "pattern match"
+    },
+    "3572823": {
+      "id": "3572823",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2021:5226: openssl security update (Moderate)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Read buffer overruns processing ASN.1 strings (CVE-2021-3712)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2021-12-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2021:5226 https://access.redhat.com/security/cve/CVE-2021-3712",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "openssl-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-5.el8_5",
+      "arch_op": "pattern match"
+    },
+    "152415": {
+      "id": "152415",
+      "updater": "osv/maven",
+      "name": "GHSA-p6xc-xr62-6r2g",
+      "description": "Apache Log4j2 vulnerable to Improper Input Validation and Uncontrolled Recursion",
+      "issued": "2021-12-18T18:00:07Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2021-45105 https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-501673.pdf https://lists.debian.org/debian-lts-announce/2021/12/msg00017.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EOKPQGV24RRBBI4TBZUDQMM4MEH7MXCY/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/SIG7FZULMNK2XF6FZRU4VWYDQXNMUGAJ/ https://logging.apache.org/log4j/2.x/security.html https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032 https://security.netapp.com/advisory/ntap-20211218-0001/ https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd https://www.debian.org/security/2021/dsa-5024 https://www.kb.cert.org/vuls/id/930724 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html https://www.zerodayinitiative.com/advisories/ZDI-21-1541/ http://www.openwall.com/lists/oss-security/2021/12/19/1",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "org.apache.logging.log4j:log4j-core",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.12.3&introduced=2.4.0"
+    },
+    "3942176": {
+      "id": "3942176",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5683: java-11-openjdk security, bug fix, and enhancement update (Important)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nThe following packages have been upgraded to a later upstream version: java-11-openjdk (11.0.16.0.8). (BZ#2084649)\n\nSecurity Fix(es):\n\n* OpenJDK: integer truncation issue in Xalan-J (JAXP, 8285407) (CVE-2022-34169)\n\n* OpenJDK: class compilation issue (Hotspot, 8281859) (CVE-2022-21540)\n\n* OpenJDK: improper restriction of MethodHandle.invokeBasic() (Hotspot, 8281866) (CVE-2022-21541)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* rh1991003 patch breaks sun.security.pkcs11.wrapper.PKCS11.getInstance() [rhel-8, openjdk-11] (BZ#2099917)\n\n* Revert to disabling system security properties and FIPS mode support together [rhel-8, openjdk-11] (BZ#2108248)\n\n* SecretKey generate/import operations don't add the CKA_SIGN attribute in FIPS mode [rhel-8, openjdk-11] (BZ#2108251)",
+      "issued": "2022-07-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5683 https://access.redhat.com/security/cve/CVE-2022-21540 https://access.redhat.com/security/cve/CVE-2022-21541 https://access.redhat.com/security/cve/CVE-2022-34169",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.16.0.8-1.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3913176": {
+      "id": "3913176",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5056: cups security and bug fix update (Important)",
+      "description": "The Common UNIX Printing System (CUPS) provides a portable printing layer for Linux, UNIX, and similar operating systems.\n\nSecurity Fix(es):\n\n* cups: authorization bypass when using \"local\" authorization (CVE-2022-26691)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* 30-second delays printing to Windows 2016 server via HTTPS (BZ#2073531)",
+      "issued": "2022-06-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5056 https://access.redhat.com/security/cve/CVE-2022-26691",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "cups-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:2.2.6-45.el8_6.2",
+      "arch_op": "pattern match"
+    },
+    "4236745": {
+      "id": "4236745",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-tools",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4588876": {
+      "id": "4588876",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4520: python-requests security update (Moderate)",
+      "description": "The python-requests package contains a library designed to make HTTP requests easy for developers.\n\nSecurity Fix(es):\n\n* python-requests: Unintended leak of Proxy-Authorization header (CVE-2023-32681)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4520 https://access.redhat.com/security/cve/CVE-2023-32681",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-requests",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.20.0-3.el8_8"
+    },
+    "3632197": {
+      "id": "3632197",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0368: rpm security update (Moderate)",
+      "description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-rpm",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.14.3-19.el8_5.2",
+      "arch_op": "pattern match"
+    },
+    "4455909": {
+      "id": "4455909",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3591: python3 security update (Important)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: urllib.parse url blocklisting bypass (CVE-2023-24329)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-14T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3591 https://access.redhat.com/security/cve/CVE-2023-24329",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "platform-python",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-51.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4445830": {
+      "id": "4445830",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3106: curl security and bug fix update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: FTP too eager connection reuse (CVE-2023-27535)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Cannot upload files to Jscape SFTP server: file gets created empty (BZ#2188029)",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3106 https://access.redhat.com/security/cve/CVE-2023-27535",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "3714457": {
+      "id": "3714457",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0951: expat security update (Important)",
+      "description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: Malformed 2- and 3-byte UTF-8 sequences can lead to arbitrary code execution (CVE-2022-25235)\n\n* expat: Namespace-separator characters in \"xmlns[:prefix]\" attribute values can lead to arbitrary code execution (CVE-2022-25236)\n\n* expat: Integer overflow in storeRawNames() (CVE-2022-25315)\n\n* expat: Large number of prefixed XML attributes on a single tag can crash libexpat (CVE-2021-45960)\n\n* expat: Integer overflow in doProlog in xmlparse.c (CVE-2021-46143)\n\n* expat: Integer overflow in addBinding in xmlparse.c (CVE-2022-22822)\n\n* expat: Integer overflow in build_model in xmlparse.c (CVE-2022-22823)\n\n* expat: Integer overflow in defineAttribute in xmlparse.c (CVE-2022-22824)\n\n* expat: Integer overflow in lookup in xmlparse.c (CVE-2022-22825)\n\n* expat: Integer overflow in nextScaffoldPart in xmlparse.c (CVE-2022-22826)\n\n* expat: Integer overflow in storeAtts in xmlparse.c (CVE-2022-22827)\n\n* expat: Integer overflow in function XML_GetBuffer (CVE-2022-23852)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0951 https://access.redhat.com/security/cve/CVE-2021-45960 https://access.redhat.com/security/cve/CVE-2021-46143 https://access.redhat.com/security/cve/CVE-2022-22822 https://access.redhat.com/security/cve/CVE-2022-22823 https://access.redhat.com/security/cve/CVE-2022-22824 https://access.redhat.com/security/cve/CVE-2022-22825 https://access.redhat.com/security/cve/CVE-2022-22826 https://access.redhat.com/security/cve/CVE-2022-22827 https://access.redhat.com/security/cve/CVE-2022-23852 https://access.redhat.com/security/cve/CVE-2022-25235 https://access.redhat.com/security/cve/CVE-2022-25236 https://access.redhat.com/security/cve/CVE-2022-25315",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "expat",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.5-4.el8_5.3",
+      "arch_op": "pattern match"
+    },
+    "4290048": {
+      "id": "4290048",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0173: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows with XML_PARSE_HUGE (CVE-2022-40303)\n\n* libxml2: dict corruption caused by entity reference cycles (CVE-2022-40304)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0173 https://access.redhat.com/security/cve/CVE-2022-40303 https://access.redhat.com/security/cve/CVE-2022-40304",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-15.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4279352": {
+      "id": "4279352",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0100: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: buffer overrun in format_timespan() function (CVE-2022-3821)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* ShutdownWatchdogSec value is not taken into account on reboot (BZ#2127170)",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0100 https://access.redhat.com/security/cve/CVE-2022-3821",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4599718": {
+      "id": "4599718",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "python3-syspurpose",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "4313296": {
+      "id": "4313296",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0842: tar security update (Moderate)",
+      "description": "The GNU tar program can save multiple files in an archive and restore files from an archive.\n\nSecurity Fix(es):\n\n* tar: heap buffer overflow at from_header() in list.c via specially crafted checksum (CVE-2022-48303)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0842 https://access.redhat.com/security/cve/CVE-2022-48303",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "tar",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:1.30-6.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "3726060": {
+      "id": "3726060",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1537: gzip security update (Important)",
+      "description": "The gzip packages contain the gzip (GNU zip) data compression utility. gzip is used to compress regular files. It replaces them with files containing the .gz extension, while retaining ownership modes, access, and modification times.\n\nSecurity Fix(es):\n\n* gzip: arbitrary-file-write vulnerability (CVE-2022-1271)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-04-26T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1537 https://access.redhat.com/security/cve/CVE-2022-1271",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "gzip",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.9-13.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4308881": {
+      "id": "4308881",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: local information leak due to systemd-coredump not respecting fs.suid_dumpable kernel setting (CVE-2022-4415)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd doesn't record messages to the journal during boot (BZ#2164049)",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0837 https://access.redhat.com/security/cve/CVE-2022-4415",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.4",
+      "arch_op": "pattern match"
+    },
+    "3953752": {
+      "id": "3953752",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5813: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: Out-of-bounds Write (CVE-2022-1785)\n\n* vim: out-of-bounds write in vim_regsub_both() in regexp.c (CVE-2022-1897)\n\n* vim: buffer over-read in utf_ptr2char() in mbyte.c (CVE-2022-1927)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-03T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5813 https://access.redhat.com/security/cve/CVE-2022-1785 https://access.redhat.com/security/cve/CVE-2022-1897 https://access.redhat.com/security/cve/CVE-2022-1927",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-19.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "3917556": {
+      "id": "3917556",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5314: expat security update (Moderate)",
+      "description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: stack exhaustion in doctype parsing (CVE-2022-25313)\n\n* expat: integer overflow in copyString() (CVE-2022-25314)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5314 https://access.redhat.com/security/cve/CVE-2022-25313 https://access.redhat.com/security/cve/CVE-2022-25314",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "expat",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.5-8.el8_6.2",
+      "arch_op": "pattern match"
+    },
+    "4327672": {
+      "id": "4327672",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1569: gnutls security and bug fix update (Moderate)",
+      "description": "The gnutls packages provide the GNU Transport Layer Security (GnuTLS) library, which implements cryptographic algorithms and protocols such as SSL, TLS, and DTLS.\n\nSecurity Fix(es):\n\n* gnutls: timing side-channel in the TLS RSA key exchange code (CVE-2023-0361)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* trap invalid opcode ip:7feef81809fe sp:7fee997419c0 error:0 in libgnutls.so.30.28.2[7feef8040000+1dd000] (BZ#2131152)",
+      "issued": "2023-04-04T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1569 https://access.redhat.com/security/cve/CVE-2023-0361",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "gnutls",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.16-6.el8_7",
+      "arch_op": "pattern match"
+    },
+    "3633515": {
+      "id": "3633515",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0370: cryptsetup security update (Moderate)",
+      "description": "The cryptsetup packages provide a utility for setting up disk encryption using the dm-crypt kernel module.\n\nSecurity Fix(es):\n\n* cryptsetup: disable encryption via header rewrite (CVE-2021-4122)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0370 https://access.redhat.com/security/cve/CVE-2021-4122",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "cryptsetup-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.3.3-4.el8_5.1",
+      "arch_op": "pattern match"
+    },
+    "4283968": {
+      "id": "4283968",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0103: expat security update (Moderate)",
+      "description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: use-after free caused by overeager destruction of a shared DTD in\nXML_ExternalEntityParserCreate (CVE-2022-43680)\n\nFor more details about the security issue(s), including the impact, a CVSS\nscore, acknowledgments, and other related information, refer to the CVE page(s)\nlisted in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0103 https://access.redhat.com/security/cve/CVE-2022-43680",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "expat",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.5-10.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4455988": {
+      "id": "4455988",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3591: python3 security update (Important)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: urllib.parse url blocklisting bypass (CVE-2023-24329)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-14T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3591 https://access.redhat.com/security/cve/CVE-2023-24329",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "platform-python",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-51.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4599522": {
+      "id": "4599522",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "python3-cloud-what",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "3572609": {
+      "id": "3572609",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2021:5226: openssl security update (Moderate)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Read buffer overruns processing ASN.1 strings (CVE-2021-3712)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2021-12-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2021:5226 https://access.redhat.com/security/cve/CVE-2021-3712",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "openssl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-5.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4191438": {
+      "id": "4191438",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7715: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Incorrect server side include parsing can lead to XSS (CVE-2016-3709)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7715 https://access.redhat.com/security/cve/CVE-2016-3709",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-15.el8",
+      "arch_op": "pattern match"
+    },
+    "144608": {
+      "id": "144608",
+      "updater": "osv/maven",
+      "name": "GHSA-cqqj-4p63-rrmm",
+      "description": "HTTP Request Smuggling in Netty",
+      "issued": "2020-02-21T18:55:24Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2019-20444 https://github.com/netty/netty/issues/9866 https://github.com/netty/netty/pull/9871 https://github.com/netty/netty/pull/9871/files#diff-e26989b9171ef22c27c9f7d80689cfb059d568c9bd10e75970d96c02d0654878 https://access.redhat.com/errata/RHSA-2020:0497 https://access.redhat.com/errata/RHSA-2020:0567 https://access.redhat.com/errata/RHSA-2020:0601 https://access.redhat.com/errata/RHSA-2020:0605 https://access.redhat.com/errata/RHSA-2020:0606 https://access.redhat.com/errata/RHSA-2020:0804 https://access.redhat.com/errata/RHSA-2020:0805 https://access.redhat.com/errata/RHSA-2020:0806 https://access.redhat.com/errata/RHSA-2020:0811 https://github.com/netty/netty https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final https://lists.apache.org/thread.html/r059b042bca47be53ff8a51fd04d95eb01bb683f1afa209db136e8cb7@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r0aa8b28e76ec01c697b15e161e6797e88fc8d406ed762e253401106e@%3Ccommits.camel.apache.org%3E https://lists.apache.org/thread.html/r0c3d49bfdbc62fd3915676433cc5899c5506d06da1c552ef1b7923a5@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r0f5e72d5f69b4720dfe64fcbc2da9afae949ed1e9cbffa84bb7d92d7@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r1b103833cb5bc8466e24ff0ecc5e75b45a705334ab6a444e64e840a0@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/r1fcccf8bdb3531c28bc9aa605a6a1bea7e68cef6fc12e01faafb2fb5@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r205937c85817a911b0c72655c2377e7a2c9322d6ef6ce1b118d34d8d@%3Cdev.geode.apache.org%3E https://lists.apache.org/thread.html/r2f2989b7815d809ff3fda8ce330f553e5f133505afd04ffbc135f35f@%3Cissues.spark.apache.org%3E https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r34912a9b1a5c269a77b8be94ef6fb6d1e9b3c69129719dc00f01cf0b@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r36fcf538b28f2029e8b4f6b9a772f3b107913a78f09b095c5b153a62@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r489886fe72a98768eed665474cba13bad8d6fe0654f24987706636c5@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4c675b2d0cc2a5e506b11ee10d60a378859ee340aca052e4c7ef4749@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4d3f1d3e333d9c2b2f6e6ae8ed8750d4de03410ac294bcd12c7eefa3@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r640eb9b3213058a963e18291f903fc1584e577f60035f941e32f760a@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r6945f3c346b7af89bbd3526a7c9b705b1e3569070ebcd0964bcedd7d@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r70b1ff22ee80e8101805b9a473116dd33265709007d2deb6f8c80bf2@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r7790b9d99696d9eddce8a8c96f13bb68460984294ea6fea3800143e4@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r804895eedd72c9ec67898286eb185e04df852b0dd5fe53cf5b6138f9@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r832724df393a7ef25ca4c7c2eb83ad2d6c21c74569acda5233f9f1ec@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r8402d67fdfe9cf169f859d52a7670b28a08eff31e54b522cc1432532@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r86befa74c5cd1482c711134104aec339bf7ae879f2c4437d7ec477d4@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/r90030b0117490caed526e57271bf4d7f9b012091ac5083c895d16543@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r91e0fa345c86c128b75a4a791b4b503b53173ff4c13049ac7129d319@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r96e08f929234e8ba1ef4a93a0fd2870f535a1f9ab628fabc46115986@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra1a71b576a45426af5ee65255be9596ff3181a342f4ba73b800db78f@%3Cdev.geode.apache.org%3E https://lists.apache.org/thread.html/ra2ace4bcb5cf487f72cbcbfa0f8cc08e755ec2b93d7e69f276148b08@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra9fbfe7d4830ae675bf34c7c0f8c22fc8a4099f65706c1bc4f54c593@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/raaac04b7567c554786132144bea3dcb72568edd410c1e6f0101742e7@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rb3361f6c6a5f834ad3db5e998c352760d393c0891b8d3bea90baa836@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rc7eb5634b71d284483e58665b22bf274a69bd184d9bd7ede52015d91@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rcb2c59428f34d4757702f9ae739a8795bda7bea97b857e708a9c62c6@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rd8f72411fb75b98d366400ae789966373b5c3eb3f511e717caf3e49e@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rdb69125652311d0c41f6066ff44072a3642cf33a4b5e3c4f9c1ec9c2@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rdd5d243a5f8ed8b83c0104e321aa420e5e98792a95749e3c9a54c0b9@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/re0b78a3d0a4ba2cf9f4e14e1d05040bde9051d5c78071177186336c9@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/re78eaef7d01ad65c370df30e45c686fffff00b37f7bfd78b26a08762@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rf2bf8e2eb0a03227f5bc100b544113f8cafea01e887bb068e8d1fa41@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rf5b2dfb7401666a19915f8eaef3ba9f5c3386e2066fcd2ae66e16a2f@%3Cdev.flink.apache.org%3E https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rff210a24f3a924829790e69eaefa84820902b7b31f17c3bf2def9114@%3Ccommits.druid.apache.org%3E https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html https://lists.debian.org/debian-lts-announce/2020/09/msg00003.html https://lists.debian.org/debian-lts-announce/2020/09/msg00004.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TS6VX7OMXPDJIU5LRGUAHRK6MENAVJ46/ https://usn.ubuntu.com/4532-1/ https://www.debian.org/security/2021/dsa-4885",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
+      "normalized_severity": "Critical",
+      "package": {
+        "id": "",
+        "name": "io.netty:netty-codec-http",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.1.44&introduced=4.0.0"
+    },
+    "4284704": {
+      "id": "4284704",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0110: sqlite security update (Moderate)",
+      "description": "SQLite is a C library that implements an SQL database engine. A large subset of SQL92 is supported. A complete database is stored in a single disk file. The API is designed for convenience and ease of use. Applications that link against SQLite can enjoy the power and flexibility of an SQL database without the administrative hassles of supporting a separate database server.\n\nSecurity Fix(es):\n\n* sqlite: an array-bounds overflow if billions of bytes are used in a string argument to a C API (CVE-2022-35737)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0110 https://access.redhat.com/security/cve/CVE-2022-35737",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "sqlite-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.26.0-17.el8_7",
+      "arch_op": "pattern match"
+    },
+    "3716480": {
+      "id": "3716480",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1065: openssl security update (Important)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Infinite loop in BN_mod_sqrt() reachable when parsing certificates (CVE-2022-0778)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-28T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1065 https://access.redhat.com/security/cve/CVE-2022-0778",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "openssl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-6.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4293931": {
+      "id": "4293931",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0200: java-11-openjdk security and bug fix update (Moderate)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: handshake DoS attack against DTLS connections (JSSE, 8287411) (CVE-2023-21835)\n\n* OpenJDK: soundbank URL remote loading (Sound, 8293742) (CVE-2023-21843)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Prepare for the next quarterly OpenJDK upstream release (2023-01, 11.0.18) [rhel-8] (BZ#2157797)",
+      "issued": "2023-01-18T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0200 https://access.redhat.com/security/cve/CVE-2023-21835 https://access.redhat.com/security/cve/CVE-2023-21843",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.18.0.10-2.el8_7",
+      "arch_op": "pattern match"
+    },
+    "139050": {
+      "id": "139050",
+      "updater": "osv/maven",
+      "name": "GHSA-5mg8-w23w-74h3",
+      "description": "Information Disclosure in Guava",
+      "issued": "2021-03-25T17:04:19Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2020-8908 https://github.com/google/guava/issues/4011 https://github.com/google/guava/issues/4011#issuecomment-1578991974 https://github.com/google/guava/commit/feb83a1c8fd2e7670b244d5afd23cba5aca43284 https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40 https://github.com/google/guava https://lists.apache.org/thread.html/r007add131977f4f576c232b25e024249a3d16f66aad14a4b52819d21%40%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r007add131977f4f576c232b25e024249a3d16f66aad14a4b52819d21@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r037fed1d0ebde50c9caf8d99815db3093c344c3f651c5a49a09824ce@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r07ed3e4417ad043a27bee7bb33322e9bfc7d7e6d1719b8e3dfd95c14%40%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r07ed3e4417ad043a27bee7bb33322e9bfc7d7e6d1719b8e3dfd95c14@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r161b87f8037bbaff400194a63cd2016c9a69f5949f06dcc79beeab54%40%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r161b87f8037bbaff400194a63cd2016c9a69f5949f06dcc79beeab54@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r215b3d50f56faeb2f9383505f3e62faa9f549bb23e8a9848b78a968e%40%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r215b3d50f56faeb2f9383505f3e62faa9f549bb23e8a9848b78a968e@%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r294be9d31c0312d2c0837087204b5d4bf49d0552890e6eec716fa6a6%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r294be9d31c0312d2c0837087204b5d4bf49d0552890e6eec716fa6a6@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r2fe45d96eea8434b91592ca08109118f6308d60f6d0e21d52438cfb4%40%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r2fe45d96eea8434b91592ca08109118f6308d60f6d0e21d52438cfb4@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r3c3b33ee5bef0c67391d27a97cbfd89d44f328cf072b601b58d4e748%40%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r3c3b33ee5bef0c67391d27a97cbfd89d44f328cf072b601b58d4e748@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r3dd8881de891598d622227e9840dd7c2ef1d08abbb49e9690c7ae1bc%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/r3dd8881de891598d622227e9840dd7c2ef1d08abbb49e9690c7ae1bc@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/r4776f62dfae4a0006658542f43034a7fc199350e35a66d4e18164ee6%40%3Ccommits.cxf.apache.org%3E https://lists.apache.org/thread.html/r4776f62dfae4a0006658542f43034a7fc199350e35a66d4e18164ee6@%3Ccommits.cxf.apache.org%3E https://lists.apache.org/thread.html/r49549a8322f62cd3acfa4490d25bfba0be04f3f9ff4d14fe36199d27%40%3Cyarn-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/r49549a8322f62cd3acfa4490d25bfba0be04f3f9ff4d14fe36199d27@%3Cyarn-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/r58a8775205ab1839dba43054b09a9ab3b25b423a4170b2413c4067ac%40%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r58a8775205ab1839dba43054b09a9ab3b25b423a4170b2413c4067ac@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r5b3d93dfdfb7708e796e8762ab40edbde8ff8add48aba53e5ea26f44%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/r5b3d93dfdfb7708e796e8762ab40edbde8ff8add48aba53e5ea26f44@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/r5d61b98ceb7bba939a651de5900dbd67be3817db6bfcc41c6e04e199%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r5d61b98ceb7bba939a651de5900dbd67be3817db6bfcc41c6e04e199@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r6874dfe26eefc41b7c9a5e4a0487846fc4accf8c78ff948b24a1104a%40%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r6874dfe26eefc41b7c9a5e4a0487846fc4accf8c78ff948b24a1104a@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r68d86f4b06c808204f62bcb254fcb5b0432528ee8d37a07ef4bc8222%40%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r68d86f4b06c808204f62bcb254fcb5b0432528ee8d37a07ef4bc8222@%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r79e47ed555bdb1180e528420a7a2bb898541367a29a3bc6bbf0baf2c%40%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r79e47ed555bdb1180e528420a7a2bb898541367a29a3bc6bbf0baf2c@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r7b0e81d8367264d6cad98766a469d64d11248eb654417809bfdacf09%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r7b0e81d8367264d6cad98766a469d64d11248eb654417809bfdacf09@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r841c5e14e1b55281523ebcde661ece00b38a0569e00ef5e12bd5f6ba%40%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/r841c5e14e1b55281523ebcde661ece00b38a0569e00ef5e12bd5f6ba@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/ra7ab308481ee729f998691e8e3e02e93b1dedfc98f6b1cd3d86923b3%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/ra7ab308481ee729f998691e8e3e02e93b1dedfc98f6b1cd3d86923b3@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rb2364f4cf4d274eab5a7ecfaf64bf575cedf8b0173551997c749d322%40%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/rb2364f4cf4d274eab5a7ecfaf64bf575cedf8b0173551997c749d322@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/rb8c0f1b7589864396690fe42a91a71dea9412e86eec66dc85bbacaaf%40%3Ccommits.cxf.apache.org%3E https://lists.apache.org/thread.html/rb8c0f1b7589864396690fe42a91a71dea9412e86eec66dc85bbacaaf@%3Ccommits.cxf.apache.org%3E https://lists.apache.org/thread.html/rbc7642b9800249553f13457e46b813bea1aec99d2bc9106510e00ff3%40%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rbc7642b9800249553f13457e46b813bea1aec99d2bc9106510e00ff3@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc2dbc4633a6eea1fcbce6831876cfa17b73759a98c65326d1896cb1a%40%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc2dbc4633a6eea1fcbce6831876cfa17b73759a98c65326d1896cb1a@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc607bc52f3507b8b9c28c6a747c3122f51ac24afe80af2a670785b97%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rc607bc52f3507b8b9c28c6a747c3122f51ac24afe80af2a670785b97@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rcafc3a637d82bdc9a24036b2ddcad1e519dd0e6f848fcc3d606fd78f%40%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/rcafc3a637d82bdc9a24036b2ddcad1e519dd0e6f848fcc3d606fd78f@%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/rd01f5ff0164c468ec7abc96ff7646cea3cce6378da2e4aa29c6bcb95%40%3Cgithub.arrow.apache.org%3E https://lists.apache.org/thread.html/rd01f5ff0164c468ec7abc96ff7646cea3cce6378da2e4aa29c6bcb95@%3Cgithub.arrow.apache.org%3E https://lists.apache.org/thread.html/rd2704306ec729ccac726e50339b8a8f079515cc29ccb77713b16e7c5%40%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/rd2704306ec729ccac726e50339b8a8f079515cc29ccb77713b16e7c5@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/rd5d58088812cf8e677d99b07f73c654014c524c94e7fedbdee047604%40%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rd5d58088812cf8e677d99b07f73c654014c524c94e7fedbdee047604@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rd7e12d56d49d73e2b8549694974b07561b79b05455f7f781954231bf%40%3Cdev.pig.apache.org%3E https://lists.apache.org/thread.html/rd7e12d56d49d73e2b8549694974b07561b79b05455f7f781954231bf@%3Cdev.pig.apache.org%3E https://lists.apache.org/thread.html/re120f6b3d2f8222121080342c5801fdafca2f5188ceeb3b49c8a1d27%40%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/re120f6b3d2f8222121080342c5801fdafca2f5188ceeb3b49c8a1d27@%3Cyarn-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/reebbd63c25bc1a946caa419cec2be78079f8449d1af48e52d47c9e85%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/reebbd63c25bc1a946caa419cec2be78079f8449d1af48e52d47c9e85@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rf00b688ffa620c990597f829ff85fdbba8bf73ee7bfb34783e1f0d4e%40%3Cyarn-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/rf00b688ffa620c990597f829ff85fdbba8bf73ee7bfb34783e1f0d4e@%3Cyarn-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/rf9f0fa84b8ae1a285f0210bafec6de2a9eba083007d04640b82aa625%40%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rf9f0fa84b8ae1a285f0210bafec6de2a9eba083007d04640b82aa625@%3Cissues.geode.apache.org%3E https://lists.apache.org/thread.html/rfc27e2727a20a574f39273e0432aa97486a332f9b3068f6ac1346594%40%3Cdev.myfaces.apache.org%3E https://lists.apache.org/thread.html/rfc27e2727a20a574f39273e0432aa97486a332f9b3068f6ac1346594@%3Cdev.myfaces.apache.org%3E https://security.netapp.com/advisory/ntap-20220210-0003/ https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415 https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+      "severity": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "com.google.guava:guava",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=32.0.0"
+    },
+    "4322553": {
+      "id": "4322553",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1405: openssl security update (Important)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: X.400 address type confusion in X.509 GeneralName (CVE-2023-0286)\n\n* openssl: timing attack in RSA Decryption implementation (CVE-2022-4304)\n\n* openssl: double free after calling PEM_read_bio_ex (CVE-2022-4450)\n\n* openssl: use-after-free following BIO_new_NDEF (CVE-2023-0215)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1405 https://access.redhat.com/security/cve/CVE-2022-4304 https://access.redhat.com/security/cve/CVE-2022-4450 https://access.redhat.com/security/cve/CVE-2023-0215 https://access.redhat.com/security/cve/CVE-2023-0286",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "openssl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-9.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4055078": {
+      "id": "4055078",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7089: libksba security update (Important)",
+      "description": "KSBA (pronounced Kasbah) is a library to make X.509 certificates as well as the CMS easily accessible by other applications.  Both specifications are building blocks of S/MIME and TLS.\n\nSecurity Fix(es):\n\n* libksba: integer overflow may lead to remote code execution (CVE-2022-3515)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-24T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7089 https://access.redhat.com/security/cve/CVE-2022-3515",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "libksba",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.3.5-8.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3911609": {
+      "id": "3911609",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:4991: xz security update (Important)",
+      "description": "XZ Utils is an integrated collection of user-space file compression utilities based on the Lempel-Ziv-Markov chain algorithm (LZMA), which performs lossless data compression. The algorithm provides a high compression ratio while keeping the decompression time short.\n\nSecurity Fix(es):\n\n* gzip: arbitrary-file-write vulnerability (CVE-2022-1271)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-13T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:4991 https://access.redhat.com/security/cve/CVE-2022-1271",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "xz-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:5.2.4-4.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4445730": {
+      "id": "4445730",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3106: curl security and bug fix update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: FTP too eager connection reuse (CVE-2023-27535)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Cannot upload files to Jscape SFTP server: file gets created empty (BZ#2188029)",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3106 https://access.redhat.com/security/cve/CVE-2023-27535",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "3689725": {
+      "id": "3689725",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0892: libarchive security update (Moderate)",
+      "description": "The libarchive programming library can create and read several different streaming archive formats, including GNU tar, cpio, and ISO 9660 CD-ROM images. Libarchive is used notably in the bsdtar utility, scripting language bindings such as python-libarchive, and several popular desktop file managers.\n\nSecurity Fix(es):\n\n* libarchive: extracting a symlink with ACLs modifies ACLs of target (CVE-2021-23177)\n\n* libarchive: symbolic links incorrectly followed when changing modes, times, ACL and flags of a file while extracting an archive (CVE-2021-31566)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0892 https://access.redhat.com/security/cve/CVE-2021-23177 https://access.redhat.com/security/cve/CVE-2021-31566",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libarchive",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.3.3-3.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4236646": {
+      "id": "4236646",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4293838": {
+      "id": "4293838",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0200: java-11-openjdk security and bug fix update (Moderate)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: handshake DoS attack against DTLS connections (JSSE, 8287411) (CVE-2023-21835)\n\n* OpenJDK: soundbank URL remote loading (Sound, 8293742) (CVE-2023-21843)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Prepare for the next quarterly OpenJDK upstream release (2023-01, 11.0.18) [rhel-8] (BZ#2157797)",
+      "issued": "2023-01-18T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0200 https://access.redhat.com/security/cve/CVE-2023-21835 https://access.redhat.com/security/cve/CVE-2023-21843",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.18.0.10-2.el8_7",
+      "arch_op": "pattern match"
+    },
+    "3632211": {
+      "id": "3632211",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0368: rpm security update (Moderate)",
+      "description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "rpm",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.14.3-19.el8_5.2",
+      "arch_op": "pattern match"
+    },
+    "4322673": {
+      "id": "4322673",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1405: openssl security update (Important)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: X.400 address type confusion in X.509 GeneralName (CVE-2023-0286)\n\n* openssl: timing attack in RSA Decryption implementation (CVE-2022-4304)\n\n* openssl: double free after calling PEM_read_bio_ex (CVE-2022-4450)\n\n* openssl: use-after-free following BIO_new_NDEF (CVE-2023-0215)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1405 https://access.redhat.com/security/cve/CVE-2022-4304 https://access.redhat.com/security/cve/CVE-2022-4450 https://access.redhat.com/security/cve/CVE-2023-0215 https://access.redhat.com/security/cve/CVE-2023-0286",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "openssl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-9.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4601249": {
+      "id": "4601249",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4864: cups security update (Important)",
+      "description": "The Common UNIX Printing System (CUPS) provides a portable printing layer for Linux, UNIX, and similar operating systems.\n\nSecurity Fix(es):\n\n* cups: Information leak through Cups-Get-Document operation (CVE-2023-32360)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-29T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4864 https://access.redhat.com/security/cve/CVE-2023-32360",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "cups-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:2.2.6-51.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4321232": {
+      "id": "4321232",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4600483": {
+      "id": "4600483",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "subscription-manager-rhsm-certificates",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "4190007": {
+      "id": "4190007",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7704: webkit2gtk3 security and bug fix update (Moderate)",
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform.\n\nGLib provides the core application building blocks for libraries and applications written in C. It provides the core object system used in GNOME, the main loop implementation, and a large set of utility functions for strings and common data structures.\n\nSecurity Fix(es):\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-22624)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-22628)\n\n* webkitgtk: Buffer overflow leading to arbitrary code execution (CVE-2022-22629)\n\n* webkitgtk: Cookie management issue leading to sensitive user information disclosure (CVE-2022-22662)\n\n* webkitgtk: Memory corruption issue leading to arbitrary code execution (CVE-2022-26700)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-26709)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-26710)\n\n* webkitgtk: Memory corruption issue leading to arbitrary code execution (CVE-2022-26716)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-26717)\n\n* webkitgtk: Memory corruption issue leading to arbitrary code execution (CVE-2022-26719)\n\n* webkitgtk: Heap buffer overflow in WebCore::TextureMapperLayer::setContentsLayer leading to arbitrary code execution (CVE-2022-30293)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7704 https://access.redhat.com/security/cve/CVE-2022-22624 https://access.redhat.com/security/cve/CVE-2022-22628 https://access.redhat.com/security/cve/CVE-2022-22629 https://access.redhat.com/security/cve/CVE-2022-22662 https://access.redhat.com/security/cve/CVE-2022-26700 https://access.redhat.com/security/cve/CVE-2022-26709 https://access.redhat.com/security/cve/CVE-2022-26710 https://access.redhat.com/security/cve/CVE-2022-26716 https://access.redhat.com/security/cve/CVE-2022-26717 https://access.redhat.com/security/cve/CVE-2022-26719 https://access.redhat.com/security/cve/CVE-2022-30293 https://access.redhat.com/security/cve/CVE-2022-32891",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "glib2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.56.4-159.el8",
+      "arch_op": "pattern match"
+    },
+    "3726145": {
+      "id": "3726145",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1537: gzip security update (Important)",
+      "description": "The gzip packages contain the gzip (GNU zip) data compression utility. gzip is used to compress regular files. It replaces them with files containing the .gz extension, while retaining ownership modes, access, and modification times.\n\nSecurity Fix(es):\n\n* gzip: arbitrary-file-write vulnerability (CVE-2022-1271)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-04-26T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1537 https://access.redhat.com/security/cve/CVE-2022-1271",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "gzip",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.9-13.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4321033": {
+      "id": "4321033",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1140: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP multi-header compression denial of service (CVE-2023-23916)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1140 https://access.redhat.com/security/cve/CVE-2023-23916",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-25.el8_7.3",
+      "arch_op": "pattern match"
+    },
+    "158147": {
+      "id": "158147",
+      "updater": "osv/maven",
+      "name": "GHSA-x3x3-qwjq-8gj4",
+      "description": "Apache CXF Server-Side Request Forgery vulnerability",
+      "issued": "2022-12-13T18:30:26Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-46364 https://cxf.apache.org/security-advisories.data/CVE-2022-46364.txt?version=1&modificationDate=1670944472739&api=v2",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "normalized_severity": "Critical",
+      "package": {
+        "id": "",
+        "name": "org.apache.cxf:cxf-core",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=3.4.10"
+    },
+    "4191586": {
+      "id": "4191586",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7715: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Incorrect server side include parsing can lead to XSS (CVE-2016-3709)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7715 https://access.redhat.com/security/cve/CVE-2016-3709",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-15.el8",
+      "arch_op": "pattern match"
+    },
+    "143632": {
+      "id": "143632",
+      "updater": "osv/maven",
+      "name": "GHSA-c4r9-r8fh-9vj2",
+      "description": "snakeYAML before 1.31 vulnerable to Denial of Service due to Out-of-bounds Write",
+      "issued": "2022-09-06T00:00:27Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-38749 https://arxiv.org/pdf/2306.05534.pdf https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/issues/525/got-stackoverflowerror-for-many-open https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47024 https://lists.debian.org/debian-lts-announce/2022/10/msg00001.html https://security.gentoo.org/glsa/202305-28",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.yaml:snakeyaml",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.31"
+    },
+    "4599450": {
+      "id": "4599450",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "python3-cloud-what",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "2108839": {
+      "id": "2108839",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHBA-2022:2065: libtirpc bug fix and enhancement update (Moderate)",
+      "description": "For detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHBA-2022:2065 https://access.redhat.com/security/cve/CVE-2021-46828",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libtirpc",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.1.4-6.el8",
+      "arch_op": "pattern match"
+    },
+    "4588975": {
+      "id": "4588975",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4523: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: GSS delegation too eager connection re-use (CVE-2023-27536)\n\n* curl: IDN wildcard match may lead to Improper Cerificate Validation (CVE-2023-28321)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4523 https://access.redhat.com/security/cve/CVE-2023-27536 https://access.redhat.com/security/cve/CVE-2023-28321",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8_8.3",
+      "arch_op": "pattern match"
+    },
+    "4321288": {
+      "id": "4321288",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4599614": {
+      "id": "4599614",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "python3-subscription-manager-rhsm",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "3690981": {
+      "id": "3690981",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0896: glibc security update (Moderate)",
+      "description": "The glibc packages provide the standard C libraries (libc), POSIX thread libraries (libpthread), standard math libraries (libm), and the name service cache daemon (nscd) used by multiple programs on the system. Without these libraries, the Linux system cannot function correctly.\n\nSecurity Fix(es):\n\n* glibc: Off-by-one buffer overflow/underflow in getcwd() (CVE-2021-3999)\n\n* glibc: Stack-based buffer overflow in svcunix_create via long pathnames (CVE-2022-23218)\n\n* glibc: Stack-based buffer overflow in sunrpc clnt_create via a long pathname (CVE-2022-23219)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0896 https://access.redhat.com/security/cve/CVE-2021-3999 https://access.redhat.com/security/cve/CVE-2022-23218 https://access.redhat.com/security/cve/CVE-2022-23219",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "glibc-common",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.28-164.el8_5.3",
+      "arch_op": "pattern match"
+    },
+    "4589048": {
+      "id": "4589048",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4523: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: GSS delegation too eager connection re-use (CVE-2023-27536)\n\n* curl: IDN wildcard match may lead to Improper Cerificate Validation (CVE-2023-28321)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4523 https://access.redhat.com/security/cve/CVE-2023-27536 https://access.redhat.com/security/cve/CVE-2023-28321",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8_8.3",
+      "arch_op": "pattern match"
+    },
+    "4599360": {
+      "id": "4599360",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "dnf-plugin-subscription-manager",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "4336583": {
+      "id": "4336583",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1895: java-11-openjdk security update (Important)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: improper connection handling during TLS handshake (8294474) (CVE-2023-21930)\n\n* OpenJDK: Swing HTML parsing issue (8296832) (CVE-2023-21939)\n\n* OpenJDK: incorrect enqueue of references in garbage collector (8298191) (CVE-2023-21954)\n\n* OpenJDK: certificate validation issue in TLS session negotiation (8298310) (CVE-2023-21967)\n\n* OpenJDK: missing string checks for NULL characters (8296622) (CVE-2023-21937)\n\n* OpenJDK: incorrect handling of NULL characters in ProcessBuilder (8295304) (CVE-2023-21938)\n\n* OpenJDK: missing check for slash characters in URI-to-path conversion (8298667) (CVE-2023-21968)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-04-20T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1895 https://access.redhat.com/security/cve/CVE-2023-21930 https://access.redhat.com/security/cve/CVE-2023-21937 https://access.redhat.com/security/cve/CVE-2023-21938 https://access.redhat.com/security/cve/CVE-2023-21939 https://access.redhat.com/security/cve/CVE-2023-21954 https://access.redhat.com/security/cve/CVE-2023-21967 https://access.redhat.com/security/cve/CVE-2023-21968",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.19.0.7-1.el8_7",
+      "arch_op": "pattern match"
+    },
+    "151884": {
+      "id": "151884",
+      "updater": "osv/maven",
+      "name": "GHSA-mjmj-j48q-9wg2",
+      "description": "SnakeYaml Constructor Deserialization Remote Code Execution",
+      "issued": "2022-12-12T21:19:47Z",
+      "links": "https://github.com/google/security-research/security/advisories/GHSA-mjmj-j48q-9wg2 https://nvd.nist.gov/vuln/detail/CVE-2022-1471 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/commits/5014df1a36f50aca54405bb8433bc99a8847f758 https://bitbucket.org/snakeyaml/snakeyaml/commits/acc44099f5f4af26ff86b4e4e4cc1c874e2dc5c4 https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in#comment-64581479 https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in#comment-64634374 https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in#comment-64876314 https://bitbucket.org/snakeyaml/snakeyaml/wiki/CVE-2022-1471 https://github.com/mbechler/marshalsec https://groups.google.com/g/kubernetes-security-announce/c/mwrakFaEdnc https://security.netapp.com/advisory/ntap-20230818-0015/ https://snyk.io/blog/unsafe-deserialization-snakeyaml-java-cve-2022-1471/ https://www.github.com/mbechler/marshalsec/blob/master/marshalsec.pdf?raw=true",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:L",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "org.yaml:snakeyaml",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.0"
+    },
+    "156852": {
+      "id": "156852",
+      "updater": "osv/maven",
+      "name": "GHSA-vwqq-5vrc-xw9h",
+      "description": "Improper validation of certificate with host mismatch in Apache Log4j SMTP appender",
+      "issued": "2020-06-05T14:15:51Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2020-9488 https://issues.apache.org/jira/browse/LOG4J2-2819 https://lists.apache.org/thread.html/r0a2699f724156a558afd1abb6c044fb9132caa66dce861b82699722a@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r0df3d7a5acb98c57e64ab9266aa21eeee1d9b399addb96f9cf1cbe05@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r1fc73f0e16ec2fa249d3ad39a5194afb9cc5afb4c023dc0bab5a5881@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r22a56beb76dd8cf18e24fda9072f1e05990f49d6439662d3782a392f@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r2721aba31a8562639c4b937150897e24f78f747cdbda8641c0f659fe@%3Cusers.kafka.apache.org%3E https://lists.apache.org/thread.html/r2f209d271349bafd91537a558a279c08ebcff8fa3e547357d58833e6@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r33864a0fc171c1c4bf680645ebb6d4f8057899ab294a43e1e4fe9d04@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r393943de452406f0f6f4b3def9f8d3c071f96323c1f6ed1a098f7fe4@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/r3d1d00441c55144a4013adda74b051ae7864128ebcfb6ee9721a2eb3@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r4285398e5585a0456d3d9db021a4fce6e6fcf3ec027dfa13a450ec98@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r45916179811a32cbaa500f972de9098e6ee80ee81c7f134fce83e03a@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/r48bcd06049c1779ef709564544c3d8a32ae6ee5c3b7281a606ac4463@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r48efc7cb5aeb4e1f67aaa06fb4b5479a5635d12f07d0b93fc2d08809@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4d5dc9f3520071338d9ebc26f9f158a43ae28a91923d176b550a807b@%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/r4db540cafc5d7232c62e076051ef661d37d345015b2e59b3f81a932f@%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/r4ed1f49616a8603832d378cb9d13e7a8b9b27972bb46d946ccd8491f@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r5a68258e5ab12532dc179edae3d6e87037fa3b50ab9d63a90c432507@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r65578f3761a89bc164e8964acd5d913b9f8fd997967b195a89a97ca3@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r7641ee788e1eb1be4bb206a7d15f8a64ec6ef23e5ec6132d5a567695@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r7e5c10534ed06bf805473ac85e8412fe3908a8fa4cabf5027bf11220@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/r7e739f2961753af95e2a3a637828fb88bfca68e5d6b0221d483a9ee5@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r8c001b9a95c0bbec06f4457721edd94935a55932e64b82cc5582b846@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r8e96c340004b7898cad3204ea51280ef6e4b553a684e1452bf1b18b1@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r9776e71e3c67c5d13a91c1eba0dc025b48b802eb7561cc6956d6961c@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r9a79175c393d14d760a0ae3731b4a873230a16ef321aa9ca48a810cd@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra051e07a0eea4943fa104247e69596f094951f51512d42c924e86c75@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/ra632b329b2ae2324fabbad5da204c4ec2e171ff60348ec4ba698fd40@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/rbc45eb0f53fd6242af3e666c2189464f848a851d408289840cecc6e3@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rbc7642b9800249553f13457e46b813bea1aec99d2bc9106510e00ff3@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc2dbc4633a6eea1fcbce6831876cfa17b73759a98c65326d1896cb1a@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rc6b81c013618d1de1b5d6b8c1088aaf87b4bacc10c2371f15a566701@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rd55f65c6822ff235eda435d31488cfbb9aa7055cdf47481ebee777cc@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rd5d58088812cf8e677d99b07f73c654014c524c94e7fedbdee047604@%3Ctorque-dev.db.apache.org%3E https://lists.apache.org/thread.html/rd8e87c4d69df335d0ba7d815b63be8bd8a6352f429765c52eb07ddac@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/re024d86dffa72ad800f2848d0c77ed93f0b78ee808350b477a6ed987@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/rec34b1cccf907898e7cb36051ffac3ccf1ea89d0b261a2a3b3fb267f@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rf1c2a81a08034c688b8f15cf58a4cfab322d00002ca46d20133bee20@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772@%3Cdev.mina.apache.org%3E https://lists.debian.org/debian-lts-announce/2021/12/msg00017.html https://security.netapp.com/advisory/ntap-20200504-0003/ https://www.debian.org/security/2021/dsa-5020 https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2021.html https://www.oracle.com/security-alerts/cpujul2020.html https://www.oracle.com/security-alerts/cpuoct2020.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+      "severity": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "org.apache.logging.log4j:log4j-core",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.13.2"
+    },
+    "4559849": {
+      "id": "4559849",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3840: sqlite security update (Moderate)",
+      "description": "SQLite is a C library that implements an SQL database engine. A large subset of SQL92 is supported. A complete database is stored in a single disk file. The API is designed for convenience and ease of use. Applications that link against SQLite can enjoy the power and flexibility of an SQL database without the administrative hassles of supporting a separate database server.\n\nSecurity Fix(es):\n\n* sqlite: Crash due to misuse of window functions. (CVE-2020-24736)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3840 https://access.redhat.com/security/cve/CVE-2020-24736",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "sqlite-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.26.0-18.el8_8",
+      "arch_op": "pattern match"
+    },
+    "142741": {
+      "id": "142741",
+      "updater": "osv/maven",
+      "name": "GHSA-98wm-3w3q-mw94",
+      "description": "snakeYAML before 1.31 vulnerable to Denial of Service due to Out-of-bounds Write",
+      "issued": "2022-09-06T00:00:27Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-38751 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/issues/530/stackoverflow-oss-fuzz-47039 https://bitbucket.org/snakeyaml/snakeyaml/src/master/src/test/java/org/yaml/snakeyaml/issues/issue530/Fuzzy47039Test.java https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47039 https://lists.debian.org/debian-lts-announce/2022/10/msg00001.html https://security.gentoo.org/glsa/202305-28",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.yaml:snakeyaml",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.31"
+    },
+    "3631646": {
+      "id": "3631646",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0366: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: heap-based buffer overflow in win_redr_status() in drawscreen.c (CVE-2021-3872)\n\n* vim: illegal memory access in find_start_brace() in cindent.c when C-indenting (CVE-2021-3984)\n\n* vim: heap-based buffer overflow in find_help_tags() in help.c (CVE-2021-4019)\n\n* vim: use-after-free in win_linetabsize() (CVE-2021-4192)\n\n* vim: out-of-bound read in getvcol() (CVE-2021-4193)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0366 https://access.redhat.com/security/cve/CVE-2021-3872 https://access.redhat.com/security/cve/CVE-2021-3984 https://access.redhat.com/security/cve/CVE-2021-4019 https://access.redhat.com/security/cve/CVE-2021-4192 https://access.redhat.com/security/cve/CVE-2021-4193",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-16.el8_5.4",
+      "arch_op": "pattern match"
+    },
+    "3572666": {
+      "id": "3572666",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2021:5226: openssl security update (Moderate)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Read buffer overruns processing ASN.1 strings (CVE-2021-3712)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2021-12-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2021:5226 https://access.redhat.com/security/cve/CVE-2021-3712",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "openssl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-5.el8_5",
+      "arch_op": "pattern match"
+    },
+    "3718247": {
+      "id": "3718247",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1442: java-11-openjdk security update (Important)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: Defective secure validation in Apache Santuario (Libraries, 8278008) (CVE-2022-21476)\n\n* OpenJDK: Unbounded memory allocation when compiling crafted XPath expressions (JAXP, 8270504) (CVE-2022-21426)\n\n* OpenJDK: Improper object-to-string conversion in AnnotationInvocationHandler (Libraries, 8277672) (CVE-2022-21434)\n\n* OpenJDK: Missing check for negative ObjectIdentifier (Libraries, 8275151) (CVE-2022-21443)\n\n* OpenJDK: URI parsing inconsistencies (JNDI, 8278972) (CVE-2022-21496)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-04-20T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1442 https://access.redhat.com/security/cve/CVE-2022-21426 https://access.redhat.com/security/cve/CVE-2022-21434 https://access.redhat.com/security/cve/CVE-2022-21443 https://access.redhat.com/security/cve/CVE-2022-21476 https://access.redhat.com/security/cve/CVE-2022-21496",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.15.0.9-2.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4445745": {
+      "id": "4445745",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3106: curl security and bug fix update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: FTP too eager connection reuse (CVE-2023-27535)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Cannot upload files to Jscape SFTP server: file gets created empty (BZ#2188029)",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3106 https://access.redhat.com/security/cve/CVE-2023-27535",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "3714109": {
+      "id": "3714109",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0899: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Use-after-free of ID and IDREF attributes (CVE-2022-23308)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0899 https://access.redhat.com/security/cve/CVE-2022-23308",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-12.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4599539": {
+      "id": "4599539",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "python3-subscription-manager-rhsm",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "149462": {
+      "id": "149462",
+      "updater": "osv/maven",
+      "name": "GHSA-j8wc-gxx9-82hx",
+      "description": "Exposure of Sensitive Information to an Unauthorized Actor in Apache Santuario",
+      "issued": "2021-09-20T23:18:41Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2021-40690 https://lists.apache.org/thread.html/r3b3f5ba9b0de8c9c125077b71af06026d344a709a8ba67db81ee9faa@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r401ecb7274794f040cd757b259ebe3e8c463ae74f7961209ccad3c59@%3Cissues.cxf.apache.org%3E https://lists.apache.org/thread.html/r8848751b6a5dd78cc9e99d627e74fecfaffdfa1bb615dce827aad633%40%3Cdev.santuario.apache.org%3E https://lists.apache.org/thread.html/r8a5c0ce9014bd07303aec1e5eed55951704878016465d3dae00e0c28@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r9c100d53c84d54cf71975e3f0cfcc2856a8846554a04c99390156ce4@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/raf352f95c19c0c4051af3180752cb69acbea88d0d066ab176c6170e8@%3Cuser.poi.apache.org%3E https://lists.apache.org/thread.html/rbbbac0759b12472abd0c278d32b5e0867bb21934df8e14e5e641597c@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/rbdac116aef912b563da54f4c152222c0754e32fb2f785519ac5e059f@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/re294cfc61f509512874ea514d8d64fd276253d54ac378ffa7a4880c8@%3Ccommits.tomee.apache.org%3E https://lists.debian.org/debian-lts-announce/2021/09/msg00015.html https://security.netapp.com/advisory/ntap-20230818-0002/ https://www.debian.org/security/2021/dsa-5010 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "org.apache.santuario:xmlsec",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.1.7"
+    },
+    "3913148": {
+      "id": "3913148",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5056: cups security and bug fix update (Important)",
+      "description": "The Common UNIX Printing System (CUPS) provides a portable printing layer for Linux, UNIX, and similar operating systems.\n\nSecurity Fix(es):\n\n* cups: authorization bypass when using \"local\" authorization (CVE-2022-26691)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* 30-second delays printing to Windows 2016 server via HTTPS (BZ#2073531)",
+      "issued": "2022-06-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5056 https://access.redhat.com/security/cve/CVE-2022-26691",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "cups-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:2.2.6-45.el8_6.2",
+      "arch_op": "pattern match"
+    },
+    "3953826": {
+      "id": "3953826",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5813: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: Out-of-bounds Write (CVE-2022-1785)\n\n* vim: out-of-bounds write in vim_regsub_both() in regexp.c (CVE-2022-1897)\n\n* vim: buffer over-read in utf_ptr2char() in mbyte.c (CVE-2022-1927)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-03T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5813 https://access.redhat.com/security/cve/CVE-2022-1785 https://access.redhat.com/security/cve/CVE-2022-1897 https://access.redhat.com/security/cve/CVE-2022-1927",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-19.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "4588891": {
+      "id": "4588891",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4523: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: GSS delegation too eager connection re-use (CVE-2023-27536)\n\n* curl: IDN wildcard match may lead to Improper Cerificate Validation (CVE-2023-28321)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4523 https://access.redhat.com/security/cve/CVE-2023-27536 https://access.redhat.com/security/cve/CVE-2023-28321",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8_8.3",
+      "arch_op": "pattern match"
+    },
+    "4585538": {
+      "id": "4585538",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-tools",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4320916": {
+      "id": "4320916",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1140: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP multi-header compression denial of service (CVE-2023-23916)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1140 https://access.redhat.com/security/cve/CVE-2023-23916",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-25.el8_7.3",
+      "arch_op": "pattern match"
+    },
+    "3872405": {
+      "id": "3872405",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1986: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python: ftplib should not use the host from the PASV response (CVE-2021-4189)\n\n* python: urllib: HTTP client possible infinite loop on a 100 Continue response (CVE-2021-3737)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1986 https://access.redhat.com/security/cve/CVE-2021-3737 https://access.redhat.com/security/cve/CVE-2021-4189",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "platform-python",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-45.el8",
+      "arch_op": "pattern match"
+    },
+    "141045": {
+      "id": "141045",
+      "updater": "osv/maven",
+      "name": "GHSA-7rjr-3q55-vv33",
+      "description": "Incomplete fix for Apache Log4j vulnerability",
+      "issued": "2021-12-14T18:01:28Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2021-45046 https://cert-portal.siemens.com/productcert/pdf/ssa-397453.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-661247.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-714170.pdf https://github.com/advisories/GHSA-jfh8-c2jp-5v3q https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/EOKPQGV24RRBBI4TBZUDQMM4MEH7MXCY/ https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/SIG7FZULMNK2XF6FZRU4VWYDQXNMUGAJ/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/EOKPQGV24RRBBI4TBZUDQMM4MEH7MXCY/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/SIG7FZULMNK2XF6FZRU4VWYDQXNMUGAJ/ https://logging.apache.org/log4j/2.x/security.html https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032 https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd https://www.cve.org/CVERecord?id=CVE-2021-44228 https://www.debian.org/security/2021/dsa-5022 https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html https://www.kb.cert.org/vuls/id/930724 https://www.openwall.com/lists/oss-security/2021/12/14/4 https://www.oracle.com/security-alerts/alert-cve-2021-44228.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html http://www.openwall.com/lists/oss-security/2021/12/14/4 http://www.openwall.com/lists/oss-security/2021/12/15/3 http://www.openwall.com/lists/oss-security/2021/12/18/1",
+      "severity": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+      "normalized_severity": "Critical",
+      "package": {
+        "id": "",
+        "name": "org.apache.logging.log4j:log4j-core",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.12.2"
+    },
+    "4308896": {
+      "id": "4308896",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: local information leak due to systemd-coredump not respecting fs.suid_dumpable kernel setting (CVE-2022-4415)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd doesn't record messages to the journal during boot (BZ#2164049)",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0837 https://access.redhat.com/security/cve/CVE-2022-4415",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-pam",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.4",
+      "arch_op": "pattern match"
+    },
+    "4321765": {
+      "id": "4321765",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss-softokn-freebl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "137417": {
+      "id": "137417",
+      "updater": "osv/maven",
+      "name": "GHSA-3w37-5p3p-jv92",
+      "description": "Apache CXF vulnerable to Exposure of Sensitive Information",
+      "issued": "2022-12-13T15:30:27Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-46363 https://github.com/apache/cxf https://lists.apache.org/thread/pdzo1qgyplf4y523tnnzrcm7hoco3l8c",
+      "severity": "",
+      "normalized_severity": "Unknown",
+      "package": {
+        "id": "",
+        "name": "org.apache.cxf:cxf-core",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=3.4.10"
+    },
+    "4336662": {
+      "id": "4336662",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1895: java-11-openjdk security update (Important)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: improper connection handling during TLS handshake (8294474) (CVE-2023-21930)\n\n* OpenJDK: Swing HTML parsing issue (8296832) (CVE-2023-21939)\n\n* OpenJDK: incorrect enqueue of references in garbage collector (8298191) (CVE-2023-21954)\n\n* OpenJDK: certificate validation issue in TLS session negotiation (8298310) (CVE-2023-21967)\n\n* OpenJDK: missing string checks for NULL characters (8296622) (CVE-2023-21937)\n\n* OpenJDK: incorrect handling of NULL characters in ProcessBuilder (8295304) (CVE-2023-21938)\n\n* OpenJDK: missing check for slash characters in URI-to-path conversion (8298667) (CVE-2023-21968)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-04-20T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1895 https://access.redhat.com/security/cve/CVE-2023-21930 https://access.redhat.com/security/cve/CVE-2023-21937 https://access.redhat.com/security/cve/CVE-2023-21938 https://access.redhat.com/security/cve/CVE-2023-21939 https://access.redhat.com/security/cve/CVE-2023-21954 https://access.redhat.com/security/cve/CVE-2023-21967 https://access.redhat.com/security/cve/CVE-2023-21968",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.19.0.7-1.el8_7",
+      "arch_op": "pattern match"
+    },
+    "138037": {
+      "id": "138037",
+      "updater": "osv/maven",
+      "name": "GHSA-4q98-wr72-h35w",
+      "description": "Improper input validation in Apache Santuario XML Security for Java",
+      "issued": "2019-08-27T17:41:33Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2019-12400 https://access.redhat.com/errata/RHSA-2020:0804 https://access.redhat.com/errata/RHSA-2020:0805 https://access.redhat.com/errata/RHSA-2020:0806 https://access.redhat.com/errata/RHSA-2020:0811 https://lists.apache.org/thread.html/8e814b925bf580bc527d96ff51e72ffe5bdeaa4b8bf5b89498cab24c@%3Cdev.santuario.apache.org%3E https://lists.apache.org/thread.html/edaa7edb9c58e5f5bd0c950f2b6232b62b15f5c44ad803e8728308ce@%3Cdev.santuario.apache.org%3E https://lists.apache.org/thread.html/r107bffb06a5e27457fe9af7dfe3a233d0d36c6c2f5122f117eb7f626@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r1c07a561426ec5579073046ad7f4207cdcef452bb3100abaf908e0cd@%3Ccommits.santuario.apache.org%3E https://lists.apache.org/thread.html/rcdc0da94fe21b26493eae47ca987a290bdf90c721a7a42491fdd41d4@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/rf82be0a7c98cd3545e20817bb96ed05551ea0020acbaf9a469fef402@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/rf958cea96236de8829940109ae07e870aa3d59235345421e4924ff03@%3Ccommits.tomee.apache.org%3E https://security.netapp.com/advisory/ntap-20190910-0003/ https://www.oracle.com/security-alerts/cpuoct2021.html http://santuario.apache.org/secadv.data/CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2",
+      "severity": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.apache.santuario:xmlsec",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.1.4&introduced=2.0.3"
+    },
+    "4585116": {
+      "id": "4585116",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-daemon",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "3872868": {
+      "id": "3872868",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1986: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python: ftplib should not use the host from the PASV response (CVE-2021-4189)\n\n* python: urllib: HTTP client possible infinite loop on a 100 Continue response (CVE-2021-3737)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1986 https://access.redhat.com/security/cve/CVE-2021-3737 https://access.redhat.com/security/cve/CVE-2021-4189",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-45.el8",
+      "arch_op": "pattern match"
+    },
+    "4558719": {
+      "id": "4558719",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: privilege escalation via the less pager (CVE-2023-26604)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd-pstore crashes when attempting to move standalone files out of /sys/fs/pstore (BZ#2190153)",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3837 https://access.redhat.com/security/cve/CVE-2023-26604",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-pam",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-74.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "4308983": {
+      "id": "4308983",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: local information leak due to systemd-coredump not respecting fs.suid_dumpable kernel setting (CVE-2022-4415)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd doesn't record messages to the journal during boot (BZ#2164049)",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0837 https://access.redhat.com/security/cve/CVE-2022-4415",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-pam",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.4",
+      "arch_op": "pattern match"
+    },
+    "4308222": {
+      "id": "4308222",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0835: python-setuptools security update (Moderate)",
+      "description": "The python-setuptools package provides a collection of enhancements to Python distribution utilities allowing convenient building and distribution of Python packages.\n\nSecurity Fix(es):\n\n* pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py (CVE-2022-40897)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0835 https://access.redhat.com/security/cve/CVE-2022-40897",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "platform-python-setuptools",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:39.2.0-6.el8_7.1"
+    },
+    "4558929": {
+      "id": "4558929",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: privilege escalation via the less pager (CVE-2023-26604)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd-pstore crashes when attempting to move standalone files out of /sys/fs/pstore (BZ#2190153)",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3837 https://access.redhat.com/security/cve/CVE-2023-26604",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-pam",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-74.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "4287975": {
+      "id": "4287975",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0116: libtasn1 security update (Moderate)",
+      "description": "A library that provides Abstract Syntax Notation One (ASN.1, as specified by the X.680 ITU-T recommendation) parsing and structures management, and Distinguished Encoding Rules (DER, as per X.690) encoding and decoding functions.\n\nSecurity Fix(es):\n\n* libtasn1: Out-of-bound access in ETYPE_OK (CVE-2021-46848)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0116 https://access.redhat.com/security/cve/CVE-2021-46848",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libtasn1",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.13-4.el8_7",
+      "arch_op": "pattern match"
+    },
+    "3953842": {
+      "id": "3953842",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5818: openssl security update (Moderate)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: c_rehash script allows command injection (CVE-2022-1292)\n\n* openssl: the c_rehash script allows command injection (CVE-2022-2068)\n\n* openssl: AES OCB fails to encrypt some bytes (CVE-2022-2097)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-03T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5818 https://access.redhat.com/security/cve/CVE-2022-1292 https://access.redhat.com/security/cve/CVE-2022-2068 https://access.redhat.com/security/cve/CVE-2022-2097",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "openssl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-7.el8_6",
+      "arch_op": "pattern match"
+    },
+    "155055": {
+      "id": "155055",
+      "updater": "osv/maven",
+      "name": "GHSA-rgv9-q543-rqg4",
+      "description": "Uncontrolled Resource Consumption in FasterXML jackson-databind",
+      "issued": "2022-10-03T00:00:31Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-42004 https://github.com/FasterXML/jackson-databind/issues/3582 https://github.com/FasterXML/jackson-databind/commit/063183589218fec19a9293ed2f17ec53ea80ba88 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50490 https://github.com/FasterXML/jackson-databind https://lists.debian.org/debian-lts-announce/2022/11/msg00035.html https://security.gentoo.org/glsa/202210-21 https://security.netapp.com/advisory/ntap-20221118-0008/ https://www.debian.org/security/2022/dsa-5283",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "com.fasterxml.jackson.core:jackson-databind",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.12.7.1"
+    },
+    "4308277": {
+      "id": "4308277",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0835: python-setuptools security update (Moderate)",
+      "description": "The python-setuptools package provides a collection of enhancements to Python distribution utilities allowing convenient building and distribution of Python packages.\n\nSecurity Fix(es):\n\n* pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py (CVE-2022-40897)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0835 https://access.redhat.com/security/cve/CVE-2022-40897",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "platform-python-setuptools",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:39.2.0-6.el8_7.1"
+    },
+    "4290140": {
+      "id": "4290140",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0173: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows with XML_PARSE_HUGE (CVE-2022-40303)\n\n* libxml2: dict corruption caused by entity reference cycles (CVE-2022-40304)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0173 https://access.redhat.com/security/cve/CVE-2022-40303 https://access.redhat.com/security/cve/CVE-2022-40304",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-15.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4600001": {
+      "id": "4600001",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "subscription-manager",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "151929": {
+      "id": "151929",
+      "updater": "osv/maven",
+      "name": "GHSA-mm9x-g8pc-w292",
+      "description": "Denial of Service in Netty",
+      "issued": "2020-06-15T19:36:16Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2020-11612 https://github.com/netty/netty/issues/6168 https://github.com/netty/netty/pull/9924 https://github.com/netty/netty/compare/netty-4.1.45.Final...netty-4.1.46.Final https://lists.apache.org/thread.html/r14446ed58208cb6d97b6faa6ebf145f1cf2c70c0886c0c133f4d3b6f@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r255ed239e65d0596812362adc474bee96caf7ba042c7ad2f3c62cec7@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r281882fdf9ea89aac02fd2f92786693a956aac2ce9840cce87c7df6b@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r2958e4d49ee046e1e561e44fdc114a0d2285927501880f15852a9b53@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r31424427cc6d7db46beac481bdeed9a823fc20bb1b9deede38557f71@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r3195127e46c87a680b5d1d3733470f83b886bfd3b890c50df718bed1@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r3ea4918d20d0c1fa26cac74cc7cda001d8990bc43473d062867ef70d@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4a7e4e23bd84ac24abf30ab5d5edf989c02b555e1eca6a2f28636692@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r4f4a14d6a608db447b725ec2e96c26ac9664d83cd879aa21e2cfeb24@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r5030cd8ea5df1e64cf6a7b633eff145992fbca03e8bfc687cd2427ab@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r5a0b1f0b1c3bcd66f5177fbd6f6de2d0f8cae24a13ab2669f274251a@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r5b1ad61552591b747cd31b3a908d5ff2e8f2a8a6847583dd6b7b1ee7@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r69b23a94d4ae45394cabae012dd1f4a963996869c44c478eb1c61082@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r7641ee788e1eb1be4bb206a7d15f8a64ec6ef23e5ec6132d5a567695@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r7790b9d99696d9eddce8a8c96f13bb68460984294ea6fea3800143e4@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r7836bbdbe95c99d4d725199f0c169927d4e87ba57e4beeeb699c097a@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r832724df393a7ef25ca4c7c2eb83ad2d6c21c74569acda5233f9f1ec@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r866288c2ada00ce148b7307cdf869f15f24302b3eb2128af33830997@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r88e2b91560c065ed67e62adf8f401c417e4d70256d11ea447215a70c@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r8a654f11e1172b0effbfd6f8d5b6ca651ae4ac724a976923c268a42f@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r9addb580456807cd11d6f0c6b6373b7d7161d06d2278866c30c7febb@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r9c30b7fca4baedebcb46d6e0f90071b30cc4a0e074164d50122ec5ec@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra98e3a8541a09271f96478d5e22c7e3bd1afdf48641c8be25d62d9f9@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/raaac04b7567c554786132144bea3dcb72568edd410c1e6f0101742e7@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rd302ddb501fa02c5119120e5fc21df9a1c00e221c490edbe2d7ad365@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rdb69125652311d0c41f6066ff44072a3642cf33a4b5e3c4f9c1ec9c2@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/re1ea144e91f03175d661b2d3e97c7d74b912e019613fa90419cf63f4@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ref2c8a0cbb3b8271e5b9a06457ba78ad2028128627186531730f50ef@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ref3943adbc3a8813aee0e3a9dd919bacbb27f626be030a3c6d6c7f83@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rf5b2dfb7401666a19915f8eaef3ba9f5c3386e2066fcd2ae66e16a2f@%3Cdev.flink.apache.org%3E https://lists.apache.org/thread.html/rf803b65b4a57589d79cf2e83d8ece0539018d32864f932f63c972844@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rf9f8bcc4ca8d2788f77455ff594468404732a4497baebe319043f4d5@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rfd173eac20d5e5f581c8984b685c836dafea8eb2f7ff85f617704cf1@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rff8859c0d06b1688344b39097f9685c43b461cf2bc41f60f001704e9@%3Ccommits.zookeeper.apache.org%3E https://lists.debian.org/debian-lts-announce/2020/09/msg00003.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TS6VX7OMXPDJIU5LRGUAHRK6MENAVJ46/ https://security.netapp.com/advisory/ntap-20201223-0001/ https://www.debian.org/security/2021/dsa-4885 https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2021.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "io.netty:netty-handler",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.1.46&introduced=4.1.0"
+    },
+    "3632531": {
+      "id": "3632531",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0368: rpm security update (Moderate)",
+      "description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "rpm-build-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.14.3-19.el8_5.2",
+      "arch_op": "pattern match"
+    },
+    "4590369": {
+      "id": "4590369",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4529: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: NULL dereference in xmlSchemaFixupComplexType (CVE-2023-28484)\n\n* libxml2: Hashing of empty dict strings isn't deterministic (CVE-2023-29469)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4529 https://access.redhat.com/security/cve/CVE-2023-28484 https://access.redhat.com/security/cve/CVE-2023-29469",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-16.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4321409": {
+      "id": "4321409",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss-softokn",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4456362": {
+      "id": "4456362",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3591: python3 security update (Important)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: urllib.parse url blocklisting bypass (CVE-2023-24329)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-14T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3591 https://access.redhat.com/security/cve/CVE-2023-24329",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "python3-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-51.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4055233": {
+      "id": "4055233",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7105: gnutls security update (Moderate)",
+      "description": "The gnutls packages provide the GNU Transport Layer Security (GnuTLS) library, which implements cryptographic algorithms and protocols such as SSL, TLS, and DTLS.\n\nSecurity Fix(es):\n\n* gnutls: Double free during gnutls_pkcs7_verify. (CVE-2022-2509)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-25T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7105 https://access.redhat.com/security/cve/CVE-2022-2509",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "gnutls",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.16-5.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4192217": {
+      "id": "4192217",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7720: e2fsprogs security and bug fix update (Moderate)",
+      "description": "The e2fsprogs packages provide a number of utilities for creating, checking, modifying, and correcting the ext2, ext3, and ext4 file systems.\n\nSecurity Fix(es):\n\n* e2fsprogs: out-of-bounds read/write via crafted filesystem (CVE-2022-1304)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7720 https://access.redhat.com/security/cve/CVE-2022-1304",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcom_err",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.45.6-5.el8",
+      "arch_op": "pattern match"
+    },
+    "3616127": {
+      "id": "3616127",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0185: java-11-openjdk security update (Moderate)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: Incomplete deserialization class filtering in ObjectInputStream (Serialization, 8264934) (CVE-2022-21248)\n\n* OpenJDK: Incorrect reading of TIFF files in TIFFNullDecompressor (ImageIO, 8270952) (CVE-2022-21277)\n\n* OpenJDK: Insufficient URI checks in the XSLT TransformerImpl (JAXP, 8270492) (CVE-2022-21282)\n\n* OpenJDK: Unexpected exception thrown in regex Pattern (Libraries, 8268813) (CVE-2022-21283)\n\n* OpenJDK: Incorrect marking of writeable fields (Hotspot, 8270386) (CVE-2022-21291)\n\n* OpenJDK: Incomplete checks of StringBuffer and StringBuilder during deserialization (Libraries, 8270392) (CVE-2022-21293)\n\n* OpenJDK: Incorrect IdentityHashMap size checks during deserialization (Libraries, 8270416) (CVE-2022-21294)\n\n* OpenJDK: Incorrect access checks in XMLEntityManager (JAXP, 8270498) (CVE-2022-21296)\n\n* OpenJDK: Infinite loop related to incorrect handling of newlines in XMLEntityScanner (JAXP, 8270646) (CVE-2022-21299)\n\n* OpenJDK: Array indexing issues in LIRGenerator (Hotspot, 8272014) (CVE-2022-21305)\n\n* OpenJDK: Excessive resource use when reading JAR manifest attributes (Libraries, 8272026) (CVE-2022-21340)\n\n* OpenJDK: Insufficient checks when deserializing exceptions in ObjectInputStream (Serialization, 8272236) (CVE-2022-21341)\n\n* OpenJDK: Excessive memory allocation in BMPImageReader (ImageIO, 8273756) (CVE-2022-21360)\n\n* OpenJDK: Integer overflow in BMPImageReader (ImageIO, 8273838) (CVE-2022-21365)\n\n* OpenJDK: Excessive memory allocation in TIFF*Decompressor (ImageIO, 8274096) (CVE-2022-21366)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-01-24T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0185 https://access.redhat.com/security/cve/CVE-2022-21248 https://access.redhat.com/security/cve/CVE-2022-21277 https://access.redhat.com/security/cve/CVE-2022-21282 https://access.redhat.com/security/cve/CVE-2022-21283 https://access.redhat.com/security/cve/CVE-2022-21291 https://access.redhat.com/security/cve/CVE-2022-21293 https://access.redhat.com/security/cve/CVE-2022-21294 https://access.redhat.com/security/cve/CVE-2022-21296 https://access.redhat.com/security/cve/CVE-2022-21299 https://access.redhat.com/security/cve/CVE-2022-21305 https://access.redhat.com/security/cve/CVE-2022-21340 https://access.redhat.com/security/cve/CVE-2022-21341 https://access.redhat.com/security/cve/CVE-2022-21360 https://access.redhat.com/security/cve/CVE-2022-21365 https://access.redhat.com/security/cve/CVE-2022-21366",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.14.0.9-2.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4236511": {
+      "id": "4236511",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-daemon",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4575222": {
+      "id": "4575222",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4175: java-11-openjdk security and bug fix update (Moderate)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: ZIP file parsing infinite loop (8302483) (CVE-2023-22036)\n\n* OpenJDK: weakness in AES implementation (8308682) (CVE-2023-22041)\n\n* OpenJDK: improper handling of slash characters in URI-to-path conversion (8305312) (CVE-2023-22049)\n\n* harfbuzz: OpenJDK: O(n^2) growth via consecutive marks (CVE-2023-25193)\n\n* OpenJDK: HTTP client insufficient file name validation (8302475) (CVE-2023-22006)\n\n* OpenJDK: array indexing integer overflow issue (8304468) (CVE-2023-22045)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* A virtual machine crash was observed in JDK 11.0.19 when executing the GregorianCalender.computeTime() method (JDK-8307683). It was found\nthat although the root cause of the crash is an old issue, a recent fix for a rare issue in the C2 compiler (JDK-8297951) made the crash much more likely. To mitigate this, the fix has been reverted in JDK 11.0.20 and will be reapplied once JDK-8307683 is resolved. (RHBZ#2222493)\n\n* Prepare for the next quarterly OpenJDK upstream release (2023-07, 11.0.20) [rhel-8] (BZ#2223101)",
+      "issued": "2023-07-20T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4175 https://access.redhat.com/security/cve/CVE-2023-22006 https://access.redhat.com/security/cve/CVE-2023-22036 https://access.redhat.com/security/cve/CVE-2023-22041 https://access.redhat.com/security/cve/CVE-2023-22045 https://access.redhat.com/security/cve/CVE-2023-22049 https://access.redhat.com/security/cve/CVE-2023-25193",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.20.0.8-2.el8",
+      "arch_op": "pattern match"
+    },
+    "4236425": {
+      "id": "4236425",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-daemon",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4053752": {
+      "id": "4053752",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7012: java-11-openjdk security and bug fix update (Moderate)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: improper MultiByte conversion can lead to buffer overflow (JGSS, 8286077) (CVE-2022-21618)\n\n* OpenJDK: excessive memory allocation in X.509 certificate parsing (Security, 8286533) (CVE-2022-21626)\n\n* OpenJDK: HttpServer no connection count limit (Lightweight HTTP Server, 8286918) (CVE-2022-21628)\n\n* OpenJDK: improper handling of long NTLM client hostnames (Security, 8286526) (CVE-2022-21619)\n\n* OpenJDK: insufficient randomization of JNDI DNS port numbers (JNDI, 8286910) (CVE-2022-21624)\n\n* OpenJDK: missing SNI caching in HTTP/2 (Networking, 8289366) (CVE-2022-39399)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Prepare for the next quarterly OpenJDK upstream release (2022-10, 11.0.17) [rhel-8] (BZ#2131863)",
+      "issued": "2022-10-19T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7012 https://access.redhat.com/security/cve/CVE-2022-21618 https://access.redhat.com/security/cve/CVE-2022-21619 https://access.redhat.com/security/cve/CVE-2022-21624 https://access.redhat.com/security/cve/CVE-2022-21626 https://access.redhat.com/security/cve/CVE-2022-21628 https://access.redhat.com/security/cve/CVE-2022-39399",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.17.0.8-2.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3631728": {
+      "id": "3631728",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0368: rpm security update (Moderate)",
+      "description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-rpm",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.14.3-19.el8_5.2",
+      "arch_op": "pattern match"
+    },
+    "4046766": {
+      "id": "4046766",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6878: expat security update (Important)",
+      "description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: a use-after-free in the doContent function in xmlparse.c (CVE-2022-40674)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-11T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6878 https://access.redhat.com/security/cve/CVE-2022-40674",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "expat",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.5-8.el8_6.3",
+      "arch_op": "pattern match"
+    },
+    "138348": {
+      "id": "138348",
+      "updater": "osv/maven",
+      "name": "GHSA-57j2-w4cx-62h2",
+      "description": "Deeply nested json in jackson-databind",
+      "issued": "2022-03-12T00:00:36Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2020-36518 https://github.com/FasterXML/jackson-databind/issues/2816 https://github.com/FasterXML/jackson-databind/commit/fcfc4998ec23f0b1f7f8a9521c2b317b6c25892b https://github.com/FasterXML/jackson-databind https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12 https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.13 https://lists.debian.org/debian-lts-announce/2022/05/msg00001.html https://lists.debian.org/debian-lts-announce/2022/11/msg00035.html https://security.netapp.com/advisory/ntap-20220506-0004/ https://www.debian.org/security/2022/dsa-5283 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "com.fasterxml.jackson.core:jackson-databind",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.12.6.1"
+    },
+    "4559742": {
+      "id": "4559742",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3840: sqlite security update (Moderate)",
+      "description": "SQLite is a C library that implements an SQL database engine. A large subset of SQL92 is supported. A complete database is stored in a single disk file. The API is designed for convenience and ease of use. Applications that link against SQLite can enjoy the power and flexibility of an SQL database without the administrative hassles of supporting a separate database server.\n\nSecurity Fix(es):\n\n* sqlite: Crash due to misuse of window functions. (CVE-2020-24736)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3840 https://access.redhat.com/security/cve/CVE-2020-24736",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "sqlite-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.26.0-18.el8_8",
+      "arch_op": "pattern match"
+    },
+    "3917121": {
+      "id": "3917121",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5311: libgcrypt security update (Moderate)",
+      "description": "The libgcrypt library provides general-purpose implementations of various cryptographic algorithms.\n\nSecurity Fix(es):\n\n* libgcrypt: ElGamal implementation allows plaintext recovery (CVE-2021-40528)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5311 https://access.redhat.com/security/cve/CVE-2021-40528",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libgcrypt",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.8.5-7.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3740378": {
+      "id": "3740378",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1642: zlib security update (Important)",
+      "description": "The zlib packages provide a general-purpose lossless data compression library that is used by many different programs.\n\nSecurity Fix(es):\n\n* zlib: A flaw found in zlib when compressing (not decompressing) certain inputs (CVE-2018-25032)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-04-28T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1642 https://access.redhat.com/security/cve/CVE-2018-25032",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "zlib",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.2.11-18.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4193161": {
+      "id": "4193161",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7745: freetype security update (Moderate)",
+      "description": "FreeType is a free, high-quality, portable font engine that can open and manage font files. FreeType loads, hints, and renders individual glyphs efficiently.\n\nSecurity Fix(es):\n\n* FreeType: Buffer overflow in sfnt_init_face (CVE-2022-27404)\n\n* FreeType: Segmentation violation via FNT_Size_Request (CVE-2022-27405)\n\n* Freetype: Segmentation violation via FT_Request_Size (CVE-2022-27406)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7745 https://access.redhat.com/security/cve/CVE-2022-27404 https://access.redhat.com/security/cve/CVE-2022-27405 https://access.redhat.com/security/cve/CVE-2022-27406",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "freetype",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.1-9.el8",
+      "arch_op": "pattern match"
+    },
+    "138457": {
+      "id": "138457",
+      "updater": "osv/maven",
+      "name": "GHSA-59j4-wjwp-mw9m",
+      "description": "Sandbox Bypass in Apache Velocity Engine",
+      "issued": "2022-01-06T20:32:36Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2020-13936 https://github.com/apache/velocity-engine https://lists.apache.org/thread.html/r01043f584cbd47959fabe18fff64de940f81a65024bb8dddbda31d9a%40%3Cuser.velocity.apache.org%3E https://lists.apache.org/thread.html/r01043f584cbd47959fabe18fff64de940f81a65024bb8dddbda31d9a@%3Cuser.velocity.apache.org%3E https://lists.apache.org/thread.html/r0bc98e9cd080b4a13b905c571b9bed87e1a0878d44dbf21487c6cca4@%3Cdev.santuario.apache.org%3E https://lists.apache.org/thread.html/r17cb932fab14801b14e5b97a7f05192f4f366ef260c10d4a8dba8ac9@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/r293284c6806c73f51098001ea86a14271c39f72cd76af9e946d9d9ad@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/r39de20c7e9c808b1f96790875d33e58c9c0aabb44fd9227e7b3dc5da@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/r3ea4c4c908505b20a4c268330dfe7188b90c84dcf777728d02068ae6@%3Cannounce.apache.org%3E https://lists.apache.org/thread.html/r4cd59453b65d4ac290fcb3b71fdf32b4f1f8989025e89558deb5a245@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/r52a5129df402352adc34d052bab9234c8ef63596306506a89fdc7328@%3Cusers.activemq.apache.org%3E https://lists.apache.org/thread.html/r7f209b837217d2a0fe5977fb692e7f15d37fa5de8214bcdc4c21d9a7@%3Ccommits.turbine.apache.org%3E https://lists.apache.org/thread.html/r9dc2505651788ac668299774d9e7af4dc616be2f56fdc684d1170882@%3Cusers.activemq.apache.org%3E https://lists.apache.org/thread.html/rb042f3b0090e419cc9f5a3d32cf0baff283ccd6fcb1caea61915d6b6@%3Ccommits.velocity.apache.org%3E https://lists.apache.org/thread.html/rbee7270556f4172322936b5ecc9fabf0c09f00d4fa56c9de1963c340@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/rd2a89e17e8a9b451ce655f1a34117752ea1d18a22ce580d8baa824fd@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rd7e865c87f9043c21d9c1fd9d4df866061d9a08cfc322771160d8058@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/re641197d204765130618086238c73dd2ce5a3f94b33785b587d72726@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/re8e7482fe54d289fc0229e61cc64947b63b12c3c312e9f25bf6f3b8c@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/reab5978b54a9f4c078402161e30a89c42807b198814acadbe6c862c7@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/rf7d369de88dc88a1347006a3323b3746d849234db40a8edfd5ebc436@%3Cdev.ws.apache.org%3E https://lists.debian.org/debian-lts-announce/2021/03/msg00019.html https://security.gentoo.org/glsa/202107-52 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html http://www.openwall.com/lists/oss-security/2021/03/10/1",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "org.apache.velocity:velocity",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "lastAffected=1.7"
+    },
+    "4056220": {
+      "id": "4056220",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7106: zlib security update (Moderate)",
+      "description": "The zlib packages provide a general-purpose lossless data compression library that is used by many different programs.\n\nSecurity Fix(es):\n\n* zlib: a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field (CVE-2022-37434)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-25T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7106 https://access.redhat.com/security/cve/CVE-2022-37434",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "zlib",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.2.11-19.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3690879": {
+      "id": "3690879",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0896: glibc security update (Moderate)",
+      "description": "The glibc packages provide the standard C libraries (libc), POSIX thread libraries (libpthread), standard math libraries (libm), and the name service cache daemon (nscd) used by multiple programs on the system. Without these libraries, the Linux system cannot function correctly.\n\nSecurity Fix(es):\n\n* glibc: Off-by-one buffer overflow/underflow in getcwd() (CVE-2021-3999)\n\n* glibc: Stack-based buffer overflow in svcunix_create via long pathnames (CVE-2022-23218)\n\n* glibc: Stack-based buffer overflow in sunrpc clnt_create via a long pathname (CVE-2022-23219)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0896 https://access.redhat.com/security/cve/CVE-2021-3999 https://access.redhat.com/security/cve/CVE-2022-23218 https://access.redhat.com/security/cve/CVE-2022-23219",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "glibc-common",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.28-164.el8_5.3",
+      "arch_op": "pattern match"
+    },
+    "3712338": {
+      "id": "3712338",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0896: glibc security update (Moderate)",
+      "description": "The glibc packages provide the standard C libraries (libc), POSIX thread libraries (libpthread), standard math libraries (libm), and the name service cache daemon (nscd) used by multiple programs on the system. Without these libraries, the Linux system cannot function correctly.\n\nSecurity Fix(es):\n\n* glibc: Off-by-one buffer overflow/underflow in getcwd() (CVE-2021-3999)\n\n* glibc: Stack-based buffer overflow in svcunix_create via long pathnames (CVE-2022-23218)\n\n* glibc: Stack-based buffer overflow in sunrpc clnt_create via a long pathname (CVE-2022-23219)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0896 https://access.redhat.com/security/cve/CVE-2021-3999 https://access.redhat.com/security/cve/CVE-2022-23218 https://access.redhat.com/security/cve/CVE-2022-23219",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "glibc-minimal-langpack",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.28-164.el8_5.3",
+      "arch_op": "pattern match"
+    },
+    "3917297": {
+      "id": "3917297",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5313: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: OAUTH2 bearer bypass in connection re-use (CVE-2022-22576)\n\n* curl: credential leak on redirect (CVE-2022-27774)\n\n* curl: auth/cookie leak on redirect (CVE-2022-27776)\n\n* curl: TLS and SSH connection too eager reuse (CVE-2022-27782)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5313 https://access.redhat.com/security/cve/CVE-2022-22576 https://access.redhat.com/security/cve/CVE-2022-27774 https://access.redhat.com/security/cve/CVE-2022-27776 https://access.redhat.com/security/cve/CVE-2022-27782",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-22.el8_6.3",
+      "arch_op": "pattern match"
+    },
+    "149634": {
+      "id": "149634",
+      "updater": "osv/maven",
+      "name": "GHSA-jfh8-c2jp-5v3q",
+      "description": "Remote code injection in Log4j",
+      "issued": "2021-12-10T00:40:56Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228 https://github.com/apache/logging-log4j2/pull/608 https://cert-portal.siemens.com/productcert/pdf/ssa-397453.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-479842.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-661247.pdf https://cert-portal.siemens.com/productcert/pdf/ssa-714170.pdf https://github.com/advisories/GHSA-7rjr-3q55-vv33 https://github.com/apache/logging-log4j2 https://github.com/cisagov/log4j-affected-db https://github.com/cisagov/log4j-affected-db/blob/develop/SOFTWARE-LIST.md https://github.com/nu11secur1ty/CVE-mitre/tree/main/CVE-2021-44228 https://github.com/tangxiaofeng7/apache-log4j-poc https://issues.apache.org/jira/browse/LOG4J2-3198 https://issues.apache.org/jira/browse/LOG4J2-3201 https://issues.apache.org/jira/browse/LOG4J2-3214 https://issues.apache.org/jira/browse/LOG4J2-3221 https://lists.debian.org/debian-lts-announce/2021/12/msg00007.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M5CSVUNV4HWZZXGOKNSK6L7RPM7BOKIB/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VU57UJDCFIASIO35GC55JMKSRXJMCDFM/ https://logging.apache.org/log4j/2.x/changes-report.html#a2.15.0 https://logging.apache.org/log4j/2.x/manual/lookups.html#JndiLookup https://logging.apache.org/log4j/2.x/manual/migration.html https://logging.apache.org/log4j/2.x/security.html https://msrc-blog.microsoft.com/2021/12/11/microsofts-response-to-cve-2021-44228-apache-log4j2/ https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0032 https://security.netapp.com/advisory/ntap-20211210-0007/ https://support.apple.com/kb/HT213189 https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-apache-log4j-qRuKNEbd https://twitter.com/kurtseifried/status/1469345530182455296 https://www.bentley.com/en/common-vulnerability-exposure/be-2022-0001 https://www.debian.org/security/2021/dsa-5020 https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00646.html https://www.kb.cert.org/vuls/id/930724 https://www.nu11secur1ty.com/2021/12/cve-2021-44228.html https://www.oracle.com/security-alerts/alert-cve-2021-44228.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html http://packetstormsecurity.com/files/165225/Apache-Log4j2-2.14.1-Remote-Code-Execution.html http://packetstormsecurity.com/files/165260/VMware-Security-Advisory-2021-0028.html http://packetstormsecurity.com/files/165261/Apache-Log4j2-2.14.1-Information-Disclosure.html http://packetstormsecurity.com/files/165270/Apache-Log4j2-2.14.1-Remote-Code-Execution.html http://packetstormsecurity.com/files/165281/Log4j2-Log4Shell-Regexes.html http://packetstormsecurity.com/files/165282/Log4j-Payload-Generator.html http://packetstormsecurity.com/files/165306/L4sh-Log4j-Remote-Code-Execution.html http://packetstormsecurity.com/files/165307/Log4j-Remote-Code-Execution-Word-Bypassing.html http://packetstormsecurity.com/files/165311/log4j-scan-Extensive-Scanner.html http://packetstormsecurity.com/files/165371/VMware-Security-Advisory-2021-0028.4.html http://packetstormsecurity.com/files/165532/Log4Shell-HTTP-Header-Injection.html http://packetstormsecurity.com/files/165642/VMware-vCenter-Server-Unauthenticated-Log4Shell-JNDI-Injection-Remote-Code-Execution.html http://packetstormsecurity.com/files/165673/UniFi-Network-Application-Unauthenticated-Log4Shell-Remote-Code-Execution.html http://packetstormsecurity.com/files/167794/Open-Xchange-App-Suite-7.10.x-Cross-Site-Scripting-Command-Injection.html http://packetstormsecurity.com/files/167917/MobileIron-Log4Shell-Remote-Command-Execution.html http://packetstormsecurity.com/files/171626/AD-Manager-Plus-7122-Remote-Code-Execution.html http://seclists.org/fulldisclosure/2022/Dec/2 http://seclists.org/fulldisclosure/2022/Jul/11 http://seclists.org/fulldisclosure/2022/Mar/23 http://www.openwall.com/lists/oss-security/2021/12/10/1 http://www.openwall.com/lists/oss-security/2021/12/10/2 http://www.openwall.com/lists/oss-security/2021/12/10/3 http://www.openwall.com/lists/oss-security/2021/12/13/1 http://www.openwall.com/lists/oss-security/2021/12/13/2 http://www.openwall.com/lists/oss-security/2021/12/14/4 http://www.openwall.com/lists/oss-security/2021/12/15/3",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+      "normalized_severity": "Critical",
+      "package": {
+        "id": "",
+        "name": "org.apache.logging.log4j:log4j-core",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.12.2&introduced=2.4"
+    },
+    "4016429": {
+      "id": "4016429",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6206: systemd security update (Important)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd-resolved: use-after-free when dealing with DnsStream in resolved-dns-stream.c (CVE-2022-2526)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-29T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6206 https://access.redhat.com/security/cve/CVE-2022-2526",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "systemd-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-58.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "3954012": {
+      "id": "3954012",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5818: openssl security update (Moderate)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: c_rehash script allows command injection (CVE-2022-1292)\n\n* openssl: the c_rehash script allows command injection (CVE-2022-2068)\n\n* openssl: AES OCB fails to encrypt some bytes (CVE-2022-2097)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-03T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5818 https://access.redhat.com/security/cve/CVE-2022-1292 https://access.redhat.com/security/cve/CVE-2022-2068 https://access.redhat.com/security/cve/CVE-2022-2097",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "openssl-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-7.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3641452": {
+      "id": "3641452",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0658: cyrus-sasl security update (Important)",
+      "description": "The cyrus-sasl packages contain the Cyrus implementation of Simple Authentication and Security Layer (SASL). SASL is a method for adding authentication support to connection-based protocols.\n\nSecurity Fix(es):\n\n* cyrus-sasl: failure to properly escape SQL input allows an attacker to execute arbitrary SQL commands (CVE-2022-24407)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-23T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0658 https://access.redhat.com/security/cve/CVE-2022-24407",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "cyrus-sasl-lib",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.1.27-6.el8_5",
+      "arch_op": "pattern match"
+    },
+    "3879204": {
+      "id": "3879204",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:2031: libssh security, bug fix, and enhancement update (Low)",
+      "description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nThe following packages have been upgraded to a later upstream version: libssh (0.9.6). (BZ#1896651)\n\nSecurity Fix(es):\n\n* libssh: possible heap-based buffer overflow when rekeying (CVE-2021-3634)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:2031 https://access.redhat.com/security/cve/CVE-2021-3634",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "libssh-config",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:0.9.6-3.el8"
+    },
+    "4236321": {
+      "id": "4236321",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4015035": {
+      "id": "4015035",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6159: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP compression denial of service (CVE-2022-32206)\n\n* curl: FTP-KRB bad message verification (CVE-2022-32208)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-24T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6159 https://access.redhat.com/security/cve/CVE-2022-32206 https://access.redhat.com/security/cve/CVE-2022-32208",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-22.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "4441754": {
+      "id": "4441754",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3018: libarchive security update (Low)",
+      "description": "The libarchive programming library can create and read several different streaming archive formats, including GNU tar, cpio, and ISO 9660 CD-ROM images. Libarchive is used notably in the bsdtar utility, scripting language bindings such as python-libarchive, and several popular desktop file managers.\n\nSecurity Fix(es):\n\n* libarchive: NULL pointer dereference in archive_write.c (CVE-2022-36227)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.8 Release Notes linked from the References section.",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3018 https://access.redhat.com/security/cve/CVE-2022-36227",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "libarchive",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.3.3-5.el8",
+      "arch_op": "pattern match"
+    },
+    "4599633": {
+      "id": "4599633",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "python3-syspurpose",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "156104": {
+      "id": "156104",
+      "updater": "osv/maven",
+      "name": "GHSA-v528-7hrm-frqp",
+      "description": "Improper Check for Unusual or Exceptional Conditions in json-smart",
+      "issued": "2021-06-16T18:03:47Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2021-27568 https://github.com/netplex/json-smart-v1/issues/7 https://github.com/netplex/json-smart-v2/issues/60 https://github.com/netplex/json-smart-v2/issues/62 https://github.com/netplex/json-smart-v2/pull/72 https://github.com/netplex/json-smart-v1/commit/768db58ee0e3e344fcdb574b7629765308a1d0af https://github.com/netplex/json-smart-v2 https://lists.apache.org/thread.html/rb6287f5aa628c8d9af52b5401ec6cc51b6fc28ab20d318943453e396@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/re237267da268c690df5e1c6ea6a38a7fc11617725e8049490f58a6fa@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rf70210b4d63191c0bfb2a0d5745e104484e71703bf5ad9cb01c980c6@%3Ccommits.druid.apache.org%3E https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html",
+      "severity": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "net.minidev:json-smart",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.3.1&introduced=2.0.0"
+    },
+    "3917266": {
+      "id": "3917266",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5313: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: OAUTH2 bearer bypass in connection re-use (CVE-2022-22576)\n\n* curl: credential leak on redirect (CVE-2022-27774)\n\n* curl: auth/cookie leak on redirect (CVE-2022-27776)\n\n* curl: TLS and SSH connection too eager reuse (CVE-2022-27782)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5313 https://access.redhat.com/security/cve/CVE-2022-22576 https://access.redhat.com/security/cve/CVE-2022-27774 https://access.redhat.com/security/cve/CVE-2022-27776 https://access.redhat.com/security/cve/CVE-2022-27782",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-22.el8_6.3",
+      "arch_op": "pattern match"
+    },
+    "4015868": {
+      "id": "4015868",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6206: systemd security update (Important)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd-resolved: use-after-free when dealing with DnsStream in resolved-dns-stream.c (CVE-2022-2526)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-29T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6206 https://access.redhat.com/security/cve/CVE-2022-2526",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "systemd",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-58.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "4029280": {
+      "id": "4029280",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6457: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-09-13T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-47.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4601158": {
+      "id": "4601158",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4864: cups security update (Important)",
+      "description": "The Common UNIX Printing System (CUPS) provides a portable printing layer for Linux, UNIX, and similar operating systems.\n\nSecurity Fix(es):\n\n* cups: Information leak through Cups-Get-Document operation (CVE-2023-32360)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-29T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4864 https://access.redhat.com/security/cve/CVE-2023-32360",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "cups-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:2.2.6-51.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "3633588": {
+      "id": "3633588",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0370: cryptsetup security update (Moderate)",
+      "description": "The cryptsetup packages provide a utility for setting up disk encryption using the dm-crypt kernel module.\n\nSecurity Fix(es):\n\n* cryptsetup: disable encryption via header rewrite (CVE-2021-4122)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0370 https://access.redhat.com/security/cve/CVE-2021-4122",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "cryptsetup-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.3.3-4.el8_5.1",
+      "arch_op": "pattern match"
+    },
+    "4600572": {
+      "id": "4600572",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "subscription-manager-rhsm-certificates",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "4016358": {
+      "id": "4016358",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6206: systemd security update (Important)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd-resolved: use-after-free when dealing with DnsStream in resolved-dns-stream.c (CVE-2022-2526)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-29T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6206 https://access.redhat.com/security/cve/CVE-2022-2526",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "systemd-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-58.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "3917079": {
+      "id": "3917079",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5311: libgcrypt security update (Moderate)",
+      "description": "The libgcrypt library provides general-purpose implementations of various cryptographic algorithms.\n\nSecurity Fix(es):\n\n* libgcrypt: ElGamal implementation allows plaintext recovery (CVE-2021-40528)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5311 https://access.redhat.com/security/cve/CVE-2021-40528",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libgcrypt",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.8.5-7.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4279858": {
+      "id": "4279858",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0100: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: buffer overrun in format_timespan() function (CVE-2022-3821)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* ShutdownWatchdogSec value is not taken into account on reboot (BZ#2127170)",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0100 https://access.redhat.com/security/cve/CVE-2022-3821",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-pam",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "3690500": {
+      "id": "3690500",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0896: glibc security update (Moderate)",
+      "description": "The glibc packages provide the standard C libraries (libc), POSIX thread libraries (libpthread), standard math libraries (libm), and the name service cache daemon (nscd) used by multiple programs on the system. Without these libraries, the Linux system cannot function correctly.\n\nSecurity Fix(es):\n\n* glibc: Off-by-one buffer overflow/underflow in getcwd() (CVE-2021-3999)\n\n* glibc: Stack-based buffer overflow in svcunix_create via long pathnames (CVE-2022-23218)\n\n* glibc: Stack-based buffer overflow in sunrpc clnt_create via a long pathname (CVE-2022-23219)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0896 https://access.redhat.com/security/cve/CVE-2021-3999 https://access.redhat.com/security/cve/CVE-2022-23218 https://access.redhat.com/security/cve/CVE-2022-23219",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "glibc",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.28-164.el8_5.3",
+      "arch_op": "pattern match"
+    },
+    "153110": {
+      "id": "153110",
+      "updater": "osv/maven",
+      "name": "GHSA-pqr6-cmr2-h8hf",
+      "description": "snappy-java's Integer Overflow vulnerability in shuffle leads to DoS",
+      "issued": "2023-06-15T16:13:20Z",
+      "links": "https://github.com/xerial/snappy-java/security/advisories/GHSA-pqr6-cmr2-h8hf https://nvd.nist.gov/vuln/detail/CVE-2023-34453 https://github.com/xerial/snappy-java/commit/820e2e074c58748b41dbd547f4edba9e108ad905 https://github.com/xerial/snappy-java https://github.com/xerial/snappy-java/blob/05c39b2ca9b5b7b39611529cc302d3d796329611/src/main/java/org/xerial/snappy/BitShuffle.java#L107 https://github.com/xerial/snappy-java/blob/master/src/main/java/org/xerial/snappy/BitShuffle.java",
+      "severity": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.xerial.snappy:snappy-java",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.1.10.1"
+    },
+    "4308437": {
+      "id": "4308437",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: local information leak due to systemd-coredump not respecting fs.suid_dumpable kernel setting (CVE-2022-4415)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd doesn't record messages to the journal during boot (BZ#2164049)",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0837 https://access.redhat.com/security/cve/CVE-2022-4415",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.4",
+      "arch_op": "pattern match"
+    },
+    "4322175": {
+      "id": "4322175",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss-util",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4302545": {
+      "id": "4302545",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0625: libksba security update (Important)",
+      "description": "KSBA (pronounced Kasbah) is a library to make X.509 certificates as well as the CMS easily accessible by other applications. Both specifications are building blocks of S/MIME and TLS.\n\nSecurity Fix(es):\n\n* libksba: integer overflow to code executiona (CVE-2022-47629)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0625 https://access.redhat.com/security/cve/CVE-2022-47629",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "libksba",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.3.5-9.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4056165": {
+      "id": "4056165",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7106: zlib security update (Moderate)",
+      "description": "The zlib packages provide a general-purpose lossless data compression library that is used by many different programs.\n\nSecurity Fix(es):\n\n* zlib: a heap-based buffer over-read or buffer overflow in inflate in inflate.c via a large gzip header extra field (CVE-2022-37434)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-25T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7106 https://access.redhat.com/security/cve/CVE-2022-37434",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "zlib",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.2.11-19.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4033190": {
+      "id": "4033190",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6463: gnupg2 security update (Moderate)",
+      "description": "The GNU Privacy Guard (GnuPG or GPG) is a tool for encrypting data and creating digital signatures, compliant with OpenPGP and S/MIME standards.\n\nSecurity Fix(es):\n\n* gpg: Signature spoofing via status line injection (CVE-2022-34903)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-09-13T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6463 https://access.redhat.com/security/cve/CVE-2022-34903",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "gnupg2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.20-3.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4191686": {
+      "id": "4191686",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7715: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Incorrect server side include parsing can lead to XSS (CVE-2016-3709)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7715 https://access.redhat.com/security/cve/CVE-2016-3709",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-15.el8",
+      "arch_op": "pattern match"
+    },
+    "4599434": {
+      "id": "4599434",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "dnf-plugin-subscription-manager",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "4456469": {
+      "id": "4456469",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3591: python3 security update (Important)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: urllib.parse url blocklisting bypass (CVE-2023-24329)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-14T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3591 https://access.redhat.com/security/cve/CVE-2023-24329",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "python3-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-51.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "156954": {
+      "id": "156954",
+      "updater": "osv/maven",
+      "name": "GHSA-w37g-rhq8-7m4j",
+      "description": "Snakeyaml vulnerable to Stack overflow leading to denial of service",
+      "issued": "2022-11-11T19:00:31Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-41854 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/commits/e230a1758842beec93d28eddfde568c21774780a https://bitbucket.org/snakeyaml/snakeyaml/issues/531/ https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50355 https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3DDXEXXWAZGF5AVHIPGFPXIWL6TSMKJE/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/7MKE4XWRXTH32757H7QJU4ACS67DYDCR/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KSPAJ5Y45A4ZDION2KN5RDWLHK4XKY2J/",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.yaml:snakeyaml",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.32"
+    },
+    "4284763": {
+      "id": "4284763",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0110: sqlite security update (Moderate)",
+      "description": "SQLite is a C library that implements an SQL database engine. A large subset of SQL92 is supported. A complete database is stored in a single disk file. The API is designed for convenience and ease of use. Applications that link against SQLite can enjoy the power and flexibility of an SQL database without the administrative hassles of supporting a separate database server.\n\nSecurity Fix(es):\n\n* sqlite: an array-bounds overflow if billions of bytes are used in a string argument to a C API (CVE-2022-35737)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0110 https://access.redhat.com/security/cve/CVE-2022-35737",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "sqlite-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.26.0-17.el8_7",
+      "arch_op": "pattern match"
+    },
+    "157977": {
+      "id": "157977",
+      "updater": "osv/maven",
+      "name": "GHSA-wx5j-54mm-rqqq",
+      "description": "HTTP request smuggling in netty",
+      "issued": "2021-12-09T19:09:17Z",
+      "links": "https://github.com/netty/netty/security/advisories/GHSA-wx5j-54mm-rqqq https://nvd.nist.gov/vuln/detail/CVE-2021-43797 https://github.com/netty/netty/pull/11891 https://github.com/netty/netty/commit/07aa6b5938a8b6ed7a6586e066400e2643897323 https://github.com/netty/netty/ https://lists.debian.org/debian-lts-announce/2023/01/msg00008.html https://security.netapp.com/advisory/ntap-20220107-0003/ https://www.debian.org/security/2023/dsa-5316 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "io.netty:netty-codec-http",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.1.71.Final&introduced=4.0.0"
+    },
+    "3920299": {
+      "id": "3920299",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5317: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows in xmlBuf and xmlBuffer lead to out-of-bounds write (CVE-2022-29824)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5317 https://access.redhat.com/security/cve/CVE-2022-29824",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-13.el8_6.1",
+      "arch_op": "pattern match"
+    },
+    "4290268": {
+      "id": "4290268",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0173: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows with XML_PARSE_HUGE (CVE-2022-40303)\n\n* libxml2: dict corruption caused by entity reference cycles (CVE-2022-40304)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0173 https://access.redhat.com/security/cve/CVE-2022-40303 https://access.redhat.com/security/cve/CVE-2022-40304",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-15.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4308353": {
+      "id": "4308353",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0835: python-setuptools security update (Moderate)",
+      "description": "The python-setuptools package provides a collection of enhancements to Python distribution utilities allowing convenient building and distribution of Python packages.\n\nSecurity Fix(es):\n\n* pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py (CVE-2022-40897)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0835 https://access.redhat.com/security/cve/CVE-2022-40897",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-setuptools-wheel",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:39.2.0-6.el8_7.1"
+    },
+    "3714338": {
+      "id": "3714338",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0899: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Use-after-free of ID and IDREF attributes (CVE-2022-23308)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0899 https://access.redhat.com/security/cve/CVE-2022-23308",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-12.el8_5",
+      "arch_op": "pattern match"
+    },
+    "3714247": {
+      "id": "3714247",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0899: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Use-after-free of ID and IDREF attributes (CVE-2022-23308)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0899 https://access.redhat.com/security/cve/CVE-2022-23308",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-12.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4558149": {
+      "id": "4558149",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: privilege escalation via the less pager (CVE-2023-26604)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd-pstore crashes when attempting to move standalone files out of /sys/fs/pstore (BZ#2190153)",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3837 https://access.redhat.com/security/cve/CVE-2023-26604",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-74.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "4236853": {
+      "id": "4236853",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-tools",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "155864": {
+      "id": "155864",
+      "updater": "osv/maven",
+      "name": "GHSA-rvwf-54qp-4r6v",
+      "description": "SnakeYAML Entity Expansion during load operation",
+      "issued": "2021-06-04T21:37:45Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2017-18640 https://bitbucket.org/asomov/snakeyaml https://bitbucket.org/asomov/snakeyaml/commits/da11ddbd91c1f8392ea932b37fa48110fa54ed8c https://bitbucket.org/asomov/snakeyaml/issues/377/allow-configuration-for-preventing-billion https://bitbucket.org/asomov/snakeyaml/wiki/Billion%20laughs%20attack https://bitbucket.org/asomov/snakeyaml/wiki/Changes https://bitbucket.org/snakeyaml/snakeyaml/issues/377 https://bitbucket.org/snakeyaml/snakeyaml/wiki/Changes https://lists.apache.org/thread.html/r1058e7646988394de6a3fd0857ea9b1ee0de14d7bb28fee5ff782457@%3Ccommits.atlas.apache.org%3E https://lists.apache.org/thread.html/r154090b871cf96d985b90864442d84eb027c72c94bc3f0a5727ba2d1@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r16ae4e529401b75a1f5aa462b272b31bf2a108236f882f06fddc14bc@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r1703a402f30c8a2ee409f8c6f393e95a63f8c952cc9ee5bf9dd586dc@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r182e9cf6f3fb22b9be0cac4ff0685199741d2ab6e9a4e27a3693c224@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r191ceadb1b883357384981848dfa5235cb02a90070c553afbaf9b3d9@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r1aab47b48a757c70e40fc0bcb1fcf1a3951afa6a17aee7cd66cf79f8@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/r1dfac8b6a7097bcb4979402bbb6e2f8c36d0d9001e3018717eb22b7e@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r1ffce2ed3017e9964f03ad2c539d69e49144fc8e9bf772d641612f98@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r20350031c60a77b45e0eded33e9b3e9cb0cbfc5e24e1c63bf264df12@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r22ac2aa053b7d9c6b75a49db78125c9316499668d0f4a044f3402e2f@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r2721aba31a8562639c4b937150897e24f78f747cdbda8641c0f659fe@%3Cusers.kafka.apache.org%3E https://lists.apache.org/thread.html/r28c9009a48d52cf448f8b02cd823da0f8601d2dff4d66f387a35f1e0@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r2a5b84fdf59042dc398497e914b5bb1aed77328320b1438144ae1953@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r2b05744c0c2867daa5d1a96832965b7d6220328b0ead06c22a6e7854@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r2db207a2431a5e9e95e899858ab1f5eabd9bcc790a6ca7193ae07e94@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r436988d2cfe8a770ae361c82b181c5b2bf48a249bad84d8a55a3b46e@%3Cdev.phoenix.apache.org%3E https://lists.apache.org/thread.html/r465d2553a31265b042cf5457ef649b71e0722ab89b6ea94a5d59529b@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r4c682fb8cf69dd14162439656a6ebdf42ea6ad0e4edba95907ea3f14@%3Ccommits.servicecomb.apache.org%3E https://lists.apache.org/thread.html/r4d7f37da1bc2df90a5a0f56eb7629b5ea131bfe11eeeb4b4c193f64a@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r5510f0125ba409fc1cabd098ab8b457741e5fa314cbd0e61e4339422@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r55d807f31e64a080c54455897c20b1667ec792e5915132c7b7750533@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r56805265475919252ba7fc10123f15b91097f3009bae86476624ca25@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r643ba53f002ae59068f9352fe1d82e1b6f375387ffb776f13efe8fda@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r666f29a7d0e1f98fa1425ca01efcfa86e6e3856e01d300828aa7c6ea@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r6c91e52b3cc9f4e64afe0f34f20507143fd1f756d12681a56a9b38da@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r6d54c2da792c74cc14b9b7665ea89e144c9e238ed478d37fd56292e6@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/r72a3588d62b2de1361dc9648f5d355385735e47f7ba49d089b0e680d@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r7ce3de03facf7e7f3e24fc25d26d555818519dafdb20f29398a3414b@%3Cdev.phoenix.apache.org%3E https://lists.apache.org/thread.html/r8464b6ec951aace8c807bac9ea526d4f9e3116aa16d38be06f7c6524@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/r8b57c57cffa01e418868a3c7535b987635ff1fb5ab534203bfa2d64a@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r900e020760c89f082df1c6e0d46320eba721e4e47bb9eb521e68cd95@%3Ccommits.servicecomb.apache.org%3E https://lists.apache.org/thread.html/raebd2019b3da8c2f90f31e8b203b45353f78770ca93bfe5376f5532e@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rb0e033d5ec8233360203431ad96580cf2ec56f47d9a425d894e279c2@%3Cpr.cassandra.apache.org%3E https://lists.apache.org/thread.html/rb34d8d3269ad47a1400f5a1a2d8310e13a80b6576ebd7f512144198d@%3Ccommon-dev.hadoop.apache.org%3E https://lists.apache.org/thread.html/rb5c33d0069c927fae16084f0605895b98d231d7c48527bcb822ac48c@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rb7b28ac741e32dd5edb2c22485d635275bead7290b056ee56baf8ce0@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/rbaa1f513d903c89a08267c91d86811fa5bcc82e0596b6142c5cea7ea@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rc3211c71f7e0973a1825d1988a3921288c06cd9d793eae97ecd34948@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rcb2a7037366c58bac6aec6ce3df843a11ef97ae4eb049f05f410eaa5@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/rcb4b61dbe2ed1c7a88781a9aff5a9e7342cc7ed026aec0418ee67596@%3Ccommon-issues.hadoop.apache.org%3E https://lists.apache.org/thread.html/rce5c93bba6e815fb62ad38e28ca1943b3019af1eddeb06507ad4e11a@%3Ccommits.atlas.apache.org%3E https://lists.apache.org/thread.html/rd582c64f66c354240290072f340505f5d026ca944ec417226bb0272e@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rdd34c0479587e32a656d976649409487d51ca0d296b3e26b6b89c3f5@%3Ccommon-commits.hadoop.apache.org%3E https://lists.apache.org/thread.html/re791a854001ec1f79cd4f47328b270e7a1d9d7056debb8f16d962722@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/re851bbfbedd47c690b6e01942acb98ee08bd00df1a94910b905bc8cd@%3Cdev.atlas.apache.org%3E https://lists.apache.org/thread.html/reb1751562ee5146d3aca654a2df76a2c13d8036645ce69946f9c219e@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/recfe569f4f260328b0036f1c82b2956e864d519ab941a5e75d0d832d@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rf95bebee6dfcc55067cebe8482bd31e6f481d9f74ba8e03f860c3ec7@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/rfe0aab6c3bebbd9cbfdedb65ff3fdf420714bcb8acdfd346077e1263@%3Ccommon-commits.hadoop.apache.org%3E https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CKN7VGIKTYBCAKYBRG55QHXAY5UDZ7HA/ https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PTVJC54XGX26UJVVYCXZ7D25X3R5T2G6/ https://mvnrepository.com/artifact/org.yaml/snakeyaml/1.25/usages https://security.gentoo.org/glsa/202305-28 https://www.oracle.com/security-alerts/cpuApr2021.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "org.yaml:snakeyaml",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.26"
+    },
+    "3920379": {
+      "id": "3920379",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5317: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows in xmlBuf and xmlBuffer lead to out-of-bounds write (CVE-2022-29824)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5317 https://access.redhat.com/security/cve/CVE-2022-29824",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-13.el8_6.1",
+      "arch_op": "pattern match"
+    },
+    "3879284": {
+      "id": "3879284",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:2031: libssh security, bug fix, and enhancement update (Low)",
+      "description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nThe following packages have been upgraded to a later upstream version: libssh (0.9.6). (BZ#1896651)\n\nSecurity Fix(es):\n\n* libssh: possible heap-based buffer overflow when rekeying (CVE-2021-3634)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:2031 https://access.redhat.com/security/cve/CVE-2021-3634",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "libssh-config",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:0.9.6-3.el8"
+    },
+    "3632719": {
+      "id": "3632719",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0368: rpm security update (Moderate)",
+      "description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "rpm-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.14.3-19.el8_5.2",
+      "arch_op": "pattern match"
+    },
+    "3553017": {
+      "id": "3553017",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2021:4587: gcc security update (Moderate)",
+      "description": "The gcc packages provide compilers for C, C++, Java, Fortran, Objective C, and Ada 95 GNU, as well as related support libraries.\n\nSecurity Fix(es):\n\n* Developer environment: Unicode's bidirectional (BiDi) override characters can cause trojan source attacks (CVE-2021-42574)\n\nThe following changes were introduced in gcc in order to facilitate detection of BiDi Unicode characters:\n\nThis update implements a new warning option -Wbidirectional to warn about possibly dangerous bidirectional characters.\n\nThere are three levels of warning supported by gcc:\n\"-Wbidirectional=unpaired\", which warns about improperly terminated BiDi contexts. (This is the default.)\n\"-Wbidirectional=none\", which turns the warning off.\n\"-Wbidirectional=any\", which warns about any use of bidirectional characters.\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2021-11-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2021:4587 https://access.redhat.com/security/cve/CVE-2021-42574",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libgcc",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:8.5.0-4.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4236336": {
+      "id": "4236336",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-common",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1"
+    },
+    "3632787": {
+      "id": "3632787",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0368: rpm security update (Moderate)",
+      "description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "rpm-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.14.3-19.el8_5.2",
+      "arch_op": "pattern match"
+    },
+    "145398": {
+      "id": "145398",
+      "updater": "osv/maven",
+      "name": "GHSA-fjpj-2g6w-x25r",
+      "description": "snappy-java's Integer Overflow vulnerability in compress leads to DoS",
+      "issued": "2023-06-15T16:28:08Z",
+      "links": "https://github.com/xerial/snappy-java/security/advisories/GHSA-fjpj-2g6w-x25r https://nvd.nist.gov/vuln/detail/CVE-2023-34454 https://github.com/xerial/snappy-java/commit/d0042551e4a3509a725038eb9b2ad1f683674d94 https://github.com/xerial/snappy-java https://github.com/xerial/snappy-java/blob/05c39b2ca9b5b7b39611529cc302d3d796329611/src/main/java/org/xerial/snappy/Snappy.java#L169 https://github.com/xerial/snappy-java/blob/05c39b2ca9b5b7b39611529cc302d3d796329611/src/main/java/org/xerial/snappy/Snappy.java#L422 https://github.com/xerial/snappy-java/blob/master/src/main/java/org/xerial/snappy/Snappy.java",
+      "severity": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.xerial.snappy:snappy-java",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.1.10.1"
+    },
+    "3716594": {
+      "id": "3716594",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1065: openssl security update (Important)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Infinite loop in BN_mod_sqrt() reachable when parsing certificates (CVE-2022-0778)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-28T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1065 https://access.redhat.com/security/cve/CVE-2022-0778",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "openssl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-6.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4308044": {
+      "id": "4308044",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0833: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: int() type in PyLong_FromString() does not limit amount of digits converting text to int leading to DoS (CVE-2020-10735)\n\n* python: open redirection vulnerability in lib/http/server.py may lead to information disclosure (CVE-2021-28861)\n\n* Python: CPU denial of service via inefficient IDNA decoder (CVE-2022-45061)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0833 https://access.redhat.com/security/cve/CVE-2020-10735 https://access.redhat.com/security/cve/CVE-2021-28861 https://access.redhat.com/security/cve/CVE-2022-45061",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-48.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "3632458": {
+      "id": "3632458",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0368: rpm security update (Moderate)",
+      "description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "rpm-build-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.14.3-19.el8_5.2",
+      "arch_op": "pattern match"
+    },
+    "4588959": {
+      "id": "4588959",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4523: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: GSS delegation too eager connection re-use (CVE-2023-27536)\n\n* curl: IDN wildcard match may lead to Improper Cerificate Validation (CVE-2023-28321)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4523 https://access.redhat.com/security/cve/CVE-2023-27536 https://access.redhat.com/security/cve/CVE-2023-28321",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8_8.3",
+      "arch_op": "pattern match"
+    },
+    "4559314": {
+      "id": "4559314",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3839: libssh security update (Moderate)",
+      "description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nSecurity Fix(es):\n\n* libssh: NULL pointer dereference during rekeying with algorithm guessing (CVE-2023-1667)\n\n* libssh: authorization bypass in pki_verify_data_signature (CVE-2023-2283)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3839 https://access.redhat.com/security/cve/CVE-2023-1667 https://access.redhat.com/security/cve/CVE-2023-2283",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libssh-config",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:0.9.6-10.el8_8"
+    },
+    "158597": {
+      "id": "158597",
+      "updater": "osv/maven",
+      "name": "GHSA-xmc8-26q4-qjhx",
+      "description": "Denial of Service (DoS) in Jackson Dataformat CBOR",
+      "issued": "2021-12-09T19:17:21Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2020-28491 https://github.com/FasterXML/jackson-dataformats-binary/issues/186 https://github.com/FasterXML/jackson-dataformats-binary/commit/3d7de83423f8f68f8e9a0c8250084e11818544c7 https://github.com/FasterXML/jackson-dataformats-binary/commit/de072d314af8f5f269c8abec6930652af67bc8e6 https://github.com/FasterXML/jackson-dataformats-binary https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATAFORMAT-1047329 https://www.oracle.com/security-alerts/cpujul2022.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=2.11.4&introduced=2.8.0rc1"
+    },
+    "3552940": {
+      "id": "3552940",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2021:4587: gcc security update (Moderate)",
+      "description": "The gcc packages provide compilers for C, C++, Java, Fortran, Objective C, and Ada 95 GNU, as well as related support libraries.\n\nSecurity Fix(es):\n\n* Developer environment: Unicode's bidirectional (BiDi) override characters can cause trojan source attacks (CVE-2021-42574)\n\nThe following changes were introduced in gcc in order to facilitate detection of BiDi Unicode characters:\n\nThis update implements a new warning option -Wbidirectional to warn about possibly dangerous bidirectional characters.\n\nThere are three levels of warning supported by gcc:\n\"-Wbidirectional=unpaired\", which warns about improperly terminated BiDi contexts. (This is the default.)\n\"-Wbidirectional=none\", which turns the warning off.\n\"-Wbidirectional=any\", which warns about any use of bidirectional characters.\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2021-11-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2021:4587 https://access.redhat.com/security/cve/CVE-2021-42574",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libgcc",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:8.5.0-4.el8_5",
+      "arch_op": "pattern match"
+    },
+    "3553964": {
+      "id": "3553964",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2021:4587: gcc security update (Moderate)",
+      "description": "The gcc packages provide compilers for C, C++, Java, Fortran, Objective C, and Ada 95 GNU, as well as related support libraries.\n\nSecurity Fix(es):\n\n* Developer environment: Unicode's bidirectional (BiDi) override characters can cause trojan source attacks (CVE-2021-42574)\n\nThe following changes were introduced in gcc in order to facilitate detection of BiDi Unicode characters:\n\nThis update implements a new warning option -Wbidirectional to warn about possibly dangerous bidirectional characters.\n\nThere are three levels of warning supported by gcc:\n\"-Wbidirectional=unpaired\", which warns about improperly terminated BiDi contexts. (This is the default.)\n\"-Wbidirectional=none\", which turns the warning off.\n\"-Wbidirectional=any\", which warns about any use of bidirectional characters.\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2021-11-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2021:4587 https://access.redhat.com/security/cve/CVE-2021-42574",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libstdc++",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:8.5.0-4.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4190096": {
+      "id": "4190096",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7704: webkit2gtk3 security and bug fix update (Moderate)",
+      "description": "WebKitGTK is the port of the portable web rendering engine WebKit to the GTK platform.\n\nGLib provides the core application building blocks for libraries and applications written in C. It provides the core object system used in GNOME, the main loop implementation, and a large set of utility functions for strings and common data structures.\n\nSecurity Fix(es):\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-22624)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-22628)\n\n* webkitgtk: Buffer overflow leading to arbitrary code execution (CVE-2022-22629)\n\n* webkitgtk: Cookie management issue leading to sensitive user information disclosure (CVE-2022-22662)\n\n* webkitgtk: Memory corruption issue leading to arbitrary code execution (CVE-2022-26700)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-26709)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-26710)\n\n* webkitgtk: Memory corruption issue leading to arbitrary code execution (CVE-2022-26716)\n\n* webkitgtk: Use-after-free leading to arbitrary code execution (CVE-2022-26717)\n\n* webkitgtk: Memory corruption issue leading to arbitrary code execution (CVE-2022-26719)\n\n* webkitgtk: Heap buffer overflow in WebCore::TextureMapperLayer::setContentsLayer leading to arbitrary code execution (CVE-2022-30293)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7704 https://access.redhat.com/security/cve/CVE-2022-22624 https://access.redhat.com/security/cve/CVE-2022-22628 https://access.redhat.com/security/cve/CVE-2022-22629 https://access.redhat.com/security/cve/CVE-2022-22662 https://access.redhat.com/security/cve/CVE-2022-26700 https://access.redhat.com/security/cve/CVE-2022-26709 https://access.redhat.com/security/cve/CVE-2022-26710 https://access.redhat.com/security/cve/CVE-2022-26716 https://access.redhat.com/security/cve/CVE-2022-26717 https://access.redhat.com/security/cve/CVE-2022-26719 https://access.redhat.com/security/cve/CVE-2022-30293 https://access.redhat.com/security/cve/CVE-2022-32891",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "glib2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.56.4-159.el8",
+      "arch_op": "pattern match"
+    },
+    "4307432": {
+      "id": "4307432",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0833: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: int() type in PyLong_FromString() does not limit amount of digits converting text to int leading to DoS (CVE-2020-10735)\n\n* python: open redirection vulnerability in lib/http/server.py may lead to information disclosure (CVE-2021-28861)\n\n* Python: CPU denial of service via inefficient IDNA decoder (CVE-2022-45061)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0833 https://access.redhat.com/security/cve/CVE-2020-10735 https://access.redhat.com/security/cve/CVE-2021-28861 https://access.redhat.com/security/cve/CVE-2022-45061",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "platform-python",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-48.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "139028": {
+      "id": "139028",
+      "updater": "osv/maven",
+      "name": "GHSA-5mcr-gq6c-3hq2",
+      "description": "Local Information Disclosure Vulnerability in Netty on Unix-Like systems",
+      "issued": "2021-02-08T21:17:48Z",
+      "links": "https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2 https://nvd.nist.gov/vuln/detail/CVE-2021-21290 https://github.com/netty/netty/commit/c735357bf29d07856ad171c6611a2e1a0e0000ec https://github.com/netty/netty https://lists.apache.org/thread.html/r0053443ce19ff125981559f8c51cf66e3ab4350f47812b8cf0733a05@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/r02e467123d45006a1dda20a38349e9c74c3a4b53e2e07be0939ecb3f@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r0857b613604c696bf9743f0af047360baaded48b1c75cf6945a083c5@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r10308b625e49d4e9491d7e079606ca0df2f0a4d828f1ad1da64ba47b@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r1908a34b9cc7120e5c19968a116ddbcffea5e9deb76c2be4fa461904@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r2748097ea4b774292539cf3de6e3b267fc7a88d6c8ec40f4e2e87bd4@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/r2936730ef0a06e724b96539bc7eacfcd3628987c16b1b99c790e7b87@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r2fda4dab73097051977f2ab818f75e04fbcb15bb1003c8530eac1059@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r326ec431f06eab7cb7113a7a338e59731b8d556d05258457f12bac1b@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/r4efed2c501681cb2e8d629da16e48d9eac429624fd4c9a8c6b8e7020@%3Cdev.tinkerpop.apache.org%3E https://lists.apache.org/thread.html/r584cf871f188c406d8bd447ff4e2fd9817fca862436c064d0951a071@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r59bac5c09f7a4179b9e2460e8f41c278aaf3b9a21cc23678eb893e41@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r5bf303d7c04da78f276765da08559fdc62420f1df539b277ca31f63b@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r5c701840aa2845191721e39821445e1e8c59711e71942b7796a6ec29@%3Cusers.activemq.apache.org%3E https://lists.apache.org/thread.html/r5e4a540089760c8ecc2c411309d74264f1dad634ad93ad583ca16214@%3Ccommits.kafka.apache.org%3E https://lists.apache.org/thread.html/r5e66e286afb5506cdfe9bbf68a323e8d09614f6d1ddc806ed0224700@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/r71dbb66747ff537640bb91eb0b2b24edef21ac07728097016f58b01f@%3Ccommits.kafka.apache.org%3E https://lists.apache.org/thread.html/r743149dcc8db1de473e6bff0b3ddf10140a7357bc2add75f7d1fbb12@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r790c2926efcd062067eb18fde2486527596d7275381cfaff2f7b3890@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/r7bb3cdc192e9a6f863d3ea05422f09fa1ae2b88d4663e63696ee7ef5@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r9924ef9357537722b28d04c98a189750b80694a19754e5057c34ca48@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/ra0fc2b4553dd7aaf75febb61052b7f1243ac3a180a71c01f29093013@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/ra503756ced78fdc2136bd33e87cb7553028645b261b1f5c6186a121e@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/rb06c1e766aa45ee422e8261a8249b561784186483e8f742ea627bda4@%3Cdev.kafka.apache.org%3E https://lists.apache.org/thread.html/rb51d6202ff1a773f96eaa694b7da4ad3f44922c40b3d4e1a19c2f325@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rb592033a2462548d061a83ac9449c5ff66098751748fcd1e2d008233@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rc0087125cb15b4b78e44000f841cd37fefedfda942fd7ddf3ad1b528@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rc488f80094872ad925f0c73d283d4c00d32def81977438e27a3dc2bb@%3Cjira.kafka.apache.org%3E https://lists.apache.org/thread.html/rcd163e421273e8dca1c71ea298dce3dd11b41d51c3a812e0394e6a5d@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rdba4f78ac55f803893a1a2265181595e79e3aa027e2e651dfba98c18@%3Cjira.kafka.apache.org%3E https://lists.debian.org/debian-lts-announce/2021/02/msg00016.html https://security.netapp.com/advisory/ntap-20220210-0011/ https://www.debian.org/security/2021/dsa-4885 https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+      "severity": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "io.netty:netty-codec-http",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.1.59.Final&introduced=4.0.0"
+    },
+    "139929": {
+      "id": "139929",
+      "updater": "osv/maven",
+      "name": "GHSA-6mjq-h674-j845",
+      "description": "netty-handler SniHandler 16MB allocation",
+      "issued": "2023-06-20T16:33:22Z",
+      "links": "https://github.com/netty/netty/security/advisories/GHSA-6mjq-h674-j845 https://nvd.nist.gov/vuln/detail/CVE-2023-34462 https://github.com/netty/netty/commit/535da17e45201ae4278c0479e6162bb4127d4c32 https://github.com/netty/netty",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "io.netty:netty-handler",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.1.94.Final"
+    },
+    "4057313": {
+      "id": "4057313",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7108: sqlite security update (Moderate)",
+      "description": "SQLite is a C library that implements an SQL database engine. A large subset of SQL92 is supported. A complete database is stored in a single disk file. The API is designed for convenience and ease of use. Applications that link against SQLite can enjoy the power and flexibility of an SQL database without the administrative hassles of supporting a separate database server.\n\nSecurity Fix(es):\n\n* sqlite: Out of bounds access during table rename (CVE-2020-35527)\n\n* sqlite: Null pointer derreference in src/select.c (CVE-2020-35525)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-25T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7108 https://access.redhat.com/security/cve/CVE-2020-35525 https://access.redhat.com/security/cve/CVE-2020-35527",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "sqlite-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.26.0-16.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4016445": {
+      "id": "4016445",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6206: systemd security update (Important)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd-resolved: use-after-free when dealing with DnsStream in resolved-dns-stream.c (CVE-2022-2526)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-29T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6206 https://access.redhat.com/security/cve/CVE-2022-2526",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "systemd-pam",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-58.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "3690258": {
+      "id": "3690258",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0894: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: Heap-based buffer overflow in block_insert() in src/ops.c (CVE-2022-0261)\n\n* vim: Heap-based buffer overflow in utf_head_off() in mbyte.c (CVE-2022-0318)\n\n* vim: Heap-based buffer overflow in init_ccline() in ex_getln.c (CVE-2022-0359)\n\n* vim: Illegal memory access when copying lines in visual mode leads to heap buffer overflow (CVE-2022-0361)\n\n* vim: Heap-based buffer overflow in getexmodeline() in ex_getln.c (CVE-2022-0392)\n\n* vim: Use after free in src/ex_cmds.c (CVE-2022-0413)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0894 https://access.redhat.com/security/cve/CVE-2022-0261 https://access.redhat.com/security/cve/CVE-2022-0318 https://access.redhat.com/security/cve/CVE-2022-0359 https://access.redhat.com/security/cve/CVE-2022-0361 https://access.redhat.com/security/cve/CVE-2022-0392 https://access.redhat.com/security/cve/CVE-2022-0413",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-16.el8_5.12",
+      "arch_op": "pattern match"
+    },
+    "3953917": {
+      "id": "3953917",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5818: openssl security update (Moderate)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: c_rehash script allows command injection (CVE-2022-1292)\n\n* openssl: the c_rehash script allows command injection (CVE-2022-2068)\n\n* openssl: AES OCB fails to encrypt some bytes (CVE-2022-2097)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-03T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5818 https://access.redhat.com/security/cve/CVE-2022-1292 https://access.redhat.com/security/cve/CVE-2022-2068 https://access.redhat.com/security/cve/CVE-2022-2097",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "openssl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-7.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4585493": {
+      "id": "4585493",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-tools",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4590483": {
+      "id": "4590483",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4529: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: NULL dereference in xmlSchemaFixupComplexType (CVE-2023-28484)\n\n* libxml2: Hashing of empty dict strings isn't deterministic (CVE-2023-29469)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4529 https://access.redhat.com/security/cve/CVE-2023-28484 https://access.redhat.com/security/cve/CVE-2023-29469",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-16.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4279968": {
+      "id": "4279968",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0100: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: buffer overrun in format_timespan() function (CVE-2022-3821)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* ShutdownWatchdogSec value is not taken into account on reboot (BZ#2127170)",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0100 https://access.redhat.com/security/cve/CVE-2022-3821",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-pam",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4585006": {
+      "id": "4585006",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4435245": {
+      "id": "4435245",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:2963: curl security and bug fix update (Low)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: Incorrect handling of control code characters in cookies (CVE-2022-35252)\n\n* curl: Use-after-free triggered by an HTTP proxy deny response (CVE-2022-43552)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.8 Release Notes linked from the References section.",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:2963 https://access.redhat.com/security/cve/CVE-2022-35252 https://access.redhat.com/security/cve/CVE-2022-43552",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8",
+      "arch_op": "pattern match"
+    },
+    "4320832": {
+      "id": "4320832",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1140: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP multi-header compression denial of service (CVE-2023-23916)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1140 https://access.redhat.com/security/cve/CVE-2023-23916",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-25.el8_7.3",
+      "arch_op": "pattern match"
+    },
+    "4279270": {
+      "id": "4279270",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0100: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: buffer overrun in format_timespan() function (CVE-2022-3821)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* ShutdownWatchdogSec value is not taken into account on reboot (BZ#2127170)",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0100 https://access.redhat.com/security/cve/CVE-2022-3821",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4585026": {
+      "id": "4585026",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-common",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1"
+    },
+    "4236730": {
+      "id": "4236730",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0096: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon crashes when receiving message with incorrectly nested parentheses and curly brackets (CVE-2022-42010)\n\n* dbus: dbus-daemon can be crashed by messages with array length inconsistent with element type (CVE-2022-42011)\n\n* dbus: `_dbus_marshal_byteswap` doesn't process fds in messages with \"foreign\" endianness correctly (CVE-2022-42012)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0096 https://access.redhat.com/security/cve/CVE-2022-42010 https://access.redhat.com/security/cve/CVE-2022-42011 https://access.redhat.com/security/cve/CVE-2022-42012",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-23.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "152217": {
+      "id": "152217",
+      "updater": "osv/maven",
+      "name": "GHSA-p2v9-g2qv-p635",
+      "description": "HTTP Request Smuggling in Netty",
+      "issued": "2020-02-21T18:55:04Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2019-20445 https://github.com/netty/netty/issues/9861 https://github.com/netty/netty/pull/9865 https://access.redhat.com/errata/RHSA-2020:0497 https://access.redhat.com/errata/RHSA-2020:0567 https://access.redhat.com/errata/RHSA-2020:0601 https://access.redhat.com/errata/RHSA-2020:0605 https://access.redhat.com/errata/RHSA-2020:0606 https://access.redhat.com/errata/RHSA-2020:0804 https://access.redhat.com/errata/RHSA-2020:0805 https://access.redhat.com/errata/RHSA-2020:0806 https://access.redhat.com/errata/RHSA-2020:0811 https://github.com/netty/netty https://github.com/netty/netty/compare/netty-4.1.43.Final...netty-4.1.44.Final https://lists.apache.org/thread.html/r030beff88aeb6d7a2d6cd21342bd18686153ce6e26a4171d0e035663@%3Cissues.flume.apache.org%3E https://lists.apache.org/thread.html/r1b103833cb5bc8466e24ff0ecc5e75b45a705334ab6a444e64e840a0@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/r1fcccf8bdb3531c28bc9aa605a6a1bea7e68cef6fc12e01faafb2fb5@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r205937c85817a911b0c72655c2377e7a2c9322d6ef6ce1b118d34d8d@%3Cdev.geode.apache.org%3E https://lists.apache.org/thread.html/r2f2989b7815d809ff3fda8ce330f553e5f133505afd04ffbc135f35f@%3Cissues.spark.apache.org%3E https://lists.apache.org/thread.html/r310d2ce22304d5298ff87f10134f918c87919b452734f9841d95682d@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r36fcf538b28f2029e8b4f6b9a772f3b107913a78f09b095c5b153a62@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r46f93de62b1e199f3f9babb18128681677c53493546f532ed88c359d@%3Creviews.spark.apache.org%3E https://lists.apache.org/thread.html/r4d3f1d3e333d9c2b2f6e6ae8ed8750d4de03410ac294bcd12c7eefa3@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r4ff40646e9ccce13560458419accdfc227b8b6ca4ead3a8a91decc74@%3Cissues.flume.apache.org%3E https://lists.apache.org/thread.html/r640eb9b3213058a963e18291f903fc1584e577f60035f941e32f760a@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r6945f3c346b7af89bbd3526a7c9b705b1e3569070ebcd0964bcedd7d@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r70b1ff22ee80e8101805b9a473116dd33265709007d2deb6f8c80bf2@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r7790b9d99696d9eddce8a8c96f13bb68460984294ea6fea3800143e4@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r804895eedd72c9ec67898286eb185e04df852b0dd5fe53cf5b6138f9@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r81700644754e66ffea465c869cb477de25f8041e21598e8818fc2c45@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r819aaeb9944bdcfca438dcc51f05650dc728daf64dfd7d774fc2499b@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r832724df393a7ef25ca4c7c2eb83ad2d6c21c74569acda5233f9f1ec@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/r959474dcf7f88565ed89f6252ca5a274419006cb71348f14764b183d@%3Ccommits.cassandra.apache.org%3E https://lists.apache.org/thread.html/r96e08f929234e8ba1ef4a93a0fd2870f535a1f9ab628fabc46115986@%3Cdev.zookeeper.apache.org%3E https://lists.apache.org/thread.html/r9b20cdac704cf9a583400350e2d5b576fa8417c18ddb961201676c60@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra1a71b576a45426af5ee65255be9596ff3181a342f4ba73b800db78f@%3Cdev.geode.apache.org%3E https://lists.apache.org/thread.html/ra2ace4bcb5cf487f72cbcbfa0f8cc08e755ec2b93d7e69f276148b08@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/ra9fbfe7d4830ae675bf34c7c0f8c22fc8a4099f65706c1bc4f54c593@%3Cissues.zookeeper.apache.org%3E https://lists.apache.org/thread.html/raaac04b7567c554786132144bea3dcb72568edd410c1e6f0101742e7@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rb5c065e7bd701b0744f9f28ad769943f91745102716c1eb516325f11@%3Cissues.spark.apache.org%3E https://lists.apache.org/thread.html/rb84c57670ec48ef23f4d07973b7fa69f629b8e7fcfb48874362feb6f@%3Ccommits.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rbdb59c683d666130906a9c05a1d2b034c4cc08cda7ed41322bd54fe2@%3Cissues.flume.apache.org%3E https://lists.apache.org/thread.html/rce71d33747010d32d31d90f5d737dae26291d96552f513a266c92fbb@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rd8f72411fb75b98d366400ae789966373b5c3eb3f511e717caf3e49e@%3Cissues.flink.apache.org%3E https://lists.apache.org/thread.html/rdb69125652311d0c41f6066ff44072a3642cf33a4b5e3c4f9c1ec9c2@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/re45ee9256d3233c31d78e59ee59c7dc841c7fbd83d0769285b41e948@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rf5b2dfb7401666a19915f8eaef3ba9f5c3386e2066fcd2ae66e16a2f@%3Cdev.flink.apache.org%3E https://lists.apache.org/thread.html/rfb55f245b08d8a6ec0fb4dc159022227cd22de34c4419c2fbb18802b@%3Cnotifications.zookeeper.apache.org%3E https://lists.apache.org/thread.html/rff210a24f3a924829790e69eaefa84820902b7b31f17c3bf2def9114@%3Ccommits.druid.apache.org%3E https://lists.debian.org/debian-lts-announce/2020/02/msg00017.html https://lists.debian.org/debian-lts-announce/2020/02/msg00018.html https://lists.debian.org/debian-lts-announce/2020/09/msg00003.html https://lists.debian.org/debian-lts-announce/2020/09/msg00004.html https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/TS6VX7OMXPDJIU5LRGUAHRK6MENAVJ46/ https://usn.ubuntu.com/4532-1/ https://www.debian.org/security/2021/dsa-4885",
+      "severity": "",
+      "normalized_severity": "Unknown",
+      "package": {
+        "id": "",
+        "name": "io.netty:netty-handler",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.1.45&introduced=4.0.0"
+    },
+    "4057537": {
+      "id": "4057537",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7108: sqlite security update (Moderate)",
+      "description": "SQLite is a C library that implements an SQL database engine. A large subset of SQL92 is supported. A complete database is stored in a single disk file. The API is designed for convenience and ease of use. Applications that link against SQLite can enjoy the power and flexibility of an SQL database without the administrative hassles of supporting a separate database server.\n\nSecurity Fix(es):\n\n* sqlite: Out of bounds access during table rename (CVE-2020-35527)\n\n* sqlite: Null pointer derreference in src/select.c (CVE-2020-35525)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-25T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7108 https://access.redhat.com/security/cve/CVE-2020-35525 https://access.redhat.com/security/cve/CVE-2020-35527",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "sqlite-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.26.0-16.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4584980": {
+      "id": "4584980",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "3942085": {
+      "id": "3942085",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5683: java-11-openjdk security, bug fix, and enhancement update (Important)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nThe following packages have been upgraded to a later upstream version: java-11-openjdk (11.0.16.0.8). (BZ#2084649)\n\nSecurity Fix(es):\n\n* OpenJDK: integer truncation issue in Xalan-J (JAXP, 8285407) (CVE-2022-34169)\n\n* OpenJDK: class compilation issue (Hotspot, 8281859) (CVE-2022-21540)\n\n* OpenJDK: improper restriction of MethodHandle.invokeBasic() (Hotspot, 8281866) (CVE-2022-21541)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* rh1991003 patch breaks sun.security.pkcs11.wrapper.PKCS11.getInstance() [rhel-8, openjdk-11] (BZ#2099917)\n\n* Revert to disabling system security properties and FIPS mode support together [rhel-8, openjdk-11] (BZ#2108248)\n\n* SecretKey generate/import operations don't add the CKA_SIGN attribute in FIPS mode [rhel-8, openjdk-11] (BZ#2108251)",
+      "issued": "2022-07-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5683 https://access.redhat.com/security/cve/CVE-2022-21540 https://access.redhat.com/security/cve/CVE-2022-21541 https://access.redhat.com/security/cve/CVE-2022-34169",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.16.0.8-1.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3920444": {
+      "id": "3920444",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5317: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows in xmlBuf and xmlBuffer lead to out-of-bounds write (CVE-2022-29824)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5317 https://access.redhat.com/security/cve/CVE-2022-29824",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-13.el8_6.1",
+      "arch_op": "pattern match"
+    },
+    "4014930": {
+      "id": "4014930",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6159: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP compression denial of service (CVE-2022-32206)\n\n* curl: FTP-KRB bad message verification (CVE-2022-32208)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-24T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6159 https://access.redhat.com/security/cve/CVE-2022-32206 https://access.redhat.com/security/cve/CVE-2022-32208",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-22.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "4435303": {
+      "id": "4435303",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:2963: curl security and bug fix update (Low)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: Incorrect handling of control code characters in cookies (CVE-2022-35252)\n\n* curl: Use-after-free triggered by an HTTP proxy deny response (CVE-2022-43552)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.8 Release Notes linked from the References section.",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:2963 https://access.redhat.com/security/cve/CVE-2022-35252 https://access.redhat.com/security/cve/CVE-2022-43552",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8",
+      "arch_op": "pattern match"
+    },
+    "3953141": {
+      "id": "3953141",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5809: pcre2 security update (Moderate)",
+      "description": "The pcre2 package contains a new generation of the Perl Compatible Regular Expression libraries for implementing regular expression pattern matching using the same syntax and semantics as Perl. \n\nSecurity Fix(es):\n\n* pcre2: Out-of-bounds read in compile_xclass_matchingpath in pcre2_jit_compile.c (CVE-2022-1586)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-03T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5809 https://access.redhat.com/security/cve/CVE-2022-1586",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "pcre2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:10.32-3.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4585330": {
+      "id": "4585330",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "140730": {
+      "id": "140730",
+      "updater": "osv/maven",
+      "name": "GHSA-7g45-4rm6-3mm3",
+      "description": "Guava vulnerable to insecure use of temporary directory",
+      "issued": "2023-06-14T18:30:38Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2023-2976 https://github.com/google/guava/issues/2575 https://github.com/google/guava/issues/6532 https://github.com/google/guava/commit/feb83a1c8fd2e7670b244d5afd23cba5aca43284 https://github.com/google/guava https://github.com/google/guava/releases/tag/v32.0.0 https://security.netapp.com/advisory/ntap-20230818-0008/",
+      "severity": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "com.google.guava:guava",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=32.0.0&introduced=1.0"
+    },
+    "4590559": {
+      "id": "4590559",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4529: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: NULL dereference in xmlSchemaFixupComplexType (CVE-2023-28484)\n\n* libxml2: Hashing of empty dict strings isn't deterministic (CVE-2023-29469)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4529 https://access.redhat.com/security/cve/CVE-2023-28484 https://access.redhat.com/security/cve/CVE-2023-29469",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-16.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "4192129": {
+      "id": "4192129",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7720: e2fsprogs security and bug fix update (Moderate)",
+      "description": "The e2fsprogs packages provide a number of utilities for creating, checking, modifying, and correcting the ext2, ext3, and ext4 file systems.\n\nSecurity Fix(es):\n\n* e2fsprogs: out-of-bounds read/write via crafted filesystem (CVE-2022-1304)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7720 https://access.redhat.com/security/cve/CVE-2022-1304",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcom_err",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.45.6-5.el8",
+      "arch_op": "pattern match"
+    },
+    "3879186": {
+      "id": "3879186",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:2031: libssh security, bug fix, and enhancement update (Low)",
+      "description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nThe following packages have been upgraded to a later upstream version: libssh (0.9.6). (BZ#1896651)\n\nSecurity Fix(es):\n\n* libssh: possible heap-based buffer overflow when rekeying (CVE-2021-3634)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:2031 https://access.redhat.com/security/cve/CVE-2021-3634",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "libssh",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:0.9.6-3.el8",
+      "arch_op": "pattern match"
+    },
+    "3632280": {
+      "id": "3632280",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0368: rpm security update (Moderate)",
+      "description": "The RPM Package Manager (RPM) is a command-line driven package management system capable of installing, uninstalling, verifying, querying, and updating software packages.\n\nSecurity Fix(es):\n\n* rpm: RPM does not require subkeys to have a valid binding signature (CVE-2021-3521)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0368 https://access.redhat.com/security/cve/CVE-2021-3521",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "rpm",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.14.3-19.el8_5.2",
+      "arch_op": "pattern match"
+    },
+    "3718158": {
+      "id": "3718158",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1442: java-11-openjdk security update (Important)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: Defective secure validation in Apache Santuario (Libraries, 8278008) (CVE-2022-21476)\n\n* OpenJDK: Unbounded memory allocation when compiling crafted XPath expressions (JAXP, 8270504) (CVE-2022-21426)\n\n* OpenJDK: Improper object-to-string conversion in AnnotationInvocationHandler (Libraries, 8277672) (CVE-2022-21434)\n\n* OpenJDK: Missing check for negative ObjectIdentifier (Libraries, 8275151) (CVE-2022-21443)\n\n* OpenJDK: URI parsing inconsistencies (JNDI, 8278972) (CVE-2022-21496)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-04-20T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1442 https://access.redhat.com/security/cve/CVE-2022-21426 https://access.redhat.com/security/cve/CVE-2022-21434 https://access.redhat.com/security/cve/CVE-2022-21443 https://access.redhat.com/security/cve/CVE-2022-21476 https://access.redhat.com/security/cve/CVE-2022-21496",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.15.0.9-2.el8_5",
+      "arch_op": "pattern match"
+    },
+    "3740332": {
+      "id": "3740332",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1642: zlib security update (Important)",
+      "description": "The zlib packages provide a general-purpose lossless data compression library that is used by many different programs.\n\nSecurity Fix(es):\n\n* zlib: A flaw found in zlib when compressing (not decompressing) certain inputs (CVE-2018-25032)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-04-28T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1642 https://access.redhat.com/security/cve/CVE-2018-25032",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "zlib",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.2.11-18.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4279842": {
+      "id": "4279842",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0100: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: buffer overrun in format_timespan() function (CVE-2022-3821)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* ShutdownWatchdogSec value is not taken into account on reboot (BZ#2127170)",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0100 https://access.redhat.com/security/cve/CVE-2022-3821",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4308799": {
+      "id": "4308799",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: local information leak due to systemd-coredump not respecting fs.suid_dumpable kernel setting (CVE-2022-4415)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd doesn't record messages to the journal during boot (BZ#2164049)",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0837 https://access.redhat.com/security/cve/CVE-2022-4415",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.4",
+      "arch_op": "pattern match"
+    },
+    "3690610": {
+      "id": "3690610",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0896: glibc security update (Moderate)",
+      "description": "The glibc packages provide the standard C libraries (libc), POSIX thread libraries (libpthread), standard math libraries (libm), and the name service cache daemon (nscd) used by multiple programs on the system. Without these libraries, the Linux system cannot function correctly.\n\nSecurity Fix(es):\n\n* glibc: Off-by-one buffer overflow/underflow in getcwd() (CVE-2021-3999)\n\n* glibc: Stack-based buffer overflow in svcunix_create via long pathnames (CVE-2022-23218)\n\n* glibc: Stack-based buffer overflow in sunrpc clnt_create via a long pathname (CVE-2022-23219)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0896 https://access.redhat.com/security/cve/CVE-2021-3999 https://access.redhat.com/security/cve/CVE-2022-23218 https://access.redhat.com/security/cve/CVE-2022-23219",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "glibc",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.28-164.el8_5.3",
+      "arch_op": "pattern match"
+    },
+    "3953070": {
+      "id": "3953070",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5809: pcre2 security update (Moderate)",
+      "description": "The pcre2 package contains a new generation of the Perl Compatible Regular Expression libraries for implementing regular expression pattern matching using the same syntax and semantics as Perl. \n\nSecurity Fix(es):\n\n* pcre2: Out-of-bounds read in compile_xclass_matchingpath in pcre2_jit_compile.c (CVE-2022-1586)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-03T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5809 https://access.redhat.com/security/cve/CVE-2022-1586",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "pcre2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:10.32-3.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4308288": {
+      "id": "4308288",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0835: python-setuptools security update (Moderate)",
+      "description": "The python-setuptools package provides a collection of enhancements to Python distribution utilities allowing convenient building and distribution of Python packages.\n\nSecurity Fix(es):\n\n* pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py (CVE-2022-40897)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0835 https://access.redhat.com/security/cve/CVE-2022-40897",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-setuptools",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:39.2.0-6.el8_7.1"
+    },
+    "4053702": {
+      "id": "4053702",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7012: java-11-openjdk security and bug fix update (Moderate)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: improper MultiByte conversion can lead to buffer overflow (JGSS, 8286077) (CVE-2022-21618)\n\n* OpenJDK: excessive memory allocation in X.509 certificate parsing (Security, 8286533) (CVE-2022-21626)\n\n* OpenJDK: HttpServer no connection count limit (Lightweight HTTP Server, 8286918) (CVE-2022-21628)\n\n* OpenJDK: improper handling of long NTLM client hostnames (Security, 8286526) (CVE-2022-21619)\n\n* OpenJDK: insufficient randomization of JNDI DNS port numbers (JNDI, 8286910) (CVE-2022-21624)\n\n* OpenJDK: missing SNI caching in HTTP/2 (Networking, 8289366) (CVE-2022-39399)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Prepare for the next quarterly OpenJDK upstream release (2022-10, 11.0.17) [rhel-8] (BZ#2131863)",
+      "issued": "2022-10-19T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7012 https://access.redhat.com/security/cve/CVE-2022-21618 https://access.redhat.com/security/cve/CVE-2022-21619 https://access.redhat.com/security/cve/CVE-2022-21624 https://access.redhat.com/security/cve/CVE-2022-21626 https://access.redhat.com/security/cve/CVE-2022-21628 https://access.redhat.com/security/cve/CVE-2022-39399",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.17.0.8-2.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4322825": {
+      "id": "4322825",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1405: openssl security update (Important)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: X.400 address type confusion in X.509 GeneralName (CVE-2023-0286)\n\n* openssl: timing attack in RSA Decryption implementation (CVE-2022-4304)\n\n* openssl: double free after calling PEM_read_bio_ex (CVE-2022-4450)\n\n* openssl: use-after-free following BIO_new_NDEF (CVE-2023-0215)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1405 https://access.redhat.com/security/cve/CVE-2022-4304 https://access.redhat.com/security/cve/CVE-2022-4450 https://access.redhat.com/security/cve/CVE-2023-0215 https://access.redhat.com/security/cve/CVE-2023-0286",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "openssl-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-9.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4014836": {
+      "id": "4014836",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6159: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP compression denial of service (CVE-2022-32206)\n\n* curl: FTP-KRB bad message verification (CVE-2022-32208)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-24T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6159 https://access.redhat.com/security/cve/CVE-2022-32206 https://access.redhat.com/security/cve/CVE-2022-32208",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-22.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "4055295": {
+      "id": "4055295",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7105: gnutls security update (Moderate)",
+      "description": "The gnutls packages provide the GNU Transport Layer Security (GnuTLS) library, which implements cryptographic algorithms and protocols such as SSL, TLS, and DTLS.\n\nSecurity Fix(es):\n\n* gnutls: Double free during gnutls_pkcs7_verify. (CVE-2022-2509)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-10-25T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7105 https://access.redhat.com/security/cve/CVE-2022-2509",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "gnutls",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.16-5.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3689646": {
+      "id": "3689646",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0892: libarchive security update (Moderate)",
+      "description": "The libarchive programming library can create and read several different streaming archive formats, including GNU tar, cpio, and ISO 9660 CD-ROM images. Libarchive is used notably in the bsdtar utility, scripting language bindings such as python-libarchive, and several popular desktop file managers.\n\nSecurity Fix(es):\n\n* libarchive: extracting a symlink with ACLs modifies ACLs of target (CVE-2021-23177)\n\n* libarchive: symbolic links incorrectly followed when changing modes, times, ACL and flags of a file while extracting an archive (CVE-2021-31566)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0892 https://access.redhat.com/security/cve/CVE-2021-23177 https://access.redhat.com/security/cve/CVE-2021-31566",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libarchive",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.3.3-3.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4279739": {
+      "id": "4279739",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0100: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: buffer overrun in format_timespan() function (CVE-2022-3821)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* ShutdownWatchdogSec value is not taken into account on reboot (BZ#2127170)",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0100 https://access.redhat.com/security/cve/CVE-2022-3821",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4308336": {
+      "id": "4308336",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0835: python-setuptools security update (Moderate)",
+      "description": "The python-setuptools package provides a collection of enhancements to Python distribution utilities allowing convenient building and distribution of Python packages.\n\nSecurity Fix(es):\n\n* pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py (CVE-2022-40897)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0835 https://access.redhat.com/security/cve/CVE-2022-40897",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-setuptools",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:39.2.0-6.el8_7.1"
+    },
+    "3729951": {
+      "id": "3729951",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1552: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: use after free in utf_ptr2char (CVE-2022-1154)",
+      "issued": "2022-04-26T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1552 https://access.redhat.com/security/cve/CVE-2022-1154",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-16.el8_5.13",
+      "arch_op": "pattern match"
+    },
+    "3631715": {
+      "id": "3631715",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0366: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: heap-based buffer overflow in win_redr_status() in drawscreen.c (CVE-2021-3872)\n\n* vim: illegal memory access in find_start_brace() in cindent.c when C-indenting (CVE-2021-3984)\n\n* vim: heap-based buffer overflow in find_help_tags() in help.c (CVE-2021-4019)\n\n* vim: use-after-free in win_linetabsize() (CVE-2021-4192)\n\n* vim: out-of-bound read in getvcol() (CVE-2021-4193)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-02-01T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0366 https://access.redhat.com/security/cve/CVE-2021-3872 https://access.redhat.com/security/cve/CVE-2021-3984 https://access.redhat.com/security/cve/CVE-2021-4019 https://access.redhat.com/security/cve/CVE-2021-4192 https://access.redhat.com/security/cve/CVE-2021-4193",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-16.el8_5.4",
+      "arch_op": "pattern match"
+    },
+    "3921068": {
+      "id": "3921068",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5319: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: heap buffer overflow (CVE-2022-1621)\n\n* vim: buffer over-read (CVE-2022-1629)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5319 https://access.redhat.com/security/cve/CVE-2022-1621 https://access.redhat.com/security/cve/CVE-2022-1629",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-19.el8_6.2",
+      "arch_op": "pattern match"
+    },
+    "147193": {
+      "id": "147193",
+      "updater": "osv/maven",
+      "name": "GHSA-grg4-wf29-r9vv",
+      "description": "Bzip2Decoder doesn't allow setting size restrictions for decompressed data",
+      "issued": "2021-09-09T17:11:21Z",
+      "links": "https://github.com/netty/netty/security/advisories/GHSA-grg4-wf29-r9vv https://nvd.nist.gov/vuln/detail/CVE-2021-37136 https://github.com/netty/netty/commit/41d3d61a61608f2223bb364955ab2045dd5e4020 https://github.com/netty/netty https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java#L294 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java#L305 https://github.com/netty/netty/blob/4.1/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java#L80 https://lists.apache.org/thread.html/r06a145c9bd41a7344da242cef07977b24abe3349161ede948e30913d@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5406eaf3b07577d233b9f07cfc8f26e28369e6bab5edfcab41f28abb@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r5e05eba32476c580412f9fbdfc9b8782d5b40558018ac4ac07192a04@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/r75490c61c2cb7b6ae2c81238fd52ae13636c60435abcd732d41531a0@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rd262f59b1586a108e320e5c966feeafbb1b8cdc96965debc7cc10b16@%3Ccommits.druid.apache.org%3E https://lists.apache.org/thread.html/rfb2bf8597e53364ccab212fbcbb2a4e9f0a9e1429b1dc08023c6868e@%3Cdev.tinkerpop.apache.org%3E https://lists.debian.org/debian-lts-announce/2023/01/msg00008.html https://security.netapp.com/advisory/ntap-20220210-0012/ https://www.debian.org/security/2023/dsa-5316 https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpujul2022.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "io.netty:netty-codec",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.1.68.Final"
+    },
+    "3917484": {
+      "id": "3917484",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5314: expat security update (Moderate)",
+      "description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: stack exhaustion in doctype parsing (CVE-2022-25313)\n\n* expat: integer overflow in copyString() (CVE-2022-25314)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5314 https://access.redhat.com/security/cve/CVE-2022-25313 https://access.redhat.com/security/cve/CVE-2022-25314",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "expat",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.5-8.el8_6.2",
+      "arch_op": "pattern match"
+    },
+    "3572765": {
+      "id": "3572765",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2021:5226: openssl security update (Moderate)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: Read buffer overruns processing ASN.1 strings (CVE-2021-3712)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2021-12-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2021:5226 https://access.redhat.com/security/cve/CVE-2021-3712",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "openssl-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-5.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4322087": {
+      "id": "4322087",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss-sysinit",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4322944": {
+      "id": "4322944",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1405: openssl security update (Important)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: X.400 address type confusion in X.509 GeneralName (CVE-2023-0286)\n\n* openssl: timing attack in RSA Decryption implementation (CVE-2022-4304)\n\n* openssl: double free after calling PEM_read_bio_ex (CVE-2022-4450)\n\n* openssl: use-after-free following BIO_new_NDEF (CVE-2023-0215)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1405 https://access.redhat.com/security/cve/CVE-2022-4304 https://access.redhat.com/security/cve/CVE-2022-4450 https://access.redhat.com/security/cve/CVE-2023-0215 https://access.redhat.com/security/cve/CVE-2023-0286",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "openssl-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-9.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4599927": {
+      "id": "4599927",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4706: subscription-manager security update (Important)",
+      "description": "The subscription-manager packages provide programs and libraries to allow users to manage subscriptions and yum repositories from the Red Hat entitlement platform.\n\nSecurity Fix(es):\n\n* subscription-manager: inadequate authorization of com.redhat.RHSM1 D-Bus interface allows local users to modify configuration (CVE-2023-3899)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-22T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4706 https://access.redhat.com/security/cve/CVE-2023-3899",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "subscription-manager",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.28.36-3.el8_8",
+      "arch_op": "pattern match"
+    },
+    "3714014": {
+      "id": "3714014",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0899: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: Use-after-free of ID and IDREF attributes (CVE-2022-23308)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0899 https://access.redhat.com/security/cve/CVE-2022-23308",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-12.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4558245": {
+      "id": "4558245",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: privilege escalation via the less pager (CVE-2023-26604)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd-pstore crashes when attempting to move standalone files out of /sys/fs/pstore (BZ#2190153)",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3837 https://access.redhat.com/security/cve/CVE-2023-26604",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-74.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "158203": {
+      "id": "158203",
+      "updater": "osv/maven",
+      "name": "GHSA-x64g-4xx9-fh6x",
+      "description": "Denial of Service in Cryptacular",
+      "issued": "2020-06-10T20:02:58Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2020-7226 https://github.com/vt-middleware/cryptacular/issues/52 https://github.com/apereo/cas/pull/4685 https://github.com/vt-middleware/cryptacular/pull/56 https://github.com/apereo/cas/commit/8810f2b6c71d73341d4dde6b09a18eb46cfd6d45 https://github.com/apereo/cas/commit/93b1c3e9d90e36a19d0fa0f6efb863c6f0235e75 https://github.com/apereo/cas/commit/a042808d6adbbf44753d52c55cac5f533e24101f https://github.com/vt-middleware/cryptacular/commit/311baf12252abf21947afd07bf0a0291ec3ec796 https://github.com/vt-middleware/cryptacular/commit/ec2fb65f2455c479376695e3d75d30c7f6884b3f https://github.com/vt-middleware/cryptacular https://github.com/vt-middleware/cryptacular/blob/fafccd07ab1214e3588a35afe3c361519129605f/src/main/java/org/cryptacular/CiphertextHeader.java#L153 https://github.com/vt-middleware/cryptacular/blob/master/src/main/java/org/cryptacular/CiphertextHeader.java#L153 https://lists.apache.org/thread.html/r0847c7eb78c8f9e87d5b841fbd5da52b2ad4b4345e04b51c30621d88@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r209de85beae4d257d27fc577e3a3e97039bdb4c2dc6f4a8e5a5a5811@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r2237a27040b57adc2fcc5570bd530ad2038e67fcb2a3ce65283d3143@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r380781f5b489cb3c818536cd3b3757e806bfe0bca188591e0051ac03@%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/r4a62133ad01d5f963755021027a4cce23f76b8674a13860d2978c7c8@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/r77c48cd851f60833df9a9c9c31f12243508e15d1b2a0961066d44fc6@%3Ccommits.tomee.apache.org%3E https://lists.apache.org/thread.html/rc36b75cabb4d700b48035d15ad8b8c2712bb32123572a1bdaec2510a@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/re04e4f8f0d095387fb6b0ff9016a0af8c93f42e1de93b09298bfa547@%3Ccommits.ws.apache.org%3E https://lists.apache.org/thread.html/re7f46c4cc29a4616e0aa669c84a0eb34832e83a8eef05189e2e59b44@%3Cdev.ws.apache.org%3E https://lists.apache.org/thread.html/rfa4647c58e375996e62a9094bffff6dc350ec311ba955b430e738945@%3Cdev.ws.apache.org%3E https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "org.cryptacular:cryptacular",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.1.4"
+    },
+    "3917196": {
+      "id": "3917196",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5313: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: OAUTH2 bearer bypass in connection re-use (CVE-2022-22576)\n\n* curl: credential leak on redirect (CVE-2022-27774)\n\n* curl: auth/cookie leak on redirect (CVE-2022-27776)\n\n* curl: TLS and SSH connection too eager reuse (CVE-2022-27782)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5313 https://access.redhat.com/security/cve/CVE-2022-22576 https://access.redhat.com/security/cve/CVE-2022-27774 https://access.redhat.com/security/cve/CVE-2022-27776 https://access.redhat.com/security/cve/CVE-2022-27782",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-22.el8_6.3",
+      "arch_op": "pattern match"
+    },
+    "154065": {
+      "id": "154065",
+      "updater": "osv/maven",
+      "name": "GHSA-qcwq-55hx-v3vh",
+      "description": "snappy-java's unchecked chunk length leads to DoS",
+      "issued": "2023-06-15T17:15:06Z",
+      "links": "https://github.com/xerial/snappy-java/security/advisories/GHSA-qcwq-55hx-v3vh https://nvd.nist.gov/vuln/detail/CVE-2023-34455 https://github.com/xerial/snappy-java/commit/3bf67857fcf70d9eea56eed4af7c925671e8eaea https://github.com/xerial/snappy-java https://github.com/xerial/snappy-java/blob/05c39b2ca9b5b7b39611529cc302d3d796329611/src/main/java/org/xerial/snappy/SnappyInputStream.java#L388 https://github.com/xerial/snappy-java/blob/master/src/main/java/org/xerial/snappy/SnappyInputStream.java https://security.netapp.com/advisory/ntap-20230818-0009/",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "org.xerial.snappy:snappy-java",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.1.10.1"
+    },
+    "4435382": {
+      "id": "4435382",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:2963: curl security and bug fix update (Low)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: Incorrect handling of control code characters in cookies (CVE-2022-35252)\n\n* curl: Use-after-free triggered by an HTTP proxy deny response (CVE-2022-43552)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.8 Release Notes linked from the References section.",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:2963 https://access.redhat.com/security/cve/CVE-2022-35252 https://access.redhat.com/security/cve/CVE-2022-43552",
+      "severity": "Low",
+      "normalized_severity": "Low",
+      "package": {
+        "id": "",
+        "name": "libcurl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8",
+      "arch_op": "pattern match"
+    },
+    "143344": {
+      "id": "143344",
+      "updater": "osv/maven",
+      "name": "GHSA-9w3m-gqgf-c4p9",
+      "description": "snakeYAML before 1.32 vulnerable to Denial of Service due to Out-of-bounds Write",
+      "issued": "2022-09-06T00:00:27Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-38752 https://bitbucket.org/snakeyaml/snakeyaml https://bitbucket.org/snakeyaml/snakeyaml/issues/531/stackoverflow-oss-fuzz-47081 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47081 https://security.gentoo.org/glsa/202305-28",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.yaml:snakeyaml",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=1.32"
+    },
+    "3714356": {
+      "id": "3714356",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0951: expat security update (Important)",
+      "description": "Expat is a C library for parsing XML documents.\n\nSecurity Fix(es):\n\n* expat: Malformed 2- and 3-byte UTF-8 sequences can lead to arbitrary code execution (CVE-2022-25235)\n\n* expat: Namespace-separator characters in \"xmlns[:prefix]\" attribute values can lead to arbitrary code execution (CVE-2022-25236)\n\n* expat: Integer overflow in storeRawNames() (CVE-2022-25315)\n\n* expat: Large number of prefixed XML attributes on a single tag can crash libexpat (CVE-2021-45960)\n\n* expat: Integer overflow in doProlog in xmlparse.c (CVE-2021-46143)\n\n* expat: Integer overflow in addBinding in xmlparse.c (CVE-2022-22822)\n\n* expat: Integer overflow in build_model in xmlparse.c (CVE-2022-22823)\n\n* expat: Integer overflow in defineAttribute in xmlparse.c (CVE-2022-22824)\n\n* expat: Integer overflow in lookup in xmlparse.c (CVE-2022-22825)\n\n* expat: Integer overflow in nextScaffoldPart in xmlparse.c (CVE-2022-22826)\n\n* expat: Integer overflow in storeAtts in xmlparse.c (CVE-2022-22827)\n\n* expat: Integer overflow in function XML_GetBuffer (CVE-2022-23852)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-03-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0951 https://access.redhat.com/security/cve/CVE-2021-45960 https://access.redhat.com/security/cve/CVE-2021-46143 https://access.redhat.com/security/cve/CVE-2022-22822 https://access.redhat.com/security/cve/CVE-2022-22823 https://access.redhat.com/security/cve/CVE-2022-22824 https://access.redhat.com/security/cve/CVE-2022-22825 https://access.redhat.com/security/cve/CVE-2022-22826 https://access.redhat.com/security/cve/CVE-2022-22827 https://access.redhat.com/security/cve/CVE-2022-23852 https://access.redhat.com/security/cve/CVE-2022-25235 https://access.redhat.com/security/cve/CVE-2022-25236 https://access.redhat.com/security/cve/CVE-2022-25315",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "expat",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.5-4.el8_5.3",
+      "arch_op": "pattern match"
+    },
+    "4302609": {
+      "id": "4302609",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0625: libksba security update (Important)",
+      "description": "KSBA (pronounced Kasbah) is a library to make X.509 certificates as well as the CMS easily accessible by other applications. Both specifications are building blocks of S/MIME and TLS.\n\nSecurity Fix(es):\n\n* libksba: integer overflow to code executiona (CVE-2022-47629)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0625 https://access.redhat.com/security/cve/CVE-2022-47629",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "libksba",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:1.3.5-9.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4558598": {
+      "id": "4558598",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: privilege escalation via the less pager (CVE-2023-26604)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd-pstore crashes when attempting to move standalone files out of /sys/fs/pstore (BZ#2190153)",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3837 https://access.redhat.com/security/cve/CVE-2023-26604",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-74.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "4307562": {
+      "id": "4307562",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0833: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: int() type in PyLong_FromString() does not limit amount of digits converting text to int leading to DoS (CVE-2020-10735)\n\n* python: open redirection vulnerability in lib/http/server.py may lead to information disclosure (CVE-2021-28861)\n\n* Python: CPU denial of service via inefficient IDNA decoder (CVE-2022-45061)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0833 https://access.redhat.com/security/cve/CVE-2020-10735 https://access.redhat.com/security/cve/CVE-2021-28861 https://access.redhat.com/security/cve/CVE-2022-45061",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "platform-python",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-48.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4029172": {
+      "id": "4029172",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6457: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-09-13T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-47.el8_6",
+      "arch_op": "pattern match"
+    },
+    "3872472": {
+      "id": "3872472",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1986: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python: ftplib should not use the host from the PASV response (CVE-2021-4189)\n\n* python: urllib: HTTP client possible infinite loop on a 100 Continue response (CVE-2021-3737)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.6 Release Notes linked from the References section.",
+      "issued": "2022-05-10T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1986 https://access.redhat.com/security/cve/CVE-2021-3737 https://access.redhat.com/security/cve/CVE-2021-4189",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "platform-python",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-45.el8",
+      "arch_op": "pattern match"
+    },
+    "4308520": {
+      "id": "4308520",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0837: systemd security and bug fix update (Moderate)",
+      "description": "The systemd packages contain systemd, a system and service manager for Linux, compatible with the SysV and LSB init scripts. It provides aggressive parallelism capabilities, uses socket and D-Bus activation for starting services, offers on-demand starting of daemons, and keeps track of processes using Linux cgroups. In addition, it supports snapshotting and restoring of the system state, maintains mount and automount points, and implements an elaborate transactional dependency-based service control logic. It can also work as a drop-in replacement for sysvinit.\n\nSecurity Fix(es):\n\n* systemd: local information leak due to systemd-coredump not respecting fs.suid_dumpable kernel setting (CVE-2022-4415)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* systemd doesn't record messages to the journal during boot (BZ#2164049)",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0837 https://access.redhat.com/security/cve/CVE-2022-4415",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "systemd",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:239-68.el8_7.4",
+      "arch_op": "pattern match"
+    },
+    "4193248": {
+      "id": "4193248",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:7745: freetype security update (Moderate)",
+      "description": "FreeType is a free, high-quality, portable font engine that can open and manage font files. FreeType loads, hints, and renders individual glyphs efficiently.\n\nSecurity Fix(es):\n\n* FreeType: Buffer overflow in sfnt_init_face (CVE-2022-27404)\n\n* FreeType: Segmentation violation via FNT_Size_Request (CVE-2022-27405)\n\n* Freetype: Segmentation violation via FT_Request_Size (CVE-2022-27406)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the Red Hat Enterprise Linux 8.7 Release Notes linked from the References section.",
+      "issued": "2022-11-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:7745 https://access.redhat.com/security/cve/CVE-2022-27404 https://access.redhat.com/security/cve/CVE-2022-27405 https://access.redhat.com/security/cve/CVE-2022-27406",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "freetype",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.1-9.el8",
+      "arch_op": "pattern match"
+    },
+    "3954084": {
+      "id": "3954084",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5818: openssl security update (Moderate)",
+      "description": "OpenSSL is a toolkit that implements the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols, as well as a full-strength general-purpose cryptography library.\n\nSecurity Fix(es):\n\n* openssl: c_rehash script allows command injection (CVE-2022-1292)\n\n* openssl: the c_rehash script allows command injection (CVE-2022-2068)\n\n* openssl: AES OCB fails to encrypt some bytes (CVE-2022-2097)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-03T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5818 https://access.redhat.com/security/cve/CVE-2022-1292 https://access.redhat.com/security/cve/CVE-2022-2068 https://access.redhat.com/security/cve/CVE-2022-2097",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "openssl-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.1.1k-7.el8_6",
+      "arch_op": "pattern match"
+    },
+    "137101": {
+      "id": "137101",
+      "updater": "osv/maven",
+      "name": "GHSA-3f7h-mf4q-vrm4",
+      "description": "Denial of Service due to parser crash",
+      "issued": "2022-09-17T00:00:41Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2022-40152 https://github.com/FasterXML/woodstox/issues/157 https://github.com/FasterXML/woodstox/issues/160 https://github.com/x-stream/xstream/issues/304 https://github.com/FasterXML/woodstox/pull/159 https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47434 https://github.com/FasterXML/woodstox",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "com.fasterxml.woodstox:woodstox-core",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=5.4.0"
+    },
+    "4559170": {
+      "id": "4559170",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3839: libssh security update (Moderate)",
+      "description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nSecurity Fix(es):\n\n* libssh: NULL pointer dereference during rekeying with algorithm guessing (CVE-2023-1667)\n\n* libssh: authorization bypass in pki_verify_data_signature (CVE-2023-2283)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3839 https://access.redhat.com/security/cve/CVE-2023-1667 https://access.redhat.com/security/cve/CVE-2023-2283",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libssh",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:0.9.6-10.el8_8",
+      "arch_op": "pattern match"
+    },
+    "3911516": {
+      "id": "3911516",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:4991: xz security update (Important)",
+      "description": "XZ Utils is an integrated collection of user-space file compression utilities based on the Lempel-Ziv-Markov chain algorithm (LZMA), which performs lossless data compression. The algorithm provides a high compression ratio while keeping the decompression time short.\n\nSecurity Fix(es):\n\n* gzip: arbitrary-file-write vulnerability (CVE-2022-1271)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-13T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:4991 https://access.redhat.com/security/cve/CVE-2022-1271",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "xz-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:5.2.4-4.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4445658": {
+      "id": "4445658",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3106: curl security and bug fix update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: FTP too eager connection reuse (CVE-2023-27535)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Cannot upload files to Jscape SFTP server: file gets created empty (BZ#2188029)",
+      "issued": "2023-05-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3106 https://access.redhat.com/security/cve/CVE-2023-27535",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-30.el8_8.2",
+      "arch_op": "pattern match"
+    },
+    "4322231": {
+      "id": "4322231",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss-util",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4028745": {
+      "id": "4028745",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6457: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems. \n\nSecurity Fix(es):\n\n* python(mailcap): findmatch() function does not sanitise the second argument (CVE-2015-20107)\n\n* python: urllib.parse does not sanitize URLs containing ASCII newline and tabs (CVE-2022-0391)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-09-13T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6457 https://access.redhat.com/security/cve/CVE-2015-20107 https://access.redhat.com/security/cve/CVE-2022-0391",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "platform-python",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-47.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4014918": {
+      "id": "4014918",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6159: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: HTTP compression denial of service (CVE-2022-32206)\n\n* curl: FTP-KRB bad message verification (CVE-2022-32208)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-08-24T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6159 https://access.redhat.com/security/cve/CVE-2022-32206 https://access.redhat.com/security/cve/CVE-2022-32208",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-22.el8_6.4",
+      "arch_op": "pattern match"
+    },
+    "4290344": {
+      "id": "4290344",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0173: libxml2 security update (Moderate)",
+      "description": "The libxml2 library is a development toolbox providing the implementation of various XML standards.\n\nSecurity Fix(es):\n\n* libxml2: integer overflows with XML_PARSE_HUGE (CVE-2022-40303)\n\n* libxml2: dict corruption caused by entity reference cycles (CVE-2022-40304)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-16T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0173 https://access.redhat.com/security/cve/CVE-2022-40303 https://access.redhat.com/security/cve/CVE-2022-40304",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libxml2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.9.7-15.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4585234": {
+      "id": "4585234",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4498: dbus security update (Moderate)",
+      "description": "D-Bus is a system for sending messages between applications. It is used both for the system-wide message bus service, and as a per-user-login-session messaging facility.\n\nSecurity Fix(es):\n\n* dbus: dbus-daemon: assertion failure when a monitor is active and a message from the driver cannot be delivered (CVE-2023-34969)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-07T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4498 https://access.redhat.com/security/cve/CVE-2023-34969",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "dbus-daemon",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:1.12.8-24.el8_8.1",
+      "arch_op": "pattern match"
+    },
+    "3729878": {
+      "id": "3729878",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:1552: vim security update (Moderate)",
+      "description": "Vim (Vi IMproved) is an updated and improved version of the vi editor.\n\nSecurity Fix(es):\n\n* vim: use after free in utf_ptr2char (CVE-2022-1154)",
+      "issued": "2022-04-26T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:1552 https://access.redhat.com/security/cve/CVE-2022-1154",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "vim-minimal",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:8.0.1763-16.el8_5.13",
+      "arch_op": "pattern match"
+    },
+    "4313209": {
+      "id": "4313209",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0842: tar security update (Moderate)",
+      "description": "The GNU tar program can save multiple files in an archive and restore files from an archive.\n\nSecurity Fix(es):\n\n* tar: heap buffer overflow at from_header() in list.c via specially crafted checksum (CVE-2022-48303)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0842 https://access.redhat.com/security/cve/CVE-2022-48303",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "tar",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "2:1.30-6.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4287880": {
+      "id": "4287880",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0116: libtasn1 security update (Moderate)",
+      "description": "A library that provides Abstract Syntax Notation One (ASN.1, as specified by the X.680 ITU-T recommendation) parsing and structures management, and Distinguished Encoding Rules (DER, as per X.690) encoding and decoding functions.\n\nSecurity Fix(es):\n\n* libtasn1: Out-of-bound access in ETYPE_OK (CVE-2021-46848)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-01-12T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0116 https://access.redhat.com/security/cve/CVE-2021-46848",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libtasn1",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:4.13-4.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4327560": {
+      "id": "4327560",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1569: gnutls security and bug fix update (Moderate)",
+      "description": "The gnutls packages provide the GNU Transport Layer Security (GnuTLS) library, which implements cryptographic algorithms and protocols such as SSL, TLS, and DTLS.\n\nSecurity Fix(es):\n\n* gnutls: timing side-channel in the TLS RSA key exchange code (CVE-2023-0361)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* trap invalid opcode ip:7feef81809fe sp:7fee997419c0 error:0 in libgnutls.so.30.28.2[7feef8040000+1dd000] (BZ#2131152)",
+      "issued": "2023-04-04T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1569 https://access.redhat.com/security/cve/CVE-2023-0361",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "gnutls",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.16-6.el8_7",
+      "arch_op": "pattern match"
+    },
+    "4589330": {
+      "id": "4589330",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:4524: libcap security update (Moderate)",
+      "description": "Libcap is a library for getting and setting POSIX.1e (formerly POSIX 6) draft 15 capabilities.\n\nSecurity Fix(es):\n\n* libcap: Integer Overflow in _libcap_strdup() (CVE-2023-2603)\n\n* libcap: Memory Leak on pthread_create() Error (CVE-2023-2602)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-08-08T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:4524 https://access.redhat.com/security/cve/CVE-2023-2602 https://access.redhat.com/security/cve/CVE-2023-2603",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libcap",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.48-5.el8_8",
+      "arch_op": "pattern match"
+    },
+    "141010": {
+      "id": "141010",
+      "updater": "osv/maven",
+      "name": "GHSA-7r82-7xv7-xcpj",
+      "description": "Cross-site scripting in Apache HttpClient",
+      "issued": "2021-06-03T23:40:23Z",
+      "links": "https://nvd.nist.gov/vuln/detail/CVE-2020-13956 https://github.com/apache/httpcomponents-client https://lists.apache.org/thread.html/r03bbc318c81be21f5c8a9b85e34f2ecc741aa804a8e43b0ef2c37749@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/r043a75acdeb52b15dd5e9524cdadef4202e6a5228644206acf9363f9@%3Cdev.hive.apache.org%3E https://lists.apache.org/thread.html/r06cf3ca5c8ceb94b39cd24a73d4e96153b485a7dac88444dd876accb@%3Cissues.drill.apache.org%3E https://lists.apache.org/thread.html/r0a75b8f0f72f3e18442dc56d33f3827b905f2fe5b7ba48997436f5d1@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r0bebe6f9808ac7bdf572873b4fa96a29c6398c90dab29f131f3ebffe@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r12cb62751b35bdcda0ae2a08b67877d665a1f4d41eee0fa7367169e0@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r132e4c6a560cfc519caa1aaee63bdd4036327610eadbd89f76dd5457@%3Cdev.creadur.apache.org%3E https://lists.apache.org/thread.html/r2835543ef0f91adcc47da72389b816e36936f584c7be584d2314fac3@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/r2a03dc210231d7e852ef73015f71792ac0fcaca6cccc024c522ef17d@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r2dc7930b43eadc78220d269b79e13ecd387e4bee52db67b2f47d4303@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/r34178ab6ef106bc940665fd3f4ba5026fac3603b3fa2aefafa0b619d@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r34efec51cb817397ccf9f86e25a75676d435ba5f83ee7b2eabdad707@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r3cecd59fba74404cbf4eb430135e1080897fb376f111406a78bed13a@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/r3f740e4c38bba1face49078aa5cbeeb558c27be601cc9712ad2dcd1e@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r4850b3fbaea02fde2886e461005e4af8d37c80a48b3ce2a6edca0e30@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r549ac8c159bf0c568c19670bedeb8d7c0074beded951d34b1c1d0d05@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r55b2a1d1e9b1ec9db792b93da8f0f99a4fd5a5310b02673359d9b4d1@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/r5b55f65c123a7481104d663a915ec45a0d103e6aaa03f42ed1c07a89@%3Cdev.jackrabbit.apache.org%3E https://lists.apache.org/thread.html/r5de3d3808e7b5028df966e45115e006456c4e8931dc1e29036f17927@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r5fec9c1d67f928179adf484b01e7becd7c0a6fdfe3a08f92ea743b90@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/r63296c45d5d84447babaf39bd1487329d8a80d8d563e67a4b6f3d8a7@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r69a94e2f302d1b778bdfefe90fcb4b8c50b226438c3c8c1d0de85a19@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/r6a3cda38d050ebe13c1bc9a28d0a8ec38945095d07eca49046bcb89f@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/r6d672b46622842e565e00f6ef6bef83eb55d8792aac2bee75bff9a2a@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/r6dab7da30f8bf075f79ee189e33b45a197502e2676481bb8787fc0d7%40%3Cdev.hc.apache.org%3E https://lists.apache.org/thread.html/r6eb2dae157dbc9af1f30d1f64e9c60d4ebef618f3dce4a0e32d6ea4d@%3Ccommits.drill.apache.org%3E https://lists.apache.org/thread.html/r70c429923100c5a4fae8e5bc71c8a2d39af3de4888f50a0ac3755e6f@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/r87ddc09295c27f25471269ad0a79433a91224045988b88f0413a97ec@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/r8aa1e5c343b89aec5b69961471950e862f15246cb6392910161c389b@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/r9e52a6c72c8365000ecd035e48cc9fee5a677a150350d4420c46443d@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/ra539f20ef0fb0c27ee39945b5f56bf162e5c13d1c60f7344dab8de3b@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/ra8bc6b61c5df301a6fe5a716315528ecd17ccb8a7f907e24a47a1a5e@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rad6222134183046f3928f733bf680919e0c390739bfbfe6c90049673@%3Cissues.drill.apache.org%3E https://lists.apache.org/thread.html/rae14ae25ff4a60251e3ba2629c082c5ba3851dfd4d21218b99b56652@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rb33212dab7beccaf1ffef9b88610047c644f644c7a0ebdc44d77e381@%3Ccommits.turbine.apache.org%3E https://lists.apache.org/thread.html/rb4ba262d6f08ab9cf8b1ebbcd9b00b0368ffe90dad7ad7918b4b56fc@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/rb725052404fabffbe093c83b2c46f3f87e12c3193a82379afbc529f8@%3Csolr-user.lucene.apache.org%3E https://lists.apache.org/thread.html/rc0863892ccfd9fd0d0ae10091f24ee769fb39b8957fe4ebabfc11f17@%3Cdev.jackrabbit.apache.org%3E https://lists.apache.org/thread.html/rc3739e0ad4bcf1888c6925233bfc37dd71156bbc8416604833095c42@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/rc505fee574fe8d18f9b0c655a4d120b0ae21bb6a73b96003e1d9be35@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rc5c6ccb86d2afe46bbd4b71573f0448dc1f87bbcd5a0d8c7f8f904b2@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rc990e2462ec32b09523deafb2c73606208599e196fa2d7f50bdbc587@%3Cissues.maven.apache.org%3E https://lists.apache.org/thread.html/rcced7ed3237c29cd19c1e9bf465d0038b8b2e967b99fc283db7ca553@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/rcd9ad5dda60c82ab0d0c9bd3e9cb1dc740804451fc20c7f451ef5cc4@%3Cgitbox.hive.apache.org%3E https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@%3Ccommits.pulsar.apache.org%3E https://lists.apache.org/thread.html/rd5ab56beb2ac6879f6ab427bc4e5f7691aed8362d17b713f61779858@%3Cissues.hive.apache.org%3E https://lists.apache.org/thread.html/re504acd4d63b8df2a7353658f45c9a3137e5f80e41cf7de50058b2c1@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rea3dbf633dde5008d38bf6600a3738b9216e733e03f9ff7becf79625@%3Cissues.drill.apache.org%3E https://lists.apache.org/thread.html/ree942561f4620313c75982a4e5f3b74fe6f7062b073210779648eec2@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/reef569c2419705754a3acf42b5f19b2a158153cef0e448158bc54917@%3Cdev.drill.apache.org%3E https://lists.apache.org/thread.html/rf03228972e56cb4a03e6d9558188c2938078cf3ceb23a3fead87c9ca@%3Cissues.bookkeeper.apache.org%3E https://lists.apache.org/thread.html/rf43d17ed0d1fb4fb79036b582810ef60b18b1ef3add0d5dea825af1e@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rf4db88c22e1be9eb60c7dc623d0528642c045fb196a24774ac2fa3a3@%3Cissues.lucene.apache.org%3E https://lists.apache.org/thread.html/rf7ca60f78f05b772cc07d27e31bcd112f9910a05caf9095e38ee150f@%3Cdev.ranger.apache.org%3E https://lists.apache.org/thread.html/rfb35f6db9ba1f1e061b63769a4eff5abadcc254ebfefc280e5a0dcf1@%3Ccommits.creadur.apache.org%3E https://lists.apache.org/thread.html/rfbedcb586a1e7dfce87ee03c720e583fc2ceeafa05f35c542cecc624@%3Cissues.solr.apache.org%3E https://lists.apache.org/thread.html/rfc00884c7b7ca878297bffe45fcb742c362b00b26ba37070706d44c3@%3Cissues.hive.apache.org%3E https://security.netapp.com/advisory/ntap-20220210-0002/ https://www.oracle.com//security-alerts/cpujul2021.html https://www.oracle.com/security-alerts/cpuApr2021.html https://www.oracle.com/security-alerts/cpuapr2022.html https://www.oracle.com/security-alerts/cpujan2022.html https://www.oracle.com/security-alerts/cpuoct2021.html",
+      "severity": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "org.apache.httpcomponents:httpclient",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "",
+        "name": "",
+        "version": "",
+        "version_code_name": "",
+        "version_id": "",
+        "arch": "",
+        "cpe": "",
+        "pretty_name": ""
+      },
+      "repository": {
+        "name": "maven",
+        "uri": "https://repo1.maven.apache.org/maven2"
+      },
+      "fixed_in_version": "fixed=4.5.13"
+    },
+    "4559255": {
+      "id": "4559255",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:3839: libssh security update (Moderate)",
+      "description": "libssh is a library which implements the SSH protocol. It can be used to implement client and server applications.\n\nSecurity Fix(es):\n\n* libssh: NULL pointer dereference during rekeying with algorithm guessing (CVE-2023-1667)\n\n* libssh: authorization bypass in pki_verify_data_signature (CVE-2023-2283)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-06-27T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:3839 https://access.redhat.com/security/cve/CVE-2023-1667 https://access.redhat.com/security/cve/CVE-2023-2283",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "libssh-config",
+        "version": "",
+        "kind": "binary"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:0.9.6-10.el8_8"
+    },
+    "4307972": {
+      "id": "4307972",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0833: python3 security update (Moderate)",
+      "description": "Python is an interpreted, interactive, object-oriented programming language, which includes modules, classes, exceptions, very high level dynamic data types and dynamic typing. Python supports interfaces to many system calls and libraries, as well as to various windowing systems.\n\nSecurity Fix(es):\n\n* python: int() type in PyLong_FromString() does not limit amount of digits converting text to int leading to DoS (CVE-2020-10735)\n\n* python: open redirection vulnerability in lib/http/server.py may lead to information disclosure (CVE-2021-28861)\n\n* Python: CPU denial of service via inefficient IDNA decoder (CVE-2022-45061)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-02-21T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0833 https://access.redhat.com/security/cve/CVE-2020-10735 https://access.redhat.com/security/cve/CVE-2021-28861 https://access.redhat.com/security/cve/CVE-2022-45061",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "python3-libs",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.6.8-48.el8_7.1",
+      "arch_op": "pattern match"
+    },
+    "4322023": {
+      "id": "4322023",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss-sysinit",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "3917260": {
+      "id": "3917260",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:5313: curl security update (Moderate)",
+      "description": "The curl packages provide the libcurl library and the curl utility for downloading files from servers using various protocols, including HTTP, FTP, and LDAP.\n\nSecurity Fix(es):\n\n* curl: OAUTH2 bearer bypass in connection re-use (CVE-2022-22576)\n\n* curl: credential leak on redirect (CVE-2022-27774)\n\n* curl: auth/cookie leak on redirect (CVE-2022-27776)\n\n* curl: TLS and SSH connection too eager reuse (CVE-2022-27782)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-06-30T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:5313 https://access.redhat.com/security/cve/CVE-2022-22576 https://access.redhat.com/security/cve/CVE-2022-27774 https://access.redhat.com/security/cve/CVE-2022-27776 https://access.redhat.com/security/cve/CVE-2022-27782",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "curl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:7.61.1-22.el8_6.3",
+      "arch_op": "pattern match"
+    },
+    "3616199": {
+      "id": "3616199",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:0185: java-11-openjdk security update (Moderate)",
+      "description": "The java-11-openjdk packages provide the OpenJDK 11 Java Runtime Environment and the OpenJDK 11 Java Software Development Kit.\n\nSecurity Fix(es):\n\n* OpenJDK: Incomplete deserialization class filtering in ObjectInputStream (Serialization, 8264934) (CVE-2022-21248)\n\n* OpenJDK: Incorrect reading of TIFF files in TIFFNullDecompressor (ImageIO, 8270952) (CVE-2022-21277)\n\n* OpenJDK: Insufficient URI checks in the XSLT TransformerImpl (JAXP, 8270492) (CVE-2022-21282)\n\n* OpenJDK: Unexpected exception thrown in regex Pattern (Libraries, 8268813) (CVE-2022-21283)\n\n* OpenJDK: Incorrect marking of writeable fields (Hotspot, 8270386) (CVE-2022-21291)\n\n* OpenJDK: Incomplete checks of StringBuffer and StringBuilder during deserialization (Libraries, 8270392) (CVE-2022-21293)\n\n* OpenJDK: Incorrect IdentityHashMap size checks during deserialization (Libraries, 8270416) (CVE-2022-21294)\n\n* OpenJDK: Incorrect access checks in XMLEntityManager (JAXP, 8270498) (CVE-2022-21296)\n\n* OpenJDK: Infinite loop related to incorrect handling of newlines in XMLEntityScanner (JAXP, 8270646) (CVE-2022-21299)\n\n* OpenJDK: Array indexing issues in LIRGenerator (Hotspot, 8272014) (CVE-2022-21305)\n\n* OpenJDK: Excessive resource use when reading JAR manifest attributes (Libraries, 8272026) (CVE-2022-21340)\n\n* OpenJDK: Insufficient checks when deserializing exceptions in ObjectInputStream (Serialization, 8272236) (CVE-2022-21341)\n\n* OpenJDK: Excessive memory allocation in BMPImageReader (ImageIO, 8273756) (CVE-2022-21360)\n\n* OpenJDK: Integer overflow in BMPImageReader (ImageIO, 8273838) (CVE-2022-21365)\n\n* OpenJDK: Excessive memory allocation in TIFF*Decompressor (ImageIO, 8274096) (CVE-2022-21366)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-01-24T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:0185 https://access.redhat.com/security/cve/CVE-2022-21248 https://access.redhat.com/security/cve/CVE-2022-21277 https://access.redhat.com/security/cve/CVE-2022-21282 https://access.redhat.com/security/cve/CVE-2022-21283 https://access.redhat.com/security/cve/CVE-2022-21291 https://access.redhat.com/security/cve/CVE-2022-21293 https://access.redhat.com/security/cve/CVE-2022-21294 https://access.redhat.com/security/cve/CVE-2022-21296 https://access.redhat.com/security/cve/CVE-2022-21299 https://access.redhat.com/security/cve/CVE-2022-21305 https://access.redhat.com/security/cve/CVE-2022-21340 https://access.redhat.com/security/cve/CVE-2022-21341 https://access.redhat.com/security/cve/CVE-2022-21360 https://access.redhat.com/security/cve/CVE-2022-21365 https://access.redhat.com/security/cve/CVE-2022-21366",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "java-11-openjdk-headless",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "1:11.0.14.0.9-2.el8_5",
+      "arch_op": "pattern match"
+    },
+    "4033279": {
+      "id": "4033279",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2022:6463: gnupg2 security update (Moderate)",
+      "description": "The GNU Privacy Guard (GnuPG or GPG) is a tool for encrypting data and creating digital signatures, compliant with OpenPGP and S/MIME standards.\n\nSecurity Fix(es):\n\n* gpg: Signature spoofing via status line injection (CVE-2022-34903)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2022-09-13T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2022:6463 https://access.redhat.com/security/cve/CVE-2022-34903",
+      "severity": "Moderate",
+      "normalized_severity": "Medium",
+      "package": {
+        "id": "",
+        "name": "gnupg2",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/o:redhat:enterprise_linux:8::baseos",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:2.2.20-3.el8_6",
+      "arch_op": "pattern match"
+    },
+    "4321661": {
+      "id": "4321661",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:1252: nss security update (Important)",
+      "description": "Network Security Services (NSS) is a set of libraries designed to support the cross-platform development of security-enabled client and server applications.\n\nSecurity Fix(es):\n\n* nss: Arbitrary memory write via PKCS 12 (CVE-2023-0767)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:1252 https://access.redhat.com/security/cve/CVE-2023-0767",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "nss-softokn-freebl",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    },
+    "10000000": {
+      "id": "10000000",
+      "updater": "RHEL8-rhel-8-including-unpatched",
+      "name": "RHSA-2023:0000: test vuln",
+      "description": "this is a test",
+      "issued": "2023-03-15T00:00:00Z",
+      "links": "https://access.redhat.com/errata/RHSA-2023:0000 https://access.redhat.com/security/cve/CVE-2023-0000",
+      "severity": "Important",
+      "normalized_severity": "High",
+      "package": {
+        "id": "",
+        "name": "test package",
+        "version": "",
+        "kind": "binary",
+        "arch": "aarch64|i686|ppc64le|s390x|x86_64"
+      },
+      "distribution": {
+        "id": "",
+        "did": "rhel",
+        "name": "Red Hat Enterprise Linux Server",
+        "version": "8",
+        "version_code_name": "",
+        "version_id": "8",
+        "arch": "",
+        "cpe": "cpe:2.3:o:redhat:enterprise_linux:8:*:*:*:*:*:*:*",
+        "pretty_name": "Red Hat Enterprise Linux Server 8"
+      },
+      "repository": {
+        "name": "cpe:/a:redhat:enterprise_linux:8::appstream",
+        "key": "rhel-cpe-repository"
+      },
+      "fixed_in_version": "0:3.79.0-11.el8_7",
+      "arch_op": "pattern match"
+    }
+
+  },
+  "package_vulnerabilities": {
+    "160": [
+      "4585108",
+      "4236413",
+      "4585026",
+      "4236336"
+    ],
+    "200": [
+      "3712453",
+      "3712338"
+    ],
+    "32": [
+      "4284065",
+      "4046865",
+      "3917556",
+      "3714457",
+      "4283968",
+      "4046766",
+      "3917484",
+      "3714356"
+    ],
+    "140": [
+      "4033279",
+      "4033190"
+    ],
+    "1054": [
+      "156104",
+      "137797"
+    ],
+    "566": [
+      "4601249",
+      "3913176",
+      "4601158",
+      "3913148"
+    ],
+    "12": [
+      "3953141",
+      "3953070"
+    ],
+    "584": [
+      "4322673",
+      "3953917",
+      "3716594",
+      "3572666",
+      "4322553",
+      "3953842",
+      "3716480",
+      "3572609"
+    ],
+    "1132": [
+      "149462",
+      "138037"
+    ],
+    "782": [
+      "4308336",
+      "4308288"
+    ],
+    "20": [
+      "4056220",
+      "3740378",
+      "4056165",
+      "3740332"
+    ],
+    "1036": [
+      "155055",
+      "149795",
+      "138348",
+      "137459"
+    ],
+    "292": [
+      "4190096",
+      "4190007"
+    ],
+    "260": [
+      "3726145",
+      "3726060"
+    ],
+    "572": [
+      "4193248",
+      "4193161"
+    ],
+    "1002": [
+      "158203"
+    ],
+    "180": [
+      "4313296",
+      "4313209"
+    ],
+    "202": [
+      "3690610",
+      "3690500"
+    ],
+    "24": [
+      "4559849",
+      "4284763",
+      "4057537",
+      "4559742",
+      "4284704",
+      "4057313"
+    ],
+    "146": [
+      "4559245",
+      "3879186",
+      "4559170",
+      "3879114"
+    ],
+    "1074": [
+      "147193",
+      "143317"
+    ],
+    "64": [
+      "4558700",
+      "4308881",
+      "4279842",
+      "4016429",
+      "4558598",
+      "4308799",
+      "4279739",
+      "4016358"
+    ],
+    "150": [
+      "4588959",
+      "4445730",
+      "4435303",
+      "4320916",
+      "4014918",
+      "3917260",
+      "4588891",
+      "4445658",
+      "4435245",
+      "4320832",
+      "4014836",
+      "3917196"
+    ],
+    "98": [
+      "4455988",
+      "4307562",
+      "4028745",
+      "3872472",
+      "4455909",
+      "4307432",
+      "4028688",
+      "3872405"
+    ],
+    "92": [
+      "2108904",
+      "2108839"
+    ],
+    "336": [
+      "3632280",
+      "3632211"
+    ],
+    "354": [
+      "4585006",
+      "4236321",
+      "4584980",
+      "4236232"
+    ],
+    "282": [
+      "4308277",
+      "4308222"
+    ],
+    "360": [
+      "4599434",
+      "4599360"
+    ],
+    "366": [
+      "3953826",
+      "3921127",
+      "3729951",
+      "3690333",
+      "3631715",
+      "3953752",
+      "3921068",
+      "3729878",
+      "3690258",
+      "3631646"
+    ],
+    "94": [
+      "4322944",
+      "3954084",
+      "3716799",
+      "3572823",
+      "4322825",
+      "3954012",
+      "3716723",
+      "3572765"
+    ],
+    "176": [
+      "4599614",
+      "4599539"
+    ],
+    "1082": [
+      "152217",
+      "151929",
+      "139929"
+    ],
+    "250": [
+      "4585484",
+      "4236730",
+      "4585330",
+      "4236646"
+    ],
+    "60": [
+      "4287975",
+      "4287880"
+    ],
+    "1126": [
+      "138457"
+    ],
+    "106": [
+      "4327672",
+      "4055295",
+      "4327560",
+      "4055233"
+    ],
+    "776": [
+      "4322087",
+      "4322023"
+    ],
+    "1076": [
+      "157977",
+      "144608",
+      "139028",
+      "136158"
+    ],
+    "562": [
+      "4321288",
+      "4321232"
+    ],
+    "840": [
+      "156852",
+      "152415",
+      "149634",
+      "141290",
+      "141045"
+    ],
+    "352": [
+      "4558929",
+      "4308983",
+      "4279968",
+      "4016581",
+      "4558719",
+      "4308896",
+      "4279858",
+      "4016445"
+    ],
+    "300": [
+      "3641452",
+      "3641368"
+    ],
+    "558": [
+      "4322231",
+      "4322175"
+    ],
+    "186": [
+      "3553017",
+      "3552940"
+    ],
+    "1004": [
+      "158147",
+      "137417"
+    ],
+    "190": [
+      "4600572",
+      "4600483"
+    ],
+    "316": [
+      "4588876",
+      "4588813"
+    ],
+    "820": [
+      "158597"
+    ],
+    "164": [
+      "3633588",
+      "3633515"
+    ],
+    "330": [
+      "4559314",
+      "3879284",
+      "4559255",
+      "3879204"
+    ],
+    "206": [
+      "3911609",
+      "3911516"
+    ],
+    "188": [
+      "4308422",
+      "4308353"
+    ],
+    "346": [
+      "4585234",
+      "4236511",
+      "4585116",
+      "4236425"
+    ],
+    "168": [
+      "4558245",
+      "4308520",
+      "4279352",
+      "4015868",
+      "4558149",
+      "4308437",
+      "4279270",
+      "4015788"
+    ],
+    "82": [
+      "4302609",
+      "4055140",
+      "4302545",
+      "4055078"
+    ],
+    "582": [
+      "4575276",
+      "4336662",
+      "4293931",
+      "4053752",
+      "3942176",
+      "3718247",
+      "3616199",
+      "4575222",
+      "4336583",
+      "4293838",
+      "4053702",
+      "3942085",
+      "3718158",
+      "3616127"
+    ],
+    "956": [
+      "147193",
+      "143317"
+    ],
+    "1020": [
+      "140730",
+      "139050"
+    ],
+    "16": [
+      "3690981",
+      "3690879"
+    ],
+    "958": [
+      "157977",
+      "136158"
+    ],
+    "212": [
+      "4589330",
+      "4589268"
+    ],
+    "170": [
+      "3632531",
+      "3632458"
+    ],
+    "964": [
+      "139929"
+    ],
+    "318": [
+      "4599718",
+      "4599633"
+    ],
+    "874": [
+      "156954",
+      "155864",
+      "151884",
+      "148367",
+      "143632",
+      "143344",
+      "142741",
+      "137268"
+    ],
+    "320": [
+      "4441833",
+      "3689725",
+      "4441754",
+      "3689646"
+    ],
+    "1128": [
+      "137101"
+    ],
+    "1024": [
+      "141010"
+    ],
+    "34": [
+      "4192217",
+      "4192129"
+    ],
+    "252": [
+      "4585538",
+      "4236853",
+      "4585493",
+      "4236745"
+    ],
+    "882": [
+      "140254"
+    ],
+    "560": [
+      "4321514",
+      "4321409"
+    ],
+    "278": [
+      "4209612",
+      "4209498"
+    ],
+    "210": [
+      "4590483",
+      "4290140",
+      "4191438",
+      "3920379",
+      "3714109",
+      "4590369",
+      "4290048",
+      "4191348",
+      "3920299",
+      "3714014"
+    ],
+    "1120": [
+      "154065",
+      "153110",
+      "145398"
+    ],
+    "308": [
+      "4590620",
+      "4290344",
+      "4191686",
+      "3920785",
+      "3714338",
+      "4590559",
+      "4290268",
+      "4191586",
+      "3920444",
+      "3714247"
+    ],
+    "52": [
+      "3917121",
+      "3917079"
+    ],
+    "152": [
+      "3632787",
+      "3632719"
+    ],
+    "944": [
+      "141010"
+    ],
+    "774": [
+      "4321765",
+      "4321661"
+    ],
+    "284": [
+      "4456469",
+      "4308044",
+      "4029280",
+      "3872868",
+      "4456362",
+      "4307972",
+      "4029172",
+      "3872785"
+    ],
+    "132": [
+      "4599522",
+      "4599450"
+    ],
+    "356": [
+      "3632197",
+      "3631728"
+    ],
+    "362": [
+      "4600001",
+      "4599927"
+    ],
+    "332": [
+      "4589048",
+      "4445830",
+      "4435382",
+      "4321033",
+      "4015035",
+      "3917297",
+      "4588975",
+      "4445745",
+      "4435315",
+      "4320940",
+      "4014930",
+      "3917266"
+    ],
+    "46": [
+      "3553964",
+      "3553907"
+    ],
+    "1000": [
+      "10000000"
+    ]
+  },
+  "enrichments": {
+    "message/vnd.clair.map.layer; enricher=clair.rhcc schema=??": {
+      "sha256:63f9f4c31162a6a5dacd999a0dc65007e15b2ca6b2d9360a1234c27de12e7f38": "372"
+    }
+  }
+}


### PR DESCRIPTION
This change adds the ability for Quay to reason with the rhcc-enrichment that Clair will return in the vulnerability reports. This information is meant to allow users or applications to determine which packages come from rhcc layers.