### PR TITLE
chore: add **/node_modules to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,5 +33,6 @@ static/build/**
 docker-compose.yaml
 test/dockerclients/**
 node_modules
+**/node_modules
 .local
 **/testdata


### PR DESCRIPTION
The `RUN npm run build` fails in `build-ui` step of quay's dockerfile because `web/node_modules` is not ignored. This changes add the folder to .dockerignore