### PR TITLE
quota: removing extra calls to get namespace quotas (PROJQUAY-6048)

### DIFF
--- a/endpoints/api/repository.py
+++ b/endpoints/api/repository.py
@@ -255,7 +255,12 @@ class RepositoryList(ApiResource):
             popularity,
         )
 
-        return {"repositories": [repo.to_dict() for repo in repos]}, next_page_token
+        repositories_with_view = [repo.to_dict() for repo in repos]
+
+        if features.QUOTA_MANAGEMENT:
+            model.add_quota_view(repositories_with_view)
+
+        return {"repositories": repositories_with_view}, next_page_token
 
 
 @resource("/v1/repository/<apirepopath:repository>")

--- a/endpoints/api/repository_models_interface.py
+++ b/endpoints/api/repository_models_interface.py
@@ -57,11 +57,6 @@ class RepositoryBaseElement(
             "state": self.state.name if self.state is not None else None,
         }
 
-        if features.QUOTA_MANAGEMENT:
-            repo["quota_report"] = model.namespacequota.get_repo_quota_for_view(
-                self.namespace_name, self.repository_name
-            )
-
         if self.should_last_modified:
             repo["last_modified"] = self.last_modified
 
@@ -330,4 +325,10 @@ class RepositoryDataInterface(object):
     def set_repository_state(self, namespace_name, repository_name, state):
         """
         Set the State of the Repository.
+        """
+
+    @abstractmethod
+    def add_quota_view(self, repos):
+        """
+        Adds quota size and limit to the repository list.
         """

--- a/endpoints/api/test/test_repository_models_pre_oci.py
+++ b/endpoints/api/test/test_repository_models_pre_oci.py
@@ -1,4 +1,3 @@
-
 import pytest
 from mock import ANY, MagicMock, patch
 

--- a/endpoints/api/test/test_repository_models_pre_oci.py
+++ b/endpoints/api/test/test_repository_models_pre_oci.py
@@ -1,0 +1,44 @@
+from endpoints.api.repository_models_pre_oci import pre_oci_model
+from test.fixtures import *
+
+import pytest
+from mock import ANY, MagicMock, patch
+
+from data import database, model
+from endpoints.api.repository import Repository, RepositoryList, RepositoryTrust
+from endpoints.api.test.shared import conduct_api_call
+from endpoints.test.shared import client_with_identity
+from features import FeatureNameValue
+
+
+def test_add_quota_view(initialized_db):
+    repos = [
+        {
+            "namespace": "buynlarge",
+            "name": "orgrepo",
+        },
+        {
+            "namespace": "devtable",
+            "name": "simple",
+        },
+        {
+            "namespace": "devtable",
+            "name": None,
+        },
+        {
+            "namespace": "buynlarge",
+            "name": "doesnotexist",
+        },
+    ]
+
+    pre_oci_model.add_quota_view(repos)
+
+    assert repos[0].get("quota_report").get("quota_bytes") == 92
+    assert repos[0].get("quota_report").get("configured_quota") == 3000
+
+    assert repos[1].get("quota_report").get("quota_bytes") == 92
+    assert repos[1].get("quota_report").get("configured_quota") is None
+
+    assert repos[2].get("quota_report") is None
+
+    assert repos[3].get("quota_report") is None

--- a/endpoints/api/test/test_repository_models_pre_oci.py
+++ b/endpoints/api/test/test_repository_models_pre_oci.py
@@ -1,14 +1,14 @@
-from endpoints.api.repository_models_pre_oci import pre_oci_model
-from test.fixtures import *
 
 import pytest
 from mock import ANY, MagicMock, patch
 
 from data import database, model
 from endpoints.api.repository import Repository, RepositoryList, RepositoryTrust
+from endpoints.api.repository_models_pre_oci import pre_oci_model
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
 from features import FeatureNameValue
+from test.fixtures import *
 
 
 def test_add_quota_view(initialized_db):


### PR DESCRIPTION
When quota is enabled and an API call is made to `GET /api/v1/repository` a query is made to fetch the namespace quota limit for each repository in the list. Most often, specifically when loading the repositories list page, the result of this call will be the same and can cause up to 99 duplicated calls with the default limit. This stores the result of the call in memory to prevent the duplicate queries. 