### PR TITLE
quota: adding indexes to the quota size tables (PROJQUAY-6048)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -981,15 +981,15 @@ class RepositorySearchScore(BaseModel):
 
 
 class QuotaNamespaceSize(BaseModel):
-    namespace_user = ForeignKeyField(User, unique=True)
-    size_bytes = BigIntegerField(null=False, default=0)
-    backfill_start_ms = BigIntegerField(null=True)
+    namespace_user = ForeignKeyField(User, unique=True, index=True)
+    size_bytes = BigIntegerField(null=False, default=0, index=True)
+    backfill_start_ms = BigIntegerField(null=True, index=True)
     backfill_complete = BooleanField(null=False, default=False)
 
 
 class QuotaRepositorySize(BaseModel):
-    repository = ForeignKeyField(Repository, unique=True)
-    size_bytes = BigIntegerField(null=False, default=0)
+    repository = ForeignKeyField(Repository, unique=True, index=True)
+    size_bytes = BigIntegerField(null=False, default=0, index=True)
     backfill_start_ms = BigIntegerField(null=True)
     backfill_complete = BooleanField(null=False, default=False)
 

--- a/data/migrations/versions/4366f54be43c_quota_indexes.py
+++ b/data/migrations/versions/4366f54be43c_quota_indexes.py
@@ -1,0 +1,46 @@
+"""add indexes to quotanamespacesize and quotarepositorysize tables
+
+Revision ID: 4366f54be43c
+Revises: b82361fba1cd
+Create Date: 2023-09-27 16:34:30.570757
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4366f54be43c'
+down_revision = 'b82361fba1cd'
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.create_index(
+        "quotanamespacesize_namespace_user_id", "quotanamespacesize", ["namespace_user_id"], unique=True
+    )
+
+    # Index used by the quotatotalworker to find the next namespace to backfill
+    op.create_index(
+        "quotanamespacesize_backfill_start_ms", "quotanamespacesize", ["backfill_start_ms"], unique=False
+    )
+
+    # Index used by future API's for quick sorting of the largest namespaces
+    op.create_index(
+        "quotanamespacesize_size_bytes", "quotanamespacesize", ["size_bytes"], unique=False
+    )
+
+    op.create_index(
+        "quotarepositorysize_repository_id", "quotarepositorysize", ["repository_id"], unique=True
+    )
+
+    # Index used by future API's for quick sorting of the largest repositories
+    op.create_index(
+        "quotarepositorysize_size_bytes", "quotarepositorysize", ["size_bytes"], unique=False
+    )
+
+
+def downgrade(op, tables, tester):
+    op.drop_index("quotanamespacesize_namespace_user_id", table_name="quotanamespacesize")
+    op.drop_index("quotanamespacesize_backfill_start_ms", table_name="quotanamespacesize")
+    op.drop_index("quotanamespacesize_size_bytes", table_name="quotanamespacesize")
+    op.drop_index("quotarepositorysize_repository_id", table_name="quotarepositorysize")
+    op.drop_index("quotarepositorysize_size_bytes", table_name="quotarepositorysize")

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -281,6 +281,11 @@ DROP INDEX IF EXISTS public.repomirrorconfig_root_rule_id;
 DROP INDEX IF EXISTS public.repomirrorconfig_repository_id;
 DROP INDEX IF EXISTS public.repomirrorconfig_mirror_type;
 DROP INDEX IF EXISTS public.repomirrorconfig_internal_robot_id;
+DROP INDEX IF EXISTS public.quotarepositorysize_size_bytes;
+DROP INDEX IF EXISTS public.quotarepositorysize_repository_id;
+DROP INDEX IF EXISTS public.quotanamespacesize_size_bytes;
+DROP INDEX IF EXISTS public.quotanamespacesize_namespace_user_id;
+DROP INDEX IF EXISTS public.quotanamespacesize_backfill_start_ms;
 DROP INDEX IF EXISTS public.quotalimits_quota_id;
 DROP INDEX IF EXISTS public.queueitem_state_id;
 DROP INDEX IF EXISTS public.queueitem_queue_name;
@@ -5464,7 +5469,7 @@ COPY public.accesstokenkind (id, name) FROM stdin;
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-b82361fba1cd
+4366f54be43c
 \.
 
 
@@ -10514,6 +10519,41 @@ CREATE UNIQUE INDEX queueitem_state_id ON public.queueitem USING btree (state_id
 --
 
 CREATE INDEX quotalimits_quota_id ON public.quotalimits USING btree (quota_id);
+
+
+--
+-- Name: quotanamespacesize_backfill_start_ms; Type: INDEX; Schema: public; Owner: quay
+--
+
+CREATE INDEX quotanamespacesize_backfill_start_ms ON public.quotanamespacesize USING btree (backfill_start_ms);
+
+
+--
+-- Name: quotanamespacesize_namespace_user_id; Type: INDEX; Schema: public; Owner: quay
+--
+
+CREATE UNIQUE INDEX quotanamespacesize_namespace_user_id ON public.quotanamespacesize USING btree (namespace_user_id);
+
+
+--
+-- Name: quotanamespacesize_size_bytes; Type: INDEX; Schema: public; Owner: quay
+--
+
+CREATE INDEX quotanamespacesize_size_bytes ON public.quotanamespacesize USING btree (size_bytes);
+
+
+--
+-- Name: quotarepositorysize_repository_id; Type: INDEX; Schema: public; Owner: quay
+--
+
+CREATE UNIQUE INDEX quotarepositorysize_repository_id ON public.quotarepositorysize USING btree (repository_id);
+
+
+--
+-- Name: quotarepositorysize_size_bytes; Type: INDEX; Schema: public; Owner: quay
+--
+
+CREATE INDEX quotarepositorysize_size_bytes ON public.quotarepositorysize USING btree (size_bytes);
 
 
 --


### PR DESCRIPTION
Adding indexes to the `quotanamespacesize` and `quotarepositorysize` tables. Required for larger registries to perform well.