### PR TITLE
ui: Implement drawer to add a new team member (PROJQUAY-6032)

### DIFF
--- a/web/cypress/e2e/manage-team-members.cy.ts
+++ b/web/cypress/e2e/manage-team-members.cy.ts
@@ -1,0 +1,235 @@
+/// <reference types="cypress" />
+
+describe('Manage team members page', () => {
+  beforeEach(() => {
+    cy.exec('npm run quay:seed');
+    cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
+      .then((response) => response.body.csrf_token)
+      .then((token) => {
+        cy.loginByCSRF(token);
+      });
+  });
+
+  it('Can search for member in Manage team members view', () => {
+    const team = 'owners';
+    cy.visit('/organization/testorg?tab=Teamsandmembership');
+    cy.get('#Teams').click();
+
+    // Search for a single team
+    cy.get('#teams-view-search').type(`${team}`);
+    cy.contains('1 - 1 of 1');
+    cy.get(`[data-testid="${team}-toggle-kebab"]`).click();
+    cy.get(`[data-testid="${team}-manage-team-member-option"]`)
+      .contains('Manage team members')
+      .click();
+
+    // verify manage members view is shown
+    cy.url().should('contain', `teams/${team}?tab=Teamsandmembership`);
+    cy.get(`[data-label="Team member"]`).contains('user1');
+  });
+
+  it('Search Filter for Team member toggle view', () => {
+    const team = 'chelsea';
+    const robotAccnt = 'testorg+testrobot';
+    const user = 'user1';
+    cy.visit('/organization/testorg?tab=Teamsandmembership');
+    cy.get('#Teams').click();
+
+    // Search for a single team
+    cy.get('#teams-view-search').type(`${team}`);
+    cy.contains('1 - 1 of 1');
+    cy.get(`[data-testid="${team}-toggle-kebab"]`).click();
+    cy.get(`[data-testid="${team}-manage-team-member-option"]`)
+      .contains('Manage team members')
+      .click();
+    cy.get(`[data-testid="Team Member"]`).click();
+
+    // verify team member is shown
+    cy.get('#team-member-search-input').type(`${user}`);
+    cy.contains('1 - 1 of 1');
+    cy.get('#team-member-search-input').clear();
+
+    // verify robot account is not shown
+    cy.get('#team-member-search-input').type(`${robotAccnt}`);
+    cy.contains('0 - 0 of 0');
+  });
+
+  it('Search Filter for Robot accounts toggle view', () => {
+    const team = 'chelsea';
+    const robotAccnt = 'testorg+testrobot';
+    const user = 'user1';
+    cy.visit('/organization/testorg?tab=Teamsandmembership');
+    cy.get('#Teams').click();
+
+    // Search for a single team
+    cy.get('#teams-view-search').type(`${team}`);
+    cy.contains('1 - 1 of 1');
+    cy.get(`[data-testid="${team}-toggle-kebab"]`).click();
+    cy.get(`[data-testid="${team}-manage-team-member-option"]`)
+      .contains('Manage team members')
+      .click();
+    cy.get(`[data-testid="Robot Accounts"]`).click();
+
+    // verify robot account is shown
+    cy.get('#team-member-search-input').type(`${robotAccnt}`);
+    cy.contains('1 - 1 of 1');
+    cy.get('#team-member-search-input').clear();
+
+    // verify team member is not shown
+    cy.get('#team-member-search-input').type(`${user}`);
+    cy.contains('0 - 0 of 0');
+  });
+
+  it('Can update team description from Manage team members view', () => {
+    const team = 'chelsea';
+    const teamDescription = 'Chelsea team needs a new manager';
+    cy.visit('/organization/testorg?tab=Teamsandmembership');
+    cy.get('#Teams').click();
+
+    // Search for a single team
+    cy.get('#teams-view-search').type(`${team}`);
+    cy.contains('1 - 1 of 1');
+    cy.get(`[data-testid="${team}-toggle-kebab"]`).click();
+    cy.get(`[data-testid="${team}-manage-team-member-option"]`)
+      .contains('Manage team members')
+      .click();
+
+    cy.get(`[data-testid="edit-team-description-btn"]`).click();
+    cy.get(`[data-testid="team-description-text-area"]`).type(
+      `${teamDescription}`,
+    );
+    cy.get(`[data-testid="save-team-description-btn"]`).click();
+
+    // verify success alert
+    cy.get('.pf-v5-c-alert.pf-m-success')
+      .contains(`Successfully updated team:${team} description`)
+      .should('exist');
+    cy.get(`[data-testid="team-description-text"]`).contains(
+      `${teamDescription}`,
+    );
+  });
+
+  it('Can delete a robot account from Manage team members view', () => {
+    const team = 'chelsea';
+    const robotAccntToBeDeleted = 'testorg+testrobot';
+    cy.visit('/organization/testorg?tab=Teamsandmembership');
+    cy.get('#Teams').click();
+
+    // Search for a single team
+    cy.get('#teams-view-search').type(`${team}`);
+    cy.contains('1 - 1 of 1');
+    cy.get(`[data-testid="${team}-toggle-kebab"]`).click();
+    cy.get(`[data-testid="${team}-manage-team-member-option"]`)
+      .contains('Manage team members')
+      .click();
+
+    // delete robot account
+    cy.get(`[data-testid="${robotAccntToBeDeleted}-delete-icon"]`).click();
+    cy.get(`[data-testid="${robotAccntToBeDeleted}-del-btn"]`).click();
+
+    // verify success alert
+    cy.get('.pf-v5-c-alert.pf-m-success')
+      .contains(`Successfully deleted team member: ${robotAccntToBeDeleted}`)
+      .should('exist');
+  });
+
+  it('Can add a new robot account to team', () => {
+    const orgName = 'testorg';
+    const team = 'arsenal';
+    const addToRepo = 'premierleague';
+    const newRobotName = 'klopprobot';
+    const newRobotDescription = 'premier league manager';
+
+    cy.visit('/organization/testorg?tab=Teamsandmembership');
+
+    // Search for a single team
+    cy.get('#teams-view-search').type(`${team}`);
+    cy.contains('1 - 1 of 1');
+    cy.get(`[data-testid="${team}-toggle-kebab"]`).click();
+    cy.get(`[data-testid="${team}-manage-team-member-option"]`)
+      .contains('Manage team members')
+      .click();
+
+    cy.get('[data-testid="add-new-member-button"]').click();
+
+    cy.get('#repository-creator-dropdown').click();
+    cy.get(`[data-testid="create-new-robot-accnt-btn"]`).click();
+
+    // create robot account wizard
+    // step - Name & Description
+    cy.get('[data-testid="new-robot-name-input"]').type(`${newRobotName}`);
+    cy.get('[data-testid="new-robot-description-input"]').type(
+      `${newRobotDescription}`,
+    );
+    cy.get('[data-testid="next-btn"]').click();
+
+    // step - Add to team (optional)
+    cy.get('[data-testid="next-btn"]').click();
+
+    // step - Add to repository
+    cy.get(`[data-testid="checkbox-row-${addToRepo}"]`).click();
+    cy.get('[data-testid="next-btn"]').click();
+
+    // step - Default permissions (optional)
+    cy.get('[data-testid="applied-to-input"]').should(
+      'have.value',
+      `${newRobotName}`,
+    );
+    cy.get('[data-testid="next-btn"]').click();
+
+    // step - Review and Finish
+    cy.get('[data-testid="review-and-finish-btn"]').click();
+
+    // verify newly created robot account is shown in the dropdown
+    cy.get('#repository-creator-dropdown-select-typeahead').should(
+      'have.value',
+      `${orgName}+${newRobotName}`,
+    );
+    // submit add member from drawer
+    cy.get('[data-testid="add-new-member-submit-btn"]').click();
+
+    // verify success alert
+    cy.get('.pf-v5-c-alert.pf-m-success')
+      .contains(`Successfully added "${orgName}+${newRobotName}" to team`)
+      .should('exist');
+    // verify table entry exists
+    cy.get(`[data-testid="${orgName}+${newRobotName}"]`).contains(
+      `${orgName}+${newRobotName}`,
+    );
+  });
+
+  it('Can add a new user to the team', () => {
+    const orgName = 'testorg';
+    const team = 'arsenal';
+    const user = 'user1';
+
+    cy.visit('/organization/testorg?tab=Teamsandmembership');
+
+    // Search for a single team
+    cy.get('#teams-view-search').type(`${team}`);
+    cy.contains('1 - 1 of 1');
+    cy.get(`[data-testid="${team}-toggle-kebab"]`).click();
+    cy.get(`[data-testid="${team}-manage-team-member-option"]`)
+      .contains('Manage team members')
+      .click();
+
+    cy.get('[data-testid="add-new-member-button"]').click();
+    cy.get('#repository-creator-dropdown').type(`${user}`);
+    cy.get(`[data-testid="${user}"]`).click();
+
+    // verify selected user is shown in the dropdown
+    cy.get('#repository-creator-dropdown-select-typeahead').should(
+      'have.value',
+      `${user}`,
+    );
+    // submit add member from drawer
+    cy.get('[data-testid="add-new-member-submit-btn"]').click();
+
+    // verify success alert
+    cy.get('.pf-v5-c-alert.pf-m-success')
+      .contains(`Successfully added "${user}" to team`)
+      .should('exist');
+    // verify table entry exists
+    cy.get(`[data-testid="${user}"]`).contains(`${user}`);
+  });
+});

--- a/web/cypress/e2e/manage-team-members.cy.ts
+++ b/web/cypress/e2e/manage-team-members.cy.ts
@@ -181,7 +181,7 @@ describe('Manage team members page', () => {
     cy.get('[data-testid="review-and-finish-btn"]').click();
 
     // verify newly created robot account is shown in the dropdown
-    cy.get('#repository-creator-dropdown-select-typeahead').should(
+    cy.get('#repository-creator-dropdown input').should(
       'have.value',
       `${orgName}+${newRobotName}`,
     );
@@ -218,7 +218,7 @@ describe('Manage team members page', () => {
     cy.get(`[data-testid="${user}"]`).click();
 
     // verify selected user is shown in the dropdown
-    cy.get('#repository-creator-dropdown-select-typeahead').should(
+    cy.get('#repository-creator-dropdown input').should(
       'have.value',
       `${user}`,
     );

--- a/web/cypress/e2e/teams-and-membership.cy.ts
+++ b/web/cypress/e2e/teams-and-membership.cy.ts
@@ -135,11 +135,12 @@ describe('Teams and membership page', () => {
     cy.get(`[data-testid="${teamToBeDeleted}-del-option"]`)
       .contains('Delete')
       .click();
+    cy.get(`[data-testid="${teamToBeDeleted}-del-btn"]`).click();
 
     // verify success alert
-    cy.get('.pf-v5-c-alert.pf-m-success')
-      .contains(`Successfully deleted team`)
-      .should('exist');
+    cy.get('.pf-v5-c-alert.pf-m-success').contains(
+      `Successfully deleted team: ${teamToBeDeleted}`,
+    );
   });
 
   it('Can delete a member from Collaborator view', () => {
@@ -155,24 +156,6 @@ describe('Teams and membership page', () => {
     cy.get('.pf-v5-c-alert.pf-m-success')
       .contains(`Successfully deleted collaborator`)
       .should('exist');
-  });
-
-  it('Can open manage team members', () => {
-    const team = 'owners';
-    cy.visit('/organization/testorg?tab=Teamsandmembership');
-    cy.get('#Teams').click();
-
-    // Search for a single team
-    cy.get('#teams-view-search').type(`${team}`);
-    cy.contains('1 - 1 of 1');
-    cy.get(`[data-testid="${team}-toggle-kebab"]`).click();
-    cy.get(`[data-testid="${team}-manage-team-member-option"]`)
-      .contains('Manage team members')
-      .click();
-
-    // verify manage members view is shown
-    cy.url().should('contain', `teams/${team}?tab=Teamsandmembership`);
-    cy.get(`[data-label="Team member"]`).contains('user1');
   });
 
   it('Can set repository permissions for a team', () => {
@@ -226,29 +209,6 @@ describe('Teams and membership page', () => {
     // verify success alert
     cy.get('.pf-v5-c-alert.pf-m-success')
       .contains(`Updated repo perm for team: ${team} successfully`)
-      .should('exist');
-  });
-
-  it('Can delete a robot account from Manage team members view', () => {
-    const team = 'chelsea';
-    const robotAccntToBeDeleted = 'testorg+testrobot';
-    cy.visit('/organization/testorg?tab=Teamsandmembership');
-    cy.get('#Teams').click();
-
-    // Search for a single team
-    cy.get('#teams-view-search').type(`${team}`);
-    cy.contains('1 - 1 of 1');
-    cy.get(`[data-testid="${team}-toggle-kebab"]`).click();
-    cy.get(`[data-testid="${team}-manage-team-member-option"]`)
-      .contains('Manage team members')
-      .click();
-
-    // delete robot account
-    cy.get(`[data-testid="${robotAccntToBeDeleted}-delete-icon"]`).click();
-
-    // verify success alert
-    cy.get('.pf-v5-c-alert.pf-m-success')
-      .contains(`Successfully deleted team member`)
       .should('exist');
   });
 });

--- a/web/src/components/EntitySearch.tsx
+++ b/web/src/components/EntitySearch.tsx
@@ -63,7 +63,6 @@ export default function EntitySearch(props: EntitySearchProps) {
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
   ) => {
-    console.log("select: %s", value)
     if (value && value !== 'no results') {
       setSearchTerm(value as string);
       setSelectedEntityName(value as string);
@@ -134,8 +133,7 @@ export default function EntitySearch(props: EntitySearchProps) {
     >
       <SelectList id="entity-search-option-list">
         {!searchTerm
-          // ? props?.defaultOptions
-          ? null
+          ? props?.defaultOptions
           : entities?.map((entity, index) => (
               <SelectOption
                 data-testid={entity.name}
@@ -143,16 +141,16 @@ export default function EntitySearch(props: EntitySearchProps) {
                 value={entity.name}
                 isFocused={focusedItemIndex === index}
                 onClick={() => {
-                  console.log("inside entity %s", JSON.stringify(entity));
                   setSelectedEntityName(entity.name);
-                  props.onSelect(entity);
+                  if (props?.onSelect) {
+                    props.onSelect(entity);
+                  }
                 }}
                 description={getMemberType(entity)}
               >
                 {entity.name}
               </SelectOption>
-            ))
-            }
+            ))}
       </SelectList>
     </Select>
   );

--- a/web/src/components/EntitySearch.tsx
+++ b/web/src/components/EntitySearch.tsx
@@ -63,6 +63,7 @@ export default function EntitySearch(props: EntitySearchProps) {
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
   ) => {
+    console.log("select: %s", value)
     if (value && value !== 'no results') {
       setSearchTerm(value as string);
       setSelectedEntityName(value as string);
@@ -133,18 +134,25 @@ export default function EntitySearch(props: EntitySearchProps) {
     >
       <SelectList id="entity-search-option-list">
         {!searchTerm
-          ? props?.defaultOptions
+          // ? props?.defaultOptions
+          ? null
           : entities?.map((entity, index) => (
               <SelectOption
+                data-testid={entity.name}
                 key={entity.name}
                 value={entity.name}
                 isFocused={focusedItemIndex === index}
-                onClick={() => setSelectedEntityName(entity.name)}
+                onClick={() => {
+                  console.log("inside entity %s", JSON.stringify(entity));
+                  setSelectedEntityName(entity.name);
+                  props.onSelect(entity);
+                }}
                 description={getMemberType(entity)}
               >
                 {entity.name}
               </SelectOption>
-            ))}
+            ))
+            }
       </SelectList>
     </Select>
   );

--- a/web/src/components/modals/DeleteModalForRowTemplate.tsx
+++ b/web/src/components/modals/DeleteModalForRowTemplate.tsx
@@ -1,0 +1,42 @@
+import {Button, Modal, ModalVariant} from '@patternfly/react-core';
+
+export default function DeleteModalForRowTemplate<T, K extends keyof T>(
+  props: DeleteModalForRowTemplateProps<T, K>,
+) {
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      title={`${props.deleteMsgTitle}`}
+      titleIconVariant="warning"
+      isOpen={props.isModalOpen}
+      onClose={props.toggleModal}
+      actions={[
+        <Button
+          key="delete"
+          variant="danger"
+          onClick={() => {
+            props.deleteHandler(props.itemToBeDeleted);
+          }}
+          data-testid={`${props.itemToBeDeleted[props.keyToDisplay]}-del-btn`}
+        >
+          Delete
+        </Button>,
+        <Button key="cancel" variant="link" onClick={props.toggleModal}>
+          Cancel
+        </Button>,
+      ]}
+    >
+      Are you sure you want to delete{' '}
+      <b> {props.itemToBeDeleted[props.keyToDisplay]} </b> ?
+    </Modal>
+  );
+}
+
+interface DeleteModalForRowTemplateProps<T, K> {
+  deleteMsgTitle: string;
+  isModalOpen: boolean;
+  toggleModal: () => void;
+  deleteHandler: (item: T | T[]) => void;
+  itemToBeDeleted: T;
+  keyToDisplay: K;
+}

--- a/web/src/hooks/UseMembers.ts
+++ b/web/src/hooks/UseMembers.ts
@@ -3,7 +3,7 @@ import {useState} from 'react';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
 import {
   IMembers,
-  addMemberToTeamAPI,
+  addMemberToTeamForOrg,
   deleteCollaboratorForOrg,
   deleteTeamMemberForOrg,
   fetchCollaboratorsForOrg,
@@ -15,7 +15,7 @@ import {collaboratorViewColumnNames} from 'src/routes/OrganizationsList/Organiza
 import {memberViewColumnNames} from 'src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/MembersView/MembersViewList';
 import {manageMemberColumnNames} from 'src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList';
 
-export function useAddMembersToTeam(org: string) {
+export function useAddMembersToTeam(org: string, {onSuccess, onError}) {
   const queryClient = useQueryClient();
   const {
     mutate: addMemberToTeam,
@@ -24,12 +24,17 @@ export function useAddMembersToTeam(org: string) {
     reset: resetAddingMemberToTeam,
   } = useMutation(
     async ({team, member}: {team: string; member: string}) => {
-      return addMemberToTeamAPI(org, team, member);
+      return addMemberToTeamForOrg(org, team, member);
     },
     {
       onSuccess: () => {
+        onSuccess();
         queryClient.invalidateQueries(['members']);
         queryClient.invalidateQueries(['teams']);
+        queryClient.invalidateQueries(['teamMembers']);
+      },
+      onError: () => {
+        onError();
       },
     },
   );

--- a/web/src/hooks/UseTeams.ts
+++ b/web/src/hooks/UseTeams.ts
@@ -5,7 +5,7 @@ import {
   fetchTeamRepoPermsForOrg,
   fetchTeamsForNamespace,
   updateTeamRepoPerm,
-  updateTeamRoleForNamespace,
+  updateTeamDetailsForNamespace,
 } from 'src/resources/TeamResources';
 import {useState} from 'react';
 import {teamViewColumnNames} from 'src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsViewList';
@@ -234,16 +234,28 @@ export function useDeleteTeam({orgName, onSuccess, onError}) {
   };
 }
 
-export function useUpdateTeamRole(orgName: string) {
+export function useUpdateTeamDetails(orgName: string) {
   const queryClient = useQueryClient();
   const {
-    mutate: updateTeamRole,
-    isError: errorUpdateTeamRole,
-    isSuccess: successUpdateTeamRole,
-    reset: resetUpdateTeamRole,
+    mutate: updateTeamDetails,
+    isError: errorUpdateTeamDetails,
+    isSuccess: successUpdateTeamDetails,
   } = useMutation(
-    async ({teamName, teamRole}: {teamName: string; teamRole: string}) => {
-      return updateTeamRoleForNamespace(orgName, teamName, teamRole);
+    async ({
+      teamName,
+      teamRole,
+      teamDescription,
+    }: {
+      teamName: string;
+      teamRole: string;
+      teamDescription?: string;
+    }) => {
+      return updateTeamDetailsForNamespace(
+        orgName,
+        teamName,
+        teamRole,
+        teamDescription,
+      );
     },
     {
       onSuccess: () => {
@@ -252,10 +264,9 @@ export function useUpdateTeamRole(orgName: string) {
     },
   );
   return {
-    updateTeamRole,
-    errorUpdateTeamRole,
-    successUpdateTeamRole,
-    resetUpdateTeamRole,
+    updateTeamDetails,
+    errorUpdateTeamDetails,
+    successUpdateTeamDetails,
   };
 }
 

--- a/web/src/resources/MembersResource.ts
+++ b/web/src/resources/MembersResource.ts
@@ -56,26 +56,17 @@ export async function deleteTeamMemberForOrg(
   teamName: string,
   memberName: string,
 ) {
-  try {
-    const response = await axios.delete(
-      `/api/v1/organization/${orgName}/team/${teamName}/members/${memberName}`,
-    );
-  } catch (err) {
-    console.error(`Unable to delete member for team: ${teamName}`, err);
-  }
+  const response = await axios.delete(
+    `/api/v1/organization/${orgName}/team/${teamName}/members/${memberName}`,
+  );
+  assertHttpCode(response.status, 204);
 }
 
 export async function deleteCollaboratorForOrg(
   orgName: string,
   collaborator: string,
 ) {
-  try {
-    await axios.delete(
-      `/api/v1/organization/${orgName}/members/${collaborator}`,
-    );
-  } catch (err) {
-    console.error(`Unable to delete collaborator for org: ${orgName}`, err);
-  }
+  await axios.delete(`/api/v1/organization/${orgName}/members/${collaborator}`);
 }
 
 export async function addMemberToTeamForOrg(

--- a/web/src/resources/MembersResource.ts
+++ b/web/src/resources/MembersResource.ts
@@ -1,6 +1,7 @@
 import {IAvatar} from './OrganizationResource';
 import axios from 'src/libs/axios';
 import {assertHttpCode} from './ErrorHandling';
+import {AxiosResponse} from 'axios';
 
 export interface IMemberTeams {
   name: string;
@@ -77,15 +78,13 @@ export async function deleteCollaboratorForOrg(
   }
 }
 
-export async function addMemberToTeamAPI(
+export async function addMemberToTeamForOrg(
   orgName: string,
   teamName: string,
   member: string,
 ) {
   const addMemberUrl = `/api/v1/organization/${orgName}/team/${teamName}/members/${member}`;
-  try {
-    await axios.put(addMemberUrl, {});
-  } catch (err) {
-    console.error('Unable to add member to team', err);
-  }
+  const response: AxiosResponse = await axios.put(addMemberUrl, {});
+  assertHttpCode(response.status, 200);
+  return response.data;
 }

--- a/web/src/resources/TeamResources.ts
+++ b/web/src/resources/TeamResources.ts
@@ -41,13 +41,17 @@ export async function updateTeamForRobot(
   return response.data?.name;
 }
 
-export async function updateTeamRoleForNamespace(
+export async function updateTeamDetailsForNamespace(
   namespace: string,
   teamName: string,
   teamRole: string,
+  description?: string,
 ) {
   const updateTeamUrl = `/api/v1/organization/${namespace}/team/${teamName}`;
   const payload = {name: teamName, role: teamRole};
+  if (description !== undefined) {
+    payload['description'] = description;
+  }
   const response: AxiosResponse = await axios.put(updateTeamUrl, payload);
   assertHttpCode(response.status, 200);
   return response.data?.name;

--- a/web/src/routes/OrganizationsList/Organization/Organization.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Organization.tsx
@@ -23,9 +23,11 @@ import TeamsAndMembershipList from './Tabs/TeamsAndMembership/TeamsAndMembership
 import ManageMembersList from './Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList';
 import CreatePermissionDrawer from './Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer';
 import DefaultPermissionsList from './Tabs/DefaultPermissions/DefaultPermissionsList';
+import AddNewTeamMemberDrawer from './Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer';
 
-export enum DrawerContentType {
+export enum OrganizationDrawerContentType {
   None,
+  AddNewTeamMemberDrawer,
   CreatePermissionSpecificUser,
 }
 
@@ -63,20 +65,27 @@ export default function Organization() {
     return false;
   };
 
-  const [drawerContent, setDrawerContent] = useState<DrawerContentType>(
-    DrawerContentType.None,
-  );
+  const [drawerContent, setDrawerContent] =
+    useState<OrganizationDrawerContentType>(OrganizationDrawerContentType.None);
 
   const closeDrawer = () => {
-    setDrawerContent(DrawerContentType.None);
+    setDrawerContent(OrganizationDrawerContentType.None);
   };
 
   const drawerRef = useRef<HTMLDivElement>();
 
   const drawerContentOptions = {
-    [DrawerContentType.None]: null,
-    [DrawerContentType.CreatePermissionSpecificUser]: (
+    [OrganizationDrawerContentType.None]: null,
+    [OrganizationDrawerContentType.CreatePermissionSpecificUser]: (
       <CreatePermissionDrawer
+        orgName={organizationName}
+        closeDrawer={closeDrawer}
+        drawerRef={drawerRef}
+        drawerContent={drawerContent}
+      />
+    ),
+    [OrganizationDrawerContentType.AddNewTeamMemberDrawer]: (
+      <AddNewTeamMemberDrawer
         orgName={organizationName}
         closeDrawer={closeDrawer}
         drawerRef={drawerRef}
@@ -96,7 +105,7 @@ export default function Organization() {
       component: !teamName ? (
         <TeamsAndMembershipList key={window.location.pathname} />
       ) : (
-        <ManageMembersList />
+        <ManageMembersList setDrawerContent={setDrawerContent} />
       ),
       visible:
         !isUserOrganization &&
@@ -137,7 +146,7 @@ export default function Organization() {
 
   return (
     <Drawer
-      isExpanded={drawerContent != DrawerContentType.None}
+      isExpanded={drawerContent != OrganizationDrawerContentType.None}
       onExpand={() => {
         drawerRef.current && drawerRef.current.focus();
       }}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsToolbar.tsx
@@ -15,8 +15,8 @@ import {SearchInput} from 'src/components/toolbar/SearchInput';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import {IDefaultPermission} from 'src/hooks/UseDefaultPermissions';
-import {DrawerContentType} from 'src/routes/OrganizationsList/Organization/Organization';
 import {TrashIcon} from '@patternfly/react-icons';
+import {OrganizationDrawerContentType} from 'src/routes/OrganizationsList/Organization/Organization';
 
 export default function DefaultPermissionsToolbar(
   props: DefaultPermissionsToolbarProps,
@@ -50,7 +50,7 @@ export default function DefaultPermissionsToolbar(
           <Button
             onClick={() =>
               props.setDrawerContent(
-                DrawerContentType.CreatePermissionSpecificUser,
+                OrganizationDrawerContentType.CreatePermissionSpecificUser,
               )
             }
             data-testid="create-default-permissions-btn"
@@ -113,7 +113,7 @@ interface DefaultPermissionsToolbarProps {
   searchOptions: string[];
   search: SearchState;
   setSearch: (search: SearchState) => void;
-  setDrawerContent: (content: DrawerContentType) => void;
+  setDrawerContent: (content: OrganizationDrawerContentType) => void;
   children?: React.ReactNode;
   handleBulkDeleteModalToggle: () => void;
 }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer.tsx
@@ -29,7 +29,7 @@ import {useFetchRobotAccounts} from 'src/hooks/useRobotAccounts';
 import CreateRobotAccountModal from 'src/components/modals/CreateRobotAccountModal';
 import {CreateTeamWizard} from 'src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/CreateTeamWizard';
 import {CreateTeamModal} from 'src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreateTeamModal';
-import {DrawerContentType} from 'src/routes/OrganizationsList/Organization/Organization';
+import {OrganizationDrawerContentType} from 'src/routes/OrganizationsList/Organization/Organization';
 import Conditional from 'src/components/empty/Conditional';
 import {useFetchTeams} from 'src/hooks/UseTeams';
 import {repoPermissions} from 'src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsList';
@@ -146,6 +146,7 @@ export default function CreatePermissionDrawer(
       org={props.orgName}
       includeTeams={false}
       onSelect={(e: Entity) => {
+        console.log("entity %s", JSON.stringify(e));
         setRepositoryCreator(e);
       }}
       onClear={setRepositoryCreator}
@@ -406,7 +407,9 @@ export default function CreatePermissionDrawer(
       <DrawerPanelContent>
         <DrawerHead className="pf-v5-c-title pf-m-xl">
           <h6
-            tabIndex={props.drawerContent != DrawerContentType.None ? 0 : -1}
+            tabIndex={
+              props.drawerContent != OrganizationDrawerContentType.None ? 0 : -1
+            }
             ref={props.drawerRef}
           >
             Create default permission
@@ -468,5 +471,5 @@ interface CreatePermissionDrawerProps {
   orgName: string;
   closeDrawer: () => void;
   drawerRef: Ref<HTMLDivElement>;
-  drawerContent: DrawerContentType;
+  drawerContent: OrganizationDrawerContentType;
 }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer.tsx
@@ -146,7 +146,6 @@ export default function CreatePermissionDrawer(
       org={props.orgName}
       includeTeams={false}
       onSelect={(e: Entity) => {
-        console.log("entity %s", JSON.stringify(e));
         setRepositoryCreator(e);
       }}
       onClear={setRepositoryCreator}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/CreateTeamWizard.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/CreateTeamWizard.tsx
@@ -69,7 +69,10 @@ export const CreateTeamWizard = (props: CreateTeamWizardProps): JSX.Element => {
     errorAddingMemberToTeam: error,
     successAddingMemberToTeam: success,
     resetAddingMemberToTeam: reset,
-  } = useAddMembersToTeam(props.orgName);
+  } = useAddMembersToTeam(props.orgName, {
+    onSuccess: {},
+    onError: {},
+  });
 
   const {addRepoPermToTeam} = useAddRepoPermissionToTeam(
     props.orgName,

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer.tsx
@@ -1,0 +1,195 @@
+import {
+  ActionGroup,
+  Button,
+  Divider,
+  DrawerActions,
+  DrawerCloseButton,
+  DrawerHead,
+  DrawerPanelBody,
+  DrawerPanelContent,
+  Form,
+  FormGroup,
+  Spinner,
+} from '@patternfly/react-core';
+import {SelectOption, SelectGroup} from '@patternfly/react-core/deprecated';
+import {DesktopIcon} from '@patternfly/react-icons';
+import React, {useState} from 'react';
+import {Ref} from 'react';
+import {useParams} from 'react-router-dom';
+import {AlertVariant} from 'src/atoms/AlertState';
+import EntitySearch from 'src/components/EntitySearch';
+import Conditional from 'src/components/empty/Conditional';
+import CreateRobotAccountModal from 'src/components/modals/CreateRobotAccountModal';
+import {useAlerts} from 'src/hooks/UseAlerts';
+import {useAddMembersToTeam} from 'src/hooks/UseMembers';
+import {useFetchTeams} from 'src/hooks/UseTeams';
+import {useFetchRobotAccounts} from 'src/hooks/useRobotAccounts';
+import {Entity} from 'src/resources/UserResource';
+import {OrganizationDrawerContentType} from 'src/routes/OrganizationsList/Organization/Organization';
+import {RepoPermissionDropdownItems} from 'src/routes/RepositoriesList/RobotAccountsList';
+
+export default function AddNewTeamMemberDrawer(
+  props: AddNewTeamMemberDrawerProps,
+) {
+  const [selectedEntity, setSelectedEntity] = useState<Entity>(null);
+  const [isCreateRobotModalOpen, setIsCreateRobotModalOpen] = useState(false);
+  const [error, setError] = useState<string>('');
+  const {teamName} = useParams();
+
+  // Get robots
+  const {robots, isLoadingRobots} = useFetchRobotAccounts(props.orgName);
+  // Get teams
+  const {teams} = useFetchTeams(props.orgName);
+  const {addAlert} = useAlerts();
+
+  const creatorDefaultOptions = [
+    <React.Fragment key="creator">
+      <SelectGroup label="Robot accounts" key="robot-account-grp">
+        {isLoadingRobots ? (
+          <Spinner />
+        ) : (
+          robots?.map(({name}) => (
+            <SelectOption
+              data-testid={`${name}-robot-accnt`}
+              key={name}
+              value={name}
+              onClick={() => {
+                setSelectedEntity({
+                  name,
+                  is_robot: true,
+                  kind: 'user',
+                  is_org_member: true,
+                });
+              }}
+            >
+              {name}
+            </SelectOption>
+          ))
+        )}
+      </SelectGroup>
+      <Divider component="li" key={7} />
+      <SelectOption
+        data-testid="create-new-robot-accnt-btn"
+        key="create-robot-account"
+        component="button"
+        onClick={() => setIsCreateRobotModalOpen(!isCreateRobotModalOpen)}
+        isFocused
+      >
+        <DesktopIcon /> &nbsp; Create robot account
+      </SelectOption>
+    </React.Fragment>,
+  ];
+
+  const dropdownForCreator = (
+    <EntitySearch
+      id="repository-creator-dropdown"
+      org={props.orgName}
+      includeTeams={false}
+      onSelect={(e: Entity) => {
+        console.log('entity %s', JSON.stringify(e));
+        setSelectedEntity(e);
+      }}
+      onClear={setSelectedEntity}
+      value={selectedEntity?.name}
+      onError={() => setError('Unable to look up users')}
+      defaultOptions={creatorDefaultOptions}
+      placeholderText="Add a registered user, robot to team"
+    />
+  );
+
+  const createRobotModal = (
+    <CreateRobotAccountModal
+      isModalOpen={isCreateRobotModalOpen}
+      handleModalToggle={() =>
+        setIsCreateRobotModalOpen(!isCreateRobotModalOpen)
+      }
+      orgName={props.orgName}
+      teams={teams}
+      RepoPermissionDropdownItems={RepoPermissionDropdownItems}
+      setEntity={setSelectedEntity}
+      showSuccessAlert={(message) =>
+        addAlert({
+          variant: AlertVariant.Success,
+          title: message,
+        })
+      }
+      showErrorAlert={(message) =>
+        addAlert({
+          variant: AlertVariant.Failure,
+          title: message,
+        })
+      }
+    />
+  );
+
+  const {addMemberToTeam} = useAddMembersToTeam(props.orgName, {
+    onSuccess: () => {
+      addAlert({
+        variant: AlertVariant.Success,
+        title: `Successfully added "${selectedEntity.name}" to team`,
+      });
+      props.closeDrawer();
+    },
+    onError: () => {
+      addAlert({
+        variant: AlertVariant.Failure,
+        title: `Unable to add "${selectedEntity.name}" to team`,
+      });
+    },
+  });
+
+  const addTeamMemberHandler = async () => {
+    await addMemberToTeam({
+      team: teamName,
+      member: selectedEntity.name,
+    });
+  };
+
+  return (
+    <>
+      <Conditional if={isCreateRobotModalOpen}>{createRobotModal}</Conditional>
+      <DrawerPanelContent>
+        <DrawerHead className="pf-c-title pf-m-xl">
+          <h6
+            tabIndex={
+              props.drawerContent != OrganizationDrawerContentType.None ? 0 : -1
+            }
+            ref={props.drawerRef}
+          >
+            Add team member
+          </h6>
+          <DrawerActions>
+            <DrawerCloseButton onClick={props.closeDrawer} />
+          </DrawerActions>
+        </DrawerHead>
+        <DrawerPanelBody>
+          <Form id="add-new-member-form">
+            <FormGroup fieldId="creator" label="Repository creator" isRequired>
+              {dropdownForCreator}
+            </FormGroup>
+            <ActionGroup>
+              <Button
+                data-testid="add-new-member-submit-btn"
+                isDisabled={
+                  selectedEntity === null ||
+                  Object.keys(selectedEntity).length === 0
+                }
+                onClick={addTeamMemberHandler}
+                variant="primary"
+              >
+                Add member
+              </Button>
+            </ActionGroup>
+          </Form>
+        </DrawerPanelBody>
+      </DrawerPanelContent>
+    </>
+  );
+}
+
+interface AddNewTeamMemberDrawerProps {
+  orgName: string;
+  closeDrawer: () => void;
+  drawerRef: Ref<HTMLDivElement>;
+  drawerContent: OrganizationDrawerContentType;
+}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer.tsx
@@ -9,9 +9,10 @@ import {
   DrawerPanelContent,
   Form,
   FormGroup,
+  SelectGroup,
+  SelectOption,
   Spinner,
 } from '@patternfly/react-core';
-import {SelectOption, SelectGroup} from '@patternfly/react-core/deprecated';
 import {DesktopIcon} from '@patternfly/react-icons';
 import React, {useState} from 'react';
 import {Ref} from 'react';
@@ -86,7 +87,6 @@ export default function AddNewTeamMemberDrawer(
       org={props.orgName}
       includeTeams={false}
       onSelect={(e: Entity) => {
-        console.log('entity %s', JSON.stringify(e));
         setSelectedEntity(e);
       }}
       onClear={setSelectedEntity}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
@@ -1,29 +1,50 @@
 import {
   Button,
+  Title,
+  Flex,
   PageSection,
   PageSectionVariants,
   Spinner,
+  TextArea,
   ToggleGroup,
   ToggleGroupItem,
   ToggleGroupItemProps,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  FlexItem,
+  TextContent,
+  TextVariants,
+  Text,
+  ButtonVariant,
+  Divider,
+  Tooltip,
 } from '@patternfly/react-core';
 import {useEffect, useState} from 'react';
 import ManageMembersToolbar from './ManageMembersToolbar';
 import {Table, Tbody, Td, Th, Thead, Tr} from '@patternfly/react-table';
+import './css/ManageMembers.css';
 import {
   ITeamMember,
   useDeleteTeamMember,
   useFetchTeamMembersForOrg,
 } from 'src/hooks/UseMembers';
-import {CubesIcon, TrashIcon} from '@patternfly/react-icons';
+import {
+  CubesIcon,
+  PencilAltIcon,
+  TimesIcon,
+  CheckIcon,
+  TrashIcon,
+} from '@patternfly/react-icons';
 import {useParams} from 'react-router-dom';
 import Empty from 'src/components/empty/Empty';
 import {useAlerts} from 'src/hooks/UseAlerts';
 import {AlertVariant} from 'src/atoms/AlertState';
 import {getAccountTypeForMember} from 'src/libs/utils';
+import {OrganizationDrawerContentType} from 'src/routes/OrganizationsList/Organization/Organization';
+import {useFetchTeams, useUpdateTeamDetails} from 'src/hooks/UseTeams';
+import DeleteModalForRowTemplate from 'src/components/modals/DeleteModalForRowTemplate';
+import Conditional from 'src/components/empty/Conditional';
 
 export enum TableModeType {
   AllMembers = 'All Members',
@@ -37,7 +58,12 @@ export const manageMemberColumnNames = {
   account: 'Account',
 };
 
-export default function ManageMembersList() {
+interface IMemberInfo {
+  teamName: string;
+  memberName: string;
+}
+
+export default function ManageMembersList(props: ManageMembersListProps) {
   const {organizationName, teamName} = useParams();
 
   const {
@@ -58,6 +84,8 @@ export default function ManageMembersList() {
     setSearch,
   } = useFetchTeamMembersForOrg(organizationName, teamName);
 
+  const {teams} = useFetchTeams(organizationName);
+
   const [tableMembersList, setTableMembersList] = useState<ITeamMember[]>([]);
   const [allMembersList, setAllMembersList] = useState<ITeamMember[]>([]);
   const [selectedTeamMembers, setSelectedTeamMembers] = useState<ITeamMember[]>(
@@ -67,6 +95,11 @@ export default function ManageMembersList() {
     TableModeType.AllMembers,
   );
   const {addAlert} = useAlerts();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [teamDescr, setTeamDescr] = useState<string>();
+  const [isDeleteModalForRowOpen, setIsDeleteModalForRowOpen] = useState(false);
+  const [memberToBeDeleted, setMemberToBeDeleted] = useState<IMemberInfo>();
 
   useEffect(() => {
     switch (tableMode) {
@@ -93,7 +126,7 @@ export default function ManageMembersList() {
       default:
         break;
     }
-  }, [tableMode, allMembers]);
+  }, [tableMode, allMembers, search]);
 
   const onTableModeChange: ToggleGroupItemProps['onChange'] = (event) => {
     const id = event.currentTarget.id;
@@ -120,9 +153,10 @@ export default function ManageMembersList() {
 
   useEffect(() => {
     if (successDeleteTeamMember) {
+      setIsDeleteModalForRowOpen(false);
       addAlert({
         variant: AlertVariant.Success,
-        title: `Successfully deleted team member`,
+        title: `Successfully deleted team member: ${memberToBeDeleted.memberName}`,
       });
     }
   }, [successDeleteTeamMember]);
@@ -131,10 +165,21 @@ export default function ManageMembersList() {
     if (errorDeleteTeamMember) {
       addAlert({
         variant: AlertVariant.Failure,
-        title: `Error deleting team member`,
+        title: `Error deleting team member:  ${memberToBeDeleted.memberName}`,
       });
     }
   }, [errorDeleteTeamMember]);
+
+  const deleteRowModal = (
+    <DeleteModalForRowTemplate
+      deleteMsgTitle={'Remove member from team'}
+      isModalOpen={isDeleteModalForRowOpen}
+      toggleModal={() => setIsDeleteModalForRowOpen(!isDeleteModalForRowOpen)}
+      deleteHandler={removeTeamMember}
+      itemToBeDeleted={memberToBeDeleted}
+      keyToDisplay="memberName"
+    />
+  );
 
   const viewToggle = (
     <Toolbar>
@@ -144,24 +189,28 @@ export default function ManageMembersList() {
             <ToggleGroupItem
               text="All members"
               buttonId={TableModeType.AllMembers}
+              data-testid={TableModeType.AllMembers}
               isSelected={tableMode == TableModeType.AllMembers}
               onChange={onTableModeChange}
             />
             <ToggleGroupItem
               text="Team member"
               buttonId={TableModeType.TeamMember}
+              data-testid={TableModeType.TeamMember}
               isSelected={tableMode == TableModeType.TeamMember}
               onChange={onTableModeChange}
             />
             <ToggleGroupItem
               text="Robot accounts"
               buttonId={TableModeType.RobotAccounts}
+              data-testid={TableModeType.RobotAccounts}
               isSelected={tableMode == TableModeType.RobotAccounts}
               onChange={onTableModeChange}
             />
             <ToggleGroupItem
               text="Invited"
               buttonId={TableModeType.Invited}
+              data-testid={TableModeType.Invited}
               isSelected={tableMode == TableModeType.Invited}
               onChange={onTableModeChange}
             />
@@ -169,6 +218,104 @@ export default function ManageMembersList() {
         </ToolbarItem>
       </ToolbarContent>
     </Toolbar>
+  );
+
+  const {updateTeamDetails, errorUpdateTeamDetails, successUpdateTeamDetails} =
+    useUpdateTeamDetails(organizationName);
+
+  useEffect(() => {
+    if (successUpdateTeamDetails) {
+      addAlert({
+        variant: AlertVariant.Success,
+        title: `Successfully updated team:${teamName} description`,
+      });
+    }
+  }, [successUpdateTeamDetails]);
+
+  useEffect(() => {
+    if (errorUpdateTeamDetails) {
+      addAlert({
+        variant: AlertVariant.Failure,
+        title: `Error updating team:${teamName} description`,
+      });
+    }
+  }, [errorUpdateTeamDetails]);
+
+  const updateTeamDescriptionHandler = () => {
+    setIsEditing(!isEditing);
+    const matchingTeam = teams.find((team) => team.name === teamName);
+    updateTeamDetails({
+      teamName: teamName,
+      teamRole: matchingTeam.role,
+      teamDescription: teamDescr,
+    });
+    setIsEditing(false);
+  };
+
+  const getTeamDescription = () => {
+    const matchingTeam = teams?.find((team) => team.name === teamName);
+    if (matchingTeam) {
+      return matchingTeam.description;
+    }
+  };
+
+  const teamDescriptionComponent = (
+    <ToolbarContent className="team-description-padding">
+      <Flex>
+        <FlexItem spacer={{default: 'spacerNone'}}>
+          <Title data-testid="teamname-title" headingLevel="h3">
+            {teamName}
+          </Title>
+        </FlexItem>
+        <Tooltip content={<div>Edit team description</div>}>
+          <Button
+            variant={'plain'}
+            onClick={() => {
+              setIsEditing(true);
+              setTeamDescr(getTeamDescription());
+            }}
+            icon={<PencilAltIcon />}
+            data-testid="edit-team-description-btn"
+          />
+        </Tooltip>
+      </Flex>
+      {!isEditing ? (
+        <Flex className="text-area-section">
+          <FlexItem>
+            <TextContent isVisited={false}>
+              <Text
+                component={TextVariants.p}
+                style={{color: 'grey'}}
+                data-testid="team-description-text"
+              >
+                {getTeamDescription()}
+              </Text>
+            </TextContent>
+          </FlexItem>
+        </Flex>
+      ) : (
+        <>
+          <TextArea
+            value={teamDescr}
+            onChange={(_event, value) => setTeamDescr(value)}
+            aria-label="team-description"
+            data-testid="team-description-text-area"
+          />
+          <Button
+            variant={ButtonVariant.link}
+            onClick={updateTeamDescriptionHandler}
+            icon={<CheckIcon />}
+            data-testid="save-team-description-btn"
+          />
+          <Button
+            variant={'plain'}
+            onClick={() => setIsEditing(false)}
+            icon={<TimesIcon />}
+          />
+        </>
+      )}
+      <Divider />
+    </ToolbarContent>
   );
 
   if (loading) {
@@ -181,6 +328,19 @@ export default function ManageMembersList() {
         title="There are no viewable members for this team"
         icon={CubesIcon}
         body="Either no team members exist yet or you may not have permission to view any."
+        button={
+          <Button
+            variant="primary"
+            data-testid="add-new-member-button"
+            onClick={() =>
+              props.setDrawerContent(
+                OrganizationDrawerContentType.AddNewTeamMemberDrawer,
+              )
+            }
+          >
+            Add new member
+          </Button>
+        }
       />
     );
   }
@@ -200,8 +360,11 @@ export default function ManageMembersList() {
         search={search}
         setSearch={setSearch}
         searchOptions={[manageMemberColumnNames.teamMember]}
+        setDrawerContent={props.setDrawerContent}
       >
         {viewToggle}
+        {teamDescriptionComponent}
+        <Conditional if={isDeleteModalForRowOpen}>{deleteRowModal}</Conditional>
         <Table aria-label="Selectable table" variant="compact">
           <Thead>
             <Tr>
@@ -224,7 +387,10 @@ export default function ManageMembersList() {
                     ),
                   }}
                 />
-                <Td dataLabel={manageMemberColumnNames.teamMember}>
+                <Td
+                  dataLabel={manageMemberColumnNames.teamMember}
+                  data-testid={teamMember.name}
+                >
                   {teamMember.name}
                 </Td>
                 <Td dataLabel={manageMemberColumnNames.account}>
@@ -234,12 +400,13 @@ export default function ManageMembersList() {
                   <Button
                     icon={<TrashIcon />}
                     variant="plain"
-                    onClick={() =>
-                      removeTeamMember({
-                        teamName,
+                    onClick={() => {
+                      setMemberToBeDeleted({
+                        teamName: teamName,
                         memberName: teamMember.name,
-                      })
-                    }
+                      });
+                      setIsDeleteModalForRowOpen(!isDeleteModalForRowOpen);
+                    }}
                     data-testid={`${teamMember.name}-delete-icon`}
                   />
                 </Td>
@@ -250,4 +417,7 @@ export default function ManageMembersList() {
       </ManageMembersToolbar>
     </PageSection>
   );
+}
+interface ManageMembersListProps {
+  setDrawerContent?: (contentType: OrganizationDrawerContentType) => void;
 }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersToolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Flex,
   FlexItem,
   PanelFooter,
@@ -11,6 +12,7 @@ import {SearchInput} from 'src/components/toolbar/SearchInput';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import {ITeamMember} from 'src/hooks/UseMembers';
+import {OrganizationDrawerContentType} from 'src/routes/OrganizationsList/Organization/Organization';
 
 export default function ManageMembersToolbar(props: ManageMembersToolbarProps) {
   return (
@@ -32,11 +34,22 @@ export default function ManageMembersToolbar(props: ManageMembersToolbarProps) {
           <Flex className="pf-v5-u-mr-md">
             <FlexItem>
               <SearchInput
+                id="team-member-search-input"
                 searchState={props.search}
                 onChange={props.setSearch}
               />
             </FlexItem>
           </Flex>
+          <Button
+            onClick={() =>
+              props.setDrawerContent(
+                OrganizationDrawerContentType.AddNewTeamMemberDrawer,
+              )
+            }
+            data-testid="add-new-member-btn"
+          >
+            Add new member
+          </Button>
           <ToolbarPagination
             itemsList={props.paginatedItems}
             perPage={props.perPage}
@@ -79,4 +92,5 @@ interface ManageMembersToolbarProps {
   search: SearchState;
   setSearch: (search: SearchState) => void;
   children?: React.ReactNode;
+  setDrawerContent: (content: OrganizationDrawerContentType) => void;
 }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/css/ManageMembers.css
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/css/ManageMembers.css
@@ -1,0 +1,8 @@
+.team-description-padding {
+  margin-top: 1rem;
+  padding: 0 3rem 0;
+}
+
+.text-area-section {
+  margin-bottom: 1rem;
+}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamViewKebab.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamViewKebab.tsx
@@ -8,32 +8,12 @@ import {
   MenuToggleElement,
 } from '@patternfly/react-core';
 import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
-import {AlertVariant} from 'src/atoms/AlertState';
-import {useAlerts} from 'src/hooks/UseAlerts';
-import {ITeams, useDeleteTeam} from 'src/hooks/UseTeams';
+import {ITeams} from 'src/hooks/UseTeams';
 import {getTeamMemberPath} from 'src/routes/NavigationPath';
 
 export default function TeamViewKebab(props: TeamViewKebabProps) {
   const [isKebabOpen, setIsKebabOpen] = useState<boolean>(false);
   const [searchParams] = useSearchParams();
-  const {addAlert} = useAlerts();
-
-  const {removeTeam} = useDeleteTeam({
-    orgName: props.organizationName,
-    onSuccess: () => {
-      props.deSelectAll();
-      addAlert({
-        variant: AlertVariant.Success,
-        title: `Successfully deleted team`,
-      });
-    },
-    onError: (err) => {
-      addAlert({
-        variant: AlertVariant.Failure,
-        title: `Failed to delete team: ${err}`,
-      });
-    },
-  });
 
   return (
     <Dropdown
@@ -77,7 +57,8 @@ export default function TeamViewKebab(props: TeamViewKebabProps) {
         </DropdownItem>
 
         <DropdownItem
-          onClick={() => removeTeam(props.team)}
+          key="delete"
+          onClick={props.onDeleteTeam}
           className="red-color"
           data-testid={`${props.team.name}-del-option`}
         >
@@ -93,4 +74,5 @@ interface TeamViewKebabProps {
   team: ITeams;
   deSelectAll: () => void;
   onSelectRepo: () => void;
+  onDeleteTeam: () => void;
 }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsRoleDropDown.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsRoleDropDown.tsx
@@ -8,7 +8,7 @@ import {
 } from '@patternfly/react-core';
 import {AlertVariant} from 'src/atoms/AlertState';
 import {useAlerts} from 'src/hooks/UseAlerts';
-import {useUpdateTeamRole} from 'src/hooks/UseTeams';
+import {useUpdateTeamDetails} from 'src/hooks/UseTeams';
 
 export enum teamPermissions {
   Admin = 'admin',
@@ -21,10 +21,10 @@ export function TeamsRoleDropDown(props: TeamsRoleDropDownProps) {
   const {addAlert} = useAlerts();
 
   const {
-    updateTeamRole,
-    errorUpdateTeamRole: error,
-    successUpdateTeamRole: success,
-  } = useUpdateTeamRole(props.organizationName);
+    updateTeamDetails,
+    errorUpdateTeamDetails: error,
+    successUpdateTeamDetails: success,
+  } = useUpdateTeamDetails(props.organizationName);
 
   useEffect(() => {
     if (error) {
@@ -68,7 +68,7 @@ export function TeamsRoleDropDown(props: TeamsRoleDropDownProps) {
             data-testid={`${props.teamName}-${key}`}
             key={key}
             onClick={() =>
-              updateTeamRole({
+              updateTeamDetails({
                 teamName: props.teamName,
                 teamRole: teamPermissions[key],
               })


### PR DESCRIPTION
This PR adds the following changes to manage team members view under Teams and membership tab:
- An editable team description section
- A reusable generic delete modal template when deleting a team or a team member
- A drawer to add a member to the team

https://github.com/quay/quay/assets/39300150/0288cad4-6485-4bd1-b829-4b4b7535acfd

