### PR TITLE
ui: Update all Patternfly deprecated components (PROJQUAY-6085)

### DIFF
--- a/web/cypress/e2e/default-permissions.cy.ts
+++ b/web/cypress/e2e/default-permissions.cy.ts
@@ -31,7 +31,7 @@ describe('Default permissions page', () => {
     // Search for creator
     cy.get('#default-permissions-search').type(`${createdBy}`);
     cy.contains('1 - 1 of 1');
-    cy.get(`[data-testid="${createdBy}-permission-dropdown"]`)
+    cy.get(`[data-testid="${createdBy}-permission-dropdown-toggle"]`)
       .contains('Read')
       .click();
     cy.get(`[data-testid="${createdBy}-WRITE"]`).click();
@@ -49,10 +49,13 @@ describe('Default permissions page', () => {
     // Search for creator
     cy.get('#default-permissions-search').type(`${permissionToBeDeleted}`);
     cy.contains('1 - 1 of 1');
-    cy.get(`[data-testid="${permissionToBeDeleted}-toggle-kebab"]`).click();
-    cy.get(`[data-testid="${permissionToBeDeleted}-del-option"]`)
-      .contains('Delete')
-      .click();
+    cy.get('[data-testid="default-permissions-table"]').within(() => {
+      cy.get(`[data-testid="${permissionToBeDeleted}-toggle-kebab"]`).click();
+
+      cy.get(`[data-testid="${permissionToBeDeleted}-del-option"]`)
+        .contains('Delete')
+        .click();
+    });
 
     // verify success alert
     cy.get('.pf-v5-c-alert.pf-m-success')
@@ -76,8 +79,8 @@ describe('Default permissions page', () => {
     cy.get('#applied-to-dropdown').click();
     cy.get(`[data-testid="${appliedTo}-team"]`).click();
 
+    cy.get('[data-testid="create-default-permission-dropdown-toggle"]').click();
     cy.get('[data-testid="create-default-permission-dropdown"]')
-      .click()
       .contains('Write')
       .click();
 
@@ -101,8 +104,8 @@ describe('Default permissions page', () => {
     cy.get('#applied-to-dropdown').click();
     cy.get(`[data-testid="${appliedTo}-team"]`).click();
 
+    cy.get('[data-testid="create-default-permission-dropdown-toggle"]').click();
     cy.get('[data-testid="create-default-permission-dropdown"]')
-      .click()
       .contains('Write')
       .click();
 
@@ -155,7 +158,7 @@ describe('Default permissions page', () => {
 
     // step - Add to repository
     cy.get(`[data-testid="checkbox-row-${repository}"]`).click();
-    cy.get(`[data-testid="${repository}-permission-dropdown"]`).contains(
+    cy.get(`[data-testid="${repository}-permission-dropdown-toggle"]`).contains(
       'Read',
     );
     cy.get('[data-testid="next-btn"]').click();
@@ -185,14 +188,11 @@ describe('Default permissions page', () => {
     cy.get('[data-testid="review-and-finish-wizard-btn"]').click();
 
     // verify newly created team is shown in the dropdown
-    cy.get('#applied-to-dropdown-select-typeahead').should(
-      'have.value',
-      `${newTeam}`,
-    );
+    cy.get('#applied-to-dropdown input').should('have.value', `${newTeam}`);
 
     // permission dropdown
+    cy.get('[data-testid="create-default-permission-dropdown-toggle"]').click();
     cy.get('[data-testid="create-default-permission-dropdown"]')
-      .click()
       .contains('Write')
       .click();
 
@@ -245,7 +245,7 @@ describe('Default permissions page', () => {
 
     // step - Add to repository
     cy.get(`[data-testid="checkbox-row-${repository}"]`).click();
-    cy.get(`[data-testid="${repository}-permission-dropdown"]`).contains(
+    cy.get(`[data-testid="${repository}-permission-dropdown-toggle"]`).contains(
       'Read',
     );
     cy.get('[data-testid="next-btn"]').click();
@@ -280,14 +280,11 @@ describe('Default permissions page', () => {
     cy.get('[data-testid="review-and-finish-wizard-btn"]').click();
 
     // verify newly created team is shown in the dropdown
-    cy.get('#applied-to-dropdown-select-typeahead').should(
-      'have.value',
-      `${newTeam}`,
-    );
+    cy.get('#applied-to-dropdown input').should('have.value', `${newTeam}`);
 
     // permission dropdown
+    cy.get('[data-testid="create-default-permission-dropdown-toggle"]').click();
     cy.get('[data-testid="create-default-permission-dropdown"]')
-      .click()
       .contains('Write')
       .click();
 
@@ -346,7 +343,7 @@ describe('Default permissions page', () => {
       .should('exist');
 
     // verify newly created robot account is shown in the dropdown
-    cy.get('#repository-creator-dropdown-select-typeahead').should(
+    cy.get('#repository-creator-dropdown input').should(
       'have.value',
       `${orgName}+${newRobotName}`,
     );
@@ -356,8 +353,8 @@ describe('Default permissions page', () => {
     cy.get(`[data-testid="${appliedTo}-team"]`).click();
 
     // permission dropdown
+    cy.get('[data-testid="create-default-permission-dropdown-toggle"]').click();
     cy.get('[data-testid="create-default-permission-dropdown"]')
-      .click()
       .contains('Write')
       .click();
 

--- a/web/cypress/e2e/repository-details.cy.ts
+++ b/web/cypress/e2e/repository-details.cy.ts
@@ -346,7 +346,7 @@ describe('Repository Details Page', () => {
   it('search by manifest', () => {
     cy.visit('/repository/user1/hello-world');
     cy.get('#toolbar-dropdown-filter').click();
-    cy.get('a').contains('Manifest').click();
+    cy.get('span').contains('Manifest').click();
     cy.get('#tagslist-search-input').type('f54a58bc1aac');
     cy.contains('latest').should('exist');
     cy.contains('manifestlist').should('not.exist');

--- a/web/cypress/e2e/repository-notifications.cy.ts
+++ b/web/cypress/e2e/repository-notifications.cy.ts
@@ -160,14 +160,14 @@ describe('Repository Settings - Notifications', () => {
   });
 
   it('Bulk enables notification', () => {
-    cy.get('#notifications-select-all').click();
+    cy.get('[name="notifications-select-all"]').click();
     cy.contains('Actions').click();
     cy.contains('Enable').click();
     cy.contains('Disabled (3 failed attempts)').should('not.exist');
   });
 
   it('Bulk deletes notification', () => {
-    cy.get('#notifications-select-all').click();
+    cy.get('[name="notifications-select-all"]').click();
     cy.contains('Actions').click();
     cy.get('#bulk-delete-notifications').contains('Delete').click();
     cy.contains('No notifications found');

--- a/web/cypress/e2e/repository-permissions.cy.ts
+++ b/web/cypress/e2e/repository-permissions.cy.ts
@@ -86,7 +86,7 @@ describe('Repository Settings - Permissions', () => {
 
   it('Bulk deletes permissions', () => {
     cy.contains('1 - 4 of 4').should('exist');
-    cy.get('#permissions-select-all').click();
+    cy.get('[name="permissions-select-all"]').click();
     cy.contains('Actions').click();
     cy.get('#bulk-delete-permissions').contains('Delete').click();
     cy.get('table').within(() => {
@@ -98,7 +98,7 @@ describe('Repository Settings - Permissions', () => {
 
   it('Bulk changes permissions', () => {
     cy.contains('1 - 4 of 4').should('exist');
-    cy.get('#permissions-select-all').click();
+    cy.get('[name="permissions-select-all"]').click();
     cy.contains('Actions').click();
     cy.contains('Change Permissions').click();
     cy.get('[data-testid="change-permissions-menu-list"]').within(() => {
@@ -128,7 +128,7 @@ describe('Repository Settings - Permissions', () => {
     cy.contains('Add Permissions').click();
     cy.get('#add-permission-form').within(() => {
       cy.get('input').type('user');
-      cy.get('li:contains("user2")').click();
+      cy.get('button:contains("user2")').click();
       cy.contains('admin').click();
       cy.contains('Read').click();
       cy.contains('Submit').click();

--- a/web/cypress/e2e/robot-accounts.cy.ts
+++ b/web/cypress/e2e/robot-accounts.cy.ts
@@ -61,9 +61,9 @@ describe('Robot Accounts Page', () => {
     cy.get('#robot-wizard-form-name').should('be.empty');
     cy.get('#robot-wizard-form-description').should('be.empty');
     cy.get('button:contains("Add to team (optional)")').click();
-    cy.get('#add-team-bulk-select').should('not.be.checked');
+    cy.get('[name="add-team-bulk-select"]').should('not.be.checked');
     cy.get('button:contains("Add to repository (optional)")').click();
-    cy.get('#add-repository-bulk-select').should('not.be.checked');
+    cy.get('[name="add-repository-bulk-select"]').should('not.be.checked');
     cy.get('button:contains("Default permissions (optional)")').click();
     cy.get('#toggle-descriptions').contains('None');
   });
@@ -75,7 +75,9 @@ describe('Robot Accounts Page', () => {
     cy.get('#robot-account-search').type('testrobot2');
     cy.contains('1 - 1 of 1');
     cy.get('button[id="testorg+testrobot2-toggle-kebab"]').click();
-    cy.get('li[id="testorg+testrobot2-del-btn"]').contains('Delete').click();
+    cy.get('button[id="testorg+testrobot2-del-btn"]')
+      .contains('Delete')
+      .click();
 
     cy.get('#delete-confirmation-input').type('confirm');
 
@@ -93,7 +95,7 @@ describe('Robot Accounts Page', () => {
   it('Update Repo Permissions', () => {
     cy.visit('/organization/testorg?tab=Robotaccounts');
     cy.contains('1 repository').click();
-    cy.get('#add-repository-bulk-select-text').contains('1 selected');
+    cy.get('#add-repository-bulk-select').contains('1 selected');
     cy.get('#toggle-descriptions').click();
     cy.get('[role="menuitem"]').contains('Admin').click();
     cy.get('footer')
@@ -120,7 +122,7 @@ describe('Robot Accounts Page', () => {
     cy.visit('/organization/testorg?tab=Robotaccounts');
     cy.get(`[id="${robotAccnt}-toggle-kebab"]`).click();
     cy.get(`[id="${robotAccnt}-set-repo-perms-btn"]`).click();
-    cy.get('#add-repository-bulk-select').click();
+    cy.get('[name="add-repository-bulk-select"]').click();
     cy.get('#toggle-bulk-perms-kebab').click();
     cy.get('[role="menuitem"]').contains('Write').click();
     cy.get('footer')

--- a/web/cypress/e2e/teams-and-membership.cy.ts
+++ b/web/cypress/e2e/teams-and-membership.cy.ts
@@ -48,7 +48,7 @@ describe('Teams and membership page', () => {
     // Search for a single team
     cy.get('#teams-view-search').type(`${teamToBeUpdated}`);
     cy.contains('1 - 1 of 1');
-    cy.get(`[data-testid="${teamToBeUpdated}-team-dropdown"]`)
+    cy.get(`[data-testid="${teamToBeUpdated}-team-dropdown-toggle"]`)
       .contains('Member')
       .click();
     cy.get(`[data-testid="${teamToBeUpdated}-Creator"]`).click();
@@ -128,7 +128,9 @@ describe('Teams and membership page', () => {
     // search for repo perm inside the modal
     cy.get('#set-repo-perm-for-team-search').type(`${repo}`);
     cy.contains('1 - 1 of 1');
-    cy.get(`[data-testid="${repo}-role-dropdown"]`).contains('None').click();
+    cy.get(`[data-testid="${repo}-role-dropdown-toggle"]`)
+      .contains('None')
+      .click();
     cy.get(`[data-testid="${repo}-Write"]`).click();
     cy.get('#update-team-repo-permissions').click();
 
@@ -152,7 +154,7 @@ describe('Teams and membership page', () => {
       .click();
 
     // bulk select entries and change role from kebab
-    cy.get('#add-repository-bulk-select').click();
+    cy.get('[name="add-repository-bulk-select"]').click();
     cy.get('#toggle-bulk-perms-kebab').click();
     cy.get('[role="menuitem"]').contains('Write').click();
     cy.get('#update-team-repo-permissions').click();

--- a/web/src/components/EntitySearch.tsx
+++ b/web/src/components/EntitySearch.tsx
@@ -1,21 +1,35 @@
+import React from 'react';
 import {
   Select,
   SelectOption,
-  SelectVariant,
-} from '@patternfly/react-core/deprecated';
-import {useEffect, useState} from 'react';
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  Button,
+} from '@patternfly/react-core';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import {useEntities} from 'src/hooks/UseEntities';
 import {Entity, getMemberType} from 'src/resources/UserResource';
 
 export default function EntitySearch(props: EntitySearchProps) {
-  const [selectedEntityName, setSelectedEntityName] = useState<string>();
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [selectedEntityName, setSelectedEntityName] = React.useState<string>();
+  const [focusedItemIndex, setFocusedItemIndex] = React.useState<number | null>(
+    null,
+  );
+  const textInputRef = React.useRef<HTMLInputElement>();
   const {entities, isError, searchTerm, setSearchTerm} = useEntities(
     props.org,
     props?.includeTeams,
   );
+  const id = props.id || 'entity-search';
 
-  useEffect(() => {
+  const onToggleClick = () => setIsOpen(!isOpen);
+
+  React.useEffect(() => {
     if (
       selectedEntityName !== undefined &&
       selectedEntityName !== '' &&
@@ -32,57 +46,105 @@ export default function EntitySearch(props: EntitySearchProps) {
     }
   }, [searchTerm, JSON.stringify(entities)]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (props?.value !== null && props?.value !== undefined) {
       setSearchTerm(props.value);
       setSelectedEntityName(props.value);
     }
   }, [props?.value]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (isError) {
       props.onError();
     }
   }, [isError]);
 
+  const onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    if (value && value !== 'no results') {
+      setSearchTerm(value as string);
+      setSelectedEntityName(value as string);
+    }
+    setIsOpen(false);
+    setFocusedItemIndex(null);
+  };
+
+  const onTextInputChange = (
+    _event: React.FormEvent<HTMLInputElement>,
+    value: string,
+  ) => {
+    setSearchTerm(value);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      id={id}
+      variant="typeahead"
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      isFullWidth
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={searchTerm}
+          onClick={onToggleClick}
+          onChange={onTextInputChange}
+          id={`${id}-input`}
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder={props.placeholderText}
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls="entity-select-listbox"
+        />
+
+        <TextInputGroupUtilities>
+          {!!searchTerm && (
+            <Button
+              variant="plain"
+              onClick={() => {
+                setSelectedEntityName('');
+                setSearchTerm('');
+                textInputRef?.current?.focus();
+                props?.onClear({});
+              }}
+              aria-label="Clear input value"
+            >
+              <TimesIcon aria-hidden />
+            </Button>
+          )}
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
   return (
     <Select
-      toggleId={props.id ? props.id : 'entity-search'}
+      id="entity-select"
       isOpen={isOpen}
-      selections={searchTerm}
-      onSelect={(e, value, isPlaceholder) => {
-        // Handles the case when the selected option is an action item. The
-        // handler is defined within the child option component
-        if (!isPlaceholder) {
-          setSearchTerm(value as string);
-          setSelectedEntityName(value as string);
-        }
-        setIsOpen(!isOpen);
-      }}
-      onToggle={() => {
-        setIsOpen(!isOpen);
-      }}
-      variant={SelectVariant.typeahead}
-      onTypeaheadInputChanged={(value) => {
-        setSearchTerm(value);
-      }}
-      shouldResetOnSelect={true}
-      onClear={() => {
-        props?.onClear({});
-        setSearchTerm('');
-      }}
-      placeholderText={props.placeholderText}
+      selected={searchTerm}
+      onSelect={onSelect}
+      onOpenChange={() => setIsOpen(false)}
+      toggle={toggle}
     >
-      <></>
-      {!searchTerm
-        ? props?.defaultOptions
-        : entities?.map((e) => (
-            <SelectOption
-              key={e.name}
-              value={e.name}
-              description={getMemberType(e)}
-            />
-          ))}
+      <SelectList id="entity-search-option-list">
+        {!searchTerm
+          ? props?.defaultOptions
+          : entities?.map((entity, index) => (
+              <SelectOption
+                key={entity.name}
+                value={entity.name}
+                isFocused={focusedItemIndex === index}
+                onClick={() => setSelectedEntityName(entity.name)}
+                description={getMemberType(entity)}
+              >
+                {entity.name}
+              </SelectOption>
+            ))}
+      </SelectList>
     </Select>
   );
 }

--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -1,22 +1,20 @@
+import React, {useState} from 'react';
 import {
   Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   Flex,
   FlexItem,
+  MenuToggle,
+  MenuToggleElement,
   Switch,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import {
-  Dropdown,
-  DropdownGroup,
-  DropdownItem,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
 import {UserIcon} from '@patternfly/react-icons';
-import React from 'react';
-import {useState} from 'react';
 import {GlobalAuthState, logoutUser} from 'src/resources/AuthResource';
 import {addDisplayError} from 'src/resources/ErrorHandling';
 import ErrorModal from '../errors/ErrorModal';
@@ -36,9 +34,9 @@ export function HeaderToolbar() {
     setIsDropdownOpen((prev) => !prev);
   };
 
-  const onDropdownSelect = async (e) => {
+  const onDropdownSelect = async (value) => {
     setIsDropdownOpen(false);
-    switch (e.target.value) {
+    switch (value) {
       case 'logout':
         try {
           await logoutUser();
@@ -60,26 +58,29 @@ export function HeaderToolbar() {
     }
   };
 
-  const userDropdownItems = [
-    <DropdownGroup key="group 2">
-      <DropdownItem value="logout" key="group 2 logout" component="button">
-        Logout
-      </DropdownItem>
-    </DropdownGroup>,
-  ];
-
   const userDropdown = (
     <Dropdown
-      position="right"
-      onSelect={(value) => onDropdownSelect(value)}
+      onSelect={(_event, value) => onDropdownSelect(value)}
       isOpen={isDropdownOpen}
-      toggle={
-        <DropdownToggle icon={<UserIcon />} onToggle={onDropdownToggle}>
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={onDropdownToggle}
+          isExpanded={isDropdownOpen}
+          icon={<UserIcon />}
+        >
           {user.username}
-        </DropdownToggle>
-      }
-      dropdownItems={userDropdownItems}
-    />
+        </MenuToggle>
+      )}
+      onOpenChange={(isOpen) => setIsDropdownOpen(isOpen)}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>
+        <DropdownItem value="logout" key="logout" component="button">
+          Logout
+        </DropdownItem>
+      </DropdownList>
+    </Dropdown>
   );
 
   const signInButton = <Button> Sign In </Button>;
@@ -115,7 +116,6 @@ export function HeaderToolbar() {
             <ToolbarItem
               spacer={{
                 default: 'spacerNone',
-                sm: 'spacerSm',
                 md: 'spacerSm',
                 lg: 'spacerMd',
                 xl: 'spacerLg',

--- a/web/src/components/modals/CreateRepoModalTemplate.tsx
+++ b/web/src/components/modals/CreateRepoModalTemplate.tsx
@@ -1,3 +1,4 @@
+import {useRef, useState} from 'react';
 import {
   Modal,
   ModalVariant,
@@ -11,14 +12,13 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
-} from '@patternfly/react-core';
-import {
-  Select,
   SelectOption,
-  SelectVariant,
-} from '@patternfly/react-core/deprecated';
+  Select,
+  SelectList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import {IRepository} from 'src/resources/RepositoryResource';
-import {useRef, useState} from 'react';
 import FormError from 'src/components/errors/FormError';
 import {ExclamationCircleIcon} from '@patternfly/react-icons';
 import {addDisplayError} from 'src/resources/ErrorHandling';
@@ -178,23 +178,28 @@ export default function CreateRepositoryModalTemplate(
               >
                 <FlexItem>
                   <Select
-                    variant={SelectVariant.single}
-                    aria-label="Select Input"
-                    onToggle={() =>
-                      setCurrentOrganization((prevState) => ({
-                        ...prevState,
-                        isDropdownOpen: !prevState.isDropdownOpen,
-                      }))
-                    }
-                    onSelect={handleNamespaceSelection}
+                    aria-label="Namespace select"
                     isOpen={currentOrganization.isDropdownOpen}
-                    maxHeight="200px"
-                    width="200px"
-                    isDisabled={props.orgName !== null}
-                    placeholderText={'Select namespace'}
-                    selections={currentOrganization.name}
+                    selected={currentOrganization.name || 'Select namespace'}
+                    onSelect={handleNamespaceSelection}
+                    toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                      <MenuToggle
+                        ref={toggleRef}
+                        onClick={() =>
+                          setCurrentOrganization((prevState) => ({
+                            ...prevState,
+                            isDropdownOpen: !prevState.isDropdownOpen,
+                          }))
+                        }
+                        isExpanded={currentOrganization.isDropdownOpen}
+                        isDisabled={props.orgName !== null}
+                      >
+                        {currentOrganization.name}
+                      </MenuToggle>
+                    )}
+                    shouldFocusToggleOnSelect
                   >
-                    {namespaceSelectionList()}
+                    <SelectList>{namespaceSelectionList()}</SelectList>
                   </Select>
                 </FlexItem>
                 <FlexItem>/</FlexItem>

--- a/web/src/components/modals/robotAccountWizard/AddToRepository.tsx
+++ b/web/src/components/modals/robotAccountWizard/AddToRepository.tsx
@@ -1,7 +1,11 @@
 import {useRecoilState} from 'recoil';
 import {searchRepoState} from 'src/atoms/RepositoryState';
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
   PageSection,
   PanelFooter,
   Text,
@@ -14,12 +18,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import {
-  Dropdown,
-  DropdownItem,
-  KebabToggle,
-  KebabToggleProps,
-} from '@patternfly/react-core/deprecated';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import {DropdownCheckbox} from 'src/components/toolbar/DropdownCheckbox';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import {Table, Tbody, Td, Th, Thead, Tr} from '@patternfly/react-table';
@@ -127,7 +126,7 @@ export default function AddToRepository(props: AddToRepositoryProps) {
 
   const updateRepoPerms = (permission, repo) => {
     const repoName = repo.name ? repo.name : repo;
-    if (props.wizardStep) {
+    if (props.isWizardStep) {
       props.setSelectedRepoPerms((prevSelected) =>
         prevSelected.filter((item) => item.name !== repoName),
       );
@@ -158,7 +157,7 @@ export default function AddToRepository(props: AddToRepositoryProps) {
   };
 
   const fetchRepoPermission = (repo) => {
-    if (!props.wizardStep && updatedRepoPerms[repo.name] != null) {
+    if (!props.isWizardStep && updatedRepoPerms[repo.name] != null) {
       return updatedRepoPerms[repo.name];
     }
 
@@ -176,13 +175,6 @@ export default function AddToRepository(props: AddToRepositoryProps) {
       // set row as selected/un-selected
       updateRepoPerms(selectedVal.name, repo);
     });
-  };
-
-  const onKebabToggle: KebabToggleProps['onToggle'] = (
-    _event,
-    isKebabOpen: boolean,
-  ) => {
-    setKebabOpen(isKebabOpen);
   };
 
   const onKebabSelect = () => {
@@ -203,7 +195,7 @@ export default function AddToRepository(props: AddToRepositoryProps) {
 
   const updateRobotAccountsList = () => {
     if (
-      !props.wizardStep &&
+      !props.isWizardStep &&
       !_.isEqual(updatedRepoPerms, robotRepoPermsMapping)
     ) {
       setTimeout(() => props.setShowRepoModalSave(true), 0);
@@ -212,7 +204,7 @@ export default function AddToRepository(props: AddToRepositoryProps) {
     }
 
     if (
-      !props.wizardStep &&
+      !props.isWizardStep &&
       _.isEqual(updatedRepoPerms, robotRepoPermsMapping)
     ) {
       setTimeout(() => props.setShowRepoModalSave(false), 0);
@@ -226,7 +218,9 @@ export default function AddToRepository(props: AddToRepositoryProps) {
       <TextContent>
         <Text component={TextVariants.h1}>Add to repository (optional)</Text>
       </TextContent>
-      <PageSection>
+      <PageSection
+        {...(props.isWizardStep && {padding: {default: 'noPadding'}})}
+      >
         <Toolbar>
           <ToolbarContent>
             <DropdownCheckbox
@@ -261,16 +255,24 @@ export default function AddToRepository(props: AddToRepositoryProps) {
             <ToolbarItem>
               <Dropdown
                 onSelect={onKebabSelect}
-                toggle={
-                  <KebabToggle
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
                     id="toggle-bulk-perms-kebab"
-                    onToggle={onKebabToggle}
-                  />
-                }
+                    aria-label="Toggle bulk permissions"
+                    variant="plain"
+                    onClick={() => setKebabOpen(!isKebabOpen)}
+                    isExpanded={isKebabOpen}
+                  >
+                    <EllipsisVIcon />
+                  </MenuToggle>
+                )}
                 isOpen={isKebabOpen}
-                isPlain
-                dropdownItems={kebabItems}
-              />
+                onOpenChange={(isOpen) => setKebabOpen(isOpen)}
+                shouldFocusToggleOnSelect
+              >
+                {kebabItems}
+              </Dropdown>
             </ToolbarItem>
             <ToolbarPagination
               itemsList={filteredItems}
@@ -354,7 +356,7 @@ interface AddToRepositoryProps {
   selectedRepoPerms: any[];
   setSelectedRepoPerms: (repoPerm) => void;
   robotPermissions?: any[];
-  wizardStep: boolean;
+  isWizardStep?: boolean;
   robotName?: string;
   fetchingRobotPerms?: boolean;
   setPrevRepoPerms?: (preVal) => void;

--- a/web/src/components/modals/robotAccountWizard/AddToTeam.tsx
+++ b/web/src/components/modals/robotAccountWizard/AddToTeam.tsx
@@ -1,6 +1,11 @@
-import {Button, Text, TextVariants, TextContent} from '@patternfly/react-core';
-import {DropdownItem} from '@patternfly/react-core/deprecated';
 import {useState} from 'react';
+import {
+  Button,
+  Text,
+  TextVariants,
+  TextContent,
+  DropdownItem,
+} from '@patternfly/react-core';
 import {DesktopIcon} from '@patternfly/react-icons';
 import ToggleDrawer from 'src/components/ToggleDrawer';
 import NameAndDescription from 'src/components/modals/robotAccountWizard/NameAndDescription';
@@ -117,6 +122,7 @@ export default function AddToTeam(props: AddToTeamProps) {
         dropdownItems={dropdownItems}
         showToggleGroup={true}
         filterWithDropdown={true}
+        isWizardStep={props.isWizardStep}
       />
     </>
   );
@@ -129,4 +135,5 @@ interface AddToTeamProps {
   setDrawerExpanded?: (boolean) => void;
   selectedTeams?: any[];
   setSelectedTeams?: (teams) => void;
+  isWizardStep?: boolean;
 }

--- a/web/src/components/modals/robotAccountWizard/Footer.tsx
+++ b/web/src/components/modals/robotAccountWizard/Footer.tsx
@@ -1,56 +1,57 @@
-import {Button} from '@patternfly/react-core';
 import {
-  WizardContextConsumer,
-  WizardFooter,
-} from '@patternfly/react-core/deprecated';
+  Button,
+  useWizardContext,
+  WizardFooterWrapper,
+} from '@patternfly/react-core';
 
 export default function Footer(props: FooterProps) {
+  const {activeStep, goToNextStep, goToPrevStep, close} = useWizardContext();
+
   if (props.isDrawerExpanded) {
     return null;
   }
+
   return (
-    <WizardFooter>
-      <WizardContextConsumer>
-        {({activeStep, onNext, onBack, onClose}) => {
-          return (
-            <>
-              {activeStep.name != 'Review and Finish' ? (
-                <Button
-                  data-testid="next-btn"
-                  variant="primary"
-                  type="submit"
-                  onClick={onNext}
-                >
-                  Next
-                </Button>
-              ) : null}
-              {activeStep.name != 'Robot name and description' ? (
-                <Button variant="secondary" type="submit" onClick={onBack}>
-                  Back
-                </Button>
-              ) : (
-                ''
-              )}
-              {activeStep.name == 'Robot name and description' ||
-              activeStep.name == 'Review and Finish' ? (
-                <Button
-                  data-testid="review-and-finish-btn"
-                  isDisabled={!props.isDataValid()}
-                  variant="secondary"
-                  onClick={props.onSubmit}
-                  id="create-robot-submit"
-                >
-                  Review and Finish
-                </Button>
-              ) : null}
-              <Button variant="link" onClick={onClose} id="create-robot-cancel">
-                Cancel
-              </Button>
-            </>
-          );
-        }}
-      </WizardContextConsumer>
-    </WizardFooter>
+    <WizardFooterWrapper>
+      {activeStep.name !== 'Review and Finish' && (
+        <Button
+          data-testid="next-btn"
+          variant="primary"
+          type="submit"
+          onClick={goToNextStep}
+        >
+          Next
+        </Button>
+      )}
+
+      {activeStep.name !== 'Robot name and description' && (
+        <Button
+          variant="secondary"
+          type="submit"
+          onClick={goToPrevStep}
+          isDisabled={activeStep.index === 1}
+        >
+          Back
+        </Button>
+      )}
+
+      {(activeStep.name === 'Robot name and description' ||
+        activeStep.name === 'Review and Finish') && (
+        <Button
+          data-testid="review-and-finish-btn"
+          isDisabled={!props.isDataValid()}
+          variant="secondary"
+          onClick={props.onSubmit}
+          id="create-robot-submit"
+        >
+          Review and Finish
+        </Button>
+      )}
+
+      <Button variant="link" onClick={close} id="create-robot-cancel">
+        Cancel
+      </Button>
+    </WizardFooterWrapper>
   );
 }
 

--- a/web/src/components/modals/robotAccountWizard/ReviewAndFinish.tsx
+++ b/web/src/components/modals/robotAccountWizard/ReviewAndFinish.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {
   TextContent,
   Text,
@@ -8,10 +9,11 @@ import {
   ToggleGroup,
   ToggleGroupItem,
   ToggleGroupItemProps,
+  Dropdown,
+  MenuToggle,
+  MenuToggleElement,
 } from '@patternfly/react-core';
-import {Dropdown, DropdownToggle} from '@patternfly/react-core/deprecated';
 import {Table, Tbody, Td, Tr} from '@patternfly/react-table';
-import React, {useState} from 'react';
 
 type TableModeType = 'Teams' | 'Repositories' | 'Default-permissions';
 
@@ -94,11 +96,11 @@ export default function ReviewAndFinish(props: ReviewAndFinishProps) {
               <Td dataLabel={RepoColumnNames.name}>{repo.name}</Td>
               <Td dataLabel={RepoColumnNames.permissions}>
                 <Dropdown
-                  toggle={
-                    <DropdownToggle id="toggle-disabled" isDisabled>
+                  toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                    <MenuToggle ref={toggleRef} id="toggle-disabled" isDisabled>
                       {repo.permission}
-                    </DropdownToggle>
-                  }
+                    </MenuToggle>
+                  )}
                 />
               </Td>
               <Td dataLabel={RepoColumnNames.lastUpdated}>
@@ -134,11 +136,11 @@ export default function ReviewAndFinish(props: ReviewAndFinishProps) {
           </FormGroup>
           <FormGroup label="Permission" fieldId="robot-permission" isRequired />
           <Dropdown
-            toggle={
-              <DropdownToggle id="toggle-disabled" isDisabled>
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle ref={toggleRef} id="toggle-disabled" isDisabled>
                 {props.robotdefaultPerm}
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
           />
         </Form>
       </>

--- a/web/src/components/modals/robotAccountWizard/TeamView.tsx
+++ b/web/src/components/modals/robotAccountWizard/TeamView.tsx
@@ -81,7 +81,7 @@ export default function TeamView(props: TeamViewProps) {
   };
 
   return (
-    <PageSection>
+    <PageSection {...(props.isWizardStep && {padding: {default: 'noPadding'}})}>
       <Toolbar>
         <ToolbarContent>
           {props.showCheckbox ? (
@@ -200,4 +200,5 @@ interface TeamViewProps {
   showToggleGroup: boolean;
   searchInputText?: string;
   filterWithDropdown: boolean;
+  isWizardStep?: boolean;
 }

--- a/web/src/components/toolbar/DropdownCheckbox.tsx
+++ b/web/src/components/toolbar/DropdownCheckbox.tsx
@@ -1,11 +1,13 @@
 import {useState} from 'react';
-import {ToolbarItem} from '@patternfly/react-core';
 import {
   Dropdown,
-  DropdownToggle,
-  DropdownToggleCheckbox,
   DropdownItem,
-} from '@patternfly/react-core/deprecated';
+  DropdownList,
+  MenuToggle,
+  MenuToggleCheckbox,
+  MenuToggleElement,
+  ToolbarItem,
+} from '@patternfly/react-core';
 
 export function DropdownCheckbox(props: DropdownCheckboxProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -59,33 +61,42 @@ export function DropdownCheckbox(props: DropdownCheckboxProps) {
     </DropdownItem>,
   ];
 
+  const toggleOpen = () => setIsOpen(() => !isOpen);
+
   return (
-    <ToolbarItem variant="bulk-select">
+    <ToolbarItem variant="bulk-select" onClick={toggleOpen}>
       <Dropdown
-        toggle={
-          <DropdownToggle
-            splitButtonItems={[
-              <DropdownToggleCheckbox
-                id={props.id ? props.id : 'split-button-text-checkbox'}
-                key="split-checkbox"
-                aria-label="Select all"
-                isChecked={props.selectedItems?.length > 0 ? true : false}
-                onChange={(_event, checked) =>
-                  checked ? selectPageItems() : deSelectAll()
-                }
-              >
-                {props.selectedItems?.length != 0
-                  ? props.selectedItems?.length + ' selected'
-                  : ''}
-              </DropdownToggleCheckbox>,
-            ]}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            splitButtonOptions={{
+              items: [
+                <MenuToggleCheckbox
+                  id={props.id ? props.id : 'split-button-text-checkbox'}
+                  key="split-checkbox"
+                  aria-label="Select all"
+                  isChecked={props.selectedItems?.length > 0 ? true : false}
+                  onChange={(checked) =>
+                    checked ? selectPageItems() : deSelectAll()
+                  }
+                >
+                  {props.selectedItems?.length != 0
+                    ? props.selectedItems?.length + ' selected'
+                    : ''}
+                </MenuToggleCheckbox>,
+              ],
+            }}
             id="toolbar-dropdown-checkbox"
-            onToggle={() => setIsOpen(!isOpen)}
+            onChange={toggleOpen}
+            onClick={toggleOpen}
           />
-        }
+        )}
         isOpen={isOpen}
-        dropdownItems={dropdownItems}
-      />
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>{dropdownItems}</DropdownList>
+      </Dropdown>
     </ToolbarItem>
   );
 }

--- a/web/src/components/toolbar/DropdownWithDescription.tsx
+++ b/web/src/components/toolbar/DropdownWithDescription.tsx
@@ -2,9 +2,10 @@ import {useEffect, useState} from 'react';
 import {
   Dropdown,
   DropdownItem,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
-import * as React from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 
 const defaultSelectedVal = 'Read';
 const defaultUnSelectedVal = 'None';
@@ -51,26 +52,34 @@ export function DropdownWithDescription(props: DropdownWithDescriptionProps) {
     <Dropdown
       data-testid={`${props.repo?.name}-permission-dropdown`}
       onSelect={() => setIsOpen(false)}
-      toggle={
-        <DropdownToggle
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
           id="toggle-descriptions"
-          onToggle={(_event, isOpen) => setIsOpen(isOpen)}
+          onClick={() => setIsOpen(() => !isOpen)}
+          isExpanded={isOpen}
+          data-testid={`${props.repo?.name}-permission-dropdown-toggle`}
         >
           {dropdownToggle}
-        </DropdownToggle>
-      }
+        </MenuToggle>
+      )}
       isOpen={isOpen}
-      dropdownItems={props.dropdownItems.map((item) => (
-        <DropdownItem
-          data-testid={`${item.name}-permission-type`}
-          key={item.name}
-          description={item.description}
-          onClick={() => dropdownOnSelect(item.name, true)}
-        >
-          {item.name}
-        </DropdownItem>
-      ))}
-    />
+      onOpenChange={(isOpen) => setIsOpen(isOpen)}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>
+        {props.dropdownItems.map((item) => (
+          <DropdownItem
+            data-testid={`${item.name}-permission-type`}
+            key={item.name}
+            description={item.description}
+            onClick={() => dropdownOnSelect(item.name, true)}
+          >
+            {item.name}
+          </DropdownItem>
+        ))}
+      </DropdownList>
+    </Dropdown>
   );
 }
 

--- a/web/src/components/toolbar/FilterWithDropdown.tsx
+++ b/web/src/components/toolbar/FilterWithDropdown.tsx
@@ -1,44 +1,71 @@
 import React from 'react';
-import {TextInput, ToolbarItem} from '@patternfly/react-core';
-import {Dropdown, DropdownToggle} from '@patternfly/react-core/deprecated';
-import {SearchState} from './SearchTypes';
 import {SetterOrUpdater} from 'recoil';
+import {
+  Button,
+  Dropdown,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
+import {SearchState} from './SearchTypes';
 
 export function FilterWithDropdown(props: FilterWithDropdownProps) {
-  const setSearchState = (val: string) => {
-    props.onChange((prev: SearchState) => ({...prev, query: val.trim()}));
-  };
   const [isOpen, setIsOpen] = React.useState(false);
 
-  const onSelect = () => {
-    setIsOpen(false);
-  };
+  const setSearchState = React.useCallback(
+    (val: string) =>
+      props.onChange((prev: SearchState) => ({...prev, query: val.trim()})),
+    [],
+  );
 
   return (
     <ToolbarItem variant="search-filter">
       <Dropdown
-        onSelect={onSelect}
-        toggle={
-          <DropdownToggle
-            splitButtonItems={[
-              <TextInput
-                isRequired
-                type="search"
+        onSelect={() => setIsOpen(false)}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="typeahead"
+            isFullWidth
+            onClick={() => setIsOpen(() => !isOpen)}
+            id="toggle-split-button"
+            isExpanded={isOpen}
+          >
+            <TextInputGroup isPlain>
+              <TextInputGroupMain
                 id="filter-with-dropdown"
-                key="filter-with-dropdown"
                 name="search input"
                 placeholder={props.searchInputText}
                 value={props.searchState.query}
                 onChange={(_event, val: string) => setSearchState(val)}
-              />,
-            ]}
-            onToggle={(_event, isOpen: boolean) => setIsOpen(isOpen)}
-            id="toggle-split-button"
-          />
-        }
+                autoComplete="off"
+              />
+            </TextInputGroup>
+
+            <TextInputGroupUtilities>
+              {!!props.searchState.query && (
+                <Button
+                  variant="plain"
+                  onClick={() => setSearchState('')}
+                  aria-label="Clear input value"
+                >
+                  <TimesIcon aria-hidden />
+                </Button>
+              )}
+            </TextInputGroupUtilities>
+          </MenuToggle>
+        )}
         isOpen={isOpen}
-        dropdownItems={props.dropdownItems}
-      />
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>{props.dropdownItems}</DropdownList>
+      </Dropdown>
     </ToolbarItem>
   );
 }

--- a/web/src/components/toolbar/Kebab.tsx
+++ b/web/src/components/toolbar/Kebab.tsx
@@ -1,37 +1,34 @@
+import React from 'react';
 import {
   Dropdown,
-  DropdownToggle,
-  KebabToggle,
-} from '@patternfly/react-core/deprecated';
-import * as React from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 
 export function Kebab(props: KebabProps) {
-  const onToggle = () => {
-    props.setKebabOpen(!props.isKebabOpen);
-  };
-
-  const fetchToggle = () => {
-    if (!props.useActions) {
-      return <KebabToggle id={props?.id} onToggle={onToggle} />;
-    }
-    return (
-      <DropdownToggle
-        onToggle={() => props.setKebabOpen(!props.isKebabOpen)}
-        id="toggle-id-6"
-      >
-        Actions
-      </DropdownToggle>
-    );
-  };
-
   return (
     <Dropdown
       onSelect={() => props.setKebabOpen(!props.isKebabOpen)}
-      toggle={fetchToggle()}
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          id={props?.id}
+          variant={props.useActions ? 'secondary' : 'plain'}
+          onClick={() => props.setKebabOpen(!props.isKebabOpen)}
+          isExpanded={props.isKebabOpen}
+        >
+          {props.useActions ? 'Actions' : <EllipsisVIcon />}
+        </MenuToggle>
+      )}
       isOpen={props.isKebabOpen}
-      dropdownItems={props.kebabItems}
       isPlain={!props.useActions}
-    />
+      onOpenChange={(isOpen) => props.setKebabOpen(isOpen)}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>{props.kebabItems}</DropdownList>
+    </Dropdown>
   );
 }
 

--- a/web/src/components/toolbar/SearchDropdown.tsx
+++ b/web/src/components/toolbar/SearchDropdown.tsx
@@ -1,10 +1,12 @@
 import {useState} from 'react';
-import {ToolbarItem} from '@patternfly/react-core';
 import {
   Dropdown,
-  DropdownToggle,
   DropdownItem,
-} from '@patternfly/react-core/deprecated';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+  ToolbarItem,
+} from '@patternfly/react-core';
 import {SetterOrUpdater} from 'recoil';
 import {SearchState} from './SearchTypes';
 
@@ -26,32 +28,32 @@ export function SearchDropdown(props: SearchDropdownProps) {
     props.setSearchState((prev: SearchState) => ({...prev, field: item}));
   };
 
-  const dropdownItems = props.items.map((item: string) => (
-    <DropdownItem
-      key={item}
-      onClick={() => {
-        onItemSelect(item);
-      }}
-    >
-      {item}
-    </DropdownItem>
-  ));
-
   return (
     <ToolbarItem spacer={{default: 'spacerNone'}}>
       <Dropdown
         onSelect={onSelect}
-        toggle={
-          <DropdownToggle
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
             id="toolbar-dropdown-filter"
-            onToggle={() => setIsOpen(!isOpen)}
+            onClick={() => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
           >
             {props.searchState.field}
-          </DropdownToggle>
-        }
+          </MenuToggle>
+        )}
         isOpen={isOpen}
-        dropdownItems={dropdownItems}
-      />
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>
+          {props.items.map((item: string) => (
+            <DropdownItem key={item} onClick={() => onItemSelect(item)}>
+              {item}
+            </DropdownItem>
+          ))}
+        </DropdownList>
+      </Dropdown>
     </ToolbarItem>
   );
 }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsDropDown.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsDropDown.tsx
@@ -1,9 +1,11 @@
+import {useEffect, useState} from 'react';
 import {
   Dropdown,
   DropdownItem,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
-import {useEffect, useState} from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import {
   IDefaultPermission,
   useUpdateDefaultPermission,
@@ -15,7 +17,7 @@ import {AlertVariant} from 'src/atoms/AlertState';
 export default function DefaultPermissionsDropDown(
   props: DefaultPermissionsDropdownProps,
 ) {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState(false);
   const {addAlert} = useAlerts();
 
   const {
@@ -46,28 +48,38 @@ export default function DefaultPermissionsDropDown(
     <Dropdown
       data-testid={`${props.defaultPermission.createdBy}-permission-dropdown`}
       onSelect={() => setIsOpen(false)}
-      toggle={
-        <DropdownToggle onToggle={() => setIsOpen(!isOpen)}>
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => setIsOpen(!isOpen)}
+          isExpanded={isOpen}
+          data-testid={`${props.defaultPermission.createdBy}-permission-dropdown-toggle`}
+        >
           {props.defaultPermission.permission.charAt(0).toUpperCase() +
             props.defaultPermission.permission.slice(1)}
-        </DropdownToggle>
-      }
+        </MenuToggle>
+      )}
       isOpen={isOpen}
-      dropdownItems={Object.keys(repoPermissions).map((key) => (
-        <DropdownItem
-          data-testid={`${props.defaultPermission.createdBy}-${key}`}
-          key={repoPermissions[key]}
-          onClick={() =>
-            setDefaultPermission({
-              id: props.defaultPermission.id,
-              newRole: repoPermissions[key],
-            })
-          }
-        >
-          {repoPermissions[key]}
-        </DropdownItem>
-      ))}
-    />
+      onOpenChange={(isOpen) => setIsOpen(isOpen)}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>
+        {Object.keys(repoPermissions).map((key) => (
+          <DropdownItem
+            data-testid={`${props.defaultPermission.createdBy}-${key}`}
+            key={repoPermissions[key]}
+            onClick={() =>
+              setDefaultPermission({
+                id: props.defaultPermission.id,
+                newRole: repoPermissions[key],
+              })
+            }
+          >
+            {repoPermissions[key]}
+          </DropdownItem>
+        ))}
+      </DropdownList>
+    </Dropdown>
   );
 }
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsList.tsx
@@ -102,7 +102,10 @@ export default function DefaultPermissionsList(
         searchOptions={[permissionColumnNames.repoCreatedBy]}
         setDrawerContent={props.setDrawerContent}
       >
-        <Table aria-label="Selectable table">
+        <Table
+          aria-label="Selectable table"
+          data-testid="default-permissions-table"
+        >
           <Thead>
             <Tr>
               <Th />

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DeleteDefaultPermissionKebab.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DeleteDefaultPermissionKebab.tsx
@@ -1,9 +1,12 @@
+import {useEffect, useState} from 'react';
 import {
   Dropdown,
   DropdownItem,
-  KebabToggle,
-} from '@patternfly/react-core/deprecated';
-import {useEffect, useState} from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import {AlertVariant} from 'src/atoms/AlertState';
 import {useAlerts} from 'src/hooks/UseAlerts';
 import {
@@ -14,14 +17,13 @@ import {
 export default function DeleteDefaultPermissionKebab(
   props: DefaultPermissionsDropdownProps,
 ) {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState(false);
   const {addAlert} = useAlerts();
 
   const {
     removeDefaultPermission,
     errorDeleteDefaultPermission: error,
     successDeleteDefaultPermission: success,
-    resetDeleteDefaultPermission: reset,
   } = useDeleteDefaultPermission(props.orgName);
 
   useEffect(() => {
@@ -45,28 +47,33 @@ export default function DeleteDefaultPermissionKebab(
   return (
     <Dropdown
       onSelect={() => setIsOpen(!isOpen)}
-      toggle={
-        <KebabToggle
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          id={`${props.defaultPermission.createdBy}-toggle-kebab`}
           data-testid={`${props.defaultPermission.createdBy}-toggle-kebab`}
-          onToggle={() => {
-            setIsOpen(!isOpen);
-          }}
-        />
-      }
+          variant="plain"
+          onClick={() => setIsOpen(!isOpen)}
+          isExpanded={isOpen}
+        >
+          <EllipsisVIcon />
+        </MenuToggle>
+      )}
       isOpen={isOpen}
-      dropdownItems={[
+      onOpenChange={(isOpen) => setIsOpen(isOpen)}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>
         <DropdownItem
-          key="delete"
           onClick={() =>
             removeDefaultPermission({id: props.defaultPermission.id})
           }
           data-testid={`${props.defaultPermission.createdBy}-del-option`}
         >
           Delete Permission
-        </DropdownItem>,
-      ]}
-      isPlain
-    />
+        </DropdownItem>
+      </DropdownList>
+    </Dropdown>
   );
 }
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer.tsx
@@ -1,3 +1,4 @@
+import {useState, Ref} from 'react';
 import {
   ActionGroup,
   Button,
@@ -7,20 +8,19 @@ import {
   DrawerHead,
   DrawerPanelBody,
   DrawerPanelContent,
-  Form,
-  FormGroup,
-  Radio,
-  Spinner,
-} from '@patternfly/react-core';
-import {
   Dropdown,
   DropdownItem,
-  DropdownToggle,
-  SelectOption,
+  DropdownList,
+  Form,
+  FormGroup,
+  MenuToggle,
+  MenuToggleElement,
+  Radio,
   SelectGroup,
-} from '@patternfly/react-core/deprecated';
+  SelectOption,
+  Spinner,
+} from '@patternfly/react-core';
 import {DesktopIcon, UsersIcon} from '@patternfly/react-icons';
-import {useState, Ref} from 'react';
 import EntitySearch from 'src/components/EntitySearch';
 import {useCreateDefaultPermission} from 'src/hooks/UseDefaultPermissions';
 import {Entity} from 'src/resources/UserResource';
@@ -105,20 +105,22 @@ export default function CreatePermissionDrawer(
         {isLoadingRobots ? (
           <Spinner />
         ) : (
-          robots?.map((r) => (
+          robots?.map(({name}) => (
             <SelectOption
-              data-testid={`${r.name}-robot-accnt`}
-              key={r.name}
-              value={r.name}
+              data-testid={`${name}-robot-accnt`}
+              key={name}
+              value={name}
               onClick={() => {
                 setRepositoryCreator({
+                  name,
                   is_robot: true,
-                  name: r.name,
                   kind: 'user',
                   is_org_member: true,
                 });
               }}
-            />
+            >
+              {name}
+            </SelectOption>
           ))
         )}
       </SelectGroup>
@@ -130,7 +132,6 @@ export default function CreatePermissionDrawer(
         onClick={() =>
           setIsCreateRobotModalForCreatorOpen(!isCreateRobotModalForCreatorOpen)
         }
-        isPlaceholder
         isFocused
       >
         <DesktopIcon /> &nbsp; Create robot account
@@ -245,39 +246,43 @@ export default function CreatePermissionDrawer(
         {isLoadingTeams ? (
           <Spinner />
         ) : (
-          teams?.map((t) => (
+          teams?.map(({name}) => (
             <SelectOption
-              data-testid={`${t.name}-team`}
-              key={t.name}
-              value={t.name}
+              data-testid={`${name}-team`}
+              key={name}
+              value={name}
               onClick={() => {
                 setAppliedTo({
+                  name,
                   is_robot: false,
-                  name: t.name,
                   kind: 'team',
                 });
               }}
-            />
+            >
+              {name}
+            </SelectOption>
           ))
         )}
       </SelectGroup>
       <Divider component="li" key={4} />
       <SelectGroup label="Robot accounts" key="group4">
-        {robots?.map((r) => {
+        {robots?.map(({name}) => {
           return (
             <SelectOption
-              data-testid={`${r.name}-robot-accnt`}
-              key={r.name}
-              value={r.name}
+              data-testid={`${name}-robot-accnt`}
+              key={name}
+              value={name}
               onClick={() => {
                 setAppliedTo({
+                  name,
                   is_robot: true,
-                  name: r.name,
                   kind: 'user',
                   is_org_member: true,
                 });
               }}
-            />
+            >
+              {name}
+            </SelectOption>
           );
         })}
       </SelectGroup>
@@ -287,7 +292,6 @@ export default function CreatePermissionDrawer(
         key="Create team1"
         component="button"
         onClick={() => setIsTeamModalOpen(!isTeamModalOpen)}
-        isPlaceholder
         isFocused
       >
         <UsersIcon /> &nbsp; Create team
@@ -301,7 +305,6 @@ export default function CreatePermissionDrawer(
             !isCreateRobotModalForAppliedToOpen,
           )
         }
-        isPlaceholder
         isFocused
       >
         <DesktopIcon /> &nbsp; Create robot account
@@ -340,17 +343,22 @@ export default function CreatePermissionDrawer(
   const dropdownForPermission = (
     <Dropdown
       data-testid={'create-default-permission-dropdown'}
-      toggle={
-        <DropdownToggle
-          id="toggle-id-6"
-          onToggle={() => setPermissionDropDownOpen(!permissionDropDownOpen)}
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => setPermissionDropDownOpen(!permissionDropDownOpen)}
+          isExpanded={permissionDropDownOpen}
+          data-testid="create-default-permission-dropdown-toggle"
         >
           {permission}
-        </DropdownToggle>
-      }
+        </MenuToggle>
+      )}
       isOpen={permissionDropDownOpen}
-      dropdownItems={optionsForPermission}
-    />
+      onOpenChange={(isOpen) => setPermissionDropDownOpen(isOpen)}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>{optionsForPermission}</DropdownList>
+    </Dropdown>
   );
   const {createDefaultPermission} = useCreateDefaultPermission(props.orgName, {
     onSuccess: () => {

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/AddTeamToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/AddTeamToolbar.tsx
@@ -1,13 +1,14 @@
+import {useState} from 'react';
 import {
   Divider,
+  SelectGroup,
+  SelectOption,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import {SelectGroup, SelectOption} from '@patternfly/react-core/deprecated';
 import {DesktopIcon} from '@patternfly/react-icons';
 import React from 'react';
-import {useState} from 'react';
 import EntitySearch from 'src/components/EntitySearch';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import {ITeamMember} from 'src/hooks/UseMembers';
@@ -19,16 +20,18 @@ export default function AddTeamToolbar(props: AddTeamToolbarProps) {
   const searchRobotAccntOptions = [
     <React.Fragment key="searchRobot">
       <SelectGroup label="Robot accounts" key="group4">
-        {props?.robots.map((r) => {
+        {props?.robots.map(({name}) => {
           return (
             <SelectOption
-              data-testid={`${r.name}-robot-accnt`}
-              key={r.name}
-              value={r.name}
+              data-testid={`${name}-robot-accnt`}
+              key={name}
+              value={name}
               onClick={() => {
-                props.addTeamMemberHandler(r.name);
+                props.addTeamMemberHandler(name);
               }}
-            />
+            >
+              {name}
+            </SelectOption>
           );
         })}
       </SelectGroup>
@@ -38,7 +41,6 @@ export default function AddTeamToolbar(props: AddTeamToolbarProps) {
         key="Create robot account2"
         component="button"
         onClick={() => props.setDrawerExpanded(true)}
-        isPlaceholder
         isFocused
       >
         <DesktopIcon /> &nbsp; Create robot account

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/CreateTeamWizard.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/CreateTeamWizard.tsx
@@ -1,3 +1,4 @@
+import {useEffect, useState} from 'react';
 import {
   Modal,
   ModalVariant,
@@ -7,9 +8,11 @@ import {
   AlertGroup,
   Alert,
   AlertActionCloseButton,
+  WizardHeader,
+  Wizard,
+  WizardStepType,
+  WizardStep,
 } from '@patternfly/react-core';
-import {Wizard} from '@patternfly/react-core/deprecated';
-import {useEffect, useState} from 'react';
 import {
   ITeamMember,
   useAddMembersToTeam,
@@ -39,7 +42,6 @@ export const CreateTeamWizard = (props: CreateTeamWizardProps): JSX.Element => {
     selectedRobotReposState,
   );
   const [isDrawerExpanded, setDrawerExpanded] = useState(false);
-  const [activeStep, setActiveStep] = useState<string>('Name & Description');
   const [addedTeamMembers, setAddedTeamMembers] = useState<ITeamMember[]>([]);
   const [deletedTeamMembers, setDeletedTeamMembers] = useState<ITeamMember[]>(
     [],
@@ -103,87 +105,6 @@ export const CreateTeamWizard = (props: CreateTeamWizardProps): JSX.Element => {
     props.handleWizardToggle();
   };
 
-  const handleStepChange = (step) => {
-    setActiveStep(step.name);
-  };
-
-  const steps = [
-    {
-      name: 'Name & Description',
-      component: (
-        <>
-          <TextContent>
-            <Text component={TextVariants.h1}>Team name and description</Text>
-          </TextContent>
-          <NameAndDescription
-            name={props.teamName}
-            description={props.teamDescription}
-            nameLabel="Team name for your new team"
-            descriptionLabel="Team description for your new team"
-          />
-        </>
-      ),
-    },
-    {
-      name: 'Add to repository (optional)',
-      component: (
-        <AddToRepository
-          namespace={props.orgName}
-          dropdownItems={RepoPermissionDropdownItems}
-          repos={repos}
-          selectedRepos={selectedRepos}
-          setSelectedRepos={setSelectedRepos}
-          selectedRepoPerms={selectedRepoPerms}
-          setSelectedRepoPerms={setSelectedRepoPerms}
-          wizardStep={true}
-        />
-      ),
-    },
-    {
-      name: 'Add team member (optional)',
-      component: (
-        <>
-          <Conditional if={!isDrawerExpanded}>
-            <TextContent>
-              <Text component={TextVariants.h1}>
-                Add team member (optional)
-              </Text>
-            </TextContent>
-          </Conditional>
-          <AddTeamMember
-            orgName={props.orgName}
-            allMembers={allMembers}
-            tableItems={tableItems}
-            setTableItems={setTableItems}
-            addedTeamMembers={addedTeamMembers}
-            setAddedTeamMembers={setAddedTeamMembers}
-            deletedTeamMembers={deletedTeamMembers}
-            setDeletedTeamMembers={setDeletedTeamMembers}
-            isDrawerExpanded={isDrawerExpanded}
-            setDrawerExpanded={setDrawerExpanded}
-          />
-        </>
-      ),
-    },
-    {
-      name: 'Review and Finish',
-      component: (
-        <>
-          <TextContent>
-            <Text component={TextVariants.h1}>Review</Text>
-          </TextContent>
-          <Review
-            orgName={props.orgName}
-            teamName={props.teamName}
-            description={props.teamDescription}
-            addedTeamMembers={addedTeamMembers}
-            selectedRepos={filteredRepos()}
-          />
-        </>
-      ),
-    },
-  ];
-
   return (
     <>
       <Conditional if={error}>
@@ -204,6 +125,7 @@ export const CreateTeamWizard = (props: CreateTeamWizardProps): JSX.Element => {
           />
         </AlertGroup>
       </Conditional>
+
       <Modal
         id="create-team-modal"
         aria-label="CreateTeam"
@@ -214,14 +136,16 @@ export const CreateTeamWizard = (props: CreateTeamWizardProps): JSX.Element => {
         hasNoBodyWrapper
       >
         <Wizard
-          titleId="create-team-wizard-label"
-          descriptionId="create-team-wizard-description"
-          title="Create team"
-          description=""
-          steps={steps}
           onClose={props.handleWizardToggle}
           height={600}
           width={1170}
+          header={
+            <WizardHeader
+              onClose={props.handleWizardToggle}
+              title="Create team"
+              description=""
+            />
+          }
           footer={
             <Conditional if={!isDrawerExpanded}>
               <ReviewAndFinishFooter
@@ -230,11 +154,71 @@ export const CreateTeamWizard = (props: CreateTeamWizardProps): JSX.Element => {
               />
             </Conditional>
           }
-          hasNoBodyPadding={
-            isDrawerExpanded && activeStep === 'Add team member (optional)'
-          }
-          onCurrentStepChanged={(currentStep) => handleStepChange(currentStep)}
-        />
+        >
+          <WizardStep name="Name & Description" id="name-and-description">
+            <TextContent>
+              <Text component={TextVariants.h1}>Team name and description</Text>
+            </TextContent>
+            <NameAndDescription
+              name={props.teamName}
+              description={props.teamDescription}
+              nameLabel="Team name for your new team"
+              descriptionLabel="Team description for your new team"
+            />
+          </WizardStep>
+
+          <WizardStep name="Add to repository (optional)" id="add-to-repo">
+            <AddToRepository
+              namespace={props.orgName}
+              dropdownItems={RepoPermissionDropdownItems}
+              repos={repos}
+              selectedRepos={selectedRepos}
+              setSelectedRepos={setSelectedRepos}
+              selectedRepoPerms={selectedRepoPerms}
+              setSelectedRepoPerms={setSelectedRepoPerms}
+              isWizardStep
+            />
+          </WizardStep>
+
+          <WizardStep
+            name="Add team member (optional)"
+            id="add-team-member"
+            body={{hasNoPadding: isDrawerExpanded}}
+          >
+            <Conditional if={!isDrawerExpanded}>
+              <TextContent>
+                <Text component={TextVariants.h1}>
+                  Add team member (optional)
+                </Text>
+              </TextContent>
+            </Conditional>
+            <AddTeamMember
+              orgName={props.orgName}
+              allMembers={allMembers}
+              tableItems={tableItems}
+              setTableItems={setTableItems}
+              addedTeamMembers={addedTeamMembers}
+              setAddedTeamMembers={setAddedTeamMembers}
+              deletedTeamMembers={deletedTeamMembers}
+              setDeletedTeamMembers={setDeletedTeamMembers}
+              isDrawerExpanded={isDrawerExpanded}
+              setDrawerExpanded={setDrawerExpanded}
+            />
+          </WizardStep>
+
+          <WizardStep name="Review and Finish" id="review-and-finish">
+            <TextContent>
+              <Text component={TextVariants.h1}>Review</Text>
+            </TextContent>
+            <Review
+              orgName={props.orgName}
+              teamName={props.teamName}
+              description={props.teamDescription}
+              addedTeamMembers={addedTeamMembers}
+              selectedRepos={filteredRepos()}
+            />
+          </WizardStep>
+        </Wizard>
       </Modal>
     </>
   );

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/ReviewAndFinishFooter.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/ReviewAndFinishFooter.tsx
@@ -1,60 +1,55 @@
-import {Button} from '@patternfly/react-core';
 import {
-  WizardContextConsumer,
-  WizardFooter,
-} from '@patternfly/react-core/deprecated';
+  Button,
+  useWizardContext,
+  WizardFooterWrapper,
+} from '@patternfly/react-core';
 
 export default function ReviewAndFinishFooter(
   props: ReviewAndFinishFooterProps,
 ) {
+  const {activeStep, goToNextStep, goToPrevStep, close} = useWizardContext();
+
   return (
-    <WizardFooter>
-      <WizardContextConsumer>
-        {({
-          activeStep,
-          goToStepByName,
-          goToStepById,
-          onNext,
-          onBack,
-          onClose,
-        }) => {
-          return (
-            <>
-              {activeStep.name !== 'Review and Finish' ? (
-                <Button
-                  data-testid="next-btn"
-                  variant="primary"
-                  type="submit"
-                  onClick={onNext}
-                >
-                  Next
-                </Button>
-              ) : null}
-              {activeStep.name !== 'Name & Description' ? (
-                <Button variant="secondary" type="submit" onClick={onBack}>
-                  Back
-                </Button>
-              ) : null}
-              {activeStep.name === 'Add team member (optional)' ||
-              activeStep.name === 'Review and Finish' ? (
-                <Button
-                  data-testid="review-and-finish-wizard-btn"
-                  isDisabled={!props.canSubmit}
-                  variant="secondary"
-                  onClick={props.onSubmit}
-                  id="create-team-submit"
-                >
-                  Review and Finish
-                </Button>
-              ) : null}
-              <Button variant="link" onClick={onClose} id="create-team-cancel">
-                Cancel
-              </Button>
-            </>
-          );
-        }}
-      </WizardContextConsumer>
-    </WizardFooter>
+    <WizardFooterWrapper>
+      {activeStep.name !== 'Review and Finish' && (
+        <Button
+          data-testid="next-btn"
+          variant="primary"
+          type="submit"
+          onClick={goToNextStep}
+        >
+          Next
+        </Button>
+      )}
+
+      {activeStep.name !== 'Name & Description' && (
+        <Button
+          variant="secondary"
+          type="submit"
+          onClick={goToPrevStep}
+          isDisabled={activeStep.index === 1}
+        >
+          Back
+        </Button>
+      )}
+
+      {(activeStep.name === 'Add team member (optional)' ||
+        activeStep.name === 'Review and Finish') && (
+        <Button
+          data-testid="review-and-finish-wizard-btn"
+          isDisabled={!props.canSubmit}
+          variant="secondary"
+          onClick={props.onSubmit}
+          id="create-team-submit"
+        >
+          Review and Finish
+        </Button>
+      )}
+
+      <Button variant="link" onClick={close} id="create-team-cancel">
+        Cancel
+      </Button>
+    </WizardFooterWrapper>
   );
 }
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/SetRepoPermissionsModal/SetRepoPermForTeamRoleDropDown.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/SetRepoPermissionsModal/SetRepoPermForTeamRoleDropDown.tsx
@@ -1,9 +1,11 @@
+import {useEffect, useState} from 'react';
 import {
   Dropdown,
   DropdownItem,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
-import {useEffect, useState} from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import {ITeamRepoPerms} from 'src/hooks/UseTeams';
 import {RepoPermissionDropdownItems} from 'src/routes/RepositoriesList/RobotAccountsList';
 
@@ -34,25 +36,35 @@ export function SetRepoPermForTeamRoleDropDown(
     <Dropdown
       data-testid={`${props.repoPerm.repoName}-role-dropdown`}
       onSelect={() => setIsOpen(false)}
-      toggle={
-        <DropdownToggle onToggle={() => setIsOpen(!isOpen)}>
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => setIsOpen(!isOpen)}
+          isExpanded={isOpen}
+          data-testid={`${props.repoPerm.repoName}-role-dropdown-toggle`}
+        >
           {dropdownValue
             ? dropdownValue?.charAt(0).toUpperCase() + dropdownValue?.slice(1)
             : 'None'}
-        </DropdownToggle>
-      }
+        </MenuToggle>
+      )}
       isOpen={isOpen}
-      dropdownItems={RepoPermissionDropdownItems.map((item) => (
-        <DropdownItem
-          data-testid={`${props.repoPerm.repoName}-${item.name}`}
-          key={item.name}
-          description={item.description}
-          onClick={() => dropdownOnSelect(item.name)}
-        >
-          {item.name}
-        </DropdownItem>
-      ))}
-    />
+      onOpenChange={(isOpen) => setIsOpen(isOpen)}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>
+        {RepoPermissionDropdownItems.map((item) => (
+          <DropdownItem
+            data-testid={`${props.repoPerm.repoName}-${item.name}`}
+            key={item.name}
+            description={item.description}
+            onClick={() => dropdownOnSelect(item.name)}
+          >
+            {item.name}
+          </DropdownItem>
+        ))}
+      </DropdownList>
+    </Dropdown>
   );
 }
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/SetRepoPermissionsModal/SetRepoPermissionsForTeamToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/SetRepoPermissionsModal/SetRepoPermissionsForTeamToolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  DropdownItem,
   Flex,
   FlexItem,
   PanelFooter,
@@ -6,7 +7,6 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import {DropdownItem} from '@patternfly/react-core/deprecated';
 import Conditional from 'src/components/empty/Conditional';
 import {DropdownCheckbox} from 'src/components/toolbar/DropdownCheckbox';
 import {Kebab} from 'src/components/toolbar/Kebab';

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamViewKebab.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamViewKebab.tsx
@@ -1,11 +1,13 @@
+import {useState} from 'react';
+import {Link, useSearchParams} from 'react-router-dom';
 import {
   Dropdown,
   DropdownItem,
-  KebabToggle,
-  DropdownPosition,
-} from '@patternfly/react-core/deprecated';
-import {useState} from 'react';
-import {Link, useSearchParams} from 'react-router-dom';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import {AlertVariant} from 'src/atoms/AlertState';
 import {useAlerts} from 'src/hooks/UseAlerts';
 import {ITeams, useDeleteTeam} from 'src/hooks/UseTeams';
@@ -36,51 +38,53 @@ export default function TeamViewKebab(props: TeamViewKebabProps) {
   return (
     <Dropdown
       onSelect={() => setIsKebabOpen(!isKebabOpen)}
-      toggle={
-        <KebabToggle
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          id={`${props.team.name}-toggle-kebab`}
           data-testid={`${props.team.name}-toggle-kebab`}
-          onToggle={() => {
-            setIsKebabOpen(!isKebabOpen);
-          }}
-        />
-      }
+          variant="plain"
+          onClick={() => setIsKebabOpen(!isKebabOpen)}
+          isExpanded={isKebabOpen}
+        >
+          <EllipsisVIcon />
+        </MenuToggle>
+      )}
       isOpen={isKebabOpen}
-      dropdownItems={[
+      onOpenChange={(isOpen) => setIsKebabOpen(isOpen)}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>
+        <DropdownItem>
+          <Link
+            to={getTeamMemberPath(
+              location.pathname,
+              props.organizationName,
+              props.team.name,
+              searchParams.get('tab'),
+            )}
+            data-testid={`${props.team.name}-manage-team-member-option`}
+          >
+            Manage team members
+          </Link>
+        </DropdownItem>
+
         <DropdownItem
-          key="link"
-          component={
-            <Link
-              to={getTeamMemberPath(
-                location.pathname,
-                props.organizationName,
-                props.team.name,
-                searchParams.get('tab'),
-              )}
-              data-testid={`${props.team.name}-manage-team-member-option`}
-            >
-              Manage team members
-            </Link>
-          }
-        ></DropdownItem>,
-        <DropdownItem
-          key="set-repo-perms"
           onClick={props.onSelectRepo}
           data-testid={`${props.team.name}-set-repo-perms-option`}
         >
           Set repository permissions
-        </DropdownItem>,
+        </DropdownItem>
+
         <DropdownItem
-          key="delete"
           onClick={() => removeTeam(props.team)}
           className="red-color"
           data-testid={`${props.team.name}-del-option`}
         >
           Delete
-        </DropdownItem>,
-      ]}
-      isPlain
-      position={DropdownPosition.right}
-    />
+        </DropdownItem>
+      </DropdownList>
+    </Dropdown>
   );
 }
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsRoleDropDown.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsRoleDropDown.tsx
@@ -1,9 +1,11 @@
+import {useEffect, useState} from 'react';
 import {
   Dropdown,
   DropdownItem,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
-import {useEffect, useState} from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import {AlertVariant} from 'src/atoms/AlertState';
 import {useAlerts} from 'src/hooks/UseAlerts';
 import {useUpdateTeamRole} from 'src/hooks/UseTeams';
@@ -46,27 +48,37 @@ export function TeamsRoleDropDown(props: TeamsRoleDropDownProps) {
     <Dropdown
       data-testid={`${props.teamName}-team-dropdown`}
       onSelect={() => setIsOpen(false)}
-      toggle={
-        <DropdownToggle onToggle={() => setIsOpen(!isOpen)}>
-          {props.teamRole.charAt(0).toUpperCase() + props.teamRole.slice(1)}
-        </DropdownToggle>
-      }
-      isOpen={isOpen}
-      dropdownItems={Object.keys(teamPermissions).map((key) => (
-        <DropdownItem
-          data-testid={`${props.teamName}-${key}`}
-          key={key}
-          onClick={() =>
-            updateTeamRole({
-              teamName: props.teamName,
-              teamRole: teamPermissions[key],
-            })
-          }
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => setIsOpen(!isOpen)}
+          isExpanded={isOpen}
+          data-testid={`${props.teamName}-team-dropdown-toggle`}
         >
-          {key}
-        </DropdownItem>
-      ))}
-    />
+          {props.teamRole.charAt(0).toUpperCase() + props.teamRole.slice(1)}
+        </MenuToggle>
+      )}
+      isOpen={isOpen}
+      onOpenChange={(isOpen) => setIsOpen(isOpen)}
+      shouldFocusToggleOnSelect
+    >
+      <DropdownList>
+        {Object.keys(teamPermissions).map((key) => (
+          <DropdownItem
+            data-testid={`${props.teamName}-${key}`}
+            key={key}
+            onClick={() =>
+              updateTeamRole({
+                teamName: props.teamName,
+                teamRole: teamPermissions[key],
+              })
+            }
+          >
+            {key}
+          </DropdownItem>
+        ))}
+      </DropdownList>
+    </Dropdown>
   );
 }
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsViewList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsViewList.tsx
@@ -1,18 +1,18 @@
+import {useEffect, useState} from 'react';
 import {Table, Tbody, Td, Th, Thead, Tr} from '@patternfly/react-table';
-import TeamsViewToolbar from './TeamsViewToolbar';
 import {Link, useSearchParams} from 'react-router-dom';
 import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
   PageSection,
   PageSectionVariants,
   PanelFooter,
   Spinner,
 } from '@patternfly/react-core';
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
-import {useEffect, useState} from 'react';
+import TeamsViewToolbar from './TeamsViewToolbar';
 import TeamViewKebab from './TeamViewKebab';
 import {ITeams, useDeleteTeam, useFetchTeams} from 'src/hooks/UseTeams';
 import {TeamsRoleDropDown} from './TeamsRoleDropDown';
@@ -98,14 +98,17 @@ export default function TeamsViewList(props: TeamsViewListProps) {
       label: 'team role',
       transformFunc: (team: ITeams) => (
         <Dropdown
-          toggle={
-            <DropdownToggle id="toggle-disabled" isDisabled>
+          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            <MenuToggle ref={toggleRef} id="toggle-disabled" isDisabled>
               {team.role}
-            </DropdownToggle>
-          }
+            </MenuToggle>
+          )}
           isOpen={false}
-          dropdownItems={[team.role]}
-        />
+        >
+          <DropdownList>
+            <DropdownItem>{team.role}</DropdownItem>
+          </DropdownList>
+        </Dropdown>
       ),
     },
   };

--- a/web/src/routes/OrganizationsList/OrganizationsList.tsx
+++ b/web/src/routes/OrganizationsList/OrganizationsList.tsx
@@ -1,19 +1,16 @@
+import {useEffect, useState} from 'react';
 import {Table, Thead, Tr, Th, Tbody, Td} from '@patternfly/react-table';
 import {
   PageSection,
   PageSectionVariants,
   Title,
   PanelFooter,
+  DropdownItem,
 } from '@patternfly/react-core';
-import {DropdownItem} from '@patternfly/react-core/deprecated';
 import './css/Organizations.scss';
 import {CreateOrganizationModal} from './CreateOrganizationModal';
 import {useRecoilState} from 'recoil';
-import {
-  searchOrgsState,
-  selectedOrgsState,
-} from 'src/atoms/OrganizationListState';
-import {useEffect, useState} from 'react';
+import {selectedOrgsState} from 'src/atoms/OrganizationListState';
 import {IOrganization} from 'src/resources/OrganizationResource';
 import OrgTableData from './OrganizationsListTableData';
 import {BulkDeleteModalTemplate} from 'src/components/modals/BulkDeleteModalTemplate';

--- a/web/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/web/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -1,15 +1,15 @@
+import {ReactElement, useState} from 'react';
 import {
   PageSection,
   PageSectionVariants,
   Spinner,
   Title,
   PanelFooter,
+  DropdownItem,
 } from '@patternfly/react-core';
-import {DropdownItem} from '@patternfly/react-core/deprecated';
 import {Table, Thead, Tr, Th, Tbody, Td} from '@patternfly/react-table';
 import {useRecoilState} from 'recoil';
 import {IRepository} from 'src/resources/RepositoryResource';
-import {ReactElement, useState} from 'react';
 import {Link, useLocation} from 'react-router-dom';
 import CreateRepositoryModalTemplate from 'src/components/modals/CreateRepoModalTemplate';
 import {getRepoDetailPath} from 'src/routes/NavigationPath';

--- a/web/src/routes/RepositoriesList/RobotAccountKebab.tsx
+++ b/web/src/routes/RepositoriesList/RobotAccountKebab.tsx
@@ -1,11 +1,13 @@
+import {useState} from 'react';
 import {
   Dropdown,
   DropdownItem,
-  KebabToggle,
-  DropdownPosition,
-} from '@patternfly/react-core/deprecated';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import {IRobot} from 'src/resources/RobotsResource';
-import {useState} from 'react';
 
 export default function RobotAccountKebab(props: RobotAccountKebabProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -31,37 +33,41 @@ export default function RobotAccountKebab(props: RobotAccountKebabProps) {
     <>
       <Dropdown
         onSelect={onSelect}
-        toggle={
-          <KebabToggle
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="plain"
             id={`${props.robotAccount.name}-toggle-kebab`}
-            onToggle={() => {
-              setIsOpen(!isOpen);
-            }}
-          />
-        }
+            data-testid={`${props.robotAccount.name}-toggle-kebab`}
+            onClick={() => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+          >
+            <EllipsisVIcon />
+          </MenuToggle>
+        )}
         isOpen={isOpen}
-        dropdownItems={[
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>
           <DropdownItem
-            key="set-repo-perms"
             onClick={() => onSetRepoPerms()}
             id={`${props.robotAccount.name}-set-repo-perms-btn`}
           >
             {props.deleteKebabIsOpen ? props.deleteModal() : null}
             Set repository permissions
-          </DropdownItem>,
+          </DropdownItem>
+
           <DropdownItem
-            key="delete"
             onClick={() => onDelete()}
             className="red-color"
             id={`${props.robotAccount.name}-del-btn`}
           >
             {props.deleteKebabIsOpen ? props.deleteModal() : null}
             Delete
-          </DropdownItem>,
-        ]}
-        isPlain
-        position={DropdownPosition.right}
-      />
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
     </>
   );
 }

--- a/web/src/routes/RepositoriesList/RobotAccountsList.tsx
+++ b/web/src/routes/RepositoriesList/RobotAccountsList.tsx
@@ -6,8 +6,8 @@ import {
   TextContent,
   Text,
   TextVariants,
+  DropdownItem,
 } from '@patternfly/react-core';
-import {DropdownItem} from '@patternfly/react-core/deprecated';
 import {
   Table,
   ExpandableRowContent,
@@ -456,7 +456,7 @@ export default function RobotAccountsList(props: RobotAccountsListProps) {
       return;
     }
     setTableExpanded(!isTableExpanded);
-    paginatedRobotAccountList.map((robotAccount, index) => {
+    paginatedRobotAccountList.map((robotAccount) => {
       setRobotExpanded(robotAccount);
     });
   };

--- a/web/src/routes/RepositoryDetails/Settings/NotificationsActions.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/NotificationsActions.tsx
@@ -1,14 +1,14 @@
+import {useEffect, useState} from 'react';
 import {
   Alert,
   AlertActionCloseButton,
   AlertGroup,
-} from '@patternfly/react-core';
-import {
   Dropdown,
   DropdownItem,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
-import {useEffect, useState} from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import Conditional from 'src/components/empty/Conditional';
 import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
 import {
@@ -77,37 +77,39 @@ export default function Actions(props: ActionsProps) {
       </Conditional>
       <Dropdown
         onSelect={() => setIsOpen(false)}
-        toggle={
-          <DropdownToggle
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
             isDisabled={props.isDisabled}
-            onToggle={(_event, isOpen) => setIsOpen(isOpen)}
+            onClick={() => setIsOpen(() => !isOpen)}
+            isExpanded={isOpen}
           >
             Actions
-          </DropdownToggle>
-        }
+          </MenuToggle>
+        )}
         isOpen={isOpen}
-        dropdownItems={[
-          <Conditional
-            key="notifications-bulk-delete"
-            if={notificationsToEnable.length > 0}
-          >
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>
+          <Conditional if={notificationsToEnable.length > 0}>
             <DropdownItem
               onClick={() => enableNotifications(notificationsToEnable)}
             >
               Enable
             </DropdownItem>
-          </Conditional>,
+          </Conditional>
+
           <DropdownItem
-            key="notifications-bulk-delete"
             id="bulk-delete-notifications"
             onClick={() => {
               deleteNotifications(props.selectedItems.map((n) => n.uuid));
             }}
           >
             Delete
-          </DropdownItem>,
-        ]}
-      />
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
     </>
   );
 }

--- a/web/src/routes/RepositoryDetails/Settings/NotificationsCreateNotification.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/NotificationsCreateNotification.tsx
@@ -1,16 +1,16 @@
+import {useState} from 'react';
 import {
   Alert,
   AlertActionCloseButton,
-  Form,
-  FormGroup,
-  Title,
-} from '@patternfly/react-core';
-import {
   Dropdown,
   DropdownItem,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
-import {useState} from 'react';
+  DropdownList,
+  Form,
+  FormGroup,
+  MenuToggle,
+  MenuToggleElement,
+  Title,
+} from '@patternfly/react-core';
 import './NotificationsCreateNotification.css';
 import Conditional from 'src/components/empty/Conditional';
 import {NotificationEvent, useEvents} from 'src/hooks/UseEvents';
@@ -27,8 +27,8 @@ import CreateSlackNotification from './NotificationsCreateNotificationSlack';
 import CreateWebhookNotification from './NotificationsCreateNotificationWebhook';
 
 export default function CreateNotification(props: CreateNotificationProps) {
-  const [isEventOpen, setIsEventOpen] = useState<boolean>();
-  const [isMethodOpen, setIsMethodOpen] = useState<boolean>();
+  const [isEventOpen, setIsEventOpen] = useState(false);
+  const [isMethodOpen, setIsMethodOpen] = useState(false);
   const [event, setEvent] = useState<NotificationEvent>();
   const [method, setMethod] = useState<NotificationMethod>();
   const {events} = useEvents();
@@ -52,24 +52,31 @@ export default function CreateNotification(props: CreateNotificationProps) {
         <FormGroup fieldId="event" label="When this event occurs" isRequired>
           <Dropdown
             className="create-notification-dropdown"
-            required
             onSelect={() => setIsEventOpen(false)}
-            toggle={
-              <DropdownToggle
-                onToggle={(_event, isOpen) => setIsEventOpen(isOpen)}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
+                id="event-dropdown-toggle"
+                onClick={() => setIsEventOpen(() => !isEventOpen)}
+                isExpanded={isEventOpen}
               >
                 {event?.title ? event?.title : 'Select event...'}
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
             isOpen={isEventOpen}
-            dropdownItems={events.map((event) => (
-              <Conditional key={event.type} if={event.enabled}>
-                <DropdownItem onClick={() => setEvent(event)}>
-                  {event.icon} {event.title}
-                </DropdownItem>
-              </Conditional>
-            ))}
-          />
+            onOpenChange={(isOpen) => setIsEventOpen(isOpen)}
+            shouldFocusToggleOnSelect
+          >
+            <DropdownList>
+              {events.map((event) => (
+                <Conditional key={event.type} if={event.enabled}>
+                  <DropdownItem onClick={() => setEvent(event)}>
+                    {event.icon} {event.title}
+                  </DropdownItem>
+                </Conditional>
+              ))}
+            </DropdownList>
+          </Dropdown>
         </FormGroup>
         <FormGroup
           fieldId="method"
@@ -79,22 +86,30 @@ export default function CreateNotification(props: CreateNotificationProps) {
           <Dropdown
             className="create-notification-dropdown"
             onSelect={() => setIsMethodOpen(false)}
-            toggle={
-              <DropdownToggle
-                onToggle={(_event, isOpen) => setIsMethodOpen(isOpen)}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
+                id="method-dropdown-toggle"
+                onClick={() => setIsMethodOpen(() => !isMethodOpen)}
+                isExpanded={isMethodOpen}
               >
                 {method?.title ? method?.title : 'Select method...'}
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
             isOpen={isMethodOpen}
-            dropdownItems={notificationMethods.map((method) => (
-              <Conditional key={method.type} if={method.enabled}>
-                <DropdownItem onClick={() => setMethod(method)}>
-                  {method.title}
-                </DropdownItem>
-              </Conditional>
-            ))}
-          />
+            onOpenChange={(isOpen) => setIsMethodOpen(isOpen)}
+            shouldFocusToggleOnSelect
+          >
+            <DropdownList>
+              {notificationMethods.map((method) => (
+                <Conditional key={method.type} if={method.enabled}>
+                  <DropdownItem onClick={() => setMethod(method)}>
+                    {method.title}
+                  </DropdownItem>
+                </Conditional>
+              ))}
+            </DropdownList>
+          </Dropdown>
         </FormGroup>
         <Conditional if={method?.type == NotificationMethodType.email}>
           <CreateEmailNotification

--- a/web/src/routes/RepositoryDetails/Settings/NotificationsKebab.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/NotificationsKebab.tsx
@@ -1,17 +1,18 @@
+import {useEffect, useState} from 'react';
 import {
   Alert,
   AlertActionCloseButton,
   AlertGroup,
   Button,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
   Modal,
   ModalVariant,
 } from '@patternfly/react-core';
-import {
-  Dropdown,
-  DropdownItem,
-  KebabToggle,
-} from '@patternfly/react-core/deprecated';
-import {useEffect, useState} from 'react';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
 import Conditional from 'src/components/empty/Conditional';
 import {
@@ -24,8 +25,8 @@ export default function NotificationsKebab({
   repo,
   notification,
 }: NotificationsKebabProps) {
-  const [isOpen, setIsOpen] = useState<boolean>();
-  const [isTestModalOpen, setIsTestModalOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isTestModalOpen, setIsTestModalOpen] = useState(false);
   const {
     deleteNotifications,
     errorDeletingNotification,
@@ -101,34 +102,40 @@ export default function NotificationsKebab({
       </Modal>
       <Dropdown
         onSelect={() => setIsOpen(false)}
-        toggle={
-          <KebabToggle
-            onToggle={() => {
-              setIsOpen(!isOpen);
-            }}
-          />
-        }
-        isOpen={isOpen}
-        dropdownItems={[
-          <DropdownItem key="test" onClick={() => test(notification.uuid)}>
-            Test Notification
-          </DropdownItem>,
-          <DropdownItem
-            key="delete"
-            onClick={() => deleteNotifications(notification.uuid)}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="plain"
+            id={`${notification.uuid}-toggle-kebab`}
+            data-testid={`${notification.uuid}-toggle-kebab`}
+            onClick={() => setIsOpen(() => !isOpen)}
+            isExpanded={isOpen}
           >
+            <EllipsisVIcon />
+          </MenuToggle>
+        )}
+        isOpen={isOpen}
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>
+          <DropdownItem onClick={() => test(notification.uuid)}>
+            Test Notification
+          </DropdownItem>
+
+          <DropdownItem onClick={() => deleteNotifications(notification.uuid)}>
             Delete Notification
-          </DropdownItem>,
-          <Conditional key="enable" if={isNotificationDisabled(notification)}>
+          </DropdownItem>
+
+          <Conditional if={isNotificationDisabled(notification)}>
             <DropdownItem
               onClick={() => enableNotifications(notification.uuid)}
             >
               Enable Notification
             </DropdownItem>
-          </Conditional>,
-        ]}
-        isPlain
-      />
+          </Conditional>
+        </DropdownList>
+      </Dropdown>
     </>
   );
 }

--- a/web/src/routes/RepositoryDetails/Settings/PermissionsAddPermission.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/PermissionsAddPermission.tsx
@@ -5,17 +5,17 @@ import {
   AlertActionCloseButton,
   Button,
   Divider,
-  Form,
-  FormGroup,
-  Title,
-} from '@patternfly/react-core';
-import {
   Dropdown,
   DropdownItem,
-  DropdownToggle,
+  DropdownList,
+  Form,
+  FormGroup,
+  MenuToggle,
+  MenuToggleElement,
   SelectGroup,
   SelectOption,
-} from '@patternfly/react-core/deprecated';
+  Title,
+} from '@patternfly/react-core';
 import {DesktopIcon, UsersIcon} from '@patternfly/react-icons';
 import Conditional from 'src/components/empty/Conditional';
 import EntitySearch from 'src/components/EntitySearch';
@@ -50,38 +50,42 @@ export default function AddPermissions(props: AddPermissionsProps) {
     <React.Fragment key="creator">
       <Conditional if={!isUserOrganization}>
         <SelectGroup label="Teams" key="group3">
-          {props.teams?.map((t) => (
+          {props.teams?.map(({name}) => (
             <SelectOption
-              data-testid={`${t.name}-team`}
-              key={t.name}
-              value={t.name}
+              data-testid={`${name}-team`}
+              key={name}
+              value={name}
               onClick={() => {
                 props.setSelectedEntity({
+                  name,
                   is_robot: false,
-                  name: t.name,
                   kind: 'team',
                 });
               }}
-            />
+            >
+              {name}
+            </SelectOption>
           ))}
         </SelectGroup>
         <Divider component="li" key={4} />
       </Conditional>
       <SelectGroup label="Robot accounts" key="robot-account-grp">
-        {robots?.map((r) => (
+        {robots?.map(({name}) => (
           <SelectOption
-            data-testid={`${r.name}-robot-accnt`}
-            key={r.name}
-            value={r.name}
+            data-testid={`${name}-robot-accnt`}
+            key={name}
+            value={name}
             onClick={() => {
               props.setSelectedEntity({
+                name,
                 is_robot: true,
-                name: r.name,
                 kind: 'user',
                 is_org_member: true,
               });
             }}
-          />
+          >
+            {name}
+          </SelectOption>
         ))}
       </SelectGroup>
       <Divider component="li" key={5} />
@@ -91,7 +95,6 @@ export default function AddPermissions(props: AddPermissionsProps) {
           key="Create team1"
           component="button"
           onClick={() => props.setIsTeamModalOpen(!props.isTeamModalOpen)}
-          isPlaceholder
           isFocused
         >
           <UsersIcon /> &nbsp; Create team
@@ -104,7 +107,6 @@ export default function AddPermissions(props: AddPermissionsProps) {
         onClick={() =>
           props.setIsCreateRobotModalOpen(!props.isCreateRobotModalOpen)
         }
-        isPlaceholder
         isFocused
       >
         <DesktopIcon /> &nbsp; Create robot account
@@ -162,24 +164,31 @@ export default function AddPermissions(props: AddPermissionsProps) {
         <FormGroup fieldId="permission" label="Select a permission" required>
           <Dropdown
             onSelect={() => setIsPermissionOpen(false)}
-            toggle={
-              <DropdownToggle
-                onToggle={(_event, isOpen) => setIsPermissionOpen(isOpen)}
+            toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+              <MenuToggle
+                ref={toggleRef}
+                onClick={() => setIsPermissionOpen(() => !isPermissionOpen)}
+                isExpanded={isPermissionOpen}
               >
                 {role}
-              </DropdownToggle>
-            }
+              </MenuToggle>
+            )}
             isOpen={isPermissionOpen}
-            dropdownItems={roles.map((role) => (
-              <DropdownItem
-                key={role.name}
-                description={role.description}
-                onClick={() => setRole(role.role)}
-              >
-                {role.name}
-              </DropdownItem>
-            ))}
-          />
+            onOpenChange={(isOpen) => setIsPermissionOpen(isOpen)}
+            shouldFocusToggleOnSelect
+          >
+            <DropdownList>
+              {roles.map((role) => (
+                <DropdownItem
+                  key={role.name}
+                  description={role.description}
+                  onClick={() => setRole(role.role)}
+                >
+                  {role.name}
+                </DropdownItem>
+              ))}
+            </DropdownList>
+          </Dropdown>
         </FormGroup>
         <ActionGroup>
           <Button

--- a/web/src/routes/RepositoryDetails/Settings/PermissionsDropdown.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/PermissionsDropdown.tsx
@@ -1,14 +1,14 @@
+import {useState} from 'react';
 import {
   Alert,
   AlertActionCloseButton,
   AlertGroup,
-} from '@patternfly/react-core';
-import {
   Dropdown,
   DropdownItem,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
-import {useState} from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import Conditional from 'src/components/empty/Conditional';
 import {useUpdateRepositoryPermissions} from 'src/hooks/UseUpdateRepositoryPermissions';
 import {RepoMember} from 'src/resources/RepositoryResource';
@@ -39,24 +39,33 @@ export default function PermissionsDropdown({
       </Conditional>
       <Dropdown
         onSelect={() => setIsOpen(false)}
-        toggle={
-          <DropdownToggle onToggle={(_event, isOpen) => setIsOpen(isOpen)}>
-            {member.role}
-          </DropdownToggle>
-        }
-        isOpen={isOpen}
-        dropdownItems={roles.map((role) => (
-          <DropdownItem
-            key={role.name}
-            description={role.description}
-            onClick={() =>
-              setPermissions({members: member, newRole: role.role})
-            }
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            onClick={() => setIsOpen(() => !isOpen)}
+            isExpanded={isOpen}
           >
-            {role.name}
-          </DropdownItem>
-        ))}
-      />
+            {member.role}
+          </MenuToggle>
+        )}
+        isOpen={isOpen}
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>
+          {roles.map((role) => (
+            <DropdownItem
+              key={role.name}
+              description={role.description}
+              onClick={() =>
+                setPermissions({members: member, newRole: role.role})
+              }
+            >
+              {role.name}
+            </DropdownItem>
+          ))}
+        </DropdownList>
+      </Dropdown>
     </>
   );
 }

--- a/web/src/routes/RepositoryDetails/Settings/PermissionsKebab.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/PermissionsKebab.tsx
@@ -1,14 +1,15 @@
+import {useState} from 'react';
 import {
   Alert,
   AlertActionCloseButton,
   AlertGroup,
-} from '@patternfly/react-core';
-import {
   Dropdown,
   DropdownItem,
-  KebabToggle,
-} from '@patternfly/react-core/deprecated';
-import {useState} from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import Conditional from 'src/components/empty/Conditional';
 import {useUpdateRepositoryPermissions} from 'src/hooks/UseUpdateRepositoryPermissions';
 import {RepoMember} from 'src/resources/RepositoryResource';
@@ -42,22 +43,28 @@ export default function PermissionsKebab({member}: PermissionsKebabProps) {
       </Conditional>
       <Dropdown
         onSelect={onSelect}
-        toggle={
-          <KebabToggle
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            variant="plain"
             id={`${member.name}-toggle-kebab`}
-            onToggle={() => {
-              setIsOpen(!isOpen);
-            }}
-          />
-        }
+            data-testid={`${member.name}-toggle-kebab`}
+            onClick={() => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+          >
+            <EllipsisVIcon />
+          </MenuToggle>
+        )}
         isOpen={isOpen}
-        dropdownItems={[
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>
           <DropdownItem key="delete" onClick={() => deletePermissions(member)}>
             Delete Permission
-          </DropdownItem>,
-        ]}
-        isPlain
-      />
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
     </>
   );
 }

--- a/web/src/routes/RepositoryDetails/Tags/TagsActions.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsActions.tsx
@@ -1,10 +1,12 @@
+import {useState} from 'react';
 import {
   Dropdown,
   DropdownItem,
-  KebabToggle,
-  DropdownPosition,
-} from '@patternfly/react-core/deprecated';
-import {useState} from 'react';
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
+import EllipsisVIcon from '@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon';
 import AddTagModal from './TagsActionsAddTagModal';
 import EditLabelsModal from './TagsActionsLabelsModal';
 import EditExpirationModal from './TagsActionsEditExpirationModal';
@@ -94,17 +96,24 @@ export default function TagActions(props: TagActionsProps) {
   return (
     <>
       <Dropdown
-        toggle={
-          <KebabToggle
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
             id="tag-actions-kebab"
-            onToggle={(_event, isOpen: boolean) => setIsOpen(isOpen)}
-          />
-        }
+            aria-label="Tag actions kebab"
+            variant="plain"
+            onClick={() => setIsOpen(() => !isOpen)}
+            isExpanded={isOpen}
+          >
+            <EllipsisVIcon />
+          </MenuToggle>
+        )}
         isOpen={isOpen}
-        isPlain
-        position={DropdownPosition.right}
-        dropdownItems={dropdownItems}
-      />
+        onOpenChange={(isOpen) => setIsOpen(isOpen)}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>{dropdownItems}</DropdownList>
+      </Dropdown>
       <AddTagModal
         org={props.org}
         repo={props.repo}

--- a/web/src/routes/RepositoryDetails/Tags/TagsToolbar.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsToolbar.tsx
@@ -1,6 +1,10 @@
-import {Toolbar, ToolbarContent, ToolbarItem} from '@patternfly/react-core';
-import {DropdownItem} from '@patternfly/react-core/deprecated';
 import {ReactElement, useState} from 'react';
+import {
+  DropdownItem,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
 import {useRecoilState} from 'recoil';
 import {searchTagsState, selectedTagsState} from 'src/atoms/TagListState';
 import {Tag} from 'src/resources/TagResource';

--- a/web/src/routes/TagDetails/TagDetailsArchSelect.tsx
+++ b/web/src/routes/TagDetails/TagDetailsArchSelect.tsx
@@ -1,46 +1,66 @@
-import {Flex, FlexItem} from '@patternfly/react-core';
+import React from 'react';
 import {
-  Select,
-  SelectOption,
-  SelectVariant,
-} from '@patternfly/react-core/deprecated';
-import {useState} from 'react';
+  Flex,
+  FlexItem,
+  MenuToggle,
+  MenuToggleElement,
+  SelectList,
+} from '@patternfly/react-core';
+import {Select, SelectOption} from '@patternfly/react-core';
 import {Manifest} from 'src/resources/TagResource';
 
 export default function ArchSelect(props: ArchSelectProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    props.setDigest(value as string);
+    setIsOpen(false);
+  };
+
   if (!props.render) return null;
-  const [isSelectOpen, setIsSelectOpen] = useState<boolean>();
 
   return (
     <Flex>
       <FlexItem>Architecture</FlexItem>
       <FlexItem>
         <Select
-          variant={SelectVariant.single}
-          placeholderText="Architecture"
-          aria-label="Architecture select"
-          onToggle={() => {
-            setIsSelectOpen(!isSelectOpen);
-          }}
-          onSelect={(e, digest) => {
-            props.setDigest(digest as string);
-            setIsSelectOpen(false);
-          }}
-          selections={props.digest}
-          isOpen={isSelectOpen}
           data-testid="arch-select"
+          aria-label="Architecture select"
+          isOpen={isOpen}
+          selected={props.digest || 'Architecture'}
+          onSelect={onSelect}
+          onOpenChange={(isOpen) => setIsOpen(isOpen)}
+          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            <MenuToggle
+              ref={toggleRef}
+              onClick={() => setIsOpen(() => !isOpen)}
+              isExpanded={isOpen}
+            >
+              {getPlatformValue(
+                props.options.find((option) => option.digest === props.digest),
+              )}
+            </MenuToggle>
+          )}
+          shouldFocusToggleOnSelect
         >
-          {props.options.map((manifest, index) => (
-            <SelectOption key={index} value={manifest.digest}>
-              {' '}
-              {`${manifest.platform.os} on ${manifest.platform.architecture}`}{' '}
-            </SelectOption>
-          ))}
+          <SelectList>
+            {props.options.map((manifest, index) => (
+              <SelectOption key={index} value={manifest.digest}>
+                {getPlatformValue(manifest)}
+              </SelectOption>
+            ))}
+          </SelectList>
         </Select>
       </FlexItem>
     </Flex>
   );
 }
+
+const getPlatformValue = (manifest: Manifest) =>
+  `${manifest.platform.os} on ${manifest.platform.architecture}`;
 
 type ArchSelectProps = {
   digest: string;


### PR DESCRIPTION
### Summary
The following were updated to rid of legacy Patternfly components that will no longer exist in Patternfly v6:
- 25 `Dropdown`s (Many of which were Kebabs)
- 3 `Select`s (1 Typeahead - EntitySearch)
- 2 `Wizard`s (Both within modals)

(Table components were updated already as a part of the initial Patternfly v5 update PR)

As a result of the change, roughly half of the cypress tests had issues which were addressed mostly through updating selectors based on a newer DOM structure of the 3 types of components mentioned above.