### PR TITLE
Revert "build(deps): bump tldextract from 2.2.2 to 3.6.0 (#2310)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ supervisor==4.2.5
 supervisor-logging==0.0.9
 supervisor-stdout @ git+https://github.com/quay/supervisor-stdout.git@9bdf630d0d1b4a16cf8b60b96adafb1ed98e7380
 text-unidecode==1.3
-tldextract==3.6.0
+tldextract==2.2.2
 toposort==1.10
 tzlocal==5.0.1
 ua-parser==0.18.0
@@ -131,7 +131,6 @@ PyPDF3==1.0.6
 arabic-reshaper==3.0.0
 cffi==1.16.0
 cssselect2==0.7.0
-filelock==3.12.4
 furl==2.1.0
 html5lib==1.1
 idna==3.4


### PR DESCRIPTION
This reverts commit adbe34be671fba7c67f692d7abb35d3aec04c1e1.

tldextract 3.6.0+ uses md5, which is not allowed in FIPS-enabled environments. Possibly will be fixed by https://github.com/john-kurkowski/tldextract/pull/309.