### PR TITLE
marketplace: use get method for ebsAccountNumber lookup (PROJQUAY-6219)

### DIFF
--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -64,7 +64,7 @@ class RedHatUserApi(object):
         info = json.loads(r.content)
         if not info:
             return None
-        account_number = info[0]["accountRelationships"][0]["account"]["ebsAccountNumber"]
+        account_number = info[0]["accountRelationships"][0]["account"].get("ebsAccountNumber")
         return account_number
 
 


### PR DESCRIPTION
Change lookup in marketplace logic to use `get()` when finding `ebsAccountNumber` so that if there is no account number it returns `None` and continues without throwing an exception.