### PR TITLE
ui: Fix styling conflict with RedHatInsights (PROJQUAY-6085)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,7 @@
         "@patternfly/react-core": "^5.1.0",
         "@patternfly/react-icons": "^5.1.0",
         "@patternfly/react-table": "^5.1.0",
-        "@redhat-cloud-services/frontend-components": "^3.9.31",
+        "@redhat-cloud-services/frontend-components": "^4.0.14",
         "@redhat-cloud-services/frontend-components-config-utilities": "^3.0.4",
         "@tanstack/react-query": "^4.13.5",
         "@testing-library/jest-dom": "^5.16.4",
@@ -2077,6 +2077,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
+      "integrity": "sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==",
+      "dependencies": {
+        "@emotion/memoize": "0.7.1"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
+      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -4046,17 +4059,17 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-2.0.1.tgz",
-      "integrity": "sha512-fiSPxk8ghs/aEp7UasDBhjdXrQ5/IQl+QuCB8FHz6IhAkN5mB/aQ7GcBHfW+ITK4g0eb6ydb4x2IaKP8iZeBJw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-4.0.0.tgz",
+      "integrity": "sha512-OQsRqpRFz8IO6dZP6oKqdS7fLpdK25jxteevhussWFDd6RETNaLAG9GaSfvN0oigrzNIUTwH59kJx8PP8PrMug==",
       "dependencies": {
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.21",
         "semver": "^7.3.7",
         "uuid": "^8.3.2",
         "yup": "^0.32.11"
       },
       "peerDependencies": {
-        "react": "^17.0.2"
+        "react": "^17 || ^18"
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk-webpack": {
@@ -4089,9 +4102,9 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.0.4.tgz",
-      "integrity": "sha512-8akdWzFpG384Q6Es8lzkfuhAlzVGrNK7TJqXGecHDAg8u1JsYn3+Nw6gLRviI88z8Kjxmg5YKirILjpclGxkIA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.1.0.tgz",
+      "integrity": "sha512-wzVgL/0xPsmuRKWc6lMNEo5gDcTUtyU231eJSBTapOKXiwBOv2flvLEHPYLO6oDYXO+hwUrVgbcZFWMd1UlLwA=="
     },
     "node_modules/@patternfly/react-charts": {
       "version": "7.1.1",
@@ -4126,6 +4139,20 @@
         "react-dom": "^17 || ^18"
       }
     },
+    "node_modules/@patternfly/react-component-groups": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-1.4.0.tgz",
+      "integrity": "sha512-Mz4SJKKzW24K/lmUv6w35a4UEpTlj1X0/R0p4yeqhXKJC/8dWvxF9PdKhRbCsOS9yjLqhe6R/23kljXFEcX3cA==",
+      "dependencies": {
+        "@patternfly/react-core": "^5.0.0",
+        "@patternfly/react-icons": "^5.0.0",
+        "react-jss": "^10.9.2"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
     "node_modules/@patternfly/react-core": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.1.0.tgz",
@@ -4144,11 +4171,6 @@
         "react-dom": "^17 || ^18"
       }
     },
-    "node_modules/@patternfly/react-core/node_modules/@patternfly/patternfly": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.0.2.tgz",
-      "integrity": "sha512-PB8+MLdYVgF1hIOxGmnVsZG+YHUX3RePe5W1oMS4gS00EmSgw1cobr1Qbpy/BqqS8/R9DRN4hZ2FKDT0d5tkFQ=="
-    },
     "node_modules/@patternfly/react-icons": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.0.tgz",
@@ -4160,11 +4182,6 @@
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
-    },
-    "node_modules/@patternfly/react-icons/node_modules/@patternfly/patternfly": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.0.2.tgz",
-      "integrity": "sha512-PB8+MLdYVgF1hIOxGmnVsZG+YHUX3RePe5W1oMS4gS00EmSgw1cobr1Qbpy/BqqS8/R9DRN4hZ2FKDT0d5tkFQ=="
     },
     "node_modules/@patternfly/react-styles": {
       "version": "5.1.1",
@@ -4375,26 +4392,27 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "3.9.31",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.31.tgz",
-      "integrity": "sha512-sFQNVaQrF9I7cY4/yg9T7GL1yhNv2eSq9y9dVqAcFr4GjNu9OLINGmpvHscF2eOekfsO3wuf6Jdl5G9/bJLX5Q==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.0.14.tgz",
+      "integrity": "sha512-GinI/xNU8aXAkCoR/5V9FWI169dz9z9GjNUaE9wJ6dyb91XJ1fFGOyeiV9K7Ej2Sh6KrPq+ZHRnZFx8TEtm4Lg==",
       "dependencies": {
-        "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
-        "@redhat-cloud-services/types": "^0.0.17",
-        "@scalprum/core": "^0.2.3",
-        "@scalprum/react-core": "^0.4.0",
+        "@patternfly/react-component-groups": "^1.2.1",
+        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
+        "@redhat-cloud-services/types": "^0.0.24",
+        "@scalprum/core": "^0.5.4",
+        "@scalprum/react-core": "^0.5.4",
         "sanitize-html": "^2.7.2"
       },
       "peerDependencies": {
-        "@patternfly/react-core": "^4.18.5",
-        "@patternfly/react-icons": "^4.53.16",
-        "@patternfly/react-table": "^4.5.7",
+        "@patternfly/react-core": "^5.0.0",
+        "@patternfly/react-icons": "^5.0.0",
+        "@patternfly/react-table": "^5.0.0",
         "classnames": "^2.2.5",
         "lodash": "^4.17.15",
         "prop-types": "^15.6.2",
-        "react": "^16.14.0 || ^17.0.0",
+        "react": "^18.2.0",
         "react-content-loader": "^6.2.0",
-        "react-dom": "^16.14.0 || ^17.0.0",
+        "react-dom": "^18.2.0",
         "react-redux": ">=7.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
@@ -4476,10 +4494,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components/node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.6.tgz",
-      "integrity": "sha512-qXevUW8Clj1AoBLwfZAmS+oFJCWKZaMp8O33cyUhkoGjrwkQaL5eJg28zjLVa1uQhdJAvAdwTNtE+Gt3hJTC1g==",
+    "node_modules/@redhat-cloud-services/frontend-components-utilities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.2.tgz",
+      "integrity": "sha512-LUAaJwpi8EmyrNrGum53HcSpO0rrwvXkdEmaXjfooRlvVtLz8twsjaiM2jFfqWXbZMq43gQufn/wy8nquRoq6w==",
       "dependencies": {
         "@redhat-cloud-services/types": "^0.0.24",
         "@sentry/browser": "^5.30.0",
@@ -4490,22 +4508,17 @@
         "react-content-loader": "^6.2.0"
       },
       "peerDependencies": {
-        "@patternfly/react-core": "^4.239.0",
-        "@patternfly/react-table": "^4.108.0",
+        "@patternfly/react-core": "^5.0.0",
+        "@patternfly/react-table": "^5.0.0",
         "@redhat-cloud-services/rbac-client": "^1.0.100",
-        "cypress": ">=10.0.0 < 13.0.0",
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
+        "cypress": ">=12.0.0 < 14.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "react-redux": ">=7.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components/node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/@redhat-cloud-services/types": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.24.tgz",
-      "integrity": "sha512-P50stc+mnWLycID46/AKmD/760r5N1eoam//O6MUVriqVorUdht7xkUL78aJZU1vw8WW6xlrDHwz3F6BM148qg=="
-    },
-    "node_modules/@redhat-cloud-services/frontend-components/node_modules/axios": {
+    "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/axios": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
       "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
@@ -4514,12 +4527,12 @@
         "form-data": "^4.0.0"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components/node_modules/commander": {
+    "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
-    "node_modules/@redhat-cloud-services/frontend-components/node_modules/mkdirp": {
+    "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
@@ -4531,9 +4544,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/rbac-client": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.9.tgz",
-      "integrity": "sha512-EyCf8WHaAdCumfK74PBedQvtqWwE42LESWu9KIInyHz6JgzsO0XmM7NsQQeUkO7PJsiHdKY+rpLF/ZXZWAjB4w==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.11.tgz",
+      "integrity": "sha512-zFTumiNZdgxAuihm53JwUM37nF5yMyMsDxlJ9EMD11SXLKh1LkNZVScie3y7JT7VQ6D8C8y74TAn/n5B25Vq4w==",
       "peer": true,
       "dependencies": {
         "axios": "^0.27.2"
@@ -4550,9 +4563,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/types": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
-      "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.24.tgz",
+      "integrity": "sha512-P50stc+mnWLycID46/AKmD/760r5N1eoam//O6MUVriqVorUdht7xkUL78aJZU1vw8WW6xlrDHwz3F6BM148qg=="
     },
     "node_modules/@remix-run/router": {
       "version": "1.8.0",
@@ -4642,30 +4655,25 @@
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw=="
     },
     "node_modules/@scalprum/core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.2.6.tgz",
-      "integrity": "sha512-EXaQkQ0T6nsk4rEpYJjDchrINSQfDEK6sAhxICr2tr927FPWDo7nGNpxhPYr5/6Vpw+pcc7YAEGyjzdQUzmfqg=="
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.5.4.tgz",
+      "integrity": "sha512-Z6/u1J8aRopYEfg5YzmPx+jFEjoeEQCHJPmEABLn44Dr1CmZJJStS4+jANRJXZCcGQhTH3Wsn/hu02hGxMVuCQ==",
+      "dependencies": {
+        "@openshift/dynamic-plugin-sdk": "^4.0.0"
+      }
     },
     "node_modules/@scalprum/react-core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
-      "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.5.4.tgz",
+      "integrity": "sha512-tBAUstwEDri7ApIyfAzVfRzVj2MmlKVy29eFL4lOEZf7M96uUCdhmYtSdDPka7CegplgHN+9AtuSLiYR97K2gg==",
       "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^2.0.1",
-        "@scalprum/core": "^0.4.1",
+        "@openshift/dynamic-plugin-sdk": "^4.0.0",
+        "@scalprum/core": "^0.5.4",
         "lodash": "^4.17.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0 || >=17.0.0",
         "react-dom": ">=16.8.0 || >=17.0.0"
-      }
-    },
-    "node_modules/@scalprum/react-core/node_modules/@scalprum/core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.4.1.tgz",
-      "integrity": "sha512-Ff8G2Mhc6ORPx+5C/B6vYYyGL2mBmQ8jR1I0yhgmYClzZU4gzQalZrSIwBDozGCoYmdKggF+hPCxojFwgE227g==",
-      "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^2.0.1"
       }
     },
     "node_modules/@sentry/browser": {
@@ -5533,9 +5541,9 @@
       "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "node_modules/@types/debounce-promise": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.7.tgz",
-      "integrity": "sha512-XzqG8zCd9n33gmusdQo0d4p9iRKg/mZbG52wfHxnuZZyeO68ryOT5xyv9Fk3vLAvQBUsHmSL14Cqpsx4jjzz1Q=="
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.8.tgz",
+      "integrity": "sha512-xtglA5PhbH1XpWrzeiE+dUwuzZlhtICqq+IoXMIepMa39qM2YHhmsqCMG5ZTDX8i4G6833PZDgSbm0ALiZcngg=="
     },
     "node_modules/@types/eslint": {
       "version": "8.44.2",
@@ -5596,9 +5604,9 @@
       "dev": true
     },
     "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.4.tgz",
+      "integrity": "sha512-ZchYkbieA+7tnxwX/SCBySx9WwvWR8TaP5tb2jRAzwvLb/rWchGw3v0w3pqUbUvj0GCwW2Xz/AVPSk6kUGctXQ==",
       "peer": true,
       "dependencies": {
         "@types/react": "*",
@@ -9450,6 +9458,16 @@
         "postcss": "^8.4"
       }
     },
+    "node_modules/css-jss": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/css-jss/-/css-jss-10.10.0.tgz",
+      "integrity": "sha512-YyMIS/LsSKEGXEaVJdjonWe18p4vXLo8CMA4FrW/kcaEyqdIGKCFXao31gbJddXEdIxSXFFURWrenBJPlKTgAA==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "^10.10.0",
+        "jss-preset-default": "^10.10.0"
+      }
+    },
     "node_modules/css-loader": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.8.1.tgz",
@@ -9747,6 +9765,15 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
       }
     },
     "node_modules/css-what": {
@@ -14388,6 +14415,11 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -14804,6 +14836,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
@@ -19023,6 +19060,158 @@
         "verror": "1.10.0"
       }
     },
+    "node_modules/jss": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
+      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/jss"
+      }
+    },
+    "node_modules/jss-plugin-camel-case": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
+      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.10.0"
+      }
+    },
+    "node_modules/jss-plugin-compose": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-compose/-/jss-plugin-compose-10.10.0.tgz",
+      "integrity": "sha512-F5kgtWpI2XfZ3Z8eP78tZEYFdgTIbpA/TMuX3a8vwrNolYtN1N4qJR/Ob0LAsqIwCMLojtxN7c7Oo/+Vz6THow==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "node_modules/jss-plugin-default-unit": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
+      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "node_modules/jss-plugin-expand": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-expand/-/jss-plugin-expand-10.10.0.tgz",
+      "integrity": "sha512-ymT62W2OyDxBxr7A6JR87vVX9vTq2ep5jZLIdUSusfBIEENLdkkc0lL/Xaq8W9s3opUq7R0sZQpzRWELrfVYzA==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "node_modules/jss-plugin-extend": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-extend/-/jss-plugin-extend-10.10.0.tgz",
+      "integrity": "sha512-sKYrcMfr4xxigmIwqTjxNcHwXJIfvhvjTNxF+Tbc1NmNdyspGW47Ey6sGH8BcQ4FFQhLXctpWCQSpDwdNmXSwg==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "node_modules/jss-plugin-global": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
+      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "node_modules/jss-plugin-nested": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
+      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "node_modules/jss-plugin-props-sort": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
+      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "node_modules/jss-plugin-rule-value-function": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
+      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "node_modules/jss-plugin-rule-value-observable": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-observable/-/jss-plugin-rule-value-observable-10.10.0.tgz",
+      "integrity": "sha512-ZLMaYrR3QE+vD7nl3oNXuj79VZl9Kp8/u6A1IbTPDcuOu8b56cFdWRZNZ0vNr8jHewooEeq2doy8Oxtymr2ZPA==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "node_modules/jss-plugin-template": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-template/-/jss-plugin-template-10.10.0.tgz",
+      "integrity": "sha512-ocXZBIOJOA+jISPdsgkTs8wwpK6UbsvtZK5JI7VUggTD6LWKbtoxUzadd2TpfF+lEtlhUmMsCkTRNkITdPKa6w==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "node_modules/jss-plugin-vendor-prefixer": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
+      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.8",
+        "jss": "10.10.0"
+      }
+    },
+    "node_modules/jss-preset-default": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-10.10.0.tgz",
+      "integrity": "sha512-GL175Wt2FGhjE+f+Y3aWh+JioL06/QWFgZp53CbNNq6ZkVU0TDplD8Bxm9KnkotAYn3FlplNqoW5CjyLXcoJ7Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "jss-plugin-camel-case": "10.10.0",
+        "jss-plugin-compose": "10.10.0",
+        "jss-plugin-default-unit": "10.10.0",
+        "jss-plugin-expand": "10.10.0",
+        "jss-plugin-extend": "10.10.0",
+        "jss-plugin-global": "10.10.0",
+        "jss-plugin-nested": "10.10.0",
+        "jss-plugin-props-sort": "10.10.0",
+        "jss-plugin-rule-value-function": "10.10.0",
+        "jss-plugin-rule-value-observable": "10.10.0",
+        "jss-plugin-template": "10.10.0",
+        "jss-plugin-vendor-prefixer": "10.10.0"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -22436,9 +22625,9 @@
       }
     },
     "node_modules/react-content-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-6.2.0.tgz",
-      "integrity": "sha512-r1dI6S+uHNLW68qraLE2njJYOuy6976PpCExuCZUcABWbfnF3FMcmuESRI8L4Bj45wnZ7n8g71hkPLzbma7/Cw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-6.2.1.tgz",
+      "integrity": "sha512-6ONbFX+Hi3SHuP66JB8CPvJn372pj+qwltJV0J8z/8MFrq98I1cbFdZuhDWeQXu3CFxiiDTXJn7DFxx2ZvrO7g==",
       "engines": {
         "node": ">=10"
       },
@@ -22619,6 +22808,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/react-display-name": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
+      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
     },
     "node_modules/react-docgen-typescript": {
       "version": "1.22.0",
@@ -23425,10 +23619,31 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-jss": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-10.10.0.tgz",
+      "integrity": "sha512-WLiq84UYWqNBF6579/uprcIUnM1TSywYq6AIjKTTTG5ziJl9Uy+pwuvpN3apuyVwflMbD60PraeTKT7uWH9XEQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "@emotion/is-prop-valid": "^0.7.3",
+        "css-jss": "10.10.0",
+        "hoist-non-react-statics": "^3.2.0",
+        "is-in-browser": "^1.1.3",
+        "jss": "10.10.0",
+        "jss-preset-default": "10.10.0",
+        "prop-types": "^15.6.0",
+        "shallow-equal": "^1.2.0",
+        "theming": "^3.3.0",
+        "tiny-warning": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.6"
+      }
+    },
     "node_modules/react-redux": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
-      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.1",
@@ -23444,7 +23659,7 @@
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0",
         "react-native": ">=0.59",
-        "redux": "^4"
+        "redux": "^4 || ^5.0.0-beta.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -26351,6 +26566,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -27528,6 +27748,14 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true
     },
+    "node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -27746,6 +27974,23 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
+    "node_modules/theming": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/theming/-/theming-3.3.0.tgz",
+      "integrity": "sha512-u6l4qTJRDaWZsqa8JugaNt7Xd8PPl9+gonZaIe28vAhqgHMIG/DOyFPqiKN/gQLQYj05tHv+YQdNILL4zoiAVA==",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0",
+        "prop-types": "^15.5.8",
+        "react-display-name": "^0.2.4",
+        "tiny-warning": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.3"
+      }
+    },
     "node_modules/throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
@@ -27817,6 +28062,11 @@
       "engines": {
         "node": ">=0.6.0"
       }
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/titleize": {
       "version": "3.0.0",
@@ -32202,6 +32452,19 @@
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true
     },
+    "@emotion/is-prop-valid": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
+      "integrity": "sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==",
+      "requires": {
+        "@emotion/memoize": "0.7.1"
+      }
+    },
+    "@emotion/memoize": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
+      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -33724,11 +33987,11 @@
       }
     },
     "@openshift/dynamic-plugin-sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-2.0.1.tgz",
-      "integrity": "sha512-fiSPxk8ghs/aEp7UasDBhjdXrQ5/IQl+QuCB8FHz6IhAkN5mB/aQ7GcBHfW+ITK4g0eb6ydb4x2IaKP8iZeBJw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-4.0.0.tgz",
+      "integrity": "sha512-OQsRqpRFz8IO6dZP6oKqdS7fLpdK25jxteevhussWFDd6RETNaLAG9GaSfvN0oigrzNIUTwH59kJx8PP8PrMug==",
       "requires": {
-        "lodash-es": "^4.17.21",
+        "lodash": "^4.17.21",
         "semver": "^7.3.7",
         "uuid": "^8.3.2",
         "yup": "^0.32.11"
@@ -33754,9 +34017,9 @@
       }
     },
     "@patternfly/patternfly": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.0.4.tgz",
-      "integrity": "sha512-8akdWzFpG384Q6Es8lzkfuhAlzVGrNK7TJqXGecHDAg8u1JsYn3+Nw6gLRviI88z8Kjxmg5YKirILjpclGxkIA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.1.0.tgz",
+      "integrity": "sha512-wzVgL/0xPsmuRKWc6lMNEo5gDcTUtyU231eJSBTapOKXiwBOv2flvLEHPYLO6oDYXO+hwUrVgbcZFWMd1UlLwA=="
     },
     "@patternfly/react-charts": {
       "version": "7.1.1",
@@ -33787,25 +34050,28 @@
         "victory-zoom-container": "^36.6.11"
       }
     },
+    "@patternfly/react-component-groups": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-1.4.0.tgz",
+      "integrity": "sha512-Mz4SJKKzW24K/lmUv6w35a4UEpTlj1X0/R0p4yeqhXKJC/8dWvxF9PdKhRbCsOS9yjLqhe6R/23kljXFEcX3cA==",
+      "requires": {
+        "@patternfly/react-core": "^5.1.0",
+        "@patternfly/react-icons": "^5.1.0",
+        "react-jss": "^10.9.2"
+      }
+    },
     "@patternfly/react-core": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.1.0.tgz",
       "integrity": "sha512-m6MtCQsWiyGM40L4oLc2aEFlxT8egdoz/58Q2oW1fMkqUaosuNUiwy9/e8zOM3SLOPOo/Qo9cetQkIHVQppCvw==",
       "requires": {
-        "@patternfly/patternfly": "5.0.2",
+        "@patternfly/patternfly": "^5.0.4",
         "@patternfly/react-icons": "^5.1.0",
         "@patternfly/react-styles": "^5.1.0",
         "@patternfly/react-tokens": "^5.1.0",
         "focus-trap": "7.4.3",
         "react-dropzone": "^14.2.3",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@patternfly/patternfly": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.0.2.tgz",
-          "integrity": "sha512-PB8+MLdYVgF1hIOxGmnVsZG+YHUX3RePe5W1oMS4gS00EmSgw1cobr1Qbpy/BqqS8/R9DRN4hZ2FKDT0d5tkFQ=="
-        }
       }
     },
     "@patternfly/react-icons": {
@@ -33813,14 +34079,7 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.0.tgz",
       "integrity": "sha512-mSFAJMrT6QUQ10DifYYGSXOPlFob88lWPZXeOyPdstJ8cJRRRVTMYgoR/VnXsUO/vthwFbViY+sS6+/jL8pl9w==",
       "requires": {
-        "@patternfly/patternfly": "5.0.2"
-      },
-      "dependencies": {
-        "@patternfly/patternfly": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.0.2.tgz",
-          "integrity": "sha512-PB8+MLdYVgF1hIOxGmnVsZG+YHUX3RePe5W1oMS4gS00EmSgw1cobr1Qbpy/BqqS8/R9DRN4hZ2FKDT0d5tkFQ=="
-        }
+        "@patternfly/patternfly": "^5.0.4"
       }
     },
     "@patternfly/react-styles": {
@@ -33947,57 +34206,16 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "3.9.31",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.31.tgz",
-      "integrity": "sha512-sFQNVaQrF9I7cY4/yg9T7GL1yhNv2eSq9y9dVqAcFr4GjNu9OLINGmpvHscF2eOekfsO3wuf6Jdl5G9/bJLX5Q==",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.0.14.tgz",
+      "integrity": "sha512-GinI/xNU8aXAkCoR/5V9FWI169dz9z9GjNUaE9wJ6dyb91XJ1fFGOyeiV9K7Ej2Sh6KrPq+ZHRnZFx8TEtm4Lg==",
       "requires": {
-        "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
-        "@redhat-cloud-services/types": "^0.0.17",
-        "@scalprum/core": "^0.2.3",
-        "@scalprum/react-core": "^0.4.0",
+        "@patternfly/react-component-groups": "^1.2.1",
+        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
+        "@redhat-cloud-services/types": "^0.0.24",
+        "@scalprum/core": "^0.5.4",
+        "@scalprum/react-core": "^0.5.4",
         "sanitize-html": "^2.7.2"
-      },
-      "dependencies": {
-        "@redhat-cloud-services/frontend-components-utilities": {
-          "version": "3.7.6",
-          "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-3.7.6.tgz",
-          "integrity": "sha512-qXevUW8Clj1AoBLwfZAmS+oFJCWKZaMp8O33cyUhkoGjrwkQaL5eJg28zjLVa1uQhdJAvAdwTNtE+Gt3hJTC1g==",
-          "requires": {
-            "@redhat-cloud-services/types": "^0.0.24",
-            "@sentry/browser": "^5.30.0",
-            "awesome-debounce-promise": "^2.1.0",
-            "axios": "^0.27.2",
-            "commander": "^2.20.3",
-            "mkdirp": "^1.0.4",
-            "react-content-loader": "^6.2.0"
-          },
-          "dependencies": {
-            "@redhat-cloud-services/types": {
-              "version": "0.0.24",
-              "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.24.tgz",
-              "integrity": "sha512-P50stc+mnWLycID46/AKmD/760r5N1eoam//O6MUVriqVorUdht7xkUL78aJZU1vw8WW6xlrDHwz3F6BM148qg=="
-            }
-          }
-        },
-        "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-          "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        }
       }
     },
     "@redhat-cloud-services/frontend-components-config-utilities": {
@@ -34055,10 +34273,45 @@
         }
       }
     },
+    "@redhat-cloud-services/frontend-components-utilities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.2.tgz",
+      "integrity": "sha512-LUAaJwpi8EmyrNrGum53HcSpO0rrwvXkdEmaXjfooRlvVtLz8twsjaiM2jFfqWXbZMq43gQufn/wy8nquRoq6w==",
+      "requires": {
+        "@redhat-cloud-services/types": "^0.0.24",
+        "@sentry/browser": "^5.30.0",
+        "awesome-debounce-promise": "^2.1.0",
+        "axios": "^0.27.2",
+        "commander": "^2.20.3",
+        "mkdirp": "^1.0.4",
+        "react-content-loader": "^6.2.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        }
+      }
+    },
     "@redhat-cloud-services/rbac-client": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.9.tgz",
-      "integrity": "sha512-EyCf8WHaAdCumfK74PBedQvtqWwE42LESWu9KIInyHz6JgzsO0XmM7NsQQeUkO7PJsiHdKY+rpLF/ZXZWAjB4w==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.2.11.tgz",
+      "integrity": "sha512-zFTumiNZdgxAuihm53JwUM37nF5yMyMsDxlJ9EMD11SXLKh1LkNZVScie3y7JT7VQ6D8C8y74TAn/n5B25Vq4w==",
       "peer": true,
       "requires": {
         "axios": "^0.27.2"
@@ -34077,9 +34330,9 @@
       }
     },
     "@redhat-cloud-services/types": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
-      "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.24.tgz",
+      "integrity": "sha512-P50stc+mnWLycID46/AKmD/760r5N1eoam//O6MUVriqVorUdht7xkUL78aJZU1vw8WW6xlrDHwz3F6BM148qg=="
     },
     "@remix-run/router": {
       "version": "1.8.0",
@@ -34140,28 +34393,21 @@
       "integrity": "sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw=="
     },
     "@scalprum/core": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.2.6.tgz",
-      "integrity": "sha512-EXaQkQ0T6nsk4rEpYJjDchrINSQfDEK6sAhxICr2tr927FPWDo7nGNpxhPYr5/6Vpw+pcc7YAEGyjzdQUzmfqg=="
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.5.4.tgz",
+      "integrity": "sha512-Z6/u1J8aRopYEfg5YzmPx+jFEjoeEQCHJPmEABLn44Dr1CmZJJStS4+jANRJXZCcGQhTH3Wsn/hu02hGxMVuCQ==",
+      "requires": {
+        "@openshift/dynamic-plugin-sdk": "^4.0.0"
+      }
     },
     "@scalprum/react-core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
-      "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.5.4.tgz",
+      "integrity": "sha512-tBAUstwEDri7ApIyfAzVfRzVj2MmlKVy29eFL4lOEZf7M96uUCdhmYtSdDPka7CegplgHN+9AtuSLiYR97K2gg==",
       "requires": {
-        "@openshift/dynamic-plugin-sdk": "^2.0.1",
-        "@scalprum/core": "^0.4.1",
+        "@openshift/dynamic-plugin-sdk": "^4.0.0",
+        "@scalprum/core": "^0.5.4",
         "lodash": "^4.17.0"
-      },
-      "dependencies": {
-        "@scalprum/core": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.4.1.tgz",
-          "integrity": "sha512-Ff8G2Mhc6ORPx+5C/B6vYYyGL2mBmQ8jR1I0yhgmYClzZU4gzQalZrSIwBDozGCoYmdKggF+hPCxojFwgE227g==",
-          "requires": {
-            "@openshift/dynamic-plugin-sdk": "^2.0.1"
-          }
-        }
       }
     },
     "@sentry/browser": {
@@ -34827,9 +35073,9 @@
       "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g=="
     },
     "@types/debounce-promise": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.7.tgz",
-      "integrity": "sha512-XzqG8zCd9n33gmusdQo0d4p9iRKg/mZbG52wfHxnuZZyeO68ryOT5xyv9Fk3vLAvQBUsHmSL14Cqpsx4jjzz1Q=="
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.8.tgz",
+      "integrity": "sha512-xtglA5PhbH1XpWrzeiE+dUwuzZlhtICqq+IoXMIepMa39qM2YHhmsqCMG5ZTDX8i4G6833PZDgSbm0ALiZcngg=="
     },
     "@types/eslint": {
       "version": "8.44.2",
@@ -34890,9 +35136,9 @@
       "dev": true
     },
     "@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.4.tgz",
+      "integrity": "sha512-ZchYkbieA+7tnxwX/SCBySx9WwvWR8TaP5tb2jRAzwvLb/rWchGw3v0w3pqUbUvj0GCwW2Xz/AVPSk6kUGctXQ==",
       "peer": true,
       "requires": {
         "@types/react": "^17.0.2",
@@ -37901,6 +38147,16 @@
         "postcss-selector-parser": "^6.0.9"
       }
     },
+    "css-jss": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/css-jss/-/css-jss-10.10.0.tgz",
+      "integrity": "sha512-YyMIS/LsSKEGXEaVJdjonWe18p4vXLo8CMA4FrW/kcaEyqdIGKCFXao31gbJddXEdIxSXFFURWrenBJPlKTgAA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "^10.10.0",
+        "jss-preset-default": "^10.10.0"
+      }
+    },
     "css-loader": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.8.1.tgz",
@@ -38097,6 +38353,15 @@
       "requires": {
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
+      }
+    },
+    "css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
       }
     },
     "css-what": {
@@ -41591,6 +41856,11 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -41862,6 +42132,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "is-inside-container": {
       "version": "1.0.0",
@@ -45063,6 +45338,154 @@
         "verror": "1.10.0"
       }
     },
+    "jss": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
+      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
+      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-plugin-compose": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-compose/-/jss-plugin-compose-10.10.0.tgz",
+      "integrity": "sha512-F5kgtWpI2XfZ3Z8eP78tZEYFdgTIbpA/TMuX3a8vwrNolYtN1N4qJR/Ob0LAsqIwCMLojtxN7c7Oo/+Vz6THow==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
+      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-plugin-expand": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-expand/-/jss-plugin-expand-10.10.0.tgz",
+      "integrity": "sha512-ymT62W2OyDxBxr7A6JR87vVX9vTq2ep5jZLIdUSusfBIEENLdkkc0lL/Xaq8W9s3opUq7R0sZQpzRWELrfVYzA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-plugin-extend": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-extend/-/jss-plugin-extend-10.10.0.tgz",
+      "integrity": "sha512-sKYrcMfr4xxigmIwqTjxNcHwXJIfvhvjTNxF+Tbc1NmNdyspGW47Ey6sGH8BcQ4FFQhLXctpWCQSpDwdNmXSwg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
+      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
+      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
+      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
+      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-rule-value-observable": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-observable/-/jss-plugin-rule-value-observable-10.10.0.tgz",
+      "integrity": "sha512-ZLMaYrR3QE+vD7nl3oNXuj79VZl9Kp8/u6A1IbTPDcuOu8b56cFdWRZNZ0vNr8jHewooEeq2doy8Oxtymr2ZPA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "symbol-observable": "^1.2.0"
+      }
+    },
+    "jss-plugin-template": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-template/-/jss-plugin-template-10.10.0.tgz",
+      "integrity": "sha512-ocXZBIOJOA+jISPdsgkTs8wwpK6UbsvtZK5JI7VUggTD6LWKbtoxUzadd2TpfF+lEtlhUmMsCkTRNkITdPKa6w==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
+      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.8",
+        "jss": "10.10.0"
+      }
+    },
+    "jss-preset-default": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-10.10.0.tgz",
+      "integrity": "sha512-GL175Wt2FGhjE+f+Y3aWh+JioL06/QWFgZp53CbNNq6ZkVU0TDplD8Bxm9KnkotAYn3FlplNqoW5CjyLXcoJ7Q==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.10.0",
+        "jss-plugin-camel-case": "10.10.0",
+        "jss-plugin-compose": "10.10.0",
+        "jss-plugin-default-unit": "10.10.0",
+        "jss-plugin-expand": "10.10.0",
+        "jss-plugin-extend": "10.10.0",
+        "jss-plugin-global": "10.10.0",
+        "jss-plugin-nested": "10.10.0",
+        "jss-plugin-props-sort": "10.10.0",
+        "jss-plugin-rule-value-function": "10.10.0",
+        "jss-plugin-rule-value-observable": "10.10.0",
+        "jss-plugin-template": "10.10.0",
+        "jss-plugin-vendor-prefixer": "10.10.0"
+      }
+    },
     "jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -47528,9 +47951,9 @@
       }
     },
     "react-content-loader": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-6.2.0.tgz",
-      "integrity": "sha512-r1dI6S+uHNLW68qraLE2njJYOuy6976PpCExuCZUcABWbfnF3FMcmuESRI8L4Bj45wnZ7n8g71hkPLzbma7/Cw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-6.2.1.tgz",
+      "integrity": "sha512-6ONbFX+Hi3SHuP66JB8CPvJn372pj+qwltJV0J8z/8MFrq98I1cbFdZuhDWeQXu3CFxiiDTXJn7DFxx2ZvrO7g==",
       "requires": {}
     },
     "react-dev-utils": {
@@ -47651,6 +48074,11 @@
           }
         }
       }
+    },
+    "react-display-name": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
+      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
     },
     "react-docgen-typescript": {
       "version": "1.22.0",
@@ -48322,10 +48750,28 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-jss": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-10.10.0.tgz",
+      "integrity": "sha512-WLiq84UYWqNBF6579/uprcIUnM1TSywYq6AIjKTTTG5ziJl9Uy+pwuvpN3apuyVwflMbD60PraeTKT7uWH9XEQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "@emotion/is-prop-valid": "^0.7.3",
+        "css-jss": "10.10.0",
+        "hoist-non-react-statics": "^3.2.0",
+        "is-in-browser": "^1.1.3",
+        "jss": "10.10.0",
+        "jss-preset-default": "10.10.0",
+        "prop-types": "^15.6.0",
+        "shallow-equal": "^1.2.0",
+        "theming": "^3.3.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
     "react-redux": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
-      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.1",
@@ -50423,6 +50869,11 @@
         "kind-of": "^6.0.2"
       }
     },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -51366,6 +51817,11 @@
         }
       }
     },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -51515,6 +51971,17 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
+    "theming": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/theming/-/theming-3.3.0.tgz",
+      "integrity": "sha512-u6l4qTJRDaWZsqa8JugaNt7Xd8PPl9+gonZaIe28vAhqgHMIG/DOyFPqiKN/gQLQYj05tHv+YQdNILL4zoiAVA==",
+      "requires": {
+        "hoist-non-react-statics": "^3.3.0",
+        "prop-types": "^15.5.8",
+        "react-display-name": "^0.2.4",
+        "tiny-warning": "^1.0.2"
+      }
+    },
     "throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
@@ -51585,6 +52052,11 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "titleize": {
       "version": "3.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "@patternfly/react-core": "^5.1.0",
     "@patternfly/react-icons": "^5.1.0",
     "@patternfly/react-table": "^5.1.0",
-    "@redhat-cloud-services/frontend-components": "^3.9.31",
+    "@redhat-cloud-services/frontend-components": "^4.0.14",
     "@redhat-cloud-services/frontend-components-config-utilities": "^3.0.4",
     "@tanstack/react-query": "^4.13.5",
     "@testing-library/jest-dom": "^5.16.4",
@@ -109,7 +109,10 @@
     "cypress": "^12.17.4"
   },
   "overrides": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "@types/react": "^17.0.2",
+    "@patternfly/patternfly": "^5.0.4",
     "@patternfly/react-core": "^5.1.0",
     "@patternfly/react-icons": "^5.1.0",
     "@patternfly/react-table": "^5.1.0"

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,4 +1,6 @@
 /* Global Styles */
+@import '~@patternfly/patternfly/patternfly.css';
+@import '~@patternfly/patternfly/patternfly-addons.css';
 
 html, body, #root,  .App {
   height: 100%;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import reportWebVitals from './reportWebVitals';
 import {RecoilRoot} from 'recoil';
-import '@patternfly/react-core/dist/styles/base.css';
-import '@patternfly/patternfly/patternfly-addons.css';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 
 // Load App after patternfly so custom CSS that overrides patternfly doesn't require !important

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/AddTeamMember.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/AddTeamMember.tsx
@@ -165,7 +165,7 @@ export default function AddTeamMember(props: AddTeamMemberProps) {
 
   return (
     <>
-      <PageSection>
+      <PageSection padding={{default: 'noPadding'}}>
         <AddTeamToolbar
           orgName={props.orgName}
           allItems={props.tableItems}


### PR DESCRIPTION
Using an older version of https://github.com/RedHatInsights/frontend-components, some styles in the patternfly v5 wizard were not being respected. Updating that package (and adding appropriate resolutions since it has a dependency on react v18), moving the import of patternfly css, and adding appropriate resolutions in the package.json seems to have remedied the styling conflicts.

Also, there was 1 page section that needed to remove padding still, which was leftover rework from the removal of deprecated patternfly components.

https://github.com/quay/quay/assets/96431149/16002d8a-2fe6-4727-adb6-01cecbfb0cc8


