### PR TITLE
deploy: update configmap for slo dashboard (PROJQUAY-6221)

### DIFF
--- a/deploy/dashboards/grafana-dashboard-quay-slo.configmap.yaml
+++ b/deploy/dashboards/grafana-dashboard-quay-slo.configmap.yaml
@@ -27,7 +27,6 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "iteration": 1675863048663,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -43,7 +42,18 @@ data:
                 "mode": "continuous-RdYlGr"
               },
               "decimals": 2,
-              "mappings": [],
+              "mappings": [
+                {
+                  "options": {
+                    "NaN": {
+                      "index": 0,
+                      "text": "0"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -70,12 +80,12 @@ data:
           "id": 34,
           "options": {
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "lastNotNull"
+                "mean"
               ],
               "fields": "",
               "values": false
@@ -83,7 +93,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -104,7 +114,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-pull-monitor-v2\"}[$rate]))\n    /\n    sum(increase(catchpoint_checks_total{probe=\"quayio-pull-monitor-v2\"}[$rate]))\n)",
+              "expr": "(sum(increase(catchpoint_checks_total{probe=\"quayio-pull-monitor-v2\"}[$rate]) - increase(catchpoint_check_failures_total{probe=\"quayio-pull-monitor-v2\"}[$rate])) * 100)\n/\nsum(increase(catchpoint_checks_total{probe=\"quayio-pull-monitor-v2\"}[$rate])) > 0",
               "hide": false,
               "instant": false,
               "legendFormat": "pull availability",
@@ -117,7 +127,7 @@ data:
                 "uid": "${catchpoint_datasource}"
               },
               "editorMode": "code",
-              "expr": "100 * (\n  (100 - 99.9) - 100 * (\n    (\n      sum(increase(catchpoint_check_failures_total{probe=\"quayio-pull-monitor-v2\"}[$rate])) \n      / sum(increase(catchpoint_checks_total{probe=\"quayio-pull-monitor-v2\"}[$rate]))\n    )\n  )\n)\n/\n(100 - 99.9)",
+              "expr": "0.1 - (\n    (sum(increase(catchpoint_check_failures_total{probe=\"quayio-pull-monitor-v2\"}[$rate])) * 100)\n    /\n    sum(increase(catchpoint_checks_total{probe=\"quayio-pull-monitor-v2\"}[$rate]))\n)",
               "hide": false,
               "legendFormat": "error budget left",
               "range": true,
@@ -139,7 +149,18 @@ data:
                 "mode": "continuous-RdYlGr"
               },
               "decimals": 2,
-              "mappings": [],
+              "mappings": [
+                {
+                  "options": {
+                    "NaN": {
+                      "index": 0,
+                      "text": "0"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -166,12 +187,12 @@ data:
           "id": 33,
           "options": {
             "colorMode": "value",
-            "graphMode": "none",
+            "graphMode": "area",
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "lastNotNull"
+                "mean"
               ],
               "fields": "",
               "values": false
@@ -179,7 +200,7 @@ data:
             "text": {},
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -199,7 +220,7 @@ data:
                 "uid": "${catchpoint_datasource}"
               },
               "editorMode": "code",
-              "expr": "100 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-monitor-v2\"}[$rate]))\n    /\n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-monitor-v2\"}[$rate]))\n)",
+              "expr": "(sum(increase(catchpoint_checks_total{probe=\"quayio-push-monitor-v2\"}[$rate]) - increase(catchpoint_check_failures_total{probe=\"quayio-push-monitor-v2\"}[$rate])) * 100)\n/\nsum(increase(catchpoint_checks_total{probe=\"quayio-push-monitor-v2\"}[$rate])) > 0",
               "hide": false,
               "legendFormat": "push availability",
               "range": true,
@@ -211,7 +232,7 @@ data:
                 "uid": "${catchpoint_datasource}"
               },
               "editorMode": "code",
-              "expr": "100 * (\n  (100 - 99.5) - 100 * (\n    (\n      sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-monitor-v2\"}[$rate])) \n      / sum(increase(catchpoint_checks_total{probe=\"quayio-push-monitor-v2\"}[$rate]))\n    )\n  )\n)\n/\n(100 - 99.5)",
+              "expr": "0.5 - (\n    (sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-monitor-v2\"}[$rate])) * 100)\n    /\n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-monitor-v2\"}[$rate]))\n)",
               "hide": false,
               "legendFormat": "error budget left",
               "range": true,
@@ -232,10 +253,20 @@ data:
                 "mode": "continuous-RdYlGr"
               },
               "decimals": 2,
-              "mappings": [],
+              "mappings": [
+                {
+                  "options": {
+                    "NaN": {
+                      "index": 0,
+                      "text": "0"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
               "min": 0,
               "thresholds": {
-                "mode": "absolute",
+                "mode": "percentage",
                 "steps": [
                   {
                     "color": "green",
@@ -266,14 +297,14 @@ data:
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "lastNotNull"
+                "mean"
               ],
               "fields": "",
               "values": false
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -293,7 +324,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",method=\"GET\"}[$rate]))",
+              "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",method=\"GET\"}[$rate])) > 0",
               "legendFormat": "GET repository",
               "range": true,
               "refId": "A"
@@ -304,7 +335,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "(\n  sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\", status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n  /\n  sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",method=\"GET\"}[$rate]))\n) - 0.995",
+              "expr": "0.005 - (\n  (sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",method=\"GET\"}[$rate])) - sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\", status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate])))\n  /\n  sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",method=\"GET\"}[$rate]))\n)",
               "hide": false,
               "legendFormat": "error budget ",
               "range": true,
@@ -325,7 +356,19 @@ data:
               "color": {
                 "mode": "continuous-RdYlGr"
               },
-              "mappings": [],
+              "decimals": 2,
+              "mappings": [
+                {
+                  "options": {
+                    "NaN": {
+                      "index": 0,
+                      "text": "0"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "noValue": "0",
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -358,14 +401,14 @@ data:
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "lastNotNull"
+                "mean"
               ],
               "fields": "",
               "values": false
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -396,7 +439,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "(\n    sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repositorymanifestsecurity\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n    /\n    sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repositorymanifestsecurity\",method=\"GET\"}[$rate]))\n)\n- 0.995",
+              "expr": "0.005 - (\n    (sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repositorymanifestsecurity\",method=\"GET\"}[$rate])) - sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repositorymanifestsecurity\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate])))\n    /\n    sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repositorymanifestsecurity\",method=\"GET\"}[$rate]))\n)",
               "hide": false,
               "legendFormat": "error budget",
               "range": true,
@@ -447,14 +490,14 @@ data:
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "lastNotNull"
+                "mean"
               ],
               "fields": "",
               "values": false
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -544,7 +587,7 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -638,7 +681,7 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -731,7 +774,7 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -820,7 +863,7 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -910,7 +953,7 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -1000,7 +1043,7 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -1085,14 +1128,14 @@ data:
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
-                "lastNotNull"
+                "mean"
               ],
               "fields": "",
               "values": false
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
@@ -1112,7 +1155,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(quay_build_jobs_total{success=\"true\"}[$rate]))\n/\nsum(increase(quay_build_jobs_total[$rate]))",
+              "expr": "sum(increase(quay_build_jobs_total{success=\"true\"}[$rate]))\n/\nsum(increase(quay_build_jobs_total[$rate])) > 0",
               "legendFormat": "success %",
               "range": true,
               "refId": "A"
@@ -1123,7 +1166,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "(\n  sum(increase(quay_build_jobs_total{success=\"true\"}[$rate]))\n  /\n  sum(increase(quay_build_jobs_total[$rate]))\n) - 0.995",
+              "expr": "0.005 - (\n  (sum(increase(quay_build_jobs_total[$rate])) - sum(increase(quay_build_jobs_total{success=\"true\"}[$rate])))\n  /\n  sum(increase(quay_build_jobs_total[$rate]))\n) != 0",
               "hide": false,
               "legendFormat": "error budget",
               "range": true,
@@ -1182,14 +1225,16 @@ data:
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.0.3",
+          "pluginVersion": "9.3.8",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(increase(quay_build_queue_duration_seconds_sum[$rate]))\n/\nsum(increase(quay_build_queue_duration_seconds_count[$rate]))",
+              "editorMode": "code",
+              "expr": "sum(increase(quay_build_queue_duration_seconds_sum[$rate]))\n/\nsum(increase(quay_build_queue_duration_seconds_count[$rate])) > 0",
+              "range": true,
               "refId": "A"
             }
           ],
@@ -1197,7 +1242,7 @@ data:
           "type": "stat"
         },
         {
-          "collapsed": true,
+          "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
@@ -1205,819 +1250,861 @@ data:
             "y": 16
           },
           "id": 49,
-          "panels": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${catchpoint_datasource}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisLabel": "success rate",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "drawStyle": "line",
-                    "fillOpacity": 4,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "links": [],
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 95
-                      }
-                    ]
-                  },
-                  "unit": "percentunit"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 9,
-                "w": 12,
-                "x": 0,
-                "y": 17
-              },
-              "id": 79,
-              "links": [],
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom"
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "pluginVersion": "9.0.3",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${catchpoint_datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-na\"}[$rate]))\n    /\n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-na\"}[$rate]))\n)\n",
-                  "legendFormat": "North America",
-                  "range": true,
-                  "refId": "A"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${catchpoint_datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-sa\"}[$rate]))\n    /\n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-sa\"}[$rate]))\n)",
-                  "hide": false,
-                  "legendFormat": "South America",
-                  "range": true,
-                  "refId": "B"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${catchpoint_datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-af\"}[$rate]))\n    /   \n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-af\"}[$rate]))\n)",
-                  "hide": false,
-                  "legendFormat": "Africa",
-                  "range": true,
-                  "refId": "C"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${catchpoint_datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-as\"}[$rate]))\n    /   \n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-as\"}[$rate]))\n)",
-                  "hide": false,
-                  "legendFormat": "Asia",
-                  "range": true,
-                  "refId": "D"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${catchpoint_datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-oc\"}[$rate]))\n    /   \n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-oc\"}[$rate]))\n)",
-                  "hide": false,
-                  "legendFormat": "Oceania",
-                  "range": true,
-                  "refId": "E"
-                }
-              ],
-              "title": "Push-Pull Monitor by Region",
-              "type": "timeseries"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${catchpoint_datasource}"
-              },
-              "description": "",
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "links": [],
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  },
-                  "unit": "none"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 9,
-                "w": 6,
-                "x": 12,
-                "y": 17
-              },
-              "id": 30,
-              "links": [],
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom"
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "pluginVersion": "9.0.3",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${catchpoint_datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "increase(catchpoint_check_failures_total{probe=\"quayio-push-monitor-v2\"}[$rate])",
-                  "legendFormat": "budget burn rate",
-                  "range": true,
-                  "refId": "A"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${catchpoint_datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "(100 - 99.5) * increase(catchpoint_checks_total{probe=\"quayio-push-monitor-v2\"}[$rate])",
-                  "hide": false,
-                  "legendFormat": "max budget",
-                  "range": true,
-                  "refId": "B"
-                }
-              ],
-              "title": "Push Error Budget Burn Rate (WIP)",
-              "type": "timeseries"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${catchpoint_datasource}"
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "drawStyle": "line",
-                    "fillOpacity": 10,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "never",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "links": [],
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  },
-                  "unit": "none"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 9,
-                "w": 6,
-                "x": 18,
-                "y": 17
-              },
-              "id": 31,
-              "links": [],
-              "options": {
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom"
-                },
-                "tooltip": {
-                  "mode": "multi",
-                  "sort": "none"
-                }
-              },
-              "pluginVersion": "9.0.3",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${catchpoint_datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "sum(increase(catchpoint_check_failures_total{probe=\"quayio-pull-monitor-v2\"}[$rate]))",
-                  "legendFormat": "budget burn rate",
-                  "range": true,
-                  "refId": "A"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${catchpoint_datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "(100 - 99.9) * sum(increase(catchpoint_checks_total{probe=\"quayio-pull-monitor-v2\"}[$rate]))",
-                  "hide": false,
-                  "legendFormat": "max budget",
-                  "range": true,
-                  "refId": "B"
-                }
-              ],
-              "title": "Pull Error Budget Burn Rate (WIP)",
-              "type": "timeseries"
-            }
-          ],
+          "panels": [],
           "title": "Push/Pull",
           "type": "row"
         },
         {
-          "collapsed": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${catchpoint_datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "success rate",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 4,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 95
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 79,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${catchpoint_datasource}"
+              },
+              "editorMode": "code",
+              "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-na\"}[$rate]))\n    /\n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-na\"}[$rate]))\n)\n",
+              "legendFormat": "North America",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${catchpoint_datasource}"
+              },
+              "editorMode": "code",
+              "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-sa\"}[$rate]))\n    /\n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-sa\"}[$rate]))\n)",
+              "hide": false,
+              "legendFormat": "South America",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${catchpoint_datasource}"
+              },
+              "editorMode": "code",
+              "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-af\"}[$rate]))\n    /   \n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-af\"}[$rate]))\n)",
+              "hide": false,
+              "legendFormat": "Africa",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${catchpoint_datasource}"
+              },
+              "editorMode": "code",
+              "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-as\"}[$rate]))\n    /   \n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-as\"}[$rate]))\n)",
+              "hide": false,
+              "legendFormat": "Asia",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${catchpoint_datasource}"
+              },
+              "editorMode": "code",
+              "expr": "1 - (\n    sum(increase(catchpoint_check_failures_total{probe=\"quayio-push-pull-monitor-v2-oc\"}[$rate]))\n    /   \n    sum(increase(catchpoint_checks_total{probe=\"quayio-push-pull-monitor-v2-oc\"}[$rate]))\n)",
+              "hide": false,
+              "legendFormat": "Oceania",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "title": "Push-Pull Monitor by Region",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${catchpoint_datasource}"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 12,
+            "y": 17
+          },
+          "id": 30,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${catchpoint_datasource}"
+              },
+              "editorMode": "code",
+              "expr": "increase(catchpoint_check_failures_total{probe=\"quayio-push-monitor-v2\"}[$rate])",
+              "legendFormat": "budget burn rate",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${catchpoint_datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(100 - 99.5) * increase(catchpoint_checks_total{probe=\"quayio-push-monitor-v2\"}[$rate])",
+              "hide": false,
+              "legendFormat": "max budget",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Push Error Budget Burn Rate (WIP)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${catchpoint_datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 6,
+            "x": 18,
+            "y": 17
+          },
+          "id": 31,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.0.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${catchpoint_datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(catchpoint_check_failures_total{probe=\"quayio-pull-monitor-v2\"}[$rate]))",
+              "legendFormat": "budget burn rate",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${catchpoint_datasource}"
+              },
+              "editorMode": "code",
+              "expr": "(100 - 99.9) * sum(increase(catchpoint_checks_total{probe=\"quayio-pull-monitor-v2\"}[$rate]))",
+              "hide": false,
+              "legendFormat": "max budget",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Pull Error Budget Burn Rate (WIP)",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 17
+            "y": 26
           },
           "id": 53,
-          "panels": [
+          "panels": [],
+          "title": "v1 Quay API",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisGridShow": true,
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 3,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "noValue": "0",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                  "id": "byNames",
+                  "options": {
+                    "mode": "exclude",
+                    "names": [
+                      "GET api.repository"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                  }
+                },
+                "properties": [
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": true
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 27
+          },
+          "id": 43,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "min",
+                "max",
+                "last"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.0.3",
+          "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "axisGridShow": true,
-                    "axisLabel": "",
-                    "axisPlacement": "auto",
-                    "barAlignment": 0,
-                    "drawStyle": "line",
-                    "fillOpacity": 3,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineInterpolation": "linear",
-                    "lineWidth": 1,
-                    "pointSize": 5,
-                    "scaleDistribution": {
-                      "type": "linear"
-                    },
-                    "showPoints": "auto",
-                    "spanNulls": false,
-                    "stacking": {
-                      "group": "A",
-                      "mode": "none"
-                    },
-                    "thresholdsStyle": {
-                      "mode": "off"
-                    }
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  },
-                  "unit": "percentunit"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 10,
-                "w": 24,
-                "x": 0,
-                "y": 18
-              },
-              "id": 43,
-              "links": [],
-              "options": {
-                "legend": {
-                  "calcs": [
-                    "mean",
-                    "min",
-                    "max",
-                    "last"
-                  ],
-                  "displayMode": "table",
-                  "placement": "bottom"
-                },
-                "tooltip": {
-                  "mode": "single",
-                  "sort": "none"
-                }
-              },
-              "pluginVersion": "9.0.3",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.user\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.user\",method=\"GET\"}[$rate]))",
-                  "legendFormat": "GET api.user",
-                  "range": true,
-                  "refId": "A"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",method=\"GET\"}[$rate]))",
-                  "hide": false,
-                  "legendFormat": "GET api.repository",
-                  "range": true,
-                  "refId": "B"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.listrepositorytags\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.listrepositorytags\",method=\"GET\"}[$rate]))",
-                  "hide": false,
-                  "legendFormat": "GET api.listrepositorytags",
-                  "range": true,
-                  "refId": "C"
-                },
-                {
-                  "datasource": {
-                    "type": "prometheus",
-                    "uid": "${datasource}"
-                  },
-                  "editorMode": "code",
-                  "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repositorymanifestsecurity\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repositorymanifestsecurity\",method=\"GET\"}[$rate]))",
-                  "hide": false,
-                  "interval": "",
-                  "legendFormat": "GET api.repositorymanifestsecurity",
-                  "range": true,
-                  "refId": "D"
-                }
-              ],
-              "title": "API v1 Availability",
-              "transformations": [],
-              "type": "timeseries"
+              "editorMode": "code",
+              "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.user\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.user\",method=\"GET\"}[$rate]))",
+              "legendFormat": "GET api.user",
+              "range": true,
+              "refId": "A"
             },
             {
               "datasource": {
-                "type": "cloudwatch",
-                "uid": "${cloudwatch_datasource}"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      },
-                      {
-                        "color": "red",
-                        "value": 80
-                      }
-                    ]
-                  },
-                  "unit": "short"
-                },
-                "overrides": []
-              },
-              "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 0,
-                "y": 28
-              },
-              "id": 54,
-              "links": [],
-              "options": {
-                "displayMode": "gradient",
-                "minVizHeight": 10,
-                "minVizWidth": 0,
-                "orientation": "auto",
-                "reduceOptions": {
-                  "calcs": [
-                    "mean"
-                  ],
-                  "fields": "",
-                  "values": false
-                },
-                "showUnfilled": true
-              },
-              "pluginVersion": "9.0.3",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "cloudwatch",
-                    "uid": "${cloudwatch_datasource}"
-                  },
-                  "dimensions": {
-                    "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
-                  },
-                  "expression": "",
-                  "id": "",
-                  "label": "HTTP 2XX",
-                  "matchExact": true,
-                  "metricEditorMode": 0,
-                  "metricName": "HTTPCode_Target_2XX_Count",
-                  "metricQueryType": 0,
-                  "namespace": "AWS/ApplicationELB",
-                  "period": "",
-                  "queryMode": "Metrics",
-                  "refId": "A",
-                  "region": "default",
-                  "sqlExpression": "",
-                  "statistic": "Sum"
-                },
-                {
-                  "datasource": {
-                    "type": "cloudwatch",
-                    "uid": "${cloudwatch_datasource}"
-                  },
-                  "dimensions": {
-                    "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
-                  },
-                  "expression": "",
-                  "hide": false,
-                  "id": "",
-                  "label": "HTTP 3XX",
-                  "matchExact": true,
-                  "metricEditorMode": 0,
-                  "metricName": "HTTPCode_Target_3XX_Count",
-                  "metricQueryType": 0,
-                  "namespace": "AWS/ApplicationELB",
-                  "period": "",
-                  "queryMode": "Metrics",
-                  "refId": "B",
-                  "region": "default",
-                  "sqlExpression": "",
-                  "statistic": "Sum"
-                },
-                {
-                  "datasource": {
-                    "type": "cloudwatch",
-                    "uid": "${cloudwatch_datasource}"
-                  },
-                  "dimensions": {
-                    "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
-                  },
-                  "expression": "",
-                  "hide": false,
-                  "id": "",
-                  "label": "HTTP 4XX",
-                  "matchExact": true,
-                  "metricEditorMode": 0,
-                  "metricName": "HTTPCode_Target_4XX_Count",
-                  "metricQueryType": 0,
-                  "namespace": "AWS/ApplicationELB",
-                  "period": "",
-                  "queryMode": "Metrics",
-                  "refId": "C",
-                  "region": "default",
-                  "sqlExpression": "",
-                  "statistic": "Sum"
-                },
-                {
-                  "datasource": {
-                    "type": "cloudwatch",
-                    "uid": "${cloudwatch_datasource}"
-                  },
-                  "dimensions": {
-                    "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
-                  },
-                  "expression": "",
-                  "hide": false,
-                  "id": "",
-                  "label": "HTTP 5XX",
-                  "matchExact": true,
-                  "metricEditorMode": 0,
-                  "metricName": "HTTPCode_Target_5XX_Count",
-                  "metricQueryType": 0,
-                  "namespace": "AWS/ApplicationELB",
-                  "period": "",
-                  "queryMode": "Metrics",
-                  "refId": "D",
-                  "region": "default",
-                  "sqlExpression": "",
-                  "statistic": "Sum"
-                }
-              ],
-              "title": "HTTP response codes",
-              "transformations": [],
-              "type": "bargauge"
+              "editorMode": "code",
+              "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repository\",method=\"GET\"}[$rate]))",
+              "hide": false,
+              "legendFormat": "GET api.repository",
+              "range": true,
+              "refId": "B"
             },
             {
               "datasource": {
-                "type": "cloudwatch",
-                "uid": "${cloudwatch_datasource}"
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
-              "fieldConfig": {
-                "defaults": {
-                  "color": {
-                    "mode": "thresholds"
-                  },
-                  "custom": {
-                    "align": "center",
-                    "displayMode": "auto",
-                    "inspect": false
-                  },
-                  "mappings": [],
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "color": "green"
-                      }
-                    ]
-                  },
-                  "unit": "short"
-                },
-                "overrides": []
+              "editorMode": "code",
+              "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.listrepositorytags\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.listrepositorytags\",method=\"GET\"}[$rate]))",
+              "hide": false,
+              "legendFormat": "GET api.listrepositorytags",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
               },
-              "gridPos": {
-                "h": 6,
-                "w": 12,
-                "x": 12,
-                "y": 28
-              },
-              "id": 55,
-              "links": [],
-              "options": {
-                "footer": {
-                  "fields": "",
-                  "reducer": [
-                    "sum"
-                  ],
-                  "show": false
-                },
-                "showHeader": true
-              },
-              "pluginVersion": "9.0.3",
-              "targets": [
-                {
-                  "datasource": {
-                    "type": "cloudwatch",
-                    "uid": "${cloudwatch_datasource}"
-                  },
-                  "dimensions": {
-                    "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
-                  },
-                  "expression": "",
-                  "id": "",
-                  "label": "HTTP 2XX",
-                  "matchExact": true,
-                  "metricEditorMode": 0,
-                  "metricName": "HTTPCode_Target_2XX_Count",
-                  "metricQueryType": 0,
-                  "namespace": "AWS/ApplicationELB",
-                  "period": "",
-                  "queryMode": "Metrics",
-                  "refId": "A",
-                  "region": "default",
-                  "sqlExpression": "",
-                  "statistic": "Sum"
-                },
-                {
-                  "datasource": {
-                    "type": "cloudwatch",
-                    "uid": "${cloudwatch_datasource}"
-                  },
-                  "dimensions": {
-                    "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
-                  },
-                  "expression": "",
-                  "hide": false,
-                  "id": "",
-                  "label": "HTTP 3XX",
-                  "matchExact": true,
-                  "metricEditorMode": 0,
-                  "metricName": "HTTPCode_Target_3XX_Count",
-                  "metricQueryType": 0,
-                  "namespace": "AWS/ApplicationELB",
-                  "period": "",
-                  "queryMode": "Metrics",
-                  "refId": "B",
-                  "region": "default",
-                  "sqlExpression": "",
-                  "statistic": "Sum"
-                },
-                {
-                  "datasource": {
-                    "type": "cloudwatch",
-                    "uid": "${cloudwatch_datasource}"
-                  },
-                  "dimensions": {
-                    "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
-                  },
-                  "expression": "",
-                  "hide": false,
-                  "id": "",
-                  "label": "HTTP 4XX",
-                  "matchExact": true,
-                  "metricEditorMode": 0,
-                  "metricName": "HTTPCode_Target_4XX_Count",
-                  "metricQueryType": 0,
-                  "namespace": "AWS/ApplicationELB",
-                  "period": "",
-                  "queryMode": "Metrics",
-                  "refId": "C",
-                  "region": "default",
-                  "sqlExpression": "",
-                  "statistic": "Sum"
-                },
-                {
-                  "datasource": {
-                    "type": "cloudwatch",
-                    "uid": "${cloudwatch_datasource}"
-                  },
-                  "dimensions": {
-                    "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
-                  },
-                  "expression": "",
-                  "hide": false,
-                  "id": "",
-                  "label": "HTTP 5XX",
-                  "matchExact": true,
-                  "metricEditorMode": 0,
-                  "metricName": "HTTPCode_Target_5XX_Count",
-                  "metricQueryType": 0,
-                  "namespace": "AWS/ApplicationELB",
-                  "period": "",
-                  "queryMode": "Metrics",
-                  "refId": "D",
-                  "region": "default",
-                  "sqlExpression": "",
-                  "statistic": "Sum"
-                }
-              ],
-              "title": "HTTP response codes",
-              "transformations": [
-                {
-                  "id": "reduce",
-                  "options": {
-                    "reducers": [
-                      "max",
-                      "min",
-                      "mean",
-                      "sum"
-                    ]
-                  }
-                }
-              ],
-              "type": "table"
+              "editorMode": "code",
+              "expr": "sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repositorymanifestsecurity\",status!~\"5[0-9][0-9]\",method=\"GET\"}[$rate]))\n/\nsum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route=\"api.repositorymanifestsecurity\",method=\"GET\"}[$rate]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "GET api.repositorymanifestsecurity",
+              "range": true,
+              "refId": "D"
             }
           ],
-          "title": "v1 Quay API",
-          "type": "row"
+          "title": "API v1 Availability",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch_datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "id": 54,
+          "links": [],
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatch_datasource}"
+              },
+              "dimensions": {
+                "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
+              },
+              "expression": "",
+              "id": "",
+              "label": "HTTP 2XX",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "HTTPCode_Target_2XX_Count",
+              "metricQueryType": 0,
+              "namespace": "AWS/ApplicationELB",
+              "period": "",
+              "queryMode": "Metrics",
+              "refId": "A",
+              "region": "default",
+              "sqlExpression": "",
+              "statistic": "Sum"
+            },
+            {
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatch_datasource}"
+              },
+              "dimensions": {
+                "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
+              },
+              "expression": "",
+              "hide": false,
+              "id": "",
+              "label": "HTTP 3XX",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "HTTPCode_Target_3XX_Count",
+              "metricQueryType": 0,
+              "namespace": "AWS/ApplicationELB",
+              "period": "",
+              "queryMode": "Metrics",
+              "refId": "B",
+              "region": "default",
+              "sqlExpression": "",
+              "statistic": "Sum"
+            },
+            {
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatch_datasource}"
+              },
+              "dimensions": {
+                "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
+              },
+              "expression": "",
+              "hide": false,
+              "id": "",
+              "label": "HTTP 4XX",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "HTTPCode_Target_4XX_Count",
+              "metricQueryType": 0,
+              "namespace": "AWS/ApplicationELB",
+              "period": "",
+              "queryMode": "Metrics",
+              "refId": "C",
+              "region": "default",
+              "sqlExpression": "",
+              "statistic": "Sum"
+            },
+            {
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatch_datasource}"
+              },
+              "dimensions": {
+                "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
+              },
+              "expression": "",
+              "hide": false,
+              "id": "",
+              "label": "HTTP 5XX",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "HTTPCode_Target_5XX_Count",
+              "metricQueryType": 0,
+              "namespace": "AWS/ApplicationELB",
+              "period": "",
+              "queryMode": "Metrics",
+              "refId": "D",
+              "region": "default",
+              "sqlExpression": "",
+              "statistic": "Sum"
+            }
+          ],
+          "title": "HTTP response codes",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "${cloudwatch_datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "center",
+                "displayMode": "auto",
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 55,
+          "links": [],
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "9.3.8",
+          "targets": [
+            {
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatch_datasource}"
+              },
+              "dimensions": {
+                "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
+              },
+              "expression": "",
+              "id": "",
+              "label": "HTTP 2XX",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "HTTPCode_Target_2XX_Count",
+              "metricQueryType": 0,
+              "namespace": "AWS/ApplicationELB",
+              "period": "",
+              "queryMode": "Metrics",
+              "refId": "A",
+              "region": "default",
+              "sqlExpression": "",
+              "statistic": "Sum"
+            },
+            {
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatch_datasource}"
+              },
+              "dimensions": {
+                "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
+              },
+              "expression": "",
+              "hide": false,
+              "id": "",
+              "label": "HTTP 3XX",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "HTTPCode_Target_3XX_Count",
+              "metricQueryType": 0,
+              "namespace": "AWS/ApplicationELB",
+              "period": "",
+              "queryMode": "Metrics",
+              "refId": "B",
+              "region": "default",
+              "sqlExpression": "",
+              "statistic": "Sum"
+            },
+            {
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatch_datasource}"
+              },
+              "dimensions": {
+                "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
+              },
+              "expression": "",
+              "hide": false,
+              "id": "",
+              "label": "HTTP 4XX",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "HTTPCode_Target_4XX_Count",
+              "metricQueryType": 0,
+              "namespace": "AWS/ApplicationELB",
+              "period": "",
+              "queryMode": "Metrics",
+              "refId": "C",
+              "region": "default",
+              "sqlExpression": "",
+              "statistic": "Sum"
+            },
+            {
+              "datasource": {
+                "type": "cloudwatch",
+                "uid": "${cloudwatch_datasource}"
+              },
+              "dimensions": {
+                "LoadBalancer": "app/quayio-production-alb01/dd2a8a128b2029c6"
+              },
+              "expression": "",
+              "hide": false,
+              "id": "",
+              "label": "HTTP 5XX",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "HTTPCode_Target_5XX_Count",
+              "metricQueryType": 0,
+              "namespace": "AWS/ApplicationELB",
+              "period": "",
+              "queryMode": "Metrics",
+              "refId": "D",
+              "region": "default",
+              "sqlExpression": "",
+              "statistic": "Sum"
+            }
+          ],
+          "title": "HTTP response codes",
+          "transformations": [
+            {
+              "id": "reduce",
+              "options": {
+                "reducers": [
+                  "max",
+                  "min",
+                  "mean",
+                  "sum"
+                ]
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "collapsed": true,
@@ -2025,7 +2112,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 18
+            "y": 43
           },
           "id": 60,
           "panels": [
@@ -2040,6 +2127,8 @@ data:
                     "mode": "palette-classic"
                   },
                   "custom": {
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
                     "axisLabel": "",
                     "axisPlacement": "auto",
                     "barAlignment": 0,
@@ -2072,7 +2161,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -2088,14 +2178,15 @@ data:
                 "h": 9,
                 "w": 9,
                 "x": 0,
-                "y": 19
+                "y": 44
               },
               "id": 58,
               "options": {
                 "legend": {
                   "calcs": [],
                   "displayMode": "list",
-                  "placement": "bottom"
+                  "placement": "bottom",
+                  "showLegend": true
                 },
                 "tooltip": {
                   "mode": "single",
@@ -2183,7 +2274,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -2199,7 +2291,7 @@ data:
                 "h": 9,
                 "w": 6,
                 "x": 9,
-                "y": 19
+                "y": 44
               },
               "id": 77,
               "maxDataPoints": 100,
@@ -2217,7 +2309,7 @@ data:
                 },
                 "showUnfilled": true
               },
-              "pluginVersion": "9.0.3",
+              "pluginVersion": "9.3.8",
               "targets": [
                 {
                   "datasource": {
@@ -2285,7 +2377,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 19
+            "y": 44
           },
           "id": 51,
           "panels": [
@@ -2304,7 +2396,8 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
@@ -2320,7 +2413,7 @@ data:
                 "h": 8,
                 "w": 5,
                 "x": 0,
-                "y": 20
+                "y": 54
               },
               "id": 40,
               "options": {
@@ -2330,21 +2423,23 @@ data:
                 "orientation": "auto",
                 "reduceOptions": {
                   "calcs": [
-                    "lastNotNull"
+                    "mean"
                   ],
                   "fields": "",
                   "values": false
                 },
                 "textMode": "auto"
               },
-              "pluginVersion": "9.0.3",
+              "pluginVersion": "9.3.8",
               "targets": [
                 {
                   "datasource": {
                     "type": "prometheus",
                     "uid": "${datasource}"
                   },
-                  "expr": "(\n    sum(\n        increase(quay_build_queue_duration_seconds_sum[$rate])\n    )\n    /\n    sum(\n        increase(quay_build_queue_duration_seconds_count[$rate])\n    )\n) + (\n    sum(\n        increase(quay_build_duration_seconds_sum[$rate])\n    )\n    /\n    sum(\n        increase(quay_build_duration_seconds_count[$rate])\n    )\n)",
+                  "editorMode": "code",
+                  "expr": "(\n    sum(\n        increase(quay_build_queue_duration_seconds_sum[$rate])\n    )\n    /\n    sum(\n        increase(quay_build_queue_duration_seconds_count[$rate])\n    ) > 0\n) + (\n    sum(\n        increase(quay_build_duration_seconds_sum[$rate])\n    )\n    /\n    sum(\n        increase(quay_build_duration_seconds_count[$rate])\n    ) > 0\n)",
+                  "range": true,
                   "refId": "A"
                 }
               ],
@@ -2377,15 +2472,15 @@ data:
                     "mode": "absolute",
                     "steps": [
                       {
-                        "color": "green"
+                        "color": "green",
+                        "value": null
                       },
                       {
                         "color": "red",
                         "value": 80
                       }
                     ]
-                  },
-                  "unit": "s"
+                  }
                 },
                 "overrides": []
               },
@@ -2393,18 +2488,19 @@ data:
                 "h": 8,
                 "w": 7,
                 "x": 5,
-                "y": 20
+                "y": 54
               },
               "id": 56,
               "options": {
                 "bucketOffset": 0,
                 "legend": {
                   "calcs": [],
-                  "displayMode": "hidden",
-                  "placement": "bottom"
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
                 }
               },
-              "pluginVersion": "9.0.3",
+              "pluginVersion": "9.3.8",
               "targets": [
                 {
                   "datasource": {
@@ -2440,11 +2536,26 @@ data:
                 "uid": "${datasource}"
               },
               "description": "Heatmap of time spent in queue for build jobs",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "scaleDistribution": {
+                      "type": "linear"
+                    }
+                  }
+                },
+                "overrides": []
+              },
               "gridPos": {
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 20
+                "y": 54
               },
               "heatmap": {},
               "hideZeroBuckets": true,
@@ -2453,7 +2564,44 @@ data:
               "legend": {
                 "show": true
               },
-              "pluginVersion": "9.0.3",
+              "options": {
+                "calculate": false,
+                "calculation": {},
+                "cellGap": 2,
+                "cellValues": {},
+                "color": {
+                  "exponent": 0.5,
+                  "fill": "#b4ff00",
+                  "mode": "scheme",
+                  "reverse": false,
+                  "scale": "exponential",
+                  "scheme": "Greens",
+                  "steps": 128
+                },
+                "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+                },
+                "filterValues": {
+                  "le": 1e-9
+                },
+                "legend": {
+                  "show": true
+                },
+                "rowsFrame": {
+                  "layout": "auto"
+                },
+                "showValue": "never",
+                "tooltip": {
+                  "show": true,
+                  "yHistogram": false
+                },
+                "yAxis": {
+                  "axisPlacement": "left",
+                  "reverse": false,
+                  "unit": "s"
+                }
+              },
+              "pluginVersion": "9.3.8",
               "reverseYBuckets": false,
               "targets": [
                 {
@@ -2499,7 +2647,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 20
+            "y": 45
           },
           "id": 71,
           "panels": [
@@ -2535,7 +2683,7 @@ data:
                 "h": 8,
                 "w": 6,
                 "x": 0,
-                "y": 21
+                "y": 63
               },
               "id": 75,
               "options": {
@@ -2552,7 +2700,7 @@ data:
                 },
                 "textMode": "auto"
               },
-              "pluginVersion": "9.0.3",
+              "pluginVersion": "9.3.8",
               "targets": [
                 {
                   "datasource": {
@@ -2581,11 +2729,26 @@ data:
                 "uid": "${datasource}"
               },
               "description": "duration of time between pushing an image to quay and receiving scan results",
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "scaleDistribution": {
+                      "type": "linear"
+                    }
+                  }
+                },
+                "overrides": []
+              },
               "gridPos": {
                 "h": 8,
                 "w": 12,
                 "x": 6,
-                "y": 21
+                "y": 63
               },
               "heatmap": {},
               "hideZeroBuckets": true,
@@ -2595,7 +2758,44 @@ data:
                 "show": true
               },
               "maxDataPoints": 100,
-              "pluginVersion": "9.0.3",
+              "options": {
+                "calculate": false,
+                "calculation": {},
+                "cellGap": 2,
+                "cellValues": {},
+                "color": {
+                  "exponent": 0.5,
+                  "fill": "#b4ff00",
+                  "mode": "scheme",
+                  "reverse": false,
+                  "scale": "exponential",
+                  "scheme": "Greens",
+                  "steps": 128
+                },
+                "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+                },
+                "filterValues": {
+                  "le": 1e-9
+                },
+                "legend": {
+                  "show": true
+                },
+                "rowsFrame": {
+                  "layout": "auto"
+                },
+                "showValue": "never",
+                "tooltip": {
+                  "show": true,
+                  "yHistogram": false
+                },
+                "yAxis": {
+                  "axisPlacement": "left",
+                  "reverse": false,
+                  "unit": "s"
+                }
+              },
+              "pluginVersion": "9.3.8",
               "reverseYBuckets": false,
               "targets": [
                 {
@@ -2637,7 +2837,7 @@ data:
         }
       ],
       "refresh": false,
-      "schemaVersion": 36,
+      "schemaVersion": 37,
       "style": "dark",
       "tags": [],
       "templating": {
@@ -2773,7 +2973,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-6h",
+        "from": "now-7d",
         "to": "now"
       },
       "timepicker": {
@@ -2804,11 +3004,12 @@ data:
       "timezone": "",
       "title": "Quay SLO",
       "uid": "quay-slo",
-      "version": 2,
+      "version": 1,
       "weekStart": ""
     }
 kind: ConfigMap
 metadata:
+  creationTimestamp: null
   name: grafana-dashboard-quay-slo.configmap.yaml
   labels:
     grafana_dashboard: "true"


### PR DESCRIPTION
SLO dashboard previously showed 100% availability during quay.io outage for `Push Operations` and `Pull Operations`
Fixing dashboard so that the stat panels show the average instead of latest value.

Attached screenshots showing updated dashboard:

![Screenshot 2023-10-18 at 11 50 42 AM](https://github.com/quay/quay/assets/47163063/24734252-ef60-4e99-a22c-947c247babe1)
![Screenshot 2023-10-18 at 12 52 34 PM](https://github.com/quay/quay/assets/47163063/7de5fd1c-9ea1-489d-bbe6-230e51b03a40)
