### PR TITLE
api: accepting empty body for create robot endpoints (PROJQUAY-6224)

### DIFF
--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -482,7 +482,7 @@ def validate_json_request(schema_name, optional=False):
         def wrapped(self, *args, **kwargs):
             schema = self.schemas[schema_name]
             try:
-                json_data = request.get_json()
+                json_data = request.get_json(silent=optional)
                 if json_data is None:
                     if not optional:
                         raise InvalidRequest("Missing JSON body")

--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -120,7 +120,7 @@ class UserRobot(ApiResource):
         Create a new user robot with the specified name.
         """
         parent = get_authenticated_user()
-        create_data = request.get_json() or {}
+        create_data = request.get_json(silent=True) or {}
         robot = model.create_user_robot(
             robot_shortname,
             parent,
@@ -236,7 +236,7 @@ class OrgRobot(ApiResource):
         """
         permission = AdministerOrganizationPermission(orgname)
         if permission.can() or allow_if_superuser():
-            create_data = request.get_json() or {}
+            create_data = request.get_json(silent=True) or {}
             robot = model.create_org_robot(
                 robot_shortname,
                 orgname,

--- a/endpoints/api/test/test_robot.py
+++ b/endpoints/api/test/test_robot.py
@@ -1,6 +1,4 @@
 import json
-from test.fixtures import *
-from test.test_ldap import mock_ldap
 
 import pytest
 
@@ -9,6 +7,8 @@ from endpoints.api import api
 from endpoints.api.robot import OrgRobot, OrgRobotList, UserRobot, UserRobotList
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
+from test.fixtures import *
+from test.test_ldap import mock_ldap
 from util.names import parse_robot_username
 
 
@@ -22,6 +22,7 @@ from util.names import parse_robot_username
 @pytest.mark.parametrize(
     "body",
     [
+        None,
         {},
         {"description": "this is a description"},
         {"unstructured_metadata": {"foo": "bar"}},


### PR DESCRIPTION
Since all the parameters are optional a body isn't required. With the updated Flask package an empty body now returns a 415 when it didn't before. Quay should go back to accepting an empty body. 