### PR TITLE
autoprune: preventing prune of mirror or readonly repos (PROJQUAY-6235)

### DIFF
--- a/data/model/autoprune.py
+++ b/data/model/autoprune.py
@@ -422,7 +422,7 @@ def execute_policies_for_repo(policies, repo, namespace_id, tag_page_limit=100):
 def get_paginated_repositories_for_namespace(namespace_id, page_token=None, page_size=50):
     try:
         query = Repository.select(Repository.name, Repository.id,).where(
-            Repository.state != RepositoryState.MARKED_FOR_DELETION,
+            Repository.state == RepositoryState.NORMAL,
             Repository.namespace_user == namespace_id,
         )
         repos, next_page_token = modelutil.paginate(

--- a/data/test/test_namespace_autoprune.py
+++ b/data/test/test_namespace_autoprune.py
@@ -157,7 +157,7 @@ class TestNameSpaceAutoprune:
         set_repository_state(readonly_repo, RepositoryState.READ_ONLY)
         deleted_repo = create_repository(ORG1_NAME, "deleted", None)
         set_repository_state(deleted_repo, RepositoryState.MARKED_FOR_DELETION)
-        mirror_repo = create_repository(ORG1_NAME, "deleted", None)
+        mirror_repo = create_repository(ORG1_NAME, "mirror", None)
         set_repository_state(mirror_repo, RepositoryState.MIRROR)
 
         repo_names = [f"repo{i}" for i in range(10)]


### PR DESCRIPTION
Prevent prune of mirror or readonly repositories even if a auto-prune policy is configured.