### PR TITLE
autoprune: adding audit logs to namespace autoprune policy API (PROJQUAY-6229)

### DIFF
--- a/data/migrations/versions/8d47693829a0_auto_prune_policy_audit_logs.py
+++ b/data/migrations/versions/8d47693829a0_auto_prune_policy_audit_logs.py
@@ -1,0 +1,35 @@
+"""auto prune policy audit logs
+
+Revision ID: 8d47693829a0
+Revises: 2062bbd5ef0e
+Create Date: 2023-10-23 14:34:38.908240
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "8d47693829a0"
+down_revision = "2062bbd5ef0e"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.bulk_insert(
+        tables.logentrykind,
+        [
+            {"name": "create_namespace_autoprune_policy"},
+            {"name": "update_namespace_autoprune_policy"},
+            {"name": "delete_namespace_autoprune_policy"},
+        ],
+    )
+
+
+def downgrade(op, tables, tester):
+    op.execute(
+        tables.logentrykind.delete().where(
+            tables.logentrykind.c.name
+            == op.inline_literal("create_namespace_autoprune_policy") | tables.logentrykind.c.name
+            == op.inline_literal("update_namespace_autoprune_policy") | tables.logentrykind.c.name
+            == op.inline_literal("delete_namespace_autoprune_policy")
+        )
+    )

--- a/endpoints/api/policy.py
+++ b/endpoints/api/policy.py
@@ -10,8 +10,8 @@ from data import model
 from endpoints.api import (
     ApiResource,
     allow_if_superuser,
-    nickname,
     log_action,
+    nickname,
     path_param,
     request_error,
     require_scope,

--- a/endpoints/api/policy.py
+++ b/endpoints/api/policy.py
@@ -11,6 +11,7 @@ from endpoints.api import (
     ApiResource,
     allow_if_superuser,
     nickname,
+    log_action,
     path_param,
     request_error,
     require_scope,
@@ -98,6 +99,16 @@ class OrgAutoPrunePolicies(ApiResource):
         except model.NamespaceAutoPrunePolicyAlreadyExists as ex:
             request_error(ex)
 
+        log_action(
+            "create_namespace_autoprune_policy",
+            orgname,
+            {
+                "method": policy_config["method"],
+                "value": policy_config["value"],
+                "namespace": orgname,
+            },
+        )
+
         return {"uuid": policy.uuid}, 201
 
 
@@ -180,6 +191,16 @@ class OrgAutoPrunePolicy(ApiResource):
         except model.NamespaceAutoPrunePolicyDoesNotExist as ex:
             raise NotFound()
 
+        log_action(
+            "update_namespace_autoprune_policy",
+            orgname,
+            {
+                "method": policy_config["method"],
+                "value": policy_config["value"],
+                "namespace": orgname,
+            },
+        )
+
         return {"uuid": policy_uuid}, 204
 
     @require_scope(scopes.ORG_ADMIN)
@@ -200,6 +221,12 @@ class OrgAutoPrunePolicy(ApiResource):
             raise NotFound()
         except model.NamespaceAutoPrunePolicyDoesNotExist as ex:
             raise NotFound()
+
+        log_action(
+            "delete_namespace_autoprune_policy",
+            orgname,
+            {"policy_uuid": policy_uuid, "namespace": orgname},
+        )
 
         return {"uuid": policy_uuid}, 200
 
@@ -271,6 +298,16 @@ class UserAutoPrunePolicies(ApiResource):
             request_error(ex)
         except model.NamespaceAutoPrunePolicyAlreadyExists as ex:
             request_error(ex)
+
+        log_action(
+            "create_namespace_autoprune_policy",
+            user.username,
+            {
+                "method": policy_config["method"],
+                "value": policy_config["value"],
+                "namespace": user.username,
+            },
+        )
 
         return {"uuid": policy.uuid}, 201
 
@@ -349,6 +386,16 @@ class UserAutoPrunePolicy(ApiResource):
         except model.NamespaceAutoPrunePolicyDoesNotExist as ex:
             raise NotFound()
 
+        log_action(
+            "update_namespace_autoprune_policy",
+            user.username,
+            {
+                "method": policy_config["method"],
+                "value": policy_config["value"],
+                "namespace": user.username,
+            },
+        )
+
         return {"uuid": policy_uuid}, 204
 
     @require_user_admin()
@@ -367,5 +414,11 @@ class UserAutoPrunePolicy(ApiResource):
             raise NotFound()
         except model.NamespaceAutoPrunePolicyDoesNotExist as ex:
             raise NotFound()
+
+        log_action(
+            "delete_namespace_autoprune_policy",
+            user.username,
+            {"policy_uuid": policy_uuid, "namespace": user.username},
+        )
 
         return {"uuid": policy_uuid}, 200

--- a/endpoints/api/test/test_policy.py
+++ b/endpoints/api/test/test_policy.py
@@ -1,6 +1,9 @@
+import json
+
 import pytest
 
 from data import database, model
+from data.model.log import get_latest_logs_query, get_log_entry_kinds
 from endpoints.api.policy import (
     OrgAutoPrunePolicies,
     OrgAutoPrunePolicy,
@@ -37,6 +40,19 @@ def test_create_org_policy(initialized_db, app):
         )
         org = model.organization.get_organization("sellnsmall")
         assert model.autoprune.namespace_has_autoprune_task(org.id)
+
+        # Check audit log was created
+        logs = list(get_latest_logs_query(performer="devtable", namespace="sellnsmall"))
+        log_kinds = get_log_entry_kinds()
+        log = None
+        for l in logs:
+            if l.kind == log_kinds["create_namespace_autoprune_policy"]:
+                log = l
+                break
+        assert log is not None
+        assert json.loads(log.metadata_json)["method"] == "creation_date"
+        assert json.loads(log.metadata_json)["value"] == "2w"
+        assert json.loads(log.metadata_json)["namespace"] == "sellnsmall"
 
 
 def test_create_org_policy_already_existing(initialized_db, app):
@@ -101,6 +117,19 @@ def test_update_org_policy(initialized_db, app):
         assert get_response["method"] == "creation_date"
         assert get_response["value"] == "2w"
 
+        # Check audit log was created
+        logs = list(get_latest_logs_query(performer="devtable", namespace="buynlarge"))
+        log_kinds = get_log_entry_kinds()
+        log = None
+        for l in logs:
+            if l.kind == log_kinds["update_namespace_autoprune_policy"]:
+                log = l
+                break
+        assert log is not None
+        assert json.loads(log.metadata_json)["method"] == "creation_date"
+        assert json.loads(log.metadata_json)["value"] == "2w"
+        assert json.loads(log.metadata_json)["namespace"] == "buynlarge"
+
 
 def test_update_org_policy_nonexistent_policy(initialized_db, app):
     with client_with_identity("devtable", app) as cl:
@@ -133,6 +162,18 @@ def test_delete_org_policy(initialized_db, app):
             {"orgname": "buynlarge", "policy_uuid": policy_uuid},
             expected_code=404,
         )
+
+        # Check audit log was created
+        logs = list(get_latest_logs_query(performer="devtable", namespace="buynlarge"))
+        log_kinds = get_log_entry_kinds()
+        log = None
+        for l in logs:
+            if l.kind == log_kinds["delete_namespace_autoprune_policy"]:
+                log = l
+                break
+        assert log is not None
+        assert json.loads(log.metadata_json)["policy_uuid"] == policy_uuid
+        assert json.loads(log.metadata_json)["namespace"] == "buynlarge"
 
 
 def test_delete_org_policy_nonexistent_policy(initialized_db, app):
@@ -171,6 +212,19 @@ def test_create_user_policy(initialized_db, app):
         )
         org = model.user.get_user("freshuser")
         assert model.autoprune.namespace_has_autoprune_task(org.id)
+
+        # Check audit log was created
+        logs = list(get_latest_logs_query(performer="freshuser", namespace="freshuser"))
+        log_kinds = get_log_entry_kinds()
+        log = None
+        for l in logs:
+            if l.kind == log_kinds["create_namespace_autoprune_policy"]:
+                log = l
+                break
+        assert log is not None
+        assert json.loads(log.metadata_json)["method"] == "creation_date"
+        assert json.loads(log.metadata_json)["value"] == "2w"
+        assert json.loads(log.metadata_json)["namespace"] == "freshuser"
 
 
 def test_create_user_policy_already_existing(initialized_db, app):
@@ -223,6 +277,19 @@ def test_update_user_policy(initialized_db, app):
         assert get_response["method"] == "creation_date"
         assert get_response["value"] == "2w"
 
+        # Check audit log was created
+        logs = list(get_latest_logs_query(performer="devtable", namespace="devtable"))
+        log_kinds = get_log_entry_kinds()
+        log = None
+        for l in logs:
+            if l.kind == log_kinds["update_namespace_autoprune_policy"]:
+                log = l
+                break
+        assert log is not None
+        assert json.loads(log.metadata_json)["method"] == "creation_date"
+        assert json.loads(log.metadata_json)["value"] == "2w"
+        assert json.loads(log.metadata_json)["namespace"] == "devtable"
+
 
 def test_update_user_policy_nonexistent_policy(initialized_db, app):
     with client_with_identity("devtable", app) as cl:
@@ -255,6 +322,18 @@ def test_delete_user_policy(initialized_db, app):
             {"orgname": "devtable", "policy_uuid": policy_uuid},
             expected_code=404,
         )
+
+        # Check audit log was created
+        logs = list(get_latest_logs_query(performer="devtable", namespace="devtable"))
+        log_kinds = get_log_entry_kinds()
+        log = None
+        for l in logs:
+            if l.kind == log_kinds["delete_namespace_autoprune_policy"]:
+                log = l
+                break
+        assert log is not None
+        assert json.loads(log.metadata_json)["policy_uuid"] == policy_uuid
+        assert json.loads(log.metadata_json)["namespace"] == "devtable"
 
 
 def test_delete_user_policy_nonexistent_policy(initialized_db, app):

--- a/initdb.py
+++ b/initdb.py
@@ -456,6 +456,10 @@ def initialize_database():
     LogEntryKind.create(name="permanently_delete_tag")
     LogEntryKind.create(name="autoprune_tag_delete")
 
+    LogEntryKind.create(name="create_namespace_autoprune_policy")
+    LogEntryKind.create(name="update_namespace_autoprune_policy")
+    LogEntryKind.create(name="delete_namespace_autoprune_policy")
+
     ImageStorageLocation.create(name="local_eu")
     ImageStorageLocation.create(name="local_us")
 

--- a/static/js/directives/ui/logs-view.js
+++ b/static/js/directives/ui/logs-view.js
@@ -506,6 +506,9 @@ angular.module('quay').directive('logsView', function () {
           }
         },
         'logout_success': 'Logout from Quay',
+        'create_namespace_autoprune_policy': 'Autoprune policy created for namespace {namespace}[[ with policy method {method} and value {value}]]',
+        'update_namespace_autoprune_policy': 'Autoprune policy updated for namespace {namespace}[[ with policy method {method} and value {value}]]',
+        'delete_namespace_autoprune_policy': 'Autoprune policy deleted for namespace {namespace}[[ with uuid {policy_uuid}]]',
 };
 
       var logKinds = {

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -6234,6 +6234,9 @@ COPY public.logentrykind (id, name) FROM stdin;
 98	logout_success
 99	permanently_delete_tag
 100	autoprune_tag_delete
+101	create_namespace_autoprune_policy
+102	update_namespace_autoprune_policy
+103	delete_namespace_autoprune_policy
 \.
 
 
@@ -8071,7 +8074,7 @@ SELECT pg_catalog.setval('public.logentry_id_seq', 1, false);
 -- Name: logentrykind_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.logentrykind_id_seq', 100, true);
+SELECT pg_catalog.setval('public.logentrykind_id_seq', 103, true);
 
 
 --

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -5569,7 +5569,7 @@ COPY public.accesstokenkind (id, name) FROM stdin;
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-2062bbd5ef0e
+8d47693829a0
 \.
 
 


### PR DESCRIPTION
Add's audit logs to the CRUD endpoints for both user and organization namespace auto-prune policies. 