### PR TITLE
api: graceful error handling for robot acct already exists (PROJQUAY-6261)

### DIFF
--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -121,12 +121,16 @@ class UserRobot(ApiResource):
         """
         parent = get_authenticated_user()
         create_data = request.get_json(silent=True) or {}
-        robot = model.create_user_robot(
-            robot_shortname,
-            parent,
-            create_data.get("description"),
-            create_data.get("unstructured_metadata"),
-        )
+
+        try:
+            robot = model.create_user_robot(
+                robot_shortname,
+                parent,
+                create_data.get("description"),
+                create_data.get("unstructured_metadata"),
+            )
+        except Exception as e:
+            raise request_error(message=str(e))
         log_action(
             "create_robot",
             parent.username,
@@ -237,12 +241,16 @@ class OrgRobot(ApiResource):
         permission = AdministerOrganizationPermission(orgname)
         if permission.can() or allow_if_superuser():
             create_data = request.get_json(silent=True) or {}
-            robot = model.create_org_robot(
-                robot_shortname,
-                orgname,
-                create_data.get("description"),
-                create_data.get("unstructured_metadata"),
-            )
+
+            try:
+                robot = model.create_org_robot(
+                    robot_shortname,
+                    orgname,
+                    create_data.get("description"),
+                    create_data.get("unstructured_metadata"),
+                )
+            except Exception as e:
+                raise request_error(message=str(e))
             log_action(
                 "create_robot",
                 orgname,

--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -9,6 +9,7 @@ from auth.permissions import (
     AdministerOrganizationPermission,
     OrganizationMemberPermission,
 )
+from data.model import InvalidRobotException
 from endpoints.api import (
     ApiResource,
     allow_if_superuser,
@@ -129,7 +130,7 @@ class UserRobot(ApiResource):
                 create_data.get("description"),
                 create_data.get("unstructured_metadata"),
             )
-        except Exception as e:
+        except InvalidRobotException as e:
             raise request_error(message=str(e))
         log_action(
             "create_robot",
@@ -249,7 +250,7 @@ class OrgRobot(ApiResource):
                     create_data.get("description"),
                     create_data.get("unstructured_metadata"),
                 )
-            except Exception as e:
+            except InvalidRobotException as e:
                 raise request_error(message=str(e))
             log_action(
                 "create_robot",

--- a/endpoints/api/test/test_robot.py
+++ b/endpoints/api/test/test_robot.py
@@ -138,3 +138,24 @@ def test_retrieve_robots_token_permission(username, is_admin, with_permissions, 
         for robot in result.json["robots"]:
             assert (robot.get("token") is not None) == is_admin
             assert (robot.get("repositories") is not None) == (is_admin and with_permissions)
+
+
+def test_duplicate_robot_creation(app):
+    with client_with_identity("devtable", app) as cl:
+        resp = conduct_api_call(
+            cl,
+            UserRobot,
+            "PUT",
+            {"robot_shortname": "dtrobot"},
+            expected_code=400,
+        )
+        assert resp.json["error_message"] == "Existing robot with name: devtable+dtrobot"
+
+        resp = conduct_api_call(
+            cl,
+            OrgRobot,
+            "PUT",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            expected_code=400,
+        )
+        assert resp.json["error_message"] == "Existing robot with name: buynlarge+coolrobot"

--- a/web/src/components/modals/CreateRobotAccountModal.tsx
+++ b/web/src/components/modals/CreateRobotAccountModal.tsx
@@ -25,6 +25,7 @@ import {
   selectedRobotReposPermissionState,
 } from 'src/atoms/RobotAccountState';
 import {useRepositories} from 'src/hooks/UseRepositories';
+import {addDisplayError} from 'src/resources/ErrorHandling';
 import {useOrganizations} from 'src/hooks/UseOrganizations';
 import {Entity} from 'src/resources/UserResource';
 
@@ -60,7 +61,7 @@ export default function CreateRobotAccountModal(
         handleModalToggle();
       },
       onError: (err) => {
-        props.showErrorAlert(err);
+        props.showErrorAlert(addDisplayError('Error', err));
       },
     });
 

--- a/web/src/hooks/useRobotAccounts.ts
+++ b/web/src/hooks/useRobotAccounts.ts
@@ -136,7 +136,7 @@ export function useCreateRobotAccount({namespace, onSuccess, onError}) {
         queryClient.invalidateQueries(['Namespace', namespace, 'robots']);
       },
       onError: (err) => {
-        onError('Error creating robot account');
+        onError(err);
       },
     },
   );


### PR DESCRIPTION
This PR takes care of graceful error handling instead of raising an exception for create robot account endpoint. Added the same error to propagate on the new UI too.