### PR TITLE
marketplace: return None if subscription api times out (PROJQUAY-5363)

### DIFF
--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -61,7 +61,7 @@ class RedHatUserApi(object):
                 timeout=REQUEST_TIMEOUT,
             )
         except requests.exceptions.ReadTimeout:
-            logger.info("request to %s timed out", self.marketplace_endpoint)
+            logger.info("request to %s timed out", self.user_endpoint)
             return None
 
         info = json.loads(r.content)
@@ -179,7 +179,7 @@ class RedHatSubscriptionApi(object):
             )
         except requests.exceptions.ReadTimeout:
             logger.info("request to %s timed out", self.marketplace_endpoint)
-            return None
+            return 408
 
         return r.status_code
 

--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -1,0 +1,27 @@
+import requests
+from mock import patch
+
+from util.marketplace import RedHatSubscriptionApi, RedHatUserApi
+
+app_config = {
+    "ENTITLEMENT_RECONCILIATION_USER_ENDPOINT": "example.com",
+    "ENTITLEMENT_RECONCILIATION_MARKETPLACE_ENDPOINT": "example.com",
+}
+
+
+@patch("requests.request")
+def test_timeout_exception(requests_mock):
+    requests_mock.side_effect = requests.exceptions.ReadTimeout()
+    user_api = RedHatUserApi(app_config)
+    subscription_api = RedHatSubscriptionApi(app_config)
+
+    customer_id = user_api.lookup_customer_id("example@example.com")
+    assert customer_id is None
+    subscription_response = subscription_api.lookup_subscription(123456, "sku")
+    assert subscription_response is None
+    subscription_sku = subscription_api.get_subscription_sku(123456)
+    assert subscription_sku is None
+    extended_subscription = subscription_api.extend_subscription(12345, 102623)
+    assert extended_subscription is None
+    create_subscription_response = subscription_api.create_entitlement(12345, "sku")
+    assert create_subscription_response == 408


### PR DESCRIPTION
For all methods that make a request to the subscription watch API, if the request times out then there should be `None` returned.