### PR TITLE
ui: display manifest list size range (PROJQUAY-6393)

### DIFF
--- a/web/cypress/e2e/repository-details.cy.ts
+++ b/web/cypress/e2e/repository-details.cy.ts
@@ -55,7 +55,7 @@ describe('Repository Details Page', () => {
         'have.text',
         'See Child Manifests',
       );
-      cy.get(`[data-label="Size"]`).should('have.text', '2.51 kB - 4.12 kB');
+      cy.get(`[data-label="Size"]`).should('have.text', '2.51 kB ~ 4.12 kB');
       cy.get(`[data-label="Last Modified"]`).should(
         'have.text',
         formatDate('Thu, 04 Nov 2022 19:15:15 -0000'),

--- a/web/cypress/e2e/repository-details.cy.ts
+++ b/web/cypress/e2e/repository-details.cy.ts
@@ -55,7 +55,7 @@ describe('Repository Details Page', () => {
         'have.text',
         'See Child Manifests',
       );
-      cy.get(`[data-label="Size"]`).should('have.text', 'Unknown');
+      cy.get(`[data-label="Size"]`).should('have.text', '2.51 kB - 4.12 kB');
       cy.get(`[data-label="Last Modified"]`).should(
         'have.text',
         formatDate('Thu, 04 Nov 2022 19:15:15 -0000'),

--- a/web/src/atoms/TagListState.ts
+++ b/web/src/atoms/TagListState.ts
@@ -1,4 +1,4 @@
-import {atom, selector} from 'recoil';
+import {atom, atomFamily, selector} from 'recoil';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
 import {Tag} from 'src/resources/TagResource';
 import ColumnNames from 'src/routes/RepositoryDetails/Tags/ColumnNames';
@@ -49,4 +49,9 @@ export const selectedTagsState = atom({
 export const currentOpenPopoverState = atom({
   key: 'currentOpenPopoverState',
   default: '',
+});
+
+export const childManifestSizeState = atomFamily({
+  key: 'childManifestDigest',
+  default: null,
 });

--- a/web/src/components/Table/ImageSize.tsx
+++ b/web/src/components/Table/ImageSize.tsx
@@ -1,40 +1,9 @@
 import {Skeleton} from '@patternfly/react-core';
-import {useEffect, useState} from 'react';
-import {
-  getManifestByDigest,
-  ManifestByDigestResponse,
-} from 'src/resources/TagResource';
 import prettyBytes from 'pretty-bytes';
-import {useRecoilState} from 'recoil';
+import {useEffect} from 'react';
+import {useSetRecoilState} from 'recoil';
 import {childManifestSizeState} from 'src/atoms/TagListState';
-
-export function useImageSize(org: string, repo: string, digest: string) {
-  const [size, setSize] = useState<number>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [err, setErr] = useState<boolean>(false);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const manifestResp: ManifestByDigestResponse =
-          await getManifestByDigest(org, repo, digest);
-        const calculatedSizeMesnifestResp = manifestResp.layers
-          ? manifestResp.layers.reduce(
-              (prev, curr) => prev + curr.compressed_size,
-              0,
-            )
-          : 0;
-        setSize(calculatedSizeMesnifestResp);
-      } catch (err) {
-        setErr(true);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [digest]);
-
-  return {size, loading, err};
-}
+import {useImageSize} from 'src/hooks/UseImageSize';
 
 export function ImageSize(props: ImageSizeProps) {
   const {size, loading, err} = useImageSize(
@@ -65,7 +34,7 @@ export function ChildManifestSize(props: ImageSizeProps) {
     props.digest,
   );
 
-  const [, setChildManifestSize] = useRecoilState(
+  const setChildManifestSize = useSetRecoilState(
     childManifestSizeState(props.digest),
   );
 

--- a/web/src/components/Table/ManifestListSize.tsx
+++ b/web/src/components/Table/ManifestListSize.tsx
@@ -1,17 +1,17 @@
 import {Skeleton} from '@patternfly/react-core';
 import prettyBytes from 'pretty-bytes';
 import {Manifest} from 'src/resources/TagResource';
-import {useRecoilValueLoadable} from 'recoil';
+import {useRecoilValue} from 'recoil';
 import {childManifestSizeState} from 'src/atoms/TagListState';
 
 export default function ManifestListSize(props: ManifestListSizeProps) {
   const childManifestSizes = props.manifests.map((manifest) =>
-    useRecoilValueLoadable(childManifestSizeState(manifest.digest)),
+    useRecoilValue(childManifestSizeState(manifest.digest)),
   );
 
   const loadedSizes = childManifestSizes
-    .filter((size) => size.contents != null)
-    .map((size) => size.contents);
+    .filter((size) => size != null)
+    .map((size) => size);
 
   const loading = loadedSizes.length < props.manifests.length;
 
@@ -26,7 +26,7 @@ export default function ManifestListSize(props: ManifestListSizeProps) {
 
       return (
         <>
-          {prettyBytes(lowestValue)} - {prettyBytes(highestValue)}
+          {prettyBytes(lowestValue)} ~ {prettyBytes(highestValue)}
         </>
       );
     }

--- a/web/src/components/Table/ManifestListSize.tsx
+++ b/web/src/components/Table/ManifestListSize.tsx
@@ -1,0 +1,34 @@
+import {Skeleton} from '@patternfly/react-core';
+import prettyBytes from 'pretty-bytes';
+import {Manifest} from 'src/resources/TagResource';
+import {useRecoilValueLoadable} from 'recoil';
+import {childManifestSizeState} from 'src/atoms/TagListState';
+
+export default function ManifestListSize(props: ManifestListSizeProps) {
+  const childManifestSizes = props.manifests.map((manifest) =>
+    useRecoilValueLoadable(childManifestSizeState(manifest.digest)),
+  );
+
+  const loadedSizes = childManifestSizes
+    .filter((size) => size.contents != null)
+    .map((size) => size.contents);
+
+  const loading = loadedSizes.length < props.manifests.length;
+
+  if (loading) {
+    return <Skeleton />;
+  } else {
+    const lowestValue = Math.min(...loadedSizes);
+    const highestValue = Math.max(...loadedSizes);
+
+    return (
+      <>
+        {prettyBytes(lowestValue)} ~ {prettyBytes(highestValue)}
+      </>
+    );
+  }
+}
+
+interface ManifestListSizeProps {
+  manifests: Manifest[];
+}

--- a/web/src/components/Table/ManifestListSize.tsx
+++ b/web/src/components/Table/ManifestListSize.tsx
@@ -18,14 +18,18 @@ export default function ManifestListSize(props: ManifestListSizeProps) {
   if (loading) {
     return <Skeleton />;
   } else {
-    const lowestValue = Math.min(...loadedSizes);
-    const highestValue = Math.max(...loadedSizes);
+    if (loadedSizes.length === 1) {
+      return <>{prettyBytes(loadedSizes[0])}</>;
+    } else {
+      const lowestValue = Math.min(...loadedSizes);
+      const highestValue = Math.max(...loadedSizes);
 
-    return (
-      <>
-        {prettyBytes(lowestValue)} ~ {prettyBytes(highestValue)}
-      </>
-    );
+      return (
+        <>
+          {prettyBytes(lowestValue)} - {prettyBytes(highestValue)}
+        </>
+      );
+    }
   }
 }
 

--- a/web/src/hooks/UseImageSize.ts
+++ b/web/src/hooks/UseImageSize.ts
@@ -1,0 +1,33 @@
+import {useEffect, useState} from 'react';
+import {
+  getManifestByDigest,
+  ManifestByDigestResponse,
+} from 'src/resources/TagResource';
+
+export function useImageSize(org: string, repo: string, digest: string) {
+  const [size, setSize] = useState<number>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [err, setErr] = useState<boolean>(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const manifestResp: ManifestByDigestResponse =
+          await getManifestByDigest(org, repo, digest);
+        const calculatedSizeMesnifestResp = manifestResp.layers
+          ? manifestResp.layers.reduce(
+              (prev, curr) => prev + curr.compressed_size,
+              0,
+            )
+          : 0;
+        setSize(calculatedSizeMesnifestResp);
+      } catch (err) {
+        setErr(true);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [digest]);
+
+  return {size, loading, err};
+}

--- a/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
@@ -20,12 +20,13 @@ import {formatDate} from 'src/libs/utils';
 import {SecurityDetailsState} from 'src/atoms/SecurityDetailsState';
 import ColumnNames from './ColumnNames';
 import {DownloadIcon} from '@patternfly/react-icons';
-import ImageSize from 'src/components/Table/ImageSize';
+import {ChildManifestSize} from 'src/components/Table/ImageSize';
 import TagActions from './TagsActions';
 import {RepositoryDetails} from 'src/resources/RepositoryResource';
 import Conditional from 'src/components/empty/Conditional';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import TagExpiration from './TagsTableExpiration';
+import ManifestListSize from 'src/components/Table/ManifestListSize';
 
 function SubRow(props: SubRowProps) {
   return (
@@ -66,7 +67,7 @@ function SubRow(props: SubRowProps) {
       </Td>
       <Td dataLabel="size" noPadding={false} colSpan={3}>
         <ExpandableRowContent>
-          <ImageSize
+          <ChildManifestSize
             org={props.org}
             repo={props.repo}
             digest={props.manifest.digest}
@@ -90,13 +91,6 @@ function TagsTableRow(props: RowProps) {
   const config = useQuayConfig();
   const tag = props.tag;
   const rowIndex = props.rowIndex;
-  let size =
-    typeof tag.manifest_list != 'undefined' ? 'N/A' : prettyBytes(tag.size);
-
-  // Behavior taken from previous UI
-  if (tag.size === 0) {
-    size = 'Unknown';
-  }
 
   // Reset SecurityDetailsState so that loading skeletons appear when viewing report
   const emptySecurityDetails = useResetRecoilState(SecurityDetailsState);
@@ -157,7 +151,13 @@ function TagsTableRow(props: RowProps) {
             />
           )}
         </Td>
-        <Td dataLabel={ColumnNames.size}>{size}</Td>
+        <Td dataLabel={ColumnNames.size}>
+          {tag.manifest_list ? (
+            <ManifestListSize manifests={tag.manifest_list.manifests} />
+          ) : (
+            prettyBytes(tag.size)
+          )}
+        </Td>
         <Td dataLabel={ColumnNames.lastModified}>
           {formatDate(tag.last_modified)}
         </Td>

--- a/web/src/routes/TagDetails/Details/Details.tsx
+++ b/web/src/routes/TagDetails/Details/Details.tsx
@@ -15,7 +15,7 @@ import {Tag} from 'src/resources/TagResource';
 import {formatDate} from 'src/libs/utils';
 import Labels from 'src/components/labels/Labels';
 import SecurityDetails from 'src/routes/RepositoryDetails/Tags/SecurityDetails';
-import ImageSize from 'src/components/Table/ImageSize';
+import {ImageSize} from 'src/components/Table/ImageSize';
 
 export default function Details(props: DetailsProps) {
   return (


### PR DESCRIPTION
Instead of displaying `N/A` or `Unknown` in the size column, a tag pointing to a manifest list should display size information. Since clients by default select only a specific child manifest of a manifest list, I opted here for a display of the size of the smallest and the largest child manifest.

https://github.com/quay/quay/assets/12664117/b42c3e78-8ae1-4592-9262-41c4c5a9d768

