### PR TITLE
storage: adding IBM COS storage option (PROJQUAY-2679)

### DIFF
--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -2,6 +2,7 @@ from storage.azurestorage import AzureStorage
 from storage.cloud import (
     CloudFrontedS3Storage,
     GoogleCloudStorage,
+    IBMCloudStorage,
     RadosGWStorage,
     RHOCSStorage,
     S3Storage,
@@ -29,6 +30,7 @@ STORAGE_DRIVER_CLASSES = {
     "RHOCSStorage": RHOCSStorage,
     "CloudFlareStorage": CloudFlareS3Storage,
     "MultiCDNStorage": MultiCDNStorage,
+    "IBMCloudStorage": IBMCloudStorage,
 }
 
 


### PR DESCRIPTION
Adds the `IBMCloudStorage` driver. This allows multipart uploads to be used for IBM Cloud storage, therefore increasing performance for large image pushes. 