### PR TITLE
ui: proper capitalization of routes (PROJQUAY-6395)

### DIFF
--- a/web/src/components/breadcrumb/Breadcrumb.tsx
+++ b/web/src/components/breadcrumb/Breadcrumb.tsx
@@ -63,6 +63,13 @@ export function QuayBreadcrumb() {
         continue;
       } else {
         newObj['title'] = object.match.pathname.split('/').slice(-1)[0];
+
+        switch (object.match.route.Component.type.name) {
+          case 'OrganizationsList':
+          case 'RepositoriesList':
+            newObj['title'] = object.match.route.breadcrumb;
+            break;
+        }
       }
       newObj['active'] =
         object.match.pathname.localeCompare(window.location.pathname) === 0;


### PR DESCRIPTION
This changes the breadcrumb creation logic from a mere parsing of the URL route to create the breadcrumb titles to recognition of known route components so that we can display the words `Repository` and `Organization` in the breadcrumb display with the first letter in capital case.
<img width="1214" alt="Screenshot 2023-11-12 at 21 02 37" src="https://github.com/quay/quay/assets/12664117/fee78931-e252-483d-a553-bef8ce64ae38">

<img width="1212" alt="Screenshot 2023-11-12 at 21 02 47" src="https://github.com/quay/quay/assets/12664117/afa7b63d-e9b2-4cc9-8dda-f58e8c6448ef">
