### PR TITLE
ui: fix path calculation for console.redhat.com deployment (PROJQUAY-5422)

### DIFF
--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -22,8 +22,12 @@ import ErrorModal from '../errors/ErrorModal';
 import 'src/components/header/HeaderToolbar.css';
 import {useQueryClient} from '@tanstack/react-query';
 import {useCurrentUser} from 'src/hooks/UseCurrentUser';
+import {useLocation, useNavigate} from 'react-router-dom';
+import {getSignInPath} from 'src/routes/NavigationPath';
 
 export function HeaderToolbar() {
+  const location = useLocation();
+  const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const queryClient = useQueryClient();
@@ -43,11 +47,7 @@ export function HeaderToolbar() {
           GlobalAuthState.csrfToken = undefined;
           queryClient.invalidateQueries(['user']);
 
-          // Ignore client side auth page and use old UI if present
-          // TODO: replace this with navigate('/signin') once new ui supports all auth methods
-          const protocol = window.location.protocol;
-          const host = window.location.host;
-          window.location.replace(`${protocol}//${host}/signin/`);
+          navigate(getSignInPath(location.pathname));
         } catch (err) {
           console.error(err);
           setErr(addDisplayError('Unable to log out', err));

--- a/web/src/routes/NavigationPath.tsx
+++ b/web/src/routes/NavigationPath.tsx
@@ -108,6 +108,14 @@ export function getTeamMemberPath(
   return domainRoute(currentRoute, teamMemberPath);
 }
 
+export function getOrganizationListPath(currentRoute: string) {
+  return domainRoute(currentRoute, NavigationPath.organizationsList);
+}
+
+export function getRepositoryListPath(currentRoute: string) {
+  return domainRoute(currentRoute, NavigationPath.repositoriesList);
+}
+
 export function getDomain() {
   return process.env.REACT_APP_QUAY_DOMAIN || 'quay.io';
 }

--- a/web/src/routes/NavigationPath.tsx
+++ b/web/src/routes/NavigationPath.tsx
@@ -38,6 +38,7 @@ const Breadcrumb = {
 export enum NavigationPath {
   // Side Nav
   home = '/',
+  signIn = '/signin',
   organizationsList = '/organization',
 
   overviewList = '/overview',
@@ -114,6 +115,10 @@ export function getOrganizationListPath(currentRoute: string) {
 
 export function getRepositoryListPath(currentRoute: string) {
   return domainRoute(currentRoute, NavigationPath.repositoriesList);
+}
+
+export function getSignInPath(currentRoute: string) {
+  return domainRoute(currentRoute, NavigationPath.signIn);
 }
 
 export function getDomain() {

--- a/web/src/routes/RepositoryDetails/Settings/DeleteRepository.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/DeleteRepository.tsx
@@ -7,18 +7,20 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import {useState} from 'react';
-import {useNavigate} from 'react-router-dom';
+import {useLocation, useNavigate} from 'react-router-dom';
 import Conditional from 'src/components/empty/Conditional';
 import {useDeleteRepositories} from 'src/hooks/UseDeleteRepositories';
+import {getRepositoryListPath} from 'src/routes/NavigationPath';
 
 export default function DeleteRepository({org, repo}: DeleteRepositoryProps) {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [repoNameInput, setRepoNameInput] = useState<string>('');
   const [isError, setIsError] = useState<boolean>(false);
+  const location = useLocation();
   const navigate = useNavigate();
   const {deleteRepositories} = useDeleteRepositories({
     onSuccess: () => {
-      navigate('/repository');
+      navigate(getRepositoryListPath(location.pathname));
     },
     onError: () => {
       setIsError(true);

--- a/web/src/routes/Signin/Signin.tsx
+++ b/web/src/routes/Signin/Signin.tsx
@@ -7,7 +7,7 @@ import {
 } from '@patternfly/react-core';
 import logo from 'src/assets/quay.svg';
 import {GlobalAuthState, loginUser} from 'src/resources/AuthResource';
-import {useNavigate} from 'react-router-dom';
+import {useLocation, useNavigate} from 'react-router-dom';
 import {useRecoilState} from 'recoil';
 import {AuthState} from 'src/atoms/AuthState';
 import axios, {getCsrfToken} from 'src/libs/axios';
@@ -24,6 +24,7 @@ export function Signin() {
   const [err, setErr] = useState<string>();
   const [, setAuthState] = useRecoilState(AuthState);
 
+  const location = useLocation();
   const navigate = useNavigate();
   const quayConfig = useQuayConfig();
 

--- a/web/src/routes/Signin/Signin.tsx
+++ b/web/src/routes/Signin/Signin.tsx
@@ -15,6 +15,7 @@ import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {AxiosError} from 'axios';
 import './Signin.css';
 import {addDisplayError} from 'src/resources/ErrorHandling';
+import {getOrganizationListPath} from '../NavigationPath';
 
 export function Signin() {
   const [username, setUsername] = useState('');
@@ -41,7 +42,7 @@ export function Signin() {
         setAuthState((old) => ({...old, isSignedIn: true, username: username}));
         await getCsrfToken();
         GlobalAuthState.isLoggedIn = true;
-        navigate('/organization');
+        navigate(getOrganizationListPath(location.pathname));
       } else {
         setErr('Invalid login credentials');
       }


### PR DESCRIPTION
This fixes the path calculation when using `navigate()` to forward the user to other screens after performing actions like deleting repositories (directly addressing [PROJQUAY-5422](https://issues.redhat.com/browse/PROJQUAY-5422)) but also when signing in or out. 

The paths were calculated incorrectly when the UI frontend was deployed at a subpath like `console.redhat.com/quay` and absolut references like `/repository` were calculated to forward to `console.redhat.com/repository` instead of `console.redhat.com/quay/repository`.