### PR TITLE
ui: only load vulnerability information when scanner feature is enabled (PROJQUAY-6429)

### DIFF
--- a/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
@@ -29,6 +29,7 @@ import TagExpiration from './TagsTableExpiration';
 import ManifestListSize from 'src/components/Table/ManifestListSize';
 
 function SubRow(props: SubRowProps) {
+  const config = useQuayConfig();
   return (
     <Tr
       key={`${props.manifest.platform.os}-${props.manifest.platform.architecture}-${props.rowIndex}`}
@@ -54,17 +55,19 @@ function SubRow(props: SubRowProps) {
       ) : (
         <Td />
       )}
-      <Td dataLabel="security" noPadding={false} colSpan={1}>
-        <ExpandableRowContent>
-          <SecurityDetails
-            org={props.org}
-            repo={props.repo}
-            digest={props.manifest.digest}
-            tag={props.tag.name}
-            variant="condensed"
-          />
-        </ExpandableRowContent>
-      </Td>
+      <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+        <Td dataLabel="security" noPadding={false} colSpan={1}>
+          <ExpandableRowContent>
+            <SecurityDetails
+              org={props.org}
+              repo={props.repo}
+              digest={props.manifest.digest}
+              tag={props.tag.name}
+              variant="condensed"
+            />
+          </ExpandableRowContent>
+        </Td>
+      </Conditional>
       <Td dataLabel="size" noPadding={false} colSpan={3}>
         <ExpandableRowContent>
           <ChildManifestSize
@@ -138,19 +141,21 @@ function TagsTableRow(props: RowProps) {
             {tag.name}
           </Link>
         </Td>
-        <Td dataLabel={ColumnNames.security}>
-          {tag.is_manifest_list ? (
-            'See Child Manifests'
-          ) : (
-            <SecurityDetails
-              org={props.org}
-              repo={props.repo}
-              digest={tag.manifest_digest}
-              tag={tag.name}
-              variant="condensed"
-            />
-          )}
-        </Td>
+        <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+          <Td dataLabel={ColumnNames.security}>
+            {tag.is_manifest_list ? (
+              'See Child Manifests'
+            ) : (
+              <SecurityDetails
+                org={props.org}
+                repo={props.repo}
+                digest={tag.manifest_digest}
+                tag={tag.name}
+                variant="condensed"
+              />
+            )}
+          </Td>
+        </Conditional>
         <Td dataLabel={ColumnNames.size}>
           {tag.manifest_list ? (
             <ManifestListSize manifests={tag.manifest_list.manifests} />
@@ -227,6 +232,7 @@ function TagsTableRow(props: RowProps) {
 }
 
 export default function TagsTable(props: TableProps) {
+  const config = useQuayConfig();
   // Control expanded tags
   const [expandedTags, setExpandedTags] = useState<string[]>([]);
   const setTagExpanded = (tag: Tag, isExpanding = true) =>
@@ -252,7 +258,9 @@ export default function TagsTable(props: TableProps) {
             <Th />
             <Th />
             <Th>Tag</Th>
-            <Th>Security</Th>
+            <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+              <Th>Security</Th>
+            </Conditional>
             <Th>Size</Th>
             <Th>Last Modified</Th>
             <Th>Expires</Th>

--- a/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
@@ -55,7 +55,7 @@ function SubRow(props: SubRowProps) {
       ) : (
         <Td />
       )}
-      <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+      <Conditional if={config?.features.SECURITY_SCANNER}>
         <Td dataLabel="security" noPadding={false} colSpan={1}>
           <ExpandableRowContent>
             <SecurityDetails
@@ -141,7 +141,7 @@ function TagsTableRow(props: RowProps) {
             {tag.name}
           </Link>
         </Td>
-        <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+        <Conditional if={config?.features.SECURITY_SCANNER}>
           <Td dataLabel={ColumnNames.security}>
             {tag.is_manifest_list ? (
               'See Child Manifests'
@@ -258,7 +258,7 @@ export default function TagsTable(props: TableProps) {
             <Th />
             <Th />
             <Th>Tag</Th>
-            <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+            <Conditional if={config?.features.SECURITY_SCANNER}>
               <Th>Security</Th>
             </Conditional>
             <Th>Size</Th>

--- a/web/src/routes/TagDetails/Details/Details.tsx
+++ b/web/src/routes/TagDetails/Details/Details.tsx
@@ -98,7 +98,7 @@ export default function Details(props: DetailsProps) {
               )}
             </DescriptionListDescription>
           </DescriptionListGroup>
-          <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+          <Conditional if={config?.features.SECURITY_SCANNER}>
             <DescriptionListGroup data-testid="vulnerabilities">
               <DescriptionListTerm>Vulnerabilities</DescriptionListTerm>
               <DescriptionListDescription>

--- a/web/src/routes/TagDetails/Details/Details.tsx
+++ b/web/src/routes/TagDetails/Details/Details.tsx
@@ -16,8 +16,11 @@ import {formatDate} from 'src/libs/utils';
 import Labels from 'src/components/labels/Labels';
 import SecurityDetails from 'src/routes/RepositoryDetails/Tags/SecurityDetails';
 import {ImageSize} from 'src/components/Table/ImageSize';
+import {useQuayConfig} from 'src/hooks/UseQuayConfig';
+import Conditional from 'src/components/empty/Conditional';
 
 export default function Details(props: DetailsProps) {
+  const config = useQuayConfig();
   return (
     <Page>
       <PageSection variant={PageSectionVariants.light}>
@@ -95,18 +98,20 @@ export default function Details(props: DetailsProps) {
               )}
             </DescriptionListDescription>
           </DescriptionListGroup>
-          <DescriptionListGroup data-testid="vulnerabilities">
-            <DescriptionListTerm>Vulnerabilities</DescriptionListTerm>
-            <DescriptionListDescription>
-              <SecurityDetails
-                org={props.org}
-                repo={props.repo}
-                digest={props.digest}
-                tag={props.tag.name}
-                cacheResults={true}
-              />
-            </DescriptionListDescription>
-          </DescriptionListGroup>
+          <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+            <DescriptionListGroup data-testid="vulnerabilities">
+              <DescriptionListTerm>Vulnerabilities</DescriptionListTerm>
+              <DescriptionListDescription>
+                <SecurityDetails
+                  org={props.org}
+                  repo={props.repo}
+                  digest={props.digest}
+                  tag={props.tag.name}
+                  cacheResults={true}
+                />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </Conditional>
           <DescriptionListGroup data-testid="labels">
             <DescriptionListTerm>Labels</DescriptionListTerm>
             <DescriptionListDescription>

--- a/web/src/routes/TagDetails/TagDetailsTabs.tsx
+++ b/web/src/routes/TagDetails/TagDetailsTabs.tsx
@@ -6,9 +6,8 @@ import SecurityReport from './SecurityReport/SecurityReport';
 import {Tag} from 'src/resources/TagResource';
 import {TabIndex} from './Types';
 import {Packages} from './Packages/Packages';
-import ErrorBoundary from 'src/components/errors/ErrorBoundary';
-import {isErrorString} from 'src/resources/ErrorHandling';
-import RequestError from 'src/components/errors/RequestError';
+import Conditional from 'src/components/empty/Conditional';
+import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 
 // Return the tab as an enum or null if it does not exist
 function getTabIndex(tab: string) {
@@ -18,6 +17,7 @@ function getTabIndex(tab: string) {
 }
 
 export default function TagTabs(props: TagTabsProps) {
+  const config = useQuayConfig();
   const [activeTabKey, setActiveTabKey] = useState<TabIndex>(TabIndex.Details);
   const navigate = useNavigate();
   const location = useLocation();
@@ -46,18 +46,20 @@ export default function TagTabs(props: TagTabsProps) {
           digest={props.digest}
         />
       </Tab>
-      <Tab
-        eventKey={TabIndex.SecurityReport}
-        title={<TabTitleText>Security Report</TabTitleText>}
-      >
-        <SecurityReport />
-      </Tab>
-      <Tab
-        eventKey={TabIndex.Packages}
-        title={<TabTitleText>Packages</TabTitleText>}
-      >
-        <Packages />
-      </Tab>
+      <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+        <Tab
+          eventKey={TabIndex.SecurityReport}
+          title={<TabTitleText>Security Report</TabTitleText>}
+        >
+          <SecurityReport />
+        </Tab>
+        <Tab
+          eventKey={TabIndex.Packages}
+          title={<TabTitleText>Packages</TabTitleText>}
+        >
+          <Packages />
+        </Tab>
+      </Conditional>
     </Tabs>
   );
 }

--- a/web/src/routes/TagDetails/TagDetailsTabs.tsx
+++ b/web/src/routes/TagDetails/TagDetailsTabs.tsx
@@ -46,7 +46,7 @@ export default function TagTabs(props: TagTabsProps) {
           digest={props.digest}
         />
       </Tab>
-      <Conditional if={config?.config?.FEATURE_SECURITY_SCANNER}>
+      <Conditional if={config?.features.SECURITY_SCANNER}>
         <Tab
           eventKey={TabIndex.SecurityReport}
           title={<TabTitleText>Security Report</TabTitleText>}


### PR DESCRIPTION
This adds a variety of conditionals to only load and display vulnerability and package information from image tags if the scanner feature is enabled.