### PR TITLE
database: use psycopg2 instead of psycopg2-binary (PROJQUAY-6453)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ ply==3.11
 prometheus-client==0.7.1
 protobuf==3.20.3
 psutil==5.9.0
-psycopg2-binary==2.9.9
+psycopg2==2.9.9
 pyasn1==0.4.8
 pyasn1-modules==0.3.0
 py-bitbucket @ git+https://github.com/quay/py-bitbucket.git@3ba167408d92eb4ba2cae78c0047b8f1e8821c67


### PR DESCRIPTION
psycopg2-binary is for dev only in prod we should use psycopg2