### PR TITLE
ui: updates Quay.io documentation redirect link (PROJQUAY-6473)

### DIFF
--- a/web/src/routes/OverviewList/RecommendedContent.tsx
+++ b/web/src/routes/OverviewList/RecommendedContent.tsx
@@ -39,7 +39,7 @@ export default function RecommendedContent() {
               <Button
                 variant="link"
                 component="a"
-                href="https://docs.projectquay.io/welcome.html"
+                href="https://docs.projectquay.io/quay_io.html"
               >
                 View Documentation <ExternalLinkAltIcon />
               </Button>


### PR DESCRIPTION
Due to the addition of dedicated Quay.io docs, the Documentation link on Quay.io needs updated to redirect directly to the Quay.io docs, instead of the more general upstream docs

https://issues.redhat.com/browse/PROJQUAY-6473