### PR TITLE
federatedusers(externalldap): report Exceptions with AD integration (PROJQUAY-6481)

### DIFF
--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -249,8 +249,9 @@ class LDAPUsers(FederatedUsers):
                 logger.debug("LDAP referral search exception")
                 return (None, "Username not found")
 
-        except ldap.LDAPError:
+        except ldap.LDAPError as ldaperr:
             logger.debug("LDAP search exception")
+            logger.debug(str(ldaperr))
             return (None, "Username not found")
 
     def _ldap_user_search(


### PR DESCRIPTION
During debugging AD integration which do look correct from configuration POV, we see logs within Quay that do not report the reason/explanation of an Exception which is raised during authenticating users. 

```
[DEBUG] [data.users.externalldap] LDAP search exception
```

The fix is trivial and reporting in the logs the Exception code and reason.