### PR TITLE
cache: adding caching on look_up repository (PROJQUAY-6472)

### DIFF
--- a/data/cache/cache_key.py
+++ b/data/cache/cache_key.py
@@ -65,3 +65,19 @@ def for_security_report(digest, cache_config):
     # Security reports don't change often so a longer TTL can be justified.
     cache_ttl = cache_config.get("security_report_cache_ttl", "300s")
     return CacheKey(f"security_report_{digest}", cache_ttl)
+
+
+def for_repository_lookup(namespace_name, repo_name, manifest_ref, kind_filter, cache_config):
+    """
+    Returns a cache key for repository lookup.
+    """
+
+    cache_ttl = cache_config.get("repository_lookup_cache_ttl", "120s")
+    cache_key = f"repository_lookup_{namespace_name}_{repo_name}"
+
+    if manifest_ref is not None:
+        cache_key = f"{cache_key}_{manifest_ref}"
+    if kind_filter is not None:
+        cache_key = f"{cache_key}_{kind_filter}"
+
+    return CacheKey(cache_key, cache_ttl)

--- a/data/registry_model/interface.py
+++ b/data/registry_model/interface.py
@@ -43,7 +43,13 @@ class RegistryDataInterface(object):
 
     @abstractmethod
     def lookup_repository(
-        self, namespace_name, repo_name, kind_filter=None, raise_on_error=False, manifest_ref=None
+        self,
+        namespace_name,
+        repo_name,
+        kind_filter=None,
+        raise_on_error=False,
+        manifest_ref=None,
+        model_cache=None,
     ):
         """
         Looks up and returns a reference to the repository with the given namespace and name, or

--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -92,7 +92,13 @@ class ProxyModel(OCIModel):
         self._proxy = Proxy(self._config, repo_name)
 
     def lookup_repository(
-        self, namespace_name, repo_name, kind_filter=None, raise_on_error=False, manifest_ref=None
+        self,
+        namespace_name,
+        repo_name,
+        kind_filter=None,
+        raise_on_error=False,
+        manifest_ref=None,
+        model_cache=None,
     ):
         """
         Looks up and returns a reference to the repository with the given namespace and name, or

--- a/endpoints/api/test/test_tag.py
+++ b/endpoints/api/test/test_tag.py
@@ -1,5 +1,3 @@
-from test.fixtures import *
-
 import pytest
 from playhouse.test_utils import assert_query_count
 
@@ -8,6 +6,7 @@ from data.registry_model import registry_model
 from endpoints.api.tag import ListRepositoryTags, RepositoryTag, RestoreTag
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
+from test.fixtures import *
 
 
 @pytest.mark.parametrize(

--- a/endpoints/api/test/test_tag.py
+++ b/endpoints/api/test/test_tag.py
@@ -90,12 +90,12 @@ def test_move_tag(manifest_exists, test_tag, expected_status, app):
 @pytest.mark.parametrize(
     "repo_namespace, repo_name, query_count",
     [
-        ("devtable", "simple", 4),
-        ("devtable", "history", 4),
-        ("devtable", "complex", 4),
-        ("devtable", "gargantuan", 4),
-        ("buynlarge", "orgrepo", 6),  # +2 for permissions checks.
-        ("buynlarge", "anotherorgrepo", 6),  # +2 for permissions checks.
+        ("devtable", "simple", 6),  # +2 for converting object to and from json
+        ("devtable", "history", 6),  # +2 for converting object to and from json
+        ("devtable", "complex", 6),  # +2 for converting object to and from json
+        ("devtable", "gargantuan", 6),  # +2 for converting object to and from json
+        ("buynlarge", "orgrepo", 8),  # +2 for permissions checks.
+        ("buynlarge", "anotherorgrepo", 8),  # +2 for permissions checks.
     ],
 )
 def test_list_repo_tags(repo_namespace, repo_name, query_count, app):
@@ -115,7 +115,7 @@ def test_list_repo_tags(repo_namespace, repo_name, query_count, app):
 @pytest.mark.parametrize(
     "repo_namespace, repo_name, query_count",
     [
-        ("devtable", "gargantuan", 4),
+        ("devtable", "gargantuan", 6),  # +2 for converting object to and from json
     ],
 )
 def test_list_repo_tags_filter(repo_namespace, repo_name, query_count, app):
@@ -129,7 +129,7 @@ def test_list_repo_tags_filter(repo_namespace, repo_name, query_count, app):
         assert len(tags) == 5
 
     with client_with_identity("devtable", app) as cl:
-        with assert_query_count(query_count - 1):
+        with assert_query_count(query_count):
             params["filter_tag_name"] = "eq:prod"
             tags = conduct_api_call(cl, ListRepositoryTags, "get", params).json["tags"]
         assert len(tags) == 1

--- a/endpoints/api/test/test_tag.py
+++ b/endpoints/api/test/test_tag.py
@@ -129,7 +129,7 @@ def test_list_repo_tags_filter(repo_namespace, repo_name, query_count, app):
         assert len(tags) == 5
 
     with client_with_identity("devtable", app) as cl:
-        with assert_query_count(query_count):
+        with assert_query_count(query_count - 1):
             params["filter_tag_name"] = "eq:prod"
             tags = conduct_api_call(cl, ListRepositoryTags, "get", params).json["tags"]
         assert len(tags) == 1

--- a/endpoints/v2/manifest.py
+++ b/endpoints/v2/manifest.py
@@ -4,7 +4,7 @@ from functools import wraps
 from flask import Response, request, url_for
 
 import features
-from app import app, storage
+from app import app, model_cache, storage
 from auth.registry_jwt_auth import process_registry_jwt_auth
 from data.database import db_disallow_replica_use
 from data.model import (
@@ -68,7 +68,11 @@ MANIFEST_TAGNAME_ROUTE = BASE_MANIFEST_ROUTE.format(VALID_TAG_PATTERN)
 def fetch_manifest_by_tagname(namespace_name, repo_name, manifest_ref, registry_model):
     try:
         repository_ref = registry_model.lookup_repository(
-            namespace_name, repo_name, raise_on_error=True, manifest_ref=manifest_ref
+            namespace_name,
+            repo_name,
+            raise_on_error=True,
+            manifest_ref=manifest_ref,
+            model_cache=model_cache,
         )
     except RepositoryDoesNotExist as e:
         image_pulls.labels("v2", "tag", 404).inc()
@@ -137,7 +141,11 @@ def fetch_manifest_by_tagname(namespace_name, repo_name, manifest_ref, registry_
 def fetch_manifest_by_digest(namespace_name, repo_name, manifest_ref, registry_model):
     try:
         repository_ref = registry_model.lookup_repository(
-            namespace_name, repo_name, raise_on_error=True, manifest_ref=manifest_ref
+            namespace_name,
+            repo_name,
+            raise_on_error=True,
+            manifest_ref=manifest_ref,
+            model_cache=model_cache,
         )
     except RepositoryDoesNotExist as e:
         image_pulls.labels("v2", "manifest", 404).inc()
@@ -293,7 +301,9 @@ def write_manifest_by_digest(namespace_name, repo_name, manifest_ref):
     # manifest does not contain the tag and this call was not given a tag name.
     # Instead, we write the manifest with a temporary tag, as it is being pushed
     # as part of a call for a manifest list.
-    repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
+    repository_ref = registry_model.lookup_repository(
+        namespace_name, repo_name, model_cache=model_cache
+    )
     if repository_ref is None:
         image_pushes.labels("v2", 404, "").inc()
         raise NameUnknown("repository not found")
@@ -362,7 +372,9 @@ def delete_manifest_by_digest(namespace_name, repo_name, manifest_ref):
     forbidden by the spec.
     """
     with db_disallow_replica_use():
-        repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
+        repository_ref = registry_model.lookup_repository(
+            namespace_name, repo_name, model_cache=model_cache
+        )
         if repository_ref is None:
             raise NameUnknown("repository not found")
 
@@ -413,7 +425,9 @@ def _write_manifest(
     namespace_name, repo_name, tag_name, manifest_impl, registry_model=registry_model
 ):
     # Ensure that the repository exists.
-    repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
+    repository_ref = registry_model.lookup_repository(
+        namespace_name, repo_name, model_cache=model_cache
+    )
     if repository_ref is None:
         raise NameUnknown("repository not found")
 


### PR DESCRIPTION
This PR caches the response of `model.repository.get_repository` as a json object instead of picking as done in https://github.com/quay/quay/pull/2515.