### PR TITLE
ui: implementing build history page (PROJQUAY-6293)

### DIFF
--- a/config.py
+++ b/config.py
@@ -821,6 +821,9 @@ class DefaultConfig(ImmutableConfig):
     # Feature Flag: Enables repository settings in the beta UI Environment
     FEATURE_UI_V2_REPO_SETTINGS = False
 
+    # Feature Flag: Enables repository builds in the beta UI Environment
+    FEATURE_UI_V2_BUILDS = False
+
     # User feedback form for UI-V2
     UI_V2_FEEDBACK_FORM = "https://7qdvkuo9rkj.typeform.com/to/XH5YE79P"
 

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1315,6 +1315,11 @@ CONFIG_SCHEMA = {
             "description": "Enables repository settings in the beta UI Environment",
             "x-example": False,
         },
+        "FEATURE_UI_V2_BUILDS": {
+            "type": "boolean",
+            "description": "Enables repository builds in the beta UI Environment",
+            "x-example": False,
+        },
         "EXPORT_COMPLIANCE_ENDPOINT": {
             "type": "string",
             "description": "The Red Hat Export Compliance Service Endpoint (only used in Quay.io)",

--- a/web/cypress/e2e/builds.cy.ts
+++ b/web/cypress/e2e/builds.cy.ts
@@ -1,0 +1,354 @@
+/// <reference types="cypress" />
+
+import moment from 'moment';
+import {formatDate, humanizeTimeForExpiry} from '../../src/libs/utils';
+
+describe('Repository Builds', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/api/v1/user/', {fixture: 'user.json'}).as('getUser');
+    cy.intercept('GET', '/config', {fixture: 'config.json'}).as('getConfig');
+    cy.intercept('GET', '/csrf_token', {fixture: 'csrfToken.json'}).as(
+      'getCsrfToken',
+    );
+    cy.intercept(
+      'GET',
+      '/api/v1/repository/testorg/testrepo?includeStats=false&includeTags=false',
+      {fixture: 'testrepo.json'},
+    ).as('getRepo');
+    cy.intercept('GET', '/api/v1/organization/testorg', {
+      fixture: 'testorg.json',
+    }).as('getOrg');
+  });
+
+  it('Shows empty list', () => {
+    cy.intercept('GET', '/api/v1/repository/testorg/testrepo/build/?limit=10', {
+      builds: [],
+    }).as('getBuilds');
+    cy.visit('/repository/testorg/testrepo?tab=builds');
+    cy.contains('Build History');
+    cy.contains(
+      'No matching builds found. Please start a new build or adjust filter to view build status.',
+    );
+  });
+
+  it('Displays build status', () => {
+    cy.intercept('GET', '/api/v1/repository/testorg/testrepo/build/?limit=10', {
+      fixture: 'builds.json',
+    }).as('getBuilds');
+    cy.visit('/repository/testorg/testrepo?tab=builds');
+    const expectedRowData = [
+      {
+        id: 'build001',
+        status: 'error',
+        trigger: {
+          message: 'Triggered by commit commit1',
+        },
+        started: 'Tue, 28 Nov 2023 15:37:33 -0000',
+        tags: ['commit1'],
+      },
+      {
+        id: 'build002',
+        status: 'internal error',
+        trigger: {
+          message: 'user1',
+        },
+        started: 'Mon, 27 Nov 2023 20:21:19 -0000',
+        tags: ['latest'],
+      },
+      {
+        id: 'build003',
+        status: 'build-scheduled',
+        trigger: {
+          message: '(Manually Triggered Build)',
+        },
+        started: 'Mon, 27 Nov 2023 20:21:19 -0000',
+        tags: ['latest'],
+      },
+      {
+        id: 'build004',
+        status: 'unpacking',
+        trigger: {
+          message:
+            'Triggered by push to repository https://github.com/quay/quay',
+        },
+        started: 'Sun, 12 Nov 2023 16:24:50 -0000',
+        tags: [],
+      },
+      {
+        id: 'build005',
+        status: 'pulling',
+        trigger: {
+          message:
+            'Triggered by push to GitHub repository https://github.com/quay/quay',
+        },
+        started: 'Sun, 12 Nov 2023 16:24:50 -0000',
+        tags: [],
+      },
+      {
+        id: 'build006',
+        status: 'building',
+        trigger: {
+          message:
+            'Triggered by push to BitBucket repository https://github.com/quay/quay',
+        },
+        started: 'Sun, 12 Nov 2023 16:24:50 -0000',
+        tags: [],
+      },
+      {
+        id: 'build007',
+        status: 'pushing',
+        trigger: {
+          message:
+            'Triggered by push to GitLab repository https://github.com/quay/quay',
+        },
+        started: 'Sun, 12 Nov 2023 16:24:50 -0000',
+        tags: [],
+      },
+      {
+        id: 'build008',
+        status: 'waiting',
+        trigger: {
+          message: 'custom-git build from branch',
+          messageLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          authoredDate: '2023-11-28T10:42:17-05:00',
+          author: 'user1',
+          commit: 'commit2',
+          commitLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          ref: 'master',
+          refLink: '',
+        },
+        started: 'Thu, 28 Sep 2023 16:52:29 -0000',
+        tags: ['latest', 'master'],
+      },
+      {
+        id: 'build009',
+        status: 'complete',
+        trigger: {
+          message: 'github build from branch',
+          messageLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          authoredDate: '2023-11-28T10:42:17-05:00',
+          author: 'user1',
+          commit: 'commit2',
+          commitLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          ref: 'master',
+          refLink: 'https://github.com/quay/quay/tree/master',
+        },
+        started: 'Thu, 28 Sep 2023 16:52:29 -0000',
+        tags: ['latest', 'master'],
+      },
+      {
+        id: 'build010',
+        status: 'cancelled',
+        trigger: {
+          message: 'gitlab build from branch',
+          messageLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          authoredDate: '2023-11-28T10:42:17-05:00',
+          author: 'user1',
+          commit: 'commit2',
+          commitLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          ref: 'master',
+          refLink: 'https://github.com/quay/quay/tree/master',
+        },
+        started: 'Thu, 28 Sep 2023 16:52:29 -0000',
+        tags: ['latest', 'master'],
+      },
+      {
+        id: 'build011',
+        status: 'expired',
+        trigger: {
+          message: 'bitbucket build from branch',
+          messageLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          authoredDate: '2023-11-28T10:42:17-05:00',
+          author: 'user1',
+          commit: 'commit2',
+          commitLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          ref: 'master',
+          refLink: 'https://github.com/quay/quay/branch/master',
+        },
+        started: 'Thu, 28 Sep 2023 16:52:29 -0000',
+        tags: ['latest', 'master'],
+      },
+      {
+        id: 'build012',
+        status: 'waiting',
+        trigger: {
+          message: 'custom git build from tag',
+          messageLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          authoredDate: '2023-11-28T10:42:17-05:00',
+          author: 'user1',
+          commit: 'commit2',
+          commitLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          ref: 'newtag',
+        },
+        started: 'Thu, 28 Sep 2023 16:52:29 -0000',
+        tags: ['latest', 'master'],
+      },
+      {
+        id: 'build013',
+        status: 'waiting',
+        trigger: {
+          message: 'github build from tag',
+          messageLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          authoredDate: '2023-11-28T10:42:17-05:00',
+          author: 'user1',
+          commit: 'commit2',
+          commitLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          ref: 'newtag',
+          refLink: 'https://github.com/quay/quay/releases/tag/newtag',
+        },
+        started: 'Thu, 28 Sep 2023 16:52:29 -0000',
+        tags: ['latest', 'master'],
+      },
+      {
+        id: 'build014',
+        status: 'waiting',
+        trigger: {
+          message: 'gitlab build from tag',
+          messageLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          authoredDate: '2023-11-28T10:42:17-05:00',
+          author: 'user1',
+          commit: 'commit2',
+          commitLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          ref: 'newtag',
+          refLink: 'https://github.com/quay/quay/commits/newtag',
+        },
+        started: 'Thu, 28 Sep 2023 16:52:29 -0000',
+        tags: ['latest', 'master'],
+      },
+      {
+        id: 'build015',
+        status: 'waiting',
+        trigger: {
+          message: 'bitbucket build from tag',
+          messageLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          authoredDate: '2023-11-28T10:42:17-05:00',
+          author: 'user1',
+          commit: 'commit2',
+          commitLink:
+            'https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda',
+          ref: 'newtag',
+          refLink: 'https://github.com/quay/quay/commits/tag/newtag',
+        },
+        started: 'Thu, 28 Sep 2023 16:52:29 -0000',
+        tags: ['latest', 'master'],
+      },
+    ];
+    for (const expectedData of expectedRowData) {
+      cy.contains('tr', expectedData.id).within(() => {
+        cy.get('td[data-label="Status"]').contains(expectedData.status);
+        cy.get('td[data-label="Triggered by"]').within(() => {
+          const messageElement = cy.contains(expectedData.trigger.message);
+          if (expectedData.trigger.messageLink) {
+            messageElement.should(
+              'have.attr',
+              'href',
+              expectedData.trigger.messageLink,
+            );
+          }
+          if (expectedData.trigger.authoredDate) {
+            // Time difference between now and author date in seconds
+            const authorDate =
+              (new Date().getTime() -
+                new Date(expectedData.trigger.authoredDate).getTime()) /
+              1000;
+            cy.contains(humanizeTimeForExpiry(authorDate));
+          }
+          if (expectedData.trigger.author) {
+            cy.contains(expectedData.trigger.author);
+          }
+          if (expectedData.trigger.commit) {
+            const commitElement = cy.contains(expectedData.trigger.commit);
+            if (expectedData.trigger.commitLink) {
+              commitElement.should(
+                'have.attr',
+                'href',
+                expectedData.trigger.commitLink,
+              );
+            }
+          }
+          if (expectedData.trigger.ref) {
+            const refElement = cy.contains(expectedData.trigger.ref);
+            if (expectedData.trigger.refLink) {
+              refElement.should(
+                'have.attr',
+                'href',
+                expectedData.trigger.refLink,
+              );
+            }
+          }
+        });
+        cy.get('td[data-label="Date started"]').contains(
+          formatDate(expectedData.started),
+        );
+        for (const tag of expectedData.tags) {
+          cy.get('td[data-label="Tags"]').contains(tag);
+        }
+      });
+    }
+  });
+
+  it('Expands long commit messages', () => {
+    cy.intercept('GET', '/api/v1/repository/testorg/testrepo/build/?limit=10', {
+      fixture: 'builds.json',
+    }).as('getBuilds');
+    cy.visit('/repository/testorg/testrepo?tab=builds');
+    cy.contains('tr', 'random text to test long description').within(() => {
+      cy.contains('success viewing long description').should('not.exist');
+      cy.get('[data-testid="expand-long-description"]').click();
+      cy.contains('success viewing long description');
+    });
+  });
+
+  it('Filters by 48 hours', () => {
+    cy.intercept('GET', '/api/v1/repository/testorg/testrepo/build/?limit=10', {
+      fixture: 'builds.json',
+    }).as('getBuilds');
+    cy.intercept(
+      'GET',
+      '/api/v1/repository/testorg/testrepo/build/?limit=100&since=*',
+      {fixture: 'builds.json'},
+    ).as('getBuilds48Hours');
+    cy.visit('/repository/testorg/testrepo?tab=builds');
+    cy.contains('Last 48 hours').click();
+    cy.wait('@getBuilds48Hours').then(({request}) => {
+      const start = moment((request.query.since as number) * 1000);
+      const end = moment(new Date());
+      const days = Math.round(moment.duration(end.diff(start)).asDays());
+      expect(days).equal(2);
+    });
+  });
+
+  it('Filters by 30 days', () => {
+    cy.intercept('GET', '/api/v1/repository/testorg/testrepo/build/?limit=10', {
+      fixture: 'builds.json',
+    }).as('getBuilds');
+    cy.intercept(
+      'GET',
+      '/api/v1/repository/testorg/testrepo/build/?limit=100&since=*',
+      {fixture: 'builds.json'},
+    ).as('getBuilds30Days');
+    cy.visit('/repository/testorg/testrepo?tab=builds');
+    cy.contains('Last 30 days').click();
+    cy.wait('@getBuilds30Days').then(({request}) => {
+      const start = moment((request.query.since as number) * 1000);
+      const end = moment(new Date());
+      const days = Math.round(moment.duration(end.diff(start)).asDays());
+      expect(days).equal(30);
+    });
+  });
+});

--- a/web/cypress/fixtures/builds.json
+++ b/web/cypress/fixtures/builds.json
@@ -1,0 +1,869 @@
+{
+  "builds": [
+    {
+      "id": "build001-9159-400b-b93a-4597bebe78f7",
+      "phase": "error",
+      "started": "Tue, 28 Nov 2023 15:37:33 -0000",
+      "display_name": "commit1",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["commit1"],
+      "manual_user": "user1",
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger1-df41-4eae-a897-f09d69aab706",
+        "service": "custom-git",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": null,
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit1e3865e0849f387533e0a272cfd7776fb4",
+        "git_url": "https://github.com/quay/quay"
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build002-6e4f-4aa0-a777-3a61e18289f4",
+      "phase": "internalerror",
+      "started": "Mon, 27 Nov 2023 20:21:19 -0000",
+      "display_name": "e49ac87",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest"],
+      "manual_user": "user1",
+      "is_writer": true,
+      "trigger": null,
+      "trigger_metadata": {},
+      "resource_key": "build002-d451-4990-bce2-c2e846f4f942",
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null,
+      "archive_url": "http://localhost:8080/userfiles/build002-d451-4990-bce2-c2e846f4f942"
+    },
+    {
+      "id": "build003-6e4f-4aa0-a777-3a61e18289f4",
+      "phase": "build-scheduled",
+      "started": "Mon, 27 Nov 2023 20:21:19 -0000",
+      "display_name": "e49aasd",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": null,
+      "trigger_metadata": {},
+      "resource_key": "build3a0-d451-4990-bce2-c2e846f4f942",
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null,
+      "archive_url": "http://localhost:8080/userfiles/build3a0-d451-4990-bce2-c2e846f4f942"
+    },
+    {
+      "id": "build004-03e8-4221-9430-01eec72cede9",
+      "phase": "unpacking",
+      "started": "Sun, 12 Nov 2023 16:24:50 -0000",
+      "display_name": "23c1123",
+      "status": {},
+      "subdirectory": "",
+      "dockerfile_path": "",
+      "context": "",
+      "tags": [],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger1-df41-4eae-a897-f09d69aab706",
+        "service": "custom-git",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": null,
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": null,
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build005-03e8-4221-9430-01eec72cede9",
+      "phase": "pulling",
+      "started": "Sun, 12 Nov 2023 16:24:50 -0000",
+      "display_name": "23c1124",
+      "status": {},
+      "subdirectory": "",
+      "dockerfile_path": "",
+      "context": "",
+      "tags": [],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger2-df41-4eae-a897-f09d69aab706",
+        "service": "github",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": null,
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": null,
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build006-03e8-4221-9430-01eec72cede9",
+      "phase": "building",
+      "started": "Sun, 12 Nov 2023 16:24:50 -0000",
+      "display_name": "23c1125",
+      "status": {},
+      "subdirectory": "",
+      "dockerfile_path": "",
+      "context": "",
+      "tags": [],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger3-df41-4eae-a897-f09d69aab706",
+        "service": "bitbucket",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": null,
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": null,
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build007-03e8-4221-9430-01eec72cede9",
+      "phase": "pushing",
+      "started": "Sun, 12 Nov 2023 16:24:50 -0000",
+      "display_name": "23c1126",
+      "status": {},
+      "subdirectory": "",
+      "dockerfile_path": "",
+      "context": "",
+      "tags": [],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger4-df41-4eae-a897-f09d69aab706",
+        "service": "gitlab",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": null,
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": null,
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build008-e52a-4cf9-87f2-9d9590df7acf",
+      "phase": "waiting",
+      "started": "Thu, 28 Sep 2023 16:52:29 -0000",
+      "display_name": "commit2",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest", "master"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger5-df41-4eae-a897-f09d69aab706",
+        "service": "custom-git",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": null,
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+        "ref": "refs/heads/master",
+        "default_branch": "master",
+        "git_url": "https://github.com/quay/quay",
+        "commit_info": {
+          "url": "https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+          "message": "custom-git build from branch",
+          "date": "2023-11-28T10:42:17-05:00",
+          "author": {
+            "username": "user1"
+          },
+          "committer": {
+            "username": "web-flow"
+          }
+        }
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build009-e52a-4cf9-87f2-9d9590df7acf",
+      "phase": "complete",
+      "started": "Thu, 28 Sep 2023 16:52:29 -0000",
+      "display_name": "commit2",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest", "master"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger6-df41-4eae-a897-f09d69aab706",
+        "service": "github",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": "https://github.com/quay/quay",
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+        "ref": "refs/heads/master",
+        "default_branch": "master",
+        "git_url": "https://github.com/quay/quay",
+        "commit_info": {
+          "url": "https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+          "message": "github build from branch",
+          "date": "2023-11-28T10:42:17-05:00",
+          "author": {
+            "username": "user1"
+          },
+          "committer": {
+            "username": "web-flow"
+          }
+        }
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build010-e52a-4cf9-87f2-9d9590df7acf",
+      "phase": "cancelled",
+      "started": "Thu, 28 Sep 2023 16:52:29 -0000",
+      "display_name": "commit2",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest", "master"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger7-df41-4eae-a897-f09d69aab706",
+        "service": "gitlab",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": "https://github.com/quay/quay",
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+        "ref": "refs/heads/master",
+        "default_branch": "master",
+        "git_url": "https://github.com/quay/quay",
+        "commit_info": {
+          "url": "https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+          "message": "gitlab build from branch",
+          "date": "2023-11-28T10:42:17-05:00",
+          "author": {
+            "username": "user1"
+          },
+          "committer": {
+            "username": "web-flow"
+          }
+        }
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build011-e52a-4cf9-87f2-9d9590df7acf",
+      "phase": "expired",
+      "started": "Thu, 28 Sep 2023 16:52:29 -0000",
+      "display_name": "commit2",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest", "master"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger8-df41-4eae-a897-f09d69aab706",
+        "service": "bitbucket",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": "https://github.com/quay/quay",
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+        "ref": "refs/heads/master",
+        "default_branch": "master",
+        "git_url": "https://github.com/quay/quay",
+        "commit_info": {
+          "url": "https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+          "message": "bitbucket build from branch",
+          "date": "2023-11-28T10:42:17-05:00",
+          "author": {
+            "username": "user1"
+          },
+          "committer": {
+            "username": "web-flow"
+          }
+        }
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build012-e52a-4cf9-87f2-9d9590df7acf",
+      "phase": "waiting",
+      "started": "Thu, 28 Sep 2023 16:52:29 -0000",
+      "display_name": "commit2",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest", "master"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger9-df41-4eae-a897-f09d69aab706",
+        "service": "custom-git",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": null,
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+        "ref": "refs/tags/newtag",
+        "default_branch": "master",
+        "git_url": "https://github.com/quay/quay",
+        "commit_info": {
+          "url": "https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+          "message": "custom git build from tag",
+          "date": "2023-11-28T10:42:17-05:00",
+          "author": {
+            "username": "user1"
+          },
+          "committer": {
+            "username": "web-flow"
+          }
+        }
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build013-e52a-4cf9-87f2-9d9590df7acf",
+      "phase": "waiting",
+      "started": "Thu, 28 Sep 2023 16:52:29 -0000",
+      "display_name": "commit2",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest", "master"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger10-df41-4eae-a897-f09d69aab70",
+        "service": "github",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": "https://github.com/quay/quay",
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+        "ref": "refs/tags/newtag",
+        "default_branch": "master",
+        "git_url": "https://github.com/quay/quay",
+        "commit_info": {
+          "url": "https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+          "message": "github build from tag",
+          "date": "2023-11-28T10:42:17-05:00",
+          "author": {
+            "username": "user1"
+          },
+          "committer": {
+            "username": "web-flow"
+          }
+        }
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build014-e52a-4cf9-87f2-9d9590df7acf",
+      "phase": "waiting",
+      "started": "Thu, 28 Sep 2023 16:52:29 -0000",
+      "display_name": "commit2",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest", "master"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger11-df41-4eae-a897-f09d69aa706",
+        "service": "gitlab",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": "https://github.com/quay/quay",
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+        "ref": "refs/tags/newtag",
+        "default_branch": "master",
+        "git_url": "https://github.com/quay/quay",
+        "commit_info": {
+          "url": "https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+          "message": "gitlab build from tag",
+          "date": "2023-11-28T10:42:17-05:00",
+          "author": {
+            "username": "user1"
+          },
+          "committer": {
+            "username": "web-flow"
+          }
+        }
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build015-e52a-4cf9-87f2-9d9590df7acf",
+      "phase": "waiting",
+      "started": "Thu, 28 Sep 2023 16:52:29 -0000",
+      "display_name": "commit2",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest", "master"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger12-df41-4eae-a897-f09d6aab706",
+        "service": "bitbucket",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": "https://github.com/quay/quay",
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+        "ref": "refs/tags/newtag",
+        "default_branch": "master",
+        "git_url": "https://github.com/quay/quay",
+        "commit_info": {
+          "url": "https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+          "message": "bitbucket build from tag",
+          "date": "2023-11-28T10:42:17-05:00",
+          "author": {
+            "username": "user1"
+          },
+          "committer": {
+            "username": "web-flow"
+          }
+        }
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    },
+    {
+      "id": "build016-e52a-4cf9-87f2-9d9590df7acf",
+      "phase": "waiting",
+      "started": "Thu, 28 Sep 2023 16:52:29 -0000",
+      "display_name": "commit2",
+      "status": {},
+      "subdirectory": "/Dockerfile",
+      "dockerfile_path": "/Dockerfile",
+      "context": "/",
+      "tags": ["latest", "master"],
+      "manual_user": null,
+      "is_writer": true,
+      "trigger": {
+        "id": "trigger13-df41-4eae-a897-f09d6aab706",
+        "service": "bitbucket",
+        "is_active": true,
+        "build_source": "https://github.com/quay/quay",
+        "repository_url": "https://github.com/quay/quay",
+        "config": {
+          "build_source": "https://github.com/quay/quay",
+          "dockerfile_path": "/Dockerfile",
+          "context": "/",
+          "default_tag_from_ref": true,
+          "tag_templates": [],
+          "credentials": [
+            {
+              "name": "SSH Public Key",
+              "value": ""
+            },
+            {
+              "name": "Webhook Endpoint URL",
+              "value": ""
+            }
+          ]
+        },
+        "can_invoke": true,
+        "enabled": true,
+        "disabled_reason": null
+      },
+      "trigger_metadata": {
+        "commit": "commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+        "ref": "refs/tags/newtag",
+        "default_branch": "master",
+        "git_url": "https://github.com/quay/quay",
+        "commit_info": {
+          "url": "https://github.com/quay/quay/commit/commit2b46cf9a7510fd9ef3bcc7191834c5abda",
+          "message": "random text to test long description, random text to test long description, random text to test long description, random text to test long description, random text to test long description, random text to test long description, random text to test long description, random text to test long description, random text to test long description, random text to test long description,  success viewing long description",
+          "date": "2023-11-28T10:42:17-05:00",
+          "author": {
+            "username": "user1"
+          },
+          "committer": {
+            "username": "web-flow"
+          }
+        }
+      },
+      "resource_key": null,
+      "pull_robot": null,
+      "repository": {
+        "namespace": "org1",
+        "name": "test"
+      },
+      "error": null
+    }
+  ]
+}

--- a/web/cypress/fixtures/config.json
+++ b/web/cypress/fixtures/config.json
@@ -127,7 +127,8 @@
     "USER_LOG_ACCESS": false,
     "USER_METADATA": true,
     "USER_RENAME": false,
-    "AUTO_PRUNE": true
+    "AUTO_PRUNE": true,
+    "UI_V2_BUILDS": true
   },
   "oauth": {
     "GITHUB_TRIGGER_CONFIG": {

--- a/web/cypress/fixtures/testorg.json
+++ b/web/cypress/fixtures/testorg.json
@@ -1,0 +1,12 @@
+{
+  "name": "testorg",
+  "email": "",
+  "avatar": {
+    "name": "testorg",
+    "hash": "randomhash2cf4cc52b46227ca8eb034e5bdb84d87283f53187810d201b821c9",
+    "color": "#2ca02c",
+    "kind": "user"
+  },
+  "is_admin": false,
+  "is_member": false
+}

--- a/web/cypress/fixtures/testrepo.json
+++ b/web/cypress/fixtures/testrepo.json
@@ -1,0 +1,16 @@
+{
+  "namespace": "testorg",
+  "name": "testrepo",
+  "kind": "image",
+  "description": "",
+  "is_public": true,
+  "is_organization": true,
+  "is_starred": false,
+  "status_token": "",
+  "trust_enabled": false,
+  "tag_expiration_s": 1209600,
+  "is_free_account": true,
+  "state": "NORMAL",
+  "can_write": true,
+  "can_admin": true
+}

--- a/web/src/components/LinkOrPlainText.tsx
+++ b/web/src/components/LinkOrPlainText.tsx
@@ -1,0 +1,14 @@
+import {isNullOrUndefined} from 'src/libs/utils';
+
+export default function LinkOrPlainText(props: LinkOrPlainText) {
+  return isNullOrUndefined(props.href) ? (
+    <>{props.children}</>
+  ) : (
+    <a href={props.href}>{props.children}</a>
+  );
+}
+
+interface LinkOrPlainText {
+  children: React.ReactNode;
+  href?: string;
+}

--- a/web/src/hooks/UseBuilds.ts
+++ b/web/src/hooks/UseBuilds.ts
@@ -1,0 +1,27 @@
+import {useQuery} from '@tanstack/react-query';
+import {isNullOrUndefined} from 'src/libs/utils';
+import {fetchBuilds} from 'src/resources/BuildResource';
+
+export function useBuilds(
+  org: string,
+  repo: string,
+  buildsSinceInSeconds: number = null,
+) {
+  const {data, isError, error, isLoading} = useQuery(
+    ['repobuilds', org, repo, String(buildsSinceInSeconds)],
+    () => {
+      // Keeping the same calls as the old UI for now, if a filter is given fetch 100 builds
+      // This can be changed after pagination has been implemented in the API
+      return isNullOrUndefined(buildsSinceInSeconds)
+        ? fetchBuilds(org, repo, buildsSinceInSeconds)
+        : fetchBuilds(org, repo, buildsSinceInSeconds, 100);
+    },
+  );
+
+  return {
+    builds: data,
+    isError: isError,
+    error: error,
+    isLoading: isLoading,
+  };
+}

--- a/web/src/resources/BuildResource.ts
+++ b/web/src/resources/BuildResource.ts
@@ -1,0 +1,115 @@
+import {AxiosResponse} from 'axios';
+import axios from 'src/libs/axios';
+import {isNullOrUndefined} from 'src/libs/utils';
+
+export enum RepositoryBuildPhase {
+  ERROR = 'error',
+  INTERNAL_ERROR = 'internalerror',
+  BUILD_SCHEDULED = 'build-scheduled',
+  UNPACKING = 'unpacking',
+  PULLING = 'pulling',
+  BUILDING = 'building',
+  PUSHING = 'pushing',
+  WAITING = 'waiting',
+  COMPLETE = 'complete',
+  CANCELLED = 'cancelled',
+  EXPIRED = 'expired',
+}
+
+export interface RepositoryBuild {
+  id: string;
+  phase: RepositoryBuildPhase;
+  started: string;
+  display_name: string;
+  subdirectory: string;
+  dockerfile_path: string;
+  context: string;
+  tags: string[];
+  manual_user: string;
+  is_writer: boolean;
+  trigger?: RepositoryBuildTrigger;
+  trigger_metadata?: RepositoryBuildTriggerMetadata;
+  resource_key: string;
+  repository: {
+    namespace: string;
+    name: string;
+  };
+  archive_url: string;
+  // Additional parameters that aren't currently used
+  // pull_robot: any;
+  // error: any;
+  // status: any;
+}
+
+export interface RepositoryBuildTrigger {
+  id: string;
+  service: string;
+  is_active: boolean;
+  build_source?: string;
+  repository_url?: string;
+  config?: {
+    build_source?: string;
+    dockerfile_path?: string;
+    context?: string;
+    branchtag_regex?: string;
+    default_tag_from_ref?: boolean;
+    latest_for_default_branch?: boolean;
+    tag_templates?: string[];
+    credentials?: [
+      {
+        name: string;
+        value: string;
+      },
+    ];
+    deploy_key_id?: number;
+    hook_id?: number;
+    master_branch?: string;
+  };
+  can_invoke?: boolean;
+  enabled?: boolean;
+  disabled_reason?: string;
+}
+
+export interface RepositoryBuildTriggerMetadata {
+  commit?: string;
+  commit_sha?: string;
+  ref?: string;
+  default_branch?: string;
+  git_url?: string;
+  commit_info?: {
+    url?: string;
+    message?: string;
+    date?: string;
+    author?: {
+      username?: string;
+      url?: string;
+      avatar_url?: string;
+    };
+    committer?: {
+      username?: string;
+      url?: string;
+      avatar_url?: string;
+    };
+  };
+}
+
+interface RepositoryBuildsResponse {
+  builds: RepositoryBuild[];
+}
+
+export async function fetchBuilds(
+  org: string,
+  repo: string,
+  buildsSinceInSeconds = null,
+  limit = 10,
+) {
+  const params = {limit: limit};
+  if (!isNullOrUndefined(buildsSinceInSeconds)) {
+    params['since'] = buildsSinceInSeconds;
+  }
+  const response: AxiosResponse<RepositoryBuildsResponse> = await axios.get(
+    `/api/v1/repository/${org}/${repo}/build/`,
+    {params: params},
+  );
+  return response.data.builds;
+}

--- a/web/src/routes/RepositoryDetails/Builds/Builds.tsx
+++ b/web/src/routes/RepositoryDetails/Builds/Builds.tsx
@@ -1,0 +1,508 @@
+import {
+  Card,
+  PageSection,
+  Title,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@patternfly/react-core';
+import {
+  BanIcon,
+  CheckCircleIcon,
+  CodeBranchIcon,
+  CodeIcon,
+  ExclamationTriangleIcon,
+  SyncAltIcon,
+  TagIcon,
+  TimesCircleIcon,
+  UserIcon,
+} from '@patternfly/react-icons';
+import {Table, Tbody, Td, Th, Thead, Tr} from '@patternfly/react-table';
+import {useState} from 'react';
+import LinkOrPlainText from 'src/components/LinkOrPlainText';
+import {LoadingPage} from 'src/components/LoadingPage';
+import Conditional from 'src/components/empty/Conditional';
+import RequestError from 'src/components/errors/RequestError';
+import {useBuilds} from 'src/hooks/UseBuilds';
+import {useQuayConfig} from 'src/hooks/UseQuayConfig';
+import {
+  formatDate,
+  humanizeTimeForExpiry,
+  isNullOrUndefined,
+} from 'src/libs/utils';
+import {
+  RepositoryBuild,
+  RepositoryBuildPhase,
+} from 'src/resources/BuildResource';
+
+const ONE_DAY_IN_SECONDS = 24 * 3600;
+const RESOURCE_URLS = {
+  github: {
+    commit: '/commit/{commit}',
+    branch: '/tree/{branch}',
+    tag: '/releases/tag/{tag}',
+  },
+  gitlab: {
+    commit: '/commit/{commit}',
+    branch: '/tree/{branch}',
+    tag: '/commits/{tag}',
+  },
+  bitbucket: {
+    commit: '/commits/{commit}',
+    branch: '/branch/{branch}',
+    tag: '/commits/tag/{tag}',
+  },
+};
+enum Filters {
+  RECENT_BUILDS = 'Recent builds',
+  LAST_48_HOURS = 'Last 48 hours',
+  LAST_30_DAYS = 'Last 30 days',
+}
+
+export default function Builds(props: BuildsProps) {
+  const [buildsSinceInSeconds, setBuildsSinceInSeconds] = useState<number>();
+  const [dateStartedFilter, setDateStartedFilter] = useState<Filters>(
+    Filters.RECENT_BUILDS,
+  );
+  const {builds, isError, error, isLoading} = useBuilds(
+    props.org,
+    props.repo,
+    buildsSinceInSeconds,
+  );
+
+  if (isLoading) {
+    return <LoadingPage />;
+  }
+
+  if (isError) {
+    return <RequestError message={error as string} />;
+  }
+
+  const setFilter = (filterType: string) => {
+    switch (filterType) {
+      case Filters.RECENT_BUILDS:
+        setDateStartedFilter(Filters.RECENT_BUILDS);
+        setBuildsSinceInSeconds(null);
+        break;
+      case Filters.LAST_48_HOURS:
+        setDateStartedFilter(Filters.LAST_48_HOURS);
+        setBuildsSinceInSeconds(
+          Math.round(new Date().getTime() / 1000) - 2 * ONE_DAY_IN_SECONDS,
+        );
+        break;
+      case Filters.LAST_30_DAYS:
+        setDateStartedFilter(Filters.LAST_30_DAYS);
+        setBuildsSinceInSeconds(
+          Math.round(new Date().getTime() / 1000) - 30 * ONE_DAY_IN_SECONDS,
+        );
+    }
+  };
+
+  return (
+    <>
+      <PageSection>
+        <Card>
+          <Title
+            headingLevel="h3"
+            style={{paddingLeft: '1em', paddingTop: '1em'}}
+          >
+            Build History
+          </Title>
+          <ToggleGroup
+            aria-label="filter build list by date"
+            style={{padding: '1em'}}
+          >
+            <ToggleGroupItem
+              text={Filters.RECENT_BUILDS}
+              aria-label="filter recent builds"
+              buttonId="filter-recent-builds"
+              isSelected={dateStartedFilter === Filters.RECENT_BUILDS}
+              onChange={() => setFilter(Filters.RECENT_BUILDS)}
+            />
+            <ToggleGroupItem
+              text={Filters.LAST_48_HOURS}
+              aria-label="filter builds from last 48 hours"
+              buttonId="filter-48-hours"
+              isSelected={dateStartedFilter === Filters.LAST_48_HOURS}
+              onChange={() => setFilter(Filters.LAST_48_HOURS)}
+            />
+            <ToggleGroupItem
+              text={Filters.LAST_30_DAYS}
+              aria-label="filter builds from last 30 days"
+              buttonId="filter-30-days"
+              isSelected={dateStartedFilter === Filters.LAST_30_DAYS}
+              onChange={() => setFilter(Filters.LAST_30_DAYS)}
+            />
+          </ToggleGroup>
+          <Conditional if={builds.length === 0}>
+            <p style={{padding: '1em'}}>
+              No matching builds found. Please start a new build or adjust
+              filter to view build status.
+            </p>
+          </Conditional>
+          <Conditional if={builds.length > 0}>
+            <Table aria-label="Repository builds table" variant="compact">
+              <Thead>
+                <Tr>
+                  <Th>Build ID</Th>
+                  <Th>Status</Th>
+                  <Th>Triggered by</Th>
+                  <Th>Date started</Th>
+                  <Th>Tags</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {builds.map((build) => (
+                  <Tr key={build.id} data-testid={`row-${build.id}`}>
+                    <Td data-label="Build ID">{build.id.substring(0, 8)}</Td>
+                    <Td data-label="Status">
+                      <BuildPhase phase={build.phase} />
+                    </Td>
+                    <Td data-label="Triggered by">
+                      <TriggeredBuildDescription build={build} />
+                    </Td>
+                    <Td data-label="Date started">
+                      {formatDate(build.started)}
+                    </Td>
+                    <Td data-label="Tags">
+                      {build.tags?.map((tag) => (
+                        <span key={tag}>
+                          <TagIcon /> {tag}{' '}
+                        </span>
+                      ))}
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </Conditional>
+        </Card>
+      </PageSection>
+    </>
+  );
+}
+
+function BuildPhase({phase}: {phase: RepositoryBuildPhase}) {
+  switch (phase) {
+    case RepositoryBuildPhase.ERROR:
+      return (
+        <span>
+          <TimesCircleIcon style={{color: 'red'}} /> error
+        </span>
+      );
+    case RepositoryBuildPhase.COMPLETE:
+      return (
+        <span>
+          <CheckCircleIcon style={{color: 'green'}} /> complete
+        </span>
+      );
+    case RepositoryBuildPhase.EXPIRED:
+      return (
+        <span>
+          <ExclamationTriangleIcon style={{color: 'orange'}} /> expired
+        </span>
+      );
+    case RepositoryBuildPhase.INTERNAL_ERROR:
+      return (
+        <span>
+          <ExclamationTriangleIcon style={{color: 'red'}} /> internal error
+        </span>
+      );
+    case RepositoryBuildPhase.CANCELLED:
+      return (
+        <span>
+          <BanIcon /> cancelled
+        </span>
+      );
+    default:
+      return (
+        <span>
+          <SyncAltIcon /> {phase}
+        </span>
+      );
+  }
+}
+
+function TriggeredBuildDescription({build}: {build: RepositoryBuild}) {
+  const commitSha = getCommitSha(build);
+  if (!isNullOrUndefined(build.trigger_metadata?.commit_info)) {
+    return <FullCommitDescription build={build} />;
+  } else if (isNullOrUndefined(build.trigger)) {
+    if (build.manual_user) {
+      return (
+        <>
+          <UserIcon /> {build.manual_user}
+        </>
+      );
+    } else {
+      return <>(Manually Triggered Build)</>;
+    }
+  } else if (!isNullOrUndefined(build.trigger?.build_source) && commitSha) {
+    return <>Triggered by commit {commitSha.substring(0, 7)}</>;
+  } else {
+    return (
+      <>
+        {' '}
+        Triggered by <TriggerDescription trigger={build.trigger} />
+      </>
+    );
+  }
+}
+
+function FullCommitDescription({build}: {build: RepositoryBuild}) {
+  const [showLongDescription, setShowLongDescription] = useState(false);
+  return (
+    <>
+      <div>
+        <CommitMessageSummary build={build} />
+        <Conditional
+          if={
+            build?.trigger_metadata?.commit_info?.message?.length >= 80 ||
+            build?.trigger_metadata?.commit_info?.message?.split('\n').length >
+              1
+          }
+        >
+          <span
+            data-testid="expand-long-description"
+            style={{paddingLeft: '.5em'}}
+            onClick={() => setShowLongDescription(!showLongDescription)}
+          >
+            ...
+          </span>
+        </Conditional>
+      </div>
+      <Conditional
+        if={
+          !isNullOrUndefined(build?.trigger_metadata?.commit_info?.date) ||
+          !isNullOrUndefined(build?.trigger_metadata?.commit_info?.author)
+        }
+      >
+        Authored{' '}
+        <Conditional
+          if={!isNullOrUndefined(build?.trigger_metadata?.commit_info?.date)}
+        >
+          {humanizeTimeForExpiry(
+            (new Date().getTime() -
+              new Date(build?.trigger_metadata?.commit_info?.date).getTime()) /
+              1000,
+          )}{' '}
+          ago{' '}
+        </Conditional>
+        <Conditional
+          if={
+            !isNullOrUndefined(
+              build?.trigger_metadata?.commit_info?.author?.username,
+            )
+          }
+        >
+          <LinkOrPlainText
+            href={build?.trigger_metadata?.commit_info?.author?.url}
+          >
+            <Conditional
+              if={
+                !isNullOrUndefined(
+                  build?.trigger_metadata?.commit_info?.author?.avatar_url,
+                )
+              }
+            >
+              <img
+                src={build?.trigger_metadata?.commit_info?.author?.avatar_url}
+              />
+            </Conditional>
+            by {build?.trigger_metadata?.commit_info?.author?.username}{' '}
+          </LinkOrPlainText>
+        </Conditional>
+        <span style={{paddingRight: '.5em'}}>
+          <a href={getCommitURL(build)}>
+            <CodeIcon /> {getCommitSha(build)?.substring(0, 7)}
+          </a>
+        </span>
+        <span style={{paddingRight: '.5em'}}>
+          <GitRefLink build={build} />
+        </span>
+      </Conditional>
+      <Conditional if={showLongDescription}>
+        <div>
+          {getLongDescription(build?.trigger_metadata?.commit_info?.message)}
+        </div>
+      </Conditional>
+    </>
+  );
+}
+
+function TriggerDescription({trigger}: {trigger: RepositoryBuild['trigger']}) {
+  const config = useQuayConfig();
+  switch (trigger.service) {
+    case 'github':
+      return (
+        <>
+          push to GitHub{' '}
+          <Conditional
+            if={
+              !config?.oauth?.GITHUB_TRIGGER_CONFIG?.AUTHORIZE_ENDPOINT.includes(
+                'https://github.com/',
+              )
+            }
+          >
+            Enterprise
+          </Conditional>{' '}
+          repository <a>{trigger?.config?.build_source}</a>
+        </>
+      );
+    case 'bitbucket':
+      return (
+        <>
+          push to BitBucket repository <a>{trigger?.config?.build_source}</a>
+        </>
+      );
+    case 'gitlab':
+      return (
+        <>
+          push to GitLab repository <a>{trigger?.config?.build_source}</a>
+        </>
+      );
+    case 'custom-git':
+      return (
+        <>
+          push to repository <a>{trigger?.config?.build_source}</a>
+        </>
+      );
+    default:
+      return <></>;
+  }
+}
+
+function GitRefLink({build}: {build: RepositoryBuild}) {
+  const ref = build?.trigger_metadata?.ref;
+  if (isNullOrUndefined(ref)) {
+    return <></>;
+  }
+
+  const {resource, refType} = getResourceNameFromGitRef(
+    build?.trigger_metadata?.ref,
+  );
+  if (isNullOrUndefined(resource)) {
+    return <></>;
+  }
+
+  if (refType === 'heads') {
+    const branchURL = getBranchURL(build);
+    return (
+      <LinkOrPlainText href={branchURL}>
+        <CodeBranchIcon /> {resource}
+      </LinkOrPlainText>
+    );
+  } else if (refType === 'tags') {
+    const tagURL = getTagURL(build);
+    return (
+      <LinkOrPlainText href={tagURL}>
+        <TagIcon /> {resource}
+      </LinkOrPlainText>
+    );
+  }
+}
+
+function getCommitSha(build: RepositoryBuild) {
+  return build.trigger_metadata?.commit || build.trigger_metadata?.commit_sha;
+}
+
+function getCommitURL(build: RepositoryBuild) {
+  if (
+    build.trigger_metadata &&
+    build.trigger_metadata?.commit_info &&
+    build.trigger_metadata?.commit_info.url
+  ) {
+    return build.trigger_metadata?.commit_info.url;
+  }
+
+  const trigger = build.trigger;
+  if (!isNullOrUndefined(trigger?.repository_url)) {
+    return (
+      trigger.repository_url +
+      RESOURCE_URLS[trigger?.service].commit.replace(
+        '{commit}',
+        getCommitSha(build),
+      )
+    );
+  }
+}
+
+function getBranchURL(build: RepositoryBuild) {
+  const {resource} = getResourceNameFromGitRef(build?.trigger_metadata?.ref);
+  if (isNullOrUndefined(resource)) {
+    return null;
+  }
+  const trigger = build.trigger;
+  if (!isNullOrUndefined(trigger?.repository_url)) {
+    return (
+      trigger.repository_url +
+      RESOURCE_URLS[trigger?.service].branch.replace('{branch}', resource)
+    );
+  }
+}
+
+function getTagURL(build: RepositoryBuild) {
+  const {resource} = getResourceNameFromGitRef(build?.trigger_metadata?.ref);
+  if (isNullOrUndefined(resource)) {
+    return null;
+  }
+  const trigger = build.trigger;
+  if (!isNullOrUndefined(trigger?.repository_url)) {
+    return (
+      trigger.repository_url +
+      RESOURCE_URLS[trigger?.service].tag.replace('{tag}', resource)
+    );
+  }
+}
+
+function CommitMessageSummary({build}: {build: RepositoryBuild}) {
+  const message = build.trigger_metadata?.commit_info?.message;
+  if (isNullOrUndefined(message) || message.length == 0) {
+    return <></>;
+  }
+  const commitURL = getCommitURL(build);
+  const lines = message.split('\n');
+  if (lines.length === 0) {
+    return <></>;
+  }
+  if (isNullOrUndefined(commitURL)) {
+    return <span>{lines[0].substring(0, 79).trim()}</span>;
+  } else {
+    return (
+      <span>
+        <a href={commitURL}>{lines[0].substring(0, 79).trim()}</a>
+      </span>
+    );
+  }
+}
+
+function getResourceNameFromGitRef(ref: string) {
+  const parts = ref.split('/');
+  if (parts.length < 3) {
+    return null;
+  }
+  return {
+    resource: parts.slice(2).join('/'),
+    refType: parts[1],
+  };
+}
+
+function getLongDescription(message: string) {
+  if (!message) {
+    return '';
+  }
+  const lines = message.split('\n');
+  if (lines.length === 0) {
+    return '';
+  }
+  if (lines[0].length >= 80) {
+    lines[0] = lines[0].substring(80);
+  } else {
+    lines.splice(0, 1);
+  }
+  return lines.join('\n').trim();
+}
+
+interface BuildsProps {
+  org: string;
+  repo: string;
+}

--- a/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
+++ b/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
@@ -41,6 +41,7 @@ import {useFetchTeams} from 'src/hooks/UseTeams';
 import {CreateTeamModal} from '../OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreateTeamModal';
 import {useAlerts} from 'src/hooks/UseAlerts';
 import {AlertVariant} from 'src/atoms/AlertState';
+import Builds from './Builds/Builds';
 
 enum TabIndex {
   Tags = 'tags',
@@ -268,6 +269,17 @@ export default function RepositoryDetails() {
                         setDrawerContent={setDrawerContent}
                         repoDetails={repoDetails}
                       />
+                    </Tab>
+                    <Tab
+                      eventKey={TabIndex.Builds}
+                      title={<TabTitleText>Builds</TabTitleText>}
+                      isHidden={
+                        config?.features.UI_V2_BUILDS != true ||
+                        config?.features.BUILD_SUPPORT != true ||
+                        !repoDetails?.can_write
+                      }
+                    >
+                      <Builds org={organization} repo={repository} />
                     </Tab>
                   </Tabs>
                 </ErrorBoundary>


### PR DESCRIPTION
Adding panel for viewing previously ran builds.

**How to test with test data**
1. Enable the `FEATURE_UI_V2_BUILDS` config option
2. Open cypress `npx cypress open`
3. Run the `builds.cy.ts` spec

![image](https://github.com/quay/quay/assets/22058392/9f7ef9f1-6d80-4d40-8383-94daf95642c8)
