### PR TITLE
sso: adding error log for export compliance (PROJQUAY-6486)

### DIFF
--- a/oauth/services/rhsso.py
+++ b/oauth/services/rhsso.py
@@ -61,8 +61,12 @@ class RHSSOOAuthService(OIDCLoginService):
                 # also any issues with reaching the export
                 # compliance API should trigger this
                 # Adding error log to capture the error on sentry without causing quay.io logins to fail
+                msg = ""
+                if result:
+                    msg = f"Got unknown response from export compliance service: {result.text}, with status_code: {result.status_code}"
+
                 logger.error(
-                    f"Got unknown response from export compliance service: {result.text}, with status_code: {result.status_code}"
+                    f"{msg}"
                     f"for sub: {sub}, lusername: {lusername}"
                     f"Failing with exception as: {str(e)}",
                     extra={"stack": True},

--- a/oauth/services/rhsso.py
+++ b/oauth/services/rhsso.py
@@ -60,6 +60,13 @@ class RHSSOOAuthService(OIDCLoginService):
                 # This generates a generic OAUTH error page
                 # also any issues with reaching the export
                 # compliance API should trigger this
-                raise OAuthLoginException(str(e))
+                # Adding error log to capture the error on sentry without causing quay.io logins to fail
+                logger.error(
+                    f"Got unknown response from export compliance service: {result.text}, with status_code: {result.status_code}"
+                    f"for sub: {sub}, lusername: {lusername}"
+                    f"Failing with exception as: {str(e)}",
+                    extra={"stack": True},
+                    exc_info=True,
+                )
 
         return sub, lusername, email_address


### PR DESCRIPTION
Adding error log instead of raising exception when we get unknown response/error from export compliance service. `exc_info` should send the error log to sentry.