### PR TITLE
deploy: fix health check endpoint for quay deployment (PROJQUAY-6456)

### DIFF
--- a/deploy/openshift/quay-py3-deploy-template.yaml
+++ b/deploy/openshift/quay-py3-deploy-template.yaml
@@ -245,7 +245,7 @@ objects:
               command:
               - curl
               - -k
-              - https://localhost:${{LOADBALANCER_SERVICE_TARGET_PORT}}/health/instance
+              - https://localhost:8443/health/instance
             failureThreshold: ${{QUAY_APP_STARTUP_PROBE_FAILURE_THRESHOLD}}
             timeoutSeconds: ${{QUAY_APP_STARTUP_PROBE_TIMEOUT_SECONDS}}
             periodSeconds: ${{QUAY_APP_STARTUP_PROBE_PERIOD_SECONDS}}
@@ -254,7 +254,7 @@ objects:
               command:
               - curl
               - -k
-              - https://localhost:${{LOADBALANCER_SERVICE_TARGET_PORT}}/health/instance
+              - https://localhost:8443/health/instance
             initialDelaySeconds: ${{QUAY_APP_LIVENESS_PROBE_INITIAL_DELAY_SECONDS}}
             periodSeconds: ${{QUAY_APP_LIVENESS_PROBE_PERIOD_SECONDS}}
             timeoutSeconds: ${{QUAY_APP_LIVENESS_PROBE_TIMEOUT_SECONDS}}
@@ -263,7 +263,7 @@ objects:
               command:
               - curl
               - -k
-              - https://localhost:${{LOADBALANCER_SERVICE_TARGET_PORT}}/health/endtoend
+              - https://localhost:8443/health/endtoend
             initialDelaySeconds: ${{QUAY_APP_READINESS_PROBE_INITIAL_DELAY_SECONDS}}
             periodSeconds: ${{QUAY_APP_READINESS_PROBE_PERIOD_SECONDS}}
             timeoutSeconds: ${{QUAY_APP_READINESS_PROBE_TIMEOUT_SECONDS}}


### PR DESCRIPTION
variable is not expanded in health check. Use port directly