### PR TITLE
marketplace: update user ebs number lookup to find personal account numbers (PROJQUAY-233)

### DIFF
--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -68,8 +68,13 @@ class RedHatUserApi(object):
         if not info:
             logger.debug("request to %s did not return any data", self.user_endpoint)
             return None
-        account_number = info[0]["accountRelationships"][0]["account"].get("ebsAccountNumber")
-        return account_number
+        for account in info:
+            if account["accountRelationships"][0]["account"]["type"] == "person":
+                account_number = account["accountRelationships"][0]["account"].get(
+                    "ebsAccountNumber"
+                )
+                return account_number
+        return None
 
 
 class RedHatSubscriptionApi(object):

--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -1,27 +1,80 @@
+import json
+
 import requests
 from mock import patch
 
 from util.marketplace import RedHatSubscriptionApi, RedHatUserApi
 
 app_config = {
-    "ENTITLEMENT_RECONCILIATION_USER_ENDPOINT": "example.com",
-    "ENTITLEMENT_RECONCILIATION_MARKETPLACE_ENDPOINT": "example.com",
+    "ENTITLEMENT_RECONCILIATION_USER_ENDPOINT": "https://example.com",
+    "ENTITLEMENT_RECONCILIATION_MARKETPLACE_ENDPOINT": "https://example.com",
 }
 
+mocked_user_service_response = [
+    {
+        "id": "12345678",
+        "accountRelationships": [
+            {
+                "emails": [{"address": "example@example.com", "status": "enabled"}],
+                "accountId": "fakeid",
+                "startDate": "2022-09-19T04:18:19.228Z",
+                "id": "fakeid",
+                "account": {
+                    "id": "222222222",
+                    "cdhPartyNumber": "11111111",
+                    "ebsAccountNumber": "102030",
+                    "name": "Red Hat",
+                    "displayName": "Red Hat",
+                    "status": "enabled",
+                    "type": "organization",
+                },
+            }
+        ],
+    },
+    {
+        "id": "87654321",
+        "accountRelationships": [
+            {
+                "emails": [{"address": "example@example.com", "status": "enabled"}],
+                "accountId": "fakeid",
+                "startDate": "2022-09-20T14:31:09.974Z",
+                "id": "fakeid",
+                "account": {
+                    "id": "fakeid",
+                    "cdhPartyNumber": "0000000",
+                    "ebsAccountNumber": "1234567",
+                    "name": "Test User",
+                    "status": "enabled",
+                    "type": "person",
+                },
+            }
+        ],
+    },
+]
 
-@patch("requests.request")
-def test_timeout_exception(requests_mock):
-    requests_mock.side_effect = requests.exceptions.ReadTimeout()
-    user_api = RedHatUserApi(app_config)
-    subscription_api = RedHatSubscriptionApi(app_config)
 
-    customer_id = user_api.lookup_customer_id("example@example.com")
-    assert customer_id is None
-    subscription_response = subscription_api.lookup_subscription(123456, "sku")
-    assert subscription_response is None
-    subscription_sku = subscription_api.get_subscription_sku(123456)
-    assert subscription_sku is None
-    extended_subscription = subscription_api.extend_subscription(12345, 102623)
-    assert extended_subscription is None
-    create_subscription_response = subscription_api.create_entitlement(12345, "sku")
-    assert create_subscription_response == 408
+class TestMarketplace:
+    @patch("requests.request")
+    def test_timeout_exception(self, requests_mock):
+        requests_mock.side_effect = requests.exceptions.ReadTimeout()
+        user_api = RedHatUserApi(app_config)
+        subscription_api = RedHatSubscriptionApi(app_config)
+
+        customer_id = user_api.lookup_customer_id("example@example.com")
+        assert customer_id is None
+        subscription_response = subscription_api.lookup_subscription(123456, "sku")
+        assert subscription_response is None
+        subscription_sku = subscription_api.get_subscription_sku(123456)
+        assert subscription_sku is None
+        extended_subscription = subscription_api.extend_subscription(12345, 102623)
+        assert extended_subscription is None
+        create_subscription_response = subscription_api.create_entitlement(12345, "sku")
+        assert create_subscription_response == 408
+
+    @patch("requests.request")
+    def test_user_lookup(self, requests_mock):
+        user_api = RedHatUserApi(app_config)
+        requests_mock.return_value.content = json.dumps(mocked_user_service_response)
+
+        customer_id = user_api.lookup_customer_id("example@example.com")
+        assert customer_id == "1234567"


### PR DESCRIPTION
User service can return more than one result when finding users by email. For example:
```
[
  {
        "id": "12345678",
        "accountRelationships": [
            {
                "emails": [{"address": "example@example.com", "status": "enabled"}],
                "accountId": "fakeid",
                "startDate": "2022-09-19T04:18:19.228Z",
                "id": "fakeid",
                "account": {
                    "id": "22222222",
                    "cdhPartyNumber": "1111111111",
                    "ebsAccountNumber": "102030",
                    "name": "Red Hat",
                    "displayName": "Red Hat",
                    "status": "enabled",
                    "type": "organization",
                },
            }
        ],
    },
    {
        "id": "87654321",
        "accountRelationships": [
            {
                "emails": [{"address": "example@example.com", "status": "enabled"}],
                "accountId": "fakeid",
                "startDate": "2022-09-20T14:31:09.974Z",
                "id": "fakeid",
                "account": {
                    "id": "fakeid",
                    "cdhPartyNumber": "0000000",
                    "ebsAccountNumber": "1234567",
                    "name": "Test User",
                    "status": "enabled",
                    "type": "person",
                },
            }
        ],
    },
]
```

In this case we should use the ebsAccountNumber that has the type "person" (1234567)