### PR TITLE
ui: fix broken update of repo description (PROJQUAY-6243)

### DIFF
--- a/static/js/directives/repo-view/repo-panel-info.js
+++ b/static/js/directives/repo-view/repo-panel-info.js
@@ -31,8 +31,17 @@ angular.module('quay').directive('repoPanelInfo', function () {
       });
 
       $scope.updateDescription = function(content) {
-        $scope.repository.description = content;
-        $scope.repository.put();
+        var params = {
+          'repository': $scope.repository.namespace + '/' + $scope.repository.name
+        };
+
+        var data = {
+          'description': content
+        };
+
+        ApiService.updateRepo(data, params).then(function() {
+          $scope.repository.description = content;
+        }, ApiService.errorDisplay('Could not update repository description'));
       };
 
       $scope.getAggregatedUsage = function(stats, days) {


### PR DESCRIPTION
This fixes a bug while trying to update the repository description by explicitly calling the `updateRepo` endpoint.