### PR TITLE
ui: updating logo for quay.io (PROJQUAY-6531)

### DIFF
--- a/web/src/components/header/QuayHeader.tsx
+++ b/web/src/components/header/QuayHeader.tsx
@@ -12,6 +12,7 @@ import {
 
 import BarsIcon from '@patternfly/react-icons/dist/js/icons/bars-icon';
 import logo from 'src/assets/quay.svg';
+import rh_logo from 'src/assets/RH_QuayIO2.svg';
 import {HeaderToolbar} from './HeaderToolbar';
 import {Link} from 'react-router-dom';
 import {SidebarState} from 'src/atoms/SidebarState';
@@ -26,6 +27,11 @@ export function QuayHeader() {
   let logoUrl = logo;
   if (quayConfig && quayConfig.config?.ENTERPRISE_DARK_LOGO_URL) {
     logoUrl = `${axios.defaults.baseURL}${quayConfig.config.ENTERPRISE_DARK_LOGO_URL}`;
+  } else if (
+    window?.location?.hostname === 'stage.quay.io' ||
+    window?.location?.hostname === 'quay.io'
+  ) {
+    logoUrl = rh_logo;
   }
 
   const toggleSidebarVisibility = () => {


### PR DESCRIPTION
Now using the Redhat logo for Quay.io.