### PR TITLE
ui: add dark mode to see Quay in a new light or lack thereof (PROJQUAY-6569)

### DIFF
--- a/web/cypress/e2e/theme-switcher.cy.ts
+++ b/web/cypress/e2e/theme-switcher.cy.ts
@@ -1,0 +1,115 @@
+/// <reference types="cypress" />
+
+describe('Account Settings Page', () => {
+  beforeEach(() => {
+    cy.exec('npm run quay:seed');
+    cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
+      .then((response) => response.body.csrf_token)
+      .then((token) => {
+        cy.loginByCSRF(token);
+      });
+    cy.intercept('GET', '/config', {fixture: 'config.json'}).as('getConfig');
+  });
+
+  it('Theme switcher', () => {
+    cy.visit('/overview');
+
+    // Check if the default theme is light
+    cy.get('html').should('not.have.class', 'pf-v5-theme-dark');
+
+    // Ensure the theme switcher is present
+    cy.get('[id=user-menu-toggle]').click();
+    cy.get('#toggle-group-light-theme').should('exist');
+    cy.get('#toggle-group-dark-theme').should('exist');
+    cy.get('#toggle-group-auto-theme').should('exist');
+
+    // Ensure the theme switcher is set to auto
+    cy.get('#toggle-group-auto-theme').should('have.class', 'pf-m-selected');
+  });
+
+  it('Switch themes', () => {
+    cy.visit('/overview');
+
+    // Check if the default theme is light
+    cy.get('html').should('not.have.class', 'pf-v5-theme-dark');
+
+    // Switch to dark theme
+    cy.get('[id=user-menu-toggle]').click();
+    cy.get('#toggle-group-dark-theme').click();
+
+    // Ensure the theme is set to dark
+    cy.get('#toggle-group-dark-theme').should('have.class', 'pf-m-selected');
+    cy.get('html').should('have.class', 'pf-v5-theme-dark');
+
+    // Ensure local preference is saved
+    cy.window().then((window) => {
+      expect(window.localStorage.getItem('theme-preference')).to.equal('DARK');
+    });
+
+    // Ensure preference used on load
+    cy.reload();
+    cy.get('html').should('have.class', 'pf-v5-theme-dark');
+
+    // Ensure the theme switcher respects local preference
+    cy.get('[id=user-menu-toggle]').click();
+    cy.get('#toggle-group-dark-theme').should('have.class', 'pf-m-selected');
+
+    // Switch to light theme
+    cy.get('#toggle-group-light-theme').click();
+
+    // Ensure the theme is set to light
+    cy.get('#toggle-group-light-theme').should('have.class', 'pf-m-selected');
+    cy.get('html').should('not.have.class', 'pf-v5-theme-dark');
+
+    // Ensure local preference is saved
+    cy.window().then((window) => {
+      expect(window.localStorage.getItem('theme-preference')).to.equal('LIGHT');
+    });
+  });
+
+  it('Theme switcher with browser in dark mode', () => {
+    cy.wrap(
+      Cypress.automation('remote:debugger:protocol', {
+        command: 'Emulation.setEmulatedMedia',
+        params: {
+          media: 'page',
+          features: [
+            {
+              name: 'prefers-color-scheme',
+              value: 'dark',
+            },
+          ],
+        },
+      }),
+    );
+
+    cy.visit('/overview');
+
+    // Check if the default theme is dark
+    cy.get('html').should('have.class', 'pf-v5-theme-dark');
+
+    // Ensure the theme switcher is present
+    cy.get('[id=user-menu-toggle]').click();
+
+    // Ensure the theme switcher is set to auto and reacts to live changes in the browser preferences
+    cy.get('#toggle-group-auto-theme')
+      .should('have.class', 'pf-m-selected')
+      .then(() => {
+        return Cypress.automation('remote:debugger:protocol', {
+          command: 'Emulation.setEmulatedMedia',
+          params: {
+            media: 'page',
+            features: [
+              {
+                name: 'prefers-color-scheme',
+                value: 'light',
+              },
+            ],
+          },
+        });
+      })
+      .then(() => {
+        cy.get('html').should('not.have.class', 'pf-v5-theme-dark');
+      });
+  });
+});

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -28,7 +28,7 @@ html, body, #root,  .App {
 
 .disabled-link {
     pointer-events: none;
-    color: black;
+    color: var(--pf-v5-global--palette--black);
 }
 
 .no-padding {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,26 +1,29 @@
-import React, {Suspense} from 'react';
+import {Suspense} from 'react';
 import {BrowserRouter, Route, Routes} from 'react-router-dom';
 
 import 'src/App.css';
 
 import {LoadingPage} from 'src/components/LoadingPage';
-import {StandaloneMain} from 'src/routes/StandaloneMain';
-import {Signin} from 'src/routes/Signin/Signin';
 import {useAnalytics} from 'src/hooks/UseAnalytics';
+import {Signin} from 'src/routes/Signin/Signin';
+import {StandaloneMain} from 'src/routes/StandaloneMain';
+import {ThemeProvider} from './contexts/ThemeContext';
 
 export default function App() {
   useAnalytics();
 
   return (
     <div className="App">
-      <BrowserRouter>
-        <Suspense fallback={<LoadingPage />}>
-          <Routes>
-            <Route path="/*" element={<StandaloneMain />} />
-            <Route path="/signin" element={<Signin />} />
-          </Routes>
-        </Suspense>
-      </BrowserRouter>
+      <ThemeProvider>
+        <BrowserRouter>
+          <Suspense fallback={<LoadingPage />}>
+            <Routes>
+              <Route path="/*" element={<StandaloneMain />} />
+              <Route path="/signin" element={<Signin />} />
+            </Routes>
+          </Suspense>
+        </BrowserRouter>
+      </ThemeProvider>
     </div>
   );
 }

--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -1,13 +1,15 @@
 import {
   Button,
-  Dropdown,
-  DropdownItem,
-  DropdownList,
+  Divider,
+  MenuGroup,
+  MenuItem,
+  MenuList,
   Flex,
   FlexItem,
   Icon,
+  MenuContent,
   MenuToggle,
-  MenuToggleElement,
+  Menu,
   Switch,
   ToggleGroup,
   ToggleGroupItem,
@@ -16,8 +18,13 @@ import {
   ToolbarGroup,
   ToolbarItem,
   Tooltip,
+  MenuContainer,
 } from '@patternfly/react-core';
-import {UserIcon, WindowMaximizeIcon} from '@patternfly/react-icons';
+import {
+  PowerOffIcon,
+  UserIcon,
+  WindowMaximizeIcon,
+} from '@patternfly/react-icons';
 import React, {useState} from 'react';
 import {GlobalAuthState, logoutUser} from 'src/resources/AuthResource';
 import {addDisplayError} from 'src/resources/ErrorHandling';
@@ -33,6 +40,8 @@ import {ThemePreference, useTheme} from 'src/contexts/ThemeContext';
 
 export function HeaderToolbar() {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
   const {themePreference, setThemePreference} = useTheme();
 
   const queryClient = useQueryClient();
@@ -43,8 +52,11 @@ export function HeaderToolbar() {
     setIsDropdownOpen((prev) => !prev);
   };
 
-  const onDropdownSelect = async (value) => {
-    switch (value) {
+  const onMenuSelect = async (
+    event: React.MouseEvent | undefined,
+    itemId: string | number | undefined,
+  ) => {
+    switch (itemId) {
       case 'logout':
         try {
           await logoutUser();
@@ -70,113 +82,137 @@ export function HeaderToolbar() {
     }
   };
 
-  const userDropdown = (
-    <Dropdown
-      onSelect={(_event, value) => onDropdownSelect(value)}
-      isOpen={isDropdownOpen}
-      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle
-          ref={toggleRef}
-          onClick={onDropdownToggle}
-          isExpanded={isDropdownOpen}
-          icon={<UserIcon />}
-        >
-          {user.username}
-        </MenuToggle>
-      )}
-      onOpenChange={(isOpen) => setIsDropdownOpen(isOpen)}
-      shouldFocusToggleOnSelect
+  const userMenu = (
+    <Menu ref={menuRef} onSelect={onMenuSelect}>
+      <MenuContent>
+        <MenuGroup label="Appearance" key="theme">
+          <MenuList>
+            <MenuItem
+              itemId="theme-selector"
+              key="theme-selector"
+              component="object"
+            >
+              <ToggleGroup id="theme-toggle" aria-label="Theme toggle group">
+                <ToggleGroupItem
+                  icon={
+                    <Icon size="sm">
+                      <SunIcon />
+                    </Icon>
+                  }
+                  aria-label="light theme"
+                  aria-describedby="tooltip-auto-theme"
+                  buttonId="toggle-group-light-theme"
+                  onChange={() => {
+                    if (themePreference !== ThemePreference.LIGHT) {
+                      setThemePreference(ThemePreference.LIGHT);
+                    }
+                  }}
+                  isSelected={themePreference === ThemePreference.LIGHT}
+                />
+                <ToggleGroupItem
+                  icon={
+                    <Icon size="sm">
+                      <MoonIcon />
+                    </Icon>
+                  }
+                  aria-label="dark theme"
+                  buttonId="toggle-group-dark-theme"
+                  onChange={() => {
+                    if (themePreference !== ThemePreference.DARK) {
+                      setThemePreference(ThemePreference.DARK);
+                    }
+                  }}
+                  isSelected={themePreference === ThemePreference.DARK}
+                />
+                <ToggleGroupItem
+                  icon={
+                    <Icon size="sm">
+                      <WindowMaximizeIcon />
+                    </Icon>
+                  }
+                  aria-label="auto theme"
+                  buttonId="toggle-group-auto-theme"
+                  onChange={() => {
+                    if (themePreference !== ThemePreference.AUTO) {
+                      setThemePreference(ThemePreference.AUTO);
+                    }
+                  }}
+                  isSelected={themePreference === ThemePreference.AUTO}
+                />
+              </ToggleGroup>
+            </MenuItem>
+          </MenuList>
+        </MenuGroup>
+        <Divider />
+        <MenuGroup label="Actions" key="user">
+          <MenuList>
+            <MenuItem
+              icon={<PowerOffIcon aria-hidden />}
+              isDanger={true}
+              itemId="logout"
+              key="logout"
+              component="button"
+            >
+              Logout
+            </MenuItem>
+          </MenuList>
+        </MenuGroup>
+        <Tooltip
+          id="tooltip-light-theme"
+          content="Light theme"
+          position="bottom"
+          triggerRef={() =>
+            document.getElementById(
+              'toggle-group-light-theme',
+            ) as HTMLButtonElement
+          }
+        />
+        <Tooltip
+          id="tooltip-dark-theme"
+          content="Dark theme"
+          position="bottom"
+          triggerRef={() =>
+            document.getElementById(
+              'toggle-group-dark-theme',
+            ) as HTMLButtonElement
+          }
+        />
+        <Tooltip
+          id="tooltip-auto-theme"
+          content="Browser-based theme"
+          position="bottom"
+          triggerRef={() =>
+            document.getElementById(
+              'toggle-group-auto-theme',
+            ) as HTMLButtonElement
+          }
+        />
+      </MenuContent>
+    </Menu>
+  );
+
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onDropdownToggle}
+      isExpanded={isDropdownOpen}
+      icon={<UserIcon />}
+      id="user-menu-toggle"
+      aria-label="User menu"
     >
-      <DropdownList>
-        <DropdownItem value="logout" key="logout" component="button">
-          Logout
-        </DropdownItem>
-        <DropdownItem
-          value="theme-selector"
-          key="theme-selector"
-          component="object"
-        >
-          <ToggleGroup aria-label="Theme toggle group">
-            <ToggleGroupItem
-              icon={
-                <Icon size="sm">
-                  <SunIcon />
-                </Icon>
-              }
-              aria-label="light theme"
-              aria-describedby="tooltip-auto-theme"
-              buttonId="toggle-group-light-theme"
-              onChange={() => {
-                if (themePreference !== ThemePreference.LIGHT) {
-                  setThemePreference(ThemePreference.LIGHT);
-                }
-              }}
-              isSelected={themePreference === ThemePreference.LIGHT}
-            />
-            <ToggleGroupItem
-              icon={
-                <Icon size="sm">
-                  <MoonIcon />
-                </Icon>
-              }
-              aria-label="dark theme"
-              buttonId="toggle-group-dark-theme"
-              onChange={() => {
-                if (themePreference !== ThemePreference.DARK) {
-                  setThemePreference(ThemePreference.DARK);
-                }
-              }}
-              isSelected={themePreference === ThemePreference.DARK}
-            />
-            <ToggleGroupItem
-              icon={
-                <Icon size="sm">
-                  <WindowMaximizeIcon />
-                </Icon>
-              }
-              aria-label="auto theme"
-              buttonId="toggle-group-auto-theme"
-              onChange={() => {
-                if (themePreference !== ThemePreference.AUTO) {
-                  setThemePreference(ThemePreference.AUTO);
-                }
-              }}
-              isSelected={themePreference === ThemePreference.AUTO}
-            />
-          </ToggleGroup>
-        </DropdownItem>
-      </DropdownList>
-      <Tooltip
-        id="tooltip-light-theme"
-        content="Light theme"
-        position="bottom"
-        triggerRef={() =>
-          document.getElementById(
-            'toggle-group-light-theme',
-          ) as HTMLButtonElement
-        }
-      />
-      <Tooltip
-        id="tooltip-dark-theme"
-        content="Dark theme"
-        position="bottom"
-        triggerRef={() =>
-          document.getElementById(
-            'toggle-group-dark-theme',
-          ) as HTMLButtonElement
-        }
-      />
-      <Tooltip
-        id="tooltip-auto-theme"
-        content="Browser-based theme"
-        position="bottom"
-        triggerRef={() =>
-          document.getElementById(
-            'toggle-group-auto-theme',
-          ) as HTMLButtonElement
-        }
-      />
-    </Dropdown>
+      {user.username}
+    </MenuToggle>
+  );
+
+  const menuContainer = (
+    <MenuContainer
+      menu={userMenu}
+      menuRef={menuRef}
+      isOpen={isDropdownOpen}
+      toggle={toggle}
+      toggleRef={toggleRef}
+      onOpenChange={(isOpen) => setIsDropdownOpen(isOpen)}
+    />
   );
 
   const signInButton = <Button> Sign In </Button>;
@@ -235,7 +271,7 @@ export function HeaderToolbar() {
               </Flex>
             </ToolbarItem>
             <ToolbarItem>
-              {user.username ? userDropdown : signInButton}
+              {user.username ? menuContainer : signInButton}
             </ToolbarItem>
           </ToolbarGroup>
         </ToolbarContent>

--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -1,4 +1,3 @@
-import React, {useState} from 'react';
 import {
   Button,
   Dropdown,
@@ -6,25 +5,35 @@ import {
   DropdownList,
   Flex,
   FlexItem,
+  Icon,
   MenuToggle,
   MenuToggleElement,
   Switch,
+  ToggleGroup,
+  ToggleGroupItem,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
+  Tooltip,
 } from '@patternfly/react-core';
-import {UserIcon} from '@patternfly/react-icons';
+import {UserIcon, WindowMaximizeIcon} from '@patternfly/react-icons';
+import React, {useState} from 'react';
 import {GlobalAuthState, logoutUser} from 'src/resources/AuthResource';
 import {addDisplayError} from 'src/resources/ErrorHandling';
 import ErrorModal from '../errors/ErrorModal';
 
-import 'src/components/header/HeaderToolbar.css';
 import {useQueryClient} from '@tanstack/react-query';
+import 'src/components/header/HeaderToolbar.css';
 import {useCurrentUser} from 'src/hooks/UseCurrentUser';
+
+import MoonIcon from '@patternfly/react-icons/dist/esm/icons/moon-icon';
+import SunIcon from '@patternfly/react-icons/dist/esm/icons/sun-icon';
+import {ThemePreference, useTheme} from 'src/contexts/ThemeContext';
 
 export function HeaderToolbar() {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const {themePreference, setThemePreference} = useTheme();
 
   const queryClient = useQueryClient();
   const {user} = useCurrentUser();
@@ -35,7 +44,6 @@ export function HeaderToolbar() {
   };
 
   const onDropdownSelect = async (value) => {
-    setIsDropdownOpen(false);
     switch (value) {
       case 'logout':
         try {
@@ -52,8 +60,12 @@ export function HeaderToolbar() {
           console.error(err);
           setErr(addDisplayError('Unable to log out', err));
         }
+        setIsDropdownOpen(false);
+        break;
+      case 'theme-selector':
         break;
       default:
+        setIsDropdownOpen(false);
         break;
     }
   };
@@ -79,7 +91,91 @@ export function HeaderToolbar() {
         <DropdownItem value="logout" key="logout" component="button">
           Logout
         </DropdownItem>
+        <DropdownItem
+          value="theme-selector"
+          key="theme-selector"
+          component="object"
+        >
+          <ToggleGroup aria-label="Theme toggle group">
+            <ToggleGroupItem
+              icon={
+                <Icon size="sm">
+                  <SunIcon />
+                </Icon>
+              }
+              aria-label="light theme"
+              aria-describedby="tooltip-auto-theme"
+              buttonId="toggle-group-light-theme"
+              onChange={() => {
+                if (themePreference !== ThemePreference.LIGHT) {
+                  setThemePreference(ThemePreference.LIGHT);
+                }
+              }}
+              isSelected={themePreference === ThemePreference.LIGHT}
+            />
+            <ToggleGroupItem
+              icon={
+                <Icon size="sm">
+                  <MoonIcon />
+                </Icon>
+              }
+              aria-label="dark theme"
+              buttonId="toggle-group-dark-theme"
+              onChange={() => {
+                if (themePreference !== ThemePreference.DARK) {
+                  setThemePreference(ThemePreference.DARK);
+                }
+              }}
+              isSelected={themePreference === ThemePreference.DARK}
+            />
+            <ToggleGroupItem
+              icon={
+                <Icon size="sm">
+                  <WindowMaximizeIcon />
+                </Icon>
+              }
+              aria-label="auto theme"
+              buttonId="toggle-group-auto-theme"
+              onChange={() => {
+                if (themePreference !== ThemePreference.AUTO) {
+                  setThemePreference(ThemePreference.AUTO);
+                }
+              }}
+              isSelected={themePreference === ThemePreference.AUTO}
+            />
+          </ToggleGroup>
+        </DropdownItem>
       </DropdownList>
+      <Tooltip
+        id="tooltip-light-theme"
+        content="Light theme"
+        position="bottom"
+        triggerRef={() =>
+          document.getElementById(
+            'toggle-group-light-theme',
+          ) as HTMLButtonElement
+        }
+      />
+      <Tooltip
+        id="tooltip-dark-theme"
+        content="Dark theme"
+        position="bottom"
+        triggerRef={() =>
+          document.getElementById(
+            'toggle-group-dark-theme',
+          ) as HTMLButtonElement
+        }
+      />
+      <Tooltip
+        id="tooltip-auto-theme"
+        content="Browser-based theme"
+        position="bottom"
+        triggerRef={() =>
+          document.getElementById(
+            'toggle-group-auto-theme',
+          ) as HTMLButtonElement
+        }
+      />
     </Dropdown>
   );
 

--- a/web/src/contexts/ThemeContext.tsx
+++ b/web/src/contexts/ThemeContext.tsx
@@ -1,0 +1,77 @@
+import React, {createContext, useContext, useEffect, useState} from 'react';
+
+type ThemePreference = string;
+export const ThemePreference = {
+  LIGHT: 'LIGHT',
+  DARK: 'DARK',
+  AUTO: 'AUTO',
+};
+
+const ThemeContext = createContext({
+  themePreference: ThemePreference.AUTO,
+  isDarkTheme: false,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
+  setThemePreference: (value: ThemePreference) => {},
+});
+
+export const ThemeProvider: React.FC = ({children}) => {
+  const storageKey = 'theme-preference';
+  const [isDarkTheme, setIsDarkTheme] = useState(false);
+  const [themePreference, setThemePreference] = useState<ThemePreference>(
+    ThemePreference[localStorage.getItem(storageKey)] !== undefined
+      ? localStorage.getItem(storageKey)
+      : ThemePreference.AUTO,
+  );
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  const mediaQueryListener = (e: MediaQueryListEvent) => {
+    if (themePreference === ThemePreference.AUTO) {
+      setIsDarkTheme(e.matches);
+    }
+  };
+
+  useEffect(() => {
+    const browserPreference = mediaQuery.matches
+      ? ThemePreference.DARK
+      : ThemePreference.LIGHT;
+
+    switch (themePreference) {
+      case ThemePreference.LIGHT:
+        localStorage.setItem(storageKey, ThemePreference.LIGHT);
+        setIsDarkTheme(false);
+        break;
+      case ThemePreference.DARK:
+        localStorage.setItem(storageKey, ThemePreference.DARK);
+        setIsDarkTheme(true);
+        break;
+      case ThemePreference.AUTO:
+        mediaQuery.addEventListener('change', mediaQueryListener);
+        switch (browserPreference) {
+          case ThemePreference.LIGHT:
+            setIsDarkTheme(false);
+            break;
+          case ThemePreference.DARK:
+            setIsDarkTheme(true);
+            break;
+        }
+        localStorage.setItem(storageKey, ThemePreference.AUTO);
+
+        return () => {
+          mediaQuery.removeEventListener('change', mediaQueryListener);
+        };
+    }
+  }, [themePreference]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('pf-v5-theme-dark', isDarkTheme);
+  }, [isDarkTheme]);
+
+  return (
+    <ThemeContext.Provider
+      value={{themePreference, isDarkTheme, setThemePreference}}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/web/src/libs/utils.ts
+++ b/web/src/libs/utils.ts
@@ -5,17 +5,17 @@ import {ITeamMember} from 'src/hooks/UseMembers';
 export function getSeverityColor(severity: VulnerabilitySeverity) {
   switch (severity) {
     case VulnerabilitySeverity.Critical:
-      return '#7D1007';
+      return 'var(--pf-v5-global--palette--red-200)';
     case VulnerabilitySeverity.High:
-      return '#C9190B';
+      return 'var(--pf-v5-global--palette--red-100)';
     case VulnerabilitySeverity.Medium:
-      return '#EC7A08';
+      return 'var(--pf-v5-global--palette--orange-300)';
     case VulnerabilitySeverity.Low:
-      return '#F0AB00';
+      return 'var(--pf-v5-global--palette--gold-300)';
     case VulnerabilitySeverity.None:
-      return '#3E8635';
+      return 'var(--pf-v5-global--palette--green-400)';
     default:
-      return '#8A8D90';
+      return 'var(--pf-v5-global--palette--black-300)';
   }
 }
 

--- a/web/src/routes/TagDetails/SecurityReport/SecurityReportChart.css
+++ b/web/src/routes/TagDetails/SecurityReport/SecurityReportChart.css
@@ -1,0 +1,3 @@
+.pf-v5-theme-dark {
+    --pf-v5-chart-donut--label--title--Fill: var(--pf-v5-global--primary-color--400);
+}

--- a/web/src/routes/TagDetails/SecurityReport/SecurityReportChart.tsx
+++ b/web/src/routes/TagDetails/SecurityReport/SecurityReportChart.tsx
@@ -9,8 +9,9 @@ import {
   TitleSizes,
 } from '@patternfly/react-core';
 import {ExclamationTriangleIcon} from '@patternfly/react-icons';
-import {Feature, VulnerabilitySeverity} from 'src/resources/TagResource';
 import {getSeverityColor} from 'src/libs/utils';
+import {Feature, VulnerabilitySeverity} from 'src/resources/TagResource';
+import './SecurityReportChart.css';
 
 function VulnerabilitySummary(props: VulnerabilityStatsProps) {
   let message = <Skeleton width="400px" />;


### PR DESCRIPTION
I bring you dark mode.

Why? Because staring at a bright screen is like staring at the sun. Not cool.

This introduces:

- Theme selector: choice is king, we are not dictators
- Dark mode: easy on the eyes, hard on the boring
- Auto mode: reflects your desktop's snazzy dark mode setting
- `Menu` menu: refactored to use MenuContainer, MenuToggle and Menu with icons like the PatternFly gods intended
- Persistent choice: browser crashed because too many tabs open? the UI remembers your theme selection, courtesy of local storage

Like sunglasses for your screen. See for yourself:

<img width="1200" alt="Screenshot 2023-12-29 at 21 13 12" src="https://github.com/quay/quay/assets/12664117/1652d64c-970d-4b1c-82fb-f0d45182b6bc">
<img width="1202" alt="Screenshot 2023-12-29 at 21 13 00" src="https://github.com/quay/quay/assets/12664117/439a8868-38b8-4807-be5a-1d7ed4129804">
<img width="1199" alt="Screenshot 2023-12-29 at 21 12 45" src="https://github.com/quay/quay/assets/12664117/b137990d-d0f9-45b0-89e9-c8e3177a0cdb">
<img width="1203" alt="Screenshot 2023-12-29 at 16 46 40" src="https://github.com/quay/quay/assets/12664117/4f892eac-3427-4d30-93d3-221eb2dcd116">

<img width="1200" alt="Screenshot 2023-12-29 at 21 13 28" src="https://github.com/quay/quay/assets/12664117/0a5367db-0308-4106-9ea8-a8490ac51673">

