### PR TITLE
ui: adding build avatar image size (PROJQUAY-6575)

### DIFF
--- a/web/cypress/fixtures/builds.json
+++ b/web/cypress/fixtures/builds.json
@@ -338,7 +338,8 @@
           "message": "custom-git build from branch",
           "date": "2023-11-28T10:42:17-05:00",
           "author": {
-            "username": "user1"
+            "username": "user1",
+            "avatar_url": "https://avatars.githubusercontent.com/u/38353654?s=200&v=4"
           },
           "committer": {
             "username": "web-flow"

--- a/web/src/routes/RepositoryDetails/Builds/Builds.tsx
+++ b/web/src/routes/RepositoryDetails/Builds/Builds.tsx
@@ -297,6 +297,7 @@ function FullCommitDescription({build}: {build: RepositoryBuild}) {
           <LinkOrPlainText
             href={build?.trigger_metadata?.commit_info?.author?.url}
           >
+            by{' '}
             <Conditional
               if={
                 !isNullOrUndefined(
@@ -305,10 +306,11 @@ function FullCommitDescription({build}: {build: RepositoryBuild}) {
               }
             >
               <img
+                style={{width: '1.5em', marginRight: '.2em'}}
                 src={build?.trigger_metadata?.commit_info?.author?.avatar_url}
               />
             </Conditional>
-            by {build?.trigger_metadata?.commit_info?.author?.username}{' '}
+            {build?.trigger_metadata?.commit_info?.author?.username}{' '}
           </LinkOrPlainText>
         </Conditional>
         <span style={{paddingRight: '.5em'}}>


### PR DESCRIPTION
Sets the image size for avatars shown in the build history table. 

How to test:
1. Run the `Displays build status` test in `web/cypress/e2e/builds.cy.ts`
2. Verify the row with build id `build008` displays the avatar with the correct size