### PR TITLE
marketplace: update reconciliationworker to use webCustomerId instead of ebsAccountNumber (PROJQUAY-233)

### DIFF
--- a/data/billing.py
+++ b/data/billing.py
@@ -348,7 +348,8 @@ PLANS = [
     },
 ]
 
-RH_SKUS = [plan["rh_sku"] for plan in PLANS if plan.get("rh_sku") is not None]
+RH_SKUS = ["MW02701"]
+RECONCILER_SKUS = [plan["rh_sku"] for plan in PLANS if plan.get("rh_sku") is not None]
 
 
 def get_plan(plan_id):

--- a/data/billing.py
+++ b/data/billing.py
@@ -223,6 +223,7 @@ PLANS = [
         "privateRepos": 5,
         "stripeId": "personal-2018",
         "rh_sku": "MW00584MO",
+        "sku_billing": False,
         "audience": "Individuals",
         "bus_features": False,
         "deprecated": False,
@@ -235,6 +236,7 @@ PLANS = [
         "price": 3000,
         "privateRepos": 10,
         "rh_sku": "MW00585MO",
+        "sku_billing": False,
         "stripeId": "bus-micro-2018",
         "audience": "For startups",
         "bus_features": True,
@@ -248,6 +250,7 @@ PLANS = [
         "price": 6000,
         "privateRepos": 20,
         "rh_sku": "MW00586MO",
+        "sku_billing": False,
         "stripeId": "bus-small-2018",
         "audience": "For small businesses",
         "bus_features": True,
@@ -261,6 +264,7 @@ PLANS = [
         "price": 12500,
         "privateRepos": 50,
         "rh_sku": "MW00587MO",
+        "sku_billing": False,
         "stripeId": "bus-medium-2018",
         "audience": "For normal businesses",
         "bus_features": True,
@@ -274,6 +278,7 @@ PLANS = [
         "price": 25000,
         "privateRepos": 125,
         "rh_sku": "MW00588MO",
+        "sku_billing": False,
         "stripeId": "bus-large-2018",
         "audience": "For large businesses",
         "bus_features": True,
@@ -313,6 +318,7 @@ PLANS = [
         "price": 160000,
         "privateRepos": 1000,
         "rh_sku": "MW00591MO",
+        "sku_billing": False,
         "stripeId": "bus-1000-2018",
         "audience": "For the SaaS savvy enterprise",
         "bus_features": True,
@@ -326,6 +332,7 @@ PLANS = [
         "price": 310000,
         "privateRepos": 2000,
         "rh_sku": "MW00592MO",
+        "sku_billing": False,
         "stripeId": "bus-2000-2018",
         "audience": "For the SaaS savvy big enterprise",
         "bus_features": True,
@@ -346,10 +353,25 @@ PLANS = [
         "superseded_by": None,
         "plans_page_hidden": False,
     },
+    {
+        "title": "subscriptionwatch",
+        "privateRepos": 100,
+        "stripeId": "not_a_stripe_plan",
+        "rh_sku": "MW02701",
+        "sku_billing": True,
+        "plans_page_hidden": True,
+    },
 ]
 
-RH_SKUS = ["MW02701"]
-RECONCILER_SKUS = [plan["rh_sku"] for plan in PLANS if plan.get("rh_sku") is not None]
+RH_SKUS = [
+    plan["rh_sku"] for plan in PLANS if plan.get("rh_sku") is not None and plan.get("sku_billing")
+]
+
+RECONCILER_SKUS = [
+    plan["rh_sku"]
+    for plan in PLANS
+    if plan.get("rh_sku") is not None and not plan.get("sku_billing")
+]
 
 
 def get_plan(plan_id):

--- a/data/model/entitlements.py
+++ b/data/model/entitlements.py
@@ -33,10 +33,10 @@ def update_web_customer_id(user, web_customer_id):
 
 def remove_web_customer_id(user, web_customer_id):
     try:
-        id = RedHatSubscriptions.get(
+        customer_id = RedHatSubscriptions.get(
             RedHatSubscriptions.user_id == user.id,
             RedHatSubscriptions.account_number == web_customer_id,
         )
-        return id.delete_instance()
+        return customer_id.delete_instance()
     except model.DataModelException as ex:
         logger.error("Problem removing customer id for %s: %s", user.username, ex)

--- a/data/model/entitlements.py
+++ b/data/model/entitlements.py
@@ -6,7 +6,7 @@ from data.database import RedHatSubscriptions
 logger = logging.getLogger(__name__)
 
 
-def get_ebs_account_number(user_id):
+def get_web_customer_id(user_id):
     try:
         query = RedHatSubscriptions.get(RedHatSubscriptions.user_id == user_id).account_number
         return query
@@ -14,8 +14,29 @@ def get_ebs_account_number(user_id):
         return None
 
 
-def save_ebs_account_number(user, ebsAccountNumber):
+def save_web_customer_id(user, web_customer_id):
     try:
-        return RedHatSubscriptions.create(user_id=user.id, account_number=ebsAccountNumber)
+        return RedHatSubscriptions.create(user_id=user.id, account_number=web_customer_id)
     except model.DataModelException as ex:
         logger.error("Problem saving account number for %s: %s", user.username, ex)
+
+
+def update_web_customer_id(user, web_customer_id):
+    try:
+        query = RedHatSubscriptions.update(
+            {RedHatSubscriptions.account_number: web_customer_id}
+        ).where(RedHatSubscriptions.user_id == user.id)
+        query.execute()
+    except model.DataModelException as ex:
+        logger.error("Problem updating customer id for %s: %s", user.username, ex)
+
+
+def remove_web_customer_id(user, web_customer_id):
+    try:
+        id = RedHatSubscriptions.get(
+            RedHatSubscriptions.user_id == user.id,
+            RedHatSubscriptions.account_number == web_customer_id,
+        )
+        return id.delete_instance()
+    except model.DataModelException as ex:
+        logger.error("Problem removing customer id for %s: %s", user.username, ex)

--- a/endpoints/api/test/test_superuser.py
+++ b/endpoints/api/test/test_superuser.py
@@ -1,5 +1,3 @@
-from test.fixtures import *
-
 import pytest
 
 from data.database import DeletedNamespace, User
@@ -10,6 +8,7 @@ from endpoints.api.superuser import (
 )
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
+from test.fixtures import *
 
 
 @pytest.mark.parametrize(
@@ -32,7 +31,7 @@ def test_list_all_users(disabled, app):
 def test_list_all_orgs(app):
     with client_with_identity("devtable", app) as cl:
         result = conduct_api_call(cl, SuperUserOrganizationList, "GET", None, None, 200).json
-        assert len(result["organizations"]) == 5
+        assert len(result["organizations"]) == 6
 
 
 def test_paginate_orgs(app):
@@ -45,7 +44,7 @@ def test_paginate_orgs(app):
         secondResult = conduct_api_call(
             cl, SuperUserOrganizationList, "GET", params, None, 200
         ).json
-        assert len(secondResult["organizations"]) == 2
+        assert len(secondResult["organizations"]) == 3
         assert secondResult.get("next_page", None) is None
 
 
@@ -57,7 +56,7 @@ def test_paginate_test_list_all_users(app):
         assert firstResult["next_page"] is not None
         params["next_page"] = firstResult["next_page"]
         secondResult = conduct_api_call(cl, SuperUserList, "GET", params, None, 200).json
-        assert len(secondResult["users"]) == 4
+        assert len(secondResult["users"]) == 5
         assert secondResult.get("next_page", None) is None
 
 

--- a/initdb.py
+++ b/initdb.py
@@ -646,6 +646,12 @@ def populate_database(minimal=False):
     outside_org.verified = True
     outside_org.save()
 
+    subscriptionuser = model.user.create_user(
+        "subscription", "password", "subscriptions@devtable.com"
+    )
+    subscriptionuser.verified = True
+    subscriptionuser.save()
+
     model.notification.create_notification(
         "test_notification",
         new_user_1,
@@ -924,6 +930,11 @@ def populate_database(minimal=False):
         "sellnsmall", "quay+sell@devtable.com", new_user_1
     )
     thirdorg.save()
+
+    subscriptionsorg = model.organization.create_organization(
+        "subscriptionsorg", "quay+subscriptionsorg@devtable.com", subscriptionuser
+    )
+    subscriptionsorg.save()
 
     model.user.create_robot("coolrobot", org)
 

--- a/static/js/directives/ui/plan-manager.js
+++ b/static/js/directives/ui/plan-manager.js
@@ -30,7 +30,7 @@ angular.module('quay').directive('planManager', function () {
         }
 
         // A plan is visible if it is not deprecated, or if it is the namespace's current plan.
-        if (plan['deprecated']) {
+        if (plan['deprecated'] || plan['plans_page_hidden']) {
           return subscribedPlan && plan.stripeId === subscribedPlan.stripeId;
         }
 
@@ -41,7 +41,7 @@ angular.module('quay').directive('planManager', function () {
         if (!subscribedPlan) {
           return false;
         }
-        
+
         return plan.stripeId === subscribedPlan.stripeId;
       };
 
@@ -122,4 +122,3 @@ angular.module('quay').directive('planManager', function () {
   };
   return directiveDefinitionObject;
 });
-

--- a/test/test_api_usage.py
+++ b/test/test_api_usage.py
@@ -8,7 +8,6 @@ import time
 import unittest
 from calendar import timegm
 from contextlib import contextmanager
-from test.helpers import assert_action_logged, check_transitive_modifications
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from cryptography.hazmat.backends import default_backend
@@ -144,6 +143,7 @@ from endpoints.api.user import (
 from endpoints.building import PreparedBuild
 from endpoints.webhooks import webhooks
 from initdb import finished_database_for_testing, setup_database_for_testing
+from test.helpers import assert_action_logged, check_transitive_modifications
 from util.morecollections import AttrDict
 from util.secscan.v4.fake import fake_security_scanner
 
@@ -175,6 +175,9 @@ ADMIN_ACCESS_EMAIL = "jschorr@devtable.com"
 ORG_REPO = "orgrepo"
 
 ORGANIZATION = "buynlarge"
+
+SUBSCRIPTION_USER = "subscription"
+SUBSCRIPTION_ORG = "subscriptionsorg"
 
 NEW_USER_DETAILS = {
     "username": "bobby",
@@ -5069,57 +5072,57 @@ class TestSuperUserManagement(ApiTestCase):
 
 class TestOrganizationRhSku(ApiTestCase):
     def test_bind_sku_to_org(self):
-        self.login(ADMIN_ACCESS_USER)
+        self.login(SUBSCRIPTION_USER)
         self.postResponse(
             resource_name=OrganizationRhSku,
-            params=dict(orgname=ORGANIZATION),
-            data={"subscription_id": 12345},
+            params=dict(orgname=SUBSCRIPTION_ORG),
+            data={"subscription_id": 12345678},
             expected_code=201,
         )
         json = self.getJsonResponse(
             resource_name=OrganizationRhSku,
-            params=dict(orgname=ORGANIZATION),
+            params=dict(orgname=SUBSCRIPTION_ORG),
         )
         self.assertEqual(len(json), 1)
 
     def test_bind_sku_duplicate(self):
-        user = model.user.get_user(ADMIN_ACCESS_USER)
-        org = model.organization.get_organization(ORGANIZATION)
-        model.organization_skus.bind_subscription_to_org(12345, org.id, user.id)
-        self.login(ADMIN_ACCESS_USER)
+        user = model.user.get_user(SUBSCRIPTION_USER)
+        org = model.organization.get_organization(SUBSCRIPTION_ORG)
+        model.organization_skus.bind_subscription_to_org(12345678, org.id, user.id)
+        self.login(SUBSCRIPTION_USER)
         self.postResponse(
             resource_name=OrganizationRhSku,
-            params=dict(orgname=ORGANIZATION),
-            data={"subscription_id": 12345},
+            params=dict(orgname=SUBSCRIPTION_ORG),
+            data={"subscription_id": 12345678},
             expected_code=400,
         )
 
     def test_bind_sku_unauthorized(self):
         # bind a sku that user does not own
-        self.login(ADMIN_ACCESS_USER)
+        self.login(SUBSCRIPTION_USER)
         self.postResponse(
             resource_name=OrganizationRhSku,
-            params=dict(orgname=ORGANIZATION),
-            data={"subscription_id": 11111},
+            params=dict(orgname=SUBSCRIPTION_ORG),
+            data={"subscription_id": 11111111},
             expected_code=401,
         )
 
     def test_remove_sku_from_org(self):
-        self.login(ADMIN_ACCESS_USER)
+        self.login(SUBSCRIPTION_USER)
         self.postResponse(
             resource_name=OrganizationRhSku,
-            params=dict(orgname=ORGANIZATION),
-            data={"subscription_id": 12345},
+            params=dict(orgname=SUBSCRIPTION_ORG),
+            data={"subscription_id": 12345678},
             expected_code=201,
         )
         self.deleteResponse(
             resource_name=OrganizationRhSkuSubscriptionField,
-            params=dict(orgname=ORGANIZATION, subscription_id=12345),
+            params=dict(orgname=SUBSCRIPTION_ORG, subscription_id=12345678),
             expected_code=204,
         )
         json = self.getJsonResponse(
             resource_name=OrganizationRhSku,
-            params=dict(orgname=ORGANIZATION),
+            params=dict(orgname=SUBSCRIPTION_ORG),
         )
         self.assertEqual(len(json), 0)
 

--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -341,10 +341,13 @@ class MarketplaceUserApi(object):
 
     def init_app(self, app):
         marketplace_enabled = app.config.get("FEATURE_RH_MARKETPLACE", False)
+        reconciler_enabled = app.config.get("ENTITLEMENT_RECONCILIATION", False)
+
+        use_rh_api = marketplace_enabled or reconciler_enabled
 
         marketplace_user_api = FakeUserApi(app.config)
 
-        if marketplace_enabled and not app.config.get("TESTING"):
+        if use_rh_api and not app.config.get("TESTING"):
             marketplace_user_api = RedHatUserApi(app.config)
 
         app.extensions = getattr(app, "extensions", {})
@@ -364,11 +367,14 @@ class MarketplaceSubscriptionApi(object):
             self.state = None
 
     def init_app(self, app):
+        reconciler_enabled = app.config.get("ENTITLEMENT_RECONCILIATION", False)
         marketplace_enabled = app.config.get("FEATURE_RH_MARKETPLACE", False)
+
+        use_rh_api = marketplace_enabled or reconciler_enabled
 
         marketplace_subscription_api = FakeSubscriptionApi()
 
-        if marketplace_enabled and not app.config.get("TESTING"):
+        if use_rh_api and not app.config.get("TESTING"):
             marketplace_subscription_api = RedHatSubscriptionApi(app.config)
 
         app.extensions = getattr(app, "extensions", {})

--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -40,7 +40,7 @@ mocked_user_service_response = [
                 "startDate": "2022-09-20T14:31:09.974Z",
                 "id": "fakeid",
                 "account": {
-                    "id": "fakeid",
+                    "id": "000000000",
                     "cdhPartyNumber": "0000000",
                     "ebsAccountNumber": "1234567",
                     "name": "Test User",
@@ -119,7 +119,7 @@ class TestMarketplace:
         requests_mock.return_value.content = json.dumps(mocked_user_service_response)
 
         customer_id = user_api.lookup_customer_id("example@example.com")
-        assert customer_id == "1234567"
+        assert customer_id == "000000000"
 
         requests_mock.return_value.content = json.dumps(mocked_organization_only_response)
         customer_id = user_api.lookup_customer_id("example@example.com")

--- a/workers/reconciliationworker.py
+++ b/workers/reconciliationworker.py
@@ -53,9 +53,8 @@ class ReconciliationWorker(Worker):
             )
 
             # check against user api
-            logger.debug("Looking up webCustomerId for email %s", email)
             customer_id = user_api.lookup_customer_id(email)
-            logger.debug("Found %s number for %s", str(customer_id), user.username)
+            logger.debug("Found %s number for %s", str(customer_id), email)
 
             if model_customer_id is None and customer_id:
                 logger.debug("Saving new customer id %s for %s", customer_id, user.username)


### PR DESCRIPTION
* fix reconciler where it was incorrectly using the ebsAccountNumber to create subscriptions
* add job to reconciler so that it reconciles different ids between the database and the user api
* separate skus to be used by billing and skus to be used by reconciler