### PR TITLE
marketplace: make sure customer id from api is returned as an int (PROJQUAY-233)

### DIFF
--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -71,6 +71,9 @@ class RedHatUserApi(object):
         for account in info:
             if account["accountRelationships"][0]["account"]["type"] == "person":
                 customer_id = account["accountRelationships"][0]["account"].get("id")
+                # convert str response from api to int value
+                if str.isdigit(customer_id):
+                    customer_id = int(customer_id)
                 return customer_id
         return None
 

--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -72,7 +72,7 @@ class RedHatUserApi(object):
             if account["accountRelationships"][0]["account"]["type"] == "person":
                 customer_id = account["accountRelationships"][0]["account"].get("id")
                 # convert str response from api to int value
-                if str.isdigit(customer_id):
+                if customer_id.isdigit():
                     customer_id = int(customer_id)
                 return customer_id
         return None

--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -119,7 +119,7 @@ class TestMarketplace:
         requests_mock.return_value.content = json.dumps(mocked_user_service_response)
 
         customer_id = user_api.lookup_customer_id("example@example.com")
-        assert customer_id == "000000000"
+        assert customer_id == 000000000
 
         requests_mock.return_value.content = json.dumps(mocked_organization_only_response)
         customer_id = user_api.lookup_customer_id("example@example.com")

--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -52,8 +52,8 @@ def test_reconcile_different_ids(initialized_db):
     worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
 
     new_id = model.entitlements.get_web_customer_id(test_user.id)
-    assert new_id != "12345"
-    assert int(new_id) == marketplace_users.lookup_customer_id(test_user.email)
+    assert new_id != 12345
+    assert new_id == marketplace_users.lookup_customer_id(test_user.email)
 
     # make sure it will remove account numbers from db that do not belong
     with patch.object(marketplace_users, "lookup_customer_id") as mock:

--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -52,11 +52,23 @@ def test_reconcile_different_ids(initialized_db):
     worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
 
     new_id = model.entitlements.get_web_customer_id(test_user.id)
-    assert new_id != 12345
-    assert new_id == marketplace_users.lookup_customer_id(test_user.email)
+    assert new_id != "12345"
+    assert int(new_id) == marketplace_users.lookup_customer_id(test_user.email)
 
     # make sure it will remove account numbers from db that do not belong
     with patch.object(marketplace_users, "lookup_customer_id") as mock:
         mock.return_value = None
         worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
     assert model.entitlements.get_web_customer_id(test_user.id) is None
+
+
+def test_update_same_id(initialized_db):
+    test_user = model.user.create_user("stripe_user", "password", "stripe_user@test.com")
+    test_user.stripe_id = "cus_" + "".join(random.choices(string.ascii_lowercase, k=14))
+    test_user.save()
+    model.entitlements.save_web_customer_id(test_user, 11111)
+
+    with patch.object(model.entitlements, "update_web_customer_id") as mock:
+        worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
+
+    mock.assert_not_called()


### PR DESCRIPTION
Make sure when parsing data from user api that the customer id is returned as an integer type. Fixes problem with reconciler where it thinks two of the same id are different.