### PR TITLE
storage: Fix big layer uploads for Ceph/RADOS driver (PROJQUAY-6586)

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -990,8 +990,8 @@ class RadosGWStorage(_CloudStorage):
         connect_kwargs = {
             "endpoint_url": _build_endpoint_url(hostname, port=port, is_secure=is_secure),
             "config": Config(
-                connect_timeout=600 if server_side_assembly == False else 60,
-                read_timeout=600 if server_side_assembly == False else 60,
+                connect_timeout=600 if not server_side_assembly else 60,
+                read_timeout=600 if not server_side_assembly else 60,
             ),
         }
 
@@ -1032,8 +1032,8 @@ class RadosGWStorage(_CloudStorage):
         return super(RadosGWStorage, self).get_direct_upload_url(path, mime_type, requires_cors)
 
     def complete_chunked_upload(self, uuid, final_path, storage_metadata):
-        logger.debug("Multipart upload is set to {}.".format(self.server_side_assembly))
-        if self.server_side_assembly == True:
+        logger.debug("Server side assembly is set to {}.".format(self.server_side_assembly))
+        if self.server_side_assembly:
             logger.debug("Initiating multipart upload and server side assembly for final push.")
             return super(RadosGWStorage, self).complete_chunked_upload(
                 uuid, final_path, storage_metadata

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -984,10 +984,15 @@ class RadosGWStorage(_CloudStorage):
         bucket_name,
         port=None,
         maximum_chunk_size_mb=None,
+        multipart_upload=True,
     ):
         upload_params = {}
         connect_kwargs = {
             "endpoint_url": _build_endpoint_url(hostname, port=port, is_secure=is_secure),
+            "config": Config(
+                connect_timeout=600 if multipart_upload == False else 60,
+                read_timeout=600 if multipart_upload == False else 60,
+            ),
         }
 
         super(RadosGWStorage, self).__init__(
@@ -1006,6 +1011,8 @@ class RadosGWStorage(_CloudStorage):
         )  # 32mb default, as used in Docker registry:2
         self.maximum_chunk_size = chunk_size * 1024 * 1024
 
+        self.multipart_upload = multipart_upload
+
     # TODO remove when radosgw supports cors: http://tracker.ceph.com/issues/8718#change-38624
     def get_direct_download_url(
         self, path, request_ip=None, expires_in=60, requires_cors=False, head=False, **kwargs
@@ -1023,6 +1030,23 @@ class RadosGWStorage(_CloudStorage):
             return None
 
         return super(RadosGWStorage, self).get_direct_upload_url(path, mime_type, requires_cors)
+
+    def complete_chunked_upload(self, uuid, final_path, storage_metadata):
+        logger.debug("Multipart upload is set to {}.".format(self.multipart_upload))
+        if self.multipart_upload == True:
+            logger.debug("Initiating multipart upload and server side assembly for final push.")
+            return super(RadosGWStorage, self).complete_chunked_upload(
+                uuid, final_path, storage_metadata
+            )
+        else:
+            logger.debug("Initiating client side chunk join for final assembly and push.")
+            logger.debug("Setting Boto timeout to 600 seconds in case of a large layer push.")
+            self._initialize_cloud_conn()
+            # Certain implementations of RadosGW do not support multipart copying from keys,
+            # so we are forced to join it all locally and then reupload.
+            # See https://github.com/ceph/ceph/pull/5139
+            chunk_list = self._chunk_list_from_metadata(storage_metadata)
+            self._client_side_chunk_join(final_path, chunk_list)
 
 
 class RHOCSStorage(RadosGWStorage):

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -984,14 +984,14 @@ class RadosGWStorage(_CloudStorage):
         bucket_name,
         port=None,
         maximum_chunk_size_mb=None,
-        multipart_upload=True,
+        server_side_assembly=True,
     ):
         upload_params = {}
         connect_kwargs = {
             "endpoint_url": _build_endpoint_url(hostname, port=port, is_secure=is_secure),
             "config": Config(
-                connect_timeout=600 if multipart_upload == False else 60,
-                read_timeout=600 if multipart_upload == False else 60,
+                connect_timeout=600 if server_side_assembly == False else 60,
+                read_timeout=600 if server_side_assembly == False else 60,
             ),
         }
 
@@ -1011,7 +1011,7 @@ class RadosGWStorage(_CloudStorage):
         )  # 32mb default, as used in Docker registry:2
         self.maximum_chunk_size = chunk_size * 1024 * 1024
 
-        self.multipart_upload = multipart_upload
+        self.server_side_assembly = server_side_assembly
 
     # TODO remove when radosgw supports cors: http://tracker.ceph.com/issues/8718#change-38624
     def get_direct_download_url(
@@ -1032,8 +1032,8 @@ class RadosGWStorage(_CloudStorage):
         return super(RadosGWStorage, self).get_direct_upload_url(path, mime_type, requires_cors)
 
     def complete_chunked_upload(self, uuid, final_path, storage_metadata):
-        logger.debug("Multipart upload is set to {}.".format(self.multipart_upload))
-        if self.multipart_upload == True:
+        logger.debug("Multipart upload is set to {}.".format(self.server_side_assembly))
+        if self.server_side_assembly == True:
             logger.debug("Initiating multipart upload and server side assembly for final push.")
             return super(RadosGWStorage, self).complete_chunked_upload(
                 uuid, final_path, storage_metadata

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -1000,7 +1000,7 @@ class RadosGWStorage(_CloudStorage):
             access_key,
             secret_key,
         )
-        
+
         chunk_size = (
             maximum_chunk_size_mb if maximum_chunk_size_mb is not None else 32
         )  # 32mb default, as used in Docker registry:2
@@ -1032,7 +1032,7 @@ class RHOCSStorage(RadosGWStorage):
     For now, this uses the same protocol as RadowsGW, but we create a distinct driver for future
     additional capabilities.
     """
-    
+
     pass
 
 


### PR DESCRIPTION
Current uploads of large images usually fail on Ceph/RADOS compatible implementations (including Noobaa) because during the last assembly, copy is done all at once. For large layers, this takes a long while and Boto times out. With this patch, we limit the size of the used chunk to 32 MB so the final copy is done in parts of up to 32 MB each. The size can be overridden by specifying the parameter `maximum_chunk_size_mb` in the driver settings, for example:

~~~
DISTRIBUTED_STORAGE_CONFIG:
    default:
        - RadosGWStorage
        - ...
           maximum_chunk_size_mb: 100
~~~