### PR TITLE
marketplace: return array of valid subscriptions when looking up subscription (PROJQUAY-6551)

### DIFF
--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -111,19 +111,20 @@ class RedHatSubscriptionApi(object):
             return None
 
         try:
-            subscription = max(
-                json.loads(r.content), key=lambda i: (i["effectiveEndDate"]), default=None
-            )
+            subscriptions = json.loads(r.content)
         except json.decoder.JSONDecodeError:
             return None
 
-        if subscription:
-            end_date = subscription["effectiveEndDate"]
-            now_ms = time.time() * 1000
-            # Is subscription still valid?
-            if now_ms < end_date:
-                logger.debug("subscription found for %s", str(skuId))
-                return subscription
+        valid_subscriptions = []
+        if subscriptions:
+            for subscription in subscriptions:
+                end_date = subscription["effectiveEndDate"]
+                now_ms = time.time() * 1000
+                # Is subscription still valid?
+                if now_ms < end_date:
+                    logger.debug("subscription found for %s", str(skuId))
+                    valid_subscriptions.append(subscription)
+            return valid_subscriptions
         return None
 
     def extend_subscription(self, subscription_id, endDate):

--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -94,6 +94,51 @@ mocked_organization_only_response = [
     },
 ]
 
+mocked_subscription_response = [
+    {
+        "id": 1,
+        "masterEndSystemName": "SUBSCRIPTION",
+        "createdEndSystemName": "SUBSCRIPTION",
+        "createdDate": 1704721749000,
+        "lastUpdateEndSystemName": "SUBSCRIPTION",
+        "lastUpdateDate": 1704721749000,
+        "installBaseStartDate": 1704672000000,
+        "installBaseEndDate": 1707350399000,
+        "webCustomerId": 12345,
+        "quantity": 1,
+        "effectiveStartDate": 1704672000000,
+        "effectiveEndDate": 1707350399000,
+    },
+    {
+        "id": 2,
+        "masterEndSystemName": "SUBSCRIPTION",
+        "createdEndSystemName": "SUBSCRIPTION",
+        "createdDate": 1705494625000,
+        "lastUpdateEndSystemName": "SUBSCRIPTION",
+        "lastUpdateDate": 1705494625000,
+        "installBaseStartDate": 1705467600000,
+        "installBaseEndDate": 1708145999000,
+        "webCustomerId": 12345,
+        "quantity": 1,
+        "effectiveStartDate": 1705467600000,
+        "effectiveEndDate": 1708145999000,
+    },
+    {
+        "id": 3,
+        "masterEndSystemName": "SUBSCRIPTION",
+        "createdEndSystemName": "SUBSCRIPTION",
+        "createdDate": 1610888071,
+        "lastUpdateEndSystemName": "SUBSCRIPTION",
+        "lastUpdateDate": 1610888071,
+        "installBaseStartDate": 1610888071,
+        "installBaseEndDate": 1610888071,
+        "webCustomerId": 12345,
+        "quantity": 1,
+        "effectiveStartDate": 1610888071,
+        "effectiveEndDate": 1610888071,
+    },
+]
+
 
 class TestMarketplace:
     @patch("requests.request")
@@ -124,3 +169,11 @@ class TestMarketplace:
         requests_mock.return_value.content = json.dumps(mocked_organization_only_response)
         customer_id = user_api.lookup_customer_id("example@example.com")
         assert customer_id is None
+
+    @patch("requests.request")
+    def test_subscription_lookup(self, requests_mock):
+        subscription_api = RedHatSubscriptionApi(app_config)
+        requests_mock.return_value.content = json.dumps(mocked_subscription_response)
+
+        subscriptions = subscription_api.lookup_subscription(12345, "some_sku")
+        assert len(subscriptions) == 2


### PR DESCRIPTION
Currently `lookup_subscription` only returns the most recent subscription found in subscription watch. For the new skus it should return an array of valid subscriptions.