### PR TITLE
api: Return layer compressed size with manifest request

### DIFF
--- a/endpoints/api/manifest.py
+++ b/endpoints/api/manifest.py
@@ -87,6 +87,9 @@ def _manifest_dict(manifest):
         "is_manifest_list": manifest.is_manifest_list,
         "manifest_data": manifest.internal_manifest_bytes.as_unicode(),
         "config_media_type": manifest.config_media_type,
+        "layers_compressed_size": manifest.layers_compressed_size
+        if not manifest.is_manifest_list
+        else 0,
         "layers": (
             [_layer_dict(lyr.layer_info, idx) for idx, lyr in enumerate(layers)] if layers else None
         ),


### PR DESCRIPTION
Previously, we weren't returning the total compressed layer size (in bytes) which is part of the manifest table. This makes it cumbersome to identify the real size of an image via `api/v1/repository/{LOCATION}/manifest/{manifestref}` endpoint since only individual layer sizes were returned and the total would then need to be manually summed over each individual layer. With this change, the API endpoint will return the compressed size of all layers if we're referencing a real image, if a reference points to an OCI index or a manifest list, the returned size will be 0.