### PR TITLE
ui: fix scrollbars and various layout issues (PROJQUAY-6619)

### DIFF
--- a/web/src/components/NewUserEmptyPage.tsx
+++ b/web/src/components/NewUserEmptyPage.tsx
@@ -1,43 +1,40 @@
 import {
-  Page,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  EmptyStateVariant,
   PageSection,
   PageSectionVariants,
-  EmptyState,
-  EmptyStateVariant,
-  EmptyStateIcon,
-  EmptyStateBody,
-  Button,
-  EmptyStateHeader,
-  EmptyStateFooter,
 } from '@patternfly/react-core';
 import {UserIcon} from '@patternfly/react-icons';
 
 export default function NewUserEmptyPage(props: NewUserEmptyPageProps) {
   return (
-    <Page>
-      <PageSection variant={PageSectionVariants.light}>
-        <EmptyState variant={EmptyStateVariant.lg}>
-          <EmptyStateHeader
-            titleText="Welcome to Quay"
-            icon={<EmptyStateIcon icon={UserIcon} color="black" />}
-            headingLevel="h5"
-          />
-          <EmptyStateBody>
-            To gain access to organizations and repositories on Quay.io you must{' '}
-            <br />
-            create a username.
-          </EmptyStateBody>
-          <EmptyStateFooter>
-            <Button
-              variant="primary"
-              onClick={() => props.setCreateUserModalOpen(true)}
-            >
-              Create username
-            </Button>
-          </EmptyStateFooter>
-        </EmptyState>
-      </PageSection>
-    </Page>
+    <PageSection variant={PageSectionVariants.light}>
+      <EmptyState variant={EmptyStateVariant.lg}>
+        <EmptyStateHeader
+          titleText="Welcome to Quay"
+          icon={<EmptyStateIcon icon={UserIcon} color="black" />}
+          headingLevel="h5"
+        />
+        <EmptyStateBody>
+          To gain access to organizations and repositories on Quay.io you must{' '}
+          <br />
+          create a username.
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <Button
+            variant="primary"
+            onClick={() => props.setCreateUserModalOpen(true)}
+          >
+            Create username
+          </Button>
+        </EmptyStateFooter>
+      </EmptyState>
+    </PageSection>
   );
 }
 

--- a/web/src/components/errors/404.tsx
+++ b/web/src/components/errors/404.tsx
@@ -1,30 +1,25 @@
-import React from 'react';
 import {
   EmptyState,
   EmptyStateBody,
-  EmptyStateIcon,
-  Page,
-  PageSection,
   EmptyStateHeader,
+  EmptyStateIcon,
+  PageSection,
 } from '@patternfly/react-core';
 import {ExclamationTriangleIcon} from '@patternfly/react-icons';
 
 export default function NotFound() {
   return (
-    <Page>
-      <PageSection>
-        <EmptyState variant="full">
-          <EmptyStateHeader
-            titleText="404 Page not found"
-            icon={<EmptyStateIcon icon={ExclamationTriangleIcon} />}
-            headingLevel="h1"
-          />
-          <EmptyStateBody>
-            We didn&apos;t find a page that matches the address you navigated
-            to.
-          </EmptyStateBody>
-        </EmptyState>
-      </PageSection>
-    </Page>
+    <PageSection>
+      <EmptyState variant="full">
+        <EmptyStateHeader
+          titleText="404 Page not found"
+          icon={<EmptyStateIcon icon={ExclamationTriangleIcon} />}
+          headingLevel="h1"
+        />
+        <EmptyStateBody>
+          We didn&apos;t find a page that matches the address you navigated to.
+        </EmptyStateBody>
+      </EmptyState>
+    </PageSection>
   );
 }

--- a/web/src/routes/OrganizationsList/Organization/Organization.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Organization.tsx
@@ -2,7 +2,6 @@ import {
   Drawer,
   DrawerContent,
   DrawerContentBody,
-  Page,
   PageSection,
   PageSectionVariants,
   Tab,
@@ -10,19 +9,19 @@ import {
   TabTitleText,
   Title,
 } from '@patternfly/react-core';
-import {useParams, useSearchParams} from 'react-router-dom';
 import {useCallback, useRef, useState} from 'react';
-import RepositoriesList from 'src/routes/RepositoriesList/RepositoriesList';
-import Settings from './Tabs/Settings/Settings';
+import {useParams, useSearchParams} from 'react-router-dom';
 import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
 import {useOrganization} from 'src/hooks/UseOrganization';
-import RobotAccountsList from 'src/routes/RepositoriesList/RobotAccountsList';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
-import TeamsAndMembershipList from './Tabs/TeamsAndMembership/TeamsAndMembershipList';
-import ManageMembersList from './Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList';
+import RepositoriesList from 'src/routes/RepositoriesList/RepositoriesList';
+import RobotAccountsList from 'src/routes/RepositoriesList/RobotAccountsList';
 import CreatePermissionDrawer from './Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer';
 import DefaultPermissionsList from './Tabs/DefaultPermissions/DefaultPermissionsList';
+import Settings from './Tabs/Settings/Settings';
+import TeamsAndMembershipList from './Tabs/TeamsAndMembership/TeamsAndMembershipList';
 import AddNewTeamMemberDrawer from './Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer';
+import ManageMembersList from './Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList';
 
 export enum OrganizationDrawerContentType {
   None,
@@ -155,35 +154,37 @@ export default function Organization() {
     >
       <DrawerContent panelContent={drawerContentOptions[drawerContent]}>
         <DrawerContentBody>
-          <Page>
-            <QuayBreadcrumb />
-            <PageSection
-              variant={PageSectionVariants.light}
-              className="no-padding-bottom"
+          <QuayBreadcrumb />
+          <PageSection
+            variant={PageSectionVariants.light}
+            className="no-padding-bottom"
+          >
+            <Title data-testid="repo-title" headingLevel="h1">
+              {organizationName}
+            </Title>
+          </PageSection>
+          <PageSection
+            variant={PageSectionVariants.light}
+            padding={{default: 'noPadding'}}
+          >
+            <Tabs
+              activeKey={activeTabKey}
+              onSelect={onTabSelect}
+              usePageInsets={true}
             >
-              <Title data-testid="repo-title" headingLevel="h1">
-                {organizationName}
-              </Title>
-            </PageSection>
-            <PageSection
-              variant={PageSectionVariants.light}
-              padding={{default: 'noPadding'}}
-            >
-              <Tabs activeKey={activeTabKey} onSelect={onTabSelect}>
-                {repositoriesSubNav
-                  .filter((nav) => nav.visible)
-                  .map((nav) => (
-                    <Tab
-                      key={nav.name}
-                      eventKey={nav.name.replace(/ /g, '')}
-                      title={<TabTitleText>{nav.name}</TabTitleText>}
-                    >
-                      {nav.component}
-                    </Tab>
-                  ))}
-              </Tabs>
-            </PageSection>
-          </Page>
+              {repositoriesSubNav
+                .filter((nav) => nav.visible)
+                .map((nav) => (
+                  <Tab
+                    key={nav.name}
+                    eventKey={nav.name.replace(/ /g, '')}
+                    title={<TabTitleText>{nav.name}</TabTitleText>}
+                  >
+                    {nav.component}
+                  </Tab>
+                ))}
+            </Tabs>
+          </PageSection>
         </DrawerContentBody>
       </DrawerContent>
     </Drawer>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsViewToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsViewToolbar.tsx
@@ -41,6 +41,16 @@ export default function TeamsViewToolbar(props: TeamsViewToolbarProps) {
           </FlexItem>
         </Flex>
         <ToolbarItem>
+          <Conditional if={props.isAdmin && !props.isReadOnly}>
+            <Button
+              onClick={() => props.handleModalToggle()}
+              data-testid="create-new-team-button"
+            >
+              Create new team
+            </Button>
+          </Conditional>
+        </ToolbarItem>
+        <ToolbarItem>
           <Conditional
             if={
               props.selectedTeams?.length !== 0 &&
@@ -60,16 +70,6 @@ export default function TeamsViewToolbar(props: TeamsViewToolbarProps) {
           </Conditional>
           <Conditional if={props.isSetRepoPermModalOpen}>
             {props.setRepoPermModal}
-          </Conditional>
-        </ToolbarItem>
-        <ToolbarItem>
-          <Conditional if={props.isAdmin && !props.isReadOnly}>
-            <Button
-              onClick={() => props.handleModalToggle()}
-              data-testid="create-new-team-button"
-            >
-              Create new team
-            </Button>
           </Conditional>
         </ToolbarItem>
         <ToolbarPagination

--- a/web/src/routes/OrganizationsList/OrganizationsList.tsx
+++ b/web/src/routes/OrganizationsList/OrganizationsList.tsx
@@ -41,7 +41,7 @@ function OrgListHeader() {
   return (
     <>
       <QuayBreadcrumb />
-      <PageSection variant={PageSectionVariants.light}>
+      <PageSection variant={PageSectionVariants.light} hasShadowBottom>
         <div className="co-m-nav-title--row">
           <Title headingLevel="h1">Organizations</Title>
         </div>

--- a/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
+++ b/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
@@ -1,11 +1,4 @@
 import {
-  Page,
-  PageSection,
-  PageSectionVariants,
-  Title,
-  Tabs,
-  Tab,
-  TabTitleText,
   Drawer,
   DrawerActions,
   DrawerCloseButton,
@@ -13,35 +6,41 @@ import {
   DrawerContentBody,
   DrawerHead,
   DrawerPanelContent,
+  PageSection,
+  PageSectionVariants,
+  Tab,
+  TabTitleText,
+  Tabs,
+  Title,
 } from '@patternfly/react-core';
-import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
-import TagsList from './Tags/TagsList';
-import {useLocation, useSearchParams, useNavigate} from 'react-router-dom';
 import {useEffect, useRef, useState} from 'react';
-import Settings from './Settings/Settings';
-import {DrawerContentType} from './Types';
-import AddPermissions from './Settings/PermissionsAddPermission';
+import {useLocation, useNavigate, useSearchParams} from 'react-router-dom';
+import {AlertVariant} from 'src/atoms/AlertState';
+import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
+import Conditional from 'src/components/empty/Conditional';
 import ErrorBoundary from 'src/components/errors/ErrorBoundary';
-import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
 import RequestError from 'src/components/errors/RequestError';
+import CreateRobotAccountModal from 'src/components/modals/CreateRobotAccountModal';
+import {useAlerts} from 'src/hooks/UseAlerts';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
-import CreateNotification from './Settings/NotificationsCreateNotification';
 import {useRepository} from 'src/hooks/UseRepository';
+import {useFetchTeams} from 'src/hooks/UseTeams';
 import {
   parseOrgNameFromUrl,
   parseRepoNameFromUrl,
   validateTeamName,
 } from 'src/libs/utils';
-import TagHistory from './TagHistory/TagHistory';
-import Conditional from 'src/components/empty/Conditional';
-import CreateRobotAccountModal from 'src/components/modals/CreateRobotAccountModal';
-import {RepoPermissionDropdownItems} from '../RepositoriesList/RobotAccountsList';
+import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
 import {Entity} from 'src/resources/UserResource';
-import {useFetchTeams} from 'src/hooks/UseTeams';
 import {CreateTeamModal} from '../OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreateTeamModal';
-import {useAlerts} from 'src/hooks/UseAlerts';
-import {AlertVariant} from 'src/atoms/AlertState';
+import {RepoPermissionDropdownItems} from '../RepositoriesList/RobotAccountsList';
 import Builds from './Builds/Builds';
+import CreateNotification from './Settings/NotificationsCreateNotification';
+import AddPermissions from './Settings/PermissionsAddPermission';
+import Settings from './Settings/Settings';
+import TagHistory from './TagHistory/TagHistory';
+import TagsList from './Tags/TagsList';
+import {DrawerContentType} from './Types';
 
 enum TabIndex {
   Tags = 'tags',
@@ -211,86 +210,81 @@ export default function RepositoryDetails() {
           }
         >
           <DrawerContentBody>
-            <Page>
-              <QuayBreadcrumb />
-              <PageSection
-                variant={PageSectionVariants.light}
-                className="no-padding-bottom"
+            <QuayBreadcrumb />
+            <PageSection variant={PageSectionVariants.light}>
+              <Title data-testid="repo-title" headingLevel="h1">
+                {repository}
+              </Title>
+            </PageSection>
+            <PageSection
+              variant={PageSectionVariants.light}
+              style={{padding: 0}}
+            >
+              <ErrorBoundary
+                hasError={isErrorString(err)}
+                fallback={<RequestError message={err} />}
               >
-                <Title data-testid="repo-title" headingLevel="h1">
-                  {repository}
-                </Title>
-              </PageSection>
-              <PageSection
-                variant={PageSectionVariants.light}
-                className="no-padding-on-sides"
-                style={{padding: 0}}
-              >
-                <ErrorBoundary
-                  hasError={isErrorString(err)}
-                  fallback={<RequestError message={err} />}
+                <Tabs
+                  mountOnEnter
+                  unmountOnExit
+                  activeKey={activeTabKey}
+                  onSelect={tabsOnSelect}
+                  usePageInsets={true}
                 >
-                  <Tabs
-                    mountOnEnter
-                    unmountOnExit
-                    activeKey={activeTabKey}
-                    onSelect={tabsOnSelect}
+                  <Tab
+                    eventKey={TabIndex.Tags}
+                    title={<TabTitleText>Tags</TabTitleText>}
                   >
-                    <Tab
-                      eventKey={TabIndex.Tags}
-                      title={<TabTitleText>Tags</TabTitleText>}
-                    >
-                      <TagsList
-                        organization={organization}
-                        repository={repository}
-                        repoDetails={repoDetails}
-                      />
-                    </Tab>
-                    <Tab
-                      eventKey={TabIndex.TagHistory}
-                      title={<TabTitleText>Tag history</TabTitleText>}
-                    >
-                      <TagHistory
-                        org={organization}
-                        repo={repository}
-                        repoDetails={repoDetails}
-                      />
-                    </Tab>
-                    <Tab
-                      eventKey={TabIndex.Settings}
-                      title={<TabTitleText>Settings</TabTitleText>}
-                      isHidden={
-                        config?.features.UI_V2_REPO_SETTINGS != true ||
-                        !repoDetails?.can_admin
-                      }
-                    >
-                      <Settings
-                        org={organization}
-                        repo={repository}
-                        setDrawerContent={setDrawerContent}
-                        repoDetails={repoDetails}
-                      />
-                    </Tab>
-                    <Tab
-                      eventKey={TabIndex.Builds}
-                      title={<TabTitleText>Builds</TabTitleText>}
-                      isHidden={
-                        config?.features.UI_V2_BUILDS != true ||
-                        config?.features.BUILD_SUPPORT != true ||
-                        !repoDetails?.can_write
-                      }
-                    >
-                      <Builds
-                        org={organization}
-                        repo={repository}
-                        setupTriggerUuid={setupBuildTriggerUuid}
-                        repoDetails={repoDetails}
-                      />
-                    </Tab>
-                  </Tabs>
-                </ErrorBoundary>
-              </PageSection>
-            </Page>
+                    <TagsList
+                      organization={organization}
+                      repository={repository}
+                      repoDetails={repoDetails}
+                    />
+                  </Tab>
+                  <Tab
+                    eventKey={TabIndex.TagHistory}
+                    title={<TabTitleText>Tag history</TabTitleText>}
+                  >
+                    <TagHistory
+                      org={organization}
+                      repo={repository}
+                      repoDetails={repoDetails}
+                    />
+                  </Tab>
+                  <Tab
+                    eventKey={TabIndex.Settings}
+                    title={<TabTitleText>Settings</TabTitleText>}
+                    isHidden={
+                      config?.features.UI_V2_REPO_SETTINGS != true ||
+                      !repoDetails?.can_admin
+                    }
+                  >
+                    <Settings
+                      org={organization}
+                      repo={repository}
+                      setDrawerContent={setDrawerContent}
+                      repoDetails={repoDetails}
+                    />
+                  </Tab>
+                  <Tab
+                    eventKey={TabIndex.Builds}
+                    title={<TabTitleText>Builds</TabTitleText>}
+                    isHidden={
+                      config?.features.UI_V2_BUILDS != true ||
+                      config?.features.BUILD_SUPPORT != true ||
+                      !repoDetails?.can_write
+                    }
+                  >
+                    <Builds
+                      org={organization}
+                      repo={repository}
+                      setupTriggerUuid={setupBuildTriggerUuid}
+                      repoDetails={repoDetails}
+                    />
+                  </Tab>
+                </Tabs>
+              </ErrorBoundary>
+            </PageSection>
           </DrawerContentBody>
         </DrawerContent>
       </Drawer>

--- a/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
+++ b/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
@@ -218,7 +218,7 @@ export default function RepositoryDetails() {
             </PageSection>
             <PageSection
               variant={PageSectionVariants.light}
-              style={{padding: 0}}
+              padding={{default: 'noPadding'}}
             >
               <ErrorBoundary
                 hasError={isErrorString(err)}

--- a/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
@@ -1,32 +1,31 @@
-import {TagsToolbar} from './TagsToolbar';
-import TagsTable from './TagsTable';
-import {useState, useEffect} from 'react';
+import {
+  PageSection,
+  PageSectionVariants,
+  PanelFooter,
+} from '@patternfly/react-core';
+import {CubesIcon} from '@patternfly/react-icons';
+import {useEffect, useState} from 'react';
+import {useRecoilState, useRecoilValue, useResetRecoilState} from 'recoil';
 import {
   searchTagsFilterState,
   searchTagsState,
   selectedTagsState,
 } from 'src/atoms/TagListState';
-import {
-  Page,
-  PageSection,
-  PageSectionVariants,
-  PanelFooter,
-} from '@patternfly/react-core';
-import {useRecoilState, useRecoilValue, useResetRecoilState} from 'recoil';
-import {
-  Tag,
-  TagsResponse,
-  getTags,
-  getManifestByDigest,
-  ManifestByDigestResponse,
-} from 'src/resources/TagResource';
-import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
+import Empty from 'src/components/empty/Empty';
 import ErrorBoundary from 'src/components/errors/ErrorBoundary';
 import RequestError from 'src/components/errors/RequestError';
-import Empty from 'src/components/empty/Empty';
-import {CubesIcon} from '@patternfly/react-icons';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
+import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
 import {RepositoryDetails} from 'src/resources/RepositoryResource';
+import {
+  ManifestByDigestResponse,
+  Tag,
+  TagsResponse,
+  getManifestByDigest,
+  getTags,
+} from 'src/resources/TagResource';
+import TagsTable from './TagsTable';
+import {TagsToolbar} from './TagsToolbar';
 
 export default function TagsList(props: TagsProps) {
   const [tags, setTags] = useState<Tag[]>([]);
@@ -115,53 +114,48 @@ export default function TagsList(props: TagsProps) {
   }
 
   return (
-    <Page>
-      <PageSection
-        variant={PageSectionVariants.light}
-        style={{paddingBottom: '8em'}}
+    <PageSection variant={PageSectionVariants.light}>
+      <ErrorBoundary
+        hasError={isErrorString(err)}
+        fallback={<RequestError message={err} />}
       >
-        <ErrorBoundary
-          hasError={isErrorString(err)}
-          fallback={<RequestError message={err} />}
-        >
-          <TagsToolbar
-            organization={props.organization}
-            repository={props.repository}
-            tagCount={filteredTags.length}
-            loadTags={loadTags}
-            TagList={filteredTags}
-            paginatedTags={paginatedTags}
-            perPage={perPage}
-            page={page}
-            setPage={setPage}
-            setPerPage={setPerPage}
-            selectTag={selectTag}
-            repoDetails={props.repoDetails}
-          />
-          <TagsTable
-            org={props.organization}
-            repo={props.repository}
-            tags={paginatedTags}
-            loading={loading}
-            selectAllTags={selectAllTags}
-            selectedTags={selectedTags}
-            selectTag={selectTag}
-            loadTags={loadTags}
-            repoDetails={props.repoDetails}
-          />
-        </ErrorBoundary>
-        <PanelFooter>
-          <ToolbarPagination
-            itemsList={filteredTags}
-            perPage={perPage}
-            page={page}
-            setPage={setPage}
-            setPerPage={setPerPage}
-            bottom={true}
-          />
-        </PanelFooter>
-      </PageSection>
-    </Page>
+        <TagsToolbar
+          organization={props.organization}
+          repository={props.repository}
+          tagCount={filteredTags.length}
+          loadTags={loadTags}
+          TagList={filteredTags}
+          paginatedTags={paginatedTags}
+          perPage={perPage}
+          page={page}
+          setPage={setPage}
+          setPerPage={setPerPage}
+          selectTag={selectTag}
+          repoDetails={props.repoDetails}
+        />
+        <TagsTable
+          org={props.organization}
+          repo={props.repository}
+          tags={paginatedTags}
+          loading={loading}
+          selectAllTags={selectAllTags}
+          selectedTags={selectedTags}
+          selectTag={selectTag}
+          loadTags={loadTags}
+          repoDetails={props.repoDetails}
+        />
+      </ErrorBoundary>
+      <PanelFooter>
+        <ToolbarPagination
+          itemsList={filteredTags}
+          perPage={perPage}
+          page={page}
+          setPage={setPage}
+          setPerPage={setPerPage}
+          bottom={true}
+        />
+      </PanelFooter>
+    </PageSection>
   );
 }
 

--- a/web/src/routes/RepositoryTagRouter.tsx
+++ b/web/src/routes/RepositoryTagRouter.tsx
@@ -3,11 +3,11 @@ import RepositoryDetails from 'src/routes/RepositoryDetails/RepositoryDetails';
 import {useLocation} from 'react-router-dom';
 
 export default function RepositoryTagRouter() {
-  const location = useLocation()
-  const pathParts = location.pathname.split("/").slice(3)
-  if( pathParts.length > 2 && pathParts[pathParts.length-2] === 'tag'){
-    return <TagDetails />
+  const location = useLocation();
+  const pathParts = location.pathname.split('/').slice(3);
+  if (pathParts.length > 2 && pathParts[pathParts.length - 2] === 'tag') {
+    return <TagDetails />;
   } else {
-    return <RepositoryDetails />
+    return <RepositoryDetails />;
   }
 }

--- a/web/src/routes/Search/Search.tsx
+++ b/web/src/routes/Search/Search.tsx
@@ -1,14 +1,8 @@
-import {
-  Page,
-  PageSection,
-  PageSectionVariants,
-  Title,
-} from '@patternfly/react-core';
-import * as React from 'react';
+import {PageSection, PageSectionVariants, Title} from '@patternfly/react-core';
 
 export default function Search() {
   return (
-    <Page>
+    <>
       <PageSection variant={PageSectionVariants.light} hasShadowBottom>
         <div className="co-m-nav-title--row">
           <Title headingLevel="h1">Search</Title>
@@ -18,6 +12,6 @@ export default function Search() {
       <PageSection>
         <PageSection variant={PageSectionVariants.light}></PageSection>
       </PageSection>
-    </Page>
+    </>
   );
 }

--- a/web/src/routes/TagDetails/Details/Details.tsx
+++ b/web/src/routes/TagDetails/Details/Details.tsx
@@ -1,25 +1,24 @@
 import {
+  ClipboardCopy,
   DescriptionList,
-  DescriptionListTerm,
-  DescriptionListGroup,
   DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
   Divider,
   PageSection,
   PageSectionVariants,
-  ClipboardCopy,
   Skeleton,
-  Page,
 } from '@patternfly/react-core';
-import CopyTags from './DetailsCopyTags';
-import {Tag} from 'src/resources/TagResource';
-import {formatDate} from 'src/libs/utils';
-import Labels from 'src/components/labels/Labels';
-import SecurityDetails from 'src/routes/RepositoryDetails/Tags/SecurityDetails';
 import {ImageSize} from 'src/components/Table/ImageSize';
+import Labels from 'src/components/labels/Labels';
+import {formatDate} from 'src/libs/utils';
+import {Tag} from 'src/resources/TagResource';
+import SecurityDetails from 'src/routes/RepositoryDetails/Tags/SecurityDetails';
+import CopyTags from './DetailsCopyTags';
 
 export default function Details(props: DetailsProps) {
   return (
-    <Page>
+    <>
       <PageSection variant={PageSectionVariants.light}>
         <DescriptionList
           columnModifier={{
@@ -132,7 +131,7 @@ export default function Details(props: DetailsProps) {
           digest={props.digest}
         />
       </PageSection>
-    </Page>
+    </>
   );
 }
 

--- a/web/src/routes/TagDetails/Packages/PackagesFilter.tsx
+++ b/web/src/routes/TagDetails/Packages/PackagesFilter.tsx
@@ -22,7 +22,7 @@ export function PackagesFilter(props: PackagesFilterProps) {
   };
 
   return (
-    <Flex className="pf-v5-u-mt-md">
+    <Flex>
       <FlexItem>
         <TextInput
           isRequired

--- a/web/src/routes/TagDetails/Packages/PackagesTable.tsx
+++ b/web/src/routes/TagDetails/Packages/PackagesTable.tsx
@@ -248,13 +248,15 @@ export default function PackagesTable({features}: PackagesProps) {
           </Tbody>
         )}
       </Table>
-      <ToolbarPagination
-        itemsList={filteredPackagesList}
-        perPage={perPage}
-        page={page}
-        setPage={setPage}
-        setPerPage={setPerPage}
-      />
+      <Toolbar>
+        <ToolbarPagination
+          itemsList={filteredPackagesList}
+          perPage={perPage}
+          page={page}
+          setPage={setPage}
+          setPerPage={setPerPage}
+        />
+      </Toolbar>
     </PageSection>
   );
 }

--- a/web/src/routes/TagDetails/SecurityReport/SecurityReportFilter.tsx
+++ b/web/src/routes/TagDetails/SecurityReport/SecurityReportFilter.tsx
@@ -37,7 +37,7 @@ export function SecurityReportFilter(props: SecurityReportFilterProps) {
   };
 
   return (
-    <Flex className="pf-v5-u-mt-md">
+    <Flex>
       <FlexItem>
         <TextInput
           isRequired

--- a/web/src/routes/TagDetails/TagDetails.tsx
+++ b/web/src/routes/TagDetails/TagDetails.tsx
@@ -1,34 +1,29 @@
-import {
-  Page,
-  PageSection,
-  PageSectionVariants,
-  Title,
-} from '@patternfly/react-core';
-import {useSearchParams, useLocation} from 'react-router-dom';
-import {useState, useEffect} from 'react';
-import TagArchSelect from './TagDetailsArchSelect';
-import TagTabs from './TagDetailsTabs';
-import {
-  TagsResponse,
-  getTags,
-  getManifestByDigest,
-  Tag,
-  ManifestByDigestResponse,
-} from 'src/resources/TagResource';
-import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
-import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
-import ErrorBoundary from 'src/components/errors/ErrorBoundary';
-import RequestError from 'src/components/errors/RequestError';
+import {PageSection, PageSectionVariants, Title} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import {useLocation, useSearchParams} from 'react-router-dom';
 import {useResetRecoilState} from 'recoil';
 import {
   SecurityDetailsErrorState,
   SecurityDetailsState,
 } from 'src/atoms/SecurityDetailsState';
+import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
+import ErrorBoundary from 'src/components/errors/ErrorBoundary';
+import RequestError from 'src/components/errors/RequestError';
+import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
+import {
+  ManifestByDigestResponse,
+  Tag,
+  TagsResponse,
+  getManifestByDigest,
+  getTags,
+} from 'src/resources/TagResource';
 import {
   parseOrgNameFromUrl,
   parseRepoNameFromUrl,
   parseTagNameFromUrl,
 } from '../../libs/utils';
+import TagArchSelect from './TagDetailsArchSelect';
+import TagTabs from './TagDetailsTabs';
 
 export default function TagDetails() {
   const [searchParams] = useSearchParams();
@@ -112,24 +107,21 @@ export default function TagDetails() {
   }, []);
 
   return (
-    <Page>
+    <>
       <QuayBreadcrumb />
-      <PageSection
-        variant={PageSectionVariants.light}
-        className="no-padding-bottom"
-      >
-        <Title headingLevel="h1">{tag}</Title>
+      <PageSection variant={PageSectionVariants.light}>
+        <Title headingLevel="h1">
+          {repo}:{tag}
+        </Title>
         <TagArchSelect
           digest={digest}
           options={tagDetails.manifest_list?.manifests}
           setDigest={setDigest}
           render={tagDetails.is_manifest_list}
+          style={{marginTop: 'var(--pf-v5-global--spacer--md)'}}
         />
       </PageSection>
-      <PageSection
-        variant={PageSectionVariants.light}
-        className="no-padding-on-sides"
-      >
+      <PageSection variant={PageSectionVariants.light} style={{padding: 0}}>
         <ErrorBoundary
           hasError={isErrorString(err)}
           fallback={<RequestError message={err} />}
@@ -143,6 +135,6 @@ export default function TagDetails() {
           />
         </ErrorBoundary>
       </PageSection>
-    </Page>
+    </>
   );
 }

--- a/web/src/routes/TagDetails/TagDetails.tsx
+++ b/web/src/routes/TagDetails/TagDetails.tsx
@@ -121,7 +121,10 @@ export default function TagDetails() {
           style={{marginTop: 'var(--pf-v5-global--spacer--md)'}}
         />
       </PageSection>
-      <PageSection variant={PageSectionVariants.light} style={{padding: 0}}>
+      <PageSection
+        variant={PageSectionVariants.light}
+        padding={{default: 'noPadding'}}
+      >
         <ErrorBoundary
           hasError={isErrorString(err)}
           fallback={<RequestError message={err} />}

--- a/web/src/routes/TagDetails/TagDetailsArchSelect.tsx
+++ b/web/src/routes/TagDetails/TagDetailsArchSelect.tsx
@@ -23,7 +23,7 @@ export default function ArchSelect(props: ArchSelectProps) {
   if (!props.render) return null;
 
   return (
-    <Flex>
+    <Flex style={props.style ? props.style : undefined}>
       <FlexItem>Architecture</FlexItem>
       <FlexItem>
         <Select
@@ -67,4 +67,5 @@ type ArchSelectProps = {
   options: Manifest[];
   setDigest: (digest: string) => void;
   render: boolean;
+  style?: React.CSSProperties;
 };

--- a/web/src/routes/TagDetails/TagDetailsTabs.tsx
+++ b/web/src/routes/TagDetails/TagDetailsTabs.tsx
@@ -34,6 +34,7 @@ export default function TagTabs(props: TagTabsProps) {
       onSelect={(e, tabIndex) => {
         navigate(`${location.pathname}?tab=${tabIndex}`);
       }}
+      usePageInsets={true}
     >
       <Tab
         eventKey={TabIndex.Details}


### PR DESCRIPTION
This PR fixes:

- the duplicate scrollbars and jumpy scrolling experience in some of the UI screens due to the nesting of `Page` components
- superfluous CSS padding settings
- consistent use of bottom shadow for top-level navigation screens
- incorrect vertical alignment of the filter bars in packages and vulnerabilities report
- lack of margin between architecture select drop-down and tag name in the title
- lack of margin between bottom-level pagination toolbar in the packages table
- consistent use of page insets for top-level tab navigation bars
- placing the action kebap in the "Teams and membership" screen right from the primary "Create Repository" button for consistency with the rest of the UI

This PR also adds:

- displaying the entire image tag spec (`repo:tag`) in the tag detail title screen

<img width="1295" alt="Screenshot 2024-01-23 at 11 11 23" src="https://github.com/quay/quay/assets/12664117/dffe7c4a-1e5e-444d-8425-88a62b85679e">
<img width="1494" alt="Screenshot 2024-01-23 at 10 49 50" src="https://github.com/quay/quay/assets/12664117/a07d4728-1809-4af3-8b8b-5995f7a9544a">
<img width="1492" alt="Screenshot 2024-01-23 at 10 49 33" src="https://github.com/quay/quay/assets/12664117/15d10c50-d395-46cb-b0d6-da0c3f96309e">
<img width="1496" alt="Screenshot 2024-01-23 at 10 49 23" src="https://github.com/quay/quay/assets/12664117/2c7c757b-9966-437f-8e72-237248f5cf14">
<img width="1497" alt="Screenshot 2024-01-23 at 10 48 40" src="https://github.com/quay/quay/assets/12664117/9466b02d-7878-4536-bf13-5bcb2e14f3d7">
