### PR TITLE
reconfigure: Add auth to comit to operator endpoint (PROJQUAY-6598)

### DIFF
--- a/config-tool/pkg/lib/editor/controllers.go
+++ b/config-tool/pkg/lib/editor/controllers.go
@@ -291,6 +291,7 @@ func commitToOperator(opts *ServerOptions) func(w http.ResponseWriter, r *http.R
 		}
 
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+opts.password)
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		if err != nil {


### PR DESCRIPTION
We are missing this commit in the 3.8 release. This fixes the config editor UI to send the auth token to the reconfigure endpoint. 