### PR TITLE
marketplace: add support for quantity from subscriptions api (PROJQUAY-6551)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -2001,6 +2001,7 @@ class OrganizationRhSkus(BaseModel):
     subscription_id = IntegerField(index=True, unique=True)
     user_id = ForeignKeyField(User, backref="org_bound_subscription")
     org_id = ForeignKeyField(User, backref="subscription")
+    quantity = IntegerField(index=True, null=True)
 
     indexes = (
         (("subscription_id", "org_id"), True),

--- a/data/migrations/versions/41d15c93c299_add_quantity_field_to_orgrhskus.py
+++ b/data/migrations/versions/41d15c93c299_add_quantity_field_to_orgrhskus.py
@@ -15,9 +15,7 @@ import sqlalchemy as sa
 
 def upgrade(op, tables, tester):
     op.add_column("organizationrhskus", sa.Column("quantity", sa.Integer(), nullable=True))
-    pass
 
 
 def downgrade(op, tables, tester):
     op.drop_column("organizationrhskus", "quantity")
-    pass

--- a/data/migrations/versions/41d15c93c299_add_quantity_field_to_orgrhskus.py
+++ b/data/migrations/versions/41d15c93c299_add_quantity_field_to_orgrhskus.py
@@ -1,0 +1,23 @@
+"""add quantity field to orgRhSkus
+
+Revision ID: 41d15c93c299
+Revises: 3f8e3657bb67
+Create Date: 2024-01-24 11:19:19.095256
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "41d15c93c299"
+down_revision = "3f8e3657bb67"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.add_column("organizationrhskus", sa.Column("quantity", sa.Integer(), nullable=True))
+    pass
+
+
+def downgrade(op, tables, tester):
+    op.drop_column("organizationrhskus", "quantity")
+    pass

--- a/data/model/organization_skus.py
+++ b/data/model/organization_skus.py
@@ -3,7 +3,7 @@ import logging
 import peewee
 
 from data import model
-from data.database import OrganizationRhSkus
+from data.database import OrganizationRhSkus, db_transaction
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +18,10 @@ def get_org_subscriptions(org_id):
 
 def bind_subscription_to_org(subscription_id, org_id, user_id, quantity=1):
     try:
-        return OrganizationRhSkus.create(
-            subscription_id=subscription_id, org_id=org_id, user_id=user_id, quantity=quantity
-        )
+        with db_transaction():
+            return OrganizationRhSkus.create(
+                subscription_id=subscription_id, org_id=org_id, user_id=user_id, quantity=quantity
+            )
     except model.DataModelException as ex:
         logger.error("Problem binding subscription to org %s: %s", org_id, ex)
     except peewee.IntegrityError:

--- a/data/model/organization_skus.py
+++ b/data/model/organization_skus.py
@@ -18,10 +18,9 @@ def get_org_subscriptions(org_id):
 
 def bind_subscription_to_org(subscription_id, org_id, user_id, quantity=1):
     try:
-        with db_transaction():
-            return OrganizationRhSkus.create(
-                subscription_id=subscription_id, org_id=org_id, user_id=user_id, quantity=quantity
-            )
+        return OrganizationRhSkus.create(
+            subscription_id=subscription_id, org_id=org_id, user_id=user_id, quantity=quantity
+        )
     except model.DataModelException as ex:
         logger.error("Problem binding subscription to org %s: %s", org_id, ex)
     except peewee.IntegrityError:

--- a/data/model/organization_skus.py
+++ b/data/model/organization_skus.py
@@ -16,10 +16,10 @@ def get_org_subscriptions(org_id):
         return None
 
 
-def bind_subscription_to_org(subscription_id, org_id, user_id):
+def bind_subscription_to_org(subscription_id, org_id, user_id, quantity=1):
     try:
         return OrganizationRhSkus.create(
-            subscription_id=subscription_id, org_id=org_id, user_id=user_id
+            subscription_id=subscription_id, org_id=org_id, user_id=user_id, quantity=quantity
         )
     except model.DataModelException as ex:
         logger.error("Problem binding subscription to org %s: %s", org_id, ex)

--- a/endpoints/api/billing.py
+++ b/endpoints/api/billing.py
@@ -984,9 +984,9 @@ class OrganizationRhSku(ApiResource):
                 subscription_id = subscription.get("subscription_id")
                 if subscription_id is None:
                     break
-                quantity = subscription.get("quantity")
-                if quantity is None:
-                    quantity = 1
+                # quantity = subscription.get("quantity")
+                # if quantity is None:
+                #     quantity = 1
                 user = get_authenticated_user()
                 account_number = marketplace_users.get_account_number(user)
                 subscriptions = marketplace_subscriptions.get_list_of_subscriptions(account_number)
@@ -996,6 +996,10 @@ class OrganizationRhSku(ApiResource):
 
                 user_subscription_ids = [int(subscription["id"]) for subscription in subscriptions]
                 if int(subscription_id) in user_subscription_ids:
+                    quantity = 1
+                    for subscription in subscriptions:
+                        if subscription["id"] == subscription_id:
+                            quantity = subscription["quantity"]
                     try:
                         model.organization_skus.bind_subscription_to_org(
                             user_id=user.id,

--- a/endpoints/api/billing.py
+++ b/endpoints/api/billing.py
@@ -984,9 +984,6 @@ class OrganizationRhSku(ApiResource):
                 subscription_id = subscription.get("subscription_id")
                 if subscription_id is None:
                     break
-                # quantity = subscription.get("quantity")
-                # if quantity is None:
-                #     quantity = 1
                 user = get_authenticated_user()
                 account_number = marketplace_users.get_account_number(user)
                 subscriptions = marketplace_subscriptions.get_list_of_subscriptions(account_number)
@@ -1000,6 +997,7 @@ class OrganizationRhSku(ApiResource):
                     for subscription in subscriptions:
                         if subscription["id"] == subscription_id:
                             quantity = subscription["quantity"]
+                            break
                     try:
                         model.organization_skus.bind_subscription_to_org(
                             user_id=user.id,

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -384,7 +384,11 @@ class OrgPrivateRepositories(ApiResource):
                     )
                     equivalent_stripe_plan = get_plan_using_rh_sku(subscription_sku)
                     if equivalent_stripe_plan:
-                        repos_allowed += equivalent_stripe_plan["privateRepos"]
+                        if subscription.get("quantity") is None:
+                            quantity = 1
+                        else:
+                            quantity = subscription["quantity"]
+                        repos_allowed += quantity * equivalent_stripe_plan["privateRepos"]
 
             data["privateAllowed"] = private_repos < repos_allowed
 

--- a/static/directives/org-binding.html
+++ b/static/directives/org-binding.html
@@ -2,40 +2,33 @@
   <span><h3>Monthly Subscriptions From Red Hat Customer Portal</h3></span>
   <div class="cor-loader-inline" ng-show="marketplaceLoading"></div>
   <span ng-show="!organization && !marketplaceLoading">
-    <div ng-repeat="(sku, subscriptions) in userMarketplaceSubscriptions">
-      {{subscriptions.length}}x {{ sku }}
+    <div ng-repeat="subscription in userMarketplaceSubscriptions">
+      {{subscription.quantity}}x {{ subscription.sku }}
+      {{subscription.assigned_to_org ? "attached to org " + subscription.assigned_to_org : ""}}
     </div>
   </span>
 
   <table ng-show="organization && !marketplaceLoading">
-    <tr class="indented-row" ng-repeat="(sku, subscriptions) in orgMarketplaceSubscriptions">
+    <tr class="indented-row" ng-repeat="subscription in orgMarketplaceSubscriptions">
       <td>
-        {{ subscriptions.length }} x {{ sku }} attached to this org
+        {{ subscription.quantity }}x {{ subscription.sku }} attached to this org
       </td>
     </tr>
     <tr class="indented-row">
       <td style="padding: 10px">
         <select class="form-control" ng-model="subscriptionBinding">
-          <option ng-repeat="(sku, subscriptions) in availableSubscriptions" value="{{ subscriptions }}">
-            {{subscriptions.length}} x {{sku}}
+          <option ng-repeat="subscription in availableSubscriptions" value="{{ subscription }}">
+            {{subscription.quantity}}x {{subscription.sku}}
           </option>
         </select>
-        <input class="form-control" type="number" min="1" max="{{subscriptions.length}}" ng-model="numSubscriptions" placeholder="Number of subscriptions">
-        <a class="btn btn-primary" ng-click="bindSku(subscriptionBinding, numSubscriptions)">Attach subscriptions</a>
+        <a class="btn btn-primary" ng-click="bindSku(subscriptionBinding)">Attach subscriptions</a>
       </td>
       <td style="padding: 10px">
         <select class="form-control" ng-model="subscriptionRemovals">
-          <option ng-repeat="(sku, orgSubscriptions) in orgMarketplaceSubscriptions" value="{{orgSubscriptions}}">
-            {{sku}}
+          <option ng-repeat="orgSubscription in orgMarketplaceSubscriptions" value="{{orgSubscription}}">
+            {{orgSubscription.quantity}}x {{orgSubscription.sku}}
           </option>
         </select>
-        <input class="form-control"
-          type="number"
-          min="1"
-          max="{{JSON.parse(subscriptions).length}}"
-          ng-model="numRemovals"
-          placeholder="Number of subscriptions"
-        >
         <a class="btn btn-default" ng-click="batchRemoveSku(subscriptionRemovals, numRemovals)">
           Remove subscriptions
         </a>

--- a/static/js/directives/ui/billing-management-panel.js
+++ b/static/js/directives/ui/billing-management-panel.js
@@ -50,7 +50,10 @@ angular.module('quay').directive('billingManagementPanel', function () {
         if ($scope.organization) {
           PlanService.listOrgMarketplaceSubscriptions($scope.organization.name, function(subscriptions){
             for (var i = 0; i < subscriptions.length; i++) {
-              total += subscriptions[i]["metadata"]["privateRepos"];
+              total += (
+                subscriptions[i]["quantity"] *
+                subscriptions[i]["metadata"]["privateRepos"]
+              );
             }
             $scope.currentMarketplace = total;
           })
@@ -58,7 +61,10 @@ angular.module('quay').directive('billingManagementPanel', function () {
           PlanService.listUserMarketplaceSubscriptions(function(subscriptions){
             for (var i = 0; i < subscriptions.length; i++) {
               if(subscriptions[i]["assigned_to_org"] === null) {
-                total += subscriptions[i]["metadata"]["privateRepos"];
+                total += (
+                  subscriptions[i]["quantity"] *
+                  subscriptions[i]["metadata"]["privateRepos"]
+                );
               }
             }
             $scope.currentMarketplace = total;

--- a/static/js/directives/ui/org-binding.js
+++ b/static/js/directives/ui/org-binding.js
@@ -8,9 +8,9 @@ angular.module('quay').directive('orgBinding', function() {
       'organization': '=organization',
     },
     controller: function($scope, $timeout, PlanService, ApiService) {
-      $scope.userMarketplaceSubscriptions = {};
-      $scope.orgMarketplaceSubscriptions = {};
-      $scope.availableSubscriptions = {};
+      $scope.userMarketplaceSubscriptions = [];
+      $scope.orgMarketplaceSubscriptions = [];
+      $scope.availableSubscriptions = [];
       $scope.marketplaceLoading = true;
       $scope.bindOrgSuccess = false;
       $scope.removeSkuSuccess = false;
@@ -34,9 +34,12 @@ angular.module('quay').directive('orgBinding', function() {
         if ($scope.organization) {
           PlanService.listOrgMarketplaceSubscriptions($scope.organization, function(marketplaceSubscriptions){
             // group the list of subscriptions by their sku field
-            $scope.orgMarketplaceSubscriptions = groupSubscriptionsBySku(marketplaceSubscriptions);
+            $scope.orgMarketplaceSubscriptions = marketplaceSubscriptions;
             for (var i = 0; i < marketplaceSubscriptions.length; i++) {
-              total += marketplaceSubscriptions[i]["metadata"]["privateRepos"];
+              total += (
+                marketplaceSubscriptions[i]["quantity"] *
+                marketplaceSubscriptions[i]["metadata"]["privateRepos"]
+              );
             }
             $scope.marketplaceTotal = total;
           });
@@ -48,12 +51,15 @@ angular.module('quay').directive('orgBinding', function() {
             return;
           }
           let notBound = [];
-          $scope.userMarketplaceSubscriptions = groupSubscriptionsBySku(marketplaceSubscriptions);
+          $scope.userMarketplaceSubscriptions = marketplaceSubscriptions;
 
           for (var i = 0; i < marketplaceSubscriptions.length; i++) {
             if (marketplaceSubscriptions[i]["assigned_to_org"] === null) {
               if(!($scope.organization)){
-                total += marketplaceSubscriptions[i]["metadata"]["privateRepos"];
+                total += (
+                  marketplaceSubscriptions[i]["quantity"] *
+                  marketplaceSubscriptions[i]["metadata"]["privateRepos"]
+                );
               }
               notBound.push(marketplaceSubscriptions[i]);
             }
@@ -61,7 +67,7 @@ angular.module('quay').directive('orgBinding', function() {
           if(!($scope.organization)){
             $scope.marketplaceTotal = total;
           }
-          $scope.availableSubscriptions = groupSubscriptionsBySku(notBound);
+          $scope.availableSubscriptions = notBound;
           $scope.marketplaceLoading = false;
         });
       }
@@ -71,21 +77,16 @@ angular.module('quay').directive('orgBinding', function() {
         loadSubscriptions();
       }
 
-      $scope.bindSku = function(subscriptions, numSubscriptions) {
-        let subscriptionArr = JSON.parse(subscriptions);
-        if(numSubscriptions > subscriptionArr.length){
-          displayError("number of subscriptions exceeds total amount");
-          return;
-        }
+      $scope.bindSku = function(subscriptionToBind) {
+        let subscription = JSON.parse(subscriptionToBind);
         $scope.marketplaceLoading = true;
         const requestData = {};
         requestData["subscriptions"] = [];
-        for(var i = 0; i < numSubscriptions; ++i) {
-          var subscriptionObject = {};
-          var subscriptionId = subscriptionArr[i].id;
-          subscriptionObject.subscription_id = subscriptionId;
-          requestData["subscriptions"].push(subscriptionObject);
-        }
+        requestData["subscriptions"].push({
+          "subscription_id": subscription["id"],
+          "quantity": subscription["quantity"]
+        });
+        console.log(JSON.stringify(requestData));
         PlanService.bindSkuToOrg(requestData, $scope.organization, function(resp){
           if (resp === "Okay"){
             bindSkuSuccessMessage();
@@ -96,16 +97,11 @@ angular.module('quay').directive('orgBinding', function() {
         });
       };
 
-      $scope.batchRemoveSku = function(removals, numRemovals) {
-        let removalArr = JSON.parse(removals);
+      $scope.batchRemoveSku = function(subscriptionToRemove) {
+        let subscription = JSON.parse(subscriptionToRemove);
         const requestData = {};
         requestData["subscriptions"] = [];
-        for(var i = 0; i < numRemovals; ++i){
-          var subscriptionObject = {};
-          var subscriptionId = removalArr[i].subscription_id;
-          subscriptionObject.subscription_id = subscriptionId;
-          requestData["subscriptions"].push(subscriptionObject);
-        }
+        requestData["subscriptions"].push({"subscription_id": subscription["subscription_id"]});
         PlanService.batchRemoveSku(requestData, $scope.organization, function(resp){
           if (resp == "") {
             removeSkuSuccessMessage();

--- a/static/js/directives/ui/org-binding.js
+++ b/static/js/directives/ui/org-binding.js
@@ -84,9 +84,7 @@ angular.module('quay').directive('orgBinding', function() {
         requestData["subscriptions"] = [];
         requestData["subscriptions"].push({
           "subscription_id": subscription["id"],
-          "quantity": subscription["quantity"]
         });
-        console.log(JSON.stringify(requestData));
         PlanService.bindSkuToOrg(requestData, $scope.organization, function(resp){
           if (resp === "Okay"){
             bindSkuSuccessMessage();

--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -239,7 +239,9 @@ class RedHatSubscriptionApi(object):
                             continue
 
                         if convert_to_stripe_plans:
-                            subscription_list.append(get_plan_using_rh_sku(sku))
+                            quantity = user_subscription["quantity"]
+                            for i in range(quantity):
+                                subscription_list.append(get_plan_using_rh_sku(sku))
                         else:
                             # add in sku field for convenience
                             user_subscription["sku"] = sku
@@ -263,7 +265,7 @@ TEST_USER = {
             "installBaseEndDate": 1707368399000,
             "webCustomerId": 123456,
             "subscriptionNumber": "12399889",
-            "quantity": 1,
+            "quantity": 2,
             "effectiveStartDate": 1707368400000,
             "effectiveEndDate": 3813177600,
         },

--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -4,8 +4,6 @@ import unittest
 import requests
 from mock import patch
 
-from app import app
-from initdb import finished_database_for_testing, setup_database_for_testing
 from util.marketplace import RedHatSubscriptionApi, RedHatUserApi
 
 app_config = {
@@ -144,12 +142,6 @@ mocked_subscription_response = [
 
 
 class TestMarketplace(unittest.TestCase):
-    def setUp(self):
-        setup_database_for_testing(self)
-
-    def tearDown(self):
-        finished_database_for_testing(self)
-
     @patch("requests.request")
     def test_timeout_exception(self, requests_mock):
         requests_mock.side_effect = requests.exceptions.ReadTimeout()
@@ -186,14 +178,3 @@ class TestMarketplace(unittest.TestCase):
 
         subscriptions = subscription_api.lookup_subscription(12345, "some_sku")
         assert len(subscriptions) == 2
-
-    @patch("requests.request")
-    def test_list_subscriptions(self, requests_mock):
-        subscription_api = RedHatSubscriptionApi(app_config)
-        requests_mock.return_value.content = json.dumps(mocked_subscription_response)
-
-        subscriptions = subscription_api.get_list_of_subscriptions(
-            12345, convert_to_stripe_plans=True
-        )
-
-        assert len(subscriptions) == 6

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -2869,7 +2869,8 @@ CREATE TABLE public.organizationrhskus (
     id integer NOT NULL,
     subscription_id integer NOT NULL,
     org_id integer NOT NULL,
-    user_id integer NOT NULL
+    user_id integer NOT NULL,
+    quantity integer
 );
 
 
@@ -5569,7 +5570,7 @@ COPY public.accesstokenkind (id, name) FROM stdin;
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-3f8e3657bb67
+41d15c93c299
 \.
 
 
@@ -6465,7 +6466,7 @@ COPY public.oauthauthorizationcode (id, application_id, scope, data, code_creden
 -- Data for Name: organizationrhskus; Type: TABLE DATA; Schema: public; Owner: quay
 --
 
-COPY public.organizationrhskus (id, subscription_id, org_id, user_id) FROM stdin;
+COPY public.organizationrhskus (id, subscription_id, org_id, user_id, quantity) FROM stdin;
 \.
 
 
@@ -8082,7 +8083,6 @@ SELECT pg_catalog.setval('public.logentry_id_seq', 1, false);
 --
 -- Name: logentrykind_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
-
 
 SELECT pg_catalog.setval('public.logentrykind_id_seq', 107, true);
 


### PR DESCRIPTION
Adds handling for when a subscription returned from the subscription watch api has a `quantity` greater than 1. Number of private repos should be correctly calculated using the quantity. 

Updates ui so that subscriptions can only be added to an org as a group, i.e. a subscription with `quantity` = 2 cannot be split across organizations.