### PR TITLE
api: Create Oauth apps and bearer tokens via command line

### DIFF
--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -24,6 +24,7 @@ from data import model
 from data.billing import get_plan, get_plan_using_rh_sku
 from data.database import ProxyCacheConfig
 from data.model import organization_skus
+from auth.scopes import validate_scope_string
 from endpoints.api import (
     ApiResource,
     allow_if_superuser,
@@ -727,6 +728,12 @@ class OrganizationApplications(ApiResource):
                 # If a scope is added to the JSON request:
                 if app_data.get("scope") is not None:
                     scope = app_data.get("scope")
+                    # We need to validate the scope string.
+                    # If the decoded string is 0, raise exception.
+                    if not validate_scope_string(scope):
+                        raise InvalidRequest(
+                            "Could not create application: Invalid or empty scope provided."
+                        )
                     application = model.oauth.create_application(
                         org,
                         app_data["name"],

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -41,7 +41,7 @@ from endpoints.api import (
     validate_json_request,
 )
 from endpoints.api.user import PrivateRepositories, User
-from endpoints.exception import NotFound, Unauthorized, InvalidRequest
+from endpoints.exception import InvalidRequest, NotFound, Unauthorized
 from proxy import Proxy, UpstreamRegistryError
 from util.marketplace import MarketplaceSubscriptionApi
 from util.names import parse_robot_username

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -24,7 +24,6 @@ from data import model
 from data.billing import get_plan, get_plan_using_rh_sku
 from data.database import ProxyCacheConfig
 from data.model import organization_skus
-from auth.scopes import validate_scope_string
 from endpoints.api import (
     ApiResource,
     allow_if_superuser,
@@ -730,7 +729,12 @@ class OrganizationApplications(ApiResource):
                     scope = app_data.get("scope")
                     # We need to validate the scope string.
                     # If the decoded string is 0, raise exception.
-                    if not validate_scope_string(scope):
+                    if not scopes.validate_scope_string(scope):
+                        logger.debug(
+                            "Failed to create appllication: invalid scope requested: '{}'.".format(
+                                scope
+                            )
+                        )
                         raise InvalidRequest(
                             "Could not create application: Invalid or empty scope provided."
                         )
@@ -755,6 +759,7 @@ class OrganizationApplications(ApiResource):
                     return app_view(application, token)
                 # If scopes are missing, raise exception
                 else:
+                    logger.debug("Failed to create application: missing scopes.")
                     raise InvalidRequest("Could not create application: missing scopes in request.")
             else:
                 # Application is not considered local, so just create it and return.

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -1,13 +1,15 @@
-from test.fixtures import *
-
 import pytest
 
 from data import model
 from endpoints.api import api
-from endpoints.api.organization import Organization, OrganizationCollaboratorList
-from endpoints.api.organization import OrganizationApplications
+from endpoints.api.organization import (
+    Organization,
+    OrganizationApplications,
+    OrganizationCollaboratorList,
+)
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
+from test.fixtures import *
 
 
 @pytest.mark.parametrize(

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -74,3 +74,27 @@ def test_create_local_oauth_application_with_scope(app):
             cl, OrganizationApplications, "POST", {"orgname": "buynlarge"}, payload, 200
         )
     assert resp.json["access_token"] is not None
+
+
+@pytest.mark.parametrize(
+    ("scope, expected_code"),
+    [
+        (" ", 400),
+        ("wrong:scope", 400),
+        ("WRONG:SCOPE", 400),
+        ("wrong scope", 400),
+        ("org:admin but wrong scope", 400),
+        ("ORG:admin", 400),
+        ("org:ADMIN", 400),
+    ],
+)
+def test_create_local_oauth_application_with_invalid_scopes(scope, expected_code, app):
+    with client_with_identity("devtable", app) as cl:
+        resp = conduct_api_call(
+            cl,
+            OrganizationApplications,
+            "POST",
+            {"orgname": "buynlarge"},
+            body={"name": "test-app", "local": True, "scope": scope},
+            expected_code=expected_code,
+        )


### PR DESCRIPTION
Current implementation of the API does not allow easy creation and retrieval of bearer tokens for newly created applications. This poses a considerable issue for any automation job. The proposed change would allow the authenticated user (authenticated via an existing bearer token) to create local Oauth applications and get the bearer token that the user can immediately use for other API calls. The token is still created on behalf of the user that is calling the endpoint. Example output:

~~~
$ curl -X POST -H "Authorization: Bearer RoY6..." -H "Content-type: application/json" -d '{"name":"Test application 1", "redirect_uri":"https://quay.skynet/oauth/localapp", "description":"Test local bearer token"}' https://quay.skynet/api/v1/organization/testorg/applications 
{"name": "Test application 1", "description": "Test local bearer token", "application_uri": "", "client_id": "OZ8...", "client_secret": "EKMX...", "redirect_uri": "https://quay.skynet/oauth/localapp", "avatar_email": null, "access_token": null}

$ curl -X POST -H "Authorization: Bearer RoY6..." -H "Content-type: application/json" -d '{"name":"Test application", "redirect_uri":"https://quay.skynet/oauth/localapp", "description":"Test local bearer token 3", "local":true, "scope":"org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read"}' https://quay.skynet/api/v1/organization/testorg/applications
{"name": "Test application", "description": "Test local bearer token 3", "application_uri": "", "client_id": "NU4F...", "client_secret": "X3F...", "redirect_uri": "https://quay.skynet/oauth/localapp", "avatar_email": null, "access_token": "SLWMB2..."}

$ $ curl -H "Authorization: Bearer SLWMB2..." https://quay.skynet/api/v1/user/ | jq '.'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   982  100   982    0     0   3721      0 --:--:-- --:--:-- --:--:--  3733
{
  "anonymous": false,
  "username": "ibazulic",
  "avatar": {
    "name": "ibazulic",
    "hash": "9b6277f06ccaf5ee50f00e85ade1ab0a7210c13c7e7c5739d1f318d4feca183c",
    "color": "#a1d99b",
    "kind": "user"
  },
...
~~~