### PR TITLE
federationuser(unittest) update to federate/link the checked entity before we do an entity search (PROJQUAY-5137)

### DIFF
--- a/endpoints/api/test/test_endtoend_auth.py
+++ b/endpoints/api/test/test_endtoend_auth.py
@@ -41,6 +41,12 @@ def test_entity_search(auth_engine, requires_email, client):
             assert len(results) == 0
 
             # Try a known prefix.
+            # For federationuser(ldap): avoid doing LDAP lookups for Robot accounts (PROJQUAY-5137) #2505
+            # we need to ensure, the user is federate before we can check it
+            link_response = conduct_api_call(
+                cl, LinkExternalEntity, "POST", params=dict(username="cool.user")
+            )
+
             response = conduct_api_call(client, EntitySearch, "GET", params=dict(prefix="cool"))
             results = response.json["results"]
             entity = results[0]


### PR DESCRIPTION
the Unittest for entity searching requires to be updated to first federate (link) the searched user into the Database.
Something like seen below.
In other words, the Unittest has been assuming wrongly up until now that the prefix=cool users was already federated when hitting the EntitySearch.

So its an ordering issue we need to address.
Compared to real-life implementations, the User method verify_and_link_user has not been called when executing, which happens at normally at login.

All other unit-tests called prior test_entity_search are not executing the method which explains why it's failing with the change to not do LDAP lookup for Robot accounts that are in the Database only.

Manual verification in a LAB show that the PR change does work as expected as the method verify_and_link_user in users/federation calls module externalldap.py and the method verify_credentials which does the LDAP lookup accordingly.

Additional reason why the context for LDAP lookup in the verify_credentials method is sufficient, from Issue PROJQUAY-5117 where it's stated, that the call is necessary because of permissions granting to the Robot, I want to challenge that for this being true, it would be necessary that Robot accounts are configured in LDAP too which is not the case.

Furthermore, in relation to PROJQUAY-5657 I was able to verify that as long s the session has not expired, Users can be removed from LDAP completely and still get access granted, obsoleting the statement for necessity once more,.