### PR TITLE
chore: amd64 nightly: add libpq-dev to fix issue while installing psycopg2

### DIFF
--- a/.github/workflows/CI-nightly.yaml
+++ b/.github/workflows/CI-nightly.yaml
@@ -75,7 +75,7 @@ jobs:
         export DEBIAN_FRONTEND=noninteractive;
         apt-get -y update;
         apt-get -y install libgpgme-dev libldap2-dev libsasl2-dev swig python3.9-dev python3-pip findutils git;
-        apt-get -y install libffi-dev libssl-dev libjpeg-dev libxml2-dev libxslt-dev;
+        apt-get -y install libffi-dev libssl-dev libjpeg-dev libpq-dev libxml2-dev libxslt-dev;
         apt-get -y install rustc cargo pkg-config;
         git clone ${GH_REPOSITORY} build;
         cd build && git checkout ${GH_REF};


### PR DESCRIPTION
Error from logs:
```
Error: pg_config executable not found.
```