### PR TITLE
ui: updating references to status.redhat.com (PROJQUAY-6654)

### DIFF
--- a/static/directives/quay-service-status.html
+++ b/static/directives/quay-service-status.html
@@ -2,6 +2,6 @@
   <span class="quay-service-status-indicator" ng-class="indicator"
         ng-if="indicator != 'loading'"></span>
   <span class="cor-loader-inline" ng-if="indicator == 'loading'"></span>
-  <a href="http://status.quay.io" class="quay-service-status-description">{{ description }}</a>
+  <a href="https://status.redhat.com" class="quay-service-status-description">{{ description }}</a>
   <span ng-if="degraded && degraded.length == 1" style="vertical-align: middle;">: {{ degraded[0].name }}</span>
 </span>

--- a/static/js/services/notification-service.js
+++ b/static/js/services/notification-service.js
@@ -70,7 +70,7 @@ function($rootScope, $interval, UserService, ApiService, StringBuilderService, P
       'level': 'warning',
       'message': 'We will be down for schedule maintenance from {from_date} to {to_date} ' +
         'for {reason}. We are sorry about any inconvenience.',
-      'page': 'http://status.quay.io/'
+      'page': 'https://status.redhat.com'
     },
     'repo_push': {
       'level': 'info',

--- a/static/js/services/status-service.js
+++ b/static/js/services/status-service.js
@@ -8,8 +8,27 @@ angular.module('quay').factory('StatusService', ['Features', function(Features) 
     };
   }
 
-  var STATUSPAGE_PAGE_ID = '8szqd6w4s277';
-  var STATUSPAGE_SRC = 'https://statuspage-production.s3.amazonaws.com/se-v2.js';
+  var STATUSPAGE_PAGE_ID = 'dn6mqn7xvzz3';
+  var STATUSPAGE_QUAY_ID = 'cllr1k2dzsf7';
+  var STATUSPAGE_SRC = 'https://cdn.statuspage.io/se-v2.js';
+  var statusToIndicator = {
+    operational: {
+      indicator: 'none',
+      description: 'All Systems Operational'
+    },
+    degraded_performance: {
+      indicator: 'minor',
+      description: 'Degraded Performance'
+    },
+    partial_outage: {
+      indicator: 'major',
+      description: 'Partial System Outage'
+    },
+    major_outage: {
+      indicator: 'critical',
+      description: 'Major Service Outage'
+    },
+  }
   var statusPageHandler = null;
   var statusPageData = null;
   var callbacks = [];
@@ -18,8 +37,35 @@ angular.module('quay').factory('StatusService', ['Features', function(Features) 
     if (!data) { return; }
     statusPageData = data;
 
+    const quayData = {status:{}};
+    const quayComponent = data.components.find((component) => component.id === STATUSPAGE_QUAY_ID);
+    if(!quayComponent) {return;}
+    const subComponentIds = quayComponent.components || [];
+
+    // incidents
+    const incidents = data.incidents.filter((incident) => {
+      return incident.components.some((component) => subComponentIds.includes(component.id));
+    });
+    quayData.incidents = incidents;
+
+    // components
+    const subComponents = data.components.filter((component) => subComponentIds.includes(component.id));
+    quayData.components = subComponents;
+
+    // scheduled_maintenances
+    const scheduledMaintenances = data.scheduled_maintenances.filter((scheduledMaintenance) => {
+      return scheduledMaintenance.components.some((component) => subComponentIds.includes(component.id));
+    });
+    quayData.scheduled_maintenances = scheduledMaintenances;
+
+    // status.indicator
+    quayData.status.indicator = statusToIndicator[quayComponent.status].indicator;
+
+    // status.description
+    quayData.status.description = statusToIndicator[quayComponent.status].description;
+
     for (var i = 0; i < callbacks.length; ++i) {
-      callbacks[i](data);
+      callbacks[i](quayData);
     }
 
     callbacks = [];

--- a/templates/500.html
+++ b/templates/500.html
@@ -17,10 +17,10 @@
     <span id="status-elem">(Loading)</span>
   </div>
 
-  <script type="text/javascript" src="//statuspage-production.s3.amazonaws.com/se.js"></script>
+  <script type="text/javascript" src="https://cdn.statuspage.io/se.js"></script>
   <script type="text/javascript">
     window.fetchStatusPage({
-      pageId: '8szqd6w4s277',
+      pageId: 'dn6mqn7xvzz3',
       renderTo: '#status-elem'
     });
   </script>

--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
   },
   plugins: ['import', 'react', '@typescript-eslint', 'prettier'],
-  ignorePatterns: ['*.md', '**/*.css', '**/*.scss', '*.svg', '*.png'],
+  ignorePatterns: ['*.md', '**/*.css', '**/*.scss', '*.svg', '*.png', '*.html'],
   rules: {
     'react/react-in-jsx-scope': 'off',
     'prettier/prettier': ['error'],

--- a/web/cypress/e2e/service-status.cy.ts
+++ b/web/cypress/e2e/service-status.cy.ts
@@ -1,0 +1,57 @@
+/// <reference types="cypress" />
+
+describe('Default permissions page', () => {
+  beforeEach(() => {
+    cy.exec('npm run quay:seed');
+    cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
+      .then((response) => response.body.csrf_token)
+      .then((token) => {
+        cy.loginByCSRF(token);
+      });
+  });
+
+  it('Displays incidents and maintanences', () => {
+    cy.intercept(
+      'GET',
+      'https://dn6mqn7xvzz3.statuspage.io/api/v2/summary.json',
+      {fixture: 'registry-status.json'},
+    );
+    cy.visit('/organization/testorg');
+    cy.contains('incident1').should(
+      'have.attr',
+      'href',
+      'https://stspg.io/incident1',
+    );
+    cy.contains('incident2').should(
+      'have.attr',
+      'href',
+      'https://stspg.io/incident2',
+    );
+    cy.contains('Scheduled for Feb 9, 2024, 10:00 AM:');
+    cy.contains('maintenance1').should(
+      'have.attr',
+      'href',
+      'https://stspg.io/maintenance1',
+    );
+    cy.contains('In progress:');
+    cy.contains('maintenance2').should(
+      'have.attr',
+      'href',
+      'https://stspg.io/maintenance2',
+    );
+  });
+
+  it('Displays no incidents and maintanences', () => {
+    cy.fixture('registry-status.json').then((statusFixture) => {
+      statusFixture.incidents = [];
+      statusFixture.scheduled_maintenances = [];
+      cy.intercept(
+        'GET',
+        'https://dn6mqn7xvzz3.statuspage.io/api/v2/summary.json',
+        statusFixture,
+      );
+    });
+    cy.visit('/organization/testorg');
+    cy.get('#registry-status').should('not.exist');
+  });
+});

--- a/web/cypress/e2e/service-status.cy.ts
+++ b/web/cypress/e2e/service-status.cy.ts
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+import {formatDate} from '../../src/libs/utils';
 
 describe('Default permissions page', () => {
   beforeEach(() => {
@@ -28,7 +29,7 @@ describe('Default permissions page', () => {
       'href',
       'https://stspg.io/incident2',
     );
-    cy.contains('Scheduled for Feb 9, 2024, 10:00 AM:');
+    cy.contains(`Scheduled for ${formatDate('2024-02-09T10:00:00.000-05:00')}`);
     cy.contains('maintenance1').should(
       'have.attr',
       'href',

--- a/web/cypress/e2e/service-status.cy.ts
+++ b/web/cypress/e2e/service-status.cy.ts
@@ -3,6 +3,7 @@
 describe('Default permissions page', () => {
   beforeEach(() => {
     cy.exec('npm run quay:seed');
+    cy.intercept('GET', '/config', {fixture: 'config.json'}).as('getConfig');
     cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
       .then((response) => response.body.csrf_token)
       .then((token) => {

--- a/web/cypress/fixtures/registry-status.json
+++ b/web/cypress/fixtures/registry-status.json
@@ -1,0 +1,168 @@
+{
+  "page": {
+    "id": "dn6mqn7xvzz3",
+    "name": "Red Hat",
+    "url": "https://status.redhat.com",
+    "time_zone": "America/New_York",
+    "updated_at": "2024-02-06T12:27:50.519-05:00"
+  },
+  "components": [
+    {
+      "id": "cllr1k2dzsf7",
+      "name": "Quay.io",
+      "status": "major_outage",
+      "created_at": "2024-01-16T15:36:01.802-05:00",
+      "updated_at": "2024-01-16T16:57:38.322-05:00",
+      "position": 16,
+      "description": null,
+      "showcase": false,
+      "start_date": null,
+      "group_id": null,
+      "page_id": "dn6mqn7xvzz3",
+      "group": true,
+      "only_show_if_degraded": false,
+      "components": [
+        "m65lxn2nf6l0",
+        "6fb8zflt4fbt",
+        "fvnvxz75h3m2",
+        "02hhmtl31chv",
+        "4y37q0jspj5n"
+      ]
+    },
+    {
+      "id": "m65lxn2nf6l0",
+      "name": "API",
+      "status": "major_outage",
+      "created_at": "2024-01-16T15:36:01.876-05:00",
+      "updated_at": "2024-01-16T15:36:01.876-05:00",
+      "position": 1,
+      "description": null,
+      "showcase": false,
+      "start_date": "2024-01-16",
+      "group_id": "cllr1k2dzsf7",
+      "page_id": "dn6mqn7xvzz3",
+      "group": false,
+      "only_show_if_degraded": false
+    },
+    {
+      "id": "6fb8zflt4fbt",
+      "name": "Build System",
+      "status": "partial_outage",
+      "created_at": "2024-01-16T15:38:09.519-05:00",
+      "updated_at": "2024-01-16T15:38:09.519-05:00",
+      "position": 2,
+      "description": null,
+      "showcase": false,
+      "start_date": "2024-01-16",
+      "group_id": "cllr1k2dzsf7",
+      "page_id": "dn6mqn7xvzz3",
+      "group": false,
+      "only_show_if_degraded": false
+    },
+    {
+      "id": "fvnvxz75h3m2",
+      "name": "Registry",
+      "status": "operational",
+      "created_at": "2024-01-16T15:38:30.060-05:00",
+      "updated_at": "2024-01-16T15:38:30.060-05:00",
+      "position": 3,
+      "description": null,
+      "showcase": false,
+      "start_date": "2024-01-16",
+      "group_id": "cllr1k2dzsf7",
+      "page_id": "dn6mqn7xvzz3",
+      "group": false,
+      "only_show_if_degraded": false
+    },
+    {
+      "id": "02hhmtl31chv",
+      "name": "Frontend",
+      "status": "operational",
+      "created_at": "2024-01-16T15:38:44.726-05:00",
+      "updated_at": "2024-01-16T15:38:44.726-05:00",
+      "position": 4,
+      "description": null,
+      "showcase": false,
+      "start_date": "2024-01-16",
+      "group_id": "cllr1k2dzsf7",
+      "page_id": "dn6mqn7xvzz3",
+      "group": false,
+      "only_show_if_degraded": false
+    },
+    {
+      "id": "4y37q0jspj5n",
+      "name": "Security Scanning",
+      "status": "operational",
+      "created_at": "2024-01-16T15:38:59.314-05:00",
+      "updated_at": "2024-01-16T15:38:59.314-05:00",
+      "position": 5,
+      "description": null,
+      "showcase": false,
+      "start_date": "2024-01-16",
+      "group_id": "cllr1k2dzsf7",
+      "page_id": "dn6mqn7xvzz3",
+      "group": false,
+      "only_show_if_degraded": false
+    }
+  ],
+  "incidents": [
+    {
+      "name": "incident1",
+      "shortlink": "https://stspg.io/incident1",
+      "components": [
+        {
+          "id": "m65lxn2nf6l0"
+        },
+        {
+          "id": "6fb8zflt4fbt"
+        }
+      ]
+    },
+    {
+      "name": "incident2",
+      "shortlink": "https://stspg.io/incident2",
+      "components": [
+        {
+          "id": "m65lxn2nf6l0"
+        },
+        {
+          "id": "6fb8zflt4fbt"
+        }
+      ]
+    }
+  ],
+  "scheduled_maintenances": [
+    {
+      "status": "scheduled",
+      "name": "maintenance1",
+      "shortlink": "https://stspg.io/maintenance1",
+      "components": [
+        {
+          "id": "m65lxn2nf6l0"
+        },
+        {
+          "id": "6fb8zflt4fbt"
+        }
+      ],
+      "scheduled_for": "2024-02-09T10:00:00.000-05:00"
+    },
+    {
+      "name": "maintenance2",
+      "status": "in_progress",
+      "shortlink": "https://stspg.io/maintenance2",
+      "components": [
+        {
+          "id": "m65lxn2nf6l0"
+        },
+        {
+          "id": "6fb8zflt4fbt"
+        }
+      ],
+      "scheduled_for": "2024-02-09T10:00:00.000-05:00"
+    }
+  ],
+  "status": {
+    "indicator": "none",
+    "description": "All Systems Operational"
+  }
+}

--- a/web/src/components/errors/SiteUnavailableError.tsx
+++ b/web/src/components/errors/SiteUnavailableError.tsx
@@ -23,7 +23,8 @@ export default function SiteUnavailableError() {
           <EmptyStateBody>
             Try refreshing the page. If the problem persists, contact your
             organization administrator or visit our{' '}
-            <a href="https://status.quay.io/">status page</a> for known outages.
+            <a href="https://status.redhat.com">status page</a> for known
+            outages.
           </EmptyStateBody>
           <EmptyStateFooter>
             <Button title="Home" onClick={() => window.location.reload()}>

--- a/web/src/hooks/UseServiceStatus.ts
+++ b/web/src/hooks/UseServiceStatus.ts
@@ -1,0 +1,105 @@
+import {useEffect, useState} from 'react';
+import {isNullOrUndefined} from 'src/libs/utils';
+
+const STATUSPAGE_PAGE_ID = 'dn6mqn7xvzz3';
+const STATUSPAGE_QUAY_ID = 'cllr1k2dzsf7';
+const statusToIndicator = {
+  operational: {
+    indicator: 'none',
+    description: 'All Systems Operational',
+  },
+  degraded_performance: {
+    indicator: 'minor',
+    description: 'Degraded Performance',
+  },
+  partial_outage: {
+    indicator: 'major',
+    description: 'Partial System Outage',
+  },
+  major_outage: {
+    indicator: 'critical',
+    description: 'Major Service Outage',
+  },
+};
+
+interface StatusData {
+  indicator: string;
+  description: string;
+  incidents: any[];
+  components: any[];
+  degraded_components: any[];
+  scheduled_maintenances: any[];
+}
+
+export function useServiceStatus() {
+  const [statusData, setStatusData] = useState<StatusData>(null);
+  if (isNullOrUndefined(StatusPage)) {
+    return {};
+  }
+  useEffect(() => {
+    const statusPageHandler = new StatusPage.page({page: STATUSPAGE_PAGE_ID});
+    statusPageHandler.summary({
+      success: (data) => {
+        if (!data) {
+          return;
+        }
+
+        const quayData: StatusData = {
+          indicator: '',
+          description: '',
+          incidents: [],
+          components: [],
+          scheduled_maintenances: [],
+          degraded_components: [],
+        };
+        const quayComponent = data.components.find(
+          (component) => component.id === STATUSPAGE_QUAY_ID,
+        );
+        if (!quayComponent) {
+          return;
+        }
+        const subComponentIds = quayComponent.components || [];
+
+        // incidents
+        const incidents = data.incidents.filter((incident) => {
+          return incident.components.some((component) =>
+            subComponentIds.includes(component.id),
+          );
+        });
+        quayData.incidents = incidents;
+
+        // components
+        const subComponents = data.components.filter((component) =>
+          subComponentIds.includes(component.id),
+        );
+        quayData.components = subComponents;
+        quayData.degraded_components = subComponents.filter(
+          (component) => component.status !== 'operational',
+        );
+
+        // scheduled_maintenances
+        const scheduledMaintenances = data.scheduled_maintenances.filter(
+          (scheduledMaintenance) => {
+            return scheduledMaintenance.components.some((component) =>
+              subComponentIds.includes(component.id),
+            );
+          },
+        );
+        quayData.scheduled_maintenances = scheduledMaintenances;
+
+        // status.indicator
+        quayData.indicator = statusToIndicator[quayComponent.status].indicator;
+
+        // status.description
+        quayData.description =
+          statusToIndicator[quayComponent.status].description;
+
+        setStatusData(quayData);
+      },
+    });
+  }, []);
+
+  return {
+    statusData,
+  };
+}

--- a/web/src/index.html
+++ b/web/src/index.html
@@ -7,6 +7,7 @@
   <meta id="appName" name="quay" content="Red Hat Quay">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://checkout.stripe.com/checkout.js"></script>
+  <script src="https://cdn.statuspage.io/se-v2.js"></script>
   <link rel="icon" type="image/svg+xml" href="/images/favicon.png">
   <base href="/">
 </head>

--- a/web/src/routes/RegistryStatus.css
+++ b/web/src/routes/RegistryStatus.css
@@ -1,0 +1,44 @@
+.quay-service-status-element {
+    display: flex;
+    align-items: center;
+  }
+
+  .quay-service-status-indicator {
+    display: inline-block;
+    border-radius: 50%;
+    width: 12px;
+    height: 12px;
+    margin-right: 6px;
+    background: #eee;
+    vertical-align: middle
+  }
+
+  .quay-service-status-description {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .quay-service-status-indicator.none {
+    background: #2fcc66;
+  }
+
+  .quay-service-status-indicator.minor {
+    background: #f1c40f;
+  }
+
+  .quay-service-status-indicator.major {
+    background: #e67e22;
+  }
+
+  .quay-service-status-indicator.critical {
+    background: #e74c3c;
+  }
+
+  .message {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-top: .5em;
+    padding-bottom: .5em;
+}

--- a/web/src/routes/RegistryStatus.tsx
+++ b/web/src/routes/RegistryStatus.tsx
@@ -1,0 +1,72 @@
+import {useServiceStatus} from 'src/hooks/UseServiceStatus';
+import {formatDate, isNullOrUndefined} from 'src/libs/utils';
+import './RegistryStatus.css';
+import Conditional from 'src/components/empty/Conditional';
+import {OutlinedCalendarAltIcon} from '@patternfly/react-icons';
+
+export default function RegistryStatus() {
+  const {statusData} = useServiceStatus();
+
+  if (isNullOrUndefined(statusData)) {
+    return <></>;
+  }
+
+  return (
+    <Conditional
+      if={
+        statusData.indicator != 'loading' &&
+        (statusData.scheduled_maintenances?.length > 0 ||
+          statusData.incidents?.length > 0)
+      }
+    >
+      <div id="registry-status" className="announcement inline">
+        {statusData.incidents.map((incident) => {
+          return (
+            <div key={incident.name} className="message">
+              <Conditional if={statusData.indicator != 'loading'}>
+                <span
+                  className={`quay-service-status-indicator ${statusData.indicator}`}
+                ></span>
+                <a
+                  href={incident.shortlink}
+                  className="quay-service-status-description"
+                >
+                  {incident.name}
+                </a>
+              </Conditional>
+            </div>
+          );
+        })}
+
+        {statusData.scheduled_maintenances.map((scheduled) => {
+          return (
+            <div key={scheduled.name}>
+              <span className="message">
+                <Conditional if={scheduled.status == 'scheduled'}>
+                  <OutlinedCalendarAltIcon style={{marginRight: '6px'}} />{' '}
+                  Scheduled for {formatDate(scheduled.scheduled_for)}:{' '}
+                </Conditional>
+                <Conditional
+                  if={
+                    scheduled.status == 'in_progress' ||
+                    scheduled.status == 'verifying'
+                  }
+                >
+                  <b style={{color: 'orange'}}>In progress: </b>
+                </Conditional>
+                <span>
+                  <a
+                    href={scheduled.shortlink}
+                    className="quay-service-status-description"
+                  >
+                    {scheduled.name}
+                  </a>
+                </span>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </Conditional>
+  );
+}

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -22,6 +22,8 @@ import axiosIns from 'src/libs/axios';
 import Alerts from './Alerts';
 import OverviewList from './OverviewList/OverviewList';
 import SetupBuildTriggerRedirect from './SetupBuildtrigger/SetupBuildTriggerRedirect';
+import Conditional from 'src/components/empty/Conditional';
+import RegistryStatus from './RegistryStatus';
 
 const NavigationRoutes = [
   {
@@ -102,6 +104,11 @@ export function StandaloneMain() {
             </FlexItem>
           </Flex>
         </Banner>
+        <Conditional if={quayConfig?.features?.BILLING}>
+          <ErrorBoundary fallback={<>Error loading registry status</>}>
+            <RegistryStatus />
+          </ErrorBoundary>
+        </Conditional>
         <Alerts />
         <Routes>
           <Route index element={<Navigate to="/organization" replace />} />


### PR DESCRIPTION
Updates references from `status.quay.io` to `status.redhat.com`. Uses responses based on the [status page API documentation](https://dn6mqn7xvzz3.statuspage.io/api). 

Gotchas:
- The `500.html` uses an imported status page script to display Quay status. Updating the page ID to use `status.redhat.com` causes the UI to display the overall RedHat status rather than specifically the Quay UI status. 
- There's the assumption that the `incidents` field contains a `components` parameter, like the `scheduled_maintenances` field.

