### PR TITLE
manifest: support empty config for artifacts (PROJQUAY-6658)

### DIFF
--- a/image/oci/config.py
+++ b/image/oci/config.py
@@ -205,6 +205,12 @@ class OCIConfig(object):
         except ValueError as ve:
             raise MalformedConfig("malformed config data: %s" % ve)
 
+        # If the config is empty, we don't need to parse it
+        # this is possible if the user is pushing an artifact that is not an image
+        # where `config.mediaType` defines the type of artifact
+        if self._parsed == {}:
+            return
+
         try:
             validate_schema(self._parsed, OCIConfig.METASCHEMA)
         except ValidationError as ve:

--- a/image/oci/test/test_oci_config.py
+++ b/image/oci/test/test_oci_config.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from contextlib import nullcontext as does_not_raise
 
 import pytest
 from dateutil.tz import tzutc
@@ -120,7 +121,7 @@ def test_config_missing_required():
 
 def test_invalid_config():
     with pytest.raises(MalformedConfig):
-        OCIConfig(Bytes.for_string_or_unicode("{}"))
+        OCIConfig(Bytes.for_string_or_unicode('{"config": "invalid"}'))
 
 
 def test_artifact_registratioon():
@@ -149,3 +150,8 @@ def test_artifact_registratioon():
         "application/tar+gzip" in ADDITIONAL_LAYER_CONTENT_TYPES
         and ADDITIONAL_LAYER_CONTENT_TYPES.count("application/tar+gzip") == 1
     )
+
+
+def test_empty_config():
+    with does_not_raise(MalformedConfig):
+        OCIConfig(Bytes.for_string_or_unicode("{}"))


### PR DESCRIPTION
Artifacts can have empty config defined
skip parsing if the config is empty