### PR TITLE
oci: remove platform requirement for image index (PROJQUAY-6658)

### DIFF
--- a/image/oci/index.py
+++ b/image/oci/index.py
@@ -153,7 +153,6 @@ class OCIIndex(ManifestListInterface):
                             ],
                         },
                     },
-                    additional_required=[INDEX_PLATFORM_KEY],
                 ),
             },
             INDEX_ANNOTATIONS_KEY: {


### PR DESCRIPTION
 The image index spec https://github.com/opencontainers/image-spec/blob/main/image-index.md
    specifics `platform` as an optional field.