### PR TITLE
proxy: Add a separate configuration option for repo visibility in case of proxy registry (PROJQUAY-4850)

### DIFF
--- a/config.py
+++ b/config.py
@@ -787,6 +787,9 @@ class DefaultConfig(ImmutableConfig):
     # Repos created by push default to private visibility
     CREATE_PRIVATE_REPO_ON_PUSH = True
 
+    # Repos created by pull through proxy default to private visibility
+    CREATE_PRIVATE_REPO_ON_PULL_THROUGH = True
+
     # Create organization on push if it does not exist
     CREATE_NAMESPACE_ON_PUSH = False
 

--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -131,7 +131,9 @@ class ProxyModel(OCIModel):
                 raise RepositoryDoesNotExist(str(e))
             return None
 
-        visibility = "private" if app.config.get("CREATE_PRIVATE_REPO_ON_PUSH", True) else "public"
+        visibility = (
+            "private" if app.config.get("CREATE_PRIVATE_REPO_ON_PULL_THROUGH", True) else "public"
+        )
 
         repo = create_repository(namespace_name, repo_name, self._user, visibility=visibility)
         return RepositoryReference.for_repo_obj(

--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -149,7 +149,7 @@ class TestLookUpRepositoryWithRepoCreationVisibilityFlag:
     @patch("data.registry_model.registry_proxy_model.Proxy", MagicMock())
     def test_lookup_repository_creates_private_repo_when_enabled(self):
         with patch("data.registry_model.registry_proxy_model.app", MagicMock()) as app_mock:
-            app_mock.config = {"CREATE_PRIVATE_REPO_ON_PUSH": True}
+            app_mock.config = {"CREATE_PRIVATE_REPO_ON_PULL_THROUGH": True}
             repo_ref = self.proxy_model.lookup_repository(
                 self.orgname, self.upstream_repository, manifest_ref=self.tag
             )
@@ -159,7 +159,7 @@ class TestLookUpRepositoryWithRepoCreationVisibilityFlag:
     @patch("data.registry_model.registry_proxy_model.Proxy", MagicMock())
     def test_lookup_repository_creates_public_repo_when_disabled(self):
         with patch("data.registry_model.registry_proxy_model.app", MagicMock()) as app_mock:
-            app_mock.config = {"CREATE_PRIVATE_REPO_ON_PUSH": False}
+            app_mock.config = {"CREATE_PRIVATE_REPO_ON_PULL_THROUGH": False}
             repo_ref = self.proxy_model.lookup_repository(
                 self.orgname, self.upstream_repository, manifest_ref=self.tag
             )

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1246,6 +1246,11 @@ CONFIG_SCHEMA = {
             "description": "Whether new repositories created by push are set to private visibility. Defaults to True.",
             "x-example": True,
         },
+        "CREATE_PRIVATE_REPO_ON_PULL_THROUGH": {
+            "type": "boolean",
+            "description": "Whether new repositories created by pull through proxy are set to private visibility. Defaults to True.",
+            "x-example": True,
+        },
         "CREATE_NAMESPACE_ON_PUSH": {
             "type": "boolean",
             "description": "Whether new push to a non-existent organization creates it. Defaults to False.",


### PR DESCRIPTION
It is possible that we might want to create public repositories by default, but at the same time, repositories created when using Quay as a proxy should be created as private. It seems to me that it would be worth providing the ability to regulate the type of repository created in this case separately.