### PR TITLE
task: Upgrade Quay nginx (PROJQUAY-6685)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH=/app/bin/:$PATH \
 ENV PYTHONUSERBASE /app
 ENV TZ UTC
 RUN set -ex\
-	; microdnf -y module enable nginx:1.20 \
+	; microdnf -y module enable nginx:1.22 \
 	; microdnf -y module enable python39:3.9 \
 	; microdnf update -y \
 	; microdnf -y --setopt=tsflags=nodocs install \


### PR DESCRIPTION
According to the [app stream lifecycle](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle), Quay's nginx 1.20 has been retired as of November 2023. The last version of nginx that is available is 1.22 and is supported till November 2025 for RHEL 8.