### PR TITLE
marketplace: add expiration check to org subscription operations (PROJQUAY-6716)

### DIFF
--- a/test/test_api_usage.py
+++ b/test/test_api_usage.py
@@ -5178,6 +5178,14 @@ class TestOrganizationRhSku(ApiTestCase):
         plans = check_internal_api_for_subscription(org)
         assert len(plans) == 1
 
+    def test_expired_attachment(self):
+        self.login(SUBSCRIPTION_USER)
+        user = model.user.get_user(SUBSCRIPTION_USER)
+        org = model.organization.get_organization(SUBSCRIPTION_ORG)
+        model.organization_skus.bind_subscription_to_org(80808080, org.id, user.id, 1)
+        json = self.getJsonResponse(OrgPrivateRepositories, params=dict(orgname=SUBSCRIPTION_ORG))
+        self.assertEqual(json["privateAllowed"], False)
+
 
 class TestUserSku(ApiTestCase):
     def test_get_user_skus(self):

--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -191,9 +191,9 @@ class RedHatSubscriptionApi(object):
 
         return r.status_code
 
-    def get_subscription_sku(self, subscription_id):
+    def get_subscription_details(self, subscription_id):
         """
-        Return the sku for a specific subscription
+        Return the sku and expiration date for a specific subscription
         """
         request_url = f"{self.marketplace_endpoint}/subscription/v5/products/subscription_id={subscription_id}"
         request_headers = {"Content-Type": "application/json"}
@@ -210,8 +210,9 @@ class RedHatSubscriptionApi(object):
 
             info = json.loads(r.content)
 
-            SubscriptionSKU = info[0]["sku"]
-            return SubscriptionSKU
+            subscription_sku = info[0]["sku"]
+            expiration_date = info[1]["activeEndDate"]
+            return {"sku": subscription_sku, "expiration_date": expiration_date}
         except requests.exceptions.SSLError:
             raise requests.exceptions.SSLError
         except requests.exceptions.ReadTimeout:
@@ -267,7 +268,7 @@ TEST_USER = {
             "subscriptionNumber": "12399889",
             "quantity": 2,
             "effectiveStartDate": 1707368400000,
-            "effectiveEndDate": 3813177600,
+            "effectiveEndDate": 3813177600000,
         },
         {
             "id": 11223344,
@@ -282,7 +283,7 @@ TEST_USER = {
             "subscriptionNumber": "12399889",
             "quantity": 1,
             "effectiveStartDate": 1707368400000,
-            "effectiveEndDate": 3813177600,
+            "effectiveEndDate": 3813177600000,
         },
     ],
 }
@@ -329,10 +330,12 @@ class FakeSubscriptionApi(RedHatSubscriptionApi):
     def extend_subscription(self, subscription_id, end_date):
         self.subscription_extended = True
 
-    def get_subscription_sku(self, subscription_id):
+    def get_subscription_details(self, subscription_id):
         valid_ids = [subscription["id"] for subscription in TEST_USER["subscriptions"]]
         if subscription_id in valid_ids:
-            return "MW02701"
+            return {"sku": "MW02701", "expiration_date": 3813177600000}
+        elif subscription_id == 80808080:
+            return {"sku": "MW02701", "expiration_date": 1645544830000}
         else:
             return None
 

--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -140,6 +140,60 @@ mocked_subscription_response = [
     },
 ]
 
+mocked_expired_sub = [
+    {
+        "id": 41619474,
+        "masterEndSystemName": "SUBSCRIPTION",
+        "createdEndSystemName": "SUBSCRIPTION",
+        "createdByUserName": None,
+        "createdDate": 1708616554000,
+        "lastUpdateEndSystemName": "SUBSCRIPTION",
+        "lastUpdateUserName": None,
+        "lastUpdateDate": 1708616554000,
+        "externalCreatedDate": None,
+        "externalLastUpdateDate": None,
+        "activeStartDate": None,
+        "activeEndDate": None,
+        "inactiveDate": None,
+        "signedDate": None,
+        "terminatedDate": None,
+        "renewedDate": None,
+        "parentSubscriptionProductId": None,
+        "externalOrderSystemName": "SUBSCRIPTION",
+        "externalOrderNumber": None,
+        "status": None,
+        "sku": "MW02701",
+        "childrenIds": [41619475],
+        "serviceable": False,
+    },
+    {
+        "id": 41619475,
+        "masterEndSystemName": "SUBSCRIPTION",
+        "createdEndSystemName": "SUBSCRIPTION",
+        "createdByUserName": None,
+        "createdDate": 1645544830000,
+        "lastUpdateEndSystemName": "SUBSCRIPTION",
+        "lastUpdateUserName": None,
+        "lastUpdateDate": 1645544830000,
+        "externalCreatedDate": None,
+        "externalLastUpdateDate": None,
+        "activeStartDate": 1645544830000,
+        "activeEndDate": 1645544830000,
+        "inactiveDate": None,
+        "signedDate": None,
+        "terminatedDate": None,
+        "renewedDate": None,
+        "parentSubscriptionProductId": 41619474,
+        "externalOrderSystemName": "SUBSCRIPTION",
+        "externalOrderNumber": None,
+        "status": "active",
+        "oracleInventoryOrgId": None,
+        "sku": "SVCMW02701",
+        "childrenIds": None,
+        "serviceable": True,
+    },
+]
+
 
 class TestMarketplace(unittest.TestCase):
     @patch("requests.request")
@@ -152,8 +206,8 @@ class TestMarketplace(unittest.TestCase):
         assert customer_id is None
         subscription_response = subscription_api.lookup_subscription(123456, "sku")
         assert subscription_response is None
-        subscription_sku = subscription_api.get_subscription_sku(123456)
-        assert subscription_sku is None
+        subscription_details = subscription_api.get_subscription_details(123456)
+        assert subscription_details is None
         extended_subscription = subscription_api.extend_subscription(12345, 102623)
         assert extended_subscription is None
         create_subscription_response = subscription_api.create_entitlement(12345, "sku")
@@ -178,3 +232,12 @@ class TestMarketplace(unittest.TestCase):
 
         subscriptions = subscription_api.lookup_subscription(12345, "some_sku")
         assert len(subscriptions) == 2
+
+    @patch("requests.request")
+    def test_subscription_details(self, requests_mock):
+        subscription_api = RedHatSubscriptionApi(app_config)
+        requests_mock.return_value.content = json.dumps(mocked_expired_sub)
+
+        subscription_details = subscription_api.get_subscription_details(12345)
+        assert subscription_details["sku"] == "MW02701"
+        assert subscription_details["expiration_date"] == 1645544830000


### PR DESCRIPTION
* Refactor function that fetches subscription sku based on subscription id to also fetch the subscription end date
* Check for end date in subscription when performing operations with org attached subscriptions (looking up private repos allowed, etc.) and if the subscription is expired remove it from the org attachment table
* Asserts that subscription does not stay attached to an org past its expiry date