### PR TITLE
logging: reduce noise in quay logs and add missing worker names (PROJQUAY-6562)

### DIFF
--- a/util/migrate/allocator.py
+++ b/util/migrate/allocator.py
@@ -5,7 +5,7 @@ from threading import Event
 from bintrees import RBTree
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)  # Set the default log level to DEBUG
 
 
 class NoAvailableKeysError(ValueError):
@@ -50,7 +50,9 @@ class CompletedKeys(object):
             if max_prev_completed >= start_index:
                 # we are going to merge with the range before us
                 logger.debug(
-                    "Merging with the prev range: %s-%s", prev_start, prev_start + prev_length
+                    "Merging with the prev range: %s-%s",
+                    prev_start,
+                    prev_start + prev_length,
                 )
                 to_discard.add(prev_start)
                 num_completed = max(num_completed - (max_prev_completed - start_index), 0)
@@ -63,7 +65,9 @@ class CompletedKeys(object):
         for merge_start, merge_length in self._slabs.iter_items(start_index, past_last_index + 1):
             if merge_start in to_discard:
                 logger.debug(
-                    "Already merged with block %s-%s", merge_start, merge_start + merge_length
+                    "Already merged with block %s-%s",
+                    merge_start,
+                    merge_start + merge_length,
                 )
                 continue
 
@@ -134,7 +138,9 @@ class CompletedKeys(object):
         return random.randint(hole_start, rand_max_bound)
 
 
-def yield_random_entries(batch_query, primary_key_field, batch_size, max_id, min_id=0):
+def yield_random_entries(
+    batch_query, primary_key_field, batch_size, max_id, min_id=0, worker_name=""
+):
     """
     This method will yield items from random blocks in the database.
 
@@ -159,17 +165,21 @@ def yield_random_entries(batch_query, primary_key_field, batch_size, max_id, min
             )
 
             if len(all_candidates) == 0:
-                logger.info(
-                    "No candidates, marking entire block completed %s-%s", start_index, end_index
+                logger.debug(
+                    "No candidates, marking entire block completed %s-%s by worker %s",
+                    start_index,
+                    end_index,
+                    worker_name,
                 )
                 allocator.mark_completed(start_index, end_index)
                 continue
 
-            logger.info(
-                "Found %s candidates, processing block start: %d end: %d",
+            logger.debug(
+                "Found %s candidates, processing block start: %d end: %d by worker %s",
                 len(all_candidates),
                 start_index,
                 end_index,
+                worker_name,
             )
             batch_completed = 0
             for candidate in all_candidates:
@@ -177,12 +187,20 @@ def yield_random_entries(batch_query, primary_key_field, batch_size, max_id, min
                 yield candidate, abort_early, allocator.num_remaining - batch_completed
                 batch_completed += 1
                 if abort_early.is_set():
-                    logger.info("Overlap with another worker, aborting")
+                    logger.debug(
+                        "Overlap with another worker, aborting by worker %s",
+                        worker_name,
+                    )
                     break
 
             completed_through = candidate.id + 1
-            logger.info("Marking id range as completed: %s-%s", start_index, completed_through)
+            logger.debug(
+                "Marking id range as completed: %s-%s by worker %s",
+                start_index,
+                completed_through,
+                worker_name,
+            )
             allocator.mark_completed(start_index, completed_through)
 
     except NoAvailableKeysError:
-        logger.info("No more work")
+        logger.debug("No more work by worker %s", worker_name)


### PR DESCRIPTION
1) Changing logger.info to logger.debug to stop too many INFO log lines from displaying in Quay logs 
2) Adding the missing worker name that print those log lines 

The idea of the log is to tell you which block is being procesed by worker that is processing it. These logs are missing the worker names
```
2023-11-27 15:24:05,825 [80] [INFO] [util.migrate.allocator] No candidates, marking entire block completed 210690-213109
2023-11-27 15:24:05,832 [80] [INFO] [util.migrate.allocator] No candidates, marking entire block completed 131657-134076
[sbhavsar-mac:~ sayalibhavsar]$ grep "No candidates, marking entire block completed" quay | wc -l
5300
```
For huge registries above logs  could be a bit noisy. We could hide it as a debug message rather than as an info message.
@sayalibhavsar