### PR TITLE
quota: removing repo size from quota verification (PROJQUAY-6637)

### DIFF
--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -708,7 +708,4 @@ def get_size_during_upload(repo_id: int):
         )
     ).get()
 
-    repo_size = get_repository_size(repo_id)
-    size_bytes = query.size_bytes if query.size_bytes is not None else 0
-
-    return repo_size + size_bytes
+    return query.size_bytes if query.size_bytes is not None else 0

--- a/data/model/test/test_repository.py
+++ b/data/model/test/test_repository.py
@@ -1,15 +1,17 @@
 import os
 from datetime import timedelta
-from test.fixtures import *
 
 import pytest
 
-from data.database import Repository
+from data.database import BlobUpload, Repository
 from data.model.repository import (
     create_repository,
     get_estimated_repository_count,
     get_filtered_matching_repositories,
+    get_size_during_upload,
 )
+from data.model.storage import get_image_location_for_name
+from test.fixtures import *
 
 
 def test_duplicate_repository_different_kinds(initialized_db):
@@ -62,3 +64,20 @@ def test_search_pagination(query, authed_username, initialized_db):
 
 def test_get_estimated_repository_count(initialized_db):
     assert get_estimated_repository_count() >= Repository.select().count()
+
+
+def test_get_size_during_upload(initialized_db):
+    upload_size = 100
+    repo1 = create_repository(
+        "devtable", "somenewrepo", None, repo_kind="image", visibility="public"
+    )
+    location = get_image_location_for_name("local_us")
+    BlobUpload.create(
+        repository=repo1.id,
+        uuid="123",
+        storage_metadata="{}",
+        byte_count=upload_size,
+        location=location.id,
+    )
+    size = get_size_during_upload(repo1.id)
+    assert size == upload_size


### PR DESCRIPTION
During quota verification, Quay fetches the size of the image currently being uploaded. That method incorrectly added the repository size to the size of the image being uploaded. That total returned was then added to the namespace size resulting in the following check: `repo_size + namespace_size + uploaded blob > quota_size_limit`. This causes the repo_size to be counted twice and images to be blocked early.