### PR TITLE
ui: fix bug in usage logs description (PROJQUAY-6755)

### DIFF
--- a/web/src/hooks/UseLogDescriptions.tsx
+++ b/web/src/hooks/UseLogDescriptions.tsx
@@ -195,7 +195,11 @@ export function useLogDescriptions() {
           return `Mirror ${metadata.changed} changed to ${metadata.to}`;
       }
     },
-    change_repo_state: 'Repository state changed to {state_changed}',
+    change_repo_state: function (metadata: Metadata) {
+      return `Repository state changed to ${metadata.state_changed
+        .toLowerCase()
+        .replace('_', ' ')}`;
+    },
     push_repo: function (metadata: Metadata) {
       if (metadata.tag) {
         return `Push of ${metadata.tag} to repository ${metadata.namespace}/${metadata.repo}`;


### PR DESCRIPTION
In usage logs description one of the entries in the `useLogDescriptions` hook is as string when it should be a function. This causes an exception when trying to view logs that contain the event `change_repo_state`

Makes `change_repo_state` to be a function so this exception does not happen. 