### PR TITLE
oidc: display error msg when signing in via username password (PROJQUAY-6740)

### DIFF
--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -39,7 +39,7 @@ class OIDCUsers(FederatedUsers):
         """
         return (
             None,
-            f"Unsupport login option. Please sign in with the configured {self._federated_service} provider",
+            f"Unsupported login option. Please sign in with the configured {self._federated_service} provider",
         )
 
     def check_group_lookup_args(self, group_lookup_args, disable_pagination=False):

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -35,9 +35,12 @@ class OIDCUsers(FederatedUsers):
 
     def verify_credentials(self, username_or_email, password):
         """
-        Verify the credentials with OIDC: To Implement
+        Unsupported to login via username/email and password
         """
-        pass
+        return (
+            None,
+            f"Unsupport login option. Please sign in with the configured {self._federated_service} provider",
+        )
 
     def check_group_lookup_args(self, group_lookup_args, disable_pagination=False):
         """

--- a/test/test_external_oidc.py
+++ b/test/test_external_oidc.py
@@ -205,3 +205,11 @@ class OIDCAuthTests(unittest.TestCase):
         self.oidc_instance.sync_user_groups(user_groups, user_obj, self.oidc_login_service)
         user_teams_after_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
         assert user_teams_before_sync == user_teams_after_sync
+
+    def test_verify_credentials(self):
+        result, error_msg = self.oidc_instance.verify_credentials("username", "password")
+        assert result is None
+        assert (
+            error_msg
+            == "Unsupported login option. Please sign in with the configured oidc provider"
+        )


### PR DESCRIPTION
This PR should fix the 500 error when trying to login via username/password:
![Screenshot 2024-03-01 at 10 32 33 AM](https://github.com/quay/quay/assets/11522230/22823d61-0097-425a-a4e2-8bcfa73ccf0a)
