### PR TITLE
ui: show repository autoprune tab only for repo write permission (PROJQUAY-6780)

### DIFF
--- a/web/src/routes/RepositoryDetails/Settings/Settings.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/Settings.tsx
@@ -28,7 +28,7 @@ export default function Settings(props: SettingsProps) {
         />
       ),
     },
-    ...(config?.features?.AUTO_PRUNE
+    ...(config?.features?.AUTO_PRUNE && props.repoDetails?.can_write
       ? [
           {
             name: 'Repository Auto-Prune Policies',


### PR DESCRIPTION
Shows repository autoprune tab only when repository has write permissions