### PR TITLE
oidc: use federated login service to sync quay teams (PROJQUAY-6741)

### DIFF
--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -58,7 +58,7 @@ class OIDCUsers(FederatedUsers):
         """
         No way to query users so returning empty list
         """
-        return ([], self._federated_service, None)
+        return ([], self._federated_service, "Not supported")
 
     def sync_oidc_groups(self, user_groups, user_obj):
         """

--- a/test/test_external_oidc.py
+++ b/test/test_external_oidc.py
@@ -155,7 +155,12 @@ class OIDCAuthTests(unittest.TestCase):
         assert model.team.set_team_syncing(team_2, "oidc", {"group_name": "test_org_2_team_1"})
         assert model.team.add_user_to_team(user_obj, team_2)
 
-        user_groups = ["test_org_1_team_1", "another_group"]
+        # add user to another team that has team sync enabled with oidc login service
+        team_3 = model.team.create_team("team_2", test_org_2, "member")
+        assert model.team.set_team_syncing(team_3, "oidc", {"group_name": "test_org_2_team_2"})
+        assert model.team.add_user_to_team(user_obj, team_3)
+
+        user_groups = ["test_org_1_team_1", "another_group", "test_org_2_team_2"]
         # user should be removed from team_2
         self.oidc_instance.resync_quay_teams(user_groups, user_obj)
         assert (
@@ -163,6 +168,14 @@ class OIDCAuthTests(unittest.TestCase):
             .where(TeamMember.user == user_obj, TeamMember.team == team_2)
             .count()
             == 0
+        )
+
+        # user should part of team_1 and team_3
+        assert (
+            TeamMember.select()
+            .where(TeamMember.user == user_obj, TeamMember.team << [team_1, team_3])
+            .count()
+            == 2
         )
 
     def test_sync_user_groups_for_empty_user_obj(self):
@@ -213,3 +226,9 @@ class OIDCAuthTests(unittest.TestCase):
             error_msg
             == "Unsupported login option. Please sign in with the configured oidc provider"
         )
+
+    def test_query_users(self):
+        result, service, error_msg = self.oidc_instance.query_users("some_query_here", None)
+        assert len(result) == 0
+        assert service == "oidc"
+        assert error_msg == "Not supported"

--- a/test/test_external_oidc.py
+++ b/test/test_external_oidc.py
@@ -64,11 +64,11 @@ class OIDCAuthTests(unittest.TestCase):
         assert model.team.add_user_to_team(user_obj, team_2)
 
         user_teams_before_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
-        self.oidc_instance.sync_oidc_groups([], user_obj, "oidc")
+        self.oidc_instance.sync_oidc_groups([], user_obj)
         user_teams_after_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
         assert user_teams_before_sync == user_teams_after_sync
 
-        self.oidc_instance.sync_oidc_groups(None, user_obj, "oidc")
+        self.oidc_instance.sync_oidc_groups(None, user_obj)
         user_teams_after_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
         assert user_teams_before_sync == user_teams_after_sync
 
@@ -103,7 +103,7 @@ class OIDCAuthTests(unittest.TestCase):
             "wrong_group_name",
         ]
         user_teams_before_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
-        self.oidc_instance.sync_oidc_groups(user_groups, user_obj, "oidc")
+        self.oidc_instance.sync_oidc_groups(user_groups, user_obj)
 
         user_teams_after_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
 
@@ -113,7 +113,7 @@ class OIDCAuthTests(unittest.TestCase):
         user_obj = model.user.get_user("devtable")
 
         user_teams_before_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
-        self.oidc_instance.resync_quay_teams([], user_obj, "oidc")
+        self.oidc_instance.resync_quay_teams([], user_obj)
         user_teams_after_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
         assert user_teams_before_sync == user_teams_after_sync
 
@@ -130,7 +130,7 @@ class OIDCAuthTests(unittest.TestCase):
         assert model.team.add_user_to_team(user_obj, team_2)
 
         user_teams_before_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
-        self.oidc_instance.resync_quay_teams([], user_obj, "oidc")
+        self.oidc_instance.resync_quay_teams([], user_obj)
         user_teams_after_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
         assert user_teams_before_sync == user_teams_after_sync
 
@@ -157,7 +157,7 @@ class OIDCAuthTests(unittest.TestCase):
 
         user_groups = ["test_org_1_team_1", "another_group"]
         # user should be removed from team_2
-        self.oidc_instance.resync_quay_teams(user_groups, user_obj, "oidc")
+        self.oidc_instance.resync_quay_teams(user_groups, user_obj)
         assert (
             TeamMember.select()
             .where(TeamMember.user == user_obj, TeamMember.team == team_2)


### PR DESCRIPTION
When login_config has prefix "rhsso", it uses [RHSSOOAuthService](https://github.com/quay/quay/blob/master/oauth/loginmanager.py#L35) which is different from [UserAuthentication](https://github.com/quay/quay/blob/master/data/users/__init__.py#L142). Team syncing assumes UserAuthentication as login_service while OIDC team sync, uses login OAuthLoginManager.services when fetching teams (in this case RHSSOOAuthService).
The PR fixes login_service for OIDC team sync to read from UserAuthentication.