### PR TITLE
autoprune: add alembic script to remove unique constraint on index (PROJQUAY-6782)

### DIFF
--- a/data/migrations/versions/cead4183265c_recreate_index_for_repository_autoprune_.py
+++ b/data/migrations/versions/cead4183265c_recreate_index_for_repository_autoprune_.py
@@ -1,0 +1,61 @@
+"""recreate index for repository autoprune policy
+
+Revision ID: cead4183265c
+Revises: 135fd3e94615
+Create Date: 2024-03-05 23:45:05.154796
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "cead4183265c"
+down_revision = "135fd3e94615"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    # Note: In order to set unique=False, we cannot simply alter index. We need to drop the corresponding foreign key constraint first
+    # and then drop the index and recreate it.
+    op.drop_constraint(
+        op.f("fk_repositoryautoprunepolicy_namespace_id_user"),
+        "repositoryautoprunepolicy",
+        type_="foreignkey",
+    )
+    op.drop_index("repositoryautoprunepolicy_namespace_id", table_name="repositoryautoprunepolicy")
+
+    op.create_foreign_key(
+        op.f("fk_repositoryautoprunepolicy_namespace_id_user"),
+        "repositoryautoprunepolicy",
+        "user",
+        ["namespace_id"],
+        ["id"],
+    )
+    op.create_index(
+        "repositoryautoprunepolicy_namespace_id",
+        "repositoryautoprunepolicy",
+        ["namespace_id"],
+        unique=False,
+    )
+
+
+def downgrade(op, tables, tester):
+    op.drop_constraint(
+        op.f("fk_repositoryautoprunepolicy_namespace_id_user"),
+        "repositoryautoprunepolicy",
+        type_="foreignkey",
+    )
+    op.drop_index("repositoryautoprunepolicy_namespace_id", table_name="repositoryautoprunepolicy")
+
+    op.create_foreign_key(
+        op.f("fk_repositoryautoprunepolicy_namespace_id_user"),
+        "repositoryautoprunepolicy",
+        "user",
+        ["namespace_id"],
+        ["id"],
+    )
+    op.create_index(
+        "repositoryautoprunepolicy_namespace_id",
+        "repositoryautoprunepolicy",
+        ["namespace_id"],
+        unique=True,
+    )

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -11019,7 +11019,7 @@ CREATE INDEX repositoryauthorizedemail_repository_id ON public.repositoryauthori
 -- Name: repositoryautoprunepolicy_namespace_id; Type: INDEX; Schema: public; Owner: quay
 --
 
-CREATE UNIQUE INDEX repositoryautoprunepolicy_namespace_id ON public.repositoryautoprunepolicy USING btree (namespace_id);
+CREATE INDEX repositoryautoprunepolicy_namespace_id ON public.repositoryautoprunepolicy USING btree (namespace_id);
 
 
 --


### PR DESCRIPTION
Remove unique constraint on `repositoryautoprunepolicy_namespace_id` index to avoid duplicate key violation error