### PR TITLE
storage: Increase GCP timeout (PROJQUAY-6819)

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -11,8 +11,10 @@ from uuid import uuid4
 import boto3.session
 import botocore.config
 import botocore.exceptions
-from botocore.credentials import create_assume_role_refresher
-from botocore.credentials import DeferredRefreshableCredentials
+from botocore.credentials import (
+    DeferredRefreshableCredentials,
+    create_assume_role_refresher,
+)
 from botocore.client import Config
 from botocore.signers import CloudFrontSigner
 from cachetools.func import lru_cache

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -11,11 +11,11 @@ from uuid import uuid4
 import boto3.session
 import botocore.config
 import botocore.exceptions
+from botocore.client import Config
 from botocore.credentials import (
     DeferredRefreshableCredentials,
     create_assume_role_refresher,
 )
-from botocore.client import Config
 from botocore.signers import CloudFrontSigner
 from cachetools.func import lru_cache
 from cryptography.hazmat.backends import default_backend
@@ -885,7 +885,7 @@ class GoogleCloudStorage(_CloudStorage):
             access_key,
             secret_key,
         )
-        
+
         self.boto_timeout = boto_timeout
 
         # Workaround for setting GCS cors at runtime with boto

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -867,13 +867,13 @@ class IBMCloudStorage(_CloudStorage):
 class GoogleCloudStorage(_CloudStorage):
     ENDPOINT_URL = "https://storage.googleapis.com"
 
-    def __init__(self, context, storage_path, access_key, secret_key, bucket_name):
+    def __init__(self, context, storage_path, access_key, secret_key, bucket_name, boto_timeout=60):
         # GCS does not support ListObjectV2
         self._list_object_version = _LIST_OBJECT_VERSIONS["v1"]
         upload_params = {}
         connect_kwargs = {
             "endpoint_url": GoogleCloudStorage.ENDPOINT_URL,
-            "config": Config(connect_timeout=600, read_timeout=600),
+            "config": Config(connect_timeout=boto_timeout, read_timeout=boto_timeout),
         }
         super(GoogleCloudStorage, self).__init__(
             context,
@@ -885,6 +885,8 @@ class GoogleCloudStorage(_CloudStorage):
             access_key,
             secret_key,
         )
+        
+        self.boto_timeout = boto_timeout
 
         # Workaround for setting GCS cors at runtime with boto
         cors_xml = """<?xml version="1.0" encoding="UTF-8"?>

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -886,8 +886,6 @@ class GoogleCloudStorage(_CloudStorage):
             secret_key,
         )
 
-        self.boto_timeout = boto_timeout
-
         # Workaround for setting GCS cors at runtime with boto
         cors_xml = """<?xml version="1.0" encoding="UTF-8"?>
         <CorsConfig>

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -869,7 +869,10 @@ class GoogleCloudStorage(_CloudStorage):
         # GCS does not support ListObjectV2
         self._list_object_version = _LIST_OBJECT_VERSIONS["v1"]
         upload_params = {}
-        connect_kwargs = {"endpoint_url": GoogleCloudStorage.ENDPOINT_URL}
+        connect_kwargs = {
+            "endpoint_url": GoogleCloudStorage.ENDPOINT_URL,
+            "config": Config(connect_timeout=600, read_timeout=600),
+        }
         super(GoogleCloudStorage, self).__init__(
             context,
             boto3.session.Session,


### PR DESCRIPTION
Currently, Boto GCP timeout is set to 60 seconds which causes a problem in pushing big layers. This change will allow users to configure `boto_timeout` manually. The parameter itself is optional and if not defined will default to 60 seconds. Connection settings:

~~~
DISTRIBUTED_STORAGE_CONFIG:
    gcs:
        - GoogleCloudStorage
        - access_key: "access_key_here"
          bucket_name: bucket_here
          secret_key: "secret_key_here"
          storage_path: /datastorage/registry
          boto_timeout: 120           # new parameter added
~~~

Result with `boto_timeout: 600`:

~~~
root@cyberdyne:~# time { docker push quay.skynet/ibazulic/gcp-test; } Using default tag: latest
The push refers to repository [quay.skynet/ibazulic/gcp-test] 4335316598de: Pushed
d101c9453715: Pushed
latest: digest: sha256:c6ffbd16c2ef43496ff13c130e31be84ceccdb5408e4f0d3b0f06ae94d378ff9 size: 744

real	7m9.881s
user	0m0.204s
sys	0m0.077s
root@cyberdyne:~#
~~~

