### PR TITLE
ui: updating nginx routing rule for userfiles (PROJQUAY-6841)

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -53,7 +53,7 @@ location / {
 }
 
 # Capture traffic that needs to go to web_app, see /web.py
-location ~* ^(/config|/csrf_token|/oauth1|/oauth2|/webhooks|/keys|/.well-known|/customtrigger) {
+location ~* ^(/config|/csrf_token|/oauth1|/oauth2|/webhooks|/keys|/.well-known|/customtrigger|/userfiles/(.*)) {
     proxy_pass   http://web_app_server;
 }
 


### PR DESCRIPTION
Upload of dockerfile for dockerfile builds currently hits the `/userfiles/<id>` endpoint in certain scenarios. From the new UI this routes to the react index.html resulting in a 405 method not found. This change routes all paths matching `^/userfiles/(.*)` to the API.