### PR TITLE
api: Using upsert to fix dulicate manifest error (PROJQUAY-6843)

### DIFF
--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -482,7 +482,7 @@ class V4SecurityScanner(SecurityScannerInterface):
                 ManifestSecurityStatus.delete().where(
                     ManifestSecurityStatus.manifest == candidate
                 ).execute()
-                ManifestSecurityStatus.create(
+                ManifestSecurityStatus.insert(
                     manifest=candidate,
                     repository=candidate.repository,
                     error_json=report["err"],
@@ -490,7 +490,17 @@ class V4SecurityScanner(SecurityScannerInterface):
                     indexer_hash=state,
                     indexer_version=IndexerVersion.V4,
                     metadata_json={},
-                )
+                ).on_conflict(
+                    conflict_target=[ManifestSecurityStatus.manifest],
+                    preserve=[
+                        ManifestSecurityStatus.repository,
+                        ManifestSecurityStatus.error_json,
+                        ManifestSecurityStatus.index_status,
+                        ManifestSecurityStatus.indexer_hash,
+                        ManifestSecurityStatus.indexer_version,
+                        ManifestSecurityStatus.metadata_json,
+                    ],
+                ).execute()
 
     def lookup_notification_page(self, notification_id, page_index=None):
         try:

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -491,7 +491,6 @@ class V4SecurityScanner(SecurityScannerInterface):
                     indexer_version=IndexerVersion.V4,
                     metadata_json={},
                 ).on_conflict(
-                    conflict_target=[ManifestSecurityStatus.manifest],
                     preserve=[
                         ManifestSecurityStatus.repository,
                         ManifestSecurityStatus.error_json,


### PR DESCRIPTION
Resolution for [IntegrityError](https://coreos.sentry.io/issues/4626339290/?project=52148&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=2) by using [upsert](https://docs.peewee-orm.com/en/latest/peewee/querying.html#upsert) in peewee.
 