### PR TITLE
ui: show delete option for robot accounts when team is synced with external group (PROJQUAY-6828)

### DIFF
--- a/web/cypress/e2e/team-sync.cy.ts
+++ b/web/cypress/e2e/team-sync.cy.ts
@@ -198,4 +198,23 @@ describe('OIDC Team Sync', () => {
     cy.contains('button', 'Confirm').click();
     cy.contains('Successfully removed team synchronization');
   });
+
+  it('Verify delete option for users and robot accounts', () => {
+    cy.intercept(
+      'GET',
+      '/api/v1/organization/teamsyncorg/team/testteam/members?includePending=true',
+      {
+        fixture: 'teamsynced-members-superuser.json',
+      },
+    ).as('getSycedTeamMembers');
+    cy.visit('/organization/teamsyncorg/teams/testteam?tab=Teamsandmembership');
+    cy.wait('@getSycedTeamMembers');
+    cy.get('button[data-testid="teamsyncorg+robotacct-delete-icon"]').should(
+      'exist',
+    );
+    cy.get('button[data-testid="teamsyncorg+test_robot-delete-icon"]').should(
+      'exist',
+    );
+    cy.get('button[data-testid="admin-delete-icon"]').should('not.exist');
+  });
 });

--- a/web/cypress/fixtures/teamsynced-members-superuser.json
+++ b/web/cypress/fixtures/teamsynced-members-superuser.json
@@ -12,6 +12,30 @@
         "kind": "robot"
       },
       "invited": false
+    },
+    {
+      "name": "teamsyncorg+test_robot",
+      "kind": "user",
+      "is_robot": true,
+      "avatar": {
+        "name": "teamsyncorg+test_robot",
+        "hash": "6fa2235019080ab57555e22663913ce47da02ca8316eb0f42b85e0311d36f365",
+        "color": "#c7c7c7",
+        "kind": "robot"
+      },
+      "invited": false
+    },
+    {
+      "name": "admin",
+      "kind": "user",
+      "is_robot": false,
+      "avatar": {
+        "name": "admin",
+        "hash": "5a3393d91c84c8f057c08f3b494fe80d26a7df2257275fc9b0d136aaf12a8ba7",
+        "color": "#b5cf6b",
+        "kind": "user"
+      },
+      "invited": false
     }
   ],
   "can_edit": true,

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
@@ -344,6 +344,16 @@ export default function ManageMembersList(props: ManageMembersListProps) {
     }
   };
 
+  const displayDeleteIcon = (teamAccountType) => {
+    if (pageInReadOnlyMode) {
+      if (teamAccountType == 'Robot account') {
+        return true;
+      }
+      return false;
+    }
+    return true;
+  };
+
   const teamDescriptionComponent = (
     <ToolbarContent className="team-description-padding">
       <Flex>
@@ -633,7 +643,7 @@ export default function ManageMembersList(props: ManageMembersListProps) {
                     if={
                       config?.registry_state !== 'readonly' &&
                       organization.is_admin &&
-                      !pageInReadOnlyMode
+                      displayDeleteIcon(getAccountTypeForMember(teamMember))
                     }
                   >
                     <Td>


### PR DESCRIPTION
When Teamsync is enabled:
![Screenshot 2024-03-08 at 3 44 43 PM](https://github.com/quay/quay/assets/11522230/29e97b28-eb59-4707-a793-16fcd6c32bf5)

When Teamsync is disabled:
![Screenshot 2024-03-08 at 3 16 14 PM](https://github.com/quay/quay/assets/11522230/2e704dbb-01f8-413a-93b8-b22052909951)
