### PR TITLE
storage: Disable pushes on registry (PROJQUAY-6870)

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -53,7 +53,7 @@ location / {
 }
 
 # Capture traffic that needs to go to web_app, see /web.py
-location ~* ^(/config|/csrf_token|/oauth1|/oauth2|/webhooks|/keys|/.well-known|/customtrigger) {
+location ~* ^(/config|/csrf_token|/oauth1|/oauth2|/webhooks|/keys|/.well-known|/customtrigger|/userfiles/(.*)) {
     proxy_pass   http://web_app_server;
 }
 

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -24,6 +24,11 @@ location /signin {
     proxy_pass   http://web_app_server/;
 }
 
+# Temporarily force /updateuser for old and new UI to route to web app
+location /updateuser {
+    proxy_pass   http://web_app_server/;
+}
+
 location /angular {
     # Expire cookie and switch to old UI
     add_header Set-Cookie "patternfly=deleted; path=/; Expires=Thu, Jan 01 1970 00:00:00 UTC";

--- a/config.py
+++ b/config.py
@@ -878,4 +878,4 @@ class DefaultConfig(ImmutableConfig):
 
     # Disable pushes while allowing other registry operations.
     # Defaults to "false".
-    DISABLE_PUSHES: False
+    DISABLE_PUSHES = False

--- a/config.py
+++ b/config.py
@@ -875,3 +875,7 @@ class DefaultConfig(ImmutableConfig):
 
     # whitelist for ROBOTS_DISALLOW to grant access/usage for mirroring
     ROBOTS_WHITELIST: Optional[List[str]] = []
+
+    # Disable pushes while allowing other registry operations.
+    # Defaults to "false".
+    DISABLE_PUSHES: False

--- a/endpoints/decorators.py
+++ b/endpoints/decorators.py
@@ -185,13 +185,17 @@ def check_readonly(func):
             return func(*args, **kwargs)
 
         # Skip if not in read only mode.
-        if app.config.get("REGISTRY_STATE", "normal") != "readonly":
+        if (
+            app.config.get("REGISTRY_STATE", "normal") != "readonly"
+            or app.config.get("DISABLE_PUSHES", False) == False
+        ):
             return func(*args, **kwargs)
 
         # Skip if readonly access is allowed.
         if hasattr(func, "__readonly_call_allowed"):
             return func(*args, **kwargs)
 
+        # Raise if complete registry is in read-only mode
         raise ReadOnlyModeException()
 
     return wrapper

--- a/endpoints/v2/__init__.py
+++ b/endpoints/v2/__init__.py
@@ -28,6 +28,7 @@ from endpoints.v2.errors import (
     Unauthorized,
     Unsupported,
     V2RegistryException,
+    PushesDisabled,
 )
 from proxy import UpstreamRegistryError
 from util.http import abort
@@ -52,7 +53,10 @@ def handle_registry_v2_exception(error):
 
 @v2_bp.app_errorhandler(ReadOnlyModeException)
 def handle_readonly(ex):
-    return _format_error_response(ReadOnlyMode())
+    if app.config.get("REGISTRY_STATE") == "readonly":
+        return _format_error_response(ReadOnlyMode())
+    if app.config.get("PUSHES_DISABLED", False):
+        return _format_error_response(PushesDisabled())
 
 
 @v2_bp.app_errorhandler(UpstreamRegistryError)

--- a/endpoints/v2/blob.py
+++ b/endpoints/v2/blob.py
@@ -42,9 +42,9 @@ from endpoints.v2.errors import (
     InvalidRequest,
     LayerTooLarge,
     NameUnknown,
+    PushesDisabled,
     QuotaExceeded,
     Unsupported,
-    PushesDisabled,
 )
 from util.cache import cache_control
 from util.names import parse_namespace_repository

--- a/endpoints/v2/errors.py
+++ b/endpoints/v2/errors.py
@@ -208,3 +208,12 @@ class ReadOnlyMode(V2RegistryException):
             + "are currently suspended."
         )
         super(ReadOnlyMode, self).__init__("DENIED", message, detail, 405, is_read_only=True)
+
+
+class PushesDisabled(V2RegistryException):
+    def __init__(self, detail=None):
+        message = (
+            "Pushes to the registry are currently disabled. Please contact"
+            + " the administrator for more information."
+        )
+        super(PushesDisabled, self).__init__("METHOD NOT ALLOWED", message, {}, 405)

--- a/endpoints/v2/test/test_blob.py
+++ b/endpoints/v2/test/test_blob.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import unittest
-from test.fixtures import *
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,6 +22,7 @@ from endpoints.test.shared import conduct_call
 from image.docker.schema2 import DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE
 from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
 from proxy.fixtures import *  # noqa: F401, F403
+from test.fixtures import *
 from util.bytes import Bytes
 from util.security.registry_jwt import build_context_and_subject, generate_bearer_token
 

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1447,5 +1447,10 @@ CONFIG_SCHEMA = {
             "description": "Number of seconds to wait after a write operation in the UI",
             "x-example": 3,
         },
+        "DISABLE_PUSHES": {
+            "type": "boolean",
+            "description": "Only disables pushes of new content to the registry, while retaining all other functionality. Differs from read only mode because database is not set as read-only.",
+            "x-example": False,
+        },
     },
 }

--- a/web/cypress/e2e/team-sync.cy.ts
+++ b/web/cypress/e2e/team-sync.cy.ts
@@ -198,4 +198,23 @@ describe('OIDC Team Sync', () => {
     cy.contains('button', 'Confirm').click();
     cy.contains('Successfully removed team synchronization');
   });
+
+  it('Verify delete option for users and robot accounts', () => {
+    cy.intercept(
+      'GET',
+      '/api/v1/organization/teamsyncorg/team/testteam/members?includePending=true',
+      {
+        fixture: 'teamsynced-members-superuser.json',
+      },
+    ).as('getSycedTeamMembers');
+    cy.visit('/organization/teamsyncorg/teams/testteam?tab=Teamsandmembership');
+    cy.wait('@getSycedTeamMembers');
+    cy.get('button[data-testid="teamsyncorg+robotacct-delete-icon"]').should(
+      'exist',
+    );
+    cy.get('button[data-testid="teamsyncorg+test_robot-delete-icon"]').should(
+      'exist',
+    );
+    cy.get('button[data-testid="admin-delete-icon"]').should('not.exist');
+  });
 });

--- a/web/cypress/fixtures/teamsynced-members-superuser.json
+++ b/web/cypress/fixtures/teamsynced-members-superuser.json
@@ -12,6 +12,30 @@
         "kind": "robot"
       },
       "invited": false
+    },
+    {
+      "name": "teamsyncorg+test_robot",
+      "kind": "user",
+      "is_robot": true,
+      "avatar": {
+        "name": "teamsyncorg+test_robot",
+        "hash": "6fa2235019080ab57555e22663913ce47da02ca8316eb0f42b85e0311d36f365",
+        "color": "#c7c7c7",
+        "kind": "robot"
+      },
+      "invited": false
+    },
+    {
+      "name": "admin",
+      "kind": "user",
+      "is_robot": false,
+      "avatar": {
+        "name": "admin",
+        "hash": "5a3393d91c84c8f057c08f3b494fe80d26a7df2257275fc9b0d136aaf12a8ba7",
+        "color": "#b5cf6b",
+        "kind": "user"
+      },
+      "invited": false
     }
   ],
   "can_edit": true,

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
@@ -344,6 +344,16 @@ export default function ManageMembersList(props: ManageMembersListProps) {
     }
   };
 
+  const displayDeleteIcon = (teamAccountType) => {
+    if (pageInReadOnlyMode) {
+      if (teamAccountType == 'Robot account') {
+        return true;
+      }
+      return false;
+    }
+    return true;
+  };
+
   const teamDescriptionComponent = (
     <ToolbarContent className="team-description-padding">
       <Flex>
@@ -633,7 +643,7 @@ export default function ManageMembersList(props: ManageMembersListProps) {
                     if={
                       config?.registry_state !== 'readonly' &&
                       organization.is_admin &&
-                      !pageInReadOnlyMode
+                      displayDeleteIcon(getAccountTypeForMember(teamMember))
                     }
                   >
                     <Td>

--- a/workers/gc/gcworker.py
+++ b/workers/gc/gcworker.py
@@ -94,6 +94,11 @@ if __name__ == "__main__":
         while True:
             time.sleep(100000)
 
+    if app.config.get("DISABLE_PUSHES", False):
+        logger.debug("Pushes are disabled; skipping startup")
+        while True:
+            time.sleep(100000)
+
     GlobalLock.configure(app.config)
     worker = GarbageCollectionWorker()
     worker.start()

--- a/workers/namespacegcworker.py
+++ b/workers/namespacegcworker.py
@@ -73,6 +73,11 @@ if __name__ == "__main__":
         while True:
             time.sleep(100000)
 
+    if app.config.get("DISABLE_PUSHES", False):
+        logger.debug("Pushes are disabled; skipping startup")
+        while True:
+            time.sleep(100000)
+
     GlobalLock.configure(app.config)
     logger.debug("Starting namespace GC worker")
     worker = NamespaceGCWorker(

--- a/workers/repositorygcworker.py
+++ b/workers/repositorygcworker.py
@@ -79,6 +79,11 @@ if __name__ == "__main__":
         while True:
             time.sleep(100000)
 
+    if app.config.get("DISABLE_PUSHES", False):
+        logger.debug("Pushes are disabled; skipping startup")
+        while True:
+            time.sleep(100000)
+
     GlobalLock.configure(app.config)
     logger.debug("Starting repository GC worker")
     worker = RepositoryGCWorker(

--- a/workers/storagereplication.py
+++ b/workers/storagereplication.py
@@ -214,6 +214,11 @@ if __name__ == "__main__":
         while True:
             time.sleep(100000)
 
+    if app.config.get("DISABLE_PUSHES", False):
+        logger.debug("Pushes to the registry are disabled; skipping")
+        while True:
+            time.sleep(100000)
+
     if features.STORAGE_REPLICATION:
         for storage_type, _ in list(app.config.get("DISTRIBUTED_STORAGE_CONFIG", {}).values()):
             if storage_type == "LocalStorage":


### PR DESCRIPTION
The current read-only option for Quay is not sometimes feasible, since it requires an insert of the service key and other manual config changes. For instance, if you want to just recalculate quota on the registry, but would like to allow all registry operations (including UI) without the possibility of pushes until recalculation is done, setting the whole registry `read-only` cannot be done since it makes the database read only as well.

This PR introduces a new flag called `DISABLE_PUSHES` which allows all registry operations to continue (changing tags, repo editing, robot account creation/deletion, user creation etc.) but will disable pushes of new images to the registry (i.e. backend storage will not change). If a registry already contains the image and a new tag is simply being added, that operation should succeed.

The following message would appear in the logs:

~~~
gunicorn-registry stdout | 2024-03-11 14:41:58,363 [285] [DEBUG] [endpoints.v2.blob] Cannot push images, pushes disabled on registry.
gunicorn-registry stdout | 2024-03-11 14:41:58,363 [285] [DEBUG] [endpoints.v2] sending response: b'{"errors":[{"code":"METHOD NOT ALLOWED","detail":{},"message":"Pushes to the registry are currently disabled. Please contact the administrator for more information."}]}\n'
gunicorn-registry stdout | 2024-03-11 14:41:58,364 [285] [DEBUG] [app] Ending request: urn:request:86c4b59b-3ca2-4038-a7ef-fff18e1c30f2 (/v2/ibazulic/big-layer-test/blobs/uploads/) {'endpoint': 'v2.start_blob_upload', 'request_id': 'urn:request:86c4b59b-3ca2-4038-a7ef-fff18e1c30f2', 'remote_addr': '172.24.20.50', 'http_method': 'POST', 'original_url': 'https://ubuntu.skynet/v2/ibazulic/big-layer-test/blobs/uploads/', 'path': '/v2/ibazulic/big-layer-test/blobs/uploads/', 'parameters': {}, 'json_body': None, 'confsha': '5c365a98', 'user-agent': 'docker/25.0.4 go/go1.21.8 git-commit/061aa95 kernel/6.5.0-25-generic os/linux arch/amd64 UpstreamClient(Docker-Client/25.0.4 \\(linux\\))'}
gunicorn-registry stdout | 2024-03-11 14:41:58,364 [285] [INFO] [gunicorn.access] 172.24.20.50 - - [11/Mar/2024:14:41:58 +0000] "POST /v2/ibazulic/big-layer-test/blobs/uploads/ HTTP/1.1" 405 169 "-" "docker/25.0.4 go/go1.21.8 git-commit/061aa95 kernel/6.5.0-25-generic os/linux arch/amd64 UpstreamClient(Docker-Client/25.0.4 \(linux\))"
nginx stdout | 172.24.20.50 (-) - - [11/Mar/2024:14:41:58 +0000] "POST /v2/ibazulic/big-layer-test/blobs/uploads/ HTTP/1.1" 405 169 "-" "docker/25.0.4 go/go1.21.8 git-commit/061aa95 kernel/6.5.0-25-generic os/linux arch/amd64 UpstreamClient(Docker-Client/25.0.4 \x5C(linux\x5C))" (0.003 1333 0.003)
~~~

The flag defaults to `False` (pushes enabled), unless set otherwise.