### PR TITLE
logs: adjust graph padding dynamically (PROJQUAY-6857)

### DIFF
--- a/web/src/routes/UsageLogs/UsageLogsGraph.tsx
+++ b/web/src/routes/UsageLogs/UsageLogsGraph.tsx
@@ -102,9 +102,9 @@ export default function UsageLogsGraph(props: UsageLogsGraphProps) {
             right: 500, // Adjusted to accommodate legend
             top: 50,
           }}
+          domainPadding={{x: 5 * Object.keys(logData).length}}
           height={400}
           width={1250}
-          domainPadding={{x: 40}}
           scale={{x: 'time', y: 'linear'}}
         >
           <ChartAxis fixLabelOverlap />


### PR DESCRIPTION
Adjusts the padding of the usage log domain based on the length of log data available. 

Should prevent overlap between the chart bars and the legend.