### PR TITLE
api: reducing db calls in repo list endpoints with quota enabled (PROJQUAY-6895)

### DIFF
--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -715,7 +715,11 @@ def get_repository_sizes(repo_ids: list):
         )
 
     tuples = (
-        QuotaRepositorySize.select(QuotaRepositorySize.repository, QuotaRepositorySize.size_bytes)
+        QuotaRepositorySize.select(
+            QuotaRepositorySize.repository,
+            QuotaRepositorySize.size_bytes,
+            can_use_read_replica=True,
+        )
         .where(QuotaRepositorySize.repository << repo_ids)
         .tuples()
     )

--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -701,6 +701,37 @@ def get_repository_size(repo_id: int):
         return 0
 
 
+def get_repository_sizes(repo_ids: list):
+    """
+    Returns a map from repository ID to the size of the repository in bytes.
+    List of repo_ids should be kept below 1000 to avoid performance issues.
+    """
+    if not repo_ids:
+        return {}
+
+    if len(repo_ids) > 1000:
+        logger.warning(
+            "Fetching more than 1000 repository sizes at once, you may experience performance issues."
+        )
+
+    tuples = (
+        QuotaRepositorySize.select(QuotaRepositorySize.repository, QuotaRepositorySize.size_bytes)
+        .where(QuotaRepositorySize.repository << repo_ids)
+        .tuples()
+    )
+
+    size_map = {}
+    for record in tuples:
+        size_map[record[0]] = record[1] if record[1] is not None else 0
+
+    # Default to 0 for any repositories that don't have a size.
+    for repo_id in repo_ids:
+        if repo_id not in size_map:
+            size_map[repo_id] = 0
+
+    return size_map
+
+
 def get_size_during_upload(repo_id: int):
     query = (
         BlobUpload.select(fn.Sum(BlobUpload.byte_count).alias("size_bytes")).where(

--- a/endpoints/api/repository.py
+++ b/endpoints/api/repository.py
@@ -255,10 +255,10 @@ class RepositoryList(ApiResource):
             popularity,
         )
 
-        repositories_with_view = [repo.to_dict() for repo in repos]
-
         if features.QUOTA_MANAGEMENT and features.EDIT_QUOTA:
-            model.add_quota_view(repositories_with_view)
+            repositories_with_view = model.add_quota_view(repos)
+        else:
+            repositories_with_view = [repo.to_dict() for repo in repos]
 
         return {"repositories": repositories_with_view}, next_page_token
 

--- a/endpoints/api/repository_models_interface.py
+++ b/endpoints/api/repository_models_interface.py
@@ -14,6 +14,7 @@ class RepositoryBaseElement(
     namedtuple(
         "RepositoryBaseElement",
         [
+            "id",
             "namespace_name",
             "repository_name",
             "is_starred",
@@ -35,6 +36,7 @@ class RepositoryBaseElement(
     """
     Repository a single quay repository.
 
+    :type id: int
     :type namespace_name: string
     :type repository_name: string
     :type is_starred: boolean

--- a/endpoints/api/test/test_repository_models_pre_oci.py
+++ b/endpoints/api/test/test_repository_models_pre_oci.py
@@ -1,8 +1,10 @@
 import pytest
 from mock import ANY, MagicMock, patch
 
-from data import database, model
+from data.database import QuotaRepositorySize
+from data.model.repository import get_repository
 from endpoints.api.repository import Repository, RepositoryList, RepositoryTrust
+from endpoints.api.repository_models_interface import RepositoryBaseElement
 from endpoints.api.repository_models_pre_oci import pre_oci_model
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
@@ -11,33 +13,56 @@ from test.fixtures import *
 
 
 def test_add_quota_view(initialized_db):
+    repo_with_no_size_row = get_repo_base_element("randomuser", "randomrepo")
     repos = [
-        {
-            "namespace": "buynlarge",
-            "name": "orgrepo",
-        },
-        {
-            "namespace": "devtable",
-            "name": "simple",
-        },
-        {
-            "namespace": "devtable",
-            "name": None,
-        },
-        {
-            "namespace": "buynlarge",
-            "name": "doesnotexist",
-        },
+        get_repo_base_element("buynlarge", "orgrepo"),
+        get_repo_base_element("devtable", "simple"),
+        repo_with_no_size_row,
+        get_repo_base_element("devtable", "building"),
     ]
 
-    pre_oci_model.add_quota_view(repos)
+    QuotaRepositorySize.delete().where(
+        QuotaRepositorySize.repository == repo_with_no_size_row.id
+    ).execute()
+    assert (
+        QuotaRepositorySize.select()
+        .where(QuotaRepositorySize.repository == repo_with_no_size_row.id)
+        .count()
+        == 0
+    )
 
-    assert repos[0].get("quota_report").get("quota_bytes") == 92
-    assert repos[0].get("quota_report").get("configured_quota") == 3000
+    repos_with_view = pre_oci_model.add_quota_view(repos)
 
-    assert repos[1].get("quota_report").get("quota_bytes") == 92
-    assert repos[1].get("quota_report").get("configured_quota") is None
+    assert repos_with_view[0].get("quota_report").get("quota_bytes") == 92
+    assert repos_with_view[0].get("quota_report").get("configured_quota") == 3000
 
-    assert repos[2].get("quota_report") is None
+    assert repos_with_view[1].get("quota_report").get("quota_bytes") == 92
+    assert repos_with_view[1].get("quota_report").get("configured_quota") is None
 
-    assert repos[3].get("quota_report") is None
+    assert repos_with_view[2].get("quota_report").get("quota_bytes") == 0
+    assert repos_with_view[2].get("quota_report").get("configured_quota") == 6000
+
+    assert repos_with_view[3].get("quota_report").get("quota_bytes") == 0
+    assert repos_with_view[3].get("quota_report").get("configured_quota") is None
+
+
+def get_repo_base_element(namespace, repo):
+    repo = get_repository(namespace, repo)
+    return RepositoryBaseElement(
+        repo.id,
+        repo.namespace_user.username,
+        repo.name,
+        False,
+        False,
+        "",
+        repo.description,
+        repo.namespace_user.organization,
+        repo.namespace_user.removed_tag_expiration_s,
+        None,
+        None,
+        False,
+        False,
+        False,
+        repo.namespace_user.stripe_id is None,
+        repo.state,
+    )


### PR DESCRIPTION
Reducing the number of DB calls in the repo list endpoint with quota enabled by:
- Adding the id to `RepositoryBaseElement` when the repositories are initially fetched, removing the need to fetch the repository ID's again
- Fetching the repository sizes with a single DB call using the `IN` operator