### PR TITLE
Changed wording from 'Vulnerabilities' to 'Advisories' on Security tab

### DIFF
--- a/static/directives/manifest-vulnerability-view.html
+++ b/static/directives/manifest-vulnerability-view.html
@@ -87,7 +87,7 @@
         <label><input type="checkbox" ng-model="options.fixableVulns">Only show fixable</label>
       </div>
     </span>
-    <h3>Vulnerabilities</h3>
+    <h3>Advisories</h3>
 
     <!-- Table -->
     <div class="empty" ng-if="!vulnerabilitiesInfo.vulnerabilities.length"
@@ -100,7 +100,7 @@
      <thead>
       <td class="caret-col"></td>
       <td ng-class="TableService.tablePredicateClass('name', options.predicate, options.reverse)">
-        <a ng-click="TableService.orderBy('name', options)">CVE</a>
+        <a ng-click="TableService.orderBy('name', options)">Advisory</a>
       </td>
       <td ng-class="TableService.tablePredicateClass('score', options.predicate, options.reverse)">
         <a ng-click="TableService.orderBy('score', options)">Severity</a>

--- a/web/src/routes/TagDetails/SecurityReport/SecurityReportTable.tsx
+++ b/web/src/routes/TagDetails/SecurityReport/SecurityReportTable.tsx
@@ -59,7 +59,7 @@ function getVulnerabilityLink(vulnerability: VulnerabilityListItem) {
 }
 
 function TableTitle() {
-  return <Title headingLevel={'h1'}> Vulnerabilities </Title>;
+  return <Title headingLevel={'h1'}> Advisories </Title>;
 }
 
 export default function SecurityReportTable({features}: SecurityDetailsProps) {


### PR DESCRIPTION
This is needed to get the Clair Certification process moving with ProdSec