### PR TITLE
marketplace: add a check for masterEndSystemName when fetching subscriptions (PROJQUAY-6905)

### DIFF
--- a/data/billing.py
+++ b/data/billing.py
@@ -374,9 +374,7 @@ PLANS = [
     },
 ]
 
-RH_SKUS = [
-    plan["rh_sku"] for plan in PLANS if plan.get("rh_sku") is not None and plan.get("sku_billing")
-]
+RH_SKUS = [plan["rh_sku"] for plan in PLANS if plan.get("rh_sku") is not None]
 
 RECONCILER_SKUS = [
     plan["rh_sku"]

--- a/test/test_api_usage.py
+++ b/test/test_api_usage.py
@@ -5191,6 +5191,20 @@ class TestOrganizationRhSku(ApiTestCase):
         json = self.getJsonResponse(OrgPrivateRepositories, params=dict(orgname=SUBSCRIPTION_ORG))
         self.assertEqual(json["privateAllowed"], False)
 
+    def test_reconciled_attachment(self):
+        self.login(SUBSCRIPTION_USER)
+        self.postResponse(
+            resource_name=OrganizationRhSku,
+            params=dict(orgname=SUBSCRIPTION_ORG),
+            data={"subscriptions": [{"subscription_id": 87654321, "quantity": 1}]},
+            expected_code=401,
+        )
+        json = self.getJsonResponse(
+            resource_name=OrganizationRhSku,
+            params=dict(orgname=SUBSCRIPTION_ORG),
+        )
+        self.assertEqual(len(json), 0)
+
 
 class TestUserSku(ApiTestCase):
     def test_get_user_skus(self):

--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -232,6 +232,9 @@ class RedHatSubscriptionApi(object):
             if subscriptions:
                 for user_subscription in subscriptions:
                     if user_subscription is not None:
+                        if user_subscription["masterEndSystemName"] == "SUBSCRIPTION":
+                            continue
+
                         bound_to_org = organization_skus.subscription_bound_to_org(
                             user_subscription["id"]
                         )
@@ -248,6 +251,9 @@ class RedHatSubscriptionApi(object):
                             user_subscription["sku"] = sku
                             subscription_list.append(user_subscription)
         return subscription_list
+
+
+# Mocked classes for unit tests
 
 
 TEST_USER = {
@@ -286,6 +292,21 @@ TEST_USER = {
             "effectiveEndDate": 3813177600000,
         },
     ],
+    "reconciled_subscription": {
+        "id": 87654321,
+        "masterEndSystemName": "SUBSCRIPTION",
+        "createdEndSystemName": "SUBSCRIPTION",
+        "createdDate": 1675957362000,
+        "lastUpdateEndSystemName": "SUBSCRIPTION",
+        "lastUpdateDate": 1675957362000,
+        "installBaseStartDate": 1707368400000,
+        "installBaseEndDate": 1707368399000,
+        "webCustomerId": 123456,
+        "subscriptionNumber": "12399889",
+        "quantity": 1,
+        "effectiveStartDate": 1707368400000,
+        "effectiveEndDate": 3813177600000,
+    },
 }
 STRIPE_USER = {"account_number": 11111, "email": "stripe_user@test.com", "username": "stripe_user"}
 FREE_USER = {
@@ -322,6 +343,8 @@ class FakeSubscriptionApi(RedHatSubscriptionApi):
     def lookup_subscription(self, customer_id, sku_id):
         if customer_id == TEST_USER["account_number"] and sku_id == "MW02701":
             return TEST_USER["subscriptions"]
+        elif customer_id == TEST_USER["account_number"] and sku_id == "MW00584MO":
+            return [TEST_USER["reconciled_subscription"]]
         return None
 
     def create_entitlement(self, customer_id, sku_id):
@@ -336,6 +359,8 @@ class FakeSubscriptionApi(RedHatSubscriptionApi):
             return {"sku": "MW02701", "expiration_date": 3813177600000}
         elif subscription_id == 80808080:
             return {"sku": "MW02701", "expiration_date": 1645544830000}
+        elif subscription_id == 87654321:
+            return {"sku": "MW00584MO", "expiration_date": 3813177600000}
         else:
             return None
 


### PR DESCRIPTION
Adds the reconciler SKUs to list of RH SKUs used for org attachment, and validates the reconciler SKUs based on if they're created by the reconciler or purchased from the AWS marketplace.

Old marketplace SKUs will be added to AWS listing. However, these SKUs are also used by the reconciler to create entitlements for paying stripe customers. In order to allow these SKUs to also be used in the marketplace, use `masterEndSystemName` property in the subscription API response. This will let us know whether the SKU can be assigned to an org or if it was created by the reconciler (`masterEndSystemName == SUBSCRIPTION`) and we should ignore it.