### PR TITLE
db: add config variable for DB pooling (PROJQUAY-6397)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -492,7 +492,8 @@ def configure(config_object, testing=False):
     logger.debug("Configuring database")
     db_kwargs = dict(config_object["DB_CONNECTION_ARGS"])
     write_db_uri = config_object["DB_URI"]
-    db.initialize(_db_from_url(write_db_uri, db_kwargs))
+    allow_pooling = config_object.get('DB_CONNECTION_POOLING', True)
+    db.initialize(_db_from_url(write_db_uri, db_kwargs, allow_pooling=allow_pooling))
 
     parsed_write_uri = make_url(write_db_uri)
     db_random_func.initialize(SCHEME_RANDOM_FUNCTION[parsed_write_uri.drivername])
@@ -516,6 +517,7 @@ def configure(config_object, testing=False):
                 ro_config["DB_URI"],
                 ro_config.get("DB_CONNECTION_ARGS", db_kwargs),
                 is_read_replica=True,
+                allow_pooling=ro_config.get("DB_CONNECTION_POOLING", True),
             )
             for ro_config in read_replicas
         ]

--- a/data/database.py
+++ b/data/database.py
@@ -492,7 +492,7 @@ def configure(config_object, testing=False):
     logger.debug("Configuring database")
     db_kwargs = dict(config_object["DB_CONNECTION_ARGS"])
     write_db_uri = config_object["DB_URI"]
-    allow_pooling = config_object.get('DB_CONNECTION_POOLING', True)
+    allow_pooling = config_object.get("DB_CONNECTION_POOLING", True)
     db.initialize(_db_from_url(write_db_uri, db_kwargs, allow_pooling=allow_pooling))
 
     parsed_write_uri = make_url(write_db_uri)

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -270,10 +270,7 @@ CONFIG_SCHEMA = {
             },
             "required": ["threadlocals", "autorollback"],
         },
-        "DB_ALLOW_POOLING": {
-            "type": "boolean",
-            "description": "Allow pooling for DB"
-        },
+        "DB_ALLOW_POOLING": {"type": "boolean", "description": "Allow pooling for DB"},
         "ALLOW_PULLS_WITHOUT_STRICT_LOGGING": {
             "type": "boolean",
             "description": "If true, pulls in which the pull audit log entry cannot be written will "

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -270,6 +270,10 @@ CONFIG_SCHEMA = {
             },
             "required": ["threadlocals", "autorollback"],
         },
+        "DB_ALLOW_POOLING": {
+            "type": "boolean",
+            "description": "Allow pooling for DB"
+        },
         "ALLOW_PULLS_WITHOUT_STRICT_LOGGING": {
             "type": "boolean",
             "description": "If true, pulls in which the pull audit log entry cannot be written will "


### PR DESCRIPTION
adding `DB_CONNECTION_POOLING` param to enable/disable connection pooling for primary and replica DBs