### PR TITLE
ui: Allow to configure the Kubernetes pull secret scope for Robot Tokens (PROJQUAY-7012)

### DIFF
--- a/web/src/components/modals/RobotTokensModal.tsx
+++ b/web/src/components/modals/RobotTokensModal.tsx
@@ -1,29 +1,30 @@
-import {useState} from 'react';
 import {
-  Tabs,
-  Tab,
-  TextContent,
-  Text,
-  TextVariants,
-  ClipboardCopy,
-  ClipboardCopyVariant,
-  ExpandableSection,
-  ExpandableSectionToggle,
-  TextArea,
-  Grid,
-  GridItem,
-  TabTitleIcon,
-  TabTitleText,
   Alert,
   Button,
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  Flex,
+  FlexItem,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectOption,
+  Tab,
+  TabTitleIcon,
+  TabTitleText,
+  Tabs,
+  Text,
+  TextContent,
+  TextVariants,
 } from '@patternfly/react-core';
+import {AngleRightIcon, DockerIcon, KeyIcon} from '@patternfly/react-icons';
+import {Buffer} from 'buffer';
+import {useState} from 'react';
+import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {useRobotToken} from 'src/hooks/useRobotAccounts';
 import {addDisplayError} from 'src/resources/ErrorHandling';
-import {IRobot, IRobotToken} from 'src/resources/RobotsResource';
-import {useQuayConfig} from 'src/hooks/UseQuayConfig';
-import {DockerIcon, KeyIcon} from '@patternfly/react-icons';
+import {IRobotToken} from 'src/resources/RobotsResource';
 import 'src/routes/RepositoriesList/css/RobotAccount.css';
-import {Buffer} from 'buffer';
 
 const EmptyRobotToken = {
   name: '',
@@ -36,12 +37,26 @@ const EmptyRobotToken = {
 
 export default function RobotTokensModal(props: RobotTokensModalProps) {
   const [activeTabKey, setActiveTabKey] = useState<string | number>(0);
-  const [isSecretExpanded, setSecretExpanded] = useState(false);
   const [, setLoading] = useState<boolean>(true);
   const [tokenData, setTokenData] = useState<IRobotToken>(EmptyRobotToken);
   const [, setErr] = useState<string[]>();
   const config = useQuayConfig();
   const domain = config?.config.SERVER_HOSTNAME;
+  const [secretScopeSelected, setSecretScopeSelected] = useState<string>(
+    domain + '/' + props.namespace,
+  );
+  const [isSecretScopeSelectOpen, setIsSecretScopeSelectOpen] =
+    useState<boolean>(false);
+  const onToggleClick = () => {
+    setIsSecretScopeSelectOpen(!isSecretScopeSelectOpen);
+  };
+  const onSecretScopeSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined,
+  ) => {
+    setSecretScopeSelected(value as string);
+    setIsSecretScopeSelectOpen(false);
+  };
 
   const {regenerateRobotToken} = useRobotToken({
     orgName: props.namespace,
@@ -58,7 +73,8 @@ export default function RobotTokensModal(props: RobotTokensModalProps) {
 
   const getDockerConfig = () => {
     const auths = {};
-    auths[domain] = {
+    const scope = secretScopeSelected;
+    auths[scope] = {
       auth: Buffer.from(tokenData.name + ':' + tokenData.token).toString(
         'base64',
       ),
@@ -153,14 +169,35 @@ export default function RobotTokensModal(props: RobotTokensModalProps) {
     downloadFile(fileContent, filename);
   };
 
-  const onViewToggle = (isSecretExpanded: boolean) => {
-    setSecretExpanded(isSecretExpanded);
-  };
-
   const kubesClusterCmd = `kubectl create -f ${props.name.replace(
     '+',
     '-',
   )}-secret.yml --namespace=NAMESPACEHERE`;
+
+  const secretScopeOptions = [
+    {value: domain + '/' + props.namespace, label: 'Organization'},
+    {value: domain, label: 'Registry'},
+  ];
+
+  const secretScopeToggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      id="secret-scope-toggle"
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isSecretScopeSelectOpen}
+      style={
+        {
+          width: '200px',
+        } as React.CSSProperties
+      }
+    >
+      {
+        secretScopeOptions.find(
+          (option) => option.value === secretScopeSelected,
+        )?.label
+      }
+    </MenuToggle>
+  );
 
   return (
     <>
@@ -204,6 +241,7 @@ export default function RobotTokensModal(props: RobotTokensModalProps) {
           </>
         </Tab>
         <Tab
+          id="kubernetes-tab"
           eventKey={1}
           title={
             <>
@@ -222,60 +260,78 @@ export default function RobotTokensModal(props: RobotTokensModalProps) {
         >
           <br />
           <TextContent>
-            <Text component={TextVariants.h6}>Step 1: Download secret</Text>
-            <Text component={TextVariants.p}>
-              First, download the Kubernetes pull secret for the robot account:
+            <Text component={TextVariants.h6}>
+              Step 1: Select the scope of the secret
             </Text>
-            <Grid>
-              <GridItem span={6} rowSpan={1}>
-                <a
-                  onClick={() =>
-                    downloadKubernetesFile(getSuffixedFilename('secret.yml'))
-                  }
-                >
-                  {'Download ' + getSuffixedFilename('secret.yml')}
-                </a>
-              </GridItem>
-              <GridItem rowSpan={1} span={6}>
-                <ExpandableSectionToggle
-                  onToggle={onViewToggle}
-                  isExpanded={isSecretExpanded}
-                  contentId="view-kube-file"
-                >
-                  {isSecretExpanded
-                    ? 'Show less'
-                    : 'View ' + getSuffixedFilename('secret.yml')}
-                </ExpandableSectionToggle>
-              </GridItem>
-            </Grid>
-            <ExpandableSection
-              isDetached
-              isExpanded={isSecretExpanded}
-              contentId="view-kube-file"
-            >
-              <TextArea
-                value={getKubernetesContent().join('')}
-                readOnly
-                readOnlyVariant="default"
-                autoResize={true}
-                className="text-area-height"
-                id="expandable-kube-content"
-              />
-            </ExpandableSection>
-            <Text component={TextVariants.h6}>Step 2: Submit</Text>
             <Text component={TextVariants.p}>
-              Second, submit the secret to the cluster using this command:
+              The Kubernetes runtime can be instructed to use this secret only
+              for a specific Quay organization or registry-wide.
+            </Text>
+            <Flex columnGap={{default: 'columnGapMd'}}>
+              <FlexItem>
+                <Select
+                  id="secret-scope-selector"
+                  isOpen={isSecretScopeSelectOpen}
+                  selected={secretScopeSelected}
+                  onSelect={onSecretScopeSelect}
+                  onOpenChange={(isOpen) => setIsSecretScopeSelectOpen(isOpen)}
+                  toggle={secretScopeToggle}
+                  shouldFocusToggleOnSelect
+                >
+                  {secretScopeOptions.map((option, index) => (
+                    <SelectOption key={index} value={option.value}>
+                      {option.label}
+                    </SelectOption>
+                  ))}
+                </Select>
+              </FlexItem>
+              <FlexItem>
+                <AngleRightIcon />
+              </FlexItem>
+              <FlexItem>
+                <Text id="secret-scope" component={TextVariants.p}>
+                  {secretScopeSelected}
+                </Text>
+              </FlexItem>
+            </Flex>
+            <Text component={TextVariants.h6}>Step 2: Download secret</Text>
+            <Text component={TextVariants.p}>
+              Next, download the Kubernetes pull secret for the robot account:
+            </Text>
+            <ClipboardCopy
+              isReadOnly
+              isCode
+              hoverTip="Copy"
+              clickTip="Copied"
+              variant={ClipboardCopyVariant.expansion}
+              id="step-2"
+              className="pf-v5-u-mb-sm"
+            >
+              {getKubernetesContent().join('')}
+            </ClipboardCopy>
+            <Text component={TextVariants.p}>
+              <a
+                onClick={() =>
+                  downloadKubernetesFile(getSuffixedFilename('secret.yml'))
+                }
+              >
+                {'Download ' + getSuffixedFilename('secret.yml')}
+              </a>
+            </Text>
+            <Text component={TextVariants.h6}>Step 3: Submit</Text>
+            <Text component={TextVariants.p}>
+              Then, submit the secret to the cluster using this command:
             </Text>
             <ClipboardCopy
               hoverTip="Copy"
               clickTip="Copied"
               variant="inline-compact"
-              id="step-2"
+              id="step-3"
             >
               {kubesClusterCmd}
             </ClipboardCopy>
             <Text component={TextVariants.h6}>
-              Step 3: Update Kubernetes Configuration
+              Step 4: Update Kubernetes Configuration
             </Text>
             <Text component={TextVariants.p}>
               Finally, add a reference to the secret to your Kuberenetes pod
@@ -338,7 +394,7 @@ export default function RobotTokensModal(props: RobotTokensModalProps) {
               <TabTitleIcon>
                 <DockerIcon />
               </TabTitleIcon>
-              <TabTitleText>Docker configuration</TabTitleText>
+              <TabTitleText>Docker</TabTitleText>
             </>
           }
         >


### PR DESCRIPTION
This changes the UI screen for the Kubernetes pull secret creation to allow the scope of the pull secret to be set. What is normally 

```
.dockerconfigjson:
{
  "auths": {
    "<quay-server-hostname>": { "auth": "TOKEN",  "email": ""}
  }
} 
```

now becomes

```
.dockerconfigjson:
{
  "auths": {
    "<quay-server-hostname>/<organization>": { "auth": "TOKEN",  "email": ""}
  }
} 
```

This makes using this pull secret in an OpenShift project easier when a cluster-wide global pull secret scoped to the same registry is already available. This requires support from the container runtime to scope the pull secret to a certain namespace only, e.g. CRI-O via c/image: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md - other runtimes may ignore this scope.

The PR also aligns the visualization of the YAML manifest for both the `Secret` and the `Pod` as a clipboard-copy-ready code box.

<img width="1116" alt="Screenshot 2024-04-16 at 09 13 45" src="https://github.com/quay/quay/assets/12664117/cf0df3b5-5eab-4b08-b380-3a6aa92e21af">
<img width="1116" alt="Screenshot 2024-04-16 at 09 13 36" src="https://github.com/quay/quay/assets/12664117/e917c3e9-82b6-455e-81ad-853bdd47b16a">
<img width="1118" alt="Screenshot 2024-04-16 at 09 13 26" src="https://github.com/quay/quay/assets/12664117/d18efc2a-9844-4715-8bcd-6291c743efd8">
<img width="1119" alt="Screenshot 2024-04-16 at 09 13 07" src="https://github.com/quay/quay/assets/12664117/b88243df-1fcc-44f2-9d6f-736af409f3d1">
