### PR TITLE
ui: show 'unlimited' if private repo count is over max number (PROJQUAY-7016)

### DIFF
--- a/static/directives/billing-management-panel.html
+++ b/static/directives/billing-management-panel.html
@@ -14,7 +14,10 @@
           </div>
 
           <a class="co-modify-link" ng-href="{{ getEntityPrefix() }}/billing">{{ currentPlan.privateRepos }} private repositories</a>
-          <div class="help-text">Up to {{ currentPlan.privateRepos + currentMarketplace}} private repositories, unlimited public repositories</div>
+          <div class="help-text">
+            {{ (currentPlan.privateRepos + currentMarketplace) >= 9223372036854776000 ? 'unlimited' : 'Up to ' + (currentPlan.privateRepos + currentMarketplace) }}
+            private repositories, unlimited public repositories
+          </div>
         </td>
       </tr>
       <tr ng-show="currentCard">


### PR DESCRIPTION
Since the unlimited sku returns a private repo count equal to a max integer, the ui should show 'unlimited' instead of the actual number.
![unlimited-repos](https://github.com/quay/quay/assets/47163063/2a76d3c7-b852-4aec-b0e7-306249b56e73)
