### PR TITLE
storage: add repo_name to direct download url parameter (PROJQUAY-7020)

### DIFF
--- a/endpoints/v2/blob.py
+++ b/endpoints/v2/blob.py
@@ -120,7 +120,12 @@ def download_blob(namespace_name, repo_name, digest, registry_model):
     user = get_authenticated_user()
     username = user.username if user else None
     direct_download_url = storage.get_direct_download_url(
-        blob.placements, path, get_request_ip(), username=username, namespace=namespace_name
+        blob.placements,
+        path,
+        get_request_ip(),
+        username=username,
+        namespace=namespace_name,
+        repo_name=repo_name,
     )
     if direct_download_url:
         logger.debug("Returning direct download URL")

--- a/storage/cloudflarestorage.py
+++ b/storage/cloudflarestorage.py
@@ -88,6 +88,8 @@ class CloudFlareS3Storage(S3Storage):
             params["namespace"] = kwargs.get("namespace")
         if kwargs.get("username"):
             params["username"] = kwargs.get("username")
+        if kwargs.get("repo_name"):
+            params["repo_name"] = kwargs.get("repo_name")
 
         url_dict.update(params)
         url_new_query = urllib.parse.urlencode(url_dict)


### PR DESCRIPTION
Adds repo_name parameter to requests to Cloudflare and Cloudfront to associate repositories with egress traffic.