### PR TITLE
ui: batching requests in repository list page (PROJQUAY-6972)

### DIFF
--- a/web/cypress/e2e/repositories-list.cy.ts
+++ b/web/cypress/e2e/repositories-list.cy.ts
@@ -278,4 +278,39 @@ describe('Repositories List Page', () => {
     cy.contains('1 - 20 of 50').should('exist');
     cy.get('td[data-label="Name"]').should('have.length', 20);
   });
+
+  it('renders many repositories', () => {
+    const repos: IRepository[] = [];
+    for (let i = 0; i < 1000; i++) {
+      const repo = {
+        namespace: 'manyrepositories',
+        name: '',
+        description: 'description',
+        is_public: false,
+        kind: 'image',
+        state: 'NORMAL',
+        quota_report: {
+          quota_bytes: 132459661,
+          configured_quota: 104857600,
+        },
+        last_modified: 1656432090,
+        popularity: 0.0,
+        is_starred: false,
+      };
+      repo.name = `repo${i}`;
+      repos.push(repo);
+    }
+    cy.intercept(
+      'GET',
+      '/api/v1/repository?last_modified=true&namespace=*&public=true',
+      {repositories: []},
+    ).as('getRepositories');
+    cy.intercept(
+      'GET',
+      '/api/v1/repository?last_modified=true&namespace=user1&public=true',
+      {repositories: repos},
+    ).as('getRepositories');
+    cy.visit('/repository');
+    cy.contains('1 - 20 of 1000').should('exist');
+  });
 });


### PR DESCRIPTION
This change batches requests when trying to fetch all repositories the current user has access too. Otherwise the UI will make simultaneous requests equal to the number of organizations, where if the number is great enough it will exhaust the browser resources and cause the page to crash. 