### PR TITLE
marketplace: check for terminated subscriptions when fetching details (PROJQUAY-7035)

### DIFF
--- a/endpoints/api/billing.py
+++ b/endpoints/api/billing.py
@@ -61,8 +61,9 @@ def check_internal_api_for_subscription(namespace_user):
             )
             sku = subscription_details["sku"]
             expiration = subscription_details["expiration_date"]
+            terminated = subscription_details["terminated_date"]
             now_ms = time.time() * 1000
-            if expiration < now_ms:
+            if expiration < now_ms or (terminated is not None and terminated < now_ms):
                 organization_skus.remove_subscription_from_org(namespace_user.id, subscription_id)
                 continue
             for x in range(quantity):
@@ -972,7 +973,11 @@ class OrganizationRhSku(ApiResource):
                         subscription["subscription_id"]
                     )
                     now_ms = time.time() * 1000
-                    if subscription_details["expiration_date"] < now_ms:
+                    expired_at = subscription_details["expiration_date"]
+                    terminated_at = subscription_details["terminated_date"]
+                    if expired_at < now_ms or (
+                        terminated_at is not None and terminated_at < now_ms
+                    ):
                         model.organization_skus.remove_subscription_from_org(
                             organization.id, subscription["subscription_id"]
                         )

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -384,7 +384,11 @@ class OrgPrivateRepositories(ApiResource):
                     subscription_details = marketplace_subscriptions.get_subscription_details(
                         subscription["subscription_id"]
                     )
-                    if subscription_details["expiration_date"] < now_ms:
+                    expired_at = subscription_details["expiration_date"]
+                    terminated_at = subscription_details["terminated_date"]
+                    if expired_at < now_ms or (
+                        terminated_at is not None and terminated_at < now_ms
+                    ):
                         organization_skus.remove_subscription_from_org(
                             organization.id, subscription["subscription_id"]
                         )

--- a/test/test_api_usage.py
+++ b/test/test_api_usage.py
@@ -5205,6 +5205,14 @@ class TestOrganizationRhSku(ApiTestCase):
         )
         self.assertEqual(len(json), 0)
 
+    def test_terminated_attachment(self):
+        self.login(SUBSCRIPTION_USER)
+        user = model.user.get_user(SUBSCRIPTION_USER)
+        org = model.organization.get_organization(SUBSCRIPTION_ORG)
+        model.organization_skus.bind_subscription_to_org(22222222, org.id, user.id, 1)
+        json = self.getJsonResponse(OrgPrivateRepositories, params=dict(orgname=SUBSCRIPTION_ORG))
+        self.assertEqual(json["privateAllowed"], False)
+
 
 class TestUserSku(ApiTestCase):
     def test_get_user_skus(self):

--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -214,7 +214,12 @@ class RedHatSubscriptionApi(object):
 
             subscription_sku = info[0]["sku"]
             expiration_date = info[1]["activeEndDate"]
-            return {"sku": subscription_sku, "expiration_date": expiration_date}
+            terminated_date = info[0]["terminatedDate"]
+            return {
+                "sku": subscription_sku,
+                "expiration_date": expiration_date,
+                "terminated_date": terminated_date,
+            }
         except requests.exceptions.SSLError:
             raise requests.exceptions.SSLError
         except requests.exceptions.ReadTimeout:
@@ -312,6 +317,21 @@ TEST_USER = {
         "effectiveStartDate": 1707368400000,
         "effectiveEndDate": 3813177600000,
     },
+    "terminated_subscription": {
+        "id": 22222222,
+        "masterEndSystemName": "SUBSCRIPTION",
+        "createdEndSystemName": "SUBSCRIPTION",
+        "createdDate": 1675957362000,
+        "lastUpdateEndSystemName": "SUBSCRIPTION",
+        "lastUpdateDate": 1675957362000,
+        "installBaseStartDate": 1707368400000,
+        "installBaseEndDate": 1707368399000,
+        "webCustomerId": 123456,
+        "subscriptionNumber": "12399889",
+        "quantity": 1,
+        "effectiveStartDate": 1707368400000,
+        "effectiveEndDate": 3813177600000,
+    },
 }
 STRIPE_USER = {"account_number": 11111, "email": "stripe_user@test.com", "username": "stripe_user"}
 FREE_USER = {
@@ -361,11 +381,17 @@ class FakeSubscriptionApi(RedHatSubscriptionApi):
     def get_subscription_details(self, subscription_id):
         valid_ids = [subscription["id"] for subscription in TEST_USER["subscriptions"]]
         if subscription_id in valid_ids:
-            return {"sku": "MW02701", "expiration_date": 3813177600000}
+            return {"sku": "MW02701", "expiration_date": 3813177600000, "terminated_date": None}
         elif subscription_id == 80808080:
-            return {"sku": "MW02701", "expiration_date": 1645544830000}
+            return {"sku": "MW02701", "expiration_date": 1645544830000, "terminated_date": None}
         elif subscription_id == 87654321:
-            return {"sku": "MW00584MO", "expiration_date": 3813177600000}
+            return {"sku": "MW00584MO", "expiration_date": 3813177600000, "terminated_date": None}
+        elif subscription_id == 22222222:
+            return {
+                "sku": "MW00584MO",
+                "expiration_date": 3813177600000,
+                "terminated_date": 1645544830000,
+            }
         else:
             return None
 

--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -152,6 +152,60 @@ mocked_expired_sub = [
     },
 ]
 
+mocked_terminated_sub = [
+    {
+        "id": 41619474,
+        "masterEndSystemName": "SUBSCRIPTION",
+        "createdEndSystemName": "SUBSCRIPTION",
+        "createdByUserName": None,
+        "createdDate": 1708616554000,
+        "lastUpdateEndSystemName": "SUBSCRIPTION",
+        "lastUpdateUserName": None,
+        "lastUpdateDate": 1708616554000,
+        "externalCreatedDate": None,
+        "externalLastUpdateDate": None,
+        "activeStartDate": None,
+        "activeEndDate": None,
+        "inactiveDate": None,
+        "signedDate": None,
+        "terminatedDate": 1645544830000,
+        "renewedDate": None,
+        "parentSubscriptionProductId": None,
+        "externalOrderSystemName": "SUBSCRIPTION",
+        "externalOrderNumber": None,
+        "status": None,
+        "sku": "MW02701",
+        "childrenIds": [41619475],
+        "serviceable": False,
+    },
+    {
+        "id": 41619475,
+        "masterEndSystemName": "SUBSCRIPTION",
+        "createdEndSystemName": "SUBSCRIPTION",
+        "createdByUserName": None,
+        "createdDate": 1645544830000,
+        "lastUpdateEndSystemName": "SUBSCRIPTION",
+        "lastUpdateUserName": None,
+        "lastUpdateDate": 1645544830000,
+        "externalCreatedDate": None,
+        "externalLastUpdateDate": None,
+        "activeStartDate": 1645544830000,
+        "activeEndDate": 4869471324000,
+        "inactiveDate": None,
+        "signedDate": None,
+        "terminatedDate": None,
+        "renewedDate": None,
+        "parentSubscriptionProductId": 41619474,
+        "externalOrderSystemName": "SUBSCRIPTION",
+        "externalOrderNumber": None,
+        "status": "active",
+        "oracleInventoryOrgId": None,
+        "sku": "SVCMW02701",
+        "childrenIds": None,
+        "serviceable": True,
+    },
+]
+
 
 class TestMarketplace(unittest.TestCase):
     @patch("requests.request")
@@ -195,3 +249,10 @@ class TestMarketplace(unittest.TestCase):
         subscription_details = subscription_api.get_subscription_details(12345)
         assert subscription_details["sku"] == "MW02701"
         assert subscription_details["expiration_date"] == 1645544830000
+        assert subscription_details["terminated_date"] is None
+
+        requests_mock.return_value.content = json.dumps(mocked_terminated_sub)
+        subscription_details = subscription_api.get_subscription_details(12345)
+        assert subscription_details["sku"] == "MW02701"
+        assert subscription_details["expiration_date"] == 4869471324000
+        assert subscription_details["terminated_date"] == 1645544830000


### PR DESCRIPTION
If a subscription is deleted in the subscription watch API it will set the field `terminatedDate` for the subscription object. This should be taken into consideration when fetching a subscription's details and the subscription should be removed from an org if it is terminated like how we already do for expired subscriptions.