### PR TITLE
ui: fix locale and layout issues with the time picker in tag expiration modal (PROJQUAY-7069)

### DIFF
--- a/web/cypress/e2e/builds.cy.ts
+++ b/web/cypress/e2e/builds.cy.ts
@@ -1922,7 +1922,13 @@ describe('Repository Builds - View build logs', () => {
               );
             });
           });
-        });
+
+        cy.contains('Copy')
+          .click()
+          .then(() => {
+            expect(clipboardStub).to.be.called;
+          });
+      });
 
       // Download
       cy.contains('a', 'Download').should(

--- a/web/cypress/e2e/builds.cy.ts
+++ b/web/cypress/e2e/builds.cy.ts
@@ -1922,13 +1922,7 @@ describe('Repository Builds - View build logs', () => {
               );
             });
           });
-
-        cy.contains('Copy')
-          .click()
-          .then(() => {
-            expect(clipboardStub).to.be.called;
-          });
-      });
+        });
 
       // Download
       cy.contains('a', 'Download').should(

--- a/web/cypress/e2e/builds.cy.ts
+++ b/web/cypress/e2e/builds.cy.ts
@@ -1031,6 +1031,7 @@ describe('Repository Builds', () => {
 describe('Repository Builds - Create Custom Git Build Triggers', () => {
   beforeEach(() => {
     cy.exec('npm run quay:seed');
+    cy.intercept('GET', '/config', {fixture: 'config.json'}).as('getConfig');
     cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
       .then((response) => response.body.csrf_token)
       .then((token) => {

--- a/web/cypress/e2e/repository-details.cy.ts
+++ b/web/cypress/e2e/repository-details.cy.ts
@@ -549,7 +549,7 @@ describe('Repository Details Page', () => {
       });
   });
 
-  it.only('changes expiration through kebab', () => {
+  it('changes expiration through kebab', () => {
     const formattedDate = new Date();
     const currentDateGB = formattedDate.toLocaleDateString('en-GB', {
       year: 'numeric',

--- a/web/cypress/e2e/repository-details.cy.ts
+++ b/web/cypress/e2e/repository-details.cy.ts
@@ -549,7 +549,7 @@ describe('Repository Details Page', () => {
       });
   });
 
-  it('changes expiration through kebab', () => {
+  it.only('changes expiration through kebab', () => {
     cy.visit('/repository/user1/hello-world');
     const latestRow = cy.get('tbody:contains("latest")');
     latestRow.first().within(() => {
@@ -591,13 +591,13 @@ describe('Repository Details Page', () => {
 
     const nextMonth = new Date();
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-GB', {
+    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
 
-    cy.get(`[aria-label="${sameDateNextMonthUS}"]`).click();
+    cy.get(`[aria-label="${sameDateNextMonthGB}"]`).click();
 
     cy.get('#expiration-time-picker').click();
 
@@ -612,10 +612,12 @@ describe('Repository Details Page', () => {
 
     nextMonth.setHours(2);
     nextMonth.setMinutes(3);
-    const formattedTime2 = nextMonth.toLocaleTimeString(navigator.language, {
-      hour: 'numeric',
-      minute: '2-digit',
-    });
+    const formattedTime2 = nextMonth
+      .toLocaleTimeString(navigator.language, {
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+      .replace(/ AM| PM/, ''); // remove AM/PM suffixes because the TimePicker adds those automatically
     cy.get('#expiration-time-picker-input').type(formattedTime2);
     cy.contains('Change Expiration').click();
 

--- a/web/cypress/e2e/repository-details.cy.ts
+++ b/web/cypress/e2e/repository-details.cy.ts
@@ -562,30 +562,76 @@ describe('Repository Details Page', () => {
         cy.contains('latest').should('exist');
       });
 
+    const formattedDate = new Date();
+    const currentDate = formattedDate.toLocaleDateString(navigator.language, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    const currentDateLong = formattedDate.toLocaleDateString(
+      navigator.language,
+      {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      },
+    );
+
     // Ensure current date can be chosen
     cy.get('[aria-label="Toggle date picker"]').click();
-    cy.get(`[aria-label="${moment().format('D MMMM YYYY')}"]`).click();
+    cy.get(`[aria-label="${currentDate}"]`).click();
     cy.get('input[aria-label="Date picker"]').should(
       'have.value',
-      moment().format('dddd, MMMM D, YYYY'),
+      currentDateLong,
     );
 
     cy.get('[aria-label="Toggle date picker"]').click();
     cy.get('button[aria-label="Next month"]').click();
-    const oneMonth = moment().add(1, 'month').format('D MMMM YYYY');
-    cy.get(`[aria-label="${oneMonth}"]`).click();
+
+    const nextMonth = new Date();
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    const sameDateNextMonth = nextMonth.toLocaleDateString(navigator.language, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+
+    cy.get(`[aria-label="${sameDateNextMonth}"]`).click();
+
     cy.get('#expiration-time-picker').click();
-    cy.contains('1:00 AM').click();
+
+    nextMonth.setHours(1);
+    nextMonth.setMinutes(0);
+    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    cy.contains(formattedTime).scrollIntoView().click();
     cy.get('#expiration-time-picker-input').clear();
-    cy.get('#expiration-time-picker-input').type('2:03');
+
+    nextMonth.setHours(2);
+    nextMonth.setMinutes(3);
+    const formattedTime2 = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    cy.get('#expiration-time-picker-input').type(formattedTime2);
     cy.contains('Change Expiration').click();
+
     const latestRowUpdated = cy.get('tbody:contains("latest")');
     latestRowUpdated.first().within(() => {
       cy.get(`[data-label="Expires"]`).should('have.text', ' a month');
     });
-    const oneMonthFormat = moment().add(1, 'month').format('MMM D, YYYY');
+
+    const oneMonthFormatLong = nextMonth.toLocaleString(navigator.language, {
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timeStyle: 'short',
+      dateStyle: 'medium',
+    });
+
     cy.contains(
-      `Successfully set expiration for tag latest to ${oneMonthFormat}, 2:03 AM`,
+      `Successfully set expiration for tag latest to ${oneMonthFormatLong}`,
     ).should('exist');
 
     // Reset back to Never
@@ -618,18 +664,39 @@ describe('Repository Details Page', () => {
       });
     cy.get('[aria-label="Toggle date picker"]').click();
     cy.get('button[aria-label="Next month"]').click();
-    const oneMonth = moment().add(1, 'month').format('D MMMM YYYY');
-    cy.get(`[aria-label="${oneMonth}"]`).click();
+
+    const nextMonth = new Date();
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    const sameDateNextMonth = nextMonth.toLocaleDateString(navigator.language, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+
+    cy.get(`[aria-label="${sameDateNextMonth}"]`).click();
     cy.get('#expiration-time-picker').click();
-    cy.contains('1:00 AM').click();
+
+    nextMonth.setHours(1);
+    nextMonth.setMinutes(0);
+    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+
+    cy.contains(formattedTime).click();
     cy.contains('Change Expiration').click();
     const latestRowUpdated = cy.get('tbody:contains("latest")');
     latestRowUpdated.first().within(() => {
       cy.get(`[data-label="Expires"]`).should('have.text', ' a month');
     });
-    const oneMonthLongFormat = moment().add(1, 'month').format('MMM D, YYYY');
+
+    const oneMonthFormatLong = nextMonth.toLocaleString(navigator.language, {
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timeStyle: 'short',
+      dateStyle: 'medium',
+    });
     cy.contains(
-      `Successfully set expiration for tag latest to ${oneMonthLongFormat}, 1:00 AM`,
+      `Successfully set expiration for tag latest to ${oneMonthFormatLong}`,
     ).should('exist');
   });
 
@@ -647,18 +714,39 @@ describe('Repository Details Page', () => {
       });
     cy.get('[aria-label="Toggle date picker"]').click();
     cy.get('button[aria-label="Next month"]').click();
-    const oneMonth = moment().add(1, 'month').format('D MMMM YYYY');
-    cy.get(`[aria-label="${oneMonth}"]`).click();
+
+    const nextMonth = new Date();
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    const sameDateNextMonth = nextMonth.toLocaleDateString(navigator.language, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+
+    cy.get(`[aria-label="${sameDateNextMonth}"]`).click();
     cy.get('#expiration-time-picker').click();
-    cy.contains('1:00 AM').click();
+
+    nextMonth.setHours(1);
+    nextMonth.setMinutes(0);
+    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+
+    cy.contains(formattedTime).click();
     cy.contains('Change Expiration').click();
     const latestRowUpdated = cy.get('tbody:contains("latest")');
     latestRowUpdated.first().within(() => {
       cy.get(`[data-label="Expires"]`).should('have.text', ' a month');
     });
-    const tomorrowLongFormat = moment().add(1, 'month').format('MMM D, YYYY');
+
+    const oneMonthFormatLong = nextMonth.toLocaleString(navigator.language, {
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timeStyle: 'short',
+      dateStyle: 'medium',
+    });
     cy.contains(
-      `Successfully updated tag expirations to ${tomorrowLongFormat}, 1:00 AM`,
+      `Successfully updated tag expirations to ${oneMonthFormatLong}`,
     ).should('exist');
   });
 
@@ -673,16 +761,32 @@ describe('Repository Details Page', () => {
     });
     cy.get('[aria-label="Toggle date picker"]').click();
     cy.get('button[aria-label="Next month"]').click();
-    const oneMonth = moment().add(1, 'month').format('D MMMM YYYY');
-    cy.get(`[aria-label="${oneMonth}"]`).click();
+
+    const nextMonth = new Date();
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    const sameDateNextMonth = nextMonth.toLocaleDateString(navigator.language, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+
+    cy.get(`[aria-label="${sameDateNextMonth}"]`).click();
     cy.get('#expiration-time-picker').click();
-    cy.contains('1:00 AM').click();
+
+    nextMonth.setHours(1);
+    nextMonth.setMinutes(0);
+    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+
+    cy.contains(formattedTime).click();
     cy.contains('Change Expiration').click();
     const latestRowUpdated = cy.get('tbody:contains("latest")');
     latestRowUpdated.first().within(() => {
       cy.get(`[data-label="Expires"]`).should('have.text', 'Never');
     });
-    const oneMonthLongFormat = moment().add(1, 'month').format('MMM D, YYYY');
+
     cy.contains(`Could not set expiration for tag latest`).should('exist');
   });
 });

--- a/web/cypress/e2e/repository-details.cy.ts
+++ b/web/cypress/e2e/repository-details.cy.ts
@@ -550,6 +550,49 @@ describe('Repository Details Page', () => {
   });
 
   it.only('changes expiration through kebab', () => {
+    const formattedDate = new Date();
+    const currentDateGB = formattedDate.toLocaleDateString('en-GB', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    // for some reason the date picker is always using UK date formats for the aria labels
+    const currentDateLong = formattedDate.toLocaleDateString(
+      navigator.language,
+      {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      },
+    );
+    const nextMonth = new Date();
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    nextMonth.setHours(1);
+    nextMonth.setMinutes(0);
+    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+
+    nextMonth.setHours(2);
+    nextMonth.setMinutes(3);
+    const formattedTime2 = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    const oneMonthFormatLong = nextMonth.toLocaleString(navigator.language, {
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timeStyle: 'short',
+      dateStyle: 'medium',
+    });
+
+    // Start
     cy.visit('/repository/user1/hello-world');
     const latestRow = cy.get('tbody:contains("latest")');
     latestRow.first().within(() => {
@@ -562,22 +605,6 @@ describe('Repository Details Page', () => {
         cy.contains('latest').should('exist');
       });
 
-    const formattedDate = new Date();
-    const currentDateGB = formattedDate.toLocaleDateString('en-GB', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-    const currentDateLong = formattedDate.toLocaleDateString(
-      navigator.language,
-      {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      },
-    );
-
     // Ensure current date can be chosen
     cy.get('[aria-label="Toggle date picker"]').click();
     cy.get(`[aria-label="${currentDateGB}"]`).click();
@@ -588,48 +615,20 @@ describe('Repository Details Page', () => {
 
     cy.get('[aria-label="Toggle date picker"]').click();
     cy.get('button[aria-label="Next month"]').click();
-
-    const nextMonth = new Date();
-    nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-
     cy.get(`[aria-label="${sameDateNextMonthGB}"]`).click();
 
     cy.get('#expiration-time-picker').click();
-
-    nextMonth.setHours(1);
-    nextMonth.setMinutes(0);
-    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
-      hour: 'numeric',
-      minute: '2-digit',
-    });
     cy.contains(formattedTime).scrollIntoView().click();
     cy.get('#expiration-time-picker-input').clear();
+    cy.get('#expiration-time-picker-input').type(
+      formattedTime2.replace(/ AM| PM/, ''),
+    );
 
-    nextMonth.setHours(2);
-    nextMonth.setMinutes(3);
-    const formattedTime2 = nextMonth
-      .toLocaleTimeString(navigator.language, {
-        hour: 'numeric',
-        minute: '2-digit',
-      })
-      .replace(/ AM| PM/, ''); // remove AM/PM suffixes because the TimePicker adds those automatically
-    cy.get('#expiration-time-picker-input').type(formattedTime2);
+    // remove AM/PM suffixes because the TimePicker adds those automatically
     cy.contains('Change Expiration').click();
-
     const latestRowUpdated = cy.get('tbody:contains("latest")');
     latestRowUpdated.first().within(() => {
       cy.get(`[data-label="Expires"]`).should('have.text', ' a month');
-    });
-
-    const oneMonthFormatLong = nextMonth.toLocaleString(navigator.language, {
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      timeStyle: 'short',
-      dateStyle: 'medium',
     });
 
     cy.contains(
@@ -654,6 +653,26 @@ describe('Repository Details Page', () => {
   });
 
   it('changes expiration through tag row', () => {
+    const nextMonth = new Date();
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    nextMonth.setHours(1);
+    nextMonth.setMinutes(0);
+    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    const oneMonthFormatLong = nextMonth.toLocaleString(navigator.language, {
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timeStyle: 'short',
+      dateStyle: 'medium',
+    });
+
+    // Start
     cy.visit('/repository/user1/hello-world');
     const latestRow = cy.get('tbody:contains("latest")');
     latestRow.first().within(() => {
@@ -666,36 +685,13 @@ describe('Repository Details Page', () => {
       });
     cy.get('[aria-label="Toggle date picker"]').click();
     cy.get('button[aria-label="Next month"]').click();
-
-    const nextMonth = new Date();
-    nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-
     cy.get(`[aria-label="${sameDateNextMonthGB}"]`).click();
     cy.get('#expiration-time-picker').click();
-
-    nextMonth.setHours(1);
-    nextMonth.setMinutes(0);
-    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-
     cy.contains(formattedTime).click();
     cy.contains('Change Expiration').click();
     const latestRowUpdated = cy.get('tbody:contains("latest")');
     latestRowUpdated.first().within(() => {
       cy.get(`[data-label="Expires"]`).should('have.text', ' a month');
-    });
-
-    const oneMonthFormatLong = nextMonth.toLocaleString(navigator.language, {
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      timeStyle: 'short',
-      dateStyle: 'medium',
     });
     cy.contains(
       `Successfully set expiration for tag latest to ${oneMonthFormatLong}`,
@@ -703,6 +699,26 @@ describe('Repository Details Page', () => {
   });
 
   it('changes multiple tag expirations', () => {
+    const nextMonth = new Date();
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    nextMonth.setHours(1);
+    nextMonth.setMinutes(0);
+    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    const oneMonthFormatLong = nextMonth.toLocaleString(navigator.language, {
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timeStyle: 'short',
+      dateStyle: 'medium',
+    });
+
+    // Start
     cy.visit('/repository/user1/hello-world');
     cy.get('#toolbar-dropdown-checkbox').click();
     cy.get('button').contains('Select page (2)').click();
@@ -716,37 +732,13 @@ describe('Repository Details Page', () => {
       });
     cy.get('[aria-label="Toggle date picker"]').click();
     cy.get('button[aria-label="Next month"]').click();
-
-    const nextMonth = new Date();
-    nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
-      // for some reason the date picker is always using UK date formats for the aria labels
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-
     cy.get(`[aria-label="${sameDateNextMonthGB}"]`).click();
     cy.get('#expiration-time-picker').click();
-
-    nextMonth.setHours(1);
-    nextMonth.setMinutes(0);
-    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-
     cy.contains(formattedTime).click();
     cy.contains('Change Expiration').click();
     const latestRowUpdated = cy.get('tbody:contains("latest")');
     latestRowUpdated.first().within(() => {
       cy.get(`[data-label="Expires"]`).should('have.text', ' a month');
-    });
-
-    const oneMonthFormatLong = nextMonth.toLocaleString(navigator.language, {
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      timeStyle: 'short',
-      dateStyle: 'medium',
     });
     cy.contains(
       `Successfully updated tag expirations to ${oneMonthFormatLong}`,
@@ -754,6 +746,21 @@ describe('Repository Details Page', () => {
   });
 
   it('alerts on failure to change expiration', () => {
+    const nextMonth = new Date();
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    nextMonth.setHours(1);
+    nextMonth.setMinutes(0);
+    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+
+    // Start
     cy.intercept('PUT', '/api/v1/repository/user1/hello-world/tag/latest', {
       statusCode: 500,
     }).as('getServerFailure');
@@ -764,32 +771,14 @@ describe('Repository Details Page', () => {
     });
     cy.get('[aria-label="Toggle date picker"]').click();
     cy.get('button[aria-label="Next month"]').click();
-
-    const nextMonth = new Date();
-    nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-
     cy.get(`[aria-label="${sameDateNextMonthGB}"]`).click();
     cy.get('#expiration-time-picker').click();
-
-    nextMonth.setHours(1);
-    nextMonth.setMinutes(0);
-    const formattedTime = nextMonth.toLocaleTimeString(navigator.language, {
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-
     cy.contains(formattedTime).click();
     cy.contains('Change Expiration').click();
     const latestRowUpdated = cy.get('tbody:contains("latest")');
     latestRowUpdated.first().within(() => {
       cy.get(`[data-label="Expires"]`).should('have.text', 'Never');
     });
-
     cy.contains(`Could not set expiration for tag latest`).should('exist');
   });
 });

--- a/web/cypress/e2e/repository-details.cy.ts
+++ b/web/cypress/e2e/repository-details.cy.ts
@@ -563,7 +563,7 @@ describe('Repository Details Page', () => {
       });
 
     const formattedDate = new Date();
-    const currentDate = formattedDate.toLocaleDateString(navigator.language, {
+    const currentDateUS = formattedDate.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -580,7 +580,7 @@ describe('Repository Details Page', () => {
 
     // Ensure current date can be chosen
     cy.get('[aria-label="Toggle date picker"]').click();
-    cy.get(`[aria-label="${currentDate}"]`).click();
+    cy.get(`[aria-label="${currentDateUS}"]`).click();
     cy.get('input[aria-label="Date picker"]').should(
       'have.value',
       currentDateLong,
@@ -591,13 +591,13 @@ describe('Repository Details Page', () => {
 
     const nextMonth = new Date();
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonth = nextMonth.toLocaleDateString(navigator.language, {
+    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
 
-    cy.get(`[aria-label="${sameDateNextMonth}"]`).click();
+    cy.get(`[aria-label="${sameDateNextMonthUS}"]`).click();
 
     cy.get('#expiration-time-picker').click();
 
@@ -667,13 +667,13 @@ describe('Repository Details Page', () => {
 
     const nextMonth = new Date();
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonth = nextMonth.toLocaleDateString(navigator.language, {
+    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
 
-    cy.get(`[aria-label="${sameDateNextMonth}"]`).click();
+    cy.get(`[aria-label="${sameDateNextMonthUS}"]`).click();
     cy.get('#expiration-time-picker').click();
 
     nextMonth.setHours(1);
@@ -717,13 +717,13 @@ describe('Repository Details Page', () => {
 
     const nextMonth = new Date();
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonth = nextMonth.toLocaleDateString(navigator.language, {
+    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
 
-    cy.get(`[aria-label="${sameDateNextMonth}"]`).click();
+    cy.get(`[aria-label="${sameDateNextMonthUS}"]`).click();
     cy.get('#expiration-time-picker').click();
 
     nextMonth.setHours(1);
@@ -764,13 +764,13 @@ describe('Repository Details Page', () => {
 
     const nextMonth = new Date();
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonth = nextMonth.toLocaleDateString(navigator.language, {
+    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
 
-    cy.get(`[aria-label="${sameDateNextMonth}"]`).click();
+    cy.get(`[aria-label="${sameDateNextMonthUS}"]`).click();
     cy.get('#expiration-time-picker').click();
 
     nextMonth.setHours(1);

--- a/web/cypress/e2e/repository-details.cy.ts
+++ b/web/cypress/e2e/repository-details.cy.ts
@@ -563,7 +563,7 @@ describe('Repository Details Page', () => {
       });
 
     const formattedDate = new Date();
-    const currentDateUS = formattedDate.toLocaleDateString('en-US', {
+    const currentDateGB = formattedDate.toLocaleDateString('en-GB', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -580,7 +580,7 @@ describe('Repository Details Page', () => {
 
     // Ensure current date can be chosen
     cy.get('[aria-label="Toggle date picker"]').click();
-    cy.get(`[aria-label="${currentDateUS}"]`).click();
+    cy.get(`[aria-label="${currentDateGB}"]`).click();
     cy.get('input[aria-label="Date picker"]').should(
       'have.value',
       currentDateLong,
@@ -591,7 +591,7 @@ describe('Repository Details Page', () => {
 
     const nextMonth = new Date();
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-US', {
+    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-GB', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -667,13 +667,13 @@ describe('Repository Details Page', () => {
 
     const nextMonth = new Date();
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-US', {
+    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
 
-    cy.get(`[aria-label="${sameDateNextMonthUS}"]`).click();
+    cy.get(`[aria-label="${sameDateNextMonthGB}"]`).click();
     cy.get('#expiration-time-picker').click();
 
     nextMonth.setHours(1);
@@ -717,13 +717,14 @@ describe('Repository Details Page', () => {
 
     const nextMonth = new Date();
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-US', {
+    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
+      // for some reason the date picker is always using UK date formats for the aria labels
       year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
 
-    cy.get(`[aria-label="${sameDateNextMonthUS}"]`).click();
+    cy.get(`[aria-label="${sameDateNextMonthGB}"]`).click();
     cy.get('#expiration-time-picker').click();
 
     nextMonth.setHours(1);
@@ -764,13 +765,13 @@ describe('Repository Details Page', () => {
 
     const nextMonth = new Date();
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    const sameDateNextMonthUS = nextMonth.toLocaleDateString('en-US', {
+    const sameDateNextMonthGB = nextMonth.toLocaleDateString('en-GB', {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
     });
 
-    cy.get(`[aria-label="${sameDateNextMonthUS}"]`).click();
+    cy.get(`[aria-label="${sameDateNextMonthGB}"]`).click();
     cy.get('#expiration-time-picker').click();
 
     nextMonth.setHours(1);

--- a/web/src/components/DateTimePicker.tsx
+++ b/web/src/components/DateTimePicker.tsx
@@ -8,7 +8,7 @@ export default function DateTimePicker(props: DateTimePickerProps) {
 
   const dateFormat = (date: Date) => {
     if (!isNullOrUndefined(date)) {
-      return date.toLocaleDateString('en-US', {
+      return date.toLocaleDateString(navigator.language, {
         year: 'numeric',
         month: 'long',
         day: 'numeric',

--- a/web/src/libs/utils.ts
+++ b/web/src/libs/utils.ts
@@ -25,7 +25,7 @@ export function formatDate(date: string | number) {
   }
 
   const adjustedDate = typeof date === 'number' ? date * 1000 : date;
-  return new Date(adjustedDate).toLocaleString('en-US', {
+  return new Date(adjustedDate).toLocaleString(navigator.language, {
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     timeStyle: 'short',
     dateStyle: 'medium',

--- a/web/src/routes/RepositoryDetails/Tags/TagsActionsEditExpirationModal.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsActionsEditExpirationModal.tsx
@@ -184,8 +184,7 @@ export default function EditExpirationModal(props: EditExpirationModalProps) {
 
   const minExpirationDateTime = () => {
     if (date !== null && isToday(date)) {
-      const now = new Date();
-      return now;
+      return new Date(); // now
     } else {
       const newDate = new Date();
       newDate.setHours(0, 0, 0);

--- a/web/src/routes/RepositoryDetails/Tags/TagsActionsEditExpirationModal.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsActionsEditExpirationModal.tsx
@@ -184,9 +184,8 @@ export default function EditExpirationModal(props: EditExpirationModalProps) {
 
   const minExpirationDateTime = () => {
     if (date !== null && isToday(date)) {
-      const newDate = new Date();
-      newDate.setHours(newDate.getHours() + 1, 0, 0);
-      return newDate;
+      const now = new Date();
+      return now;
     } else {
       const newDate = new Date();
       newDate.setHours(0, 0, 0);

--- a/web/src/routes/RepositoryDetails/Tags/TagsActionsEditExpirationModal.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsActionsEditExpirationModal.tsx
@@ -95,7 +95,7 @@ export default function EditExpirationModal(props: EditExpirationModalProps) {
 
   const dateFormat = (date: Date) => {
     if (!isNullOrUndefined(date)) {
-      return date.toLocaleDateString('en-US', {
+      return date.toLocaleDateString(navigator.language, {
         weekday: 'long',
         year: 'numeric',
         month: 'long',
@@ -181,6 +181,12 @@ export default function EditExpirationModal(props: EditExpirationModalProps) {
     setTimePickerError(null);
   };
 
+  const is24HourFormat = () => {
+    const dateString = new Date().toLocaleTimeString();
+    const lastTwoCharacters = dateString.slice(-2);
+    return lastTwoCharacters !== 'AM' && lastTwoCharacters !== 'PM';
+  };
+
   return (
     <>
       <Modal
@@ -232,6 +238,7 @@ export default function EditExpirationModal(props: EditExpirationModalProps) {
                 placeholder="No time selected"
                 time={date === null ? ' ' : date.toLocaleTimeString()}
                 onChange={onTimeChange}
+                is24Hour={is24HourFormat()}
               />
               <span style={{paddingRight: '1em'}} />
               <Button variant={ButtonVariant.secondary} onClick={onClear}>


### PR DESCRIPTION
This addresses a broader issue with hard-coded locale in the UI in some places of the UI vs. locale-dependent formatting of date and time output in other areas. Now, all parts of the UI leverage the browser's locale. This also means that the Cypress tests now expect locale-specific date and time formatting.

This addresses a more specific issue where the time picker in the tag expiration modal is causing error messages because it does not switch to the 24-hour mode when the locale demands it. This PR also addresses UI layout glitches in this modal and cleans up the error state visualization and enhances the guidance to valid inputs for expiration time by using the `minTime` property of the `TimePicker` component if the expiration time is on the same day as the current day.

<img width="841" alt="Screenshot 2024-04-24 at 11 37 02" src="https://github.com/quay/quay/assets/12664117/6f1c4f16-bd79-417c-9201-38ceda7ddad0">
<img width="836" alt="Screenshot 2024-04-24 at 11 36 49" src="https://github.com/quay/quay/assets/12664117/166bb7b2-0ce3-45d9-abcf-647072552d08">


Lastly, because I ran into this in CI, I am addressing a Cypress flake where the clipboard access in test runs sometimes fails. This is implemented by stubbing the `writeText` calls to the clipboard.