### PR TITLE
logs: allow without strict logging (PROJQUAY-7116)

### DIFF
--- a/config-tool/utils/scripts/dumpschema.py
+++ b/config-tool/utils/scripts/dumpschema.py
@@ -182,6 +182,13 @@ CONFIG_SCHEMA = {
             + "and it is desired for pulls to continue during that time. Defaults to False.",
             "x-example": True,
         },
+        "ALLOW_WITHOUT_STRICT_LOGGING": {
+            "type": "boolean",
+            "description": "If true, any action in which the audit log entry cannot be written will "
+            + "still succeed. Useful if using an external logging service that may be down "
+            + "intermittently and the registry should continue to work. Defaults to False.",
+            "x-example": False,
+        },
         # Storage.
         "FEATURE_STORAGE_REPLICATION": {
             "type": "boolean",

--- a/config.py
+++ b/config.py
@@ -456,6 +456,9 @@ class DefaultConfig(ImmutableConfig):
     # Allow registry pulls when unable to write to the audit log
     ALLOW_PULLS_WITHOUT_STRICT_LOGGING = False
 
+    # Allow any registry action when unable to write to the audit log
+    ALLOW_WITHOUT_STRICT_LOGGING = False
+
     # Temporary tag expiration in seconds, this may actually be longer based on GC policy
     PUSH_TEMP_TAG_EXPIRATION_SEC = 60 * 60  # One hour per layer
 

--- a/data/logs_model/splunk_logs_model.py
+++ b/data/logs_model/splunk_logs_model.py
@@ -94,9 +94,13 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
         try:
             self._logs_producer.send(log_data)
         except LogSendException as lse:
-            strict_logging_disabled = config.app_config.get("ALLOW_PULLS_WITHOUT_STRICT_LOGGING")
-            logger.exception("log_action failed", extra=({"exception": lse}).update(log_data))
-            if not (strict_logging_disabled and kind_name in ACTIONS_ALLOWED_WITHOUT_AUDIT_LOGGING):
+            strict_logging_disabled = config.app_config.get("ALLOW_WITHOUT_STRICT_LOGGING") or (
+                config.app_config.get("ALLOW_PULLS_WITHOUT_STRICT_LOGGING")
+                and kind_name in ACTIONS_ALLOWED_WITHOUT_AUDIT_LOGGING
+            )
+            if strict_logging_disabled:
+                logger.exception("log_action failed", extra=({"exception": lse}).update(log_data))
+            else:
                 raise
 
     def lookup_logs(

--- a/data/logs_model/test/test_splunk.py
+++ b/data/logs_model/test/test_splunk.py
@@ -232,9 +232,12 @@ def test_splunk_logs_producers(
     app_config["ALLOW_PULLS_WITHOUT_STRICT_LOGGING"] = unlogged_pulls_ok
     app_config["ALLOW_WITHOUT_STRICT_LOGGING"] = unlogged_ok
 
-    with patch(
-        "data.logs_model.logs_producer.splunk_logs_producer.SplunkLogsProducer.send"
-    ) as mock_send, patch("splunklib.client.connect"):
+    with (
+        patch(
+            "data.logs_model.logs_producer.splunk_logs_producer.SplunkLogsProducer.send"
+        ) as mock_send,
+        patch("splunklib.client.connect"),
+    ):
         with patch("ssl.SSLContext.load_verify_locations"):
             configure(splunk_logs_model_config)
 
@@ -282,7 +285,7 @@ def test_splunk_logs_producers(
                     repository_name,
                     timestamp,
                 )
-                
+
                 expected_event = {
                     "account": "devtable",
                     "datetime": datetime(2019, 1, 1, 3, 30),

--- a/data/model/_basequery.py
+++ b/data/model/_basequery.py
@@ -224,7 +224,9 @@ def update_last_accessed(token_or_user):
         pass
     except PeeweeException as ex:
         # If there is any form of DB exception, only fail if strict logging is enabled.
-        strict_logging_disabled = config.app_config.get("ALLOW_PULLS_WITHOUT_STRICT_LOGGING")
+        strict_logging_disabled = config.app_config.get(
+            "ALLOW_WITHOUT_STRICT_LOGGING"
+        ) or config.app_config.get("ALLOW_PULLS_WITHOUT_STRICT_LOGGING")
         if strict_logging_disabled:
             data = {
                 "exception": ex,

--- a/data/model/log.py
+++ b/data/model/log.py
@@ -11,7 +11,13 @@ from data.model import DataModelException, config, user
 
 logger = logging.getLogger(__name__)
 
-ACTIONS_ALLOWED_WITHOUT_AUDIT_LOGGING = ["pull_repo", "login_failure", "pull_repo_failed"]
+ACTIONS_ALLOWED_WITHOUT_AUDIT_LOGGING = [
+    "pull_repo",
+    "login_failure",
+    "pull_repo_failed",
+    "login_success",
+    "logout_success",
+]
 
 
 def _logs_query(

--- a/data/model/log.py
+++ b/data/model/log.py
@@ -11,7 +11,7 @@ from data.model import DataModelException, config, user
 
 logger = logging.getLogger(__name__)
 
-ACTIONS_ALLOWED_WITHOUT_AUDIT_LOGGING = ["pull_repo"]
+ACTIONS_ALLOWED_WITHOUT_AUDIT_LOGGING = ["pull_repo", "login_failure", "pull_repo_failed"]
 
 
 def _logs_query(

--- a/data/model/log.py
+++ b/data/model/log.py
@@ -266,8 +266,11 @@ def log_action(
     try:
         LogEntry3.create(**log_data)
     except PeeweeException as ex:
-        strict_logging_disabled = config.app_config.get("ALLOW_PULLS_WITHOUT_STRICT_LOGGING")
-        if strict_logging_disabled and kind_name in ACTIONS_ALLOWED_WITHOUT_AUDIT_LOGGING:
+        strict_logging_disabled = config.app_config.get("ALLOW_WITHOUT_STRICT_LOGGING") or (
+            config.app_config.get("ALLOW_PULLS_WITHOUT_STRICT_LOGGING")
+            and kind_name in ACTIONS_ALLOWED_WITHOUT_AUDIT_LOGGING
+        )
+        if strict_logging_disabled:
             logger.exception("log_action failed", extra=({"exception": ex}).update(log_data))
         else:
             raise

--- a/data/model/test/test_log.py
+++ b/data/model/test/test_log.py
@@ -54,22 +54,25 @@ def test_log_action_unknown_action(action_kind):
     ],
 )
 @pytest.mark.parametrize(
-    "unlogged_pulls_ok,action_kind,db_exception,throws",
+    "unlogged_ok,unlogged_pulls_ok,action_kind,db_exception,throws",
     [
-        (False, "pull_repo", None, False),
-        (False, "push_repo", None, False),
-        (False, "pull_repo", PeeweeException, True),
-        (False, "push_repo", PeeweeException, True),
-        (True, "pull_repo", PeeweeException, False),
-        (True, "push_repo", PeeweeException, True),
-        (True, "pull_repo", Exception, True),
-        (True, "push_repo", Exception, True),
+        (False, False, "pull_repo", None, False),
+        (False, False, "push_repo", None, False),
+        (False, False, "pull_repo", PeeweeException, True),
+        (False, False, "push_repo", PeeweeException, True),
+        (False, True, "pull_repo", PeeweeException, False),
+        (False, True, "push_repo", PeeweeException, True),
+        (False, True, "pull_repo", Exception, True),
+        (False, True, "push_repo", Exception, True),
+        (True, False, "push_repo", Exception, True),
+        (True, True, "push_repo", Exception, True),
     ],
 )
 def test_log_action(
     user_or_org_name,
     account_id,
     account,
+    unlogged_ok,
     unlogged_pulls_ok,
     action_kind,
     db_exception,
@@ -87,6 +90,7 @@ def test_log_action(
     }
     app_config["SERVICE_LOG_ACCOUNT_ID"] = account_id
     app_config["ALLOW_PULLS_WITHOUT_STRICT_LOGGING"] = unlogged_pulls_ok
+    app_config["ALLOW_WITHOUT_STRICT_LOGGING"] = unlogged_ok
 
     logentry.create.side_effect = db_exception
 

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -278,6 +278,13 @@ CONFIG_SCHEMA = {
             + "and it is desired for pulls to continue during that time. Defaults to False.",
             "x-example": True,
         },
+        "ALLOW_WITHOUT_STRICT_LOGGING": {
+            "type": "boolean",
+            "description": "If true, any action in which the audit log entry cannot be written will "
+            + "still succeed. Useful if using an external logging service that may be down "
+            + "intermittently and the registry should continue to work. Defaults to False.",
+            "x-example": False,
+        },
         # Storage.
         "FEATURE_STORAGE_REPLICATION": {
             "type": "boolean",


### PR DESCRIPTION
This introduce the config option `ALLOW_WITHOUT_STRICT_LOGGING` which when set to `True` will make any error encountered during writing logs to remote systems non-fatal and logged to stdout instead.

This is useful, when an external log storage system like Splunk or ElasticSearch is intermittently down and the user favors the uptime of the registry more than audit log coverage.

Defaults to false.