### PR TITLE
healthcheck: add option to check preferred storage during instance check (PROJQUAY-5074)

### DIFF
--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -93,6 +93,9 @@ class Storage(object):
             download_proxy,
             app.config.get("REGISTRY_STATE") == "readonly",
             validate_endtoend=app.config.get("DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND", False),
+            requires_all_available=app.config.get(
+                "DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE", False
+            ),
         )
 
         # register extension with app


### PR DESCRIPTION
- `HEALTH_CHECKER_INSTANCE_CHECK_PREFERRED_STORAGE`: If set, instance health check will include the storage status of the first preferred storage 
- DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND: Validate all storage during endtoend health checks
- DISTRIBUTED_STORAGE_REQUIRES_ALL_AVAILABLE: Requires all storages be available when during endtoend health checks and `DISTRIBUTED_STORAGE_VALIDATE_ENDTOEND` is set
