### PR TITLE
logs: adding support for Splunk HTTP Event collectors as producers (PROJQUAY-7124)

### DIFF
--- a/config-tool/utils/scripts/dumpschema.py
+++ b/config-tool/utils/scripts/dumpschema.py
@@ -955,6 +955,117 @@ CONFIG_SCHEMA = {
                         },
                     },
                 },
+                "splunk_config": {
+                    "type": "object",
+                    "description": "Logs model config for splunk action logs/ splunk cluster configuration",
+                    "x-reference": "https://dev.splunk.com/enterprise/docs/devtools/python/sdk-python"
+                    "/howtousesplunkpython/howtogetdatapython#To-add-data-directly-to-an-index",
+                    "properties": {
+                        "host": {
+                            "type": "string",
+                            "description": "Splunk cluster endpoint",
+                            "x-example": "host.splunk.example",
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Splunk management cluster endpoint port",
+                            "x-example": 1234,
+                        },
+                        "bearer_token": {
+                            "type": "string",
+                            "description": "Bearer_Token for splunk.See: "
+                            "https://dev.splunk.com/enterprise/docs/devtools/python/sdk-python"
+                            "/howtousesplunkpython/howtoconnectpython/#Log-in-using-a-bearer-token",
+                            "x-example": "us-east-1",
+                        },
+                        "url_scheme": {
+                            "type": "string",
+                            "description": "The url scheme for accessing the splunk service. If Splunk is behind SSL"
+                            "*at all*, this *must* be `https`",
+                            "enum": ["http", "https"],
+                            "x-example": "https",
+                        },
+                        "verify_ssl": {
+                            "type": "boolean",
+                            "description": "Enable (True) or disable (False) SSL verification for https connections."
+                            "Defaults to True",
+                            "x-example": True,
+                        },
+                        "index_prefix": {
+                            "type": "string",
+                            "description": "Splunk's index prefix",
+                            "x-example": "splunk_logentry_",
+                        },
+                        "ssl_ca_path": {
+                            "type": "string",
+                            "description": "*Relative container path* to a single .pem file containing a CA "
+                            "certificate for SSL verification",
+                            "x-example": "conf/stack/ssl-ca-cert.pem",
+                        },
+                    },
+                },
+                "splunk_hec_config": {
+                    "type": "object",
+                    "description": "Logs model config for splunk HTTP event collector action logs configuration",
+                    "x-reference": "https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector#More_information_on_HEC_for_developers",
+                    "properties": {
+                        "host": {
+                            "type": "string",
+                            "description": "Splunk cluster endpoint",
+                            "x-example": "host.splunk.example",
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Splunk management cluster endpoint port",
+                            "x-example": 8080,
+                            "default": 443,
+                        },
+                        "hec_token": {
+                            "type": "string",
+                            "description": "HEC token for splunk.",
+                            "x-example": "1ad4d7bb-eed9-443a-897d-29e3b27df7a8",
+                        },
+                        "url_scheme": {
+                            "type": "string",
+                            "description": "The url scheme for accessing the splunk service. If Splunk is behind SSL"
+                            "*at all*, this *must* be `https`",
+                            "enum": ["http", "https"],
+                            "x-example": "https",
+                            "default": "https",
+                        },
+                        "verify_ssl": {
+                            "type": "boolean",
+                            "description": "Enable (True) or disable (False) SSL verification for https connections."
+                            "Defaults to True",
+                            "x-example": True,
+                            "default": True,
+                        },
+                        "ssl_ca_path": {
+                            "type": "string",
+                            "description": "*Relative container path* to a single .pem file containing a CA "
+                            "certificate for SSL verification",
+                            "x-example": "conf/stack/ssl-ca-cert.pem",
+                        },
+                        "index": {
+                            "type": "string",
+                            "description": "The splunk index to use (overrides the token's default index).",
+                            "x-example": "main",
+                        },
+                        "splunk_host": {
+                            "type": "string",
+                            "description": "The host name to log this event with (Defaults to the configured server hostname).",
+                            "x-example": "quay.dev",
+                            "default": "configured server hostname",
+                        },
+                        "splunk_sourcetype": {
+                            "type": "string",
+                            "description": "The name of the Splunk sourcetype to use.",
+                            "x-example": "quay-sourcetype",
+                            "default": "access_combined",
+                        },
+                    },
+                    "required": ["host", "hec_token"],
+                },
                 "kafka_config": {
                     "type": "object",
                     "description": "Kafka cluster configuration",

--- a/data/logs_model/logs_producer/splunk_hec_logs_producer.py
+++ b/data/logs_model/logs_producer/splunk_hec_logs_producer.py
@@ -1,0 +1,70 @@
+import json
+import logging
+
+import requests
+
+from data.logs_model.logs_producer import LogSendException
+from data.logs_model.logs_producer.interface import LogProducerInterface
+from data.model import config
+
+logger = logging.getLogger(__name__)
+
+
+class SplunkHECLogsProducer(LogProducerInterface):
+    """
+    Log producer for writing log entries to Splunk via HTTP Event Collector (HEC).
+    """
+
+    def __init__(
+        self,
+        host,
+        port,
+        hec_token,
+        url_scheme="https",
+        verify_ssl=True,
+        ssl_ca_path=None,
+        index=None,
+        splunk_host=None,
+        splunk_sourcetype=None,
+    ):
+        splunk_port = port if port else (443 if verify_ssl else 80)
+        self.hec_url = f"{url_scheme}://{host}:{splunk_port}/services/collector/event"
+        self.headers = {"Authorization": f"Splunk {hec_token}", "Content-Type": "application/json"}
+        self.verify_ssl = verify_ssl
+        if not verify_ssl:
+            self.ssl_verify_context = False
+        else:
+            self.ssl_verify_context = ssl_ca_path if ssl_ca_path else True
+
+        self.index = index
+        self.splunk_host = splunk_host
+        self.splunk_sourcetype = splunk_sourcetype
+
+    def send(self, log):
+        try:
+            host = self.splunk_host if self.splunk_host else config.app_config["SERVER_HOSTNAME"]
+            sourcetype = self.splunk_sourcetype if self.splunk_sourcetype else "access_combined"
+
+            log_event = {
+                "event": log,
+                "sourcetype": sourcetype,
+                "host": host,
+            }
+
+            if self.index:
+                log_event["index"] = self.index
+
+            log_data = json.dumps(
+                log_event, sort_keys=True, default=str, ensure_ascii=False
+            ).encode("utf-8")
+
+            response = requests.post(
+                self.hec_url,
+                headers=self.headers,
+                data=log_data,
+                verify=self.ssl_verify_context,
+            )
+            response.raise_for_status()
+        except Exception as e:
+            logger.exception("Failed to send log to Splunk via HEC: %s", e)
+            raise LogSendException(f"Failed to send log to Splunk via HEC: {e}")

--- a/data/logs_model/logs_producer/splunk_logs_producer.py
+++ b/data/logs_model/logs_producer/splunk_logs_producer.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import ssl
 
@@ -64,7 +65,10 @@ class SplunkLogsProducer(LogProducerInterface):
 
     def send(self, log):
         try:
-            self.index.submit(log, sourcetype="access_combined", host="quay")
+            log_data = json.dumps(log, sort_keys=True, default=str, ensure_ascii=False).encode(
+                "utf-8"
+            )
+            self.index.submit(log_data, sourcetype="access_combined", host="quay")
         except Exception as e:
             logger.exception("SplunkLogsProducer exception sending log to Splunk: %s", e)
             raise LogSendException("SplunkLogsProducer exception sending log to Splunk: %s" % e)

--- a/data/logs_model/splunk_logs_model.py
+++ b/data/logs_model/splunk_logs_model.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from data import model
 from data.logs_model.interface import ActionLogsDataInterface
 from data.logs_model.logs_producer import LogProducerProxy, LogSendException
+from data.logs_model.logs_producer.splunk_hec_logs_producer import SplunkHECLogsProducer
 from data.logs_model.logs_producer.splunk_logs_producer import SplunkLogsProducer
 from data.logs_model.shared import SharedModel
 from data.model import config
@@ -18,11 +19,19 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
     SplunkLogsModel implements model for establishing connection and sending events to Splunk cluster
     """
 
-    def __init__(self, producer, splunk_config, should_skip_logging=None):
+    def __init__(
+        self, producer, splunk_config=None, splunk_hec_config=None, should_skip_logging=None
+    ):
         self._should_skip_logging = should_skip_logging
         self._logs_producer = LogProducerProxy()
         if producer == "splunk":
+            if splunk_config is None:
+                raise Exception("splunk_config must be provided for 'splunk' producer")
             self._logs_producer.initialize(SplunkLogsProducer(**splunk_config))
+        elif producer == "splunk_hec":
+            if splunk_hec_config is None:
+                raise Exception("splunk_hec_config must be provided for 'splunk_hec' producer")
+            self._logs_producer.initialize(SplunkHECLogsProducer(**splunk_hec_config))
         else:
             raise Exception("Invalid log producer: %s" % producer)
 
@@ -83,7 +92,7 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
         }
 
         try:
-            self._logs_producer.send(json.dumps(log_data, sort_keys=True, default=str))
+            self._logs_producer.send(log_data)
         except LogSendException as lse:
             strict_logging_disabled = config.app_config.get("ALLOW_PULLS_WITHOUT_STRICT_LOGGING")
             logger.exception("log_action failed", extra=({"exception": lse}).update(log_data))

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1045,12 +1045,11 @@ CONFIG_SCHEMA = {
         "LOGS_MODEL_CONFIG": {
             "type": "object",
             "description": "Logs model config for action logs",
-            "x-reference": "https://www.elastic.co/guide/en/elasticsearch/guide/master/_index_settings.html",
             "properties": {
                 "producer": {
                     "type": "string",
                     "description": "Logs producer",
-                    "enum": ["kafka", "elasticsearch", "kinesis_stream", "splunk"],
+                    "enum": ["kafka", "elasticsearch", "kinesis_stream", "splunk", "splunk_hec"],
                     "x-example": "kafka",
                 },
                 "elasticsearch_config": {
@@ -1216,6 +1215,68 @@ CONFIG_SCHEMA = {
                             "x-example": "conf/stack/ssl-ca-cert.pem",
                         },
                     },
+                },
+                "splunk_hec_config": {
+                    "type": "object",
+                    "description": "Logs model config for splunk HTTP event collector action logs configuration",
+                    "x-reference": "https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector#More_information_on_HEC_for_developers",
+                    "properties": {
+                        "host": {
+                            "type": "string",
+                            "description": "Splunk cluster endpoint",
+                            "x-example": "host.splunk.example",
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Splunk management cluster endpoint port",
+                            "x-example": 8080,
+                            "default": 443,
+                        },
+                        "hec_token": {
+                            "type": "string",
+                            "description": "HEC token for splunk.",
+                            "x-example": "1ad4d7bb-eed9-443a-897d-29e3b27df7a8",
+                        },
+                        "url_scheme": {
+                            "type": "string",
+                            "description": "The url scheme for accessing the splunk service. If Splunk is behind SSL"
+                            "*at all*, this *must* be `https`",
+                            "enum": ["http", "https"],
+                            "x-example": "https",
+                            "default": "https",
+                        },
+                        "verify_ssl": {
+                            "type": "boolean",
+                            "description": "Enable (True) or disable (False) SSL verification for https connections."
+                            "Defaults to True",
+                            "x-example": True,
+                            "default": True,
+                        },
+                        "ssl_ca_path": {
+                            "type": "string",
+                            "description": "*Relative container path* to a single .pem file containing a CA "
+                            "certificate for SSL verification",
+                            "x-example": "conf/stack/ssl-ca-cert.pem",
+                        },
+                        "index": {
+                            "type": "string",
+                            "description": "The splunk index to use (overrides the token's default index).",
+                            "x-example": "main",
+                        },
+                        "splunk_host": {
+                            "type": "string",
+                            "description": "The host name to log this event with (Defaults to the configured server hostname).",
+                            "x-example": "quay.dev",
+                            "default": "configured server hostname",
+                        },
+                        "splunk_sourcetype": {
+                            "type": "string",
+                            "description": "The name of the Splunk sourcetype to use.",
+                            "x-example": "quay-sourcetype",
+                            "default": "access_combined",
+                        },
+                    },
+                    "required": ["host", "hec_token"],
                 },
             },
         },


### PR DESCRIPTION
This adds a producer to the Splunk log model for [Splunk HTTP Event Collectors](https://docs.splunk.com/Documentation/SplunkCloud/9.1.2312/Data/UsetheHTTPEventCollector#Set_up_and_use_HTTP_Event_Collector_in_Splunk_Web). HECs are available on Splunk Cloud and on Splunk Enterprise, whereas our existing implementation is for Splunk Simple Receivers which are only available on Splunk Enterprise. It seems HECs are more commonly used with our users.

This adds a new config schema to configure the Splunk HEC producer:

```
LOGS_MODEL: "splunk"
LOGS_MODEL_CONFIG: {
  "producer": "splunk_hec",
  "splunk_hec_config": {
    "host": "prd-p-aaaaaq.splunkcloud.com",
    "port": "8088",
    "hec_token": "12345678-1234-1234-1234-1234567890ab",
    "url_scheme": "https",
    "verify_ssl": False,
    "index": "quay",
    "splunk_host": "quay-dev",
    "splunk_sourcetype": "quay",
  }
}
```

<img width="1562" alt="Screenshot 2024-04-29 at 22 08 13" src="https://github.com/quay/quay/assets/12664117/d1793a77-d68c-458c-b42a-cb42fe597ea2">
