### PR TITLE
marketplace: change api call to return array of customer ids (PROJQUAY-7129)

### DIFF
--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -53,48 +53,6 @@ mocked_user_service_response = [
     },
 ]
 
-mocked_organization_only_response = [
-    {
-        "id": "12345678",
-        "accountRelationships": [
-            {
-                "emails": [{"address": "example@example.com", "status": "enabled"}],
-                "accountId": "fakeid",
-                "startDate": "2022-09-19T04:18:19.228Z",
-                "id": "fakeid",
-                "account": {
-                    "id": "222222222",
-                    "cdhPartyNumber": "11111111",
-                    "ebsAccountNumber": "102030",
-                    "name": "Red Hat",
-                    "displayName": "Red Hat",
-                    "status": "enabled",
-                    "type": "organization",
-                },
-            }
-        ],
-    },
-    {
-        "id": "87654321",
-        "accountRelationships": [
-            {
-                "emails": [{"address": "example@example.com", "status": "enabled"}],
-                "accountId": "fakeid",
-                "startDate": "2022-09-20T14:31:09.974Z",
-                "id": "fakeid",
-                "account": {
-                    "id": "fakeid",
-                    "cdhPartyNumber": "0000000",
-                    "ebsAccountNumber": "1234567",
-                    "name": "Test Org",
-                    "status": "enabled",
-                    "type": "organization",
-                },
-            }
-        ],
-    },
-]
-
 mocked_subscription_response = [
     {
         "id": 1,
@@ -219,11 +177,7 @@ class TestMarketplace(unittest.TestCase):
         requests_mock.return_value.content = json.dumps(mocked_user_service_response)
 
         customer_id = user_api.lookup_customer_id("example@example.com")
-        assert customer_id == 000000000
-
-        requests_mock.return_value.content = json.dumps(mocked_organization_only_response)
-        customer_id = user_api.lookup_customer_id("example@example.com")
-        assert customer_id is None
+        assert customer_id == [222222222, 00000000]
 
     @patch("requests.request")
     def test_subscription_lookup(self, requests_mock):

--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -55,7 +55,7 @@ def test_reconcile_different_ids(initialized_db):
 
     new_id = model.entitlements.get_web_customer_id(test_user.id)
     assert new_id != 12345
-    assert new_id == marketplace_users.lookup_customer_id(test_user.email)
+    assert [new_id] == marketplace_users.lookup_customer_id(test_user.email)
 
     # make sure it will remove account numbers from db that do not belong
     with patch.object(marketplace_users, "lookup_customer_id") as mock:


### PR DESCRIPTION
Changes marketplace api handler to now return a list of all web customer ids for a user.

Allows quay.io to keep track of all web customer ids instead of just personal types.

