### PR TITLE
cve: update Jinja to 3.1.4 (PROJQUAY-7173)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ importlib-metadata==6.7.0
 iso8601==0.1.12
 isodate==0.6.1
 itsdangerous==2.1.2
-Jinja2==3.1.3
+Jinja2==3.1.4
 jmespath==0.9.4
 jsonpath-rw==1.4.0
 jsonpointer==2.4


### PR DESCRIPTION
update Jinja2 to 3.1.4 to address CVE-2024-34064 jinja2: accepts keys containing non-attribute characters