### PR TITLE
model: capture container build dates (PROJQUAY-6210)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -1729,6 +1729,7 @@ class Manifest(BaseModel):
 
     config_media_type = CharField(null=True)
     layers_compressed_size = BigIntegerField(null=True)
+    created = BigIntegerField(null=True, index=True)
 
     class Meta:
         database = db

--- a/data/migrations/versions/d241e4f6e5bd_add_manifest_creation_date.py
+++ b/data/migrations/versions/d241e4f6e5bd_add_manifest_creation_date.py
@@ -1,0 +1,21 @@
+"""add manifest creation date
+
+Revision ID: d241e4f6e5bd
+Revises: 36cd2b747a08
+Create Date: 2024-03-27 09:42:51.183411
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "d241e4f6e5bd"
+down_revision = "36cd2b747a08"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.add_column("manifest", sa.Column("created", sa.BigInteger(), nullable=True))
+
+
+def downgrade(op, tables, tester):
+    op.drop_column("manifest", "created")

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -182,6 +182,7 @@ def list_repository_tag_history(
             Manifest.media_type,
             Manifest.layers_compressed_size,
             Manifest.config_media_type,
+            Manifest.created,
         )
         .join(Manifest)
         .where(Tag.repository == repository_id)

--- a/data/registry_model/datatypes.py
+++ b/data/registry_model/datatypes.py
@@ -296,6 +296,7 @@ class Manifest(
             "config_media_type",
             "_layers_compressed_size",
             "internal_manifest_bytes",
+            "created",
         ],
     )
 ):
@@ -321,6 +322,7 @@ class Manifest(
             media_type=ManifestTable.media_type.get_name(manifest.media_type_id),
             _layers_compressed_size=manifest.layers_compressed_size,
             config_media_type=manifest.config_media_type,
+            created=manifest.created,
             inputs=dict(
                 legacy_id_handler=legacy_id_handler,
                 legacy_image_row=legacy_image_row,

--- a/image/docker/schema1.py
+++ b/image/docker/schema1.py
@@ -418,6 +418,12 @@ class DockerSchema1Manifest(ManifestInterface):
                 internal_layer=layer,
             )
 
+    def get_created_date(self, content_retriever):
+        """
+        Returns the datetime when this manifest was created, or None if not applicable.
+        """
+        return self.created_datetime
+
     @property
     def is_image_manifest(self):
         return True

--- a/image/docker/schema2/config.py
+++ b/image/docker/schema2/config.py
@@ -93,7 +93,6 @@ Example:
 """
 
 import copy
-import hashlib
 import json
 from collections import namedtuple
 
@@ -228,6 +227,21 @@ class DockerSchema2Config(object):
         Returns a dictionary of all the labels defined in this configuration.
         """
         return self._parsed.get("config", {}).get("Labels", {}) or {}
+
+    @property
+    def created(self):
+        """
+        Returns the creation timestamp if it exists or None.
+        """
+        created = self._parsed.get(DOCKER_SCHEMA2_CONFIG_CREATED_KEY, None) or None
+
+        if created:
+            try:
+                return parse_date(created)
+            except ValueError:
+                return None
+        else:
+            return None
 
     @property
     def has_empty_layer(self):

--- a/image/docker/schema2/list.py
+++ b/image/docker/schema2/list.py
@@ -230,6 +230,23 @@ class DockerSchema2ManifestList(ManifestListInterface):
         """
         return None
 
+    def get_created_date(self, content_retriever):
+        """
+        Returns the datetime of the most recent created date of the child manifests or None if not applicable.
+        """
+
+        child_created_dates = [
+            child_manifest.manifest_obj.get_created_date(content_retriever)
+            for child_manifest in self.child_manifests(content_retriever)
+        ]
+
+        not_none_dates = [date for date in child_created_dates if date is not None]
+
+        if len(not_none_dates) == 0:
+            return None
+        else:
+            return max(not_none_dates)
+
     @property
     def blob_digests(self):
         # Manifest lists have no blob digests, since everything is stored as a manifest.

--- a/image/docker/schema2/list.py
+++ b/image/docker/schema2/list.py
@@ -235,17 +235,22 @@ class DockerSchema2ManifestList(ManifestListInterface):
         Returns the datetime of the most recent created date of the child manifests or None if not applicable.
         """
 
-        child_created_dates = [
-            child_manifest.manifest_obj.get_created_date(content_retriever)
-            for child_manifest in self.child_manifests(content_retriever)
-        ]
+        child_created_dates = []
+        for child_manifest in self.child_manifests(content_retriever):
+            try:
+                manifest = child_manifest.manifest_obj
+                created_date = manifest.get_created_date(content_retriever)
+                if created_date is not None:
+                    child_created_dates.append(created_date)
+            except (ManifestException):
+                logger.debug(
+                    "Could not load child manifest of when determining manifest list creation date"
+                )
 
-        not_none_dates = [date for date in child_created_dates if date is not None]
-
-        if len(not_none_dates) == 0:
+        if len(child_created_dates) == 0:
             return None
         else:
-            return max(not_none_dates)
+            return max(child_created_dates)
 
     @property
     def blob_digests(self):

--- a/image/docker/schema2/manifest.py
+++ b/image/docker/schema2/manifest.py
@@ -265,6 +265,9 @@ class DockerSchema2Manifest(ManifestInterface):
     def get_manifest_labels(self, content_retriever):
         return self._get_built_config(content_retriever).labels
 
+    def get_created_date(self, content_retriever):
+        return self._get_built_config(content_retriever).created
+
     def get_layers(self, content_retriever):
         """
         Returns the layers of this manifest, from base to leaf or None if this kind of manifest does

--- a/image/docker/schema2/test/test_manifest.py
+++ b/image/docker/schema2/test/test_manifest.py
@@ -4,6 +4,7 @@ import json
 import os
 
 import pytest
+from dateutil.parser import parse as parse_date
 
 from app import docker_v2_signing_key
 from image.docker.schema1 import (
@@ -130,6 +131,7 @@ def test_valid_manifest():
                 "Labels": {},
             },
             "rootfs": {"type": "layers", "diff_ids": []},
+            "created": "2018-04-03T18:37:09.284840891Z",
             "history": [
                 {"created": "2018-04-03T18:37:09.284840891Z", "created_by": "foo"},
                 {"created": "2018-04-12T18:37:09.284840891Z", "created_by": "bar"},
@@ -166,6 +168,9 @@ def test_valid_manifest():
         assert manifest_image_layers[index].blob_digest == str(
             manifest.filesystem_layers[index].digest
         )
+
+    manifest_created = manifest.get_created_date(retriever)
+    assert manifest_created == parse_date("2018-04-03T18:37:09.284840891Z")
 
 
 def test_valid_remote_manifest():

--- a/image/oci/config.py
+++ b/image/oci/config.py
@@ -59,7 +59,6 @@ Example:
 """
 
 import copy
-import hashlib
 import json
 from collections import namedtuple
 
@@ -243,6 +242,21 @@ class OCIConfig(object):
         Returns a dictionary of all the labels defined in this configuration.
         """
         return self._parsed.get("config", {}).get("Labels", {}) or {}
+
+    @property
+    def created(self):
+        """
+        Returns the creation timestamp if it exists or None.
+        """
+        created = self._parsed.get(CONFIG_CREATED_KEY, None) or None
+
+        if created:
+            try:
+                return parse_date(created)
+            except ValueError:
+                return None
+        else:
+            return None
 
     @property
     def has_empty_layer(self):

--- a/image/oci/index.py
+++ b/image/oci/index.py
@@ -261,6 +261,23 @@ class OCIIndex(ManifestListInterface):
         """
         return None
 
+    def get_created_date(self, content_retriever):
+        """
+        Returns the datetime of the most recent created date of the child manifests or None if not applicable.
+        """
+
+        child_created_dates = [
+            child_manifest.manifest_obj.get_created_date(content_retriever)
+            for child_manifest in self.child_manifests(content_retriever)
+        ]
+
+        not_none_dates = [date for date in child_created_dates if date is not None]
+
+        if len(not_none_dates) == 0:
+            return None
+        else:
+            return max(not_none_dates)
+
     @property
     def blob_digests(self):
         # Manifest lists have no blob digests, since everything is stored as a manifest.

--- a/image/oci/index.py
+++ b/image/oci/index.py
@@ -266,17 +266,22 @@ class OCIIndex(ManifestListInterface):
         Returns the datetime of the most recent created date of the child manifests or None if not applicable.
         """
 
-        child_created_dates = [
-            child_manifest.manifest_obj.get_created_date(content_retriever)
-            for child_manifest in self.child_manifests(content_retriever)
-        ]
+        child_created_dates = []
+        for child_manifest in self.child_manifests(content_retriever):
+            try:
+                manifest = child_manifest.manifest_obj
+                created_date = manifest.get_created_date(content_retriever)
+                if created_date is not None:
+                    child_created_dates.append(created_date)
+            except (ManifestException):
+                logger.debug(
+                    "Could not load child manifest of when determining index creation date"
+                )
 
-        not_none_dates = [date for date in child_created_dates if date is not None]
-
-        if len(not_none_dates) == 0:
+        if len(child_created_dates) == 0:
             return None
         else:
-            return max(not_none_dates)
+            return max(child_created_dates)
 
     @property
     def blob_digests(self):

--- a/image/oci/manifest.py
+++ b/image/oci/manifest.py
@@ -297,6 +297,13 @@ class OCIManifest(ManifestInterface):
         labels.update(self.annotations)
         return labels
 
+    def get_created_date(self, content_retriever):
+        if not self.is_image_manifest:
+            return None
+
+        built_config = self._get_built_config(content_retriever)
+        return built_config.created
+
     def get_layers(self, content_retriever):
         """
         Returns the layers of this manifest, from base to leaf or None if this kind of manifest does

--- a/image/shared/interfaces.py
+++ b/image/shared/interfaces.py
@@ -113,6 +113,13 @@ class ManifestInterface(object):
         pass
 
     @abstractmethod
+    def get_created_date(self, content_retriever):
+        """
+        Returns the datetime when this manifest was created, or None if not applicable.
+        """
+        pass
+
+    @abstractmethod
     def get_leaf_layer_v1_image_id(self, content_retriever):
         """
         Returns the Docker V1 image ID for the leaf (top) layer, if any, or None if not applicable.

--- a/image/shared/types.py
+++ b/image/shared/types.py
@@ -158,6 +158,12 @@ class ManifestReference(ManifestInterface):
         """
         pass
 
+    def get_created_date(self, content_retriever):
+        """
+        Returns the datetime when this manifest was created, or None if not applicable.
+        """
+        pass
+
     def get_leaf_layer_v1_image_id(self, content_retriever):
         """
         Returns the Docker V1 image ID for the leaf (top) layer, if any, or None if not applicable.
@@ -408,6 +414,12 @@ class SparseManifestList(ManifestListInterface):
         The layer must be of type ManifestImageLayer.
         """
         pass
+
+    def get_created_date(self, content_retriever):
+        """
+        Returns the datetime when this manifest was created, or None if not applicable.
+        """
+        return None
 
     def get_leaf_layer_v1_image_id(self, content_retriever):
         """

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -2316,7 +2316,8 @@ CREATE TABLE public.manifest (
     media_type_id integer NOT NULL,
     manifest_bytes text NOT NULL,
     config_media_type character varying(255),
-    layers_compressed_size bigint
+    layers_compressed_size bigint,
+    created bigint
 );
 
 
@@ -5623,7 +5624,7 @@ COPY public.accesstokenkind (id, name) FROM stdin;
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-b4da5b09c8df
+d241e4f6e5bd
 \.
 
 
@@ -5880,6 +5881,7 @@ COPY public.imagestoragelocation (id, name) FROM stdin;
 7	local
 8	s3_us_west_1
 9	default
+10	radosGWStorage
 \.
 
 
@@ -6298,6 +6300,8 @@ COPY public.logentrykind (id, name) FROM stdin;
 108	create_repository_autoprune_policy
 109	update_repository_autoprune_policy
 110	delete_repository_autoprune_policy
+111	enable_team_sync
+112	disable_team_sync
 \.
 
 
@@ -6313,6 +6317,7 @@ COPY public.loginservice (id, name) FROM stdin;
 5	keystone
 6	dex
 7	jwtauthn
+8	oidc
 \.
 
 
@@ -6320,19 +6325,19 @@ COPY public.loginservice (id, name) FROM stdin;
 -- Data for Name: manifest; Type: TABLE DATA; Schema: public; Owner: quay
 --
 
-COPY public.manifest (id, repository_id, digest, media_type_id, manifest_bytes, config_media_type, layers_compressed_size) FROM stdin;
-1	1	sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1469,\n      "digest": "sha256:feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2479,\n         "digest": "sha256:2db29710123e3e53a794f2694094b9b4338aa9ee5c40b930cb8063a1be392c54"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2479
-2	1	sha256:7b8b7289d0536a08eabdf71c20246e23f7116641db7e1d278592236ea4dcb30c	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1482,\n      "digest": "sha256:c0218de6585df06a66d67b25237bdda42137c727c367373a32639710c7a9fa94"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3684,\n         "digest": "sha256:b921b04d0447ddcd82a9220d887cd146f6ef39e20a938ee5e19a90fc3323e030"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3684
-3	1	sha256:f130bd2d67e6e9280ac6d0a6c83857bfaf70234e8ef4236876eccfbd30973b1c	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1482,\n      "digest": "sha256:1ec996c686eb87d8f091080ec29dd1862b39b5822ddfd8f9a1e2c9288fad89fe"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2993,\n         "digest": "sha256:9b157615502ddff86482f7fe2fa7a074db74a62fce12b4e8507827ac8f08d0ce"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2993
-4	1	sha256:432f982638b3aefab73cc58ab28f5c16e96fdb504e8c134fc58dff4bae8bf338	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1485,\n      "digest": "sha256:46331d942d6350436f64e614d75725f6de3bb5c63e266e236e04389820a234c4"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3208,\n         "digest": "sha256:7050e35b49f5e348c4809f5eff915842962cb813f32062d3bbdd35c750dd7d01"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3208
-5	1	sha256:995efde2e81b21d1ea7066aa77a59298a62a9e9fbb4b77f36c189774ec9b1089	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1468,\n      "digest": "sha256:36d89aa75357c8f99e359f8cabc0aae667d47d8f25ed51cbe66e148e3a77e19c"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2736,\n         "digest": "sha256:7f0d4fad461d1ac69488092b5914b5ec642133c0fb884539045de33fbcd2eadb"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2736
-6	1	sha256:eb11b1a194ff8e236a01eff392c4e1296a53b0fb4780d8b0382f7996a15d5392	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1473,\n      "digest": "sha256:5004e9d559e7a75f42249ddeca4d5764fa4db05592a7a9a641e4ac37cc619ba1"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 4092,\n         "digest": "sha256:bbc6052697e5fdcd1b311e0b3f65189ffbe354cf8ae97e7a55d588e855097174"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	4092
-7	1	sha256:b836bb24a270b9cc935962d8228517fde0f16990e88893d935efcb1b14c0017a	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1471,\n      "digest": "sha256:61fff98d5ca765a4351964c8f4b5fb1a0d2c48458026f5452a389eb52d146fe8"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3929,\n         "digest": "sha256:33450689bfb495ed64ead935c9933f1d6b3e42fe369b8de9680cf4ff9d89ce5c"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3929
-8	1	sha256:98c9722322be649df94780d3fbe594fce7996234b259f27eac9428b84050c849	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1471,\n      "digest": "sha256:b3593dab05491cdf5ee88c29bee36603c0df0bc34798eed5067f6e1335a9d391"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3000,\n         "digest": "sha256:3caa6dc69d0b73f21d29bfa75356395f2695a7abad34f010656740e90ddce399"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3000
-9	1	sha256:c7b6944911848ce39b44ed660d95fb54d69bbd531de724c7ce6fc9f743c0b861	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1469,\n      "digest": "sha256:df5477cea5582b0ae6a31de2d1c9bbacb506091f42a3b0fe77a209006f409fd8"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3276,\n         "digest": "sha256:abc70fcc95b2f52b325d69cc5c259dd9babb40a9df152e88b286fada1d3248bd"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3276
-10	1	sha256:7693efac53eb85ff1afb03f7f2560015c57ac2175707f1f141f31161634c9dba	15	{"manifests":[{"digest":"sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"amd64","os":"linux"},"size":525},{"digest":"sha256:7b8b7289d0536a08eabdf71c20246e23f7116641db7e1d278592236ea4dcb30c","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"arm","os":"linux","variant":"v5"},"size":525},{"digest":"sha256:f130bd2d67e6e9280ac6d0a6c83857bfaf70234e8ef4236876eccfbd30973b1c","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"arm","os":"linux","variant":"v7"},"size":525},{"digest":"sha256:432f982638b3aefab73cc58ab28f5c16e96fdb504e8c134fc58dff4bae8bf338","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"arm64","os":"linux","variant":"v8"},"size":525},{"digest":"sha256:995efde2e81b21d1ea7066aa77a59298a62a9e9fbb4b77f36c189774ec9b1089","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"386","os":"linux"},"size":525},{"digest":"sha256:eb11b1a194ff8e236a01eff392c4e1296a53b0fb4780d8b0382f7996a15d5392","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"mips64le","os":"linux"},"size":525},{"digest":"sha256:b836bb24a270b9cc935962d8228517fde0f16990e88893d935efcb1b14c0017a","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"ppc64le","os":"linux"},"size":525},{"digest":"sha256:98c9722322be649df94780d3fbe594fce7996234b259f27eac9428b84050c849","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"riscv64","os":"linux"},"size":525},{"digest":"sha256:c7b6944911848ce39b44ed660d95fb54d69bbd531de724c7ce6fc9f743c0b861","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"s390x","os":"linux"},"size":525}],"mediaType":"application\\/vnd.docker.distribution.manifest.list.v2+json","schemaVersion":2}	\N	0
-11	155	sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1469,\n      "digest": "sha256:feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2479,\n         "digest": "sha256:2db29710123e3e53a794f2694094b9b4338aa9ee5c40b930cb8063a1be392c54"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2479
-12	1	sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1470,\n      "digest": "sha256:9c7a54a9a43cca047013b82af109fe963fde787f63f9e016fdc3384500c2823d"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2457,\n         "digest": "sha256:719385e32844401d57ecfd3eacab360bf551a1491c05b85806ed8f1b08d792f6"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2457
+COPY public.manifest (id, repository_id, digest, media_type_id, manifest_bytes, config_media_type, layers_compressed_size, created) FROM stdin;
+1	1	sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1469,\n      "digest": "sha256:feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2479,\n         "digest": "sha256:2db29710123e3e53a794f2694094b9b4338aa9ee5c40b930cb8063a1be392c54"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2479	1680516000
+2	1	sha256:7b8b7289d0536a08eabdf71c20246e23f7116641db7e1d278592236ea4dcb30c	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1482,\n      "digest": "sha256:c0218de6585df06a66d67b25237bdda42137c727c367373a32639710c7a9fa94"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3684,\n         "digest": "sha256:b921b04d0447ddcd82a9220d887cd146f6ef39e20a938ee5e19a90fc3323e030"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3684	\N
+3	1	sha256:f130bd2d67e6e9280ac6d0a6c83857bfaf70234e8ef4236876eccfbd30973b1c	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1482,\n      "digest": "sha256:1ec996c686eb87d8f091080ec29dd1862b39b5822ddfd8f9a1e2c9288fad89fe"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2993,\n         "digest": "sha256:9b157615502ddff86482f7fe2fa7a074db74a62fce12b4e8507827ac8f08d0ce"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2993	\N
+4	1	sha256:432f982638b3aefab73cc58ab28f5c16e96fdb504e8c134fc58dff4bae8bf338	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1485,\n      "digest": "sha256:46331d942d6350436f64e614d75725f6de3bb5c63e266e236e04389820a234c4"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3208,\n         "digest": "sha256:7050e35b49f5e348c4809f5eff915842962cb813f32062d3bbdd35c750dd7d01"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3208	\N
+5	1	sha256:995efde2e81b21d1ea7066aa77a59298a62a9e9fbb4b77f36c189774ec9b1089	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1468,\n      "digest": "sha256:36d89aa75357c8f99e359f8cabc0aae667d47d8f25ed51cbe66e148e3a77e19c"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2736,\n         "digest": "sha256:7f0d4fad461d1ac69488092b5914b5ec642133c0fb884539045de33fbcd2eadb"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2736	\N
+6	1	sha256:eb11b1a194ff8e236a01eff392c4e1296a53b0fb4780d8b0382f7996a15d5392	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1473,\n      "digest": "sha256:5004e9d559e7a75f42249ddeca4d5764fa4db05592a7a9a641e4ac37cc619ba1"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 4092,\n         "digest": "sha256:bbc6052697e5fdcd1b311e0b3f65189ffbe354cf8ae97e7a55d588e855097174"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	4092	\N
+7	1	sha256:b836bb24a270b9cc935962d8228517fde0f16990e88893d935efcb1b14c0017a	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1471,\n      "digest": "sha256:61fff98d5ca765a4351964c8f4b5fb1a0d2c48458026f5452a389eb52d146fe8"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3929,\n         "digest": "sha256:33450689bfb495ed64ead935c9933f1d6b3e42fe369b8de9680cf4ff9d89ce5c"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3929	\N
+8	1	sha256:98c9722322be649df94780d3fbe594fce7996234b259f27eac9428b84050c849	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1471,\n      "digest": "sha256:b3593dab05491cdf5ee88c29bee36603c0df0bc34798eed5067f6e1335a9d391"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3000,\n         "digest": "sha256:3caa6dc69d0b73f21d29bfa75356395f2695a7abad34f010656740e90ddce399"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3000	\N
+9	1	sha256:c7b6944911848ce39b44ed660d95fb54d69bbd531de724c7ce6fc9f743c0b861	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1469,\n      "digest": "sha256:df5477cea5582b0ae6a31de2d1c9bbacb506091f42a3b0fe77a209006f409fd8"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 3276,\n         "digest": "sha256:abc70fcc95b2f52b325d69cc5c259dd9babb40a9df152e88b286fada1d3248bd"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	3276	\N
+10	1	sha256:7693efac53eb85ff1afb03f7f2560015c57ac2175707f1f141f31161634c9dba	15	{"manifests":[{"digest":"sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"amd64","os":"linux"},"size":525},{"digest":"sha256:7b8b7289d0536a08eabdf71c20246e23f7116641db7e1d278592236ea4dcb30c","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"arm","os":"linux","variant":"v5"},"size":525},{"digest":"sha256:f130bd2d67e6e9280ac6d0a6c83857bfaf70234e8ef4236876eccfbd30973b1c","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"arm","os":"linux","variant":"v7"},"size":525},{"digest":"sha256:432f982638b3aefab73cc58ab28f5c16e96fdb504e8c134fc58dff4bae8bf338","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"arm64","os":"linux","variant":"v8"},"size":525},{"digest":"sha256:995efde2e81b21d1ea7066aa77a59298a62a9e9fbb4b77f36c189774ec9b1089","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"386","os":"linux"},"size":525},{"digest":"sha256:eb11b1a194ff8e236a01eff392c4e1296a53b0fb4780d8b0382f7996a15d5392","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"mips64le","os":"linux"},"size":525},{"digest":"sha256:b836bb24a270b9cc935962d8228517fde0f16990e88893d935efcb1b14c0017a","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"ppc64le","os":"linux"},"size":525},{"digest":"sha256:98c9722322be649df94780d3fbe594fce7996234b259f27eac9428b84050c849","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"riscv64","os":"linux"},"size":525},{"digest":"sha256:c7b6944911848ce39b44ed660d95fb54d69bbd531de724c7ce6fc9f743c0b861","mediaType":"application\\/vnd.docker.distribution.manifest.v2+json","platform":{"architecture":"s390x","os":"linux"},"size":525}],"mediaType":"application\\/vnd.docker.distribution.manifest.list.v2+json","schemaVersion":2}	\N	0	1649070000
+11	155	sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1469,\n      "digest": "sha256:feb5d9fea6a5e9606aa995e879d862b825965ba48de054caab5ef356dc6b3412"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2479,\n         "digest": "sha256:2db29710123e3e53a794f2694094b9b4338aa9ee5c40b930cb8063a1be392c54"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2479	\N
+12	1	sha256:7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3	16	{\n   "schemaVersion": 2,\n   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",\n   "config": {\n      "mediaType": "application/vnd.docker.container.image.v1+json",\n      "size": 1470,\n      "digest": "sha256:9c7a54a9a43cca047013b82af109fe963fde787f63f9e016fdc3384500c2823d"\n   },\n   "layers": [\n      {\n         "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",\n         "size": 2457,\n         "digest": "sha256:719385e32844401d57ecfd3eacab360bf551a1491c05b85806ed8f1b08d792f6"\n      }\n   ]\n}	application/vnd.docker.container.image.v1+json	2457	\N
 \.
 
 
@@ -8078,7 +8083,7 @@ SELECT pg_catalog.setval('public.imagestorage_id_seq', 21, true);
 -- Name: imagestoragelocation_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.imagestoragelocation_id_seq', 9, true);
+SELECT pg_catalog.setval('public.imagestoragelocation_id_seq', 10, true);
 
 
 --
@@ -8148,14 +8153,14 @@ SELECT pg_catalog.setval('public.logentry_id_seq', 1, false);
 -- Name: logentrykind_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.logentrykind_id_seq', 110, true);
+SELECT pg_catalog.setval('public.logentrykind_id_seq', 112, true);
 
 
 --
 -- Name: loginservice_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.loginservice_id_seq', 7, true);
+SELECT pg_catalog.setval('public.loginservice_id_seq', 8, true);
 
 
 --
@@ -8232,7 +8237,7 @@ SELECT pg_catalog.setval('public.namespacegeorestriction_id_seq', 1, false);
 -- Name: notification_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.notification_id_seq', 1, true);
+SELECT pg_catalog.setval('public.notification_id_seq', 1, false);
 
 
 --
@@ -8477,14 +8482,14 @@ SELECT pg_catalog.setval('public.role_id_seq', 3, true);
 -- Name: servicekey_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.servicekey_id_seq', 1, true);
+SELECT pg_catalog.setval('public.servicekey_id_seq', 1, false);
 
 
 --
 -- Name: servicekeyapproval_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.servicekeyapproval_id_seq', 1, true);
+SELECT pg_catalog.setval('public.servicekeyapproval_id_seq', 1, false);
 
 
 --


### PR DESCRIPTION
This adds the capability to for the data model to track the creation date of a manifest or manifest list. This is essentially the creation date found in the `config` manifest of a OCI image: https://github.com/opencontainers/image-spec/blob/main/config.md - the same concept exists for Docker images. It aims to implement the following functionality:

Non-manifest list images

1. A Quay user pushes an image they built locally on their machine
2. The image contains a single manifest only because the user did not build the image for multiple architectures or added metadata in the form of additional manifest to it.
3. The user pushes the image to Quay
4. Quay reads the metadata of the image and captures the creation date, typically in ISO 8601 format, and stores it in the database

Manifest list images:

1. A Quay users leverages Quay's repository mirroring to mirror images from an external registry into Quay
2. The images mirrored are usually manifests lists, containing manifests for the various supported CPU architectures of this software or additional metadata supplied as child manifests like in-toto attestations
3. The mirroring processes pushes these images into Quay
4. Quay reads the metadata of each individual child manifest and captures the creation dates, typically in ISO 8601 format, and stores them in the database like so::
5. the child manifests creation date is represented with the information from the individual child manifest metadata
6. the parent manifest-list creation date is computed from the newest creation date found among the child manifest

The required API and UI changes will follow in separate PRs to fully implement [PROJQUAY-6210](https://issues.redhat.com/browse/PROJQUAY-6210).