### PR TITLE
federatedusers(externalldap): fix blocking at_least_one_user_exists (PROJQUAY-3810)

### DIFF
--- a/config-tool/pkg/lib/shared/validators.go
+++ b/config-tool/pkg/lib/shared/validators.go
@@ -855,9 +855,11 @@ func ValidateLDAPServer(opts Options, ldapUri, ldapAdminDn, ldapAdminPasswd, lda
 
 	userFilter := fmt.Sprintf("(&(%s=*)%s)", ldapUidAttr, ldapUserFilter)
 	request := &ldap.SearchRequest{
-		BaseDN: strings.Join(InterfaceArrayToStringArray(ldapBaseDn), ","),
-		Scope:  ldap.ScopeWholeSubtree,
-		Filter: userFilter,
+		BaseDN:    strings.Join(InterfaceArrayToStringArray(ldapBaseDn), ","),
+		Scope:     ldap.ScopeWholeSubtree,
+		SizeLimit: 1,
+		TimeLimit: 10,
+		Filter:    userFilter,
 		Attributes: []string{
 			ldapEmailAttr, ldapUidAttr,
 		},

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -378,18 +378,31 @@ class LDAPUsers(FederatedUsers):
                     else:
                         return (False, "Restricted user filter not set")
 
+                # PagesResultsControl of size=1 blocks if there's no iteration handle on rdata == []
                 lc = ldap.controls.libldap.SimplePagedResultsControl(
                     criticality=True, size=1, cookie=""
                 )
                 try:
                     if has_pagination:
+                        # add sizelimit as we do not want to iter over all records, just one
                         msgid = conn.search_ext(
-                            user_search_dn, ldap.SCOPE_SUBTREE, search_flt, serverctrls=[lc]
+                            user_search_dn,
+                            ldap.SCOPE_SUBTREE,
+                            search_flt,
+                            serverctrls=[lc],
+                            sizelimit=1,
                         )
                         _, rdata, _, serverctrls = conn.result3(msgid)
                     else:
-                        msgid = conn.search(user_search_dn, ldap.SCOPE_SUBTREE, search_flt)
+                        # ensure none paged requets are sizelimited as well
+                        msgid = conn.search_ext(
+                            user_search_dn, ldap.SCOPE_SUBTREE, search_flt, sizelimit=1
+                        )
                         _, rdata = conn.result(msgid)
+
+                    # if no data is returned fail
+                    if rdata == []:
+                        return (False, None)
 
                     for entry in rdata:  # Handles both lists and iterators.
                         return (True, None)

--- a/test/test_ldap.py
+++ b/test/test_ldap.py
@@ -1,5 +1,6 @@
 import unittest
 from contextlib import contextmanager
+from time import time
 
 import ldap
 from ldap.filter import filter_format
@@ -967,6 +968,42 @@ class TestLDAP(unittest.TestCase):
             (response, err_msg) = ldap.at_least_one_user_exists()
             self.assertIsNone(err_msg)
             self.assertFalse(response)
+
+    def test_at_least_one_user_exists_not_blocking(self):
+        base_dn = ["dc=quay", "dc=io"]
+        admin_dn = "uid=testy,ou=employees,dc=quay,dc=io"
+        admin_passwd = "password"
+        user_rdn = ["ou=employees"]
+        uid_attr = "uid"
+        email_attr = "mail"
+        memberof_attr = "memberOf"
+        secondary_user_rdns = ["ou=otheremployees"]
+
+        with mock_ldap():
+            ldap = LDAPUsers(
+                "ldap://localhost",
+                base_dn,
+                admin_dn,
+                admin_passwd,
+                user_rdn,
+                uid_attr,
+                email_attr,
+                memberof_attr,
+                ldap_user_filter="(filterField=invalidfilterwithnodatareturned)",
+            )
+            # check if result/result3 stops blocking
+            try:
+                starttime = time()
+                (response, err_msg) = ldap.at_least_one_user_exists()
+                stoptime = time()
+                self.assertFalse(response)
+                self.assertLess((stoptime - starttime), 10, "Timeout limit of 10 breached")
+            except ldap.TIMEOUT as lerr:
+                # cannot and should not
+                raise ldap.TIMEOUT("PROJQUAY-3810 should not raise a timeout anymore")
+            except ldap.TIMELIMIT_EXCEEDED as lerr:
+                # cannot and should not
+                raise ldap.TIMEOUT("PROJQUAY-3810 should not raise a timeout anymore")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
method `at_least_one_user_exists` might block on empty page results in particular seen with `memberOf:1.2.840.113556.1.4.1941:=` 
Adding a sizelimit to `search_ext` as well as stoping the iteration on `[]`results should improve the situation.

The initial tests have been documented in PROJQUAY-3810 and are copied from there.

```
export LDAPTLS_REQCERT=never # we do not want to block on TLS errors
export LDAPTLS_REQSAN=never  # we do not want to block on TLS errors

BASEDN=cn=users,dc=example,dc=com \
BINDDN='Administrator@example.com' \
BINDPWD='changeme' \
LDAP_URI=ldap://ldap.example.com \ # FQDN or IP (see reqcert/reqsan)
LDAP_FILTER='(&(objectClass=*)(memberOf:1.2.840.113556.1.4.1941:=cn=quay-superuser,cn=groups,dc=example,dc=com))' \
python ldap-perf-tester.py
# output 
(101, [], 2, [<ldap.controls.libldap.SimplePagedResultsControl object at 0x7f28610c70d0>])
timed out
search_ext paginated took total=10.01084 avg=10.01084
search_ext paginated ext took total=0.00053 avg=0.00053
search_ext took total=0.00047 avg=0.00047
```

the line (101, [], 2, ...) and timeout are expected in the original query (search_ext paginated)
After verifying that we see (delay) what we expect we can verify if the PR will remove the burden of delay

```
export LDAPTLS_REQCERT=never # we do not want to block on TLS errors
export LDAPTLS_REQSAN=never # we do not want to block on TLS errors

PROJQUAY_3810_FIXED=1 \
BASEDN=cn=users,dc=example,dc=com \
BINDDN='Administrator@example.com' \
BINDPWD='changeme' \
LDAP_URI=ldap://ldap.example.com \ # FQDN or IP (see reqcert/reqsan)
LDAP_FILTER='(&(objectClass=*)(memberOf:1.2.840.113556.1.4.1941:=cn=quay-superuser,cn=groups,dc=example,dc=com))' \
python ldap-perf-tester.py
# output  
search_ext paginated took total=0.00036 avg=0.00036
search_ext paginated ext took total=0.00034 avg=0.00034
search_ext took total=0.00033 avg=0.00033
```

We should not see any delay anymore with the environment variable `PROJQUAY_3810_FIXED=1 