### PR TITLE
api: OCI compliant tag listing and pagination (PROJQUAY-6931)

### DIFF
--- a/data/cache/cache_key.py
+++ b/data/cache/cache_key.py
@@ -49,14 +49,14 @@ def for_namespace_geo_restrictions(namespace_name, cache_config):
     return CacheKey("geo_restrictions__%s" % namespace_name, cache_ttl)
 
 
-def for_active_repo_tags(repository_id, start_pagination_id, limit, cache_config):
+def for_active_repo_tags(repository_id, last_pagination_tag_name, limit, cache_config):
     """
     Returns a cache key for the active tags in a repository.
     """
 
     cache_ttl = cache_config.get("active_repo_tags_cache_ttl", "120s")
     return CacheKey(
-        "repo_active_tags__%s_%s_%s" % (repository_id, start_pagination_id, limit), cache_ttl
+        "repo_active_tags__%s_%s_%s" % (repository_id, last_pagination_tag_name, limit), cache_ttl
     )
 
 

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -127,7 +127,7 @@ def test_list_alive_tags(initialized_db):
 def test_lookup_alive_tags_shallow(initialized_db):
     found = False
     for tag in filter_to_visible_tags(filter_to_alive_tags(Tag.select())):
-        tags = lookup_alive_tags_shallow(tag.repository)
+        tags, _ = lookup_alive_tags_shallow(tag.repository)
         found = True
         assert tag in tags
 
@@ -138,7 +138,7 @@ def test_lookup_alive_tags_shallow(initialized_db):
     tag.hidden = True
     tag.save()
 
-    tags = lookup_alive_tags_shallow(tag.repository)
+    tags, _ = lookup_alive_tags_shallow(tag.repository)
     assert tag not in tags
 
 

--- a/data/registry_model/interface.py
+++ b/data/registry_model/interface.py
@@ -149,7 +149,7 @@ class RegistryDataInterface(object):
 
     @abstractmethod
     def lookup_cached_active_repository_tags(
-        self, model_cache, repository_ref, start_pagination_id, limit
+        self, model_cache, repository_ref, last_pagination_tag_name, limit
     ):
         """
         Returns a page of active tags in a repository.
@@ -160,9 +160,9 @@ class RegistryDataInterface(object):
         """
 
     @abstractmethod
-    def lookup_active_repository_tags(self, repository_ref, start_pagination_id, limit):
+    def lookup_active_repository_tags(self, repository_ref, last_pagination_tag_name, limit):
         """
-        Returns a page of active tags in a repository.
+        Returns a page of active tags in a repository and whether there are more tags to paginate through.
 
         Note that the tags returned by this method are ShallowTag objects, which only contain the
         tag name.

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -252,15 +252,17 @@ class OCIModel(RegistryDataInterface):
         """
         return Label.for_label(oci.label.delete_manifest_label(label_uuid, manifest._db_id))
 
-    def lookup_active_repository_tags(self, repository_ref, start_pagination_id, limit):
+    def lookup_active_repository_tags(self, repository_ref, last_pagination_tag_name, limit):
         """
-        Returns a page of actvie tags in a repository.
+        Returns a page of active tags in a repository and has_more to indicate if there are more.
 
         Note that the tags returned by this method are ShallowTag objects, which only contain the
         tag name.
         """
-        tags = oci.tag.lookup_alive_tags_shallow(repository_ref._db_id, start_pagination_id, limit)
-        return [ShallowTag.for_tag(tag) for tag in tags]
+        tags, has_more = oci.tag.lookup_alive_tags_shallow(
+            repository_ref._db_id, last_pagination_tag_name, limit
+        )
+        return [ShallowTag.for_tag(tag) for tag in tags], has_more
 
     def list_all_active_repository_tags(self, repository_ref):
         """
@@ -883,7 +885,7 @@ class OCIModel(RegistryDataInterface):
         return Manifest.from_dict(result)
 
     def lookup_cached_active_repository_tags(
-        self, model_cache, repository_ref, start_pagination_id, limit
+        self, model_cache, repository_ref, last_pagination_tag_name, limit
     ):
         """
         Returns a page of active tags in a repository.
@@ -894,18 +896,22 @@ class OCIModel(RegistryDataInterface):
         """
 
         def load_tags():
-            tags = self.lookup_active_repository_tags(repository_ref, start_pagination_id, limit)
-            return [tag.asdict() for tag in tags]
+            tags, has_more = self.lookup_active_repository_tags(
+                repository_ref, last_pagination_tag_name, limit
+            )
+            return [tag.asdict() for tag in tags], has_more
 
         tags_cache_key = cache_key.for_active_repo_tags(
-            repository_ref._db_id, start_pagination_id, limit, model_cache.cache_config
+            repository_ref._db_id, last_pagination_tag_name, limit, model_cache.cache_config
         )
-        result = model_cache.retrieve(tags_cache_key, load_tags)
+        result, has_more = tuple(model_cache.retrieve(tags_cache_key, load_tags))
 
         try:
-            return [ShallowTag.from_dict(tag_dict) for tag_dict in result]
+            return [ShallowTag.from_dict(tag_dict) for tag_dict in result], has_more
         except FromDictionaryException:
-            return self.lookup_active_repository_tags(repository_ref, start_pagination_id, limit)
+            return self.lookup_active_repository_tags(
+                repository_ref, last_pagination_tag_name, limit
+            )
 
     def get_cached_namespace_region_blacklist(self, model_cache, namespace_name):
         """

--- a/endpoints/v2/errors.py
+++ b/endpoints/v2/errors.py
@@ -126,6 +126,13 @@ class TagInvalid(V2RegistryException):
         super(TagInvalid, self).__init__("TAG_INVALID", "manifest tag did not match URI", detail)
 
 
+class TooManyTagsRequested(V2RegistryException):
+    def __init__(self, message, detail=None):
+        super(TooManyTagsRequested, self).__init__(
+            "TOO_MANY_TAGS_REQUESTED", message or "too many tags requested", detail, 413
+        )
+
+
 class LayerTooLarge(V2RegistryException):
     def __init__(self, uploaded=None, max_allowed=None):
         detail = {}

--- a/endpoints/v2/tag.py
+++ b/endpoints/v2/tag.py
@@ -7,10 +7,14 @@ from endpoints.decorators import (
     anon_protect,
     disallow_for_account_recovery_mode,
     parse_repository_name,
-    route_show_if,
 )
-from endpoints.v2 import paginate, require_repo_read, v2_bp
-from endpoints.v2.errors import NameUnknown
+from endpoints.v2 import (
+    _MAX_RESULTS_PER_PAGE,
+    oci_tag_paginate,
+    require_repo_read,
+    v2_bp,
+)
+from endpoints.v2.errors import NameUnknown, TooManyTagsRequested
 
 
 @v2_bp.route("/<repopath:repository>/tags/list", methods=["GET"])
@@ -19,16 +23,14 @@ from endpoints.v2.errors import NameUnknown
 @process_registry_jwt_auth(scopes=["pull"])
 @require_repo_read(allow_for_superuser=True)
 @anon_protect
-@paginate()
-def list_all_tags(namespace_name, repo_name, start_id, limit, pagination_callback):
+@oci_tag_paginate()
+def list_all_tags(namespace_name, repo_name, last_pagination_tag_name, limit, pagination_callback):
     repository_ref = registry_model.lookup_repository(namespace_name, repo_name)
     if repository_ref is None:
         raise NameUnknown("repository not found")
 
-    # NOTE: We add 1 to the limit because that's how pagination_callback knows if there are
-    # additional tags.
-    tags = registry_model.lookup_cached_active_repository_tags(
-        model_cache, repository_ref, start_id, limit + 1
+    tags, has_more = registry_model.lookup_cached_active_repository_tags(
+        model_cache, repository_ref, last_pagination_tag_name, limit
     )
     response = jsonify(
         {
@@ -37,5 +39,5 @@ def list_all_tags(namespace_name, repo_name, start_id, limit, pagination_callbac
         }
     )
 
-    pagination_callback(tags, response)
+    pagination_callback(tags, has_more, response)
     return response

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -414,7 +414,7 @@ def rollback(
 
 
 def delete_obsolete_tags(mirror, tags):
-    existing_tags = lookup_alive_tags_shallow(mirror.repository.id)
+    existing_tags, _ = lookup_alive_tags_shallow(mirror.repository.id)
     obsolete_tags = list([tag for tag in existing_tags if tag.name not in tags])
 
     for tag in obsolete_tags:


### PR DESCRIPTION
This aligns Quay's v2 tag listing endpoint to the most current tag listing specification: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#content-discovery

It solves three problems:
- the tag order returned is not alphabetical ([PROJQUAY-2806](https://issues.redhat.com/browse/PROJQUAY-2806))
- the `last` parameter cannot be used to manually paginate through the result set ([PROJQUAY-6931](https://issues.redhat.com/browse/PROJQUAY-6931))
- we silently retrieve less than `n` tags if it exceeds the maximum configured v2 pagination size in the registry config

 Now we:
- return tags in lexical order
- interpret the `last` parameter as the name of a tag in previous result page to indicate that there are more pages and to allow clients to continue to the next page beginning with the tag name non-inclusively 
- raise HTTP413 when too many tags are requested

A `Link` header with `rel="next"` is still always returned and is simply a pre-constructed URL to the next page leveraging the `n` and the `last` parameter. The `next_page` token isn't used anymore and this shouldn't break clients at all since they should have just extracted the URL to the next page from the `Link` header we've responded with so far.

This should make Quay comply to the recently revised tag pagination specification in OCI 1.0/1.1 and more compatible with existing clients out that haven't read the memo on the OCI update yet.
On the other hand it might break clients which relied on the behavior that you could stuff the `next_page` token into the `last` parameter and get pagination to work but from [what I've seen](https://github.com/regclient/regclient/pull/276) clients just parse the `Link` header for `rel="next"`.

There is a small wrinkle though: as per the OCI spec, a client is still allowed to request an arbitrarily high number of tags to be returned in a single API call, which we so far silently ignored and returned the configured maximum. Now we return an HTTP 413 response, which technically is against the spec but needed in order to protect the registry against rogue clients and also return a clear error signal instead of less tags than the client asked for, which in some implementations could be implemented as: no more tags here.