### PR TITLE
api: allow refining search with an organization (PROJQUAY-7244)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 venv
+.venv
 screenshots/screenshots/
 conf/stack
 */node_modules

--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -534,10 +534,10 @@ def _get_sorted_matching_repositories(
         )
 
         # If an organization/user was found and it was not blank.
-        if (user_name_value is not None) and (user_name_value != ""):
+        if user_name_value is not None and user_name_value != "":
             query = (
                 query.switch(Repository)
-                .join(Namespace, on=(Namespace.id == Repository.namespace_user))
+                .join(Namespace)
                 .where(Namespace.username == user_name_value)
             )
             is_namespace_table_joined = True
@@ -548,11 +548,8 @@ def _get_sorted_matching_repositories(
     if not include_private:
         query = query.where(Repository.visibility == _basequery.get_public_repo_visibility())
 
-    if not ids_only:
-        if not is_namespace_table_joined:
-            query = query.switch(Repository).join(
-                Namespace, on=(Namespace.id == Repository.namespace_user)
-            )
+    if not ids_only and not is_namespace_table_joined:
+        query = query.switch(Repository).join(Namespace)
 
     return query
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,7 +139,7 @@ Quay is covered by tests using various approaches. Read our [testing guide](/TES
 
 ## Contributing
 
-How great that you want to contribute to Quay! Before starting make sure to check our [contributing guidelines](.github/CONTRIBUTE.md).
+How great that you want to contribute to Quay! Before starting make sure to check our [contributing guidelines](../.github/CONTRIBUTING.md).
 
 # Using Quay
 


### PR DESCRIPTION
[Jira Ticket ](https://issues.redhat.com/browse/PROJQUAY-7244?orderby=priority+ASC%2C+updated+DESC) has more details

## Problem

It is currently not possible to search for repositories under a specific organization (e.g: fedora/python-311). The search only uses the `Repository.name` to do a search. 

## Change

Allow users to specify an organization in their search query

## Extra Changes

1. Added `.venv` to the `.gitignore`
2. Fixed the broken link to the `Contributing.md` document in the Getting Started guide

## Possible Issues

1. There are some repositories with `/` in their name on [quay.io](quay.io). One example would be `start/ingiress/controller`, where the org is `start` and the name is `ingress/controller`. If one were to search `ingress/controller` it would (with this change) not find the right repo. One would have to do `/ingress/controller` (test case provided). 

Disclaimer: I was not able to get the full local development environment setup to run the whole thing (node issues with podman), but the `make unit-test`   all passed on my machine


Edits:

1. I noticed that `buildah/stable` returns results, but I'm not sure why
