### PR TITLE
ci: update requests to fix failing build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,7 @@ recaptcha2==0.1
 redis==3.5.3
 redis-py-cluster==2.1.3
 rehash==1.0.1
-requests==2.31.0
+requests==2.32.2
 requests-aws4auth==1.2.3
 requests-file==1.5.1
 requests-oauthlib==1.3.1


### PR DESCRIPTION
CI is failing with the error:
`urllib3.exceptions.URLSchemeUnknown: Not supported URL scheme http+docker`

Resolving as stated [here](https://github.com/docker/docker-py/issues/3256)