### PR TITLE
ldap: allow global readonly superuser to be filtered (PROJQUAY-7044)

### DIFF
--- a/data/users/__init__.py
+++ b/data/users/__init__.py
@@ -69,6 +69,9 @@ def get_users_handler(config, _, override_config_dir, oauth_login):
         network_timeout = config.get("LDAP_NETWORK_TIMEOUT")
         ldap_user_filter = config.get("LDAP_USER_FILTER", None)
         ldap_superuser_filter = config.get("LDAP_SUPERUSER_FILTER", None)
+        ldap_global_readonly_superuser_filter = config.get(
+            "LDAP_GLOBAL_READONLY_SUPERUSER_FILTER", None
+        )
         ldap_restricted_user_filter = config.get("LDAP_RESTRICTED_USER_FILTER", None)
         ldap_referrals = int(config.get("LDAP_FOLLOW_REFERRALS", True))
 
@@ -89,6 +92,7 @@ def get_users_handler(config, _, override_config_dir, oauth_login):
             network_timeout=network_timeout,
             ldap_user_filter=ldap_user_filter,
             ldap_superuser_filter=ldap_superuser_filter,
+            ldap_global_readonly_superuser_filter=ldap_global_readonly_superuser_filter,
             ldap_restricted_user_filter=ldap_restricted_user_filter,
             ldap_referrals=ldap_referrals,
         )
@@ -362,6 +366,9 @@ class UserAuthentication(object):
     def is_superuser(self, username):
         return self.state.is_superuser(username)
 
+    def is_global_readonly_superuser(self, username):
+        return self.state.is_global_readonly_superuser(username)
+
     def has_superusers(self):
         return self.state.has_superusers()
 
@@ -437,4 +444,6 @@ class FederatedUserManager(ConfigUserManager):
         return self.federated_users.has_restricted_users() or super().has_restricted_users()
 
     def is_global_readonly_superuser(self, username: str) -> bool:
-        return super().is_global_readonly_superuser(username)
+        return self.federated_users.is_global_readonly_superuser(
+            username
+        ) or super().is_global_readonly_superuser(username)

--- a/data/users/apptoken.py
+++ b/data/users/apptoken.py
@@ -69,6 +69,9 @@ class AppTokenInternalAuth(object):
     def is_superuser(self, username):
         raise NotImplementedError()
 
+    def is_global_readonly_superuser(self, username):
+        raise NotImplementedError()
+
     def has_superusers(self):
         raise NotImplementedError()
 

--- a/data/users/database.py
+++ b/data/users/database.py
@@ -89,6 +89,9 @@ class DatabaseUsers(object):
     def is_superuser(self, username):
         raise NotImplementedError()
 
+    def is_global_readonly_superuser(self, username):
+        raise NotImplementedError()
+
     def has_superusers(self):
         raise NotImplementedError()
 

--- a/data/users/externaljwt.py
+++ b/data/users/externaljwt.py
@@ -152,6 +152,9 @@ class ExternalJWTAuthN(FederatedUsers):
     def is_superuser(self, username):
         raise NotImplementedError()
 
+    def is_global_readonly_superuser(self, username):
+        raise NotImplementedError()
+
     def has_superusers(self):
         raise NotImplementedError()
 

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -121,6 +121,7 @@ class LDAPUsers(FederatedUsers):
         force_no_pagination=False,
         ldap_user_filter=None,
         ldap_superuser_filter=None,
+        ldap_global_readonly_superuser_filter=None,
         ldap_restricted_user_filter=None,
         ldap_referrals=_DEFAULT_REFERRALS,
     ):
@@ -144,6 +145,7 @@ class LDAPUsers(FederatedUsers):
         self._force_no_pagination = force_no_pagination
         self._ldap_user_filter = ldap_user_filter
         self._ldap_superuser_filter = ldap_superuser_filter
+        self._ldap_global_readonly_superuser_filter = ldap_global_readonly_superuser_filter
         self._ldap_restricted_user_filter = ldap_restricted_user_filter
         self._ldap_referrals = int(ldap_referrals)
 
@@ -201,6 +203,10 @@ class LDAPUsers(FederatedUsers):
         assert self._ldap_superuser_filter
         return self._add_filter(query, self._ldap_superuser_filter)
 
+    def _add_global_readonly_superuser_filter(self, query):
+        assert self._ldap_global_readonly_superuser_filter
+        return self._add_filter(query, self._ldap_global_readonly_superuser_filter)
+
     def _add_restricted_user_filter(self, query):
         assert self._ldap_restricted_user_filter
         return self._add_filter(query, self._ldap_restricted_user_filter)
@@ -213,6 +219,7 @@ class LDAPUsers(FederatedUsers):
         suffix="",
         filter_superusers=False,
         filter_restricted_users=False,
+        filter_global_readonly_superusers=False,
     ):
         query = "(|({0}={2}{3})({1}={2}{3}))".format(
             self._uid_attr, self._email_attr, escape_filter_chars(username_or_email), suffix
@@ -231,6 +238,11 @@ class LDAPUsers(FederatedUsers):
                 return (None, "Superuser username not found")
 
             query = self._add_superuser_filter(query)
+        elif filter_global_readonly_superusers:
+            if not self._ldap_global_readonly_superuser_filter:
+                return (None, "Global readonly superuser username not found")
+
+            query = self._add_global_readonly_superuser_filter(query)
 
         logger.debug("Conducting user search: %s under %s", query, user_search_dn)
         try:
@@ -259,6 +271,7 @@ class LDAPUsers(FederatedUsers):
         suffix="",
         filter_superusers=False,
         filter_restricted_users=False,
+        filter_global_readonly_superusers=False,
     ):
         if not username_or_email:
             return (None, "Empty username/email")
@@ -282,6 +295,7 @@ class LDAPUsers(FederatedUsers):
                     suffix=suffix,
                     filter_superusers=filter_superusers,
                     filter_restricted_users=filter_restricted_users,
+                    filter_global_readonly_superusers=filter_global_readonly_superusers,
                 )
                 if pairs is not None and len(pairs) > 0:
                     break
@@ -299,12 +313,17 @@ class LDAPUsers(FederatedUsers):
             return (with_dns, None)
 
     def _ldap_single_user_search(
-        self, username_or_email, filter_superusers=False, filter_restricted_users=False
+        self,
+        username_or_email,
+        filter_superusers=False,
+        filter_restricted_users=False,
+        filter_global_readonly_superusers=False,
     ):
         with_dns, err_msg = self._ldap_user_search(
             username_or_email,
             filter_superusers=filter_superusers,
             filter_restricted_users=filter_restricted_users,
+            filter_global_readonly_superusers=filter_global_readonly_superusers,
         )
         if err_msg is not None:
             return (None, err_msg)
@@ -525,6 +544,27 @@ class LDAPUsers(FederatedUsers):
     def has_superusers(self) -> bool:
         has_superusers, _ = self.at_least_one_user_exists(filter_superusers=True)
         return has_superusers
+
+    def is_global_readonly_superuser(self, username_or_email: str) -> bool:
+        if not username_or_email:
+            return False
+
+        logger.debug(
+            "Looking up LDAP global readonly superuser username or email %s", username_or_email
+        )
+        (found_user, err_msg) = self._ldap_single_user_search(
+            username_or_email, filter_global_readonly_superusers=True
+        )
+        if found_user is None:
+            logger.debug(
+                "LDAP global readonly superuser %s not found: %s", username_or_email, err_msg
+            )
+            return False
+
+        logger.debug(
+            "Found global readonly superuser for LDAP username or email %s", username_or_email
+        )
+        return True
 
     def is_restricted_user(self, username_or_email: str) -> bool:
         if not username_or_email:

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -43,6 +43,12 @@ class OIDCUsers(FederatedUsers):
         """
         return None
 
+    def is_global_readonly_superuser(self, username: str):
+        """
+        Initiated from FederatedUserManager.is_global_readonly_superuser(), falls back to ConfigUserManager.is_global_readonly_superuser()
+        """
+        return None
+
     def iterate_group_members(self, group_lookup_args, page_size=None, disable_pagination=False):
         """
         Used by teamSync worker, unsupported for oidc team sync

--- a/data/users/federated.py
+++ b/data/users/federated.py
@@ -134,6 +134,9 @@ class FederatedUsers(object):
     def is_superuser(self, username):
         raise NotImplementedError()
 
+    def is_global_readonly_superuser(self, username):
+        raise NotImplementedError()
+
     def has_superusers(self):
         raise NotImplementedError()
 

--- a/data/users/keystone.py
+++ b/data/users/keystone.py
@@ -358,6 +358,9 @@ class KeystoneV3Users(FederatedUsers):
     def is_superuser(self, username):
         raise NotImplementedError()
 
+    def is_global_readonly_superuser(self, username):
+        raise NotImplementedError()
+
     def has_superusers(self, username):
         raise NotImplementedError()
 


### PR DESCRIPTION
Allows the global readonly superuser to be specified via a ldap filter `LDAP_GLOBAL_READONLY_SUPERUSER_FILTER`.