### PR TITLE
secscan: Fix Slack notification creation on initial index (PROJQUAY-7037)

### DIFF
--- a/config.py
+++ b/config.py
@@ -846,7 +846,7 @@ class DefaultConfig(ImmutableConfig):
 
     # Set minimal security level for new notifications on detected vulnerabilities. Avoids
     # creation of large number of notifications after first index. If not defined, defaults to "High".
-    NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX = ""
+    NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX = "High"
 
     FEATURE_SUPERUSERS_FULL_ACCESS = False
     FEATURE_SUPERUSERS_ORG_CREATION_ONLY = False

--- a/config.py
+++ b/config.py
@@ -844,6 +844,10 @@ class DefaultConfig(ImmutableConfig):
     # Feature Flag: Enables notifications about vulnerabilities to be sent for new pushes
     FEATURE_SECURITY_SCANNER_NOTIFY_ON_NEW_INDEX = True
 
+    # Set minimal security level for new notifications on detected vulnerabilities. Avoids
+    # creation of large number of notifications after first index. If not defined, defaults to "High".
+    NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX = ""
+
     FEATURE_SUPERUSERS_FULL_ACCESS = False
     FEATURE_SUPERUSERS_ORG_CREATION_ONLY = False
 

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -460,7 +460,6 @@ class V4SecurityScanner(SecurityScannerInterface):
                             if self.app.config.get("NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX")
                             else "High"
                         )
-                        logger.debug("Minimal level set: %s", level)
                         lowest_severity = PRIORITY_LEVELS[level]
 
                         if found_vulnerabilities is not None:
@@ -480,10 +479,6 @@ class V4SecurityScanner(SecurityScannerInterface):
                                 )
 
                                 if found_severity["score"] >= lowest_severity["score"]:
-                                    logger.debug(
-                                        "Found severity score of %s for vulnerability.",
-                                        found_severity["score"],
-                                    )
                                     tag_names = list(
                                         registry_model.tag_names_for_manifest(manifest, TAG_LIMIT)
                                     )

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -473,7 +473,6 @@ class V4SecurityScanner(SecurityScannerInterface):
                             for key in keys:
                                 vuln = found_vulnerabilities[key]
 
-                                # logger.debug("Found vulneraiblity %s", vuln)
                                 found_severity = PRIORITY_LEVELS.get(
                                     vuln["normalized_severity"], PRIORITY_LEVELS["Unknown"]
                                 )

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -1,7 +1,6 @@
 import itertools
 import logging
 import urllib
-
 from collections import namedtuple
 from datetime import datetime, timedelta
 from math import log10

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import urllib
+
 from collections import namedtuple
 from datetime import datetime, timedelta
 from math import log10
@@ -57,6 +58,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_SECURITY_SCANNER_V4_REINDEX_THRESHOLD = 86400  # 1 day
+TAG_LIMIT = 100
 
 IndexReportState = namedtuple("IndexReportState", ["Index_Finished", "Index_Error"])(  # type: ignore[call-arg]
     "IndexFinished", "IndexError"
@@ -450,27 +452,75 @@ class V4SecurityScanner(SecurityScannerInterface):
                         if vulnerability_report is not None:
                             found_vulnerabilities = vulnerability_report.get("vulnerabilities")
 
+                        # Current implementation creates events for all detected vulnerabilities, including vulnerabilities that are low
+                        # or unknown severity, which makes the whole thing a bit pointless. We'll filter out all vulnerabilities that aren't
+                        # high or critical.
+                        level = (
+                            self.app.config.get("NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX")
+                            if self.app.config.get("NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX")
+                            else "High"
+                        )
+                        logger.debug("Minimal level set: %s", level)
+                        lowest_severity = PRIORITY_LEVELS[level]
+
                         if found_vulnerabilities is not None:
                             import notifications
+
+                            logger.debug(
+                                "Attempting to create notifications for manifest %s", manifest
+                            )
 
                             keys = list(found_vulnerabilities)
                             for key in keys:
                                 vuln = found_vulnerabilities[key]
 
-                                event_data = {
-                                    "vulnerable_index_report_created": "true",
-                                    "vulnerability": {
-                                        "id": vuln["id"],
-                                        "description": vuln["description"],
-                                        "link": vuln["links"],
-                                        "priority": vuln["severity"],
-                                        "has_fix": bool(vuln["fixed_in_version"]),
-                                    },
-                                }
-
-                                notifications.spawn_notification(
-                                    manifest.repository, "vulnerability_found", event_data
+                                # logger.debug("Found vulneraiblity %s", vuln)
+                                found_severity = PRIORITY_LEVELS.get(
+                                    vuln["normalized_severity"], PRIORITY_LEVELS["Unknown"]
                                 )
+
+                                if found_severity["score"] >= lowest_severity["score"]:
+                                    logger.debug(
+                                        "Found severity score of %s for vulnerability.",
+                                        found_severity["score"],
+                                    )
+                                    tag_names = list(
+                                        registry_model.tag_names_for_manifest(manifest, TAG_LIMIT)
+                                    )
+                                    if tag_names:
+                                        event_data = {
+                                            "tags": list(tag_names),
+                                            "vulnerable_index_report_created": "true",
+                                            "vulnerability": {
+                                                "id": vuln["id"],
+                                                "description": vuln["description"],
+                                                "link": vuln["links"],
+                                                "priority": vuln["severity"],
+                                                "has_fix": bool(vuln["fixed_in_version"]),
+                                            },
+                                        }
+
+                                    else:
+                                        event_data = {
+                                            "tags": [
+                                                manifest.digest,
+                                            ],
+                                            "vulnerable_index_report_created": "true",
+                                            "vulnerability": {
+                                                "id": vuln["id"],
+                                                "description": vuln["description"],
+                                                "link": vuln["links"],
+                                                "priority": vuln["severity"],
+                                                "has_fix": bool(vuln["fixed_in_version"]),
+                                            },
+                                        }
+
+                                    logger.debug(
+                                        "Created notification with event_data: %s", event_data
+                                    )
+                                    notifications.spawn_notification(
+                                        manifest.repository, "vulnerability_found", event_data
+                                    )
 
             elif report["state"] == IndexReportState.Index_Error:
                 index_status = IndexStatus.FAILED

--- a/events/vulnerability_found.html
+++ b/events/vulnerability_found.html
@@ -1,7 +1,7 @@
 {% if event_data.vulnerabilities %}
 {{ event_data.vulnerabilities|length }} vulnerabilities were detected in tags
 {% else %}
-A <a href="{{ event_data.vulnerability.link }}">{{ event_data.vulnerability.priority }} vulnerability</a> ({{ event_data.vulnerability.id }}) was detected in tags
+A <a href="{{ event_data.vulnerability.link }}">{{ event_data.vulnerability.priority }} vulnerability</a> ({{ event_data.vulnerability.id }}) was detected in tags/manifests
 {% endif %}
  {{ 'tags' | icon_image }}
 {% for tag in event_data.tags[0:3] %}{%if loop.index > 1 %}, {% endif %}{{ (event_data.repository, tag) | repository_tag_reference }}{% endfor %} {% if event_data.tags|length > 3 %}(and {{ event_data.tags|length - 3 }} more) {% endif %} in

--- a/events/vulnerability_found.html
+++ b/events/vulnerability_found.html
@@ -6,3 +6,4 @@ A <a href="{{ event_data.vulnerability.link }}">{{ event_data.vulnerability.prio
  {{ 'tags' | icon_image }}
 {% for tag in event_data.tags[0:3] %}{%if loop.index > 1 %}, {% endif %}{{ (event_data.repository, tag) | repository_tag_reference }}{% endfor %} {% if event_data.tags|length > 3 %}(and {{ event_data.tags|length - 3 }} more) {% endif %} in
  repository {{ event_data.repository | repository_reference }}
+ 

--- a/events/vulnerability_found.html
+++ b/events/vulnerability_found.html
@@ -2,7 +2,7 @@
 {{ event_data.vulnerabilities|length }} vulnerabilities were detected in tags
 {% else %}
 A <a href="{{ event_data.vulnerability.link }}">{{ event_data.vulnerability.priority }} vulnerability</a> ({{ event_data.vulnerability.id }}) was detected in tags/manifests
- {% endif %}
-  {{ 'tags' | icon_image }}
- {% for tag in event_data.tags[0:3] %}{%if loop.index > 1 %}, {% endif %}{{ (event_data.repository, tag) | repository_tag_reference }}{% endfor %} {% if event_data.tags|length > 3 %}(and {{ event_data.tags|length - 3 }} more) {% endif %} in
-  repository {{ event_data.repository | repository_reference }}
+{% endif %}
+ {{ 'tags' | icon_image }}
+{% for tag in event_data.tags[0:3] %}{%if loop.index > 1 %}, {% endif %}{{ (event_data.repository, tag) | repository_tag_reference }}{% endfor %} {% if event_data.tags|length > 3 %}(and {{ event_data.tags|length - 3 }} more) {% endif %} in
+ repository {{ event_data.repository | repository_reference }}

--- a/events/vulnerability_found.html
+++ b/events/vulnerability_found.html
@@ -1,8 +1,8 @@
 {% if event_data.vulnerabilities %}
 {{ event_data.vulnerabilities|length }} vulnerabilities were detected in tags
 {% else %}
-A <a href="{{ event_data.vulnerability.link }}">{{ event_data.vulnerability.priority }} vulnerability</a> ({{ event_data.vulnerability.id }}) was detected in tags/manifests 
-{% endif %}
-{{ 'tags' | icon_image }}
-{% for tag in event_data.tags[0:3] %}{%if loop.index > 1 %}, {% endif %}{{ (event_data.repository, tag) | repository_tag_reference }}{% endfor %} {% if event_data.tags|length > 3 %}(and {{ event_data.tags|length - 3 }} more) {% endif %} in 
-repository {{ event_data.repository | repository_reference }}
+A <a href="{{ event_data.vulnerability.link }}">{{ event_data.vulnerability.priority }} vulnerability</a> ({{ event_data.vulnerability.id }}) was detected in tags/manifests
+ {% endif %}
+  {{ 'tags' | icon_image }}
+ {% for tag in event_data.tags[0:3] %}{%if loop.index > 1 %}, {% endif %}{{ (event_data.repository, tag) | repository_tag_reference }}{% endfor %} {% if event_data.tags|length > 3 %}(and {{ event_data.tags|length - 3 }} more) {% endif %} in
+  repository {{ event_data.repository | repository_reference }}

--- a/events/vulnerability_found.html
+++ b/events/vulnerability_found.html
@@ -1,9 +1,8 @@
 {% if event_data.vulnerabilities %}
 {{ event_data.vulnerabilities|length }} vulnerabilities were detected in tags
 {% else %}
-A <a href="{{ event_data.vulnerability.link }}">{{ event_data.vulnerability.priority }} vulnerability</a> ({{ event_data.vulnerability.id }}) was detected in tags/manifests
+A <a href="{{ event_data.vulnerability.link }}">{{ event_data.vulnerability.priority }} vulnerability</a> ({{ event_data.vulnerability.id }}) was detected in tags/manifests 
 {% endif %}
- {{ 'tags' | icon_image }}
-{% for tag in event_data.tags[0:3] %}{%if loop.index > 1 %}, {% endif %}{{ (event_data.repository, tag) | repository_tag_reference }}{% endfor %} {% if event_data.tags|length > 3 %}(and {{ event_data.tags|length - 3 }} more) {% endif %} in
- repository {{ event_data.repository | repository_reference }}
- 
+{{ 'tags' | icon_image }}
+{% for tag in event_data.tags[0:3] %}{%if loop.index > 1 %}, {% endif %}{{ (event_data.repository, tag) | repository_tag_reference }}{% endfor %} {% if event_data.tags|length > 3 %}(and {{ event_data.tags|length - 3 }} more) {% endif %} in 
+repository {{ event_data.repository | repository_reference }}

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1447,5 +1447,10 @@ CONFIG_SCHEMA = {
             "description": "Number of seconds to wait after a write operation in the UI",
             "x-example": 3,
         },
+        "NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX": {
+            "type": "string",
+            "description": "Set minimal security level for new notifications on detected vulnerabilities. Avoids creation of large number of notifications after first index.",
+            "x-example": "High",
+        },
     },
 }


### PR DESCRIPTION
This fixes the Slack and e-mail notifications when images are indexed on initial push, where `tags` information was missing. If an image is a manifest child, instead of the tag, we provide a full SHA digest to the client.

Also adds the ability to filter security vulnerabilites depending on their severity. If the `NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX` is not set in the `config.yaml` file, we will automatically create notifications only for vulnerabilities marked "high" or "critical". This variable can take values defined [here](https://github.com/quay/quay/blob/3248a72da68ee70f4bd2b00dd03adaf76719269c/util/secscan/__init__.py#L1).

Example:

```
NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX: Medium
```