### PR TITLE
storage(RadosGWStorage): add Region to RadosGWStorage for multi-zone setups (PROJQUAY-7300)

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -1012,6 +1012,7 @@ class RadosGWStorage(_CloudStorage):
         access_key,
         secret_key,
         bucket_name,
+        region_name=None,
         port=None,
         maximum_chunk_size_mb=None,
         server_side_assembly=True,
@@ -1023,6 +1024,7 @@ class RadosGWStorage(_CloudStorage):
                 connect_timeout=600 if not server_side_assembly else 60,
                 read_timeout=600 if not server_side_assembly else 60,
             ),
+            "region_name": region_name,
         }
 
         super(RadosGWStorage, self).__init__(


### PR DESCRIPTION
### Reason

Red Hat/IBM Ceph Storage provides multi-zone setups for on prem and geo-replication of Buckets. 

The RadosGWStorage Class in quay does not provide capability to configure `region_name` which is mandator for S3v4 signature in such scenarios. 


### Expectation and change description

The default behavior is not changed as boto3 anyway sets `us-east-1` as default region 

```

>>> import boto3

>>> client = boto3.client("s3", endpoint_url="https://s3.example.com", aws_access_key_id="user1", aws_secret_access_key="user1")

>>> boto3.set_stream_logger(name='botocore')

>>> client.list_buckets()

...

2024-06-10 06:42:41,550 botocore.hooks [DEBUG] Event request-created.s3.ListBuckets: calling handler <function add_retry_headers at 0x7fb041ca9820>

2024-06-10 06:42:41,550 botocore.endpoint [DEBUG] Sending http request: <AWSPreparedRequest stream_output=False, method=GET, url=https://s3.example.com/, headers={'User-Agent': b'Boto3/1.34.54 md/Botocore#1.34.54 ua/2.0 os/linux#5.14.0-362.24.2.el9_3.x86_64 md/arch#x86_64 lang/python#3.9.18 md/pyimpl#CPython cfg/retry-mode#legacy Botocore/1.34.54', 'X-Amz-Date': b'20240610T044241Z', 'X-Amz-Content-SHA256': b'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', 'Authorization': b'AWS4-HMAC-SHA256 Credential=user1/20240610/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=8470aac39171991fdd9296cdc239ef785bd9be8c9084a8adc08f49d75a47968a', 'amz-sdk-invocation-id': b'506a670b-f4e9-4cc9-be86-300c3bef38ea', 'amz-sdk-request': b'attempt=3; max=5'}>

```

The reason Red Hat/IBM Ceph storage accepts the region is that without Zones in RGW the  `default` configuration will accept all signatures in that regards.




By extending the RadosGWStorage with the `region_name` parameter we will be able to adjust the region and S3v4 signatures accordingly.




The change is minimal inversive as we only need to extend the Class initialization accepted parameters and hand it over to the `connect_kwargs` which are boto3's client/session parameters.

The region is called `region_name` which is the reason for the naming schema choosen.




### Documentation

It is expected that we update the Documentation of the RadosGWStorage class with `region_name` as optional parameter.