### PR TITLE
security: Add Vary header to 404 responses (PROJQUAY-7304)

### DIFF
--- a/util/http.py
+++ b/util/http.py
@@ -26,6 +26,7 @@ def _abort(status_code, data_object, description, headers):
     headers["Access-Control-Allow-Methods"] = options_resp.headers["allow"]
     headers["Access-Control-Max-Age"] = str(21600)
     headers["Access-Control-Allow-Headers"] = ["Authorization", "Content-Type"]
+    headers["Vary"] = "Origin"
 
     resp = make_response(json.dumps(data_object), status_code, headers)
 


### PR DESCRIPTION
Per recommendation from the W3C, we add `Vary: Origin` header to the 404 responses to instruct browsers (and other utilities) to cache various requests properly (based on their origin) in order to avoid cache poisoning. See the [W3C security details](https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-security) for more information.