### PR TITLE
api: OCI-compliant tag listing behavior with limit = 0 (PROJQUAY-7327)

### DIFF
--- a/endpoints/v2/__init__.py
+++ b/endpoints/v2/__init__.py
@@ -152,7 +152,7 @@ def oci_tag_paginate(
                 requested_limit = _MAX_RESULTS_PER_PAGE
                 last_tag_name = None
 
-            limit = max(min(requested_limit, _MAX_RESULTS_PER_PAGE), 1)
+            limit = max(min(requested_limit, _MAX_RESULTS_PER_PAGE), 0)
 
             if last_tag_name is not None:
                 last_tag_name = last_tag_name.strip()

--- a/endpoints/v2/tag.py
+++ b/endpoints/v2/tag.py
@@ -29,15 +29,22 @@ def list_all_tags(namespace_name, repo_name, last_pagination_tag_name, limit, pa
     if repository_ref is None:
         raise NameUnknown("repository not found")
 
-    tags, has_more = registry_model.lookup_cached_active_repository_tags(
-        model_cache, repository_ref, last_pagination_tag_name, limit
-    )
+    tags = []
+    has_more = False
+
+    if limit > 0:
+        tags, has_more = registry_model.lookup_cached_active_repository_tags(
+            model_cache, repository_ref, last_pagination_tag_name, limit
+        )
+
     response = jsonify(
         {
-            "name": "{0}/{1}".format(namespace_name, repo_name),
+            "name": f"{namespace_name}/{repo_name}",
             "tags": [tag.name for tag in tags][0:limit],
         }
     )
 
-    pagination_callback(tags, has_more, response)
+    if limit > 0:
+        pagination_callback(tags, has_more, response)
+
     return response

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -3,16 +3,6 @@ import binascii
 import hashlib
 import tarfile
 from io import BytesIO
-from test.fixtures import *
-from test.registry.fixtures import *
-from test.registry.liveserverfixture import *
-from test.registry.protocol_fixtures import *
-from test.registry.protocols import (
-    Failures,
-    Image,
-    ProtocolOptions,
-    layer_bytes_for_contents,
-)
 
 import bencode
 import rehash
@@ -26,6 +16,16 @@ from image.docker.schema2 import DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE
 from image.docker.schema2.list import DockerSchema2ManifestListBuilder
 from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
 from image.oci.index import OCIIndexBuilder
+from test.fixtures import *
+from test.registry.fixtures import *
+from test.registry.liveserverfixture import *
+from test.registry.protocol_fixtures import *
+from test.registry.protocols import (
+    Failures,
+    Image,
+    ProtocolOptions,
+    layer_bytes_for_contents,
+)
 from util.security.registry_jwt import decode_bearer_header
 from util.timedeltastring import convert_to_timedelta
 
@@ -1662,6 +1662,7 @@ def test_catalog_disabled_namespace(
 @pytest.mark.parametrize(
     "page_size",
     [
+        0,
         1,
         2,
         10,
@@ -1692,8 +1693,8 @@ def test_tags(
 
     repo_ref = registry_model.lookup_repository(namespace, repository)
     expected_tags = [tag.name for tag in registry_model.list_all_active_repository_tags(repo_ref)]
-    assert len(results) == len(expected_tags)
-    assert set([r for r in results]) == set(expected_tags)
+    assert len(results) == len(expected_tags) if page_size > 0 else len(results) == 0
+    assert set([r for r in results]) == set(expected_tags) if page_size > 0 else len(results) == 0
 
     # Invoke the tags endpoint again to ensure caching works.
     results = v2_protocol.tags(
@@ -1703,8 +1704,8 @@ def test_tags(
         namespace=namespace,
         repo_name=repository,
     )
-    assert len(results) == len(expected_tags)
-    assert set([r for r in results]) == set(expected_tags)
+    assert len(results) == len(expected_tags) if page_size > 0 else len(results) == 0
+    assert set([r for r in results]) == set(expected_tags) if page_size > 0 else len(results) == 0
 
 
 def test_tags_disabled_namespace(
@@ -1960,15 +1961,17 @@ def test_login(
             "devtable",
             "password",
             ["repository:someinvalid/devtable/simple:pull"],
-            []
-            if not original_app.config["FEATURE_EXTENDED_REPOSITORY_NAMES"]
-            else [
-                {
-                    "type": "repository",
-                    "name": "someinvalid/devtable/simple",
-                    "actions": [],
-                },
-            ],
+            (
+                []
+                if not original_app.config["FEATURE_EXTENDED_REPOSITORY_NAMES"]
+                else [
+                    {
+                        "type": "repository",
+                        "name": "someinvalid/devtable/simple",
+                        "actions": [],
+                    },
+                ]
+            ),
             False if not original_app.config["FEATURE_EXTENDED_REPOSITORY_NAMES"] else True,
         ),
         # Pull with no access.


### PR DESCRIPTION
This corrects the behavior when requesting a list of tags with a an `n` parameter set to 0. Whereas before at least one tag was returned, now, an empty list is returned.

Signed-off-by: dmesser <dmesser@redhat.com>