### PR TITLE
storage: use managed copy for single chunk uploads (PROJQUAY-7328)

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -670,10 +670,12 @@ class _CloudStorage(BaseStorageV2):
                     # copy of 5GB (for S3) chunks in the next block
 
                     chunk_path = self._init_path(chunk_list[0].path)
-                    self.get_cloud_conn().copy(
+
+                    self._perform_action_with_retry(
+                        self.get_cloud_conn().copy,
                         CopySource={"Bucket": self.get_cloud_bucket().name, "Key": chunk_path},
                         Bucket=self.get_cloud_bucket().name,
-                        Key=final_path,
+                        Key=self._init_path(final_path),
                     )
 
                     return

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -673,7 +673,8 @@ class _CloudStorage(BaseStorageV2):
                     self.get_cloud_conn().copy(
                         CopySource={"Bucket": self.get_cloud_bucket().name, "Key": chunk_path},
                         Bucket=self.get_cloud_bucket().name,
-                        Key=final_path)
+                        Key=final_path,
+                    )
 
                     return
 


### PR DESCRIPTION
We do a multi-part copy from the staging location to the final blob location in 5GB chunks sequentially. For large layers this is extremely slow. Use managed `copy` to move the blob to the final location faster