### PR TITLE
database: adding subject_backfilled index to manifest table (PROJQUAY-7360)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -1730,7 +1730,7 @@ class Manifest(BaseModel):
     config_media_type = CharField(null=True)
     layers_compressed_size = BigIntegerField(null=True)
     subject = CharField(null=True)
-    subject_backfilled = BooleanField(default=False)
+    subject_backfilled = BooleanField(default=False, index=True)
 
     class Meta:
         database = db

--- a/data/migrations/versions/0cdd1f27a450_add_subject_backfilled_index.py
+++ b/data/migrations/versions/0cdd1f27a450_add_subject_backfilled_index.py
@@ -1,0 +1,31 @@
+"""add subject backfilled index
+
+Revision ID: 0cdd1f27a450
+Revises: 946f0e90f9c9
+Create Date: 2024-06-21 11:49:00.173665
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "0cdd1f27a450"
+down_revision = "946f0e90f9c9"
+
+import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
+
+
+def upgrade(op, tables, tester):
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    manifest_indexes = inspector.get_indexes("manifest")
+    if not "manifest_subject_backfilled" in [i["name"] for i in manifest_indexes]:
+        op.create_index(
+            "manifest_subject_backfilled",
+            "manifest",
+            ["subject_backfilled"],
+            unique=False,
+        )
+
+
+def downgrade(op, tables, tester):
+    op.drop_index("manifest_subject_backfilled", table_name="manifest")

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -365,6 +365,7 @@ DROP INDEX IF EXISTS public.manifestblob_repository_id;
 DROP INDEX IF EXISTS public.manifestblob_manifest_id_blob_id;
 DROP INDEX IF EXISTS public.manifestblob_manifest_id;
 DROP INDEX IF EXISTS public.manifestblob_blob_id;
+DROP INDEX IF EXISTS public.manifest_subject_backfilled;
 DROP INDEX IF EXISTS public.manifest_repository_id_subject;
 DROP INDEX IF EXISTS public.manifest_repository_id_media_type_id;
 DROP INDEX IF EXISTS public.manifest_repository_id_digest;
@@ -5626,7 +5627,7 @@ COPY public.accesstokenkind (id, name) FROM stdin;
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-946f0e90f9c9
+0cdd1f27a450
 \.
 
 
@@ -10321,6 +10322,13 @@ CREATE INDEX manifest_repository_id_media_type_id ON public.manifest USING btree
 --
 
 CREATE INDEX manifest_repository_id_subject ON public.manifest USING btree (repository_id, subject);
+
+
+--
+-- Name: manifest_subject_backfilled; Type: INDEX; Schema: public; Owner: quay
+--
+
+CREATE INDEX manifest_subject_backfilled ON public.manifest USING btree (subject_backfilled);
 
 
 --


### PR DESCRIPTION
Adds the `manifest_repository_id_subject_backfilled` to the manifest table to improve lookup of manifests that require subject backfill.