### PR TITLE
metrics: add metrics for registry, namespace and repo sizes plus quota-related information (PROJQUAY-6560)

### DIFF
--- a/config.py
+++ b/config.py
@@ -824,8 +824,12 @@ class DefaultConfig(ImmutableConfig):
     # deployment to complete. Defaults to 30m.
     QUOTA_TOTAL_DELAY_SECONDS = 60 * 30
 
-    # Enables the quota backfill worker
+    # Enables the quota backfill worker.
     QUOTA_BACKFILL = True
+
+    # Enables exposing quota metrics for the registry, organizations and repositories
+    # Beware of high cardinality if there are many organizations and repositories.
+    QUOTA_METRICS = False
 
     # Feature Flag: Enables Quay to act as a pull through cache for upstream registries
     FEATURE_PROXY_CACHE = False

--- a/data/model/namespacequota.py
+++ b/data/model/namespacequota.py
@@ -137,6 +137,16 @@ def get_namespace_quota_limit(quota, limit_id):
         return None
 
 
+def get_namespaces_with_quotas():
+    namespaces_with_quotas = (
+        UserOrganizationQuota.select(User.id, User.username, UserOrganizationQuota.limit_bytes)
+        .join(User)
+        .dicts()
+    )
+
+    return list(namespaces_with_quotas)
+
+
 def create_namespace_quota_limit(quota, quota_type, percent_of_limit):
     if not percent_of_limit > 0 or not percent_of_limit <= 100:
         raise InvalidNamespaceQuotaLimit("Quota limit threshold must be between 1 and 100")

--- a/data/model/quota.py
+++ b/data/model/quota.py
@@ -264,6 +264,22 @@ def get_namespace_size(namespace_id: int):
         return None
 
 
+def get_all_namespace_sizes() -> List[Dict[str, int]]:
+    namespaces_with_sizes = (
+        User.select(
+            User.id,
+            User.username,
+            User.organization,
+            QuotaNamespaceSize.size_bytes,
+            can_use_read_replica=True,
+        )
+        .join(QuotaNamespaceSize)
+        .dicts()
+    )
+
+    return namespaces_with_sizes
+
+
 def get_repository_size(repository_id: int):
     try:
         repository_size = (
@@ -274,6 +290,23 @@ def get_repository_size(repository_id: int):
         return repository_size
     except QuotaRepositorySize.DoesNotExist:
         return None
+
+
+def get_all_repository_sizes() -> List[Dict[str, int]]:
+    repositories_with_sizes = (
+        Repository.select(
+            Repository.id,
+            Repository.name,
+            User.username.alias("namespace"),
+            QuotaRepositorySize.size_bytes,
+            can_use_read_replica=True,
+        )
+        .join(User)
+        .join(QuotaRepositorySize, on=(Repository.id == QuotaRepositorySize.repository))
+        .dicts()
+    )
+
+    return repositories_with_sizes
 
 
 def only_manifest_in_namespace(namespace_id: int, manifest_id: int):

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1387,6 +1387,11 @@ CONFIG_SCHEMA = {
             "description": "The amount of time between runs of the quota registry size worker in seconds",
             "x-example": 30,
         },
+        "QUOTA_METRICS": {
+            "type": "boolean",
+            "description": "Whether quota metrics are exposed about total registry storage consumption, organization and repository usage and organization quota limits and attainment. Defaults to False",
+            "x-example": False,
+        },
         "FEATURE_EDIT_QUOTA": {
             "type": "boolean",
             "description": "Allow editing of quota configurations",

--- a/workers/globalpromstats/globalpromstats.py
+++ b/workers/globalpromstats/globalpromstats.py
@@ -114,7 +114,7 @@ def populate_registry_size_stats():
     registry_size = model.quota.get_registry_size()
 
     if registry_size is not None:
-        registry_total_used_bytes.set(registry_size.size_bytes)
+        registry_total_used_bytes.set(registry_size["size_bytes"])
 
 
 class GlobalPrometheusStatsWorker(Worker):

--- a/workers/globalpromstats/globalpromstats.py
+++ b/workers/globalpromstats/globalpromstats.py
@@ -114,7 +114,7 @@ def populate_registry_size_stats():
     registry_size = model.quota.get_registry_size()
 
     if registry_size is not None:
-        registry_total_used_bytes.set(registry_size)
+        registry_total_used_bytes.set(registry_size.size_bytes)
 
 
 class GlobalPrometheusStatsWorker(Worker):

--- a/workers/globalpromstats/globalpromstats.py
+++ b/workers/globalpromstats/globalpromstats.py
@@ -13,8 +13,6 @@ from workers.worker import Worker
 
 logger = logging.getLogger(__name__)
 
-GlobalLock.configure(app.config)
-
 repository_rows = Gauge("quay_repository_rows", "number of repositories in the database")
 user_rows = Gauge("quay_user_rows", "number of users in the database")
 org_rows = Gauge("quay_org_rows", "number of organizations in the database")
@@ -145,8 +143,8 @@ class GlobalPrometheusStatsWorker(Worker):
         try:
             with GlobalLock("GLOBAL_PROM_STATS"):
                 self._report_stats()
-        except LockNotAcquiredException as e:
-            logger.debug("Could not acquire global lock for global prometheus stats: " + str(e))
+        except LockNotAcquiredException:
+            logger.debug("Could not acquire global lock for global prometheus stats")
 
     def _report_stats(self):
         logger.debug("Reporting global stats")

--- a/workers/globalpromstats/globalpromstats.py
+++ b/workers/globalpromstats/globalpromstats.py
@@ -114,7 +114,7 @@ def populate_registry_size_stats():
     registry_size = model.quota.get_registry_size()
 
     if registry_size is not None:
-        registry_total_used_bytes.set(registry_size["size_bytes"])
+        registry_total_used_bytes.set(registry_size.size_bytes)
 
 
 class GlobalPrometheusStatsWorker(Worker):

--- a/workers/globalpromstats/globalpromstats.py
+++ b/workers/globalpromstats/globalpromstats.py
@@ -13,13 +13,40 @@ from workers.worker import Worker
 
 logger = logging.getLogger(__name__)
 
+GlobalLock.configure(app.config)
+
 repository_rows = Gauge("quay_repository_rows", "number of repositories in the database")
 user_rows = Gauge("quay_user_rows", "number of users in the database")
 org_rows = Gauge("quay_org_rows", "number of organizations in the database")
 robot_rows = Gauge("quay_robot_rows", "number of robot accounts in the database")
+registry_total_used_bytes = Gauge(
+    "registry_total_used_bytes",
+    "Storage consumption in bytes for the entire registry",
+)
+namespace_stats_used_bytes = Gauge(
+    "namespace_stats_used_bytes",
+    "Storage consumption in bytes per namespace",
+    labelnames=["namespace", "entity_type"],
+)
+repository_stats_used_bytes = Gauge(
+    "repository_stats_used_bytes",
+    "Storage consumption in bytes per repository",
+    labelnames=["repository", "namespace"],
+)
+namespace_quota_stats_capacity_bytes = Gauge(
+    "namespace_quota_stats_capacity_bytes",
+    "Storage quota in bytes per namespace",
+    labelnames=["namespace", "entity_type"],
+)
+namespace_quota_stats_available_bytes = Gauge(
+    "namespace_quota_stats_available_bytes",
+    "Remaining storage capacity per quota in bytes per namespace",
+    labelnames=["namespace", "entity_type"],
+)
 
 
 WORKER_FREQUENCY = app.config.get("GLOBAL_PROMETHEUS_STATS_FREQUENCY", 60 * 60)
+QUOTA_METRICS = app.config.get("QUOTA_METRICS", False)
 
 
 def get_repository_count():
@@ -38,6 +65,71 @@ def get_robot_count():
     return model.user.get_estimated_robot_count()
 
 
+def populate_namespace_quota_stats():
+    namespaces = model.quota.get_all_namespace_sizes()
+    namespace_quotas = model.namespacequota.get_namespaces_with_quotas()
+
+    for namespace in namespaces:
+        namespace_id = namespace["id"]
+        namespace_name = namespace["username"]
+        namespace_entity_type = "organization" if namespace["organization"] else "user"
+        namespace_used_bytes = namespace["size_bytes"]
+
+        namespace_stats_used_bytes.labels(
+            namespace=namespace_name, entity_type=namespace_entity_type
+        ).set(namespace_used_bytes)
+
+        namespace_quota = next(
+            (quota for quota in namespace_quotas if quota["id"] == namespace_id), None
+        )
+
+        if namespace_quota is not None:
+            namespace_capacity = namespace_quota["limit_bytes"]
+            namespace_available = (
+                0
+                if namespace_capacity < namespace_used_bytes
+                else namespace_capacity - namespace_used_bytes
+            )
+
+            namespace_quota_stats_capacity_bytes.labels(
+                namespace=namespace_name, entity_type=namespace_entity_type
+            ).set(namespace_capacity)
+            namespace_quota_stats_available_bytes.labels(
+                namespace=namespace_name, entity_type=namespace_entity_type
+            ).set(namespace_available)
+
+        logger.debug(
+            "Emitting namespace stats for %s with sitze %s", namespace_name, namespace_used_bytes
+        )
+
+
+def populate_repo_quota_stats():
+    repositories = model.quota.get_all_repository_sizes()
+
+    for repository in repositories:
+        repository_name = repository["name"]
+        repository_namespace = repository["namespace"]
+        repository_used_bytes = repository["size_bytes"]
+
+        repository_stats_used_bytes.labels(
+            repository=repository_name, namespace=repository_namespace
+        ).set(repository_used_bytes)
+
+        logger.debug(
+            "Emitting repo stats for %s/%s with size %s",
+            repository_namespace,
+            repository_name,
+            repository_used_bytes,
+        )
+
+
+def populate_registry_size_stats():
+    registry_size = model.quota.get_registry_size()
+
+    if registry_size is not None:
+        registry_total_used_bytes.set(registry_size)
+
+
 class GlobalPrometheusStatsWorker(Worker):
     """
     Worker which reports global stats (# of users, orgs, repos, etc) to Prometheus periodically.
@@ -53,8 +145,8 @@ class GlobalPrometheusStatsWorker(Worker):
         try:
             with GlobalLock("GLOBAL_PROM_STATS"):
                 self._report_stats()
-        except LockNotAcquiredException:
-            logger.debug("Could not acquire global lock for global prometheus stats")
+        except LockNotAcquiredException as e:
+            logger.debug("Could not acquire global lock for global prometheus stats: " + str(e))
 
     def _report_stats(self):
         logger.debug("Reporting global stats")
@@ -63,6 +155,12 @@ class GlobalPrometheusStatsWorker(Worker):
             user_rows.set(get_active_user_count())
             org_rows.set(get_active_org_count())
             robot_rows.set(get_robot_count())
+
+            if QUOTA_METRICS:
+                logger.debug("Reporting quota stats")
+                populate_namespace_quota_stats()
+                populate_repo_quota_stats()
+                populate_registry_size_stats()
 
 
 def create_gunicorn_worker():

--- a/workers/globalpromstats/globalpromstats.py
+++ b/workers/globalpromstats/globalpromstats.py
@@ -96,10 +96,6 @@ def populate_namespace_quota_stats():
                 namespace=namespace_name, entity_type=namespace_entity_type
             ).set(namespace_available)
 
-        logger.debug(
-            "Emitting namespace stats for %s with sitze %s", namespace_name, namespace_used_bytes
-        )
-
 
 def populate_repo_quota_stats():
     repositories = model.quota.get_all_repository_sizes()
@@ -112,13 +108,6 @@ def populate_repo_quota_stats():
         repository_stats_used_bytes.labels(
             repository=repository_name, namespace=repository_namespace
         ).set(repository_used_bytes)
-
-        logger.debug(
-            "Emitting repo stats for %s/%s with size %s",
-            repository_namespace,
-            repository_name,
-            repository_used_bytes,
-        )
 
 
 def populate_registry_size_stats():

--- a/workers/globalpromstats/test/test_globalpromstats.py
+++ b/workers/globalpromstats/test/test_globalpromstats.py
@@ -23,7 +23,8 @@ class TestGlobalPrometheusStatsWorker(unittest.TestCase):
         return_value=2,
     )
     @patch(
-        "workers.globalpromstats.globalpromstats.model.quota.get_registry_size", return_value=100000
+        "workers.globalpromstats.globalpromstats.model.quota.get_registry_size",
+        return_value={"id": "1", "queued": False, "running": False, "size_bytes": 100000},
     )
     @patch(
         "workers.globalpromstats.globalpromstats.model.quota.get_all_namespace_sizes",

--- a/workers/globalpromstats/test/test_globalpromstats.py
+++ b/workers/globalpromstats/test/test_globalpromstats.py
@@ -6,7 +6,7 @@ from prometheus_client import REGISTRY
 
 from workers.globalpromstats.globalpromstats import GlobalPrometheusStatsWorker
 
-MockRegistrySize = namedtuple("RegistrySize", ["id", "queued", "running", "size_bytes"])
+MockRegistrySize = namedtuple("MockRegistrySize", ["id", "queued", "running", "size_bytes"])
 
 
 class TestGlobalPrometheusStatsWorker(unittest.TestCase):

--- a/workers/globalpromstats/test/test_globalpromstats.py
+++ b/workers/globalpromstats/test/test_globalpromstats.py
@@ -1,8 +1,132 @@
-from test.fixtures import *
+import unittest
+from unittest.mock import patch
+
+from prometheus_client import REGISTRY
 
 from workers.globalpromstats.globalpromstats import GlobalPrometheusStatsWorker
 
 
-def test_globalpromstats(initialized_db):
-    worker = GlobalPrometheusStatsWorker()
-    worker._report_stats()
+class TestGlobalPrometheusStatsWorker(unittest.TestCase):
+    @patch(
+        "workers.globalpromstats.globalpromstats.model.repository.get_estimated_repository_count",
+        return_value=10,
+    )
+    @patch(
+        "workers.globalpromstats.globalpromstats.model.user.get_active_user_count", return_value=20
+    )
+    @patch(
+        "workers.globalpromstats.globalpromstats.model.organization.get_active_org_count",
+        return_value=5,
+    )
+    @patch(
+        "workers.globalpromstats.globalpromstats.model.user.get_estimated_robot_count",
+        return_value=2,
+    )
+    @patch(
+        "workers.globalpromstats.globalpromstats.model.quota.get_registry_size", return_value=100000
+    )
+    @patch(
+        "workers.globalpromstats.globalpromstats.model.quota.get_all_namespace_sizes",
+        return_value=[
+            {"id": "1", "username": "test_org1", "organization": False, "size_bytes": 1000},
+            {"id": "2", "username": "test_org2", "organization": True, "size_bytes": 2000},
+            {"id": "3", "username": "test_org3", "organization": True, "size_bytes": 3000},
+        ],
+    )
+    @patch(
+        "workers.globalpromstats.globalpromstats.model.quota.get_all_repository_sizes",
+        return_value=[
+            {"id": "4", "name": "repo1", "namespace": "test_org1", "size_bytes": 4000},
+            {"id": "5", "name": "repo2", "namespace": "test_org2", "size_bytes": 5000},
+            {"id": "6", "name": "repo3", "namespace": "test_org3", "size_bytes": 6000},
+        ],
+    )
+    @patch(
+        "workers.globalpromstats.globalpromstats.model.namespacequota.get_namespaces_with_quotas",
+        return_value=[
+            {"id": "1", "username": "test_org1", "limit_bytes": 10000},
+            {"id": "3", "username": "test_org3", "limit_bytes": 20000},
+        ],
+    )
+    def test_report_stats(
+        self,
+        mock_get_registry_size,
+        mock_get_all_repository_sizes,
+        mock_get_namespaces_with_quotas,
+        mock_get_all_namespace_sizes,
+        mock_get_estimated_robot_count,
+        mock_get_active_org_count,
+        mock_get_active_user_count,
+        mock_get_estimated_repository_count,
+    ):
+        with patch("workers.globalpromstats.globalpromstats.QUOTA_METRICS", True):
+            worker = GlobalPrometheusStatsWorker()
+            worker._report_stats()
+
+            self.assertEqual(REGISTRY.get_sample_value("quay_repository_rows"), 10)
+            self.assertEqual(REGISTRY.get_sample_value("quay_user_rows"), 20)
+            self.assertEqual(REGISTRY.get_sample_value("quay_org_rows"), 5)
+            self.assertEqual(REGISTRY.get_sample_value("quay_robot_rows"), 2)
+            self.assertEqual(REGISTRY.get_sample_value("registry_total_used_bytes"), 100000)
+
+            # used org bytes calculation
+            org1_used_bytes = REGISTRY.get_sample_value(
+                "namespace_stats_used_bytes", {"namespace": "test_org1", "entity_type": "user"}
+            )
+            self.assertEqual(org1_used_bytes, 1000)
+
+            org2_used_bytes = REGISTRY.get_sample_value(
+                "namespace_stats_used_bytes",
+                {"namespace": "test_org2", "entity_type": "organization"},
+            )
+            self.assertEqual(org2_used_bytes, 2000)
+
+            org3_used_bytes = REGISTRY.get_sample_value(
+                "namespace_stats_used_bytes",
+                {"namespace": "test_org2", "entity_type": "organization"},
+            )
+            self.assertEqual(org3_used_bytes, 2000)
+
+            # used repo bytes calculation
+            repo1_used_bytes = REGISTRY.get_sample_value(
+                "repository_stats_used_bytes",
+                {"repository": "repo1", "namespace": "test_org1"},
+            )
+            self.assertEqual(repo1_used_bytes, 4000)
+
+            repo2_used_bytes = REGISTRY.get_sample_value(
+                "repository_stats_used_bytes",
+                {"repository": "repo2", "namespace": "test_org2"},
+            )
+            self.assertEqual(repo2_used_bytes, 5000)
+
+            repo3_used_bytes = REGISTRY.get_sample_value(
+                "repository_stats_used_bytes",
+                {"repository": "repo3", "namespace": "test_org3"},
+            )
+            self.assertEqual(repo3_used_bytes, 6000)
+
+            # quota stats
+            org1_capacity_bytes = REGISTRY.get_sample_value(
+                "namespace_quota_stats_capacity_bytes",
+                {"namespace": "test_org1", "entity_type": "user"},
+            )
+            self.assertEqual(org1_capacity_bytes, 10000)
+
+            org3_capacity_bytes = REGISTRY.get_sample_value(
+                "namespace_quota_stats_capacity_bytes",
+                {"namespace": "test_org3", "entity_type": "organization"},
+            )
+            self.assertEqual(org3_capacity_bytes, 20000)
+
+            org1_available_bytes = REGISTRY.get_sample_value(
+                "namespace_quota_stats_available_bytes",
+                {"namespace": "test_org1", "entity_type": "user"},
+            )
+            self.assertEqual(org1_available_bytes, 10000 - 1000)
+
+            org3_available_bytes = REGISTRY.get_sample_value(
+                "namespace_quota_stats_available_bytes",
+                {"namespace": "test_org3", "entity_type": "organization"},
+            )
+            self.assertEqual(org3_available_bytes, 20000 - 3000)

--- a/workers/globalpromstats/test/test_globalpromstats.py
+++ b/workers/globalpromstats/test/test_globalpromstats.py
@@ -1,9 +1,12 @@
 import unittest
+from collections import namedtuple
 from unittest.mock import patch
 
 from prometheus_client import REGISTRY
 
 from workers.globalpromstats.globalpromstats import GlobalPrometheusStatsWorker
+
+MockRegistrySize = namedtuple("RegistrySize", ["id", "queued", "running", "size_bytes"])
 
 
 class TestGlobalPrometheusStatsWorker(unittest.TestCase):
@@ -24,7 +27,7 @@ class TestGlobalPrometheusStatsWorker(unittest.TestCase):
     )
     @patch(
         "workers.globalpromstats.globalpromstats.model.quota.get_registry_size",
-        return_value={"id": "1", "queued": False, "running": False, "size_bytes": 100000},
+        return_value=MockRegistrySize("1", False, False, 100000),
     )
     @patch(
         "workers.globalpromstats.globalpromstats.model.quota.get_all_namespace_sizes",


### PR DESCRIPTION
This adds the following metrics related to the quota system:

- `namespace_stats_used_bytes` - Storage consumption in bytes per namespace (labels for namespace and entity type (whether it's an "organization" or a "user"))
- `namespace_quota_stats_capacity_bytes` - Storage quota in bytes per namespace, if defined (labels for namespace and entity type)
- `namespace_quota_stats_available_bytes` - Remaining storage capacity per quota in bytes per namespace, if quota exists (labels for namespace and entity type)
- `repository_stats_used_bytes` - Storage consumption in bytes per repository (labels for repository name and parent namespace)
- `registry_total_used_bytes` - Storage consumption in bytes for the entire registry

It also introduces a new config tunable called `QUOTA_METRICS`, which is `False` by default. Only if it's true will the above metrics be emitted. `GLOBAL_PROMETHEUS_STATS_FREQUENCY` is used to control how often the metrics are refreshed; the default is 1 hour. 
The default values for both settings are due to the potential performance impact on the database for very large installs with thousands of orgs and tens of thousands of repositories. These environments may lead to high cardinality on the Prometheus side too.