### PR TITLE
ui: adjust large legends for usage logs (PROJQUAY-7384)

### DIFF
--- a/web/src/routes/UsageLogs/UsageLogsGraph.tsx
+++ b/web/src/routes/UsageLogs/UsageLogsGraph.tsx
@@ -91,13 +91,15 @@ export default function UsageLogsGraph(props: UsageLogsGraphProps) {
             x: [new Date(props.starttime), new Date(props.endtime)],
             y: [0, maxRange],
           }}
-          legendOrientation="vertical"
-          legendPosition="right"
+          legendOrientation={
+            getLegendData().length >= 12 ? 'horizontal' : 'vertical'
+          }
+          legendPosition={getLegendData().length >= 12 ? 'bottom' : 'right'}
           legendData={getLegendData()}
           legendAllowWrap
           name="usage-logs-graph"
           padding={{
-            bottom: 50,
+            bottom: 10 * getLegendData().length,
             left: 80,
             right: 500, // Adjusted to accommodate legend
             top: 50,


### PR DESCRIPTION
![Screenshot 2024-06-25 at 11 20 37 AM](https://github.com/quay/quay/assets/47163063/6ffb99ae-c3b3-428b-b7db-d223080bca5d)

Adjust legend position and orientation if the amount of log kinds for the legend exceeds 12. Fixes issue where some operation types did not show on the legend.