### PR TITLE
chore: don't create supervisord.log

### DIFF
--- a/conf/supervisord.conf.jnj
+++ b/conf/supervisord.conf.jnj
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
 
 [unix_http_server]
 file=%(ENV_QUAYRUN)s/supervisord.sock


### PR DESCRIPTION
We don't need this file, as all log messages are printed to stdout.