### PR TITLE
oauth: adding check for assignment uuid when creating token (PROJQUAY-7457)

### DIFF
--- a/templates/oauthorize.html
+++ b/templates/oauthorize.html
@@ -109,7 +109,9 @@
             <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
             <input type="hidden" name="scope" value="{{ scope }}">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token_val }}">
+            {% if assignment_uuid %}
             <input type="hidden" name="assignment_uuid" value="{{ assignment_uuid }}">
+            {% endif %}
             <button type="submit" class="btn btn-success">Authorize Application</button>
           </form>
           <form method="post" action="/oauth/denyapp" style="display: inline-block">


### PR DESCRIPTION
Adding check for `assignment_uuid`, otherwise sends value to API as the string `'None'` and breaks.