### PR TITLE
mirror: increase char length in repo mirror config for externalregistrypassword (PROJQUAY-7430)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -1910,10 +1910,10 @@ class RepoMirrorConfig(BaseModel):
     )
     external_reference = CharField()
     external_registry_username = EncryptedCharField(max_length=4096, null=True)
-    external_registry_password = EncryptedCharField(max_length=9000, null=True) 
+    external_registry_password = EncryptedCharField(max_length=9000, null=True)
     external_registry_config = JSONField(default={})
 
-    # Worker Queuing
+    # Worker Queuingg
     sync_interval = IntegerField()  # seconds between syncs
     sync_start_date = DateTimeField(null=True)  # next start time
     sync_expiration_date = DateTimeField(null=True)  # max duration

--- a/data/database.py
+++ b/data/database.py
@@ -1910,7 +1910,7 @@ class RepoMirrorConfig(BaseModel):
     )
     external_reference = CharField()
     external_registry_username = EncryptedCharField(max_length=4096, null=True)
-    external_registry_password = EncryptedCharField(max_length=4096, null=True)
+    external_registry_password = EncryptedCharField(max_length=9000, null=True)
     external_registry_config = JSONField(default={})
 
     # Worker Queuing

--- a/data/database.py
+++ b/data/database.py
@@ -1910,7 +1910,7 @@ class RepoMirrorConfig(BaseModel):
     )
     external_reference = CharField()
     external_registry_username = EncryptedCharField(max_length=4096, null=True)
-    external_registry_password = EncryptedCharField(max_length=9000, null=True)
+    external_registry_password = EncryptedCharField(max_length=9000, null=True) #madechanges here
     external_registry_config = JSONField(default={})
 
     # Worker Queuing

--- a/data/database.py
+++ b/data/database.py
@@ -1910,7 +1910,7 @@ class RepoMirrorConfig(BaseModel):
     )
     external_reference = CharField()
     external_registry_username = EncryptedCharField(max_length=4096, null=True)
-    external_registry_password = EncryptedCharField(max_length=9000, null=True) #madechanges here
+    external_registry_password = EncryptedCharField(max_length=9000, null=True) 
     external_registry_config = JSONField(default={})
 
     # Worker Queuing

--- a/data/migrations/versions/a32e17bfad20_increase_upstreamregistry_s_password_.py
+++ b/data/migrations/versions/a32e17bfad20_increase_upstreamregistry_s_password_.py
@@ -17,7 +17,7 @@ def upgrade(op, tables, tester):
     with op.batch_alter_table('repomirrorconfig') as batch_op:
         batch_op.add_column(sa.Column('external_registry_password_new', sa.String(length=9000), nullable=True))
     
-    # Copy data from the old columnn to the new column
+    # Copy data from the old column to the new column
     op.execute("""
         UPDATE repomirrorconfig
         SET external_registry_password_new = external_registry_password

--- a/data/migrations/versions/a32e17bfad20_increase_upstreamregistry_s_password_.py
+++ b/data/migrations/versions/a32e17bfad20_increase_upstreamregistry_s_password_.py
@@ -7,38 +7,54 @@ Create Date: 2024-07-13 20:47:26.649828
 """
 
 # revision identifiers, used by Alembic.
-revision = 'a32e17bfad20'
-down_revision = '2664723e1b4b'
+revision = "a32e17bfad20"
+down_revision = "2664723e1b4b"
 
 import sqlalchemy as sa
 
 
 def upgrade(op, tables, tester):
-    with op.batch_alter_table('repomirrorconfig') as batch_op:
-        batch_op.add_column(sa.Column('external_registry_password_new', sa.String(length=9000), nullable=True))
-    
-    # Copy data from the old column to the new column
-    op.execute("""
+    with op.batch_alter_table("repomirrorconfig") as batch_op:
+        batch_op.add_column(
+            sa.Column("external_registry_password_new", sa.String(length=9000), nullable=True)
+        )
+
+    # Copyy data from the old column to the new column
+    op.execute(
+        """
         UPDATE repomirrorconfig
         SET external_registry_password_new = external_registry_password
-    """)
-    
-    with op.batch_alter_table('repomirrorconfig') as batch_op:
-        batch_op.drop_column('external_registry_password')
-        batch_op.alter_column('external_registry_password_new', new_column_name='external_registry_password')
+    """
+    )
+
+    with op.batch_alter_table("repomirrorconfig") as batch_op:
+        batch_op.drop_column("external_registry_password")
+        batch_op.alter_column(
+            "external_registry_password_new",
+            new_column_name="external_registry_password",
+            existing_type=sa.String(length=4096),
+        )
     # ### end Alembic commands ###
 
 
 def downgrade(op, tables, tester):
-    with op.batch_alter_table('repomirrorconfig') as batch_op:
-        batch_op.add_column(sa.Column('external_registry_password_old', sa.String(length=4096), nullable=True))
-    
+    with op.batch_alter_table("repomirrorconfig") as batch_op:
+        batch_op.add_column(
+            sa.Column("external_registry_password_old", sa.String(length=4096), nullable=True)
+        )
+
     # Copy data from the new column to the old column
-    op.execute("""
+    op.execute(
+        """
         UPDATE repomirrorconfig
         SET external_registry_password_old = external_registry_password
-    """)
-    
-    with op.batch_alter_table('repomirrorconfig') as batch_op:
-        batch_op.drop_column('external_registry_password')
-        batch_op.alter_column('external_registry_password_old', new_column_name='external_registry_password')
+    """
+    )
+
+    with op.batch_alter_table("repomirrorconfig") as batch_op:
+        batch_op.drop_column("external_registry_password")
+        batch_op.alter_column(
+            "external_registry_password_old",
+            new_column_name="external_registry_password",
+            existing_type=sa.String(length=9000),
+        )

--- a/data/migrations/versions/a32e17bfad20_increase_upstreamregistry_s_password_.py
+++ b/data/migrations/versions/a32e17bfad20_increase_upstreamregistry_s_password_.py
@@ -17,7 +17,7 @@ def upgrade(op, tables, tester):
     with op.batch_alter_table('repomirrorconfig') as batch_op:
         batch_op.add_column(sa.Column('external_registry_password_new', sa.String(length=9000), nullable=True))
     
-    # Copy data from the old column to the new column
+    # Copy data from the old columnn to the new column
     op.execute("""
         UPDATE repomirrorconfig
         SET external_registry_password_new = external_registry_password

--- a/data/migrations/versions/a32e17bfad20_increase_upstreamregistry_s_password_.py
+++ b/data/migrations/versions/a32e17bfad20_increase_upstreamregistry_s_password_.py
@@ -1,0 +1,44 @@
+"""increase upstreamregistry's password length (PROJQUAY-7430)
+
+Revision ID: a32e17bfad20
+Revises: 2664723e1b4b
+Create Date: 2024-07-13 20:47:26.649828
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a32e17bfad20'
+down_revision = '2664723e1b4b'
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    with op.batch_alter_table('repomirrorconfig') as batch_op:
+        batch_op.add_column(sa.Column('external_registry_password_new', sa.String(length=9000), nullable=True))
+    
+    # Copy data from the old column to the new column
+    op.execute("""
+        UPDATE repomirrorconfig
+        SET external_registry_password_new = external_registry_password
+    """)
+    
+    with op.batch_alter_table('repomirrorconfig') as batch_op:
+        batch_op.drop_column('external_registry_password')
+        batch_op.alter_column('external_registry_password_new', new_column_name='external_registry_password')
+    # ### end Alembic commands ###
+
+
+def downgrade(op, tables, tester):
+    with op.batch_alter_table('repomirrorconfig') as batch_op:
+        batch_op.add_column(sa.Column('external_registry_password_old', sa.String(length=4096), nullable=True))
+    
+    # Copy data from the new column to the old column
+    op.execute("""
+        UPDATE repomirrorconfig
+        SET external_registry_password_old = external_registry_password
+    """)
+    
+    with op.batch_alter_table('repomirrorconfig') as batch_op:
+        batch_op.drop_column('external_registry_password')
+        batch_op.alter_column('external_registry_password_old', new_column_name='external_registry_password')


### PR DESCRIPTION
Increased password length from 4096 to 9000 chars for upstream registry password.
