### PR TITLE
storage(StorageClasses): support changing signature version for pre-signed URL (PROJQUAY-7491)

### DIFF
--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -33,6 +33,9 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 	var token string = ""
 	var signature = "s3v2"
 
+	// we do not have any signature checks so to avoid any compiling errors
+	signature = "s3v2"
+
 	switch storageType {
 	case "LocalStorage":
 		return true, []ValidationError{}

--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -31,10 +31,6 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 	var isSecure bool
 	var bucketName string
 	var token string = ""
-	var signature = "s3v2"
-
-	// we do not have any signature checks so to avoid any compiling errors
-	signature = "s3v2"
 
 	switch storageType {
 	case "LocalStorage":

--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -31,6 +31,7 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 	var isSecure bool
 	var bucketName string
 	var token string = ""
+	var signature = "s3v2"
 
 	switch storageType {
 	case "LocalStorage":
@@ -60,6 +61,8 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 		endpoint = args.Hostname
 		isSecure = args.IsSecure
 		bucketName = args.BucketName
+
+		signature = args.Signature
 
 		// Append port if present
 		if args.Port != 0 {

--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -61,8 +61,6 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 		isSecure = args.IsSecure
 		bucketName = args.BucketName
 
-		signature = args.Signature
-
 		// Append port if present
 		if args.Port != 0 {
 			endpoint = endpoint + ":" + strconv.Itoa(args.Port)

--- a/config-tool/pkg/lib/shared/structs.go
+++ b/config-tool/pkg/lib/shared/structs.go
@@ -27,6 +27,8 @@ type DistributedStorageArgs struct {
 	AccessKey   string `default:"" validate:"" json:"access_key,omitempty" yaml:"access_key,omitempty"`
 	SecretKey   string `default:"" validate:"" json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
 	BucketName  string `default:"" validate:"" json:"bucket_name,omitempty" yaml:"bucket_name,omitempty"`
+
+	Signature string `default:"s3v2" validate: "" json:"signature_version,omitempty" yaml:"signature_version,omitempty"`
 	// Args for S3Storage
 	S3Bucket    string `default:"" validate:"" json:"s3_bucket,omitempty" yaml:"s3_bucket,omitempty"`
 	S3AccessKey string `default:"" validate:"" json:"s3_access_key,omitempty" yaml:"s3_access_key,omitempty"`


### PR DESCRIPTION
Pre-signed URL's are only on the `S3Storage` Class configured vor `s3v4` (hard coded).

This PR adds the attribute `signature_version` to all StorageClass definitions to be configured individually.
The behavior when not set defaults back to `v2` for all StorageClasses except `S3Storage` which defaults to `s3v4` 

Manual verification has been documented in https://issues.redhat.com/browse/PROJQUAY-7491 as  we do not have any validation tests as presigning is `client-local only` and therefor only would validate the string returned by the underlying function of botocore.