### PR TITLE
audit: fix auto-prune audit logging (PROJQUAY-7423)

### DIFF
--- a/data/model/autoprune.py
+++ b/data/model/autoprune.py
@@ -7,6 +7,7 @@ from data.database import NamespaceAutoPrunePolicy as NamespaceAutoPrunePolicyTa
 from data.database import Repository
 from data.database import RepositoryAutoPrunePolicy as RepositoryAutoPrunePolicyTable
 from data.database import RepositoryState, User, db_for_update, get_epoch_timestamp_ms
+from data.logs_model import logs_model
 from data.model import (
     InvalidNamespaceAutoPruneMethod,
     InvalidNamespaceAutoPrunePolicy,
@@ -18,7 +19,6 @@ from data.model import (
     RepositoryAutoPrunePolicyAlreadyExists,
     RepositoryAutoPrunePolicyDoesNotExist,
     db_transaction,
-    log,
     modelutil,
     oci,
     repository,
@@ -513,7 +513,7 @@ def prune_tags(tags, repo, namespace):
         try:
             tag = oci.tag.delete_tag(repo.id, tag.name)
             if tag is not None:
-                log.log_action(
+                logs_model.log_action(
                     "autoprune_tag_delete",
                     namespace.username,
                     repository=repo,

--- a/data/model/autoprune.py
+++ b/data/model/autoprune.py
@@ -7,7 +7,6 @@ from data.database import NamespaceAutoPrunePolicy as NamespaceAutoPrunePolicyTa
 from data.database import Repository
 from data.database import RepositoryAutoPrunePolicy as RepositoryAutoPrunePolicyTable
 from data.database import RepositoryState, User, db_for_update, get_epoch_timestamp_ms
-from data.logs_model import logs_model
 from data.model import (
     InvalidNamespaceAutoPruneMethod,
     InvalidNamespaceAutoPrunePolicy,
@@ -509,6 +508,9 @@ def delete_autoprune_task(task):
 
 
 def prune_tags(tags, repo, namespace):
+    # imported here to avoid cyclic imports
+    from data.logs_model import logs_model
+
     for tag in tags:
         try:
             tag = oci.tag.delete_tag(repo.id, tag.name)


### PR DESCRIPTION
This fixes an issue where the autoprune logic would not use the logs data model proxy but directly reach into the table-based audit logs model, leading to log coverage gaps when using another backend for audit logs.