### PR TITLE
registry: return 400 instead of 404 for manifest errors on referrers api (PROJQUAY-7523)

### DIFF
--- a/endpoints/v2/referrers.py
+++ b/endpoints/v2/referrers.py
@@ -46,7 +46,7 @@ def list_manifest_referrers(namespace_name, repo_name, manifest_ref, registry_mo
             repository_ref, manifest_ref, raise_on_error=True, allow_hidden=True
         )
     except ManifestDoesNotExist as e:
-        raise ManifestUnknown(str(e))
+        raise ManifestInvalid(str(e))
 
     artifact_type = request.args.get("artifactType", None)
 


### PR DESCRIPTION
Given that a repository is found, the request must not return a 404.