### PR TITLE
nginx: dropping x-forwarded-host (PROJQUAY-7563)

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -90,6 +90,7 @@ location ~ ^/_storage_proxy/([^/]+)/([^/]+)/([^/]+)/(.+) {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $3;
     proxy_set_header Authorization "";
+    proxy_set_header x-forwarded-host "";
     proxy_ssl_name $3;
     proxy_ssl_server_name on;
 


### PR DESCRIPTION
Description: dropping x-forwared-host from the request ensures S3 signatures are valid

With Hitachi Vantara S3 Buckets integration, the `x-forwarded-host` invalidated the Signature in v4 mode.
Removing it accordinlgy in the nginx `_storage_proxy` location match enables us to use HCP Buckets.



