### PR TITLE
chore: change docker-compose to 'docker compose' (PROJQUAY-0000)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -203,9 +203,9 @@ jobs:
 
     - name: Start Quay
       run: |
-        docker-compose up -d redis quay-db
+        docker compose up -d redis quay-db
         docker exec -t quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
-        DOCKER_USER="1001:0" docker-compose up -d --no-build quay
+        DOCKER_USER="1001:0" docker compose up -d --no-build quay
 
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
Cypress tests failing with error
```
/home/runner/work/_temp/b4e3ed70-1870-4883-9bcf-44735b3007f4.sh: line 1: docker-compose: command not found
```

Try changing `docker-compose` to `docker compose`