### PR TITLE
ui: add refetch to usage logs search (PROJQUAY-7109)

### DIFF
--- a/web/src/routes/UsageLogs/UsageLogsTable.tsx
+++ b/web/src/routes/UsageLogs/UsageLogsTable.tsx
@@ -12,7 +12,7 @@ import {useInfiniteQuery} from '@tanstack/react-query';
 import RequestError from 'src/components/errors/RequestError';
 import {getLogs} from 'src/hooks/UseUsageLogs';
 import {useLogDescriptions} from 'src/hooks/UseLogDescriptions';
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 
 interface UsageLogsTableProps {
   starttime: string;
@@ -29,6 +29,7 @@ export function UsageLogsTable(props: UsageLogsTableProps) {
 
   const filterOnChange = (value: string) => {
     setFilterValue(value);
+    refetch();
   };
 
   const filterLogs = (data, filterValue) => {
@@ -44,6 +45,7 @@ export function UsageLogsTable(props: UsageLogsTableProps) {
     isError: errorLogs,
     fetchNextPage,
     hasNextPage,
+    refetch,
   } = useInfiniteQuery({
     queryKey: [
       'usageLogs',


### PR DESCRIPTION
Usage logs are not updating when the user changes the filter value in the search bar.

Adding a callback to refetch the query when filter value changes to have the log data update with filter value state. 