### PR TITLE
bug: too strict validateTeamName regex (PROJQUAY-7606)

### DIFF
--- a/web/src/libs/utils.ts
+++ b/web/src/libs/utils.ts
@@ -52,7 +52,7 @@ export function isValidEmail(email: string): boolean {
 }
 
 export const validateTeamName = (name: string) => {
-  return /^[a-z][a-z0-9]+$/.test(name);
+  return /^([a-z0-9]+(?:[._-][a-z0-9]+)*)$/.test(name);
 };
 
 export function parseRepoNameFromUrl(url: string): string {


### PR DESCRIPTION
If you PUT against /api/v1/organization/mirrors/team/CAPITAL-LETTERS you'll get a different regex back.

  Invalid team name CAPITAL-LETTERS: Namespace must match expression
  ^([a-z0-9]+(?:[._-][a-z0-9]+)*)$

Let's use this more permissive regex in the web-ui instead.