### PR TITLE
api: Add tag deletion endpoint for v2 api (PROJQUAY-7599)

### DIFF
--- a/.github/workflows/oci-distribution-spec.yaml
+++ b/.github/workflows/oci-distribution-spec.yaml
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: opencontainers/distribution-spec
-        ref: v1.1.0-rc1
+        ref: v1.1.0
         path: dist-spec
 
     - name: Set up Go 1.18

--- a/.github/workflows/oci-distribution-spec.yaml
+++ b/.github/workflows/oci-distribution-spec.yaml
@@ -145,7 +145,7 @@ jobs:
         export OCI_TEST_PULL=1
         export OCI_TEST_PUSH=1
         export OCI_TEST_CONTENT_DISCOVERY=1
-        export OCI_TEST_CONTENT_MANAGEMENT=0
+        export OCI_TEST_CONTENT_MANAGEMENT=1
 
         # Extra settings
         export OCI_HIDE_SKIPPED_WORKFLOWS=0

--- a/.github/workflows/oci-distribution-spec.yaml
+++ b/.github/workflows/oci-distribution-spec.yaml
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: opencontainers/distribution-spec
-        ref: v1.1.0
+        ref: v1.1.0-rc1
         path: dist-spec
 
     - name: Set up Go 1.18
@@ -145,7 +145,7 @@ jobs:
         export OCI_TEST_PULL=1
         export OCI_TEST_PUSH=1
         export OCI_TEST_CONTENT_DISCOVERY=1
-        export OCI_TEST_CONTENT_MANAGEMENT=1
+        export OCI_TEST_CONTENT_MANAGEMENT=0
 
         # Extra settings
         export OCI_HIDE_SKIPPED_WORKFLOWS=0

--- a/endpoints/v2/manifest.py
+++ b/endpoints/v2/manifest.py
@@ -405,6 +405,38 @@ def delete_manifest_by_digest(namespace_name, repo_name, manifest_ref):
         return Response(status=202)
 
 
+@v2_bp.route(MANIFEST_TAGNAME_ROUTE, methods=["DELETE"])
+@disallow_for_account_recovery_mode
+@parse_repository_name()
+@process_registry_jwt_auth(scopes=["pull", "push"])
+@log_unauthorized_delete
+@require_repo_write(allow_for_superuser=True, disallow_for_restricted_users=True)
+@anon_protect
+@check_readonly
+@check_pushes_disabled
+def delete_manifest_by_tag(namespace_name, repo_name, manifest_ref):
+    """
+    Deletes the manifest specified by the tag.
+    """
+    with db_disallow_replica_use():
+        repository_ref = registry_model.lookup_repository(
+            namespace_name, repo_name, model_cache=model_cache
+        )
+        if repository_ref is None:
+            raise NameUnknown("repository not found")
+
+        tag = registry_model.get_repo_tag(repository_ref, manifest_ref)
+        if tag is None:
+            raise ManifestUnknown()
+
+        deleted_tag = registry_model.delete_tag(model_cache, repository_ref, manifest_ref)
+        if not deleted_tag:
+            raise ManifestUnknown()
+
+        track_and_log("delete_tag", repository_ref, tag=deleted_tag.name, digest=manifest_ref)
+        return Response(status=202)
+
+
 def _write_manifest_and_log(namespace_name, repo_name, tag_name, manifest_impl):
     _validate_schema1_manifest(namespace_name, repo_name, manifest_impl)
     with db_disallow_replica_use():

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -3139,6 +3139,7 @@ def test_attempt_pull_by_tag_reference_for_deleted_tag(
         "devtable",
         "newrepo",
         "latest",
+        basic_images,
         credentials=credentials,
         expected_failure=Failures.UNKNOWN_TAG,
     )

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -3129,7 +3129,7 @@ def test_attempt_pull_by_tag_reference_for_deleted_tag(
     )
 
     # Delete the tag by reference
-    manifest.protocol.delete(
+    manifest_protocol.delete(
         liveserver_session, "devtable", "newrepo", "latest", credentials=credentials
     )
 

--- a/test/specs.py
+++ b/test/specs.py
@@ -670,6 +670,19 @@ def build_v2_index_specs():
         IndexV2TestSpec(
             "v2.write_manifest_by_digest", "PUT", ANOTHER_ORG_REPO, manifest_ref=FAKE_DIGEST
         ).request_status(401, 401, 401, 401, 400),
+        # v2.delete_manifest_by_tag
+        IndexV2TestSpec(
+            "v2.delete_manifest_by_tag", "DELETE", PUBLIC_REPO, manifest_ref=FAKE_MANIFEST
+        ).request_status(401, 401, 401, 401, 401),
+        IndexV2TestSpec(
+            "v2.delete_manifest_by_tag", "DELETE", PRIVATE_REPO, manifest_ref=FAKE_MANIFEST
+        ).request_status(401, 401, 401, 401, 404),
+        IndexV2TestSpec(
+            "v2.delete_manifest_by_tag", "DELETE", ORG_REPO, manifest_ref=FAKE_MANIFEST
+        ).request_status(401, 401, 401, 401, 404),
+        IndexV2TestSpec(
+            "v2.delete_manifest_by_tag", "DELETE", ANOTHER_ORG_REPO, manifest_ref=FAKE_MANIFEST
+        ).request_status(401, 401, 401, 401, 404),
         # v2.delete_manifest_by_digest
         IndexV2TestSpec(
             "v2.delete_manifest_by_digest", "DELETE", PUBLIC_REPO, manifest_ref=FAKE_DIGEST


### PR DESCRIPTION
The deletion of tags was previously not supported by the Docker v2 API. Current versions of both the OCI spec and Docker v2 API provide this ability, hence adding it to Quay as well. See [OCI spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md) for more details.