### PR TITLE
oldui: Fix horizontal scrolling on vulnerability reports (PROJQUAY-7686)

### DIFF
--- a/static/css/directives/ui/manifest-vulnerability-view.css
+++ b/static/css/directives/ui/manifest-vulnerability-view.css
@@ -184,6 +184,8 @@
 .manifest-vulnerability-view-element .description {
   display: inline-block;
   max-width: 1000px;
+  text-align: justify;
+  text-justify: auto;
 }
 
 .manifest-vulnerability-view-element .asterisk {
@@ -200,4 +202,22 @@
   margin: 0px;
   margin-left: 2px;
   margin-right: 2px;
+}
+
+.manifest-vulnerability-view-element .truncate-link {
+  display: inline-block;
+  max-width: 500px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.manifest-vulnerability-view-element .current-version {
+  display: inline-block;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
 }

--- a/static/directives/manifest-vulnerability-view.html
+++ b/static/directives/manifest-vulnerability-view.html
@@ -96,7 +96,7 @@
       <div class="empty-secondary-msg">Quay Security Scanner has detected no vulnerabilities in this manifest.</div>
     </div>
 
-    <table class="co-table" ng-show="vulnerabilitiesInfo.vulnerabilities.length">
+    <table class="co-table" ng-show="vulnerabilitiesInfo.vulnerabilities.length" style="width: 100%">
      <thead>
       <td class="caret-col"></td>
       <td ng-class="TableService.tablePredicateClass('name', options.predicate, options.reverse)">
@@ -124,9 +124,11 @@
           </span>
          </td>
          <td class="single-col nowrap-col">
-            <a bo-text="vuln.name" ng-click="toggleDetails(vuln)" class="expand-link"></a>
+            <span class="truncate-link">
+              <a bo-text="vuln.name" ng-click="toggleDetails(vuln)" class="expand-link"></a>
+            </span>
             <a href="{{ vuln.link }}" class="external-link hidden-xs hidden-sm hidden-md" bo-if="vuln.link" ng-safenewtab >
-              <i class="fa fa-link"></i>
+            <i class="fa fa-link"></i>
             </a>
          </td>
          <td class="single-col nowrap-col">
@@ -144,7 +146,7 @@
          </td>
          <td class="single-col hidden-xs"><span bo-text="vuln.featureName"></span></td>
          <td class="single-col hidden-xs hidden-sm">
-           <span bo-text="vuln.introducedInVersion"></span>
+           <span bo-text="vuln.introducedInVersion" class="current-version"></span>
          </td>
          <td class="single-col hidden-xs">
             <span class="empty" bo-if="!vuln.fixedInVersion">(None)</span>


### PR DESCRIPTION
Old manifest vulnerability status page, still in use, would cause artifacts on long URLs and huge horizontal scroll bars. This fix limits the size of the displayed link thus eliminating horizontal scrolls. Tested on up to 150% zoom on 4k resolution.

![image](https://github.com/user-attachments/assets/58941eaf-f70d-4e46-b628-89b478701a0a)
