### PR TITLE
storage(StorageClasses): Presign v2/v4 stsfix (PROJQUAY-7689)

### DIFF
--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -33,6 +33,9 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 	var token string = ""
 	var signature = "s3v2"
 
+	// we do not have any signature checks so to avoid any compiling errors
+	signature = "s3v2"
+
 	switch storageType {
 	case "LocalStorage":
 		return true, []ValidationError{}

--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -31,10 +31,6 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 	var isSecure bool
 	var bucketName string
 	var token string = ""
-	var signature = "s3v2"
-
-	// we do not have any signature checks so to avoid any compiling errors
-	signature = "s3v2"
 
 	switch storageType {
 	case "LocalStorage":

--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -31,6 +31,7 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 	var isSecure bool
 	var bucketName string
 	var token string = ""
+	var signature = "s3v2"
 
 	switch storageType {
 	case "LocalStorage":
@@ -60,6 +61,8 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 		endpoint = args.Hostname
 		isSecure = args.IsSecure
 		bucketName = args.BucketName
+
+		signature = args.Signature
 
 		// Append port if present
 		if args.Port != 0 {

--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -61,8 +61,6 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 		isSecure = args.IsSecure
 		bucketName = args.BucketName
 
-		signature = args.Signature
-
 		// Append port if present
 		if args.Port != 0 {
 			endpoint = endpoint + ":" + strconv.Itoa(args.Port)

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -1257,7 +1257,7 @@ class STSS3Storage(S3Storage):
             method="sts-assume-role",
         )
 
-        # !! NOTE !! connect_kwargs here initializes the S3Storage Class not the s3 connection (mis leading re-use of the name)
+        # !! NOTE !! connect_kwargs here initializes the S3Storage Class not the s3 connection (mis leading re-use of the name) 
         connect_kwargs = {
             "s3_access_key": credentials["AccessKeyId"],
             "s3_secret_key": credentials["SecretAccessKey"],

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -1257,7 +1257,7 @@ class STSS3Storage(S3Storage):
             method="sts-assume-role",
         )
 
-        # !! NOTE !! connect_kwargs here initializes the S3Storage Class not the s3 connection (mis leading re-use of the name) 
+        # !! NOTE !! connect_kwargs here initializes the S3Storage Class not the s3 connection (mis leading re-use of the name)
         connect_kwargs = {
             "s3_access_key": credentials["AccessKeyId"],
             "s3_secret_key": credentials["SecretAccessKey"],

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -1243,7 +1243,7 @@ class STSS3Storage(S3Storage):
         s3_region=None,
         endpoint_url=None,
         maximum_chunk_size_gb=None,
-        signature_version=None,
+        signature_version="s3v4",
     ):
         sts_client = boto3.client(
             "sts", aws_access_key_id=sts_user_access_key, aws_secret_access_key=sts_user_secret_key
@@ -1257,6 +1257,7 @@ class STSS3Storage(S3Storage):
             method="sts-assume-role",
         )
 
+        # !! NOTE !! connect_kwargs here initializes the S3Storage Class not the s3 connection (mis leading re-use of the name)
         connect_kwargs = {
             "s3_access_key": credentials["AccessKeyId"],
             "s3_secret_key": credentials["SecretAccessKey"],
@@ -1265,7 +1266,7 @@ class STSS3Storage(S3Storage):
             "endpoint_url": endpoint_url,
             "maximum_chunk_size_gb": maximum_chunk_size_gb,
             "deferred_refreshable_credentials": deferred_refreshable_credentials,
-            "config": Config(signature_version=signature_version),
+            "signature_version": signature_version,
         }
 
         super().__init__(context, storage_path, s3_bucket, **connect_kwargs)


### PR DESCRIPTION
fixing the error seen with signature_v2/v4 patch https://github.com/quay/quay/pull/3041 when using STSS3Storage

Explanation:
the `STSS3Storage` Class is using the `connect_kwargs` dictionary to initialze the `S3Storage` Class where all other use that dict for the connection parameters which is misleading and I did not catch that when submitting the patch for the signature v2/v4 

```
File "/quay-registry/storage/__init__.py", line 62, in __init__
self.state = self.init_app(
File "/quay-registry/storage/__init__.py", line 71, in init_app
storages[location] = get_storage_driver(
File "/quay-registry/storage/__init__.py", line 48, in get_storage_driver
return driver_class(context, **parameters)
File "/quay-registry/storage/[cloud.py](https://cloud.py/)", line 1271, in __init__
super().__init__(context, storage_path, s3_bucket, **connect_kwargs)
TypeError: __init__() got an unexpected keyword argument 'config'
```