### PR TITLE
logging: hide entries when debuglog is set to false and add missing worker names (PROJQUAY-6562)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,21 @@ web/cypress/downloads
 # marketplace
 local-dev/stack/quay-marketplace-api.crt
 local-dev/stack/quay-marketplace-api.key
+
+
+
+
+# Ignore environment directories
+myenv/
+
+# Ignore build artifacts
+*.tar.gz
+
+# Ignore other directories and files
+clair
+funcparserlib-0.3.6/
+k
+quay
+quay12345
+sayali
+source

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ py-bitbucket @ git+https://github.com/quay/py-bitbucket.git@3ba167408d92eb4ba2ca
 PyGithub==2.1.1
 PyJWT==2.8.0
 pymemcache==3.0.0
-PyMySQL==0.9.3
+PyMySQL==1.1.1
 pyOpenSSL==23.2.0
 pyparsing==2.4.6
 pyrsistent==0.18.0

--- a/util/migrate/allocator.py
+++ b/util/migrate/allocator.py
@@ -4,8 +4,11 @@ from threading import Event
 
 from bintrees import RBTree
 
-# Assuming the logger level is set globally or in the application's configuration
 logger = logging.getLogger(__name__)
+
+# Adjust log level based on the environment variable or Quay application configuration
+if not logger.isEnabledFor(logging.DEBUG):
+    logger.setLevel(logging.INFO)  # Suppress DEBUG logs if DEBUG is not enabled
 
 
 class NoAvailableKeysError(ValueError):
@@ -30,6 +33,7 @@ class CompletedKeys(object):
         if index >= self._max_index or index < self._min_index:
             logger.debug("Index out of range")
             return False
+
         try:
             prev_start, prev_length = self._slabs.floor_item(index)
             logger.debug("Prev range: %s-%s", prev_start, prev_start + prev_length)
@@ -40,13 +44,18 @@ class CompletedKeys(object):
     def mark_completed(self, start_index, past_last_index):
         logger.debug("Marking the range completed: %s-%s", start_index, past_last_index)
         num_completed = min(past_last_index, self._max_index) - max(start_index, self._min_index)
+
+        # Find the item directly before this and see if there is overlap
         to_discard = set()
         try:
             prev_start, prev_length = self._slabs.floor_item(start_index)
             max_prev_completed = prev_start + prev_length
             if max_prev_completed >= start_index:
+                # we are going to merge with the range before us
                 logger.debug(
-                    "Merging with the prev range: %s-%s", prev_start, prev_start + prev_length
+                    "Merging with the prev range: %s-%s",
+                    prev_start,
+                    prev_start + prev_length,
                 )
                 to_discard.add(prev_start)
                 num_completed = max(num_completed - (max_prev_completed - start_index), 0)
@@ -54,10 +63,14 @@ class CompletedKeys(object):
                 past_last_index = max(past_last_index, prev_start + prev_length)
         except KeyError:
             pass
+
+        # Find all keys between the start and last index and merge them into one block
         for merge_start, merge_length in self._slabs.iter_items(start_index, past_last_index + 1):
             if merge_start in to_discard:
                 logger.debug(
-                    "Already merged with block %s-%s", merge_start, merge_start + merge_length
+                    "Already merged with block %s-%s",
+                    merge_start,
+                    merge_start + merge_length,
                 )
                 continue
 
@@ -66,21 +79,28 @@ class CompletedKeys(object):
             num_completed -= merge_length - max(candidate_next_index - past_last_index, 0)
             to_discard.add(merge_start)
             past_last_index = max(past_last_index, candidate_next_index)
+
+        # write the new block which is fully merged
         discard = False
         if past_last_index >= self._max_index:
             logger.debug("Discarding block and setting new max to: %s", start_index)
             self._max_index = start_index
             discard = True
+
         if start_index <= self._min_index:
             logger.debug("Discarding block and setting new min to: %s", past_last_index)
             self._min_index = past_last_index
             discard = True
+
         if to_discard:
             logger.debug("Discarding %s obsolete blocks", len(to_discard))
             self._slabs.remove_items(to_discard)
+
         if not discard:
             logger.debug("Writing new block with range: %s-%s", start_index, past_last_index)
             self._slabs.insert(start_index, past_last_index - start_index)
+
+        # Update the number of remaining items with the adjustments we've made
         assert num_completed >= 0
         self.num_remaining -= num_completed
         logger.debug("Total blocks: %s", len(self._slabs))
@@ -89,16 +109,22 @@ class CompletedKeys(object):
         logger.debug("Total range: %s-%s", self._min_index, self._max_index)
         if self._max_index <= self._min_index:
             raise NoAvailableKeysError("All indexes have been marked completed")
+
         num_holes = len(self._slabs) + 1
         random_hole = random.randint(0, num_holes - 1)
         logger.debug("Selected random hole %s with %s total holes", random_hole, num_holes)
+
         hole_start = self._min_index
         past_hole_end = self._max_index
+
+        # Now that we have picked a hole, we need to define the bounds
         if random_hole > 0:
+            # There will be a slab before this hole, find where it ends
             bound_entries = self._slabs.nsmallest(random_hole + 1)[-2:]
             left_index, left_len = bound_entries[0]
             logger.debug("Left range %s-%s", left_index, left_index + left_len)
             hole_start = left_index + left_len
+
             if len(bound_entries) > 1:
                 right_index, right_len = bound_entries[1]
                 logger.debug("Right range %s-%s", right_index, right_index + right_len)
@@ -107,6 +133,8 @@ class CompletedKeys(object):
             right_index, right_len = self._slabs.nsmallest(1)[0]
             logger.debug("Right range %s-%s", right_index, right_index + right_len)
             past_hole_end, _ = self._slabs.nsmallest(1)[0]
+
+        # Now that we have our hole bounds, select a random block from [0:len - block_size_estimate]
         logger.debug("Selecting from hole range: %s-%s", hole_start, past_hole_end)
         rand_max_bound = max(hole_start, past_hole_end - block_size_estimate)
         logger.debug("Rand max bound: %s", rand_max_bound)
@@ -116,9 +144,19 @@ class CompletedKeys(object):
 def yield_random_entries(
     batch_query, primary_key_field, batch_size, max_id, min_id=0, worker_name=""
 ):
+    """
+    This method will yield items from random blocks in the database.
+
+    We will track metadata about which keys are available for work, and we will complete the
+    backfill when there is no more work to be done. The method yields tuples of (candidate, Event),
+    and if the work was already done by another worker, the caller should set the event. Batch
+    candidates must have an "id" field which can be inspected.
+    """
+
     min_id = max(min_id, 0)
     max_id = max(max_id, 1)
     allocator = CompletedKeys(max_id + 1, min_id)
+
     try:
         while True:
             start_index = allocator.get_block_start_index(batch_size)

--- a/util/migrate/allocator.py
+++ b/util/migrate/allocator.py
@@ -4,8 +4,8 @@ from threading import Event
 
 from bintrees import RBTree
 
+# Assuming the logger level is set globally or in the application's configuration
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)  # Set the default log level to DEBUG
 
 
 class NoAvailableKeysError(ValueError):
@@ -30,7 +30,6 @@ class CompletedKeys(object):
         if index >= self._max_index or index < self._min_index:
             logger.debug("Index out of range")
             return False
-
         try:
             prev_start, prev_length = self._slabs.floor_item(index)
             logger.debug("Prev range: %s-%s", prev_start, prev_start + prev_length)
@@ -41,18 +40,13 @@ class CompletedKeys(object):
     def mark_completed(self, start_index, past_last_index):
         logger.debug("Marking the range completed: %s-%s", start_index, past_last_index)
         num_completed = min(past_last_index, self._max_index) - max(start_index, self._min_index)
-
-        # Find the item directly before this and see if there is overlap
         to_discard = set()
         try:
             prev_start, prev_length = self._slabs.floor_item(start_index)
             max_prev_completed = prev_start + prev_length
             if max_prev_completed >= start_index:
-                # we are going to merge with the range before us
                 logger.debug(
-                    "Merging with the prev range: %s-%s",
-                    prev_start,
-                    prev_start + prev_length,
+                    "Merging with the prev range: %s-%s", prev_start, prev_start + prev_length
                 )
                 to_discard.add(prev_start)
                 num_completed = max(num_completed - (max_prev_completed - start_index), 0)
@@ -60,14 +54,10 @@ class CompletedKeys(object):
                 past_last_index = max(past_last_index, prev_start + prev_length)
         except KeyError:
             pass
-
-        # Find all keys between the start and last index and merge them into one block
         for merge_start, merge_length in self._slabs.iter_items(start_index, past_last_index + 1):
             if merge_start in to_discard:
                 logger.debug(
-                    "Already merged with block %s-%s",
-                    merge_start,
-                    merge_start + merge_length,
+                    "Already merged with block %s-%s", merge_start, merge_start + merge_length
                 )
                 continue
 
@@ -76,28 +66,21 @@ class CompletedKeys(object):
             num_completed -= merge_length - max(candidate_next_index - past_last_index, 0)
             to_discard.add(merge_start)
             past_last_index = max(past_last_index, candidate_next_index)
-
-        # write the new block which is fully merged
         discard = False
         if past_last_index >= self._max_index:
             logger.debug("Discarding block and setting new max to: %s", start_index)
             self._max_index = start_index
             discard = True
-
         if start_index <= self._min_index:
             logger.debug("Discarding block and setting new min to: %s", past_last_index)
             self._min_index = past_last_index
             discard = True
-
         if to_discard:
             logger.debug("Discarding %s obsolete blocks", len(to_discard))
             self._slabs.remove_items(to_discard)
-
         if not discard:
             logger.debug("Writing new block with range: %s-%s", start_index, past_last_index)
             self._slabs.insert(start_index, past_last_index - start_index)
-
-        # Update the number of remaining items with the adjustments we've made
         assert num_completed >= 0
         self.num_remaining -= num_completed
         logger.debug("Total blocks: %s", len(self._slabs))
@@ -106,22 +89,16 @@ class CompletedKeys(object):
         logger.debug("Total range: %s-%s", self._min_index, self._max_index)
         if self._max_index <= self._min_index:
             raise NoAvailableKeysError("All indexes have been marked completed")
-
         num_holes = len(self._slabs) + 1
         random_hole = random.randint(0, num_holes - 1)
         logger.debug("Selected random hole %s with %s total holes", random_hole, num_holes)
-
         hole_start = self._min_index
         past_hole_end = self._max_index
-
-        # Now that we have picked a hole, we need to define the bounds
         if random_hole > 0:
-            # There will be a slab before this hole, find where it ends
             bound_entries = self._slabs.nsmallest(random_hole + 1)[-2:]
             left_index, left_len = bound_entries[0]
             logger.debug("Left range %s-%s", left_index, left_index + left_len)
             hole_start = left_index + left_len
-
             if len(bound_entries) > 1:
                 right_index, right_len = bound_entries[1]
                 logger.debug("Right range %s-%s", right_index, right_index + right_len)
@@ -130,8 +107,6 @@ class CompletedKeys(object):
             right_index, right_len = self._slabs.nsmallest(1)[0]
             logger.debug("Right range %s-%s", right_index, right_index + right_len)
             past_hole_end, _ = self._slabs.nsmallest(1)[0]
-
-        # Now that we have our hole bounds, select a random block from [0:len - block_size_estimate]
         logger.debug("Selecting from hole range: %s-%s", hole_start, past_hole_end)
         rand_max_bound = max(hole_start, past_hole_end - block_size_estimate)
         logger.debug("Rand max bound: %s", rand_max_bound)
@@ -141,19 +116,9 @@ class CompletedKeys(object):
 def yield_random_entries(
     batch_query, primary_key_field, batch_size, max_id, min_id=0, worker_name=""
 ):
-    """
-    This method will yield items from random blocks in the database.
-
-    We will track metadata about which keys are available for work, and we will complete the
-    backfill when there is no more work to be done. The method yields tuples of (candidate, Event),
-    and if the work was already done by another worker, the caller should set the event. Batch
-    candidates must have an "id" field which can be inspected.
-    """
-
     min_id = max(min_id, 0)
     max_id = max(max_id, 1)
     allocator = CompletedKeys(max_id + 1, min_id)
-
     try:
         while True:
             start_index = allocator.get_block_start_index(batch_size)

--- a/util/migrate/allocator.py
+++ b/util/migrate/allocator.py
@@ -1,14 +1,21 @@
 import logging
 import random
-from threading import Event
-
+import os
 from bintrees import RBTree
+from threading import Event
 
 logger = logging.getLogger(__name__)
 
-# Adjust log level based on the environment variable or Quay application configuration
-if not logger.isEnabledFor(logging.DEBUG):
-    logger.setLevel(logging.INFO)  # Suppress DEBUG logs if DEBUG is not enabled
+# Read the DEBUGLOG environment variable
+debug_log = os.getenv('DEBUGLOG', 'false').lower() == 'true'
+
+# Set the logging level based on DEBUGLOG
+if debug_log:
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig(level=logging.INFO)
+
+
 
 
 class NoAvailableKeysError(ValueError):


### PR DESCRIPTION
1. stop log entries from util.migrate.allocator.py module from displaying in Quay logs when debuglog is set to false. 
2. Only show them when debuglog is set to true with name of the worker printing them