### PR TITLE
api: adding tag_pattern to autoprune API (PROJQUAY-7668)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -49,7 +49,7 @@ from data.readreplica import (
     ReadReplicaSupportedModel,
     disallow_replica_use,
 )
-from data.text import match_like, match_mysql, regex_mysql, regex_postgres, regex_sqlite
+from data.text import match_like, match_mysql, regex_search, regex_sqlite
 from util.metrics.prometheus import (
     db_close_calls,
     db_connect_calls,
@@ -90,11 +90,7 @@ SCHEME_MATCH_FUNCTION = {
 }
 
 SCHEME_REGEX_FUNCTION = {
-    "mysql": regex_mysql,
-    "mysql+pymysql": regex_mysql,
     "sqlite": regex_sqlite,
-    "postgresql": regex_postgres,
-    "postgresql+psycopg2": regex_postgres,
 }
 
 
@@ -515,7 +511,7 @@ def configure(config_object, testing=False):
     )
     db_encrypter.initialize(FieldEncrypter(config_object.get("DATABASE_SECRET_KEY")))
     db_count_estimator.initialize(SCHEME_ESTIMATOR_FUNCTION[parsed_write_uri.drivername])
-    db_regex_search.initialize(SCHEME_REGEX_FUNCTION[parsed_write_uri.drivername])
+    db_regex_search.initialize(SCHEME_REGEX_FUNCTION.get(parsed_write_uri.drivername, regex_search))
 
     read_replicas = config_object.get("DB_READ_REPLICAS", None)
     is_read_only = config_object.get("REGISTRY_STATE", "normal") == "readonly"

--- a/data/database.py
+++ b/data/database.py
@@ -49,7 +49,7 @@ from data.readreplica import (
     ReadReplicaSupportedModel,
     disallow_replica_use,
 )
-from data.text import match_like, match_mysql
+from data.text import match_like, match_mysql, regex_mysql, regex_postgres, regex_sqlite
 from util.metrics.prometheus import (
     db_close_calls,
     db_connect_calls,
@@ -87,6 +87,14 @@ SCHEME_MATCH_FUNCTION = {
     "sqlite": match_like,
     "postgresql": match_like,
     "postgresql+psycopg2": match_like,
+}
+
+SCHEME_REGEX_FUNCTION = {
+    "mysql": regex_mysql,
+    "mysql+pymysql": regex_mysql,
+    "sqlite": regex_sqlite,
+    "postgresql": regex_postgres,
+    "postgresql+psycopg2": regex_postgres,
 }
 
 
@@ -329,6 +337,7 @@ db = Proxy()
 read_only_config = Proxy()
 db_random_func = CallableProxy()
 db_match_func = CallableProxy()
+db_regex_search = CallableProxy()
 db_for_update = CallableProxy()
 db_transaction = CallableProxy()
 db_disallow_replica_use = CallableProxy()
@@ -506,6 +515,7 @@ def configure(config_object, testing=False):
     )
     db_encrypter.initialize(FieldEncrypter(config_object.get("DATABASE_SECRET_KEY")))
     db_count_estimator.initialize(SCHEME_ESTIMATOR_FUNCTION[parsed_write_uri.drivername])
+    db_regex_search.initialize(SCHEME_REGEX_FUNCTION[parsed_write_uri.drivername])
 
     read_replicas = config_object.get("DB_READ_REPLICAS", None)
     is_read_only = config_object.get("REGISTRY_STATE", "normal") == "readonly"

--- a/data/model/autoprune.py
+++ b/data/model/autoprune.py
@@ -583,20 +583,15 @@ def fetch_tags_expiring_by_tag_count_policy(repo_id, policy_config, tag_page_lim
     page = 1
     while True:
         tags = oci.tag.fetch_paginated_autoprune_repo_tags_by_number(
-            repo_id, int(policy_config["value"]), tag_page_limit, page
+            repo_id,
+            int(policy_config["value"]),
+            tag_page_limit,
+            page,
+            policy_config.get("tag_pattern"),
+            policy_config.get("tag_pattern_matches"),
         )
         if len(tags) == 0:
             break
-
-        if policy_config.get("tag_pattern") is not None:
-            if policy_config.get("tag_pattern_matches") is None or policy_config.get(
-                "tag_pattern_matches"
-            ):
-                tags = [tag for tag in tags if re.match(policy_config.get("tag_pattern"), tag.name)]
-            else:
-                tags = [
-                    tag for tag in tags if not re.search(policy_config.get("tag_pattern"), tag.name)
-                ]
 
         all_tags.extend(tags)
         page += 1
@@ -628,20 +623,15 @@ def fetch_tags_expiring_by_creation_date_policy(repo_id, policy_config, tag_page
     page = 1
     while True:
         tags = oci.tag.fetch_paginated_autoprune_repo_tags_older_than_ms(
-            repo_id, time_ms, tag_page_limit, page
+            repo_id,
+            time_ms,
+            tag_page_limit,
+            page,
+            policy_config.get("tag_pattern"),
+            policy_config.get("tag_pattern_matches"),
         )
         if len(tags) == 0:
             break
-
-        if policy_config.get("tag_pattern") is not None:
-            if policy_config.get("tag_pattern_matches") is None or policy_config.get(
-                "tag_pattern_matches"
-            ):
-                tags = [tag for tag in tags if re.match(policy_config.get("tag_pattern"), tag.name)]
-            else:
-                tags = [
-                    tag for tag in tags if not re.search(policy_config.get("tag_pattern"), tag.name)
-                ]
 
         all_tags.extend(tags)
         page += 1

--- a/data/text.py
+++ b/data/text.py
@@ -61,11 +61,7 @@ def match_like(field, search_query):
     return Field.__pow__(field, clause)
 
 
-def regex_mysql(query, field, pattern, matches=True):
-    return query.where(field.regexp(pattern)) if matches else query.where(~field.regexp(pattern))
-
-
-def regex_postgres(query, field, pattern, matches=True):
+def regex_search(query, field, pattern, matches=True):
     return query.where(field.regexp(pattern)) if matches else query.where(~field.regexp(pattern))
 
 

--- a/data/text.py
+++ b/data/text.py
@@ -62,11 +62,7 @@ def match_like(field, search_query):
 
 
 def regex_mysql(query, field, pattern, matches=True):
-    return (
-        query.where(fn.REGEXP(field, pattern))
-        if matches
-        else query.where(~fn.REGEXP(field, pattern))
-    )
+    return query.where(field.regexp(pattern)) if matches else query.where(~field.regexp(pattern))
 
 
 def regex_postgres(query, field, pattern, matches=True):

--- a/endpoints/api/policy.py
+++ b/endpoints/api/policy.py
@@ -54,6 +54,14 @@ class OrgAutoPrunePolicies(ApiResource):
                     "type": ["integer", "string"],
                     "description": "The value to use for the pruning method (number of tags e.g. 10, time delta e.g. 7d (7 days))",
                 },
+                "tagPattern": {
+                    "type": "string",
+                    "description": "Tags only matching this pattern will be pruned",
+                },
+                "tagPatternMatches": {
+                    "type": "boolean",
+                    "description": "Determine whether pruned tags should or should not match the tagPattern",
+                },
             },
         },
     }
@@ -90,6 +98,10 @@ class OrgAutoPrunePolicies(ApiResource):
         app_data = request.get_json()
         method = app_data.get("method", None)
         value = app_data.get("value", None)
+        tag_pattern = app_data.get("tagPattern", None)
+        if tag_pattern is not None and isinstance(tag_pattern, str):
+            tag_pattern = tag_pattern.strip()
+        tag_pattern_matches = app_data.get("tagPatternMatches", True)
 
         if method is None or value is None:
             request_error(message="Missing the following parameters: method, value")
@@ -97,6 +109,8 @@ class OrgAutoPrunePolicies(ApiResource):
         policy_config = {
             "method": method,
             "value": value,
+            "tag_pattern": tag_pattern,
+            "tag_pattern_matches": tag_pattern_matches,
         }
 
         try:
@@ -116,6 +130,8 @@ class OrgAutoPrunePolicies(ApiResource):
             {
                 "method": policy_config["method"],
                 "value": policy_config["value"],
+                "tag_pattern": policy_config.get("tag_pattern"),
+                "tag_pattern_matches": policy_config.get("tag_pattern_matches"),
                 "namespace": orgname,
             },
         )
@@ -145,6 +161,14 @@ class OrgAutoPrunePolicy(ApiResource):
                 "value": {
                     "type": ["integer", "string"],
                     "description": "The value to use for the pruning method (number of tags e.g. 10, time delta e.g. 7d (7 days))",
+                },
+                "tagPattern": {
+                    "type": "string",
+                    "description": "Tags only matching this pattern will be pruned",
+                },
+                "tagPatternMatches": {
+                    "type": "boolean",
+                    "description": "Determine whether pruned tags should or should not match the tagPattern",
                 },
             },
         },
@@ -184,6 +208,10 @@ class OrgAutoPrunePolicy(ApiResource):
         app_data = request.get_json()
         method = app_data.get("method", None)
         value = app_data.get("value", None)
+        tag_pattern = app_data.get("tagPattern", None)
+        if tag_pattern is not None and isinstance(tag_pattern, str):
+            tag_pattern = tag_pattern.strip()
+        tag_pattern_matches = app_data.get("tagPatternMatches", True)
 
         if method is None or value is None:
             request_error(message="Missing the following parameters: method, value")
@@ -191,6 +219,8 @@ class OrgAutoPrunePolicy(ApiResource):
         policy_config = {
             "method": method,
             "value": value,
+            "tag_pattern": tag_pattern,
+            "tag_pattern_matches": tag_pattern_matches,
         }
 
         try:
@@ -212,6 +242,8 @@ class OrgAutoPrunePolicy(ApiResource):
             {
                 "method": policy_config["method"],
                 "value": policy_config["value"],
+                "tag_pattern": policy_config.get("tag_pattern"),
+                "tag_pattern_matches": policy_config.get("tag_pattern_matches"),
                 "namespace": orgname,
             },
         )
@@ -268,6 +300,14 @@ class RepositoryAutoPrunePolicies(RepositoryParamResource):
                     "type": ["integer", "string"],
                     "description": "The value to use for the pruning method (number of tags e.g. 10, time delta e.g. 7d (7 days))",
                 },
+                "tagPattern": {
+                    "type": "string",
+                    "description": "Tags only matching this pattern will be pruned",
+                },
+                "tagPatternMatches": {
+                    "type": "boolean",
+                    "description": "Determine whether pruned tags should or should not match the tagPattern",
+                },
             },
         },
     }
@@ -312,6 +352,10 @@ class RepositoryAutoPrunePolicies(RepositoryParamResource):
         app_data = request.get_json()
         method = app_data.get("method", None)
         value = app_data.get("value", None)
+        tag_pattern = app_data.get("tagPattern", None)
+        if tag_pattern is not None and isinstance(tag_pattern, str):
+            tag_pattern = tag_pattern.strip()
+        tag_pattern_matches = app_data.get("tagPatternMatches", True)
 
         if method is None or value is None:
             request_error(message="Missing the following parameters: method, value")
@@ -319,6 +363,8 @@ class RepositoryAutoPrunePolicies(RepositoryParamResource):
         policy_config = {
             "method": method,
             "value": value,
+            "tag_pattern": tag_pattern,
+            "tag_pattern_matches": tag_pattern_matches,
         }
 
         try:
@@ -340,6 +386,8 @@ class RepositoryAutoPrunePolicies(RepositoryParamResource):
             {
                 "method": policy_config["method"],
                 "value": policy_config["value"],
+                "tag_pattern": policy_config.get("tag_pattern"),
+                "tag_pattern_matches": policy_config.get("tag_pattern_matches"),
                 "namespace": namespace,
                 "repo": repository,
             },
@@ -371,6 +419,14 @@ class RepositoryAutoPrunePolicy(RepositoryParamResource):
                 "value": {
                     "type": ["integer", "string"],
                     "description": "The value to use for the pruning method (number of tags e.g. 10, time delta e.g. 7d (7 days))",
+                },
+                "tagPattern": {
+                    "type": "string",
+                    "description": "Tags only matching this pattern will be pruned",
+                },
+                "tagPatternMatches": {
+                    "type": "boolean",
+                    "description": "Determine whether pruned tags should or should not match the tagPattern",
                 },
             },
         },
@@ -410,6 +466,10 @@ class RepositoryAutoPrunePolicy(RepositoryParamResource):
         app_data = request.get_json()
         method = app_data.get("method", None)
         value = app_data.get("value", None)
+        tag_pattern = app_data.get("tagPattern", None)
+        if tag_pattern is not None and isinstance(tag_pattern, str):
+            tag_pattern = tag_pattern.strip()
+        tag_pattern_matches = app_data.get("tagPatternMatches", True)
 
         if method is None or value is None:
             request_error(message="Missing the following parameters: method, value")
@@ -417,6 +477,8 @@ class RepositoryAutoPrunePolicy(RepositoryParamResource):
         policy_config = {
             "method": method,
             "value": value,
+            "tag_pattern": tag_pattern,
+            "tag_pattern_matches": tag_pattern_matches,
         }
 
         try:
@@ -440,6 +502,8 @@ class RepositoryAutoPrunePolicy(RepositoryParamResource):
             {
                 "method": policy_config["method"],
                 "value": policy_config["value"],
+                "tag_pattern": policy_config.get("tag_pattern"),
+                "tag_pattern_matches": policy_config.get("tag_pattern_matches"),
                 "namespace": namespace,
                 "repo": repository,
             },
@@ -502,6 +566,14 @@ class UserAutoPrunePolicies(ApiResource):
                     "type": ["integer", "string"],
                     "description": "The value to use for the pruning method (number of tags e.g. 10, time delta e.g. 7d (7 days))",
                 },
+                "tagPattern": {
+                    "type": "string",
+                    "description": "Tags only matching this pattern will be pruned",
+                },
+                "tagPatternMatches": {
+                    "type": "boolean",
+                    "description": "Determine whether pruned tags should or should not match the tagPattern",
+                },
             },
         },
     }
@@ -530,6 +602,10 @@ class UserAutoPrunePolicies(ApiResource):
         app_data = request.get_json()
         method = app_data.get("method", None)
         value = app_data.get("value", None)
+        tag_pattern = app_data.get("tagPattern", None)
+        if tag_pattern is not None and isinstance(tag_pattern, str):
+            tag_pattern = tag_pattern.strip()
+        tag_pattern_matches = app_data.get("tagPatternMatches", True)
 
         if method is None or value is None:
             request_error(message="Missing the following parameters: method, value")
@@ -537,7 +613,10 @@ class UserAutoPrunePolicies(ApiResource):
         policy_config = {
             "method": method,
             "value": value,
+            "tag_pattern": tag_pattern,
+            "tag_pattern_matches": tag_pattern_matches,
         }
+
         try:
             policy = model.autoprune.create_namespace_autoprune_policy(
                 user.username, policy_config, create_task=True
@@ -556,6 +635,8 @@ class UserAutoPrunePolicies(ApiResource):
                 "method": policy_config["method"],
                 "value": policy_config["value"],
                 "namespace": user.username,
+                "tag_pattern": policy_config.get("tag_pattern"),
+                "tag_pattern_matches": policy_config.get("tag_pattern_matches"),
             },
         )
 
@@ -583,6 +664,14 @@ class UserAutoPrunePolicy(ApiResource):
                 "value": {
                     "type": ["integer", "string"],
                     "description": "The value to use for the pruning method (number of tags e.g. 10, time delta e.g. 7d (7 days))",
+                },
+                "tagPattern": {
+                    "type": "string",
+                    "description": "Tags only matching this pattern will be pruned",
+                },
+                "tagPatternMatches": {
+                    "type": "boolean",
+                    "description": "Determine whether pruned tags should or should not match the tagPattern",
                 },
             },
         },
@@ -614,6 +703,10 @@ class UserAutoPrunePolicy(ApiResource):
         app_data = request.get_json()
         method = app_data.get("method", None)
         value = app_data.get("value", None)
+        tag_pattern = app_data.get("tagPattern", None)
+        if tag_pattern is not None and isinstance(tag_pattern, str):
+            tag_pattern = tag_pattern.strip()
+        tag_pattern_matches = app_data.get("tagPatternMatches", True)
 
         if method is None or value is None:
             request_error(message="Missing the following parameters: method, value")
@@ -621,6 +714,8 @@ class UserAutoPrunePolicy(ApiResource):
         policy_config = {
             "method": method,
             "value": value,
+            "tag_pattern": tag_pattern,
+            "tag_pattern_matches": tag_pattern_matches,
         }
 
         try:
@@ -643,6 +738,8 @@ class UserAutoPrunePolicy(ApiResource):
                 "method": policy_config["method"],
                 "value": policy_config["value"],
                 "namespace": user.username,
+                "tag_pattern": policy_config.get("tag_pattern"),
+                "tag_pattern_matches": policy_config.get("tag_pattern_matches"),
             },
         )
 

--- a/web/cypress/e2e/autopruning.cy.ts
+++ b/web/cypress/e2e/autopruning.cy.ts
@@ -166,6 +166,28 @@ describe('Namespace settings - autoprune policies', () => {
     cy.get('[data-testid="registry-autoprune-policy-value"]').contains('10');
   });
 
+  it('creates policy with tag filter', () => {
+    cy.visit('/organization/testorg?tab=Settings');
+    cy.contains('Auto-Prune Policies').click();
+    cy.get('[data-testid="namespace-auto-prune-method"]').select(
+      'By age of tags',
+    );
+    cy.get('input[aria-label="tag creation date value"]').should(
+      'have.value',
+      '7',
+    );
+    cy.get('select[aria-label="tag creation date unit"]').contains('days');
+    cy.get('input[aria-label="tag creation date value"]').type(
+      '2{leftArrow}{backspace}',
+    );
+    cy.get('select[aria-label="tag creation date unit"]').select('weeks');
+
+    cy.get('input[aria-label="tag pattern"]').type('v1.*');
+    cy.get('select[aria-label="tag pattern matches"]').select('does not match');
+    cy.contains('Save').click();
+    cy.contains('Successfully created auto-prune policy');
+  });
+
   // TODO: Uncomment once user settings is supported
   // it('updates policy for users', () => {
   //     cy.visit('/organization/user1?tab=Settings');

--- a/web/cypress/e2e/repository-autopruning.cy.ts
+++ b/web/cypress/e2e/repository-autopruning.cy.ts
@@ -196,4 +196,24 @@ describe('Repository settings - Repository autoprune policies', () => {
     );
     cy.get('[data-testid="registry-autoprune-policy-value"]').contains('10');
   });
+
+  it('creates policy with tag filter', () => {
+    cy.visit('/repository/testorg/testrepo?tab=settings');
+    cy.contains('Repository Auto-Prune Policies').click();
+    cy.get('[data-testid="repository-auto-prune-method"]').select(
+      'By age of tags',
+    );
+    cy.get('input[aria-label="tag creation date value"]').should(
+      'have.value',
+      '7',
+    );
+    cy.get('select[aria-label="tag creation date unit"]').contains('days');
+    cy.get('input[aria-label="tag creation date value"]').type(
+      '2{leftArrow}{backspace}',
+    );
+    cy.get('select[aria-label="tag creation date unit"]').select('weeks');
+    cy.get('input[aria-label="tag pattern"]').type('v1.*');
+    cy.get('select[aria-label="tag pattern matches"]').select('does not match');
+    cy.contains('Save').click();
+  });
 });

--- a/web/src/resources/NamespaceAutoPruneResource.ts
+++ b/web/src/resources/NamespaceAutoPruneResource.ts
@@ -12,6 +12,8 @@ export interface NamespaceAutoPrunePolicy {
   method: AutoPruneMethod;
   uuid?: string;
   value?: string | number;
+  tagPattern?: string;
+  tagPatternMatches?: boolean;
 }
 
 export async function fetchNamespaceAutoPrunePolicies(

--- a/web/src/resources/RepositoryAutoPruneResource.ts
+++ b/web/src/resources/RepositoryAutoPruneResource.ts
@@ -7,6 +7,8 @@ export interface RepositoryAutoPrunePolicy {
   method: AutoPruneMethod;
   uuid?: string;
   value?: string | number;
+  tagPattern?: string;
+  tagPatternMatches?: boolean;
 }
 
 export async function fetchRepositoryAutoPrunePolicies(


### PR DESCRIPTION
Allows users to specify a regex tag pattern when creating namespace/repository autoprune policies via the new UI. Users will have the option to prune tags that only match the tag pattern or exclude tags that match the tag pattern.