### PR TITLE
db: adding immutable column to tag table (PROJQUAY-7777)

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -1770,6 +1770,7 @@ class Tag(BaseModel):
     manifest_id: int
     lifetime_start_ms = BigIntegerField(default=get_epoch_timestamp_ms)
     lifetime_end_ms = BigIntegerField(null=True, index=True)
+    immutable = BooleanField(default=False)
     hidden = BooleanField(default=False)
     reversion = BooleanField(default=False)
     tag_kind = EnumField(TagKind)
@@ -1786,6 +1787,9 @@ class Tag(BaseModel):
             (("repository", "lifetime_end_ms"), False),
             # This unique index prevents deadlocks when concurrently moving and deleting tags
             (("repository", "name", "lifetime_end_ms"), True),
+            (("repository", "immutable"), False),
+            (("manifest", "immutable"), False),
+            (("manifest", "lifetime_end_ms"), False),
         )
 
 

--- a/data/migrations/versions/5b8dc452f5c3_add_tag_immutability_column_and_logentry_kinds.py
+++ b/data/migrations/versions/5b8dc452f5c3_add_tag_immutability_column_and_logentry_kinds.py
@@ -1,0 +1,74 @@
+"""add tag immutability column
+
+Revision ID: 5b8dc452f5c3
+Revises: a32e17bfad20
+Create Date: 2023-05-21 13:13:10.565161
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "5b8dc452f5c3"
+down_revision = "a32e17bfad20"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    # add column to track tack immutability
+    op.add_column(
+        table_name="tag",
+        column=sa.Column(
+            name="immutable",
+            type_=sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+    )
+
+    with op.get_context().autocommit_block():
+        # needed to quickly find repositories with immutable tags (can't make those be a mirror)
+        op.create_index(
+            table_name="tag",
+            index_name="tag_repository_id_immutable",
+            columns=["repository_id", "immutable"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+        # needed to quickly find manifests with immutable tags (can't expire those via label)
+        op.create_index(
+            table_name="tag",
+            index_name="tag_manifest_id_immutable",
+            columns=["manifest_id", "immutable"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+        # needed to quickly find manifests with expiring tags (can't make those immutable)
+        op.create_index(
+            table_name="tag",
+            index_name="tag_manifest_id_lifetime_end_ms",
+            columns=["manifest_id", "lifetime_end_ms"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+    # add logentrykind for tag immutability changes
+    op.bulk_insert(
+        tables.logentrykind,
+        [
+            {"name": "change_tag_immutability"},
+        ],
+    )
+
+
+def downgrade(op, tables, tester):
+    op.drop_index(table_name="tag", index_name="tag_repository_id_immutable")
+    op.drop_index(table_name="tag", index_name="tag_manifest_id_immutable")
+    op.drop_index(table_name="tag", index_name="tag_manifest_id_lifetime_end_ms")
+    op.drop_column(table_name="tag", column_name="immutable")
+    op.execute(
+        tables.logentrykind.delete().where(
+            tables.logentrykind.name == op.inline_literal("change_tag_immutability")
+        )
+    )

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -211,7 +211,10 @@ DROP INDEX IF EXISTS public.tag_repository_id_name_hidden;
 DROP INDEX IF EXISTS public.tag_repository_id_name;
 DROP INDEX IF EXISTS public.tag_repository_id_lifetime_start_ms;
 DROP INDEX IF EXISTS public.tag_repository_id_lifetime_end_ms;
+DROP INDEX IF EXISTS public.tag_repository_id_immutable;
 DROP INDEX IF EXISTS public.tag_repository_id;
+DROP INDEX IF EXISTS public.tag_manifest_id_lifetime_end_ms;
+DROP INDEX IF EXISTS public.tag_manifest_id_immutable;
 DROP INDEX IF EXISTS public.tag_manifest_id;
 DROP INDEX IF EXISTS public.tag_linked_tag_id;
 DROP INDEX IF EXISTS public.tag_lifetime_end_ms;
@@ -4204,7 +4207,8 @@ CREATE TABLE public.tag (
     hidden boolean DEFAULT false NOT NULL,
     reversion boolean DEFAULT false NOT NULL,
     tag_kind_id integer NOT NULL,
-    linked_tag_id integer
+    linked_tag_id integer,
+    immutable boolean DEFAULT false NOT NULL
 );
 
 
@@ -5738,7 +5742,7 @@ COPY public.accesstokenkind (id, name) FROM stdin;
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-a32e17bfad20
+5b8dc452f5c3
 \.
 
 
@@ -6419,6 +6423,7 @@ COPY public.logentrykind (id, name) FROM stdin;
 112	disable_team_sync
 113	oauth_token_assigned
 114	oauth_token_revoked
+115	change_tag_immutability
 \.
 
 
@@ -8290,7 +8295,7 @@ SELECT pg_catalog.setval('public.logentry_id_seq', 1, false);
 -- Name: logentrykind_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.logentrykind_id_seq', 114, true);
+SELECT pg_catalog.setval('public.logentrykind_id_seq', 115, true);
 
 
 --
@@ -11643,10 +11648,31 @@ CREATE INDEX tag_manifest_id ON public.tag USING btree (manifest_id);
 
 
 --
+-- Name: tag_manifest_id_immutable; Type: INDEX; Schema: public; Owner: quay
+--
+
+CREATE INDEX tag_manifest_id_immutable ON public.tag USING btree (manifest_id, immutable);
+
+
+--
+-- Name: tag_manifest_id_lifetime_end_ms; Type: INDEX; Schema: public; Owner: quay
+--
+
+CREATE INDEX tag_manifest_id_lifetime_end_ms ON public.tag USING btree (manifest_id, lifetime_end_ms);
+
+
+--
 -- Name: tag_repository_id; Type: INDEX; Schema: public; Owner: quay
 --
 
 CREATE INDEX tag_repository_id ON public.tag USING btree (repository_id);
+
+
+--
+-- Name: tag_repository_id_immutable; Type: INDEX; Schema: public; Owner: quay
+--
+
+CREATE INDEX tag_repository_id_immutable ON public.tag USING btree (repository_id, immutable);
 
 
 --


### PR DESCRIPTION
Database schema changes required to implement immutable tags as described in [PROJQUAY-7653](https://issues.redhat.com/browse/PROJQUAY-7653). Adds the `immutable` column as well as required indexes.

This is the first commit of 4 from the [original pull request](https://github.com/quay/quay/pull/1927).

Co-Authored-By: dmesser <dmesser@redhat.com>