### PR TITLE
init: adding Postgres cert install to entrypoint (PROJQUAY-7694)

### DIFF
--- a/quay-entrypoint.sh
+++ b/quay-entrypoint.sh
@@ -78,6 +78,7 @@ case "$QUAYENTRY" in
         echo ""; echo "Startup timestamp: "; date; echo ""
         : "${MIGRATION_VERSION:=$2}"
         : "${MIGRATION_VERSION:?Missing version argument}"
+        "${QUAYPATH}/conf/init/client_certs.sh" || exit
         echo "Entering migration mode to version: ${MIGRATION_VERSION}"
         PYTHONPATH="${QUAYPATH}" alembic upgrade "${MIGRATION_VERSION}"
         ;;


### PR DESCRIPTION
`client_certs.sh` set's the correct permissions on the postgres certificates if they're found. This script was missing from the `migrate` command which would cause the migration to fail when using postgres certificate authentication.