### PR TITLE
api: proxy clair vulnerability reports [PROJQUAY-6633]

### DIFF
--- a/data/secscan_model/__init__.py
+++ b/data/secscan_model/__init__.py
@@ -39,12 +39,19 @@ class SecurityScannerModelProxy(SecurityScannerInterface):
         self._model.perform_indexing_recent_manifests(batch_size)
 
     def load_security_information(
-        self, manifest_or_legacy_image, include_vulnerabilities, model_cache=None
+        self,
+        manifest_or_legacy_image,
+        include_vulnerabilities,
+        proxy_clair_response,
+        model_cache=None,
     ):
         manifest = manifest_or_legacy_image.as_manifest()
 
-        info = self._model.load_security_information(manifest, include_vulnerabilities, model_cache)
-        if info.status != ScanLookupStatus.NOT_YET_INDEXED:
+        info = self._model.load_security_information(
+            manifest, include_vulnerabilities, proxy_clair_response, model_cache
+        )
+
+        if proxy_clair_response or info.status != ScanLookupStatus.NOT_YET_INDEXED:
             return info
 
         return SecurityInformationLookupResult.with_status(ScanLookupStatus.NOT_YET_INDEXED)

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -78,7 +78,11 @@ class NoopV4SecurityScanner(SecurityScannerInterface):
     """
 
     def load_security_information(
-        self, manifest_or_legacy_image, include_vulnerabilities=False, model_cache=None
+        self,
+        manifest_or_legacy_image,
+        include_vulnerabilities=False,
+        proxy_clair_response=False,
+        model_cache=None,
     ):
         return SecurityInformationLookupResult.for_request_error("security scanner misconfigured")
 
@@ -155,7 +159,11 @@ class V4SecurityScanner(SecurityScannerInterface):
         )
 
     def load_security_information(
-        self, manifest_or_legacy_image, include_vulnerabilities=False, model_cache=None
+        self,
+        manifest_or_legacy_image,
+        include_vulnerabilities=False,
+        proxy_clair_response=False,
+        model_cache=None,
     ):
         if not isinstance(manifest_or_legacy_image, ManifestDataType):
             return SecurityInformationLookupResult.with_status(
@@ -192,7 +200,8 @@ class V4SecurityScanner(SecurityScannerInterface):
         try:
             if model_cache:
                 security_report_key = cache_key.for_security_report(
-                    manifest_or_legacy_image.digest, model_cache.cache_config
+                    manifest_or_legacy_image.digest,
+                    model_cache.cache_config,
                 )
                 report = model_cache.retrieve(security_report_key, security_report_loader)
             else:
@@ -204,6 +213,9 @@ class V4SecurityScanner(SecurityScannerInterface):
             return SecurityInformationLookupResult.with_status(ScanLookupStatus.NOT_YET_INDEXED)
 
         # TODO(alecmerdler): Provide a way to indicate the current scan is outdated (`report.state != status.indexer_hash`)
+
+        if proxy_clair_response:
+            return report
 
         return SecurityInformationLookupResult.for_data(
             SecurityInformation(Layer(report["manifest_hash"], "", "", 4, features_for(report)))

--- a/data/secscan_model/test/test_secscan_interface.py
+++ b/data/secscan_model/test/test_secscan_interface.py
@@ -43,7 +43,7 @@ def test_load_security_information(indexed_v4, expected_status, initialized_db):
             metadata_json={},
         )
 
-    result = secscan_model.load_security_information(manifest, True)
+    result = secscan_model.load_security_information(manifest, True, False)
 
     assert isinstance(result, SecurityInformationLookupResult)
     assert result.status == expected_status

--- a/endpoints/api/secscan.py
+++ b/endpoints/api/secscan.py
@@ -55,7 +55,7 @@ MAPPED_STATUSES[
 logger = logging.getLogger(__name__)
 
 
-def _security_info(manifest_or_legacy_image, include_vulnerabilities=True):
+def _security_info(manifest_or_legacy_image, include_vulnerabilities=True, raw=False):
     """
     Returns a dict representing the result of a call to the security status API for the given
     manifest or image.
@@ -63,8 +63,14 @@ def _security_info(manifest_or_legacy_image, include_vulnerabilities=True):
     result = secscan_model.load_security_information(
         manifest_or_legacy_image,
         include_vulnerabilities=include_vulnerabilities,
+        proxy_clair_response=raw,
         model_cache=model_cache,
     )
+
+    # lets see if we can bundle raw in result and status check
+    if raw:
+        return result
+
     if result.status == ScanLookupStatus.UNKNOWN_MANIFEST_OR_IMAGE:
         raise NotFound()
 
@@ -98,6 +104,12 @@ class RepositoryManifestSecurity(RepositoryParamResource):
     @query_param(
         "vulnerabilities", "Include vulnerabilities informations", type=truthy_bool, default=False
     )
+    @query_param(
+        "raw",
+        "Returns a vulnerability report for the specified manifest from Clair",
+        type=truthy_bool,
+        default=False,
+    )
     def get(self, namespace, repository, manifestref, parsed_args):
         repo_ref = registry_model.lookup_repository(namespace, repository)
         if repo_ref is None:
@@ -107,4 +119,4 @@ class RepositoryManifestSecurity(RepositoryParamResource):
         if manifest is None:
             raise NotFound()
 
-        return _security_info(manifest, parsed_args.vulnerabilities)
+        return _security_info(manifest, parsed_args.vulnerabilities, parsed_args.raw)


### PR DESCRIPTION
Adds `raw` as a query param to the `/security` API to return Clair's response directly 