### PR TITLE
api: adding tag immutability to the api (PROJQUAY-7778)

### DIFF
--- a/data/model/__init__.py
+++ b/data/model/__init__.py
@@ -117,6 +117,10 @@ class TagDoesNotExist(DataModelException):
     pass
 
 
+class TagImmutableException(DataModelException):
+    pass
+
+
 class TagAlreadyCreatedException(DataModelException):
     pass
 

--- a/data/model/oci/label.py
+++ b/data/model/oci/label.py
@@ -1,5 +1,6 @@
 import logging
 
+from data import model
 from data.database import (
     Label,
     LabelSourceType,
@@ -14,6 +15,7 @@ from data.model import (
     InvalidLabelKeyException,
     InvalidMediaTypeException,
 )
+from data.model.oci.tag import has_immutable_tags_for_manifest
 from data.text import prefix_search
 from util.validation import is_json, validate_label_key
 
@@ -58,7 +60,9 @@ def get_manifest_label(label_uuid, manifest):
         return None
 
 
-def create_manifest_label(manifest_id, key, value, source_type_name, media_type_name=None):
+def create_manifest_label(
+    manifest_id, key, value, source_type_name, media_type_name=None, raise_on_error=False
+):
     """
     Creates a new manifest label on a specific tag manifest.
     """
@@ -92,7 +96,20 @@ def create_manifest_label(manifest_id, key, value, source_type_name, media_type_
             .get()
         )
     except Manifest.DoesNotExist:
+        if raise_on_error:
+            raise model.ManifestDoesNotExist(
+                "Cannot create label '%s=%s', requested manifest does not exist" % (key, value)
+            )
         return None
+
+    # raise TagImmutableException() if manifest has immutable tags
+    if has_immutable_tags_for_manifest(manifest.id):
+        if raise_on_error:
+            raise model.TagImmutableException(
+                "Cannot add label to manifest %s which has immutable tags" % manifest.digest
+            )
+        else:
+            return None
 
     repository = manifest.repository
 
@@ -107,7 +124,7 @@ def create_manifest_label(manifest_id, key, value, source_type_name, media_type_
     return label
 
 
-def delete_manifest_label(label_uuid, manifest):
+def delete_manifest_label(label_uuid, manifest, raise_on_error=False):
     """
     Deletes the manifest label on the tag manifest with the given ID.
 
@@ -118,8 +135,19 @@ def delete_manifest_label(label_uuid, manifest):
     if label is None:
         return None
 
+    if has_immutable_tags_for_manifest(manifest):
+        if raise_on_error:
+            raise model.TagImmutableException(
+                "Cannot delete label from manifest which has immutable tags"
+            )
+        else:
+            return None
+
     if not label.source_type.mutable:
-        raise DataModelException("Cannot delete immutable label")
+        if raise_on_error:
+            raise DataModelException("Cannot delete immutable label")
+        else:
+            return None
 
     # Delete the mapping records and label.
     with db_transaction():

--- a/data/model/organization.py
+++ b/data/model/organization.py
@@ -4,6 +4,7 @@ from data.database import (
     Namespace,
     Repository,
     RepositoryPermission,
+    Tag,
     Team,
     TeamMember,
     TeamRole,
@@ -203,5 +204,21 @@ def is_org_admin(user, org):
         .switch(Team)
         .join(TeamRole)
         .where(Team.organization == org, TeamRole.name == "admin", TeamMember.user == user)
+        .exists()
+    )
+
+
+def has_immutable_tags(org_name):
+    """
+    Returns true if the given organization has any repositories containing tags that are set to immutable.
+
+    """
+    return (
+        Tag.select()
+        .join(Repository)
+        .join(User)
+        .where(User.username == org_name)
+        .where(User.organization == True)
+        .where(Tag.immutable == True)
         .exists()
     )

--- a/data/model/test/test_organization.py
+++ b/data/model/test/test_organization.py
@@ -1,8 +1,16 @@
 import pytest
 
-from data.model.organization import get_organization, get_organizations, is_org_admin
+from data.model.organization import (
+    get_organization,
+    get_organizations,
+    has_immutable_tags,
+    is_org_admin,
+)
+from data.model.repository import create_repository
+from data.model.test.test_repository import _create_tag
 from data.model.user import get_user, mark_namespace_for_deletion
 from data.queue import WorkQueue
+from data.registry_model import registry_model
 from test.fixtures import *
 
 
@@ -30,3 +38,23 @@ def test_is_org_admin(initialized_db):
     user = get_user("devtable")
     org = get_organization("sellnsmall")
     assert is_org_admin(user, org) is True
+
+
+def test_check_for_repositories_with_immutable_tags(initialized_db):
+    # Create a repository and some tags
+    repo = create_repository(
+        "sellnsmall", "somenewrepo", None, repo_kind="image", visibility="public"
+    )
+    _ = _create_tag(repo, "tag1")
+    _ = _create_tag(repo, "tag2")
+    _ = _create_tag(repo, "tag3")
+
+    # Expect the organization to not have repositories with immutable tags
+    assert not has_immutable_tags("sellnsmall")
+
+    # Set one of the tags to immutable
+    tag = _create_tag(repo, "tag4")
+    registry_model.set_tag_immutable(tag)
+
+    # Expect the organization to have repositories with immutable tags
+    assert has_immutable_tags("sellnsmall")

--- a/data/registry_model/datatypes.py
+++ b/data/registry_model/datatypes.py
@@ -214,6 +214,7 @@ class Tag(
             "lifetime_end_ts",
             "lifetime_start_ms",
             "lifetime_end_ms",
+            "immutable",
         ],
     )
 ):
@@ -234,6 +235,7 @@ class Tag(
             lifetime_end_ms=tag.lifetime_end_ms,
             lifetime_start_ts=tag.lifetime_start_ms // 1000,
             lifetime_end_ts=tag.lifetime_end_ms // 1000 if tag.lifetime_end_ms else None,
+            immutable=tag.immutable,
             manifest_digest=manifest_row.digest if manifest_row else tag.manifest.digest,
             inputs=dict(
                 legacy_id_handler=legacy_id_handler,

--- a/data/registry_model/interface.py
+++ b/data/registry_model/interface.py
@@ -378,6 +378,12 @@ class RegistryDataInterface(object):
         """
 
     @abstractmethod
+    def set_tags_immutable_for_manifest(self, manifest):
+        """
+        Sets the immutable flag on all tags that point to the given manifest.
+        """
+
+    @abstractmethod
     def get_schema1_parsed_manifest(
         self, manifest, namespace_name, repo_name, tag_name, storage, raise_on_error=False
     ):

--- a/data/registry_model/label_handlers.py
+++ b/data/registry_model/label_handlers.py
@@ -6,6 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 LABEL_EXPIRY_KEY = "quay.expires-after"
+LABEL_IMMUTABLE_KEY = "quay.immutable"
 
 
 def _expires_after(label_dict, manifest, model):
@@ -23,8 +24,25 @@ def _expires_after(label_dict, manifest, model):
     model.set_tags_expiration_for_manifest(manifest, total_seconds)
 
 
+def _immutable(label_dict, manifest, model):
+    """
+    Sets the immutability of a manifest based on the quay.immutable label.
+    """
+
+    try:
+        immutable = label_dict["value"] == "true"
+
+        if immutable:
+            logger.debug("Labeling manifest %s as immutable", manifest)
+            model.set_tags_immutable_for_manifest(manifest)
+    except ValueError:
+        logger.exception("Could not convert %s to boolean", label_dict["value"])
+        return
+
+
 _LABEL_HANDLERS = {
     LABEL_EXPIRY_KEY: _expires_after,
+    LABEL_IMMUTABLE_KEY: _immutable,
 }
 
 

--- a/data/registry_model/test/test_datatypes.py
+++ b/data/registry_model/test/test_datatypes.py
@@ -15,6 +15,7 @@ class TestTag:
             lifetime_start_ms=one_hour_ago_ms,
             lifetime_end_ts=one_minute_ago_ms // 1000,
             lifetime_end_ms=one_minute_ago_ms,
+            immutable=False,
         )
         assert tag.expired
 
@@ -29,6 +30,7 @@ class TestTag:
             lifetime_start_ms=one_hour_ago_ms,
             lifetime_end_ts=now_ms // 1000,
             lifetime_end_ms=now_ms,
+            immutable=False,
         )
         assert tag.expired
 
@@ -44,6 +46,7 @@ class TestTag:
             lifetime_start_ms=one_hour_ago_ms,
             lifetime_end_ts=one_hour_from_now_ms // 1000,
             lifetime_end_ms=one_hour_from_now_ms,
+            immutable=False,
         )
         assert not tag.expired
 
@@ -58,5 +61,6 @@ class TestTag:
             lifetime_start_ms=one_hour_ago_ms,
             lifetime_end_ts=None,
             lifetime_end_ms=None,
+            immutable=False,
         )
         assert not tag.expired

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -39,9 +39,7 @@ from image.docker.schema1 import (
     DockerSchema1Manifest,
     DockerSchema1ManifestBuilder,
 )
-from image.docker.schema2.list import DockerSchema2ManifestListBuilder
 from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
-from image.oci.index import OCIIndexBuilder
 from image.shared.types import ManifestImageLayer
 from test.fixtures import *
 from util.bytes import Bytes
@@ -198,7 +196,28 @@ def test_manifest_labels(registry_model):
     assert created not in registry_model.list_manifest_labels(found_manifest)
 
 
-def test_manifest_label_handlers(registry_model):
+def test_manifest_label_with_immutable_tags(registry_model):
+    repo = model.repository.get_repository("devtable", "simple")
+    repository_ref = RepositoryReference.for_repo_obj(repo)
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    assert not tag.immutable
+
+    manifest = registry_model.get_manifest_for_tag(tag)
+
+    created = registry_model.create_manifest_label(manifest, "foo", "bar", "api")
+
+    registry_model.set_tag_immutable(tag)
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    assert tag.immutable
+
+    with pytest.raises(model.TagImmutableException):
+        registry_model.create_manifest_label(manifest, "foo", "baz", "api", raise_on_error=True)
+
+    with pytest.raises(model.TagImmutableException):
+        registry_model.delete_manifest_label(manifest, created.uuid, raise_on_error=True)
+
+
+def test_manifest_label_expiry_handler(registry_model):
     repo = model.repository.get_repository("devtable", "simple")
     repository_ref = RepositoryReference.for_repo_obj(repo)
     found_tag = registry_model.get_repo_tag(repository_ref, "latest")
@@ -215,6 +234,26 @@ def test_manifest_label_handlers(registry_model):
     assert updated_tag.lifetime_end_ts == (updated_tag.lifetime_start_ts + (60 * 60 * 2))
 
 
+def test_manifest_label_immutability_handler(registry_model):
+    repo = model.repository.get_repository("devtable", "simple")
+    repository_ref = RepositoryReference.for_repo_obj(repo)
+    found_tag = registry_model.get_repo_tag(repository_ref, "prod")
+    found_manifest = registry_model.get_manifest_for_tag(found_tag)
+
+    # Ensure the tag has no expiration.
+    assert found_tag.lifetime_end_ts is None
+
+    # Ensure the tag is not immutable alread.
+    assert not found_tag.immutable
+
+    # Create a new label with an immutable.
+    registry_model.create_manifest_label(found_manifest, "quay.immutable", "true", "api")
+
+    # Ensure the tag is now immutable.
+    updated_tag = registry_model.get_repo_tag(repository_ref, "prod")
+    assert updated_tag.immutable
+
+
 def test_batch_labels(registry_model):
     repo = model.repository.get_repository("devtable", "history")
     repository_ref = RepositoryReference.for_repo_obj(repo)
@@ -228,6 +267,23 @@ def test_batch_labels(registry_model):
 
     # Ensure we can look them up.
     assert len(registry_model.list_manifest_labels(found_manifest)) == 3
+
+
+def test_batch_labels_fail_with_immutable_tags(registry_model):
+    repo = model.repository.get_repository("devtable", "history")
+    repository_ref = RepositoryReference.for_repo_obj(repo)
+    found_tag = registry_model.find_matching_tag(repository_ref, ["latest"])
+    found_manifest = registry_model.get_manifest_for_tag(found_tag)
+
+    registry_model.set_tag_immutable(found_tag)
+
+    with pytest.raises(model.TagImmutableException):
+        with registry_model.batch_create_manifest_labels(
+            found_manifest, raise_on_error=True
+        ) as add_label:
+            add_label("foo", "1", "api")
+            add_label("bar", "2", "api")
+            add_label("baz", "3", "api")
 
 
 @pytest.mark.parametrize(
@@ -389,6 +445,37 @@ def test_delete_tags(repo_namespace, repo_name, via_manifest, registry_model):
 
 
 @pytest.mark.parametrize(
+    "via_manifest",
+    [
+        False,
+        True,
+    ],
+)
+def test_delete_immutable_tag(via_manifest, registry_model):
+    # Get a tag.
+    repository_ref = registry_model.lookup_repository("devtable", "simple")
+    latest_tag = registry_model.get_repo_tag(repository_ref, "latest")
+
+    # Set the tag to be immutable.
+    registry_model.set_tag_immutable(latest_tag)
+
+    # Attempt to delete the immutable tag.
+    with pytest.raises(model.TagImmutableException):
+        if via_manifest:
+            manifest = registry_model.get_manifest_for_tag(latest_tag)
+            registry_model.delete_tags_for_manifest(model_cache, manifest, raise_on_error=True)
+        else:
+            registry_model.delete_tag(
+                model_cache, repository_ref, latest_tag.name, raise_on_error=True
+            )
+
+    # Ensure the tag still exists.
+    tag = registry_model.get_repo_tag(repository_ref, latest_tag.name)
+    assert tag is not None
+    assert tag.immutable
+
+
+@pytest.mark.parametrize(
     "use_manifest",
     [
         True,
@@ -430,6 +517,30 @@ def test_retarget_tag_history(use_manifest, registry_model):
     assert len(new_history) == len(history) + 1
 
 
+def test_retarget_tag_history_with_immutable_tag(registry_model):
+    repository_ref = registry_model.lookup_repository("devtable", "history")
+    history, _ = registry_model.list_repository_tag_history(repository_ref)
+
+    # Set the tag to be immutable.
+    registry_model.set_tag_immutable(history[0])
+
+    # Retarget the tag.
+    manifest_or_legacy_image = registry_model.lookup_manifest_by_digest(
+        repository_ref, history[0].manifest_digest, allow_dead=True
+    )
+    assert manifest_or_legacy_image
+    with pytest.raises(model.TagImmutableException):
+        registry_model.retarget_tag(
+            repository_ref,
+            "latest",
+            manifest_or_legacy_image,
+            storage,
+            docker_v2_signing_key,
+            is_reversion=True,
+            raise_on_error=True,
+        )
+
+
 def test_change_repository_tag_expiration(registry_model):
     repository_ref = registry_model.lookup_repository("devtable", "simple")
     tag = registry_model.get_repo_tag(repository_ref, "latest")
@@ -443,6 +554,162 @@ def test_change_repository_tag_expiration(registry_model):
 
     tag = registry_model.get_repo_tag(repository_ref, "latest")
     assert tag.lifetime_end_ts is not None
+
+
+def test_change_repository_tag_expiration_immutable_tag(registry_model):
+    repository_ref = registry_model.lookup_repository("devtable", "simple")
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    registry_model.set_tag_immutable(tag)
+
+    new_datetime = datetime.utcnow() + timedelta(days=2)
+    previous, okay = registry_model.change_repository_tag_expiration(tag, new_datetime)
+
+    assert not okay
+    assert previous is None
+
+    with pytest.raises(model.TagImmutableException):
+        registry_model.change_repository_tag_expiration(tag, new_datetime, raise_on_error=True)
+
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    assert tag.lifetime_end_ts is None
+
+
+@pytest.mark.parametrize(
+    "with_exception",
+    [
+        True,
+        False,
+    ],
+)
+def test_set_tag_immutability(with_exception, registry_model):
+    repository_ref = registry_model.lookup_repository("devtable", "simple")
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    assert not tag.immutable
+
+    registry_model.set_tag_immutable(tag)
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    assert tag.immutable
+
+    registry_model.set_tag_mutable(tag)
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    assert not tag.immutable
+
+    _, okay = registry_model.change_repository_tag_expiration(
+        tag, datetime.utcnow() + timedelta(days=2)
+    )
+    assert okay
+
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+
+    if with_exception:
+        with pytest.raises(model.TagImmutableException):
+            registry_model.set_tag_immutable(tag, raise_on_error=with_exception)
+    else:
+        assert registry_model.set_tag_immutable(tag) is None
+
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    assert not tag.immutable
+
+
+def test_has_immutable_tags_for_manifest(registry_model):
+    repository_ref = registry_model.lookup_repository("devtable", "simple")
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    assert not registry_model.has_immutable_tags_for_manifest(tag.manifest)
+
+    registry_model.set_tag_immutable(tag)
+    assert registry_model.has_immutable_tags_for_manifest(tag.manifest)
+
+    registry_model.set_tag_mutable(tag)
+    assert not registry_model.has_immutable_tags_for_manifest(tag.manifest)
+
+
+def test_get_immutable_tags_for_manifest(registry_model):
+    repository_ref = registry_model.lookup_repository("devtable", "simple")
+    tag = registry_model.get_repo_tag(repository_ref, "latest")
+    assert not registry_model.get_immutable_tags_for_manifest(tag.manifest)
+
+    registry_model.set_tag_immutable(tag)
+
+    assert tag in registry_model.get_immutable_tags_for_manifest(tag.manifest)
+
+
+def test_set_immutable_tags_for_manifest(registry_model):
+    manifest, v2_manifest_tag = _create_v2_manifest_and_tag(
+        "devtable", "simple", "v2_manifest_tag", registry_model
+    )
+    repository_ref = manifest.repository
+
+    another_v2_manifest_tag = registry_model.retarget_tag(
+        repository_ref, "another_v2_manifest_tag", manifest, storage, docker_v2_signing_key
+    )
+
+    assert not registry_model.get_immutable_tags_for_manifest(manifest)
+
+    registry_model.set_tags_immutable_for_manifest(manifest)
+
+    immutable_manifest_tags = registry_model.get_immutable_tags_for_manifest(manifest)
+
+    v2_manifest_tag = registry_model.get_repo_tag(repository_ref, "v2_manifest_tag")
+    another_v2_manifest_tag = registry_model.get_repo_tag(repository_ref, "another_v2_manifest_tag")
+
+    assert v2_manifest_tag in immutable_manifest_tags
+    assert another_v2_manifest_tag in immutable_manifest_tags
+
+
+def test_set_immutable_tag_for_manifest_with_expiring_tags(registry_model):
+    manifest, tag = _create_v2_manifest_and_tag(
+        "devtable", "simple", "v2_manifest_tag", registry_model
+    )
+    repository_ref = manifest.repository
+
+    another_tag = registry_model.retarget_tag(
+        repository_ref, "another_v2_manifest_tag", manifest, storage, docker_v2_signing_key
+    )
+
+    assert not registry_model.has_immutable_tags_for_manifest(manifest)
+
+    registry_model.set_tags_expiration_for_manifest(manifest, timedelta(days=2).total_seconds())
+
+    assert another_tag.lifetime_end_ms is None
+
+    with pytest.raises(model.TagImmutableException):
+        registry_model.set_tags_immutable_for_manifest(manifest, raise_on_error=True)
+
+
+def test_set_tag_expiration_for_manifest(registry_model):
+    manifest, _ = _create_v2_manifest_and_tag("devtable", "simple", "sometag", registry_model)
+    repository_ref = manifest.repository
+
+    registry_model.retarget_tag(
+        repository_ref, "anothertag", manifest, storage, docker_v2_signing_key
+    )
+    assert not registry_model.has_immutable_tags_for_manifest(manifest)
+
+    registry_model.set_tags_expiration_for_manifest(manifest, timedelta(days=2).total_seconds())
+
+    some_tag = registry_model.get_repo_tag(repository_ref, "sometag")
+    another_tag = registry_model.get_repo_tag(repository_ref, "anothertag")
+
+    assert some_tag.lifetime_end_ms is not None
+    assert another_tag.lifetime_end_ms is not None
+
+
+def test_set_tags_expiration_for_manifest_with_immutable_tags(registry_model):
+    manifest, _ = _create_v2_manifest_and_tag("devtable", "simple", "sometag", registry_model)
+    repository_ref = manifest.repository
+
+    another_tag = registry_model.retarget_tag(
+        repository_ref, "anothertag", manifest, storage, docker_v2_signing_key
+    )
+
+    assert not registry_model.has_immutable_tags_for_manifest(manifest)
+
+    registry_model.set_tag_immutable(another_tag)
+
+    with pytest.raises(model.TagImmutableException):
+        registry_model.set_tags_expiration_for_manifest(
+            manifest, timedelta(days=2).total_seconds(), raise_on_error=True
+        )
 
 
 @pytest.fixture()
@@ -1140,3 +1407,41 @@ def test_tag_names_for_manifest(initialized_db, registry_model):
                 found_tag = registry_model.get_repo_tag(repo_ref, found_name)
                 assert registry_model.get_manifest_for_tag(found_tag) == manifest
     assert verified_tag
+
+
+def _create_v2_manifest_and_tag(namespace_name, repo_name, tag_name, registry_model):
+    repo_ref = registry_model.lookup_repository(namespace_name, repo_name)
+
+    with upload_blob(repo_ref, storage, BlobUploadSettings(500, 500)) as upload:
+        app_config = {"TESTING": True}
+        config_json = json.dumps(
+            {
+                "config": {
+                    "author": "Repo Mirror",
+                },
+                "rootfs": {"type": "layers", "diff_ids": []},
+                "history": [
+                    {
+                        "created": "2019-07-30T18:37:09.284840891Z",
+                        "created_by": "base",
+                        "author": "Repo Mirror",
+                    },
+                ],
+            }
+        )
+        upload.upload_chunk(app_config, BytesIO(config_json.encode("utf-8")))
+        blob = upload.commit_to_blob(app_config)
+        assert blob
+
+    builder = DockerSchema2ManifestBuilder()
+    builder.set_config_digest(blob.digest, blob.compressed_size)
+    builder.add_layer("sha256:abcd", 1234, urls=["http://hello/world"])
+    manifest = builder.build()
+
+    manifest, tag = registry_model.create_manifest_and_retarget_tag(
+        repo_ref, manifest, tag_name, storage, raise_on_error=True
+    )
+    assert tag
+    assert tag.name == tag_name
+
+    return manifest, tag

--- a/endpoints/api/manifest.py
+++ b/endpoints/api/manifest.py
@@ -3,13 +3,16 @@ Manage the manifests of a repository.
 """
 import json
 import logging
-from datetime import datetime
 from typing import List, Optional
 
 from flask import request
 
 from app import label_validator, storage
-from data.model import InvalidLabelKeyException, InvalidMediaTypeException
+from data.model import (
+    InvalidLabelKeyException,
+    InvalidMediaTypeException,
+    TagImmutableException,
+)
 from data.registry_model import registry_model
 from digest import digest_tools
 from endpoints.api import (
@@ -30,7 +33,7 @@ from endpoints.api import (
     resource,
     validate_json_request,
 )
-from endpoints.exception import NotFound
+from endpoints.exception import NotFound, PreconditionFailed
 from util.validation import VALID_LABEL_KEY_REGEX
 
 BASE_MANIFEST_ROUTE = '/v1/repository/<apirepopath:repository>/manifest/<regex("{0}"):manifestref>'
@@ -210,7 +213,12 @@ class RepositoryManifestLabels(RepositoryParamResource):
         label = None
         try:
             label = registry_model.create_manifest_label(
-                manifest, label_data["key"], label_data["value"], "api", label_data["media_type"]
+                manifest,
+                label_data["key"],
+                label_data["value"],
+                "api",
+                label_data["media_type"],
+                raise_on_error=True,
             )
         except InvalidLabelKeyException:
             message = (
@@ -223,6 +231,9 @@ class RepositoryManifestLabels(RepositoryParamResource):
                 "Media type is invalid please use a valid media type: text/plain, application/json"
             )
             abort(400, message=message)
+        except TagImmutableException:
+            message = "Cannot set label on manifest with immutable tag"
+            raise PreconditionFailed(message)
 
         if label is None:
             raise NotFound()
@@ -299,7 +310,13 @@ class ManageRepositoryManifestLabel(RepositoryParamResource):
         if manifest is None:
             raise NotFound()
 
-        deleted = registry_model.delete_manifest_label(manifest, labelid)
+        deleted = None
+
+        try:
+            deleted = registry_model.delete_manifest_label(manifest, labelid, raise_on_error=True)
+        except TagImmutableException:
+            raise PreconditionFailed("Cannot delete label on manifest with immutable tag")
+
         if deleted is None:
             raise NotFound()
 

--- a/endpoints/api/repository.py
+++ b/endpoints/api/repository.py
@@ -3,7 +3,6 @@ List, create and manage repositories.
 """
 
 import logging
-from collections import defaultdict
 from datetime import datetime, timedelta
 
 from flask import abort, request
@@ -21,14 +20,13 @@ from auth.permissions import (
     AdministerRepositoryPermission,
     CreateRepositoryPermission,
     ModifyRepositoryPermission,
-    ReadRepositoryPermission,
 )
 from data.database import RepositoryState
+from data.model import TagImmutableException
 from endpoints.api import (
     ApiResource,
     RepositoryParamResource,
     allow_if_superuser,
-    format_date,
     log_action,
     nickname,
     page_support,
@@ -46,12 +44,12 @@ from endpoints.api import (
 )
 from endpoints.api.billing import get_namespace_plan, lookup_allowed_private_repos
 from endpoints.api.repository_models_pre_oci import pre_oci_model as model
-from endpoints.api.subscribe import check_repository_usage
 from endpoints.exception import (
     DownstreamIssue,
     ExceedsLicenseException,
     InvalidRequest,
     NotFound,
+    PreconditionFailed,
     Unauthorized,
 )
 from util.names import REPOSITORY_NAME_EXTENDED_REGEX, REPOSITORY_NAME_REGEX
@@ -145,7 +143,6 @@ class RepositoryList(ApiResource):
             and usermanager.is_restricted_user(owner.username)
             and owner.username == namespace_name
         ):
-
             repository_name = req["repository"]
             visibility = req["visibility"]
 
@@ -527,7 +524,10 @@ class RepositoryStateResource(RepositoryParamResource):
         if state is None:
             return {"detail": "%s is not a valid Repository state." % state_name}, 400
 
-        model.set_repository_state(namespace, repository, state)
+        try:
+            model.set_repository_state(namespace, repository, state, raise_on_error=True)
+        except TagImmutableException as e:
+            raise PreconditionFailed(str(e))
 
         log_action(
             "change_repo_state",

--- a/endpoints/api/repository_models_pre_oci.py
+++ b/endpoints/api/repository_models_pre_oci.py
@@ -70,9 +70,9 @@ class PreOCIModel(RepositoryDataInterface):
         repo = model.repository.get_repository(namespace_name, repository_name)
         model.repository.set_repository_visibility(repo, visibility)
 
-    def set_repository_state(self, namespace_name, repository_name, state):
+    def set_repository_state(self, namespace_name, repository_name, state, raise_on_error=False):
         repo = model.repository.get_repository(namespace_name, repository_name)
-        model.repository.set_repository_state(repo, state)
+        model.repository.set_repository_state(repo, state, raise_on_error)
 
     def get_repo_list(
         self,

--- a/endpoints/api/test/test_security.py
+++ b/endpoints/api/test/test_security.py
@@ -18,7 +18,7 @@ from endpoints.api.build import *
 from endpoints.api.discovery import *
 from endpoints.api.globalmessages import *  # type: ignore[no-redef]
 from endpoints.api.logs import *  # type: ignore[no-redef]
-from endpoints.api.manifest import *  # type: ignore[no-redef]
+from endpoints.api.manifest import *
 from endpoints.api.mirror import *  # type: ignore[no-redef]
 from endpoints.api.namespacequota import *
 from endpoints.api.organization import *  # type: ignore[assignment,no-redef]

--- a/endpoints/exception.py
+++ b/endpoints/exception.py
@@ -17,6 +17,7 @@ class ApiErrorType(Enum):
     exceeds_license = "exceeds_license"
     not_found = "not_found"
     downstream_issue = "downstream_issue"
+    precondition_failed = "precondition_failed"
 
 
 ERROR_DESCRIPTION = {
@@ -30,6 +31,7 @@ ERROR_DESCRIPTION = {
     ApiErrorType.exceeds_license.value: "The action was refused because the current license does not allow it.",
     ApiErrorType.not_found.value: "The resource was not found.",
     ApiErrorType.downstream_issue.value: "An error occurred in a downstream service.",
+    ApiErrorType.precondition_failed.value: "The request failed because a precondition was not met.",
 }
 
 
@@ -106,6 +108,13 @@ class InvalidToken(ApiException):
 class ExpiredToken(ApiException):
     def __init__(self, error_description, payload=None):
         ApiException.__init__(self, ApiErrorType.expired_token, 401, error_description, payload)
+
+
+class PreconditionFailed(ApiException):
+    def __init__(self, error_description, payload=None):
+        ApiException.__init__(
+            self, ApiErrorType.precondition_failed, 412, error_description, payload
+        )
 
 
 class Unauthorized(ApiException):

--- a/endpoints/v2/errors.py
+++ b/endpoints/v2/errors.py
@@ -86,6 +86,13 @@ class TagExpired(V2RegistryException):
         super(TagExpired, self).__init__("TAG_EXPIRED", message or "Tag has expired", detail, 404)
 
 
+class TagImmutable(V2RegistryException):
+    def __init__(self, message=None, detail=None):
+        super(TagImmutable, self).__init__(
+            "TAG_IMMUTABLE", message or "Tag is immutable", detail, 412
+        )
+
+
 class ManifestUnverified(V2RegistryException):
     def __init__(self, detail=None):
         super(ManifestUnverified, self).__init__(

--- a/initdb.py
+++ b/initdb.py
@@ -224,7 +224,9 @@ def __create_manifest_and_tags(
         )
 
 
-def __generate_repository(user_obj, name, description, is_public, permissions, structure):
+def __generate_repository(
+    user_obj, name, description, is_public, permissions, structure, builder=None
+):
     repo = model.repository.create_repository(user_obj.username, name, user_obj)
 
     if is_public:
@@ -240,9 +242,9 @@ def __generate_repository(user_obj, name, description, is_public, permissions, s
     tag_map = {}
     if isinstance(structure, list):
         for leaf in structure:
-            __create_manifest_and_tags(repo, leaf, user_obj.username, tag_map)
+            __create_manifest_and_tags(repo, leaf, user_obj.username, tag_map, builder=builder)
     else:
-        __create_manifest_and_tags(repo, structure, user_obj.username, tag_map)
+        __create_manifest_and_tags(repo, structure, user_obj.username, tag_map, builder=builder)
 
     return repo
 
@@ -446,6 +448,7 @@ def initialize_database():
     LogEntryKind.create(name="manifest_label_delete")
 
     LogEntryKind.create(name="change_tag_expiration")
+    LogEntryKind.create(name="change_tag_immutability")
     LogEntryKind.create(name="toggle_repo_trigger")
 
     LogEntryKind.create(name="create_app_specific_token")

--- a/test/test_api_usage.py
+++ b/test/test_api_usage.py
@@ -12,12 +12,11 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from httmock import HTTMock, all_requests, urlmatch
+from httmock import HTTMock, urlmatch
 from mock import patch
-from playhouse.test_utils import _QueryLogHandler, assert_query_count
+from playhouse.test_utils import assert_query_count
 
 from app import (
-    all_queues,
     app,
     config_provider,
     docker_v2_signing_key,
@@ -103,7 +102,6 @@ from endpoints.api.robot import (
     UserRobotList,
 )
 from endpoints.api.search import ConductSearch, EntitySearch
-from endpoints.api.secscan import RepositoryManifestSecurity
 from endpoints.api.superuser import (
     SuperUserLogs,
     SuperUserManagement,
@@ -153,7 +151,6 @@ from endpoints.webhooks import webhooks
 from initdb import finished_database_for_testing, setup_database_for_testing
 from test.helpers import assert_action_logged, check_transitive_modifications
 from util.morecollections import AttrDict
-from util.secscan.v4.fake import fake_security_scanner
 
 try:
     app.register_blueprint(api_bp, url_prefix="/api")


### PR DESCRIPTION
API changes required to support immutable tags. Includes the following features:
- Modified API to support make a tag immutable
- Preventing repositories from being set to mirror or proxy if they contain immutable tags
- Preventing the deletion/retagging/editting labels/expiration of immutable tags
- Setting tag immutability via manifest labels on push

This is the second commit of 4 from the https://github.com/quay/quay/pull/1927. Previous commits:
[db: adding immutable column to tag table (PROJQUAY-7777)](https://github.com/quay/quay/pull/3195)

Co-Authored-By: dmesser [dmesser@redhat.com](mailto:dmesser@redhat.com)