### PR TITLE
marketplace: remove database lookup when retrieving customer ids (PROJQUAY-8017)

### DIFF
--- a/util/marketplace.py
+++ b/util/marketplace.py
@@ -22,13 +22,7 @@ class RedHatUserApi(object):
 
     def get_account_number(self, user):
         email = user.email
-        account_numbers = entitlements.get_web_customer_ids(user.id)
-        if account_numbers is None:
-            account_numbers = self.lookup_customer_id(email)
-            if account_numbers:
-                # store in database for next lookup
-                for account_number in account_numbers:
-                    entitlements.save_web_customer_id(user, account_number)
+        account_numbers = self.lookup_customer_id(email)
         return account_numbers
 
     def lookup_customer_id(self, email):


### PR DESCRIPTION
Removes the database lookup from occurring when getting account number for a user in quay.io.

Have a user that is unable to view their subscription in quay.io. When looking at the database, only one of their accounts is present for the user, but the subscription is attached to another account they are part of. Quay is unable to retrieve the subscription for the account because if it finds an account number in the database it uses that and doesn't query the user api.

Skip querying the database so the user api is used as the source of truth when looking for customer ids.