### PR TITLE
api: allowing superuser to read catalog endpoint (PROJQUAY-8023)

### DIFF
--- a/data/model/_basequery.py
+++ b/data/model/_basequery.py
@@ -124,7 +124,7 @@ def filter_to_repos_for_user(
     # If use is a superuser and a namespace was given return the given query,
     # else filter repositories to those the user has permissions in.
     # We do not want to return all repositories due to performance impact
-    if user_id is not None and is_superuser and namespace:
+    if user_id is not None and is_superuser:
         queries.append(query)
     elif user_id is not None:
         AdminTeam = Team.alias()

--- a/data/model/_basequery.py
+++ b/data/model/_basequery.py
@@ -95,6 +95,7 @@ def filter_to_repos_for_user(
     include_public=True,
     start_id=None,
     is_superuser=False,
+    return_all=False,
 ):
     if not include_public and not user_id:
         return Repository.select().where(Repository.id == "-1")
@@ -121,10 +122,9 @@ def filter_to_repos_for_user(
     if include_public:
         queries.append(query.where(Repository.visibility == get_public_repo_visibility()))
 
-    # If use is a superuser and a namespace was given return the given query,
-    # else filter repositories to those the user has permissions in.
-    # We do not want to return all repositories due to performance impact
-    if user_id is not None and is_superuser:
+    # If user is a superuser and only return query when filtered to a namespace or explicitly
+    # returning all repositories, otherwise filter to the user's permissions.
+    if user_id is not None and is_superuser and (namespace or return_all):
         queries.append(query)
     elif user_id is not None:
         AdminTeam = Team.alias()

--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -308,6 +308,7 @@ def get_visible_repositories(
     start_id=None,
     limit=None,
     is_superuser=False,
+    return_all=False,
 ):
     """
     Returns the repositories visible to the given user (if any).
@@ -350,6 +351,7 @@ def get_visible_repositories(
         include_public,
         start_id=start_id,
         is_superuser=is_superuser,
+        return_all=return_all,
     )
 
     if limit is not None:

--- a/data/model/test/test_visible_repos.py
+++ b/data/model/test/test_visible_repos.py
@@ -1,6 +1,6 @@
-from test.fixtures import *
-
 from data import model
+from data.database import Repository, RepositoryState
+from test.fixtures import *
 
 NO_ACCESS_USER = "freshuser"
 READ_ACCESS_USER = "reader"
@@ -86,3 +86,20 @@ def test_admin(initialized_db):
     assertHasRepo(ADMIN_ACCESS_USER, ANOTHER_ORG_REPO)
 
     assertDoesNotHaveRepo(ADMIN_ACCESS_USER, OUTSIDE_ORG_REPO)
+
+
+def test_global_readonly_superuser(initialized_db):
+    all_repos = list(
+        Repository.select().where(
+            Repository.state != RepositoryState.MARKED_FOR_DELETION,
+            Repository.kind == Repository.kind.get_id("image"),
+        )
+    )
+    repos = list(
+        model.repository.get_visible_repositories(
+            "globalreadonlysuperuser", is_superuser=True, return_all=True
+        )
+    )
+    assert len(repos) == len(all_repos)
+    for repo in all_repos:
+        assert repo.id in [r.rid for r in repos]

--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -490,7 +490,7 @@ log_unauthorized_delete = log_unauthorized("delete_tag_failed")
 
 
 def allow_if_superuser():
-    return features.SUPERUSERS_FULL_ACCESS and SuperUserPermission().can()
+    return bool(features.SUPERUSERS_FULL_ACCESS and SuperUserPermission().can())
 
 
 def allow_if_global_readonly_superuser():

--- a/endpoints/v2/catalog.py
+++ b/endpoints/v2/catalog.py
@@ -8,6 +8,7 @@ from auth.auth_context import get_authenticated_context, get_authenticated_user
 from auth.registry_jwt_auth import process_registry_jwt_auth
 from data import model
 from data.cache import cache_key
+from endpoints.api import allow_if_global_readonly_superuser, allow_if_superuser
 from endpoints.decorators import (
     anon_protect,
     disallow_for_account_recovery_mode,
@@ -41,6 +42,7 @@ def catalog_search(start_id, limit, pagination_callback):
             include_public=include_public,
             start_id=start_id,
             limit=limit + 1,
+            is_superuser=allow_if_superuser() or allow_if_global_readonly_superuser(),
         )
         # NOTE: The repository ID is in `rid` (not `id`) here, as per the requirements of
         # the `get_visible_repositories` call.

--- a/endpoints/v2/catalog.py
+++ b/endpoints/v2/catalog.py
@@ -43,6 +43,7 @@ def catalog_search(start_id, limit, pagination_callback):
             start_id=start_id,
             limit=limit + 1,
             is_superuser=allow_if_superuser() or allow_if_global_readonly_superuser(),
+            return_all=True,
         )
         # NOTE: The repository ID is in `rid` (not `id`) here, as per the requirements of
         # the `get_visible_repositories` call.


### PR DESCRIPTION
Allows for the full access and global readonly superuser to read all repositories from the `/v2/_catalog` endpoint.