### PR TITLE
autoprune: fix tags returned by autoprune worker (PROJQUAY-8070)

### DIFF
--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -790,8 +790,7 @@ def fetch_paginated_autoprune_repo_tags_by_number(
         tags_offset = max_tags_allowed + ((page - 1) * items_per_page)
         now_ms = get_epoch_timestamp_ms()
         query = (
-            Tag.select(Tag.name)
-            .where(
+            Tag.select(Tag.name).where(
                 Tag.repository_id == repo_id,
                 (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
                 Tag.hidden == False,
@@ -799,18 +798,19 @@ def fetch_paginated_autoprune_repo_tags_by_number(
             # TODO: Ignoring type error for now, but it seems order_by doesn't
             # return anything to be modified by offset. Need to investigate
             .order_by(Tag.lifetime_start_ms.desc())  # type: ignore[func-returns-value]
-            .limit(items_per_page)
         )
+
         if tag_pattern is not None:
             query = db_regex_search(
                 Tag.select(query.c.name).from_(query),
                 query.c.name,
                 tag_pattern,
                 tags_offset,
+                items_per_page,
                 matches=tag_pattern_matches,
             )
         else:
-            query = query.offset(tags_offset)
+            query = query.offset(tags_offset).limit(items_per_page)
         return list(query)
     except Exception as err:
         raise Exception(
@@ -832,22 +832,23 @@ def fetch_paginated_autoprune_repo_tags_older_than_ms(
     try:
         tags_offset = items_per_page * (page - 1)
         now_ms = get_epoch_timestamp_ms()
-        query = (
-            Tag.select(Tag.name)  # type: ignore[func-returns-value]
-            .where(
-                Tag.repository_id == repo_id,
-                (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
-                (now_ms - Tag.lifetime_start_ms) > tag_lifetime_ms,
-                Tag.hidden == False,
-            )
-            .limit(items_per_page)
+        query = Tag.select(Tag.name).where(
+            Tag.repository_id == repo_id,
+            (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
+            (now_ms - Tag.lifetime_start_ms) > tag_lifetime_ms,
+            Tag.hidden == False,
         )
         if tag_pattern is not None:
             query = db_regex_search(
-                query, Tag.name, tag_pattern, tags_offset, matches=tag_pattern_matches
+                query,
+                Tag.name,
+                tag_pattern,
+                tags_offset,
+                items_per_page,
+                matches=tag_pattern_matches,
             )
         else:
-            query = query.offset(tags_offset)
+            query = query.offset(tags_offset).limit(items_per_page)  # type: ignore[func-returns-value]
         return list(query)
     except Exception as err:
         raise Exception(

--- a/data/text.py
+++ b/data/text.py
@@ -61,12 +61,16 @@ def match_like(field, search_query):
     return Field.__pow__(field, clause)
 
 
-def regex_search(query, field, pattern, matches=True):
-    return query.where(field.regexp(pattern)) if matches else query.where(~field.regexp(pattern))
+def regex_search(query, field, pattern, offset, matches=True):
+    return (
+        query.where(field.regexp(pattern)).offset(offset)
+        if matches
+        else query.where(~field.regexp(pattern)).offset(offset)
+    )
 
 
-def regex_sqlite(query, field, pattern, matches=True):
-    rows = query.execute()
+def regex_sqlite(query, field, pattern, offset, matches=True):
+    rows = query.offset(offset).execute()
     return (
         [row for row in rows if re.search(pattern, getattr(row, field.name))]
         if matches

--- a/data/text.py
+++ b/data/text.py
@@ -70,9 +70,10 @@ def regex_search(query, field, pattern, offset, matches=True):
 
 
 def regex_sqlite(query, field, pattern, offset, matches=True):
-    rows = query.offset(offset).execute()
-    return (
+    rows = query.execute()
+    result = (
         [row for row in rows if re.search(pattern, getattr(row, field.name))]
         if matches
         else [row for row in rows if not re.search(pattern, getattr(row, field.name))]
     )
+    return result[offset:]

--- a/data/text.py
+++ b/data/text.py
@@ -70,6 +70,7 @@ def regex_search(query, field, pattern, offset, limit, matches=True):
 
 
 def regex_sqlite(query, field, pattern, offset, limit, matches=True):
+    # fetching all rows of the query here irrespective of limit and offset as sqlite does not support regexes.
     rows = query.execute()
     result = (
         [row for row in rows if re.search(pattern, getattr(row, field.name))]

--- a/data/text.py
+++ b/data/text.py
@@ -61,19 +61,19 @@ def match_like(field, search_query):
     return Field.__pow__(field, clause)
 
 
-def regex_search(query, field, pattern, offset, matches=True):
+def regex_search(query, field, pattern, offset, limit, matches=True):
     return (
-        query.where(field.regexp(pattern)).offset(offset)
+        query.where(field.regexp(pattern)).offset(offset).limit(limit)
         if matches
-        else query.where(~field.regexp(pattern)).offset(offset)
+        else query.where(~field.regexp(pattern)).offset(offset).limit(limit)
     )
 
 
-def regex_sqlite(query, field, pattern, offset, matches=True):
+def regex_sqlite(query, field, pattern, offset, limit, matches=True):
     rows = query.execute()
     result = (
         [row for row in rows if re.search(pattern, getattr(row, field.name))]
         if matches
         else [row for row in rows if not re.search(pattern, getattr(row, field.name))]
     )
-    return result[offset:]
+    return result[offset : offset + limit]

--- a/workers/test/test_autopruneworker.py
+++ b/workers/test/test_autopruneworker.py
@@ -711,22 +711,27 @@ def test_registry_prune_invalid_policy(initialized_db):
         ),
         (
             ["match1", "match2", "test1", "test2", "test3"],
-            ["match1", "match2", "test1"],
+            ["match1", "match2", "test1", "test2", "test3"],
             False,
         ),
         (
             ["match1", "match2", "match3", "test1", "test2"],
-            ["match1", "match2", "match3"],
+            ["match1", "match2", "match3", "test1", "test2"],
             False,
         ),
         (
             ["match1", "match2", "match3", "match4", "test1"],
-            ["match1", "match2", "match3", "match4"],
+            ["match1", "match2", "match3", "match4", "test1"],
             False,
         ),
         (
             ["match1", "match2", "match3", "match4", "match5"],
             ["match1", "match2", "match3", "match4", "match5"],
+            False,
+        ),
+        (
+            ["test1", "test2", "test3", "test4", "test5"],
+            ["test1", "test2", "test3"],
             False,
         ),
     ],

--- a/workers/test/test_autopruneworker.py
+++ b/workers/test/test_autopruneworker.py
@@ -689,24 +689,87 @@ def test_registry_prune_invalid_policy(initialized_db):
             True,
         ),
         (
-            ["match1", "match2", "test1", "test2", "test3"],
-            ["match1", "match2", "test1", "test2", "test3"],
+            ["match1", "match2", "test1", "test2", "test3", "test4"],
+            ["match1", "match2", "test1", "test2", "test3", "test4"],
             True,
         ),
         (
-            ["match1", "match2", "match3", "test1", "test2"],
-            ["match1", "match2", "match3", "test1", "test2"],
+            ["match1", "match2", "match3", "test1", "test2", "test3", "test4"],
+            ["match1", "match2", "match3", "test1", "test2", "test3", "test4"],
             True,
         ),
         (
-            ["match1", "match2", "match3", "match4", "test1"],
-            ["match1", "match2", "match3", "test1"],
+            ["match1", "match2", "match3", "match4", "test1", "test2", "test3", "test4"],
+            ["match1", "match2", "match3", "test1", "test2", "test3", "test4"],
             True,
         ),
-        (["match1", "match2", "match3", "match4", "match5"], ["match1", "match2", "match3"], True),
+        (
+            [
+                "match1",
+                "match2",
+                "test1",
+                "test2",
+                "test3",
+                "test4",
+                "match3",
+                "match4",
+            ],
+            ["match1", "match2", "test1", "test2", "test3", "test4", "match3"],
+            True,
+        ),
+        (
+            ["match1", "match2", "match3", "test1", "test2", "test3", "test4", "match4", "match5"],
+            ["match1", "match2", "match3", "test1", "test2", "test3", "test4"],
+            True,
+        ),
+        (
+            [
+                "match1",
+                "test1",
+                "match2",
+                "test2",
+                "match3",
+                "test3",
+                "match4",
+                "test4",
+                "match5",
+                "test5",
+            ],
+            ["match1", "test1", "match2", "test2", "match3", "test3", "test4", "test5"],
+            True,
+        ),
+        (
+            [
+                "match1",
+                "test1",
+                "match2",
+                "test2",
+                "match3",
+                "test3",
+                "match4",
+                "test4",
+                "match5",
+                "test5",
+                "match6",
+                "match7",
+                "match8",
+            ],
+            ["match1", "test1", "match2", "test2", "match3", "test3", "test4", "test5"],
+            True,
+        ),
         (
             ["test1", "test2", "test3", "test4", "test5"],
             ["test1", "test2", "test3"],
+            False,
+        ),
+        (
+            ["test1", "match1", "test2", "match2", "test3", "match3", "test4", "test5", "match4"],
+            ["test1", "match1", "test2", "match2", "test3", "match3", "match4"],
+            False,
+        ),
+        (
+            ["match1", "match2", "match3", "match4", "match5", "test1", "test2", "test3", "test4"],
+            ["match1", "match2", "match3", "match4", "match5", "test1", "test2", "test3"],
             False,
         ),
         (
@@ -732,6 +795,22 @@ def test_registry_prune_invalid_policy(initialized_db):
         (
             ["test1", "test2", "test3", "test4", "test5"],
             ["test1", "test2", "test3"],
+            False,
+        ),
+        (
+            [
+                "match1",
+                "test1",
+                "match2",
+                "test2",
+                "match3",
+                "test3",
+                "match4",
+                "test4",
+                "match5",
+                "test5",
+            ],
+            ["match1", "test1", "match2", "test2", "match3", "test3", "match4", "match5"],
             False,
         ),
     ],
@@ -762,7 +841,7 @@ def test_prune_by_tag_count_with_tag_filter(tags, expected, matches, initialized
         creation_time = now_ms - i
         _create_tag(repo1, manifest_repo1.manifest, start=creation_time, name=tag)
 
-    _assert_repo_tag_count(repo1, 5)
+    _assert_repo_tag_count(repo1, len(tags))
 
     worker = AutoPruneWorker()
     worker.prune()


### PR DESCRIPTION
We have the offset being applied before querying for tag_pattern. This is returning wrong results. So, moved offset to be applied on `db_regex_search` if tag_pattern exists.