### PR TITLE
workers(quotaregistrysize): added to run quotasizeworker when SUPERUSERS are retrieved from LDAP (PROJQUAY-8086)

### DIFF
--- a/workers/quotaregistrysizeworker.py
+++ b/workers/quotaregistrysizeworker.py
@@ -39,10 +39,14 @@ if __name__ == "__main__":
             time.sleep(100000)
 
     # Registry size is only viewable by superusers, don't calculate if not used
-    if not any(
+    if not all(
         [
-            features.SUPER_USERS,
-            len(app.config.get("SUPER_USERS", [])) == 0,
+            any(
+                [
+                    features.SUPER_USERS,
+                    len(app.config.get("SUPER_USERS", [])) == 0,
+                ]
+            ),
             app.config.get("LDAP_SUPERUSER_FILTER", False),
         ]
     ):

--- a/workers/quotaregistrysizeworker.py
+++ b/workers/quotaregistrysizeworker.py
@@ -39,7 +39,13 @@ if __name__ == "__main__":
             time.sleep(100000)
 
     # Registry size is only viewable by superusers, don't calculate if not used
-    if not features.SUPER_USERS or len(app.config.get("SUPER_USERS", [])) == 0:
+    if not any(
+        [
+            features.SUPER_USERS,
+            len(app.config.get("SUPER_USERS", [])) == 0,
+            app.config.get("LDAP_SUPERUSER_FILTER", False),
+        ]
+    ):
         logger.debug("Super users disabled or none specified; skipping quotaregistrysizeworker")
         while True:
             time.sleep(100000)

--- a/workers/test/test_quotaregistrysizeworker.py
+++ b/workers/test/test_quotaregistrysizeworker.py
@@ -1,5 +1,7 @@
 from test.fixtures import *
 from unittest.mock import MagicMock, patch
+import app
+import features
 
 from workers.quotaregistrysizeworker import QuotaRegistrySizeWorker
 
@@ -11,3 +13,65 @@ def test_registrysizeworker(initialized_db):
         worker = QuotaRegistrySizeWorker()
         worker._calculate_registry_size()
         assert mock_calculate_registry_size.called
+
+
+def test_registrysizeworker_recovery(initialized_db):
+    # we expect to fail since we are in recovery mode
+    app.config.update({"ACCOUNT_RECOVERY_MODE": True})
+    app.config.update({"SUPER_USERS": ["someone"]})
+
+    if app.config.get("ACCOUNT_RECOVERY_MODE", False):
+        with patch(
+            "workers.quotaregistrysizeworker.calculate_registry_size", MagicMock()
+        ) as mock_calculate_registry_size:
+            worker = QuotaRegistrySizeWorker()
+            worker._calculate_registry_size()
+            assert not mock_calculate_registry_size.called
+
+
+def test_registrysizeworker_no_quotamanagement(initialized_db):
+    # we expect to fail since we do not have quota management enabled
+    features.QUOTA_MANAGEMENT = False
+    app.config.update({"SUPER_USERS": ["someone"]})
+    if not features.QUOTA_MANAGEMENT:
+        with patch(
+            "workers.quotaregistrysizeworker.calculate_registry_size", MagicMock()
+        ) as mock_calculate_registry_size:
+            worker = QuotaRegistrySizeWorker()
+            worker._calculate_registry_size()
+            assert not mock_calculate_registry_size.called
+
+
+def test_registrysizeworker_no_superusers(initialized_db):
+    # we expect to fail since we do not have any superusers
+    app.config.update({"SUPER_USERS": [""]})
+    if not features.QUOTA_MANAGEMENT:
+        with patch(
+            "workers.quotaregistrysizeworker.calculate_registry_size", MagicMock()
+        ) as mock_calculate_registry_size:
+            worker = QuotaRegistrySizeWorker()
+            worker._calculate_registry_size()
+            assert not mock_calculate_registry_size.called
+
+
+def test_registrysizeworker_ldap_superusers(initialized_db):
+    # we expect to succeed since LDAP_SUPERUSERS_FILTER is not empty
+    app.config.update({"LDAP_SUPERUSER_FILTER": "(objectClass=*)"})
+    app.config.update({"SUPER_USERS": []})
+    if not all(
+        [
+            any(
+                [
+                    features.SUPER_USERS,
+                    len(app.config.get("SUPER_USERS", [])) == 0,
+                ]
+            ),
+            app.config.get("LDAP_SUPERUSER_FILTER", False),
+        ]
+    ):
+        with patch(
+            "workers.quotaregistrysizeworker.calculate_registry_size", MagicMock()
+        ) as mock_calculate_registry_size:
+            worker = QuotaRegistrySizeWorker()
+            worker._calculate_registry_size()
+            assert mock_calculate_registry_size.called

--- a/workers/test/test_quotaregistrysizeworker.py
+++ b/workers/test/test_quotaregistrysizeworker.py
@@ -1,8 +1,8 @@
-from test.fixtures import *
 from unittest.mock import MagicMock, patch
+
 import app
 import features
-
+from test.fixtures import *
 from workers.quotaregistrysizeworker import QuotaRegistrySizeWorker
 
 

--- a/workers/test/test_quotaregistrysizeworker.py
+++ b/workers/test/test_quotaregistrysizeworker.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-import app
 import features
 from test.fixtures import *
 from workers.quotaregistrysizeworker import QuotaRegistrySizeWorker

--- a/workers/test/test_quotaregistrysizeworker.py
+++ b/workers/test/test_quotaregistrysizeworker.py
@@ -32,7 +32,7 @@ def test_registrysizeworker_no_quotamanagement(initialized_db):
     # we expect to fail since we do not have quota management enabled
     features.QUOTA_MANAGEMENT = False
     app.config.update({"SUPER_USERS": ["someone"]})
-    if not features.QUOTA_MANAGEMENT:
+    if features.QUOTA_MANAGEMENT:
         with patch(
             "workers.quotaregistrysizeworker.calculate_registry_size", MagicMock()
         ) as mock_calculate_registry_size:
@@ -44,7 +44,7 @@ def test_registrysizeworker_no_quotamanagement(initialized_db):
 def test_registrysizeworker_no_superusers(initialized_db):
     # we expect to fail since we do not have any superusers
     app.config.update({"SUPER_USERS": [""]})
-    if not features.QUOTA_MANAGEMENT:
+    if features.QUOTA_MANAGEMENT:
         with patch(
             "workers.quotaregistrysizeworker.calculate_registry_size", MagicMock()
         ) as mock_calculate_registry_size:

--- a/workers/test/test_quotaregistrysizeworker.py
+++ b/workers/test/test_quotaregistrysizeworker.py
@@ -19,7 +19,7 @@ def test_registrysizeworker_recovery(initialized_db):
     app.config.update({"ACCOUNT_RECOVERY_MODE": True})
     app.config.update({"SUPER_USERS": ["someone"]})
 
-    if app.config.get("ACCOUNT_RECOVERY_MODE", False):
+    if not app.config.get("ACCOUNT_RECOVERY_MODE", False):
         with patch(
             "workers.quotaregistrysizeworker.calculate_registry_size", MagicMock()
         ) as mock_calculate_registry_size:


### PR DESCRIPTION
worker(quotaregistrysize) lacks the check to run calculation if no **superusers** are defined statically but retrieved from **LDAP** instead.

Reproducer:
```
$ grep 'SUPERUSER' conf/stack/config.yaml
FEATURE_NONSUPERUSER_TEAM_SYNCING_SETUP: false
LDAP_SUPERUSER_FILTER: (|(memberOf=cn=quay-superusers,ou=Groups,dc=example,dc=com)(memberOf=cn=quay-readonly-superuser,ou=Groups,dc=example,dc=com))
FEATURE_SUPERUSERS_FULL_ACCESS: true
```
```
$  python workers/quotaregistrysizeworker.py
Super users disabled or none specified; skipping quotaregistrysizeworker
```
