### PR TITLE
conf(nginx): change forwarded header removing host (PROJQUAY-8024)

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -91,6 +91,7 @@ location ~ ^/_storage_proxy/([^/]+)/([^/]+)/([^/]+)/(.+) {
     proxy_set_header Host $3;
     proxy_set_header Authorization "";
     proxy_set_header x-forwarded-host "";
+    proxy_set_header forwarded "for=$remote_addr;";
     proxy_ssl_name $3;
     proxy_ssl_server_name on;
 


### PR DESCRIPTION
According to HCP support, the Ingress Load Balancer rejects requests with a `host=...;` in the `forwarded` Header.

The PR changes that only the originating Client ($remote_addr) is injected in the request as

```
Host: ....
Forwarded: for=127.0.0.1;
...
```

Reference: https://datatracker.ietf.org/doc/html/rfc7239#section-5.3