### PR TITLE
ui: conditionally support custom tag expiration durations (PROJQUAY-6700)

### DIFF
--- a/web/cypress/e2e/account-settings.cy.ts
+++ b/web/cypress/e2e/account-settings.cy.ts
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import {humanizeTimeForExpiry, parseTimeDuration} from 'src/libs/utils';
+
 describe('Account Settings Page', () => {
   beforeEach(() => {
     cy.exec('npm run quay:seed');
@@ -44,6 +46,66 @@ describe('Account Settings Page', () => {
     cy.get('#org-settings-fullname').should('have.value', 'Joe Smith');
     cy.get('#org-settings-location').should('have.value', 'Raleigh, NC');
     cy.get('#org-settings-company').should('have.value', 'Red Hat');
+  });
+
+  it('Tag Expiration picker visibility', () => {
+    cy.fixture('config.json').then((config) => {
+      config.features.CHANGE_TAG_EXPIRATION = false;
+      cy.intercept('GET', '/config', config).as('getConfigDisabled');
+    });
+
+    cy.visit('/organization/user1?tab=Settings');
+    cy.wait('@getConfigDisabled');
+
+    // Verify the FormGroup is not visible
+    cy.get('[data-testid="tag-expiration-picker"]').should('not.exist');
+
+    cy.fixture('config.json').then((config) => {
+      config.features.CHANGE_TAG_EXPIRATION = true;
+      cy.intercept('GET', '/config', config).as('getConfigEnabled');
+    });
+
+    cy.visit('/organization/user1?tab=Settings');
+    cy.wait('@getConfigEnabled');
+
+    // Verify the FormGroup is visible
+    cy.get('[data-testid="tag-expiration-picker"]').should('be.visible');
+  });
+
+  it('Tag expiration picker dropdown values', () => {
+    cy.fixture('config.json').then((config) => {
+      config.features.CHANGE_TAG_EXPIRATION = true;
+      cy.intercept('GET', '/config', config).as('getConfigEnabled');
+    });
+    cy.intercept('GET', '/api/v1/user', (req) => {
+      req.continue((res) => {
+        res.body.tag_expiration_s = 60 * 60 * 24 * 80; // 80 days in seconds
+      });
+    }).as('getUser');
+
+    cy.visit('/organization/user1?tab=Settings');
+    cy.wait('@getConfigEnabled');
+    cy.wait('@getUser');
+
+    // Verify the dropdown values
+    cy.fixture('config.json').then((config) => {
+      const options = config.config.TAG_EXPIRATION_OPTIONS;
+      options.forEach((option, index) => {
+        const duration = parseTimeDuration(option);
+        const durationInSeconds = duration.asSeconds();
+        const humanized = humanizeTimeForExpiry(durationInSeconds);
+
+        cy.get(`[data-testid="tag-expiration-picker"] option:eq(${index})`)
+          .should('have.value', durationInSeconds.toString())
+          .and('contain', humanized);
+      });
+    });
+
+    // Verify the correct value is selected
+    cy.get('[data-testid="tag-expiration-picker"]').should(
+      'have.value',
+      60 * 60 * 24 * 80, // Assuming '80d' is the format in the config.json
+    );
   });
 
   it('Billing Information', () => {

--- a/web/cypress/fixtures/config.json
+++ b/web/cypress/fixtures/config.json
@@ -62,7 +62,7 @@
     "SERVER_HOSTNAME": "localhost:8080",
     "SETUP_COMPLETE": true,
     "STATIC_SITE_BUCKET": null,
-    "TAG_EXPIRATION_OPTIONS": ["2w"],
+    "TAG_EXPIRATION_OPTIONS": ["0s", "1d", "1w", "2w", "4w", "80d", "90d", "180d", "365d"],
     "PERMANENTLY_DELETE_TAGS": true,
     "FEATURE_AUTO_PRUNE": true,
     "DEFAULT_NAMESPACE_AUTOPRUNE_POLICY": {

--- a/web/src/libs/utils.ts
+++ b/web/src/libs/utils.ts
@@ -1,6 +1,6 @@
-import {VulnerabilitySeverity} from 'src/resources/TagResource';
-import moment from 'moment';
+import moment, {Duration} from 'moment';
 import {ITeamMember} from 'src/hooks/UseMembers';
+import {VulnerabilitySeverity} from 'src/resources/TagResource';
 
 export function getSeverityColor(severity: VulnerabilitySeverity) {
   switch (severity) {
@@ -123,8 +123,55 @@ export function parseTeamNameFromUrl(url: string): string {
   return urlParts[teamKeywordIndex + 1];
 }
 
-export function humanizeTimeForExpiry(time_seconds: number): string {
-  return moment.duration(time_seconds || 0, 's').humanize();
+export function parseTimeDuration(input: string): Duration {
+  if (!input) {
+    return moment.duration(NaN);
+  }
+
+  const durationRegex = /^(\d+)([smhdw])$/i; // suffixes supported by Quay
+  const match = input.match(durationRegex);
+
+  if (!match) {
+    return moment.duration(NaN);
+  }
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+
+  const duration = moment.duration(
+    value,
+    unit as moment.unitOfTime.DurationConstructor,
+  );
+
+  return duration;
+}
+
+export function humanizeTimeForExpiry(time_seconds: number | Duration): string {
+  let duration;
+
+  if (typeof time_seconds === 'number') {
+    duration = moment.duration(time_seconds || 0, 'seconds');
+  } else if (moment.isDuration(time_seconds)) {
+    duration = time_seconds;
+  } else {
+    throw new Error('Invalid type for time_seconds');
+  }
+  const days = duration.asDays();
+
+  if (Math.floor(days) < 31) {
+    return duration.humanize();
+  } else if (Math.floor(days) < 365) {
+    const remainingDays = Math.floor(days % 31);
+    const closeToAMonth =
+      (remainingDays >= 0 && remainingDays < 7) ||
+      (remainingDays > 24 && remainingDays < 31);
+    return closeToAMonth ? duration.humanize() : `${Math.floor(days)} days`;
+  } else {
+    const years = Math.floor(days / 365);
+    const remainingDays = Math.floor(days % 365);
+    const months = Math.floor(remainingDays / 31);
+    return months > 0 ? `${years} years ${months} months` : duration.humanize();
+  }
 }
 
 export function getSeconds(duration_str: string): number {

--- a/web/src/resources/UserResource.ts
+++ b/web/src/resources/UserResource.ts
@@ -111,7 +111,7 @@ export interface UpdateUserRequest {
   company?: string;
   password?: string;
   invoice_email_address?: string;
-  tag_expiration_s?: string;
+  tag_expiration_s?: number;
   email?: string;
 }
 


### PR DESCRIPTION
This adds support for user-supplied tag expiration values from `TAG_EXPIRATION_OPTIONS` via config.yaml in the new UI. In the current code, these values weren't properly processed and led to the bug described in https://issues.redhat.com/browse/PROJQUAY-6700

This implementation also adds a number of additional improvements:

- conditional display of the time machine configuration depending on the `CHANGE_TAG_EXPIRATION` feature in the account settings
- actualy support for setting the time machines' default tag expiration in the account settings UI
- improved logic to set the currently selected expiration value in the dropdown list (based on the value in seconds instead of the human readable form)
- improved human-readable output of custom durations that prevent excessive rounding, e.g. `80d` is now displayed as 80 days instead of 3 months
- cypress unit test coverage
- the UI form will now also ignore values from `TAG_EXPIRATION_OPTIONS` that neither moment.js nor Quay supports

Attached a screenshot how the user-supplied tag expiration options are now rendered in human-friendly form in the new UI with the following setting from the bug report:

```
TAG_EXPIRATION_OPTIONS:
- 0s
- 30m
- 1800s    
- 1h
- 2w
- 4w
- 10w
- 6048000s
- 80d 
```

<img width="1047" alt="Screenshot 2024-10-18 at 09 27 38" src="https://github.com/user-attachments/assets/e9ce1f8e-f7c7-4904-aa38-25f7f6c004fc">
