### PR TITLE
app: Alert user if TESTING is not properly set (PROJQUAY-8123)

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,6 +93,15 @@ else:
 # Load the override config via the provider.
 config_provider.update_app_config(app.config)
 
+# Check if TESTING is properly set
+if app.config.get("TESTING", False):
+    logger.warning(
+        "🟡🟡🟡 Detected TESTING: true on startup. TESTING property is either missing from config.yaml or set to 'true'."
+    )
+    logger.warning(
+        "🟡🟡🟡 Quay starting in TESTING mode, some functionality such as e-mail sending will not be available."
+    )
+
 # Update any configuration found in the override environment variable.
 environ_config = json.loads(os.environ.get(OVERRIDE_CONFIG_KEY, "{}"))
 app.config.update(environ_config)


### PR DESCRIPTION
The `TESTING` flag is used to set Quay in testing mode. In certain occasions (when Quay is deployed on VMs but config tool hasn't verified the validity of the configuration or when users build their own confuguration), this flag sometimes gets omitted from the end `config.yaml` file. When this happens, Quay will start with `TESTING: true` which will disable certain functionality (such as e-mail sending).
We add the check to `app.py` to notify the user that `TESTING: false` is missing or misconfigured in their `config.yaml` file. The change doesn't break Quay startup, merely prints a warning in the container logs when `app.py` gets initialized.