### PR TITLE
api: override flask application function to catch error (PROJQUAY-8026)

### DIFF
--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -9,6 +9,7 @@ from flask import Blueprint, request, session
 from flask_restful import Api, Resource, abort, reqparse
 from flask_restful.utils import unpack
 from jsonschema import ValidationError, validate
+from werkzeug.routing.exceptions import RequestRedirect
 
 import features
 from .__init__models_pre_oci import pre_oci_model as model
@@ -63,6 +64,12 @@ class ApiExceptionHandlingApi(Api):
     @crossorigin()
     def handle_error(self, error):
         return super(ApiExceptionHandlingApi, self).handle_error(error)
+
+    def _should_use_fr_error_handler(self):
+        try:
+            return super(ApiExceptionHandlingApi, self)._should_use_fr_error_handler()
+        except RequestRedirect:
+            return False
 
 
 api = ApiExceptionHandlingApi()

--- a/endpoints/decorated.py
+++ b/endpoints/decorated.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import jsonify, make_response, redirect
+from flask import jsonify, make_response
 from werkzeug.routing.exceptions import RequestRedirect
 
 from app import app

--- a/endpoints/decorated.py
+++ b/endpoints/decorated.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import jsonify, make_response
+from flask import jsonify, make_response, redirect
 from werkzeug.routing.exceptions import RequestRedirect
 
 from app import app
@@ -74,8 +74,4 @@ def handle_not_implemented_error(ex):
 
 @app.errorhandler(RequestRedirect)
 def handle_bad_redirect(ex):
-    response = jsonify(
-        {"message": "bad path, there may be a trailing slash", "new_url": ex.new_url}
-    )
-    response.status_code = 308
-    return response
+    return ex.get_response()

--- a/endpoints/test/test_request_redirect.py
+++ b/endpoints/test/test_request_redirect.py
@@ -34,8 +34,4 @@ class TestRequestRedirect(unittest.TestCase):
 
         path = "/raise-request-redirect"
         response = self.app.get(path)
-        print(response.get_data(as_text=True))
-        resp_data = json.loads(response.get_data(as_text=True))
         self.assertEqual(response.status_code, 308)
-        self.assertEqual(resp_data["message"], "bad path, there may be a trailing slash")
-        self.assertEqual(resp_data["new_url"], "somepath")


### PR DESCRIPTION
Handling exception when a request with the wrong method is made to quay without a trailing slash:
```
gunicorn-web stdout | 2024-10-18 18:56:31,053 [171] [ERROR] [gunicorn.error] Error handling request /oauth2/exchange
gunicorn-web stdout | Traceback (most recent call last):
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/gunicorn/workers/base_async.py", line 55, in handle
gunicorn-web stdout |     self.handle_request(listener_name, req, client, addr)
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/gunicorn/workers/ggevent.py", line 128, in handle_request
gunicorn-web stdout |     super().handle_request(listener_name, req, sock, addr)
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/gunicorn/workers/base_async.py", line 108, in handle_request
gunicorn-web stdout |     respiter = self.wsgi(environ, resp.start_response)
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/flask/app.py", line 2213, in __call__
gunicorn-web stdout |     return self.wsgi_app(environ, start_response)
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/werkzeug/middleware/proxy_fix.py", line 183, in __call__
gunicorn-web stdout |     return self.app(environ, start_response)
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/flask/app.py", line 2193, in wsgi_app
gunicorn-web stdout |     response = self.handle_exception(e)
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/flask_restful/__init__.py", line 293, in error_router
gunicorn-web stdout |     if self._has_fr_route():
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/flask_restful/__init__.py", line 271, in _has_fr_route
gunicorn-web stdout |     if self._should_use_fr_error_handler():
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/flask_restful/__init__.py", line 260, in _should_use_fr_error_handler
gunicorn-web stdout |     rule, _ = adapter.match(method=valid_route_method, return_rule=True)
gunicorn-web stdout |   File "/app/lib/python3.9/site-packages/werkzeug/routing/map.py", line 609, in match
gunicorn-web stdout |     raise RequestRedirect(
gunicorn-web stdout | werkzeug.routing.exceptions.RequestRedirect: 308 Permanent Redirect: http://localhost/oauth2/exchange/
gunicorn-web stdout | 2024-10-18 18:56:31,067 [171] [INFO] [gunicorn.access]  - - [18/Oct/2024:18:56:31 +0000] "POST /oauth2/exchange HTTP/1.0" 500 0 "-" "-"
nginx stdout | 192.168.97.1 (-) - - [18/Oct/2024:18:56:31 +0000] "POST /oauth2/exchange HTTP/1.1" 500 141 "-" "curl/8.7.1" (0.022 93 0.022)
```
For example a POST request to `/oauth2/exchange` will cause this exception. This is because flask-restful will try to look for other methods that would work on the endpoint since POST is not allowed. When it does this werkzeug will raise the `RequestRedirect` exception by default because the path in the request is missing a trailing slash.

Overrides [this function call](https://github.com/flask-restful/flask-restful/blob/master/flask_restful/__init__.py#L244-L266) in flask-restful that checks for which error handler it should use and catches RequestRedirect exception thrown by werkzeug; in which case assume we use the default flask error handler.

Also cleans up error handler created previously to catch this error. If the error handler is called it should just redirect instead of trying to send any additional response.