### PR TITLE
ui: Render namespace values for <SelectOption> dropdown under Create Repository modal (PROJQUAY-8118)

### DIFF
--- a/web/cypress/e2e/repositories-list.cy.ts
+++ b/web/cypress/e2e/repositories-list.cy.ts
@@ -62,8 +62,8 @@ describe('Repositories List Page', () => {
     cy.wait('@getRepositories');
     cy.contains('Create Repository').click();
     cy.contains('Create Repository').should('exist');
-    //cy.contains('Select namespace').click();
-    //cy.get('li:contains("user1")').click();
+    cy.get('[data-testid="selected-namespace-dropdown"]').click();
+    cy.get('[data-testid="user-user1"]').click();
     cy.get('input[id="repository-name-input"]').type('new-repo');
     cy.get('input[id="repository-description-input"]').type(
       'This is a new public repository',
@@ -82,8 +82,8 @@ describe('Repositories List Page', () => {
     cy.visit('/repository');
     cy.contains('Create Repository').click();
     cy.contains('Create Repository').should('exist');
-    //cy.contains('Select namespace').click();
-    //cy.get('li:contains("user1")').click();
+    cy.get('[data-testid="selected-namespace-dropdown"]').click();
+    cy.get('[data-testid="user-user1"]').click();
     cy.get('input[id="repository-name-input"]').type('new-repo');
     cy.get('input[id="repository-description-input"]').type(
       'This is a new private repository',

--- a/web/src/components/modals/CreateRepoModalTemplate.tsx
+++ b/web/src/components/modals/CreateRepoModalTemplate.tsx
@@ -124,12 +124,20 @@ export default function CreateRepositoryModalTemplate(
   // namespace list includes both the orgs list and the user namespace
   const namespaceSelectionList = () => {
     const userSelection = (
-      <SelectOption key={props.username} value={props.username}>
+      <SelectOption
+        key={props.username}
+        value={props.username}
+        data-testid={`user-${props.username}`}
+      >
         {props.username}
       </SelectOption>
     );
     const orgsSelectionList = props.organizations.map((orgs, idx) => (
-      <SelectOption key={idx} value={orgs.name}>
+      <SelectOption
+        key={idx}
+        value={orgs.name}
+        data-testid={`org-${orgs.name}`}
+      >
         {orgs.name}
       </SelectOption>
     ));
@@ -197,6 +205,7 @@ export default function CreateRepositoryModalTemplate(
                         }
                         isExpanded={currentOrganization.isDropdownOpen}
                         isDisabled={props.orgName !== null}
+                        data-testid="selected-namespace-dropdown"
                       >
                         {currentOrganization.name}
                       </MenuToggle>

--- a/web/src/components/modals/CreateRepoModalTemplate.tsx
+++ b/web/src/components/modals/CreateRepoModalTemplate.tsx
@@ -124,10 +124,14 @@ export default function CreateRepositoryModalTemplate(
   // namespace list includes both the orgs list and the user namespace
   const namespaceSelectionList = () => {
     const userSelection = (
-      <SelectOption key={props.username} value={props.username}></SelectOption>
+      <SelectOption key={props.username} value={props.username}>
+        {props.username}
+      </SelectOption>
     );
     const orgsSelectionList = props.organizations.map((orgs, idx) => (
-      <SelectOption key={idx} value={orgs.name}></SelectOption>
+      <SelectOption key={idx} value={orgs.name}>
+        {orgs.name}
+      </SelectOption>
     ));
 
     return [userSelection, ...orgsSelectionList];


### PR DESCRIPTION
Fixes the issue where namespaces were not being displayed via the dropdown under Create Repository modal 

<img width="1147" alt="Screenshot 2024-10-21 at 3 31 16 PM" src="https://github.com/user-attachments/assets/55f4807c-d642-48bc-a5d3-3b9bb2d3a37f">
