### PR TITLE
ui: tag expiration settings support year values (PROJQUAY-8171)

### DIFF
--- a/web/cypress/fixtures/config.json
+++ b/web/cypress/fixtures/config.json
@@ -62,7 +62,7 @@
     "SERVER_HOSTNAME": "localhost:8080",
     "SETUP_COMPLETE": true,
     "STATIC_SITE_BUCKET": null,
-    "TAG_EXPIRATION_OPTIONS": ["0s", "1d", "1w", "2w", "4w", "80d", "90d", "180d", "365d"],
+    "TAG_EXPIRATION_OPTIONS": ["0s", "1d", "1w", "2w", "4w", "80d", "90d", "180d", "365d", "2y"],
     "PERMANENTLY_DELETE_TAGS": true,
     "FEATURE_AUTO_PRUNE": true,
     "DEFAULT_NAMESPACE_AUTOPRUNE_POLICY": {

--- a/web/src/libs/utils.ts
+++ b/web/src/libs/utils.ts
@@ -128,7 +128,7 @@ export function parseTimeDuration(input: string): Duration {
     return moment.duration(NaN);
   }
 
-  const durationRegex = /^(\d+)([smhdw])$/i; // suffixes supported by Quay
+  const durationRegex = /^(\d+)([smhdwy])$/i; // suffixes supported by Quay
   const match = input.match(durationRegex);
 
   if (!match) {


### PR DESCRIPTION
Adds support for yearly values as tag expiration options with the `y` suffix.