### PR TITLE
ui: Add proxy cache config UI to org settings (PROJQUAY-7697)

### DIFF
--- a/web/cypress/e2e/proxy-cache.cy.ts
+++ b/web/cypress/e2e/proxy-cache.cy.ts
@@ -9,17 +9,82 @@ describe('Organization settings - Proxy-cache configuration', () => {
         cy.loginByCSRF(token);
       });
     cy.intercept('GET', '/config', {fixture: 'config.json'}).as('getConfig');
+
+    // Intercept the /validateproxycache API call
+    cy.intercept('POST', '/api/v1/organization/*/validateproxycache', (req) => {
+      const {upstream_registry_username, upstream_registry_password} = req.body;
+      if (upstream_registry_username && upstream_registry_password) {
+        req.reply({
+          statusCode: 202,
+          body: 'Valid',
+        });
+      } else {
+        req.reply({
+          statusCode: 202,
+          body: 'Anonymous',
+        });
+      }
+    }).as('validateProxyCache');
+
+    // Intercept the /proxycache API call
+    cy.intercept('POST', '/api/v1/organization/*/proxycache', {
+      statusCode: 201,
+      body: 'Created',
+    }).as('createProxyCache');
   });
 
-  const createProxyCacheConfig = (cy) => {
+  const createAnonymousProxyCacheConfig = (cy) => {
     cy.get('[data-testid="remote-registry-input"]').type('docker.io');
     cy.get('[data-testid="save-proxy-cache-btn"]').click();
   };
 
-  it('can create proxy cache configuration for an organization', () => {
+  it('can create anonymous proxy cache configuration for an organization', () => {
     cy.visit('/organization/projectquay?tab=Settings');
-    cy.contains('Proxy Cache').click();
-    createProxyCacheConfig(cy);
+    cy.get('[data-testid="Proxy Cache"]').click();
+    createAnonymousProxyCacheConfig(cy);
+
+    // Wait for the validateproxycache API call and assert the response
+    cy.wait('@validateProxyCache').then((interception) => {
+      expect(interception.response?.statusCode).to.eq(202);
+      expect(interception.response?.body).to.eq('Anonymous');
+    });
+
+    // Wait for the proxycache API call and assert the response
+    cy.wait('@createProxyCache').then((interception) => {
+      expect(interception.response?.statusCode).to.eq(201);
+      expect(interception.response?.body).to.eq('Created');
+    });
+
+    // verify success alert
+    cy.get('.pf-v5-c-alert.pf-m-success')
+      .contains('Successfully configured proxy cache')
+      .should('exist');
+  });
+
+  it('can create proxy cache configuration with registry credentials for an organization', () => {
+    cy.visit('/organization/projectquay?tab=Settings');
+    cy.get('[data-testid="Proxy Cache"]').click();
+
+    cy.get('[data-testid="remote-registry-input"]').type('docker.io');
+    cy.get('[data-testid="remote-registry-username"]').type('testuser1');
+    cy.get('[data-testid="remote-registry-password"]').type('testpass');
+    cy.get('[data-testid="remote-registry-expiration"]').clear().type('76400');
+    cy.get('[data-testid="remote-registry-insecure"]').check();
+
+    cy.get('[data-testid="save-proxy-cache-btn"]').click();
+
+    // Wait for the validateproxycache API call and assert the response
+    cy.wait('@validateProxyCache').then((interception) => {
+      expect(interception.response?.statusCode).to.eq(202);
+      expect(interception.response?.body).to.eq('Valid');
+    });
+
+    // Wait for the proxycache API call and assert the response
+    cy.wait('@createProxyCache').then((interception) => {
+      expect(interception.response?.statusCode).to.eq(201);
+      expect(interception.response?.body).to.eq('Created');
+    });
+
     // verify success alert
     cy.get('.pf-v5-c-alert.pf-m-success')
       .contains('Successfully configured proxy cache')
@@ -27,17 +92,18 @@ describe('Organization settings - Proxy-cache configuration', () => {
   });
 
   it('can delete proxy cache configuration for an organization', () => {
-    cy.visit('/organization/projectquay?tab=Settings');
-    cy.contains('Proxy Cache').click();
-    createProxyCacheConfig(cy);
-    // verify success alert
-    cy.get('.pf-v5-c-alert.pf-m-success')
-      .contains('Successfully configured proxy cache')
-      .should('exist');
+    cy.visit('/organization/prometheus?tab=Settings');
+    cy.get('[data-testid="Proxy Cache"]').click();
+
     cy.get('[data-testid="delete-proxy-cache-btn"]').click();
     // verify success alert
     cy.get('.pf-v5-c-alert.pf-m-success')
       .contains('Successfully deleted proxy cache configuration')
       .should('exist');
+  });
+
+  it('proxy cache config is not shown for user organization', () => {
+    cy.visit('/organization/user1?tab=Settings');
+    cy.get('[data-testid="Proxy Cache"]').should('not.exist');
   });
 });

--- a/web/cypress/e2e/proxy-cache.cy.ts
+++ b/web/cypress/e2e/proxy-cache.cy.ts
@@ -18,7 +18,7 @@ describe('Organization settings - Proxy-cache configuration', () => {
 
   it('can create proxy cache configuration for an organization', () => {
     cy.visit('/organization/projectquay?tab=Settings');
-    cy.contains('Proxy-Cache config').click();
+    cy.contains('Proxy Cache').click();
     createProxyCacheConfig(cy);
     // verify success alert
     cy.get('.pf-v5-c-alert.pf-m-success')
@@ -28,7 +28,7 @@ describe('Organization settings - Proxy-cache configuration', () => {
 
   it('can delete proxy cache configuration for an organization', () => {
     cy.visit('/organization/projectquay?tab=Settings');
-    cy.contains('Proxy-Cache config').click();
+    cy.contains('Proxy Cache').click();
     createProxyCacheConfig(cy);
     // verify success alert
     cy.get('.pf-v5-c-alert.pf-m-success')

--- a/web/cypress/e2e/proxy-cache.cy.ts
+++ b/web/cypress/e2e/proxy-cache.cy.ts
@@ -1,0 +1,43 @@
+/// <reference types="cypress" />
+
+describe('Organization settings - Proxy-cache configuration', () => {
+  beforeEach(() => {
+    cy.exec('npm run quay:seed');
+    cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
+      .then((response) => response.body.csrf_token)
+      .then((token) => {
+        cy.loginByCSRF(token);
+      });
+    cy.intercept('GET', '/config', {fixture: 'config.json'}).as('getConfig');
+  });
+
+  const createProxyCacheConfig = (cy) => {
+    cy.get('[data-testid="remote-registry-input"]').type('docker.io');
+    cy.get('[data-testid="save-proxy-cache-btn"]').click();
+  };
+
+  it('can create proxy cache configuration for an organization', () => {
+    cy.visit('/organization/projectquay?tab=Settings');
+    cy.contains('Proxy-Cache config').click();
+    createProxyCacheConfig(cy);
+    // verify success alert
+    cy.get('.pf-v5-c-alert.pf-m-success')
+      .contains('Successfully configured proxy cache')
+      .should('exist');
+  });
+
+  it('can delete proxy cache configuration for an organization', () => {
+    cy.visit('/organization/projectquay?tab=Settings');
+    cy.contains('Proxy-Cache config').click();
+    createProxyCacheConfig(cy);
+    // verify success alert
+    cy.get('.pf-v5-c-alert.pf-m-success')
+      .contains('Successfully configured proxy cache')
+      .should('exist');
+    cy.get('[data-testid="delete-proxy-cache-btn"]').click();
+    // verify success alert
+    cy.get('.pf-v5-c-alert.pf-m-success')
+      .contains('Successfully deleted proxy cache configuration')
+      .should('exist');
+  });
+});

--- a/web/cypress/fixtures/config.json
+++ b/web/cypress/fixtures/config.json
@@ -106,7 +106,7 @@
     "NONSUPERUSER_TEAM_SYNCING_SETUP": false,
     "PARTIAL_USER_AUTOCOMPLETE": true,
     "PERMANENT_SESSIONS": true,
-    "PROXY_CACHE": false,
+    "PROXY_CACHE": true,
     "PROXY_STORAGE": false,
     "PUBLIC_CATALOG": false,
     "QUOTA_MANAGEMENT": true,

--- a/web/cypress/fixtures/config.json
+++ b/web/cypress/fixtures/config.json
@@ -47,7 +47,7 @@
     "DEBUG": false,
     "DOCUMENTATION_ROOT": "https://docs.projectquay.io/",
     "ENTERPRISE_LOGO_URL": "/static/img/quay-horizontal-color.svg",
-    "FEATURE_PROXY_CACHE": false,
+    "FEATURE_PROXY_CACHE": true,
     "FEATURE_QUOTA_MANAGEMENT": false,
     "FEATURE_EDIT_QUOTA": true,
     "FEATURE_REPO_MIRROR": false,

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -6301,6 +6301,7 @@ COPY public.logentry3 (id, kind_id, account_id, performer_id, repository_id, dat
 201	31	32	29	\N	2023-11-07 19:54:08.826725	172.18.0.1	{"member": "user1", "team": "teamforreadonly"}
 202	98	29	29	\N	2023-11-07 19:54:14.934915	172.18.0.1	{}
 203	97	1	\N	\N	2023-11-07 19:54:19.160078	172.18.0.1	{"type": "quayauth", "useragent": "Mozilla/5.0"}
+204	76	6	1	\N	2024-11-26 13:28:52.179631	172.20.0.1	{"upstream_registry": "docker.io"}
 \.
 
 
@@ -6683,6 +6684,7 @@ COPY public.permissionprototype (id, org_id, uuid, activating_user_id, delegate_
 --
 
 COPY public.proxycacheconfig (id, organization_id, creation_date, upstream_registry, upstream_registry_username, upstream_registry_password, expiration_s, insecure) FROM stdin;
+1	6	2024-11-26 13:28:52.175714	docker.io	\N	\N	86400	f
 \.
 
 
@@ -6715,8 +6717,8 @@ COPY public.quayservice (id, name) FROM stdin;
 --
 
 COPY public.queueitem (id, queue_name, body, available_after, available, processing_expires, retries_remaining, state_id) FROM stdin;
-2	namespacegc/3/	{"marker_id": 2, "original_username": "clair"}	2024-09-30 17:51:28.055159	t	2024-09-30 20:46:28.041972	5	245c3f97-bac6-4742-93eb-2b61f948c6b9
-1	namespacegc/2/	{"marker_id": 1, "original_username": "quay"}	2024-09-30 17:51:33.074743	t	2024-09-30 20:46:33.062514	5	daa3897c-92bf-4678-a49a-8dbf4efed18c
+1	namespacegc/2/	{"marker_id": 1, "original_username": "quay"}	2024-11-26 13:33:24.969707	t	2024-11-26 16:28:24.944791	5	b26bfbb7-6d52-4adb-81bd-9674dfc4359d
+2	namespacegc/3/	{"marker_id": 2, "original_username": "clair"}	2024-11-26 13:33:30.012937	t	2024-11-26 16:28:29.982092	5	be21614e-6c32-4f3c-9454-6c8c94a8b672
 \.
 
 
@@ -8286,7 +8288,7 @@ SELECT pg_catalog.setval('public.logentry2_id_seq', 1, false);
 -- Name: logentry3_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.logentry3_id_seq', 207, true);
+SELECT pg_catalog.setval('public.logentry3_id_seq', 204, true);
 
 
 --
@@ -8440,7 +8442,7 @@ SELECT pg_catalog.setval('public.permissionprototype_id_seq', 3, true);
 -- Name: proxycacheconfig_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.proxycacheconfig_id_seq', 1, false);
+SELECT pg_catalog.setval('public.proxycacheconfig_id_seq', 1, true);
 
 
 --

--- a/web/src/hooks/UseAlerts.ts
+++ b/web/src/hooks/UseAlerts.ts
@@ -9,7 +9,13 @@ export function useAlerts() {
     }
     setAlerts([...alerts, alert]);
   };
+
+  const clearAllAlerts = () => {
+    setAlerts([]);
+  };
+
   return {
-    addAlert: addAlert,
+    addAlert,
+    clearAllAlerts,
   };
 }

--- a/web/src/hooks/UseProxyCache.ts
+++ b/web/src/hooks/UseProxyCache.ts
@@ -6,6 +6,8 @@ import {
   validateProxyCacheConfig,
 } from 'src/resources/ProxyCacheResource';
 import {useCurrentUser} from './UseCurrentUser';
+import {addDisplayError} from 'src/resources/ErrorHandling';
+import {AxiosError} from 'axios';
 
 export interface IProxyCacheConfig {
   upstream_registry: string;
@@ -55,8 +57,8 @@ export function useValidateProxyCacheConfig(
         onSuccess(response);
         queryClient.invalidateQueries(['proxycacheconfig']);
       },
-      onError: (err) => {
-        onError(err);
+      onError: (err: AxiosError) => {
+        onError(addDisplayError('proxy cache validation error', err));
       },
     },
   );
@@ -65,53 +67,45 @@ export function useValidateProxyCacheConfig(
   };
 }
 
-export function useCreateProxyCacheConfig() {
+export function useCreateProxyCacheConfig({onSuccess, onError}) {
   const queryClient = useQueryClient();
-  const {
-    mutate: createProxyCacheConfigMutation,
-    isError: isErrorProxyCacheCreation,
-    isSuccess: successProxyCacheCreation,
-    error: proxyCacheCreationError,
-  } = useMutation(
+  const {mutate: createProxyCacheConfigMutation} = useMutation(
     async (proxyCacheConfig: IProxyCacheConfig) => {
       return createProxyCacheConfig(proxyCacheConfig);
     },
     {
       onSuccess: () => {
+        onSuccess();
         queryClient.invalidateQueries(['proxycacheconfig']);
+      },
+      onError: (err: AxiosError) => {
+        onError(addDisplayError('proxy cache creation error', err));
       },
     },
   );
 
   return {
     createProxyCacheConfigMutation,
-    isErrorProxyCacheCreation,
-    successProxyCacheCreation,
-    proxyCacheCreationError,
   };
 }
 
-export function useDeleteProxyCacheConfig(orgName) {
+export function useDeleteProxyCacheConfig(orgName, {onSuccess, onError}) {
   const queryClient = useQueryClient();
-  const {
-    mutate: deleteProxyCacheConfigMutation,
-    isError: isErrorProxyCacheDeletion,
-    isSuccess: successProxyCacheDeletion,
-    error: proxyCacheDeletionError,
-  } = useMutation(
+  const {mutate: deleteProxyCacheConfigMutation} = useMutation(
     async () => {
       return deleteProxyCacheConfig(orgName);
     },
     {
       onSuccess: () => {
+        onSuccess();
         queryClient.invalidateQueries(['proxycacheconfig']);
+      },
+      onError: (err: AxiosError) => {
+        onError(addDisplayError('proxy cache deletion error', err));
       },
     },
   );
   return {
     deleteProxyCacheConfigMutation,
-    successProxyCacheDeletion,
-    isErrorProxyCacheDeletion,
-    proxyCacheDeletionError,
   };
 }

--- a/web/src/hooks/UseProxyCache.ts
+++ b/web/src/hooks/UseProxyCache.ts
@@ -1,0 +1,105 @@
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {
+  createProxyCacheConfig,
+  deleteProxyCacheConfig,
+  fetchProxyCacheConfig,
+  validateProxyCacheConfig,
+} from 'src/resources/ProxyCacheResource';
+import {useCurrentUser} from './UseCurrentUser';
+
+export interface IProxyCacheConfig {
+  upstream_registry: string;
+  expiration_s: number;
+  insecure?: boolean;
+  org_name?: string;
+  upstream_registry_username?: string;
+  upstream_registry_password?: string;
+}
+
+export function useFetchProxyCacheConfig(orgName: string) {
+  const {user} = useCurrentUser();
+
+  const {
+    data: fetchedProxyCacheConfig,
+    isLoading: isLoadingProxyCacheConfig,
+    isSuccess: isSuccessLoadingProxyCacheConfig,
+    isError: errorLoadingProxyCacheConfig,
+  } = useQuery<IProxyCacheConfig>(
+    ['proxycacheconfig'],
+    ({signal}) => fetchProxyCacheConfig(orgName, signal),
+    {
+      enabled: !(user.username === orgName),
+    },
+  );
+
+  return {
+    fetchedProxyCacheConfig,
+    isLoadingProxyCacheConfig,
+    errorLoadingProxyCacheConfig,
+    isSuccessLoadingProxyCacheConfig,
+  };
+}
+
+export function useValidateProxyCacheConfig(
+  proxyCacheConfig: IProxyCacheConfig,
+  {onSuccess, onError},
+) {
+  const queryClient = useQueryClient();
+  const {user} = useCurrentUser();
+
+  const {mutate: proxyCacheConfigValidation} = useMutation(
+    async () => {
+      return validateProxyCacheConfig(proxyCacheConfig);
+    },
+    {
+      onSuccess: (response) => {
+        onSuccess(response);
+        queryClient.invalidateQueries(['proxycacheconfig']);
+      },
+      onError: (err) => {
+        onError(err);
+      },
+    },
+  );
+  return {
+    proxyCacheConfigValidation,
+  };
+}
+
+export function useCreateProxyCacheConfig() {
+  const {
+    mutate: createProxyCacheConfigMutation,
+    isError: isErrorProxyCacheCreation,
+    isSuccess: successProxyCacheCreation,
+    error: proxyCacheCreationError,
+  } = useMutation(async (proxyCacheConfig: IProxyCacheConfig) => {
+    return createProxyCacheConfig(proxyCacheConfig);
+  });
+
+  return {
+    createProxyCacheConfigMutation,
+    isErrorProxyCacheCreation,
+    successProxyCacheCreation,
+    proxyCacheCreationError,
+  };
+}
+
+export function useDeleteProxyCacheConfig(orgName) {
+  const queryClient = useQueryClient();
+  const {
+    mutate: deleteProxyCacheConfigMutation,
+    isError: isErrorProxyCacheDeletion,
+    isSuccess: successProxyCacheDeletion,
+    error: proxyCacheDeletionError,
+  } = useMutation(
+    async () => {
+      return deleteProxyCacheConfig(orgName);
+    }
+  );
+  return {
+    deleteProxyCacheConfigMutation,
+    successProxyCacheDeletion,
+    isErrorProxyCacheDeletion,
+    proxyCacheDeletionError,
+  };
+}

--- a/web/src/hooks/UseProxyCache.ts
+++ b/web/src/hooks/UseProxyCache.ts
@@ -45,7 +45,6 @@ export function useValidateProxyCacheConfig(
   {onSuccess, onError},
 ) {
   const queryClient = useQueryClient();
-  const {user} = useCurrentUser();
 
   const {mutate: proxyCacheConfigValidation} = useMutation(
     async () => {
@@ -67,14 +66,22 @@ export function useValidateProxyCacheConfig(
 }
 
 export function useCreateProxyCacheConfig() {
+  const queryClient = useQueryClient();
   const {
     mutate: createProxyCacheConfigMutation,
     isError: isErrorProxyCacheCreation,
     isSuccess: successProxyCacheCreation,
     error: proxyCacheCreationError,
-  } = useMutation(async (proxyCacheConfig: IProxyCacheConfig) => {
-    return createProxyCacheConfig(proxyCacheConfig);
-  });
+  } = useMutation(
+    async (proxyCacheConfig: IProxyCacheConfig) => {
+      return createProxyCacheConfig(proxyCacheConfig);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['proxycacheconfig']);
+      },
+    },
+  );
 
   return {
     createProxyCacheConfigMutation,
@@ -94,7 +101,12 @@ export function useDeleteProxyCacheConfig(orgName) {
   } = useMutation(
     async () => {
       return deleteProxyCacheConfig(orgName);
-    }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['proxycacheconfig']);
+      },
+    },
   );
   return {
     deleteProxyCacheConfigMutation,

--- a/web/src/resources/ProxyCacheResource.ts
+++ b/web/src/resources/ProxyCacheResource.ts
@@ -19,7 +19,10 @@ export async function validateProxyCacheConfig(
   return proxyResponse.data;
 }
 
-export async function deleteProxyCacheConfig(org: string, signal?: AbortSignal) {
+export async function deleteProxyCacheConfig(
+  org: string,
+  signal?: AbortSignal,
+) {
   const proxyCacheConfigUrl = `/api/v1/organization/${org}/proxycache`;
   const proxyResponse = await axios.delete(proxyCacheConfigUrl, {signal});
   assertHttpCode(proxyResponse.status, 201);

--- a/web/src/resources/ProxyCacheResource.ts
+++ b/web/src/resources/ProxyCacheResource.ts
@@ -14,9 +14,20 @@ export async function validateProxyCacheConfig(
   proxyCacheConfig: IProxyCacheConfig,
 ) {
   const proxyCacheConfigUrl = `/api/v1/organization/${proxyCacheConfig.org_name}/validateproxycache`;
-  const proxyResponse = await axios.post(proxyCacheConfigUrl, proxyCacheConfig);
-  assertHttpCode(proxyResponse.status, 202);
-  return proxyResponse.data;
+  const payload = {
+    ...proxyCacheConfig,
+    upstream_registry_username:
+      proxyCacheConfig.upstream_registry_username || null,
+    upstream_registry_password:
+      proxyCacheConfig.upstream_registry_password || null,
+  };
+  try {
+    const proxyResponse = await axios.post(proxyCacheConfigUrl, payload);
+    assertHttpCode(proxyResponse.status, 202);
+    return proxyResponse.data;
+  } catch (error) {
+    throw error;
+  }
 }
 
 export async function deleteProxyCacheConfig(
@@ -24,9 +35,13 @@ export async function deleteProxyCacheConfig(
   signal?: AbortSignal,
 ) {
   const proxyCacheConfigUrl = `/api/v1/organization/${org}/proxycache`;
-  const proxyResponse = await axios.delete(proxyCacheConfigUrl, {signal});
-  assertHttpCode(proxyResponse.status, 201);
-  return proxyResponse.data;
+  try {
+    const proxyResponse = await axios.delete(proxyCacheConfigUrl, {signal});
+    assertHttpCode(proxyResponse.status, 201);
+    return proxyResponse.data;
+  } catch (error) {
+    throw error;
+  }
 }
 
 export async function createProxyCacheConfig(
@@ -34,18 +49,20 @@ export async function createProxyCacheConfig(
 ) {
   const createProxyCacheConfigUrl = `/api/v1/organization/${proxyCacheConfig.org_name}/proxycache`;
   const payload = {
-    upstream_registry: proxyCacheConfig.upstream_registry,
-    expiration_s: proxyCacheConfig.expiration_s,
-    insecure: proxyCacheConfig.insecure,
-    org_name: proxyCacheConfig.org_name,
-    upstream_registry_username: proxyCacheConfig.upstream_registry_username,
-    upstream_registry_password: proxyCacheConfig.upstream_registry_password,
+    ...proxyCacheConfig,
+    upstream_registry_username:
+      proxyCacheConfig.upstream_registry_username || null,
+    upstream_registry_password:
+      proxyCacheConfig.upstream_registry_password || null,
   };
-
-  const response: AxiosResponse = await axios.post(
-    createProxyCacheConfigUrl,
-    payload,
-  );
-  assertHttpCode(response.status, 201);
-  return response.data;
+  try {
+    const response: AxiosResponse = await axios.post(
+      createProxyCacheConfigUrl,
+      payload,
+    );
+    assertHttpCode(response.status, 201);
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
 }

--- a/web/src/resources/ProxyCacheResource.ts
+++ b/web/src/resources/ProxyCacheResource.ts
@@ -21,13 +21,9 @@ export async function validateProxyCacheConfig(
     upstream_registry_password:
       proxyCacheConfig.upstream_registry_password || null,
   };
-  try {
-    const proxyResponse = await axios.post(proxyCacheConfigUrl, payload);
-    assertHttpCode(proxyResponse.status, 202);
-    return proxyResponse.data;
-  } catch (error) {
-    throw error;
-  }
+  const proxyResponse = await axios.post(proxyCacheConfigUrl, payload);
+  assertHttpCode(proxyResponse.status, 202);
+  return proxyResponse.data;
 }
 
 export async function deleteProxyCacheConfig(
@@ -35,13 +31,9 @@ export async function deleteProxyCacheConfig(
   signal?: AbortSignal,
 ) {
   const proxyCacheConfigUrl = `/api/v1/organization/${org}/proxycache`;
-  try {
-    const proxyResponse = await axios.delete(proxyCacheConfigUrl, {signal});
-    assertHttpCode(proxyResponse.status, 201);
-    return proxyResponse.data;
-  } catch (error) {
-    throw error;
-  }
+  const proxyResponse = await axios.delete(proxyCacheConfigUrl, {signal});
+  assertHttpCode(proxyResponse.status, 201);
+  return proxyResponse.data;
 }
 
 export async function createProxyCacheConfig(
@@ -55,14 +47,10 @@ export async function createProxyCacheConfig(
     upstream_registry_password:
       proxyCacheConfig.upstream_registry_password || null,
   };
-  try {
-    const response: AxiosResponse = await axios.post(
-      createProxyCacheConfigUrl,
-      payload,
-    );
-    assertHttpCode(response.status, 201);
-    return response.data;
-  } catch (error) {
-    throw error;
-  }
+  const response: AxiosResponse = await axios.post(
+    createProxyCacheConfigUrl,
+    payload,
+  );
+  assertHttpCode(response.status, 201);
+  return response.data;
 }

--- a/web/src/resources/ProxyCacheResource.ts
+++ b/web/src/resources/ProxyCacheResource.ts
@@ -1,0 +1,48 @@
+import axios from 'src/libs/axios';
+import {assertHttpCode} from './ErrorHandling';
+import {IProxyCacheConfig} from 'src/hooks/UseProxyCache';
+import {AxiosResponse} from 'axios';
+
+export async function fetchProxyCacheConfig(org: string, signal?: AbortSignal) {
+  const proxyCacheConfigUrl = `/api/v1/organization/${org}/proxycache`;
+  const proxyResponse = await axios.get(proxyCacheConfigUrl, {signal});
+  assertHttpCode(proxyResponse.status, 200);
+  return proxyResponse.data;
+}
+
+export async function validateProxyCacheConfig(
+  proxyCacheConfig: IProxyCacheConfig,
+) {
+  const proxyCacheConfigUrl = `/api/v1/organization/${proxyCacheConfig.org_name}/validateproxycache`;
+  const proxyResponse = await axios.post(proxyCacheConfigUrl, proxyCacheConfig);
+  assertHttpCode(proxyResponse.status, 202);
+  return proxyResponse.data;
+}
+
+export async function deleteProxyCacheConfig(org: string, signal?: AbortSignal) {
+  const proxyCacheConfigUrl = `/api/v1/organization/${org}/proxycache`;
+  const proxyResponse = await axios.delete(proxyCacheConfigUrl, {signal});
+  assertHttpCode(proxyResponse.status, 201);
+  return proxyResponse.data;
+}
+
+export async function createProxyCacheConfig(
+  proxyCacheConfig: IProxyCacheConfig,
+) {
+  const createProxyCacheConfigUrl = `/api/v1/organization/${proxyCacheConfig.org_name}/proxycache`;
+  const payload = {
+    upstream_registry: proxyCacheConfig.upstream_registry,
+    expiration_s: proxyCacheConfig.expiration_s,
+    insecure: proxyCacheConfig.insecure,
+    org_name: proxyCacheConfig.org_name,
+    upstream_registry_username: proxyCacheConfig.upstream_registry_username,
+    upstream_registry_password: proxyCacheConfig.upstream_registry_password,
+  };
+
+  const response: AxiosResponse = await axios.post(
+    createProxyCacheConfigUrl,
+    payload,
+  );
+  assertHttpCode(response.status, 201);
+  return response.data;
+}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
@@ -56,32 +56,27 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           fetchedProxyCacheConfig.expiration_s ||
           tagExpirationInSecsForProxyCache,
         insecure: fetchedProxyCacheConfig.insecure || false,
-        upstream_registry_username:
-          fetchedProxyCacheConfig.upstream_registry_username,
-        upstream_registry_password:
-          fetchedProxyCacheConfig.upstream_registry_password,
       }));
     } else {
       // reset the config if there's no fetchedProxyCacheConfig data
       setProxyCacheConfig(defaultProxyCacheConfig);
     }
-  }, [fetchedProxyCacheConfig]);
+  }, [fetchedProxyCacheConfig, props.organizationName]);
 
-  const {
-    createProxyCacheConfigMutation,
-    isErrorProxyCacheCreation,
-    successProxyCacheCreation,
-    proxyCacheCreationError,
-  } = useCreateProxyCacheConfig();
-
-  useEffect(() => {
-    if (successProxyCacheCreation) {
+  const {createProxyCacheConfigMutation} = useCreateProxyCacheConfig({
+    onSuccess: () => {
       addAlert({
         variant: AlertVariant.Success,
         title: `Successfully configured proxy cache`,
       });
-    }
-  }, [successProxyCacheCreation]);
+    },
+    onError: (err) => {
+      addAlert({
+        variant: AlertVariant.Failure,
+        title: err,
+      });
+    },
+  });
 
   useEffect(() => {
     // clear alerts when switching tabs
@@ -89,15 +84,6 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
       clearAllAlerts();
     };
   }, []);
-
-  useEffect(() => {
-    if (isErrorProxyCacheCreation) {
-      addAlert({
-        variant: AlertVariant.Failure,
-        title: `Unable to create proxy cache config: ${proxyCacheCreationError}`,
-      });
-    }
-  }, [isErrorProxyCacheCreation]);
 
   const {proxyCacheConfigValidation} = useValidateProxyCacheConfig(
     proxyCacheConfig,
@@ -111,37 +97,29 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
       onError: (err) => {
         addAlert({
           variant: AlertVariant.Failure,
-          title: `Unable to create proxy cache config: ${err}`,
+          title: err,
         });
       },
     },
   );
 
-  const {
-    deleteProxyCacheConfigMutation,
-    successProxyCacheDeletion,
-    isErrorProxyCacheDeletion,
-    proxyCacheDeletionError,
-  } = useDeleteProxyCacheConfig(props.organizationName);
-
-  useEffect(() => {
-    if (successProxyCacheDeletion) {
-      setProxyCacheConfig(defaultProxyCacheConfig);
-      addAlert({
-        variant: AlertVariant.Success,
-        title: `Successfully deleted proxy cache configuration`,
-      });
-    }
-  }, [successProxyCacheDeletion]);
-
-  useEffect(() => {
-    if (isErrorProxyCacheDeletion) {
-      addAlert({
-        variant: AlertVariant.Failure,
-        title: `Unable to delete proxy cache configuration: ${proxyCacheDeletionError}`,
-      });
-    }
-  }, [isErrorProxyCacheDeletion]);
+  const {deleteProxyCacheConfigMutation} = useDeleteProxyCacheConfig(
+    props.organizationName,
+    {
+      onSuccess: () => {
+        addAlert({
+          variant: AlertVariant.Success,
+          title: 'Successfully deleted proxy cache configuration',
+        });
+      },
+      onError: (err) => {
+        addAlert({
+          variant: AlertVariant.Failure,
+          title: err,
+        });
+      },
+    },
+  );
 
   const handleRemoteRegistryInput = (registryName: string) => {
     setProxyCacheConfig((prevConfig) => ({
@@ -194,7 +172,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           type="text"
           id="form-name"
           data-testid="remote-registry-input"
-          value={proxyCacheConfig?.upstream_registry}
+          value={proxyCacheConfig?.upstream_registry || ''}
           onChange={(_event, registryName) =>
             handleRemoteRegistryInput(registryName)
           }
@@ -220,7 +198,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           type="text"
           id="remote-registry-username"
           data-testid="remote-registry-username"
-          value={proxyCacheConfig?.upstream_registry_username}
+          value={proxyCacheConfig?.upstream_registry_username || ''}
           onChange={(_event, registryUsername) =>
             handleRemoteRegistryUsername(registryUsername)
           }
@@ -246,7 +224,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           type="password"
           id="remote-registry-password"
           data-testid="remote-registry-password"
-          value={proxyCacheConfig?.upstream_registry_password}
+          value={proxyCacheConfig?.upstream_registry_password || ''}
           onChange={(_event, password) =>
             handleRemoteRegistryPassword(password)
           }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
@@ -41,7 +41,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
   const [proxyCacheConfig, setProxyCacheConfig] = useState<IProxyCacheConfig>(
     defaultProxyCacheConfig,
   );
-  const {addAlert} = useAlerts();
+  const {addAlert, clearAllAlerts} = useAlerts();
 
   const {fetchedProxyCacheConfig, isLoadingProxyCacheConfig} =
     useFetchProxyCacheConfig(props.organizationName);
@@ -61,7 +61,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           fetchedProxyCacheConfig.upstream_registry_password,
       }));
     } else {
-      // Optionally reset the config if there's no fetchedProxyCacheConfig data
+      // reset the config if there's no fetchedProxyCacheConfig data
       setProxyCacheConfig(defaultProxyCacheConfig);
     }
   }, [fetchedProxyCacheConfig]);
@@ -81,6 +81,13 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
       });
     }
   }, [successProxyCacheCreation]);
+
+  useEffect(() => {
+    // clear alerts when switching tabs
+    return () => {
+      clearAllAlerts();
+    };
+  }, []);
 
   useEffect(() => {
     if (isErrorProxyCacheCreation) {
@@ -233,7 +240,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
       >
         <TextInput
           isDisabled={!!fetchedProxyCacheConfig?.upstream_registry_password}
-          type="text"
+          type="password"
           id="remote-registry-password"
           value={proxyCacheConfig?.upstream_registry_password}
           onChange={(_event, password) =>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
@@ -28,12 +28,12 @@ type ProxyCacheConfigProps = {
   isUser: boolean;
 };
 
-const tagExpirationForProxyCache = 86400;
+const tagExpirationInSecsForProxyCache = 86400;
 
 export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
   const defaultProxyCacheConfig = {
     upstream_registry: '',
-    expiration_s: tagExpirationForProxyCache,
+    expiration_s: tagExpirationInSecsForProxyCache,
     insecure: false,
     org_name: props.organizationName,
   };
@@ -53,7 +53,8 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
         ...prevConfig,
         upstream_registry: fetchedProxyCacheConfig.upstream_registry,
         expiration_s:
-          fetchedProxyCacheConfig.expiration_s || tagExpirationForProxyCache,
+          fetchedProxyCacheConfig.expiration_s ||
+          tagExpirationInSecsForProxyCache,
         insecure: fetchedProxyCacheConfig.insecure || false,
         upstream_registry_username:
           fetchedProxyCacheConfig.upstream_registry_username,
@@ -267,7 +268,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           id="remote-registry-expiration"
           data-testid="remote-registry-expiration"
           value={proxyCacheConfig?.expiration_s}
-          placeholder={tagExpirationForProxyCache.toString()}
+          placeholder={tagExpirationInSecsForProxyCache.toString()}
           onChange={(_event, inputSecs) =>
             handleRemoteRegistryExpiration(inputSecs)
           }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
@@ -192,6 +192,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           isDisabled={!!fetchedProxyCacheConfig?.upstream_registry}
           type="text"
           id="form-name"
+          data-testid="remote-registry-input"
           value={proxyCacheConfig?.upstream_registry}
           onChange={(_event, registryName) =>
             handleRemoteRegistryInput(registryName)
@@ -217,6 +218,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           isDisabled={!!fetchedProxyCacheConfig?.upstream_registry_username}
           type="text"
           id="remote-registry-username"
+          data-testid="remote-registry-username"
           value={proxyCacheConfig?.upstream_registry_username}
           onChange={(_event, registryUsername) =>
             handleRemoteRegistryUsername(registryUsername)
@@ -242,6 +244,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           isDisabled={!!fetchedProxyCacheConfig?.upstream_registry_password}
           type="password"
           id="remote-registry-password"
+          data-testid="remote-registry-password"
           value={proxyCacheConfig?.upstream_registry_password}
           onChange={(_event, password) =>
             handleRemoteRegistryPassword(password)
@@ -262,6 +265,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
         <TextInput
           type="text"
           id="remote-registry-expiration"
+          data-testid="remote-registry-expiration"
           value={proxyCacheConfig?.expiration_s}
           placeholder={tagExpirationForProxyCache.toString()}
           onChange={(_event, inputSecs) =>
@@ -285,6 +289,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           isChecked={proxyCacheConfig?.insecure}
           onChange={handleInsecureProtocol}
           id="controlled-check-2"
+          data-testid="remote-registry-insecure"
         />
         <FormHelperText>
           <HelperText>
@@ -303,6 +308,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
         >
           <Button
             id="save-proxy-cache"
+            data-testid="save-proxy-cache-btn"
             variant="primary"
             type="submit"
             onClick={(event) => {
@@ -320,6 +326,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           <Button
             isDisabled={!fetchedProxyCacheConfig?.upstream_registry}
             id="delete-proxy-cache"
+            data-testid="delete-proxy-cache-btn"
             variant="danger"
             type="submit"
             onClick={(event) => {

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
@@ -1,0 +1,330 @@
+import {
+  ActionGroup,
+  Button,
+  Checkbox,
+  Flex,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Spinner,
+  TextInput,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import {AlertVariant} from 'src/atoms/AlertState';
+import {useAlerts} from 'src/hooks/UseAlerts';
+import {
+  IProxyCacheConfig,
+  useCreateProxyCacheConfig,
+  useDeleteProxyCacheConfig,
+  useFetchProxyCacheConfig,
+  useValidateProxyCacheConfig,
+} from 'src/hooks/UseProxyCache';
+import Alerts from 'src/routes/Alerts';
+
+type ProxyCacheConfigProps = {
+  organizationName: string;
+  isUser: boolean;
+};
+
+const tagExpirationForProxyCache = 86400;
+
+export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
+  const defaultProxyCacheConfig = {
+    upstream_registry: '',
+    expiration_s: tagExpirationForProxyCache,
+    insecure: false,
+    org_name: props.organizationName,
+  };
+
+  const [proxyCacheConfig, setProxyCacheConfig] = useState<IProxyCacheConfig>(
+    defaultProxyCacheConfig,
+  );
+  const {addAlert} = useAlerts();
+
+  const {fetchedProxyCacheConfig, isLoadingProxyCacheConfig} =
+    useFetchProxyCacheConfig(props.organizationName);
+
+  useEffect(() => {
+    if (fetchedProxyCacheConfig) {
+      // only set values that are fetched
+      setProxyCacheConfig((prevConfig) => ({
+        ...prevConfig,
+        upstream_registry: fetchedProxyCacheConfig.upstream_registry,
+        expiration_s:
+          fetchedProxyCacheConfig.expiration_s || tagExpirationForProxyCache,
+        insecure: fetchedProxyCacheConfig.insecure || false,
+        upstream_registry_username:
+          fetchedProxyCacheConfig.upstream_registry_username,
+        upstream_registry_password:
+          fetchedProxyCacheConfig.upstream_registry_password,
+      }));
+    } else {
+      // Optionally reset the config if there's no fetchedProxyCacheConfig data
+      setProxyCacheConfig(defaultProxyCacheConfig);
+    }
+  }, [fetchedProxyCacheConfig]);
+
+  const {
+    createProxyCacheConfigMutation,
+    isErrorProxyCacheCreation,
+    successProxyCacheCreation,
+    proxyCacheCreationError,
+  } = useCreateProxyCacheConfig();
+
+  useEffect(() => {
+    if (successProxyCacheCreation) {
+      addAlert({
+        variant: AlertVariant.Success,
+        title: `Successfully configured proxy cache`,
+      });
+    }
+  }, [successProxyCacheCreation]);
+
+  useEffect(() => {
+    if (isErrorProxyCacheCreation) {
+      addAlert({
+        variant: AlertVariant.Failure,
+        title: `Unable to create proxy cache config: ${proxyCacheCreationError}`,
+      });
+    }
+  }, [isErrorProxyCacheCreation]);
+
+  const {proxyCacheConfigValidation} = useValidateProxyCacheConfig(
+    proxyCacheConfig,
+    {
+      onSuccess: (response) => {
+        if (response === 'Valid' || response === 'Anonymous') {
+          createProxyCacheConfigMutation(proxyCacheConfig);
+          setProxyCacheConfig(proxyCacheConfig);
+        }
+      },
+      onError: (err) => {
+        addAlert({
+          variant: AlertVariant.Failure,
+          title: `Unable to create proxy cache config: ${err}`,
+        });
+      },
+    },
+  );
+
+  const {
+    deleteProxyCacheConfigMutation,
+    successProxyCacheDeletion,
+    isErrorProxyCacheDeletion,
+    proxyCacheDeletionError,
+  } = useDeleteProxyCacheConfig(props.organizationName);
+
+  useEffect(() => {
+    if (successProxyCacheDeletion) {
+      setProxyCacheConfig(defaultProxyCacheConfig);
+      addAlert({
+        variant: AlertVariant.Success,
+        title: `Successfully deleted proxy cache configuration`,
+      });
+    }
+  }, [successProxyCacheDeletion]);
+
+  useEffect(() => {
+    if (isErrorProxyCacheDeletion) {
+      addAlert({
+        variant: AlertVariant.Failure,
+        title: `Unable to delete proxy cache configuration: ${proxyCacheDeletionError}`,
+      });
+    }
+  }, [isErrorProxyCacheDeletion]);
+
+  const handleRemoteRegistryInput = (registryName: string) => {
+    setProxyCacheConfig((prevConfig) => ({
+      ...prevConfig,
+      upstream_registry: registryName,
+    }));
+  };
+
+  const handleRemoteRegistryUsername = (registryUsername: string) => {
+    setProxyCacheConfig((prevConfig) => ({
+      ...prevConfig,
+      upstream_registry_username: registryUsername,
+    }));
+  };
+
+  const handleRemoteRegistryPassword = (registryPass: string) => {
+    setProxyCacheConfig((prevConfig) => ({
+      ...prevConfig,
+      upstream_registry_password: registryPass,
+    }));
+  };
+
+  const handleRemoteRegistryExpiration = (expiration: string) => {
+    setProxyCacheConfig((prevConfig) => ({
+      ...prevConfig,
+      expiration_s: Number(expiration),
+    }));
+  };
+
+  const handleInsecureProtocol = (e, checked: boolean) => {
+    setProxyCacheConfig((prevConfig) => ({
+      ...prevConfig,
+      insecure: checked,
+    }));
+  };
+
+  if (isLoadingProxyCacheConfig) {
+    return <Spinner size="md" />;
+  }
+
+  return (
+    <Form id="form-form" maxWidth="70%">
+      <FormGroup
+        isInline
+        label="Remote Registry"
+        fieldId="form-remote-registry"
+      >
+        <TextInput
+          isDisabled={!!fetchedProxyCacheConfig?.upstream_registry}
+          type="text"
+          id="form-name"
+          value={proxyCacheConfig?.upstream_registry}
+          onChange={(_event, registryName) =>
+            handleRemoteRegistryInput(registryName)
+          }
+        />
+
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              Remote registry that is to be cached. (Eg: For docker hub,
+              docker.io, docker.io/library)
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+
+      <FormGroup
+        isInline
+        label="Remote Registry username"
+        fieldId="form-username"
+      >
+        <TextInput
+          isDisabled={!!fetchedProxyCacheConfig?.upstream_registry_username}
+          type="text"
+          id="remote-registry-username"
+          value={proxyCacheConfig?.upstream_registry_username}
+          onChange={(_event, registryUsername) =>
+            handleRemoteRegistryUsername(registryUsername)
+          }
+        />
+
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              Username for authenticating into the entered remote registry. For
+              anonymous pulls from the upstream, leave this empty.
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+
+      <FormGroup
+        isInline
+        label="Remote Registry password"
+        fieldId="form-password"
+      >
+        <TextInput
+          isDisabled={!!fetchedProxyCacheConfig?.upstream_registry_password}
+          type="text"
+          id="remote-registry-password"
+          value={proxyCacheConfig?.upstream_registry_password}
+          onChange={(_event, password) =>
+            handleRemoteRegistryPassword(password)
+          }
+        />
+
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              Password for authenticating into the entered remote registry. For
+              anonymous pulls from the upstream, leave this empty.{' '}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+
+      <FormGroup isInline label="Expiration" fieldId="form-username">
+        <TextInput
+          type="text"
+          id="remote-registry-expiration"
+          value={proxyCacheConfig?.expiration_s}
+          placeholder={tagExpirationForProxyCache.toString()}
+          onChange={(_event, inputSecs) =>
+            handleRemoteRegistryExpiration(inputSecs)
+          }
+        />
+
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              Default tag expiration for cached images, in seconds. This value
+              is refreshed on every pull. Default is 86400 i.e, 24 hours.{' '}
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+
+      <FormGroup isInline label="Insecure" fieldId="form-insecure">
+        <Checkbox
+          label="http"
+          isChecked={proxyCacheConfig?.insecure}
+          onChange={handleInsecureProtocol}
+          id="controlled-check-2"
+        />
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              If set, http (unsecure protocol) will be used. If not set, https
+              (secure protocol) will be used to request the remote registry.
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      </FormGroup>
+
+      <ActionGroup>
+        <Flex
+          justifyContent={{default: 'justifyContentFlexEnd'}}
+          width={'100%'}
+        >
+          <Button
+            id="save-proxy-cache"
+            variant="primary"
+            type="submit"
+            onClick={(event) => {
+              event.preventDefault();
+              proxyCacheConfigValidation();
+            }}
+            isDisabled={
+              !proxyCacheConfig?.upstream_registry ||
+              !!fetchedProxyCacheConfig?.upstream_registry
+            }
+          >
+            Save
+          </Button>
+
+          <Button
+            isDisabled={!fetchedProxyCacheConfig?.upstream_registry}
+            id="delete-proxy-cache"
+            variant="danger"
+            type="submit"
+            onClick={(event) => {
+              event.preventDefault();
+              deleteProxyCacheConfigMutation();
+            }}
+          >
+            Delete
+          </Button>
+        </Flex>
+      </ActionGroup>
+      <Alerts />
+    </Form>
+  );
+};

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
@@ -78,6 +78,7 @@ export default function Settings(props: SettingsProps) {
               <Tab
                 key={tab.id}
                 id={tab.id}
+                data-testid={tab.name}
                 eventKey={tabIndex}
                 title={<TabTitleText>{tab.name}</TabTitleText>}
               />

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
@@ -6,7 +6,7 @@ import AutoPruning from './AutoPruning';
 import {BillingInformation} from './BillingInformation';
 import {CliConfiguration} from './CLIConfiguration';
 import {GeneralSettings} from './GeneralSettings';
-import { ProxyCacheConfig } from './ProxyCacheConfig';
+import {ProxyCacheConfig} from './ProxyCacheConfig';
 
 export default function Settings(props: SettingsProps) {
   const organizationName = location.pathname.split('/')[2];
@@ -47,7 +47,7 @@ export default function Settings(props: SettingsProps) {
           isUser={props.isUserOrganization}
         />
       ),
-      visible: quayConfig?.features?.AUTO_PRUNE,
+      visible: quayConfig?.features?.AUTO_PRUNE || true,
     },
     {
       name: 'Proxy-Cache config',
@@ -58,7 +58,7 @@ export default function Settings(props: SettingsProps) {
           isUser={props.isUserOrganization}
         />
       ),
-      visible: quayConfig?.features?.FEATURE_PROXY_CACHE,
+      visible: quayConfig?.features?.FEATURE_PROXY_CACHE || true,
     },
   ];
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
@@ -47,7 +47,7 @@ export default function Settings(props: SettingsProps) {
           isUser={props.isUserOrganization}
         />
       ),
-      visible: quayConfig?.features?.AUTO_PRUNE || true,
+      visible: quayConfig?.features?.AUTO_PRUNE,
     },
     {
       name: 'Proxy-Cache config',
@@ -58,7 +58,7 @@ export default function Settings(props: SettingsProps) {
           isUser={props.isUserOrganization}
         />
       ),
-      visible: quayConfig?.features?.FEATURE_PROXY_CACHE || true,
+      visible: quayConfig?.features?.PROXY_CACHE,
     },
   ];
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
@@ -6,6 +6,7 @@ import AutoPruning from './AutoPruning';
 import {BillingInformation} from './BillingInformation';
 import {CliConfiguration} from './CLIConfiguration';
 import {GeneralSettings} from './GeneralSettings';
+import { ProxyCacheConfig } from './ProxyCacheConfig';
 
 export default function Settings(props: SettingsProps) {
   const organizationName = location.pathname.split('/')[2];
@@ -47,6 +48,17 @@ export default function Settings(props: SettingsProps) {
         />
       ),
       visible: quayConfig?.features?.AUTO_PRUNE,
+    },
+    {
+      name: 'Proxy-Cache config',
+      id: 'proxycacheconfig',
+      content: (
+        <ProxyCacheConfig
+          organizationName={props.organizationName}
+          isUser={props.isUserOrganization}
+        />
+      ),
+      visible: quayConfig?.features?.FEATURE_PROXY_CACHE,
     },
   ];
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
@@ -50,7 +50,7 @@ export default function Settings(props: SettingsProps) {
       visible: quayConfig?.features?.AUTO_PRUNE,
     },
     {
-      name: 'Proxy-Cache config',
+      name: 'Proxy Cache',
       id: 'proxycacheconfig',
       content: (
         <ProxyCacheConfig
@@ -58,7 +58,7 @@ export default function Settings(props: SettingsProps) {
           isUser={props.isUserOrganization}
         />
       ),
-      visible: quayConfig?.features?.PROXY_CACHE,
+      visible: quayConfig?.features?.PROXY_CACHE && !props.isUserOrganization,
     },
   ];
 


### PR DESCRIPTION
Adds proxy cache config UI to organization settings tab

![proxy-cache-config](https://github.com/user-attachments/assets/9d134d69-64db-45c7-80e5-760e8d6f09c2)



Follow up:
- show proxy cache configuration during org creation (separate PR)