### PR TITLE
build(deps): bump netaddr from 0.7.19 to 1.3.0 in requirements.txt (PROJQUAY-8222)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ maxminddb==2.6.2
 mixpanel==4.5.0
 msgpack==0.6.2
 msrest==0.7.1
-netaddr==0.7.19
+netaddr==1.3.0
 netifaces==0.11.0
 oauthlib==3.2.2
 orderedmultidict==1.0.1


### PR DESCRIPTION
This change aims to get rid of "SyntaxWarning" messages during the initialization of netaddr.