### PR TITLE
auth: Implement is_restricted_user for federated auth systems (PROJQUAY-8208)

### DIFF
--- a/data/users/__init__.py
+++ b/data/users/__init__.py
@@ -405,6 +405,12 @@ class UserManager(object):
 
         return self.state.is_restricted_user(username)
 
+    def is_superuser(self, username):
+        if not features.SUPER_USERS:
+            return False
+
+        return self.state.is_superuser(username)
+
 
 class FederatedUserManager(ConfigUserManager):
     """
@@ -438,7 +444,9 @@ class FederatedUserManager(ConfigUserManager):
         if super().restricted_whitelist_is_set() and not super().is_restricted_user(username):
             return False
 
-        return self.federated_users.is_restricted_user(username)
+        return self.federated_users.is_restricted_user(username) or super().is_restricted_user(
+            username
+        )
 
     def has_restricted_users(self) -> bool:
         return self.federated_users.has_restricted_users() or super().has_restricted_users()

--- a/data/users/externaljwt.py
+++ b/data/users/externaljwt.py
@@ -150,16 +150,16 @@ class ExternalJWTAuthN(FederatedUsers):
             return (None, "Exception when decoding returned JWT")
 
     def is_superuser(self, username):
-        raise NotImplementedError()
+        return None
 
     def is_global_readonly_superuser(self, username):
-        raise NotImplementedError()
+        return None
 
     def has_superusers(self):
         raise NotImplementedError()
 
     def is_restricted_user(self, username):
-        raise NotImplementedError()
+        return None
 
     def has_restricted_users(self):
         raise NotImplementedError()

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -49,6 +49,12 @@ class OIDCUsers(FederatedUsers):
         """
         return None
 
+    def is_restricted_user(self, username):
+        """
+        Checks whether the currently logged in user is restricted.
+        """
+        return None
+
     def iterate_group_members(self, group_lookup_args, page_size=None, disable_pagination=False):
         """
         Used by teamSync worker, unsupported for oidc team sync

--- a/data/users/keystone.py
+++ b/data/users/keystone.py
@@ -356,16 +356,16 @@ class KeystoneV3Users(FederatedUsers):
             )
 
     def is_superuser(self, username):
-        raise NotImplementedError()
+        return None
 
     def is_global_readonly_superuser(self, username):
-        raise NotImplementedError()
+        return None
 
     def has_superusers(self, username):
-        raise NotImplementedError()
+        return None
 
     def is_restricted_user(self, username):
-        raise NotImplementedError()
+        return None
 
     def has_restricted_users(self):
-        raise NotImplementedError()
+        return None

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -158,8 +158,10 @@ class OrganizationList(ApiResource):
         org_data = request.get_json()
         existing = None
 
-        if features.RESTRICTED_USERS and usermanager.is_restricted_user(user.username):
-            raise Unauthorized()
+        # Super users should be able to create new orgs regardless of user restriction
+        if user.username not in app.config.get("SUPER_USERS", None):
+            if features.RESTRICTED_USERS and usermanager.is_restricted_user(user.username):
+                raise Unauthorized()
 
         try:
             existing = model.organization.get_organization(org_data["name"])

--- a/endpoints/api/repository.py
+++ b/endpoints/api/repository.py
@@ -10,6 +10,7 @@ from flask import abort, request
 
 import features
 from app import (
+    app,
     dockerfile_build_queue,
     repository_gc_queue,
     tuf_metadata_api,
@@ -144,6 +145,7 @@ class RepositoryList(ApiResource):
             features.RESTRICTED_USERS
             and usermanager.is_restricted_user(owner.username)
             and owner.username == namespace_name
+            and owner.username not in app.config.get("SUPER_USERS", None)
         ):
 
             repository_name = req["repository"]


### PR DESCRIPTION
Currently, if any federated auth system is set as an authentication mechanism and restricted users is set, Quay will return a `501 Not Implemented` on invocation. Now, Quay will properly check the restricted user whitelist for federated users. 

Additionally, if user restriction is in place and super user's username was **not** explicitly whitelisted, super users would not be able to create new content inside the registry. Now, the username is explicitly checked in the UI to allow super users to create both organizations and repos regardless of restricted users whitelist.