### PR TITLE
cve: upgrade elasticsearch and elasticsearch-dsl to 8.13.0 (PROJQUAY-6962)

### DIFF
--- a/data/logs_model/logs_producer/elasticsearch_logs_producer.py
+++ b/data/logs_model/logs_producer/elasticsearch_logs_producer.py
@@ -1,6 +1,6 @@
 import logging
 
-from elasticsearch.exceptions import ElasticsearchException
+from elasticsearch.exceptions import ApiError
 
 from data.logs_model.logs_producer import LogSendException
 from data.logs_model.logs_producer.interface import LogProducerInterface
@@ -18,7 +18,7 @@ class ElasticsearchLogsProducer(LogProducerInterface):
     def send(self, logentry):
         try:
             logentry.save()
-        except ElasticsearchException as ex:
+        except ApiError as ex:
             logger.exception("ElasticsearchLogsProducer error sending log to Elasticsearch: %s", ex)
             raise LogSendException(
                 "ElasticsearchLogsProducer error sending log to Elasticsearch: %s" % ex

--- a/data/logs_model/test/fake_elasticsearch.py
+++ b/data/logs_model/test/fake_elasticsearch.py
@@ -8,6 +8,8 @@ from datetime import datetime
 import dateutil.parser
 from httmock import HTTMock, urlmatch
 
+from data.logs_model.test.test_elasticsearch import add_elastic_headers
+
 FAKE_ES_HOST = "fakees"
 
 EMPTY_RESULT = {
@@ -42,6 +44,7 @@ def fake_elasticsearch(allow_wildcard=True):
 
         return value
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST, path=r"/_template/(.+)", method="GET")
     def get_template(url, request):
         template_name = url[len("/_template/") :]
@@ -50,12 +53,14 @@ def fake_elasticsearch(allow_wildcard=True):
 
         return {"status_code": 404}
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST, path=r"/_template/(.+)", method="PUT")
     def put_template(url, request):
         template_name = url[len("/_template/") :]
         templates[template_name] = True
         return {"status_code": 201}
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST, path=r"/([^/]+)/_doc", method="POST")
     def post_doc(url, request):
         index_name, _ = url.path[1:].split("/")
@@ -75,6 +80,7 @@ def fake_elasticsearch(allow_wildcard=True):
             ),
         }
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST, path=r"/([^/]+)$", method="DELETE")
     def index_delete(url, request):
         index_name_or_pattern = url.path[1:]
@@ -96,6 +102,7 @@ def fake_elasticsearch(allow_wildcard=True):
             "content": {"acknowledged": True},
         }
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST, path=r"/([^/]+)$", method="GET")
     def index_lookup(url, request):
         index_name_or_pattern = url.path[1:]
@@ -184,6 +191,7 @@ def fake_elasticsearch(allow_wildcard=True):
 
         return found, found_index or (index_name_or_pattern.find("*") >= 0)
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST, path=r"/([^/]+)/_count$", method="POST")
     def count_docs(url, request):
         request = json.loads(request.body)
@@ -203,6 +211,7 @@ def fake_elasticsearch(allow_wildcard=True):
             "content": json.dumps({"count": len(found)}),
         }
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST, path=r"/_search/scroll$", method="POST")
     def lookup_scroll(url, request):
         request_obj = json.loads(request.body)
@@ -220,6 +229,7 @@ def fake_elasticsearch(allow_wildcard=True):
             "status_code": 404,
         }
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST, path=r"/_search/scroll$", method="DELETE")
     def delete_scroll(url, request):
         request = json.loads(request.body)
@@ -230,6 +240,7 @@ def fake_elasticsearch(allow_wildcard=True):
             "status_code": 404,
         }
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST, path=r"/([^/]+)/_search$", method="POST")
     def lookup_docs(url, request):
         query_params = parse_query(url.query)
@@ -383,6 +394,7 @@ def fake_elasticsearch(allow_wildcard=True):
             "content": json.dumps(final_result),
         }
 
+    @add_elastic_headers
     @urlmatch(netloc=FAKE_ES_HOST)
     def catchall_handler(url, request):
         print(

--- a/data/logs_model/test/mock_elasticsearch.py
+++ b/data/logs_model/test/mock_elasticsearch.py
@@ -315,11 +315,12 @@ SCROLL_REQUESTS = [
             "query": {
                 "range": {"datetime": {"lt": "2018-04-02T00:00:00", "gte": "2018-03-08T00:00:00"}}
             },
+            "size": 1,
         },
     ],
     [{"scroll": "5m", "scroll_id": _scroll_id}],
     [{"scroll": "5m", "scroll_id": _scroll_id}],
-    [{"scroll_id": [_scroll_id]}],
+    [{"scroll_id": _scroll_id}],
 ]
 
 SCROLL_RESPONSES = [SCROLL_CREATE, SCROLL_GET, SCROLL_GET_2, SCROLL_DELETE]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ debtcollector==1.22.0
 decorator==5.1.1
 Deprecated==1.2.14
 dumb-init==1.2.5.post1
+elastic-transport==8.15.1
 elasticsearch==8.13.0
 elasticsearch-dsl==8.13.0
 Flask==2.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,8 @@ debtcollector==1.22.0
 decorator==5.1.1
 Deprecated==1.2.14
 dumb-init==1.2.5.post1
-elasticsearch==7.6.0
-elasticsearch-dsl==7.0.0
+elasticsearch==8.13.0
+elasticsearch-dsl==8.13.0
 Flask==2.3.2
 Flask-Login==0.6.3
 Flask-Mail==0.9.1


### PR DESCRIPTION
Addresses [CVE-2024-23450](https://access.redhat.com/security/cve/CVE-2024-23450) via elasticsearch upgrade:
* Upgrade of elasticsearch packages from 7.6.0 to 8.13.0
* Update tests and elasticsearch logs to handle new major version

Should also resolve the following trackers:
* [PROJQUAY-6944](https://issues.redhat.com/browse/PROJQUAY-6944)
* [PROJQUAY-6943](https://issues.redhat.com/browse/PROJQUAY-6943)