### PR TITLE
oci: fix nested index parsing (PROJQUAY-8272)

### DIFF
--- a/data/model/oci/manifest.py
+++ b/data/model/oci/manifest.py
@@ -327,7 +327,7 @@ def _create_manifest(
 
             # Retrieve its labels.
             labels = child_manifest.get_manifest_labels(retriever)
-            if labels is None:
+            if labels is None and isinstance(child_manifest, ManifestInterface):
                 if raise_on_error:
                     raise CreateManifestException("Unable to retrieve manifest labels")
 

--- a/image/oci/index.py
+++ b/image/oci/index.py
@@ -177,7 +177,7 @@ class OCIIndex(ManifestListInterface):
         }
         return METASCHEMA
 
-    def __init__(self, manifest_bytes):
+    def __init__(self, manifest_bytes, validate=False):
         assert isinstance(manifest_bytes, Bytes)
 
         self._layers = None


### PR DESCRIPTION
image index can refer to another index when parsing. We currently assume only a manifest can be referenced from an index. This fixes the parse logic