### PR TITLE
cve: updated async version and dependencies to 3.5.6 (PROJQUAY-7469)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "angular": "1.6.2",
         "angular-route": "1.6.2",
         "angular-sanitize": "1.6.2",
+        "async": "^3.2.6",
         "bootbox": "^4.1.0",
         "clipboard": "^1.6.1",
         "core-js": "^2.4.1",
@@ -808,10 +809,9 @@
       }
     },
     "node_modules/async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-      "dev": true
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
@@ -9337,6 +9337,12 @@
         "source-map": "~0.1.33"
       }
     },
+    "node_modules/source-map-loader/node_modules/async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==",
+      "dev": true
+    },
     "node_modules/source-map-loader/node_modules/source-map": {
       "version": "0.1.43",
       "resolved": "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz",
@@ -12502,10 +12508,9 @@
       "dev": true
     },
     "async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-      "dev": true
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -19504,6 +19509,12 @@
         "source-map": "~0.1.33"
       },
       "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "angular": "1.6.2",
     "angular-route": "1.6.2",
     "angular-sanitize": "1.6.2",
+    "async": "^3.2.6",
     "bootbox": "^4.1.0",
     "clipboard": "^1.6.1",
     "core-js": "^2.4.1",


### PR DESCRIPTION
Async <= 2.6.4 and <= 3.2.5 are vulnerable to ReDoS (Regular Expression Denial of Service) while parsing function in autoinject function. Updating the async version to the most recent release

### Testing
- e2e tests
- manual testing