### PR TITLE
deps: downgrading cryptography

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -26,8 +26,6 @@ hatchling==1.18.0
     # via
     #   -r requirements-build.in
     #   hatch-vcs
-maturin==1.7.8
-    # via cryptography
 packaging==23.2
     # via
     #   -r requirements-build.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ certifi==2024.7.4
 chardet==5.2.0
 charset-normalizer==2.0.12
 click==8.1.7
-cryptography==43.0.3
+cryptography==42.0.5
 DateTime==4.3
 debtcollector==1.22.0
 decorator==5.1.1


### PR DESCRIPTION
43.0.3 requires maturin which breaks downstream builds. Downgrading to 42.0.5 which still resolves CVE's but doesn't require maturin.