### PR TITLE
dep: adding fallback for process/browser as dependency of axios update (PROJQUAY-7657)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "moment": "^2.29",
         "ng-metadata": "^4.0.1",
         "package.json": "^2.0.1",
+        "process": "^0.11.10",
         "raven-js": "^3.1.0",
         "rxjs": "5.5.7",
         "showdown": "^1.6.4",
@@ -7925,9 +7926,8 @@
     },
     "node_modules/process": {
       "version": "0.11.10",
-      "resolved": "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -18356,9 +18356,8 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "moment": "^2.29",
     "ng-metadata": "^4.0.1",
     "package.json": "^2.0.1",
+    "process": "^0.11.10",
     "raven-js": "^3.1.0",
     "rxjs": "5.5.7",
     "showdown": "^1.6.4",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.7.6",
         "null-loader": "^4.0.1",
+        "process": "^0.11.10",
         "react": "^17.0.2",
         "react-router-dom": "^6.15.0",
         "react-scripts": "5.0.1",
@@ -22544,7 +22545,7 @@
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -34432,8 +34433,8 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-1.4.0.tgz",
       "integrity": "sha512-Mz4SJKKzW24K/lmUv6w35a4UEpTlj1X0/R0p4yeqhXKJC/8dWvxF9PdKhRbCsOS9yjLqhe6R/23kljXFEcX3cA==",
       "requires": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
+        "@patternfly/react-core": "^5.1.0",
+        "@patternfly/react-icons": "^5.1.0",
         "react-jss": "^10.9.2"
       }
     },
@@ -34442,7 +34443,7 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.1.0.tgz",
       "integrity": "sha512-m6MtCQsWiyGM40L4oLc2aEFlxT8egdoz/58Q2oW1fMkqUaosuNUiwy9/e8zOM3SLOPOo/Qo9cetQkIHVQppCvw==",
       "requires": {
-        "@patternfly/patternfly": "5.0.2",
+        "@patternfly/patternfly": "^5.0.4",
         "@patternfly/react-icons": "^5.1.0",
         "@patternfly/react-styles": "^5.1.0",
         "@patternfly/react-tokens": "^5.1.0",
@@ -34456,7 +34457,7 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.1.0.tgz",
       "integrity": "sha512-mSFAJMrT6QUQ10DifYYGSXOPlFob88lWPZXeOyPdstJ8cJRRRVTMYgoR/VnXsUO/vthwFbViY+sS6+/jL8pl9w==",
       "requires": {
-        "@patternfly/patternfly": "5.0.2"
+        "@patternfly/patternfly": "^5.0.4"
       }
     },
     "@patternfly/react-styles": {
@@ -35512,7 +35513,7 @@
       "integrity": "sha512-ZchYkbieA+7tnxwX/SCBySx9WwvWR8TaP5tb2jRAzwvLb/rWchGw3v0w3pqUbUvj0GCwW2Xz/AVPSk6kUGctXQ==",
       "peer": true,
       "requires": {
-        "@types/react": "*",
+        "@types/react": "^17.0.2",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -35664,7 +35665,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.16.tgz",
       "integrity": "sha512-DWcXf8EbMrO/gWnQU7Z88Ws/p16qxGpPyjTKTpmBSFKeE+HveVubqGO1CVK7FrwlWD5MuOcvh8gtd0/XO38NdQ==",
       "requires": {
-        "@types/react": "^17"
+        "@types/react": "^17.0.2"
       }
     },
     "@types/react-router": {
@@ -35674,7 +35675,7 @@
       "dev": true,
       "requires": {
         "@types/history": "^4.7.11",
-        "@types/react": "*"
+        "@types/react": "^17.0.2"
       }
     },
     "@types/react-router-dom": {
@@ -35684,7 +35685,7 @@
       "dev": true,
       "requires": {
         "@types/history": "^4.7.11",
-        "@types/react": "*",
+        "@types/react": "^17.0.2",
         "@types/react-router": "*"
       }
     },
@@ -48203,7 +48204,7 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.7.6",
     "null-loader": "^4.0.1",
+    "process": "^0.11.10",
     "react": "^17.0.2",
     "react-router-dom": "^6.15.0",
     "react-scripts": "5.0.1",

--- a/web/webpack.plugin.js
+++ b/web/webpack.plugin.js
@@ -71,6 +71,9 @@ module.exports = {
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.js', '.jsx'],
+    fallback: {
+      'process/browser': require.resolve('process/browser'),
+    },
     plugins: [
       new TsconfigPathsPlugin({
         configFile: path.resolve(__dirname, './tsconfig.json'),


### PR DESCRIPTION
This commit should fix the Webpack 5 breaking changes with axios:

```
ERROR in ./node_modules/axios/lib/utils.js 698:42-49

Module not found: Error: Can't resolve 'process/browser' in '/container_workspace/node_modules/axios/lib'

Did you mean 'browser.js'?

BREAKING CHANGE: The request 'process/browser' failed to resolve only because it was resolved as fully specified
```