### PR TITLE
deps: downgrading cryptography (#3492)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ cffi==1.14.3
 chardet==3.0.4
 charset-normalizer==2.0.12
 click==8.1.7
-cryptography==43.0.3
+cryptography==42.0.5
 DateTime==4.3
 debtcollector==1.22.0
 decorator==4.4.1


### PR DESCRIPTION
43.0.3 requires maturin which breaks downstream builds. Downgrading to 42.0.5 which still resolves CVE's but doesn't require maturin. Cherrypick of https://github.com/quay/quay/pull/3492