### PR TITLE
Updating setuptools-rust

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -152,7 +152,7 @@ flit_core==3.7.1
 toml==0.10.2
 pip==22.2.1
 setuptools==65.5.1
-setuptools-rust==1.5.2
+setuptools-rust==1.7.0
 setuptools-scm[toml]==4.1.2
 typing_extensions==4.0.1
 wheel==0.38.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -150,6 +150,7 @@ tqdm==4.65.0
 Cython==3.0.0a9
 flit_core==3.7.1
 toml==0.10.2
+tomli==2.2.1
 pip==22.2.1
 setuptools==65.5.1
 setuptools-rust==1.7.0


### PR DESCRIPTION
Downstream builds require `setuptools-rust==1.7.0`