### PR TITLE
ui: fixing cypress flake (PROJQUAY-8352)

### DIFF
--- a/web/cypress/e2e/repository-permissions.cy.ts
+++ b/web/cypress/e2e/repository-permissions.cy.ts
@@ -120,7 +120,15 @@ describe('Repository Settings - Permissions', () => {
   it('Adds user/robot/team permission', () => {
     cy.contains('Add permissions').click();
     cy.get('#add-permission-form').within(() => {
-      cy.get('input').type('user');
+      // We need the wait otherwise the dropdown won't open
+      cy.wait(2000);
+      cy.get('input[placeholder="Search for user, add/create robot account"]')
+        .click()
+        .type('user');
+      cy.get(
+        'input[placeholder="Search for user, add/create robot account"]',
+      ).should('have.value', 'user');
+
       cy.get('button:contains("user2")').click();
       cy.contains('admin').click();
       cy.contains('Read').click();
@@ -134,7 +142,15 @@ describe('Repository Settings - Permissions', () => {
     });
     cy.contains('Add permissions').click();
     cy.get('#add-permission-form').within(() => {
-      cy.get('input').type('test');
+      // We need the wait otherwise the dropdown won't open
+      cy.wait(2000);
+      cy.get('input[placeholder="Search for user, add/create robot account"]')
+        .click()
+        .type('test');
+      cy.get(
+        'input[placeholder="Search for user, add/create robot account"]',
+      ).should('have.value', 'test');
+
       cy.contains('testorg+testrobot2').click();
       cy.contains('admin').click();
       cy.contains('Read').click();
@@ -151,7 +167,15 @@ describe('Repository Settings - Permissions', () => {
     });
     cy.contains('Add permissions').click();
     cy.get('#add-permission-form').within(() => {
-      cy.get('input').type('test');
+      // We need the wait otherwise the dropdown won't open
+      cy.wait(2000);
+      cy.get('input[placeholder="Search for user, add/create robot account"]')
+        .click()
+        .type('test');
+      cy.get(
+        'input[placeholder="Search for user, add/create robot account"]',
+      ).should('have.value', 'test');
+
       cy.contains('testteam2').click();
       cy.contains('admin').click();
       cy.contains('Read').click();


### PR DESCRIPTION
There's a flake in the web/cypress/e2e/repository-permissions.cy.ts test where it is intermittently unable to type in the "Search for user, add/create robot account" search dropdown which occasionally fails the test. Since updating cypress the test fails consistently. This changes waits and clicks on the input allowing the type to complete and the dropdown to populate.

Cherrypick of https://github.com/quay/quay/pull/3509