### PR TITLE
storage(adjustment): ensure we default to empty for none CDN configuration

### DIFF
--- a/endpoints/v2/blob.py
+++ b/endpoints/v2/blob.py
@@ -155,7 +155,7 @@ def download_blob(namespace_name, repo_name, digest, registry_model):
 def _is_cdn_specific(namespace):
     # Checks if blob belongs to namespace that should have cdn url returned
     logger.debug("Checking for namespace %s", namespace)
-    namespaces = app.config.get("CDN_SPECIFIC_NAMESPACES")
+    namespaces = app.config.get("CDN_SPECIFIC_NAMESPACES", [])
     return namespace in namespaces
 
 


### PR DESCRIPTION
CDN isn't a everyone's configuration Item. We might encounter that configurations without `CDN_SPECIFIC_NAMESPACES`  configured fail downloading blobs accordingly with an error Traceback of

```
gunicorn-registry stdout |   File "/quay-registry/endpoints/v2/blob.py", line 224, in _is_cdn_specific
gunicorn-registry stdout |     return namespace in namespaces or []
gunicorn-registry stdout | TypeError: argument of type 'NoneType' is not iterable
```