### PR TITLE
dep: upgrading actions/download-artifact to v4 (PROJQUAY-8379)

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -61,7 +61,7 @@ jobs:
           tag=`basename ${{ github.ref }}`
           echo "VERSION=${tag}" >> $GITHUB_ENV
       - name: Fetch Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: release
@@ -97,7 +97,7 @@ jobs:
           echo "QUAY_USER=projectquay+quay_github" >> $GITHUB_ENV
           echo "::add-mask::${{ secrets.QUAY_TOKEN }}"
       - name: Fetch Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         id: download
         with:
           name: release


### PR DESCRIPTION
actions/download-artifact@v2 has been deprecated and has broken the release pipelines. It needs to be updated to v4 to get the pipelines running again.