### PR TITLE
teamsync: peewee integrity error check on teamsync (PROJQUAY-7747)

### DIFF
--- a/data/model/team.py
+++ b/data/model/team.py
@@ -65,12 +65,10 @@ def create_team(name, org_obj, team_role_name, description=""):
 
 
 def add_user_to_team(user_obj, team):
-    try:
-        return TeamMember.create(user=user_obj, team=team)
-    except Exception:
-        raise UserAlreadyInTeam(
-            "User %s is already a member of team %s" % (user_obj.username, team.name)
-        )
+    if user_exists_in_team(user_obj, team):
+        return
+
+    return TeamMember.create(user=user_obj, team=team)
 
 
 def remove_user_from_team(org_name, team_name, username, removed_by_username):

--- a/data/model/team.py
+++ b/data/model/team.py
@@ -170,7 +170,10 @@ def add_or_invite_to_team(inviter, team, user_obj=None, email=None, requires_inv
 
     # If we have a valid user and no invite is required, simply add the user to the team.
     if user_obj and not requires_invite:
-        add_user_to_team(user_obj, team)
+        if add_user_to_team(user_obj, team) is None:
+            raise UserAlreadyInTeam(
+                "User %s is already a member of team %s" % (user_obj.username, team.name)
+            )
         return None
 
     email_address = email if not user_obj else None

--- a/data/model/team.py
+++ b/data/model/team.py
@@ -619,3 +619,11 @@ def get_oidc_team_from_groupname(group_name, login_service_name):
             response.append(row)
 
     return response
+
+
+def user_exists_in_team(user_obj, team):
+    try:
+        TeamMember.get(TeamMember.user == user_obj, TeamMember.team == team)
+        return True
+    except TeamMember.DoesNotExist:
+        return False

--- a/data/model/team.py
+++ b/data/model/team.py
@@ -66,7 +66,9 @@ def create_team(name, org_obj, team_role_name, description=""):
 
 def add_user_to_team(user_obj, team):
     if user_exists_in_team(user_obj, team):
-        return
+        raise UserAlreadyInTeam(
+            "User %s is already a member of team %s" % (user_obj.username, team.name)
+        )
 
     return TeamMember.create(user=user_obj, team=team)
 
@@ -170,10 +172,7 @@ def add_or_invite_to_team(inviter, team, user_obj=None, email=None, requires_inv
 
     # If we have a valid user and no invite is required, simply add the user to the team.
     if user_obj and not requires_invite:
-        if add_user_to_team(user_obj, team) is None:
-            raise UserAlreadyInTeam(
-                "User %s is already a member of team %s" % (user_obj.username, team.name)
-            )
+        add_user_to_team(user_obj, team)
         return None
 
     email_address = email if not user_obj else None
@@ -623,9 +622,4 @@ def get_oidc_team_from_groupname(group_name, login_service_name):
 
 
 def user_exists_in_team(user_obj, team):
-    try:
-        return (
-            TeamMember.select().where(TeamMember.user == user_obj, TeamMember.team == team).exists()
-        )
-    except TeamMember.DoesNotExist:
-        return False
+    return TeamMember.select().where(TeamMember.user == user_obj, TeamMember.team == team).exists()

--- a/data/model/team.py
+++ b/data/model/team.py
@@ -624,7 +624,8 @@ def get_oidc_team_from_groupname(group_name, login_service_name):
 
 def user_exists_in_team(user_obj, team):
     try:
-        TeamMember.get(TeamMember.user == user_obj, TeamMember.team == team)
-        return True
+        return (
+            TeamMember.select().where(TeamMember.user == user_obj, TeamMember.team == team).exists()
+        )
     except TeamMember.DoesNotExist:
         return False

--- a/data/model/team.py
+++ b/data/model/team.py
@@ -608,14 +608,14 @@ def get_oidc_team_from_groupname(group_name, login_service_name):
     Fetch TeamSync row synced with login_service_name from `group_name` in TeamSync.config
     """
     response = []
-    with db_transaction():
-        query_result = (
-            TeamSync.select()
-            .join(LoginService)
-            .where(TeamSync.config.contains(group_name), LoginService.name == login_service_name)
-        )
-        for row in query_result:
-            if json.loads(row.config).get("group_name", None) == group_name:
-                response.append(row)
+    query_result = (
+        TeamSync.select()
+        .join(LoginService)
+        .where(TeamSync.config.contains(group_name), LoginService.name == login_service_name)
+    )
+
+    for row in query_result:
+        if json.loads(row.config).get("group_name", None) == group_name:
+            response.append(row)
 
     return response

--- a/data/model/test/test_team.py
+++ b/data/model/test/test_team.py
@@ -181,7 +181,8 @@ def test_user_exists_in_team(initialized_db):
     assert user_exists_in_team(dev_user, team_1) is True
 
     # add user to team already part of
-    assert add_user_to_team(dev_user, team_1) is None
+    with pytest.raises(UserAlreadyInTeam):
+        add_user_to_team(dev_user, team_1)
 
     team_2 = create_team("team_2", new_org, "member")
     assert user_exists_in_team(dev_user, team_2) is False

--- a/data/model/test/test_team.py
+++ b/data/model/test/test_team.py
@@ -181,8 +181,7 @@ def test_user_exists_in_team(initialized_db):
     assert user_exists_in_team(dev_user, team_1) is True
 
     # add user to team already part of
-    with pytest.raises(UserAlreadyInTeam):
-        add_user_to_team(dev_user, team_1)
+    assert add_user_to_team(dev_user, team_1) is None
 
     team_2 = create_team("team_2", new_org, "member")
     assert user_exists_in_team(dev_user, team_2) is False

--- a/data/model/test/test_team.py
+++ b/data/model/test/test_team.py
@@ -187,7 +187,7 @@ def test_user_exists_in_team(initialized_db):
     assert user_exists_in_team(dev_user, team_2) is False
 
 
-def test_get_get_oidc_team_from_groupname(initialized_db):
+def test_get_oidc_team_from_groupname(initialized_db):
     dev_user = get_user("devtable")
     new_org = create_organization("testorg", "testorg" + "@example.com", dev_user)
 

--- a/data/model/test/test_team.py
+++ b/data/model/test/test_team.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from data.database import TeamMember
-from data.model import DataModelException
+from data.model import DataModelException, UserAlreadyInTeam
 from data.model.organization import create_organization
 from data.model.team import (
     __get_user_admin_teams,
@@ -179,6 +179,10 @@ def test_user_exists_in_team(initialized_db):
     team_1 = create_team("team_1", new_org, "member")
     assert add_user_to_team(dev_user, team_1)
     assert user_exists_in_team(dev_user, team_1) is True
+
+    # add user to team already part of
+    with pytest.raises(UserAlreadyInTeam):
+        add_user_to_team(dev_user, team_1)
 
     team_2 = create_team("team_2", new_org, "member")
     assert user_exists_in_team(dev_user, team_2) is False

--- a/data/model/test/test_team.py
+++ b/data/model/test/test_team.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from data.database import TeamMember
@@ -11,10 +13,12 @@ from data.model.team import (
     create_team,
     delete_all_team_members,
     get_federated_user_teams,
+    get_oidc_team_from_groupname,
     list_team_users,
     remove_team,
     remove_user_from_team,
     set_team_syncing,
+    user_exists_in_team,
     validate_team_name,
 )
 from data.model.user import create_user_noverify, get_user
@@ -166,3 +170,34 @@ def test_get_federated_user_teams(login_service_name, initialized_db):
         assert len(user_teams) == 2
     elif login_service_name == "ldap":
         assert len(user_teams) == 1
+
+
+def test_user_exists_in_team(initialized_db):
+    dev_user = get_user("devtable")
+    new_org = create_organization("testorg", "testorg" + "@example.com", dev_user)
+
+    team_1 = create_team("team_1", new_org, "member")
+    assert add_user_to_team(dev_user, team_1)
+    assert user_exists_in_team(dev_user, team_1) is True
+
+    team_2 = create_team("team_2", new_org, "member")
+    assert user_exists_in_team(dev_user, team_2) is False
+
+
+def test_get_get_oidc_team_from_groupname(initialized_db):
+    dev_user = get_user("devtable")
+    new_org = create_organization("testorg", "testorg" + "@example.com", dev_user)
+
+    team_1 = create_team("team_1", new_org, "member")
+    assert add_user_to_team(dev_user, team_1)
+    assert set_team_syncing(team_1, "oidc", {"group_name": "grp1"})
+    response = get_oidc_team_from_groupname(group_name="grp1", login_service_name="oidc")
+    assert len(response) == 1
+    assert response[0].team.name == "team_1"
+    assert json.loads(response[0].config).get("group_name") == "grp1"
+
+    response = get_oidc_team_from_groupname(group_name="team_1", login_service_name="ldap")
+    assert len(response) == 0
+
+    response = get_oidc_team_from_groupname(group_name="team_1", login_service_name="ldap")
+    assert len(response) == 0

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -149,12 +149,7 @@ class OIDCUsers(FederatedUsers):
                     continue
 
                 # add user to team
-                try:
-                    team.add_user_to_team(user_obj, team_synced.team)
-                except Exception as err:
-                    logger.exception(
-                        f"External OIDC Group Sync: Exception occurred when adding user: {user_obj.username} to quay team: {team_synced.team} as {err}"
-                    )
+                team.add_user_to_team(user_obj, team_synced.team)
         return
 
     def ping(self):

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from urllib.parse import urlparse
+from peewee import IntegrityError
 
 import app
 from data.model import InvalidTeamException, UserAlreadyInTeam, team
@@ -150,7 +151,7 @@ class OIDCUsers(FederatedUsers):
                     logger.exception(
                         f"External OIDC Group Sync: Exception occurred when adding user: {user_obj.username} to quay team: {team_synced.team} as {err}"
                     )
-                except UserAlreadyInTeam:
+                except (IntegrityError, UserAlreadyInTeam):
                     # Ignore
                     pass
         return

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -2,8 +2,6 @@ import json
 import logging
 from urllib.parse import urlparse
 
-from peewee import IntegrityError
-
 import app
 from data.model import InvalidTeamException, UserAlreadyInTeam, team
 from data.users.federated import FederatedUsers, UserInformation

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from urllib.parse import urlparse
+
 from peewee import IntegrityError
 
 import app

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -144,7 +144,15 @@ class OIDCUsers(FederatedUsers):
                     )
 
                 # add user to team
-                team.add_user_to_team(user_obj, team_synced.team)
+                try:
+                    team.add_user_to_team(user_obj, team_synced.team)
+                except InvalidTeamException as err:
+                    logger.exception(
+                        f"External OIDC Group Sync: Exception occurred when adding user: {user_obj.username} to quay team: {team_synced.team} as {err}"
+                    )
+                except UserAlreadyInTeam:
+                    # Ignore
+                    pass
         return
 
     def ping(self):

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -145,9 +145,6 @@ class OIDCUsers(FederatedUsers):
                         f"External OIDC Group Sync: Cannot retrieve quay team synced with the oidc group: {oidc_group}"
                     )
 
-                if team.user_exists_in_team(user_obj, team_synced.team):
-                    continue
-
                 # add user to team
                 team.add_user_to_team(user_obj, team_synced.team)
         return

--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -145,16 +145,16 @@ class OIDCUsers(FederatedUsers):
                         f"External OIDC Group Sync: Cannot retrieve quay team synced with the oidc group: {oidc_group}"
                     )
 
+                if team.user_exists_in_team(user_obj, team_synced.team):
+                    continue
+
                 # add user to team
                 try:
                     team.add_user_to_team(user_obj, team_synced.team)
-                except InvalidTeamException as err:
+                except Exception as err:
                     logger.exception(
                         f"External OIDC Group Sync: Exception occurred when adding user: {user_obj.username} to quay team: {team_synced.team} as {err}"
                     )
-                except (IntegrityError, UserAlreadyInTeam):
-                    # Ignore
-                    pass
         return
 
     def ping(self):

--- a/test/test_external_oidc.py
+++ b/test/test_external_oidc.py
@@ -179,6 +179,12 @@ class OIDCAuthTests(unittest.TestCase):
 
         assert user_teams_before_sync + 2 == user_teams_after_sync
 
+        # attempt to sync already synced groups
+        self.oidc_instance.sync_oidc_groups(user_groups, user_obj)
+        user_teams_after_sync = TeamMember.select().where(TeamMember.user == user_obj).count()
+
+        assert user_teams_before_sync + 2 == user_teams_after_sync
+
     def test_resync_for_empty_quay_teams(self):
         user_obj = model.user.get_user("devtable")
 


### PR DESCRIPTION
This issue should fix [PROJQUAY-7747](https://issues.redhat.com/browse/PROJQUAY-7747) and [PROJQUAY-8130](https://issues.redhat.com/browse/PROJQUAY-8130). Adding `IntegrityError` to the try except block to skip adding existing user to team.