### PR TITLE
ui: Expand support for customized footer links (PROJQUAY-5648)

### DIFF
--- a/config.py
+++ b/config.py
@@ -879,7 +879,7 @@ class DefaultConfig(ImmutableConfig):
     FEATURE_RH_MARKETPLACE = False
 
     # Set up custom footer links for on-premise installations
-    FOOTER_LINKS = {}
+    FOOTER_LINKS: Optional[Dict[str, str]] = {}
 
     FEATURE_AUTO_PRUNE = False
     # delay after a write operation is made to the DB. This

--- a/config.py
+++ b/config.py
@@ -878,8 +878,8 @@ class DefaultConfig(ImmutableConfig):
 
     FEATURE_RH_MARKETPLACE = False
 
-    # Set up custom TOS for on-premise installations
-    TERMS_OF_SERVICE_URL = ""
+    # Set up custom footer links for on-premise installations
+    FOOTER_LINKS: Optional[Dict[str, Any]] = None
 
     FEATURE_AUTO_PRUNE = False
     # delay after a write operation is made to the DB. This

--- a/config.py
+++ b/config.py
@@ -49,7 +49,7 @@ CLIENT_WHITELIST = [
     "QUOTA_BACKFILL",
     "PERMANENTLY_DELETE_TAGS",
     "UI_V2_FEEDBACK_FORM",
-    "TERMS_OF_SERVICE_URL",
+    "FOOTER_LINKS",
     "UI_DELAY_AFTER_WRITE_SECONDS",
     "FEATURE_ASSIGN_OAUTH_TOKEN",
     "FEATURE_IMAGE_EXPIRY_TRIGGER",
@@ -879,7 +879,7 @@ class DefaultConfig(ImmutableConfig):
     FEATURE_RH_MARKETPLACE = False
 
     # Set up custom footer links for on-premise installations
-    FOOTER_LINKS: Optional[Dict[str, Any]] = None
+    FOOTER_LINKS = {}
 
     FEATURE_AUTO_PRUNE = False
     # delay after a write operation is made to the DB. This

--- a/endpoints/api/discovery.py
+++ b/endpoints/api/discovery.py
@@ -41,7 +41,7 @@ SERVER_HOSTNAME = app.config["SERVER_HOSTNAME"]
 if SERVER_HOSTNAME == "quay.io" or SERVER_HOSTNAME == "stage.quay.io":
     TERMS_OF_SERVICE_URL = "https://www.openshift.com/legal/terms"
 else:
-    TERMS_OF_SERVICE_URL = app.config["TERMS_OF_SERVICE_URL"]
+    TERMS_OF_SERVICE_URL = app.config["FOOTER_LINKS"]["TERMS_OF_SERVICE_URL"]
 CONTACT_EMAIL = app.config["MAIL_DEFAULT_SENDER"]
 
 

--- a/endpoints/api/discovery.py
+++ b/endpoints/api/discovery.py
@@ -41,7 +41,14 @@ SERVER_HOSTNAME = app.config["SERVER_HOSTNAME"]
 if SERVER_HOSTNAME == "quay.io" or SERVER_HOSTNAME == "stage.quay.io":
     TERMS_OF_SERVICE_URL = "https://www.openshift.com/legal/terms"
 else:
-    TERMS_OF_SERVICE_URL = app.config["FOOTER_LINKS"]["TERMS_OF_SERVICE_URL"]
+    if app.config["FOOTER_LINKS"]:
+        TERMS_OF_SERVICE_URL = (
+            app.config["FOOTER_LINKS"]["TERMS_OF_SERVICE_URL"]
+            if app.config["FOOTER_LINKS"]["TERMS_OF_SERVICE_URL"]
+            else ""
+        )
+    else:
+        TERMS_OF_SERVICE_URL = ""
 CONTACT_EMAIL = app.config["MAIL_DEFAULT_SENDER"]
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -136,24 +136,27 @@ mixpanel.init("{{ mixpanel_key }}", { track_pageview : false, debug: {{ is_debug
       <div class="col-md-12">
         <ul>
           {% if config_set['BRANDING']['footer_img'] %}
-          <li><a href="{{ config_set['BRANDING']['footer_url'] }}" ng-safenewtab><img src="{{ config_set['BRANDING']['footer_img'] }}"></a></li>
-          {% endif %}
-          {% if config_set['FOOTER_LINKS']['TERMS_OF_SERVICE_URL'] %}
-          <li><a href="{{ config_set['FOOTER_LINKS']['TERMS_OF_SERVICE_URL'] }}" ng-safenewtab>Terms of Service</a></li>
+            <li><a href="{{ config_set['BRANDING']['footer_url'] }}" ng-safenewtab><img src="{{ config_set['BRANDING']['footer_img'] }}"></a></li>
           {% endif %}
           <li><a href="{{ config_set['DOCUMENTATION_ROOT'] }}" ng-safenewtab>Documentation</a></li>
-          <li quay-require="['BILLING']"><a href="https://www.openshift.com/legal/terms" target="_blank">Terms</a></li>
-          <li quay-require="['BILLING']"><a href="https://www.redhat.com/en/about/privacy-policy" target="_blank">Privacy</a></li>
-          <li quay-require="['BILLING']"><a href="/security/" target="_self">Security</a></li>
-          <li quay-require="['BILLING']"><a href="/about/" target="_self">About</a></li>
-          {% if config_set['FOOTER_LINKS']['PRIVACY_POLICY_URL'] %}
-          <li><a href="{{ config_set['FOOTER_LINKS']['PRIVACY_POLICY_URL'] }}" target="_blank">Privacy</a></li>
-          {% endif %}
-          {% if config_set['FOOTER_LINKS']['SECURITY_URL'] %}
-          <li><a href="{{ config_set['FOOTER_LINKS']['SECURITY_URL'] }}" target="_blank">Security</a></li>
-          {% endif %}
-          {% if config_set['FOOTER_LINKS']['ABOUT_URL'] %}
-          <li><a href="{{ config_set['FOOTER_LINKS']['ABOUT_URL'] }}" target="_blank">About</a></li>
+          {% if config_set['SERVER_HOSTNAME'] == ('quay.io') or config_set['SERVER_HOSTNAME'] == ('stage.quay.io') %}
+            <li quay-require="['BILLING']"><a href="https://www.openshift.com/legal/terms" target="_blank">Terms</a></li>
+            <li quay-require="['BILLING']"><a href="https://www.redhat.com/en/about/privacy-policy" target="_blank">Privacy</a></li>
+            <li quay-require="['BILLING']"><a href="/security/" target="_self">Security</a></li>
+            <li quay-require="['BILLING']"><a href="/about/" target="_self">About</a></li>
+          {% else %}
+            {% if config_set['FOOTER_LINKS']['TERMS_OF_SERVICE_URL'] %}
+              <li><a href="{{ config_set['FOOTER_LINKS']['TERMS_OF_SERVICE_URL'] }}" ng-safenewtab>Terms of Service</a></li>
+            {% endif %}
+            {% if config_set['FOOTER_LINKS']['PRIVACY_POLICY_URL'] %}
+              <li><a href="{{ config_set['FOOTER_LINKS']['PRIVACY_POLICY_URL'] }}" target="_blank">Privacy</a></li>
+            {% endif %}
+            {% if config_set['FOOTER_LINKS']['PRIVACY_SECURITY_URL'] %}
+              <li><a href="{{ config_set['FOOTER_LINKS']['SECURITY_URL'] }}" target="_blank">Security</a></li>
+            {% endif %}
+            {% if config_set['FOOTER_LINKS']['ABOUT_URL'] %}
+              <li><a href="{{ config_set['FOOTER_LINKS']['ABOUT_URL'] }}" target="_blank">About</a></li>
+            {% endif %}
           {% endif %}
           {% if has_contact %}
           <li><b><a href="{{ contact_href or '/contact/' }}" target="_self">Contact</a></b></li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -138,14 +138,23 @@ mixpanel.init("{{ mixpanel_key }}", { track_pageview : false, debug: {{ is_debug
           {% if config_set['BRANDING']['footer_img'] %}
           <li><a href="{{ config_set['BRANDING']['footer_url'] }}" ng-safenewtab><img src="{{ config_set['BRANDING']['footer_img'] }}"></a></li>
           {% endif %}
-          {% if config_set['TERMS_OF_SERVICE_URL'] %}
-          <li><a href="{{ config_set['TERMS_OF_SERVICE_URL'] }}" ng-safenewtab>Terms of Service</a></li>
+          {% if config_set['FOOTER_LINKS']['TERMS_OF_SERVICE_URL'] %}
+          <li><a href="{{ config_set['FOOTER_LINKS']['TERMS_OF_SERVICE_URL'] }}" ng-safenewtab>Terms of Service</a></li>
           {% endif %}
           <li><a href="{{ config_set['DOCUMENTATION_ROOT'] }}" ng-safenewtab>Documentation</a></li>
           <li quay-require="['BILLING']"><a href="https://www.openshift.com/legal/terms" target="_blank">Terms</a></li>
           <li quay-require="['BILLING']"><a href="https://www.redhat.com/en/about/privacy-policy" target="_blank">Privacy</a></li>
           <li quay-require="['BILLING']"><a href="/security/" target="_self">Security</a></li>
           <li quay-require="['BILLING']"><a href="/about/" target="_self">About</a></li>
+          {% if config_set['FOOTER_LINKS']['PRIVACY_POLICY_URL'] %}
+          <li><a href="{{ config_set['FOOTER_LINKS']['PRIVACY_POLICY_URL'] }}" target="_blank">Privacy</a></li>
+          {% endif %}
+          {% if config_set['FOOTER_LINKS']['SECURITY_URL'] %}
+          <li><a href="{{ config_set['FOOTER_LINKS']['SECURITY_URL'] }}" target="_blank">Security</a></li>
+          {% endif %}
+          {% if config_set['FOOTER_LINKS']['ABOUT_URL'] %}
+          <li><a href="{{ config_set['FOOTER_LINKS']['ABOUT_URL'] }}" target="_blank">About</a></li>
+          {% endif %}
           {% if has_contact %}
           <li><b><a href="{{ contact_href or '/contact/' }}" target="_self">Contact</a></b></li>
           {% endif %}

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1506,7 +1506,7 @@ CONFIG_SCHEMA = {
                 "TERMS_OF_SERVICE_URL": {
                     "type": "string",
                     "description": "Custom terms of service for on-prem installations",
-                    "x-example": "https://quay.io/tos",
+                    "x-example": "https://www.openshift.com/legal/terms",
                 },
                 "PRIVACY_POLICY_URL": {
                     "type": "string",

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1498,11 +1498,32 @@ CONFIG_SCHEMA = {
             "description": "Endpoint for internal RH marketplace API",
             "x-example": "https://internal-rh-marketplace-endpoint",
         },
-        # Custom terms of service
-        "TERMS_OF_SERVICE_URL": {
-            "type": "string",
-            "description": "Enable customizing of terms of service for on-prem installations",
-            "x-example": "https://quay.io/tos",
+        # Custom footer links
+        "FOOTER_LINKS": {
+            "type": "object",
+            "description": "Enable customization of footer links in Quay's UI for on-prem installations",
+            "properties": {
+                "TERMS_OF_SERVICE_URL": {
+                    "type": "string",
+                    "description": "Custom terms of service for on-prem installations",
+                    "x-example": "https://quay.io/tos",
+                },
+                "PRIVACY_POLICY_URL": {
+                    "type": "string",
+                    "description": "Custom privacy policy for on-prem installations",
+                    "x-example": "https://www.redhat.com/en/about/privacy-policy",
+                },
+                "SECURITY_URL": {
+                    "type": "string",
+                    "description": "Custom security page for on-prem installations",
+                    "x-example": "https://quay.io/security/",
+                },
+                "ABOUT_URL": {
+                    "type": "string",
+                    "description": "Custom about page for on-prem installations",
+                    "x-example": "https://quay.io/about/",
+                },
+            },
         },
         "ROBOTS_DISALLOW": {
             "type": "boolean",


### PR DESCRIPTION
Previous iteration only allowed changes to the terms of service. With this push, all footer links should be customizable through the `FOOTER_LINKS` object. Example:

~~~
FOOTER_LINKS:
  TERMS_OF_SERVICE_URL: "some_url"
  PRIVACY_POLICY_URL: "some_url"
  SECURITY_URL: "some_url"
  ABOUT_URL: "some_url"
~~~

Missing entries should not be printed out in the UI.

Example:

~~~
FOOTER_LINKS:
  "TERMS_OF_SERVICE_URL": "https://www.index.hr"
  "PRIVACY_POLICY_URL": "https://www.jutarnji.hr"
  "SECURITY_URL": "https://www.bug.hr"
  "ABOUT_URL": "https://www.zagreb.hr"
~~~

shows the following in the UI:
![image](https://github.com/user-attachments/assets/1ec0c4df-11e1-4340-a04d-09788b8b10f7)
