### PR TITLE
worker: include orgs in reconciler runs (PROJQUAY-8431)

### DIFF
--- a/data/model/user.py
+++ b/data/model/user.py
@@ -1231,8 +1231,11 @@ def get_public_repo_count(username):
     )
 
 
-def get_active_users(disabled=True, deleted=False):
+def get_active_users(disabled=True, deleted=False, include_orgs=False):
     query = User.select().where(User.organization == False, User.robot == False)
+
+    if include_orgs:
+        query = User.select().where(User.robot == False)
 
     if not disabled:
         query = query.where(User.enabled == True)

--- a/workers/reconciliationworker.py
+++ b/workers/reconciliationworker.py
@@ -40,7 +40,7 @@ class ReconciliationWorker(Worker):
         """
         logger.info("Reconciliation worker looking to create new subscriptions...")
 
-        users = model.user.get_active_users()
+        users = model.user.get_active_users(include_orgs=True)
 
         stripe_users = [user for user in users if user.stripe_id is not None]
 


### PR DESCRIPTION
Adds an `include_orgs` param to the active users query used by the reconciler and sets it to true for reconciler runs

Reconciler is not including orgs as a candidate for creating corresponding RH entitlements. As a result it misses users with stripe billing that are considered orgs.
