### PR TITLE
endpoints(repository): fixing repository return with starred repos to paged response (PROJQUAY-8450)

### DIFF
--- a/endpoints/api/repository_models_pre_oci.py
+++ b/endpoints/api/repository_models_pre_oci.py
@@ -100,6 +100,20 @@ class PreOCIModel(RepositoryDataInterface):
                 user, kind_filter=repo_kind
             )
             repos = [repo for repo in unfiltered_repos if can_view_repo(repo)]
+            if not page_token in [{}, None]:
+                repos = repos[
+                    (REPOS_PER_PAGE) * page_token.get("start_index")
+                    - get("start_index") : REPOS_PER_PAGE
+                    + 1
+                ]
+                next_page_token = {
+                    "start_index": page_token.get("start_index") + 1,
+                    "page_number": page_token.get("start_index") + 1,
+                    "is_datetime": False,
+                    "offset_val": 0,
+                }
+            else:
+                repos = repos[REPOS_PER_PAGE : REPOS_PER_PAGE - 1]
         else:
             # Determine the starting offset for pagination. Note that we don't use the normal
             # model.modelutil.paginate method here, as that does not operate over UNION queries, which

--- a/endpoints/api/repository_models_pre_oci.py
+++ b/endpoints/api/repository_models_pre_oci.py
@@ -113,7 +113,7 @@ class PreOCIModel(RepositoryDataInterface):
                     "offset_val": 0,
                 }
             else:
-                repos = repos[REPOS_PER_PAGE : REPOS_PER_PAGE - 1]
+                repos = repos[0 : REPOS_PER_PAGE - 1]
         else:
             # Determine the starting offset for pagination. Note that we don't use the normal
             # model.modelutil.paginate method here, as that does not operate over UNION queries, which

--- a/endpoints/api/test/test_repository.py
+++ b/endpoints/api/test/test_repository.py
@@ -71,6 +71,27 @@ def test_list_starred_repos(app):
         assert "devtable/simple" in repos
         assert "public/publicrepo" not in repos
 
+        # testing starred pagination with static rules
+        # since this is a list and not a database result we need to start with 0
+        # list start: index (min1) -1 -> 0 * REPOS_PER_PAGE (100) == 0,100,200,300,...
+        # list end:   index (min1) -1 -> 0 * REPOS_PER_PAGE (100) == 101, 201, 301, ...
+        # but we need a check to not exceed the list size with the list end value
+        page_token = dict(start_index=1)
+        REPOS_PER_PAGE = 100
+        repos = range(259)
+        retrepos = []
+        for page in range(10):
+            ls = (page_token.get("start_index", 1) - 1) * REPOS_PER_PAGE
+            le = ((page_token.get("start_index", 1) - 1) * REPOS_PER_PAGE) + REPOS_PER_PAGE
+            if len(repos) < le:
+                le = len(repos)
+            retrepos = repos[ls:le]
+            assert len(retrepos) <= REPOS_PER_PAGE
+            assert page <= 3
+            if len(retrepos) < REPOS_PER_PAGE:
+                break
+        assert retrepos[-1] != 258
+
 
 def test_list_repos(initialized_db, app):
     with client_with_identity("devtable", app) as cl:

--- a/endpoints/api/test/test_repository.py
+++ b/endpoints/api/test/test_repository.py
@@ -90,6 +90,7 @@ def test_list_starred_repos(app):
             assert page <= 3
             if len(retrepos) < REPOS_PER_PAGE:
                 break
+            page_tolen["start_index"] += 1
         assert retrepos[-1] != 258
 
 

--- a/endpoints/api/test/test_repository.py
+++ b/endpoints/api/test/test_repository.py
@@ -90,7 +90,7 @@ def test_list_starred_repos(app):
             assert page <= 3
             if len(retrepos) < REPOS_PER_PAGE:
                 break
-            page_tolen["start_index"] += 1
+            page_token["start_index"] += 1
         assert retrepos[-1] != 258
 
 

--- a/endpoints/api/test/test_repository.py
+++ b/endpoints/api/test/test_repository.py
@@ -91,7 +91,7 @@ def test_list_starred_repos(app):
             if len(retrepos) < REPOS_PER_PAGE:
                 break
             page_token["start_index"] += 1
-        assert retrepos[-1] != 258
+        assert retrepos[-1] == 258
 
 
 def test_list_repos(initialized_db, app):


### PR DESCRIPTION
When setting repositories in the Quay UI as starred, a 500 error occurs and renders the UI use-less due to starred queries are not paged.
Details are in the Jira accordingly.