### PR TITLE
marketplace: free tier integration for reconciler (PROJQUAY-5698)

### DIFF
--- a/data/billing.py
+++ b/data/billing.py
@@ -372,6 +372,14 @@ PLANS = [
         "sku_billing": True,
         "plans_page_hidden": True,
     },
+    {
+        "title": "freetier",
+        "privateRepos": 0,
+        "stripeId": "not_a_stripe_plan",
+        "rh_sku": "MW04192",
+        "sku_billing": False,
+        "plans_page_hidden": True,
+    },
 ]
 
 RH_SKUS = [plan["rh_sku"] for plan in PLANS if plan.get("rh_sku") is not None]

--- a/util/test/test_marketplace.py
+++ b/util/test/test_marketplace.py
@@ -224,6 +224,8 @@ class TestMarketplace(unittest.TestCase):
         assert extended_subscription is None
         create_subscription_response = subscription_api.create_entitlement(12345, "sku")
         assert create_subscription_response == 408
+        remove_entitlement_response = subscription_api.remove_entitlement(12345)
+        assert remove_entitlement_response == 408
 
     @patch("requests.request")
     def test_user_lookup(self, requests_mock):


### PR DESCRIPTION
Adds the following changes for integrating a free tier SKU to the reconciler:
- Adds remove method to marketplace api class to allow for the removal of free tier SKUs
- Refactors reconciliationworker to account for the actions of creating free/paid SKUs for users and removing free SKUs when users obtain paid subscriptions
- Adds test coverage for free tier cases to reconciliationworker