### PR TITLE
endpoints(user): added filter to avoid NoneType being return to function that expects objects (PROJQUAY-8497)

### DIFF
--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -198,7 +198,15 @@ def user_view(user, previous_username=None):
         user_response.update(
             {
                 "organizations": [
-                    org_view(o, user_admin=is_admin) for o in list(organizations.values())
+                    # the filter check is introduced as PUBLIC_NAMESPACES populated without the
+                    # appropriate organisations being present will return None which will fail
+                    # the org_view function calling o.username
+                    # if you change the logic below adjust the unittest in file
+                    # endpoints/api/test/test_user.py -> test_endpoints_donot_return_none
+                    org_view(o, user_admin=is_admin)
+                    for o in filter(
+                        lambda x: not isinstance(x, type(None)), list(organizations.values())
+                    )
                 ],
             }
         )


### PR DESCRIPTION
Setting up a Quay with a config bundle containing:
```
PUBLIC_NAMESPACES:

some
someother
``´
will fail login in any User into the UI with
```
gunicorn-web stdout |   File "/quay-registry/endpoints/api/user.py", line 118, in org_view
gunicorn-web stdout |     admin_org = AdministerOrganizationPermission(o.username)
gunicorn-web stdout | AttributeError: 'NoneType' object has no attribute 'username'
``` 

reason for that is that the missing organization entries in the `user` table exlode to `None` in the function `list(organizations.values())`from `endpoints/api/user.py`
