### PR TITLE
marketplace: handle exception thrown by stripe when customer has no subscription (PROJQUAY-8431)

### DIFF
--- a/workers/reconciliationworker.py
+++ b/workers/reconciliationworker.py
@@ -87,8 +87,12 @@ class ReconciliationWorker(Worker):
             except stripe.error.InvalidRequestError:
                 logger.warn("Invalid request for stripe_id %s", user.stripe_id)
                 continue
+            try:
+                subscription = stripe_customer.subscription
+            except AttributeError:
+                subscription = None
             for sku_id in RECONCILER_SKUS:
-                if stripe_customer.subscription:
+                if subscription is not None:
                     plan = get_plan(stripe_customer.subscription.plan.id)
                     if plan is None:
                         continue

--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -1,7 +1,6 @@
-import logging
 import random
 import string
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 from app import billing as stripe
 from app import marketplace_subscriptions, marketplace_users

--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -1,6 +1,7 @@
+import logging
 import random
 import string
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from app import billing as stripe
 from app import marketplace_subscriptions, marketplace_users
@@ -34,15 +35,28 @@ def test_reconcile_org_user(initialized_db):
     mock.assert_called_with(org_user.email)
 
 
-def test_exception_handling(initialized_db):
+def test_exception_handling(initialized_db, caplog):
     with patch("data.billing.FakeStripe.Customer.retrieve") as mock:
         mock.side_effect = stripe.error.InvalidRequestException
         worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
     with patch("data.billing.FakeStripe.Customer.retrieve") as mock:
         mock.side_effect = stripe.error.APIConnectionError
         worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
-    with patch("data.billing.FakeStripe.Customer.subscription") as mock:
-        mock.side_effect = AttributeError
+
+
+def test_attribute_error(initialized_db, caplog):
+    test_user = model.user.create_user("stripe_user", "password", "stripe_user@test.com")
+    test_user.stripe_id = "cus_" + "".join(random.choices(string.ascii_lowercase, k=14))
+    test_user.save()
+
+    with patch("data.billing.FakeStripe.Customer.retrieve") as mock:
+
+        class MockCustomer:
+            @property
+            def subscription(self):
+                raise AttributeError
+
+        mock.return_value = MockCustomer()
         worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
 
 

--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -41,6 +41,9 @@ def test_exception_handling(initialized_db):
     with patch("data.billing.FakeStripe.Customer.retrieve") as mock:
         mock.side_effect = stripe.error.APIConnectionError
         worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
+    with patch("data.billing.FakeStripe.Customer.subscription") as mock:
+        mock.side_effect = AttributeError
+        worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
 
 
 def test_create_for_stripe_user(initialized_db):


### PR DESCRIPTION
If there is no subscription in the customer object found by stripe an `AttributeError` will be thrown. This should be caught and handled as if there is no subscription present so that the reconciler can continue its work for other users/orgs