### PR TITLE
ui: adding under_maintenance state to status indicator (PROJQUAY-8507)

### DIFF
--- a/static/js/services/status-service.js
+++ b/static/js/services/status-service.js
@@ -28,6 +28,10 @@ angular.module('quay').factory('StatusService', ['Features', function(Features) 
       indicator: 'critical',
       description: 'Major Service Outage'
     },
+    under_maintenance: {
+      indicator: 'minor',
+      description: 'Under Maintenance',
+    },
   }
   var statusPageHandler = null;
   var statusPageData = null;

--- a/web/cypress/support/e2e.ts
+++ b/web/cypress/support/e2e.ts
@@ -18,3 +18,10 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+beforeEach(() => {
+  cy.intercept('GET', 'api/v2/summary.json', {
+    statusCode: 200,
+    body: {page: {}, components: []},
+  }).as('getStatusData');
+});

--- a/web/src/hooks/UseServiceStatus.ts
+++ b/web/src/hooks/UseServiceStatus.ts
@@ -20,6 +20,10 @@ const statusToIndicator = {
     indicator: 'critical',
     description: 'Major Service Outage',
   },
+  under_maintenance: {
+    indicator: 'minor',
+    description: 'Under Maintenance',
+  },
 };
 
 interface StatusData {


### PR DESCRIPTION
Status indicator on the old and new UI does not account for `under_maintenance` state, causing the lookup for icon and description to fail with `Cannot read properties of undefined (reading 'indicator')`.