### PR TITLE
chore: added test for proxy cache (PROJQUAY-8440)

### DIFF
--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -9,6 +9,7 @@ from app import storage
 from data.database import (
     ImageStorage,
     ImageStorageLocation,
+    ImageStoragePlacement,
     Manifest,
     ManifestBlob,
     ManifestChild,
@@ -39,7 +40,15 @@ from image.docker.schema2 import (
     DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE,
     DOCKER_SCHEMA2_MANIFESTLIST_CONTENT_TYPE,
 )
-from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
+from image.docker.schema2.manifest import (
+    DockerSchema2Manifest,
+    DockerSchema2ManifestBuilder,
+)
+from image.docker.schema2.test.test_config import (
+    CONFIG_BYTES,
+    CONFIG_DIGEST,
+    CONFIG_SIZE,
+)
 from image.shared import ManifestException
 from image.shared.schemas import parse_manifest_from_bytes
 from proxy.fixtures import proxy_manifest_response  # noqa: F401,F403
@@ -1246,6 +1255,76 @@ class TestRegistryProxyModelGetRepoTag:
             tag = proxy_model.get_repo_tag(repo_ref, self.tag)
         assert tag is not None
         assert tag.lifetime_end_ms == first_tag.lifetime_end_ms
+
+    def test_missing_layers_in_proxy_cache(self, proxy_manifest_response):
+        """
+        Test to verify that layers are missing in proxy cache when they exist locally
+        but were not explicitly requested by the client.
+        """
+        proxy_mock = proxy_manifest_response(
+            UBI8_8_4_DIGEST, UBI8_8_4_MANIFEST_SCHEMA2, DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE
+        )
+
+        with patch(
+            "data.registry_model.registry_proxy_model.Proxy", MagicMock(return_value=proxy_mock)
+        ):
+            proxy_model = ProxyModel(
+                self.orgname,
+                self.upstream_repository,
+                self.user,
+            )
+
+            manifest = DockerSchema2Manifest(
+                Bytes.for_string_or_unicode(self.create_manifest_with_valid_layers())
+            )
+
+        assert manifest is not None
+        assert len(manifest.filesystem_layers) == 4
+        missing_layers = []
+        for layer in manifest.filesystem_layers:
+            exists = (
+                ImageStorage.select().where(ImageStorage.content_checksum == layer.digest).exists()
+            )
+            if not exists:
+                missing_layers.append(layer.digest)
+
+        # Assert that we have missing layers
+        assert len(missing_layers) > 0
+
+    def create_manifest_with_valid_layers(self):
+        return json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "config": {
+                    "mediaType": "application/vnd.docker.container.image.v1+json",
+                    "size": CONFIG_SIZE,
+                    "digest": CONFIG_DIGEST,
+                },
+                "layers": [
+                    {
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": 1234,
+                        "digest": "sha256:ec4b8955958665577945c89419d1af06b5f7636b4ac3da7f12184802ad867736",
+                    },
+                    {
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": 32654,
+                        "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+                    },
+                    {
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": 16724,
+                        "digest": "sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b",
+                    },
+                    {
+                        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                        "size": 73109,
+                        "digest": "sha256:ec4b8955958665577945c89419d1af06b5f7636b4ac3da7f12184802ad867736",
+                    },
+                ],
+            }
+        ).encode("utf-8")
 
 
 class TestPruningLRUProxiedImagesToAllowBlobUpload:

--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -1260,6 +1260,8 @@ class TestRegistryProxyModelGetRepoTag:
         """
         Test to verify that layers are missing in proxy cache when they exist locally
         but were not explicitly requested by the client.
+
+        Note: this is not an expected behavior. The fix is expected with (PROJQUAY-8440)
         """
         proxy_mock = proxy_manifest_response(
             UBI8_8_4_DIGEST, UBI8_8_4_MANIFEST_SCHEMA2, DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE


### PR DESCRIPTION
added test for proxy cache. This test validates current proxy behavior. This test would fail once we implement the fix.

Note: This is not a expected behavior. This is how current proxy cache behavior looks like. The fix expected in this Jeera would rectify this behavior. 
https://issues.redhat.com/browse/PROJQUAY-8440