### PR TITLE
deps: updating jquery to 3.5.0 (PROJQUAY-8522) (#3629)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4387,9 +4387,9 @@
       }
     },
     "jquery": {
-      "version": "1.12.4",
-      "resolved": "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz",
-      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "js-base64": {
       "version": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "core-js": "^2.4.1",
     "file-saver": "^1.3.3",
     "highlight.js": "^9.12.0",
-    "jquery": "1.12.4",
+    "jquery": "^3.5.0",
     "moment": "^2.29",
     "ng-metadata": "^4.0.1",
     "package.json": "^2.0.1",


### PR DESCRIPTION
updating jquery to 3.5.0. cherrypick of https://github.com/quay/quay/pull/3629