### PR TITLE
chore: Filtering repeatPassword in debuglogs (PROJQUAY-8559)

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,6 +177,7 @@ FILTERED_VALUES = [
     {"key": ["upstream_registry_password"], "fn": DEFAULT_FILTER},
     {"key": ["upstream_registry_username"], "fn": DEFAULT_FILTER},
     {"key": ["user", "password"], "fn": DEFAULT_FILTER},
+    {"key": ["user", "repeatPassword"], "fn": DEFAULT_FILTER},
     {"key": ["blob"], "fn": lambda x: x[0:8]},
 ]
 

--- a/util/test/test_log_util.py
+++ b/util/test/test_log_util.py
@@ -9,16 +9,22 @@ from util.log import filter_logs, logfile_path
 
 def test_filter_logs():
     values = {
-        "user": {"password": "toto"},
         "user": {"password": "toto", "repeatPassword": "toto"},
-        "password" : "toto",
-        "upstream_registry_username" : "testuser",
-        "upstream_registry_password" : "testpass",
+        "password": "toto",
+        "upstream_registry_username": "user",
+        "upstream_registry_password": "testpass",
         "blob": "1234567890asdfewkqresfdsfewfdsfd",
         "unfiltered": "foo",
     }
     filter_logs(values, FILTERED_VALUES)
-    assert values == {"user": {"password": "[FILTERED]"},"user": {"password": "[FILTERED]", "repeatPassword": "[FILTERED]"},"password": "[FILTERED]", "upstream_registry_username" : "[FILTERED]", "upstream_registry_password" : "[FILTERED]", "blob": "12345678", "unfiltered": "foo"}
+    assert values == {
+        "user": {"password": "[FILTERED]", "repeatPassword": "[FILTERED]"},
+        "password": "[FILTERED]",
+        "upstream_registry_username": "[FILTERED]",
+        "upstream_registry_password": "[FILTERED]",
+        "blob": "12345678",
+        "unfiltered": "foo",
+    }
 
 
 @pytest.mark.parametrize(

--- a/util/test/test_log_util.py
+++ b/util/test/test_log_util.py
@@ -10,11 +10,15 @@ from util.log import filter_logs, logfile_path
 def test_filter_logs():
     values = {
         "user": {"password": "toto"},
+        "user": {"password": "toto", "repeatPassword": "toto"},
+        "password" : "toto",
+        "upstream_registry_username" : "testuser",
+        "upstream_registry_password" : "testpass",
         "blob": "1234567890asdfewkqresfdsfewfdsfd",
         "unfiltered": "foo",
     }
     filter_logs(values, FILTERED_VALUES)
-    assert values == {"user": {"password": "[FILTERED]"}, "blob": "12345678", "unfiltered": "foo"}
+    assert values == {"user": {"password": "[FILTERED]"},"user": {"password": "[FILTERED]", "repeatPassword": "[FILTERED]"},"password": "[FILTERED]", "upstream_registry_username" : "[FILTERED]", "upstream_registry_password" : "[FILTERED]", "blob": "12345678", "unfiltered": "foo"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description
Filter the repeatPassword key while creating the new user. 

## Expected logs, 
'repeatPassword': '[FILTERED]'

## Test Result

```
# pytest util/test/test_log_util.py -vv
============================================================================ test session starts =============================================================================
platform linux -- Python 3.9.20, pytest-8.3.4, pluggy-1.5.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /quay-registry
configfile: tox.ini
collected 1 item                                                                                                                                                             

util/test/test_log_util.py::test_filter_logs PASSED 
```
