### PR TITLE
[Feature] storage: Modify the STS S3 implementation of the storage backend to use Web Identity Tokens when available (PROJQUAY-8576)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ git checkout $SHA
 
 REPO=quay.io/quay/quay:$SHA
 
-# Use buildah, podman or docker 
+# Use buildah, podman or docker
 if [ -x /usr/bin/buildah ]; then
 	BUILDER="/usr/bin/buildah bud"
 elif [ -x /usr/bin/podman ]; then
@@ -30,7 +30,7 @@ if [[ -z "$BUILDER" ]]; then
   echo 'Unable to find buildah, podman or docker' >&2
   exit 1
 fi
-echo $BUILDER 
+echo $BUILDER
 
 $BUILDER -t $REPO .
 echo $REPO

--- a/build.sh
+++ b/build.sh
@@ -18,13 +18,17 @@ git checkout $SHA
 
 REPO=quay.io/quay/quay:$SHA
 
-# Use buildah or podman or docker 
+# Use buildah, podman or docker 
 if [ -x /usr/bin/buildah ]; then
 	BUILDER="/usr/bin/buildah bud"
 elif [ -x /usr/bin/podman ]; then
 	BUILDER="/usr/bin/podman build"
 elif [ -x /usr/bin/docker ] ; then
 	BUILDER="/usr/bin/docker build"
+fi
+if [[ -z "$BUILDER" ]]; then
+  echo 'Unable to find buildah, podman or docker' >&2
+  exit 1
 fi
 echo $BUILDER 
 

--- a/config-tool/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
+++ b/config-tool/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
@@ -379,6 +379,13 @@ func NewDistributedStorageArgs(storageArgs map[string]interface{}) (*shared.Dist
 		}
 	}
 
+	if value, ok := storageArgs["sts_web_token_filen"]; ok {
+		newDistributedStorageArgs.STSWebIdentityTokenFile, ok = value.(string)
+		if !ok {
+			return newDistributedStorageArgs, errors.New("sts_web_token_file must be a string")
+		}
+	}
+
 	return newDistributedStorageArgs, nil
 }
 

--- a/config-tool/pkg/lib/shared/structs.go
+++ b/config-tool/pkg/lib/shared/structs.go
@@ -59,7 +59,8 @@ type DistributedStorageArgs struct {
 	Providers       map[string]interface{} `default:"" validate:"" json:"providers,omitempty" yaml:"providers,omitempty"`
 	StorageConfig   map[string]interface{} `default:"" validate:"" json:"storage_config,omitempty" yaml:"storage_config,omitempty"`
 	// Args for STSS3Storage
-	STSUserAccessKey string `default:"" validate:"" json:"sts_user_access_key,omitempty" yaml:"sts_user_access_key,omitempty"`
-	STSUserSecretKey string `default:"" validate:"" json:"sts_user_secret_key,omitempty" yaml:"sts_user_secret_key,omitempty"`
-	STSRoleArn       string `default:"" validate:"" json:"sts_role_arn,omitempty" yaml:"sts_role_arn,omitempty"`
+	STSUserAccessKey        string `default:"" validate:"" json:"sts_user_access_key,omitempty" yaml:"sts_user_access_key,omitempty"`
+	STSUserSecretKey        string `default:"" validate:"" json:"sts_user_secret_key,omitempty" yaml:"sts_user_secret_key,omitempty"`
+	STSRoleArn              string `default:"" validate:"" json:"sts_role_arn,omitempty" yaml:"sts_role_arn,omitempty"`
+	STSWebIdentityTokenFile string `default:"" validate:"" json:"sts_web_identity_token_file,omitempty" yaml:"sts_web_identity_token_file,omitempty"`
 }

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -1245,28 +1245,39 @@ class STSS3Storage(S3Storage):
         maximum_chunk_size_gb=None,
         signature_version="s3v4",
     ):
-        sts_client = boto3.client(
-            "sts", aws_access_key_id=sts_user_access_key, aws_secret_access_key=sts_user_secret_key
-        )
-        assumed_role = sts_client.assume_role(RoleArn=sts_role_arn, RoleSessionName="quay")
-        credentials = assumed_role["Credentials"]
-        deferred_refreshable_credentials = DeferredRefreshableCredentials(
-            refresh_using=create_assume_role_refresher(
-                sts_client, {"RoleArn": sts_role_arn, "RoleSessionName": "quay"}
-            ),
-            method="sts-assume-role",
-        )
+        if sts_user_access_key == "" or sts_user_secret_key == "":
+            sts_client = boto3.client("sts")
+        else:
+            sts_client = boto3.client(
+                "sts",
+                aws_access_key_id=sts_user_access_key,
+                aws_secret_access_key=sts_user_secret_key,
+            )
 
         # !! NOTE !! connect_kwargs here initializes the S3Storage Class not the s3 connection (mis leading re-use of the name)
         connect_kwargs = {
-            "s3_access_key": credentials["AccessKeyId"],
-            "s3_secret_key": credentials["SecretAccessKey"],
-            "aws_session_token": credentials["SessionToken"],
             "s3_region": s3_region,
             "endpoint_url": endpoint_url,
             "maximum_chunk_size_gb": maximum_chunk_size_gb,
-            "deferred_refreshable_credentials": deferred_refreshable_credentials,
             "signature_version": signature_version,
         }
+        if sts_role_arn is not None:
+            assumed_role = sts_client.assume_role(RoleArn=sts_role_arn, RoleSessionName="quay")
+            credentials = assumed_role["Credentials"]
+            deferred_refreshable_credentials = DeferredRefreshableCredentials(
+                refresh_using=create_assume_role_refresher(
+                    sts_client, {"RoleArn": sts_role_arn, "RoleSessionName": "quay"}
+                ),
+                method="sts-assume-role",
+            )
+
+            connect_kwargs.update(
+                {
+                    "s3_access_key": credentials["AccessKeyId"],
+                    "s3_secret_key": credentials["SecretAccessKey"],
+                    "aws_session_token": credentials["SessionToken"],
+                    "deferred_refreshable_credentials": deferred_refreshable_credentials,
+                }
+            )
 
         super().__init__(context, storage_path, s3_bucket, **connect_kwargs)


### PR DESCRIPTION
When deploying Quay in a Secure AWS environment, we can't use IAM Access Keys or Secrets since these credentials are often blocked for multiple reasons (credentials are long-lived, can be shared / stolen, etc.). So the preferred deployment method is to use an alternative method, like the Web Identity Token files that are automatically created in a Kubernetes cluster that has a federation link with IAM using the OIDC provider federation.

The current code of Quay force the use of an IAM account that is then used to assume another role that has S3 access to store the image files. The current pull request removes the need to use that IAM account and allows to directly assume the correct role using Web Identity Tokens while retaining compatibility with the old method of using IAM credentials.

The code relies on the automatic detection of the correct configurations using environment variables where possible. The code has been tested on an OpenShift cluster deployed using manual mode with AWS STS.

The Quay storage configuration used is:

```
DISTRIBUTED_STORAGE_CONFIG:
    default:
      - STSS3Storage
      - s3_bucket: test-quay-bucket
        storage_path: /datastorage/registry
```

The Quay pod is using a Service Account that has the following annotation:

```
kind: ServiceAccount
apiVersion: v1
metadata:
  name: quay
  namespace: quay
  annotations:
    eks.amazonaws.com/role-arn: 'arn:aws:iam::111111111111:role/test-quay-bucket-role'
```

That role has the following trust relationship:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Quay",
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::111111111111:oidc-provider/my-provider-url.com/my-cluster-name"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "my-provider-url.com/my-cluster-name:sub": "system:serviceaccount:quay:quay"
                }
            }
        }
    ]
}
```

Basic tests that have been done:

- Start Quay in OpenShift with database / redis integration and a default route
- Created a test repository
- Pushed a test image in the repository
