### PR TITLE
repomirror(skopeo): changed skopeo calls to use temporary authfile and not expose creds in process list (PROJQUAY-7340)

### DIFF
--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -1,0 +1,68 @@
+import base64
+import os
+
+import pytest
+
+from util.repomirror.skopeomirror import (
+    SKOPEO_TIMEOUT_SECONDS,
+    AuthContent,
+    SkopeoMirror,
+    create_authfile_content,
+)
+
+
+def test_create_authfile_content():
+    content = create_authfile_content(
+        [
+            AuthContent("quay.io", "user1", "user1"),
+            AuthContent("registry.redhat.io", "user2", "user2"),
+            AuthContent("docker.io", "anonymous", ""),
+        ]
+    )
+    assert content.get("auths").get("quay.io").get("auth") == base64.b64encode(
+        "user1:user1".encode("utf8")
+    ).decode("utf8")
+    assert content.get("auths").get("registry.redhat.io").get("auth") == base64.b64encode(
+        "user2:user2".encode("utf8")
+    ).decode("utf8")
+    assert content.get("auths").get("docker.io").get("auth") == ""
+
+
+def test_skopeo_command_copy():
+    result = SkopeoMirror().copy(
+        "docker://quay.io/quay/busybox:latest",
+        "oci-archive://dev/null",
+        proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
+        timeout=SKOPEO_TIMEOUT_SECONDS,
+    )
+    assert result.success == True
+    assert "Copying blob sha256:" in result.stdout
+    assert result.stderr == ""
+
+
+def test_skopeo_command_authenticated():
+    # since there's no fixed user to test authenticated skip for now
+    assert True == True
+    return
+    result = SkopeoMirror().copy(
+        f"docker://{os.environ.get('src_image')}",
+        "oci-archive://dev/null",
+        src_username=os.environ.get("user-to-authenticated"),
+        src_password=os.environ.get("pass-to-authenticated"),
+        proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
+        timeout=SKOPEO_TIMEOUT_SECONDS,
+    )
+    assert result.success == True
+    assert "Copying blob sha256:" in result.stdout
+    assert result.stderr == ""
+
+
+def test_skopeo_command_tags():
+    result = SkopeoMirror().tags(
+        "docker://quay.io/quay/busybox",
+        proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
+        timeout=SKOPEO_TIMEOUT_SECONDS,
+    )
+    assert result.success == True
+    assert len(result.tags) > 0
+    assert result.stderr == ""

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -114,11 +114,23 @@ def test_successful_mirror(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
         except Exception as e:
+            print(f"Exception {e} {args}")
             skopeo_calls.append(skopeo_call)
             raise e
 
@@ -173,7 +185,18 @@ def test_mirror_unsigned_images(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -232,7 +255,18 @@ def test_successful_disabled_sync_now(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -290,7 +324,18 @@ def test_successful_mirror_verbose_logs(run_skopeo_mock, initialized_db, app, mo
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -413,7 +458,18 @@ def test_rollback(
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             if args[1] == "copy" and args[8].endswith(":updated"):
@@ -506,7 +562,18 @@ def test_mirror_config_server_hostname(run_skopeo_mock, initialized_db, app, mon
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -573,7 +640,18 @@ def test_quote_params(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -637,7 +715,18 @@ def test_quote_params_password(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -666,7 +755,18 @@ def test_inspect_error_mirror(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]


### PR DESCRIPTION
changing the repomirror skopeo calls from list of arguments containing the credentials
```
args = ["/usr/bin/skopeo", 
             ...,
             "--dest-creds",
             "user:password",
             "--src-creds",
             "user:password",
             ...
             ]
```
which ends up with the command being printing the credentials in the process list.
The PR changes that to create and use a `auth.json` file which is used in context (meaning being removed once the context closes.

The PR also add's unittests for the copy and tag skopeo class.       