### PR TITLE
chore: allow OIDC tokens for fresh login required API endpoints (PROJQUAY-7804)

### DIFF
--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -19,6 +19,7 @@ from auth.auth_context import (
     get_authenticated_context,
     get_authenticated_user,
     get_validated_oauth_token,
+    get_sso_token,
 )
 from auth.decorators import process_oauth
 from auth.permissions import (
@@ -539,7 +540,7 @@ def require_fresh_login(func):
         if not user or user.robot:
             raise Unauthorized()
 
-        if get_validated_oauth_token():
+        if get_validated_oauth_token() or get_sso_token():
             return func(*args, **kwargs)
 
         last_login = session.get("login_time", datetime.datetime.min)


### PR DESCRIPTION
## Description
These changes allow API endpoints that require a fresh login (`@require_fresh_login`) to be accessed with an OIDC token.

## Linked Issues
This appears to be related to the following issue: https://issues.redhat.com/browse/PROJQUAY-7804

## Steps to reproduce

1. Run Quay with OIDC authentication type:
    ```
    AUTHENTICATION_TYPE: OIDC
    AUTH0_LOGIN_CONFIG:
      CLIENT_ID: *****
      CLIENT_SECRET: *****
      OIDC_SERVER: https://*****.auth0.com/
      SERVICE_NAME: Auth0
    ```
2. Generate a token directly from your auth server.
3. Call an API endpoint that **does not** require a fresh login
    ```
    curl -X GET 'http://localhost:8080/api/v1/user/' -H 'Authorization: Bearer <YOUR_ACCESS_TOKEN>'
    ```
    This returns a successful response.
4. Call an API endpoint that **requires** a fresh login (annotated with `@require_fresh_login`)
    ```
    curl -XPOST 'http://localhost:8080/api/v1/user/apptoken' \
    -H 'Authorization: Bearer <YOUR_ACCESS_TOKEN>' \
    -H 'Content-Type: application/json' \
    -d '{"title": "my token"}'
    ```
    This returns 401.

## Expected behavior
A success response is expected in this scenario, similar to when using an [OAuth token](https://docs.projectquay.io/api_quay.html#creating-oauth-access-token).
