### PR TITLE
chore: removing pip from requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -152,7 +152,6 @@ Cython==3.0.2
 flit_core==3.7.1
 toml==0.10.2
 tomli==2.2.1
-pip==22.2.1
 setuptools==65.5.1
 setuptools-rust==1.7.0
 setuptools-scm[toml]==4.1.2


### PR DESCRIPTION
Pip installed from requirements.txt breaks the release pipeline.