### PR TITLE
bumping gevent and greenlet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,8 +35,8 @@ Flask-Principal==0.4.0
 Flask-RESTful==0.3.9
 furl==2.1.0
 geoip2==3.0.0
-gevent==21.8.0
-greenlet==1.1.2
+gevent==23.9.1
+greenlet==2.0.2
 grpcio==1.67.0
 gunicorn==20.1.0
 hashids==1.2.0


### PR DESCRIPTION
Required for supporting s390x builds in the release pipeline.