### PR TITLE
oci: skip validation of labels for nested manifest indexes (PROJQUAY-8272)

### DIFF
--- a/data/model/oci/manifest.py
+++ b/data/model/oci/manifest.py
@@ -327,7 +327,7 @@ def _create_manifest(
 
             # Retrieve its labels.
             labels = child_manifest.get_manifest_labels(retriever)
-            if labels is None and isinstance(child_manifest, ManifestInterface):
+            if labels is None and not isinstance(child_manifest, ManifestListInterface):
                 if raise_on_error:
                     raise CreateManifestException("Unable to retrieve manifest labels")
 


### PR DESCRIPTION
When parsing a nested manifest index, the nested index will not have labels. Skip that check if the nested manifest is an index