### PR TITLE
chore: revert #3714 and remove pip from requirements.txt in workflow

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -102,6 +102,11 @@ jobs:
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
+      - name: Remove pip from requirements.txt
+        run: |
+          # Having pip in the requirements.txt interferes with the workflow
+          sed -i '/^pip=/d' requirements.txt
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -152,6 +152,7 @@ Cython==3.0.2
 flit_core==3.7.1
 toml==0.10.2
 tomli==2.2.1
+pip==22.2.1
 setuptools==65.5.1
 setuptools-rust==1.7.0
 setuptools-scm[toml]==4.1.2


### PR DESCRIPTION
Because the cpaas pipeline is now failing due to the removal of pip in requirements.txt. I reverted the removal in #3714 and I am now removing it during the GitHub workflow instead.
