### PR TITLE
storage: Enable multipart upload for Google Cloud Storage (PROJQUAY-6862)

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -911,6 +911,8 @@ class GoogleCloudStorage(_CloudStorage):
         secret_key,
         bucket_name,
         boto_timeout=60,
+        minimum_chunk_size_mb=None,
+        maximum_chunk_size_mb=None,
         signature_version=None,
     ):
         # GCS does not support ListObjectV2
@@ -933,6 +935,15 @@ class GoogleCloudStorage(_CloudStorage):
             bucket_name,
             access_key,
             secret_key,
+        )
+
+        chunk_size = (
+            maximum_chunk_size_mb if maximum_chunk_size_mb is not None else 100
+        )  # 100 MiB default
+        self.maximum_chunk_size = chunk_size * 1024 * 1024
+
+        self.minimum_chunk_size = (
+            (minimum_chunk_size_mb if minimum_chunk_size_mb is not None else 5) * 1024 * 1024
         )
 
         # Workaround for setting GCS cors at runtime with boto
@@ -985,50 +996,6 @@ class GoogleCloudStorage(_CloudStorage):
             .get_direct_download_url(path, request_ip, expires_in, requires_cors, head, **kwargs)
             .replace("AWSAccessKeyId", "GoogleAccessId")
         )
-
-    def _stream_write_internal(
-        self,
-        path,
-        fp,
-        content_type=None,
-        content_encoding=None,
-        cancel_on_error=True,
-        size=filelike.READ_UNTIL_END,
-    ):
-        """
-        Writes the data found in the file-like stream to the given path, with optional limit on
-        size. Note that this method returns a *tuple* of (bytes_written, write_error) and should.
-
-        *not* raise an exception (such as IOError) if a problem uploading occurred. ALWAYS check
-        the returned tuple on calls to this method.
-        """
-        # Minimum size of upload part size on S3 is 5MB
-        self._initialize_cloud_conn()
-        path = self._init_path(path)
-        obj = self.get_cloud_bucket().Object(path)
-
-        extra_args = {}
-        if content_type is not None:
-            extra_args["ContentType"] = content_type
-
-        if content_encoding is not None:
-            extra_args["ContentEncoding"] = content_encoding
-
-        if size != filelike.READ_UNTIL_END:
-            fp = filelike.StreamSlice(fp, 0, size)
-
-        with BytesIO() as buf:
-            # Stage the bytes into the buffer for use with the multipart upload file API
-            bytes_staged = self.stream_write_to_fp(fp, buf, size)
-            buf.seek(0)
-
-            # TODO figure out how to handle cancel_on_error=False
-            try:
-                obj.put(Body=buf, **extra_args)
-            except Exception as ex:
-                return 0, ex
-
-        return bytes_staged, None
 
     def complete_chunked_upload(self, uuid, final_path, storage_metadata):
         self._initialize_cloud_conn()

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -912,7 +912,6 @@ class GoogleCloudStorage(_CloudStorage):
         bucket_name,
         boto_timeout=60,
         minimum_chunk_size_mb=None,
-        maximum_chunk_size_mb=None,
         signature_version=None,
     ):
         # GCS does not support ListObjectV2
@@ -936,11 +935,6 @@ class GoogleCloudStorage(_CloudStorage):
             access_key,
             secret_key,
         )
-
-        chunk_size = (
-            maximum_chunk_size_mb if maximum_chunk_size_mb is not None else 100
-        )  # 100 MiB default
-        self.maximum_chunk_size = chunk_size * 1024 * 1024
 
         self.minimum_chunk_size = (
             (minimum_chunk_size_mb if minimum_chunk_size_mb is not None else 5) * 1024 * 1024


### PR DESCRIPTION
This PR removes the `_stream_write_internal` function override that caused excessive memory consumption and defaults to the old one which chunks uploads. Server assembly is still not suppored by GCS, so we have to assemble everything locally. However, GCS does support the copy function, so a reupload is not needed.

~~~
# podman images
REPOSITORY                                        TAG         IMAGE ID      CREATED      SIZE
registry.fedoraproject.org/fedora                 latest      ecd9f7ee77f4  2 days ago   165 MB
quay.skynet/ibazulic/big-mirror-test              size138gb   8e6ba9ff13c0  3 days ago   148 GB
quay.skynet/quay-mirror/big-mirror-test           size138gb   8e6ba9ff13c0  3 days ago   148 GB
quay.skynet/ibazulic/mfs-image-test               latest      ab14f2230dd9  7 days ago   5.96 GB
quay.skynet/ibazulic/azure-storage-big-file-test  latest      ede194b926e0  7 days ago   16.1 GB
quay.skynet/ibazulic/minio/minio                  latest      76ed5b96833a  6 weeks ago  532 B

# podman push quay.skynet/ibazulic/big-mirror-test:size138gb
Getting image source signatures
Copying blob 9d9c3d76c421 done   |
Copying blob fce7cf3b093c skipped: already exists
Copying config 8e6ba9ff13 done   |
Writing manifest to image destination
~~~

Quay logs:

~~~
gunicorn-registry stdout | 2025-03-28 14:36:23,367 [286] [DEBUG] [urllib3.connectionpool] https://storage.googleapis.com:443 "POST /ibazulic-quay-test-push-bucket/datastorage/registry/uploads/8fd2b0ef-43d0-4160-a597-607de833ea33?uploadId=ABPnzm5l2... HTTP/1.1" 200 471
gunicorn-registry stdout | 2025-03-28 14:36:23,368 [286] [DEBUG] [botocore.parsers] Response headers: {'X-GUploader-UploadID': 'AKDAyIsUzAEkOBan...', 'x-goog-stored-content-length': '
145873211306', 'x-goog-hash': 'crc32c=+m8xGQ==', 'x-amz-checksum-crc32c': '+m8xGQ==', 'x-goog-generation': '1743172583318676', 'x-goog-metageneration': '1', 'Vary': 'Origin', 'Content-Length': '471', 'Date': 'Fri, 28 Mar 2025 14:36:23 GMT', 'Server
': 'UploadServer', 'Content-Type': 'text/html; charset=UTF-8', 'Alt-Svc': 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000'}
gunicorn-registry stdout | 2025-03-28 14:36:23,368 [286] [DEBUG] [botocore.parsers] Response body:
gunicorn-registry stdout | b'<?xml version=\'1.0\' encoding=\'UTF-8\'?><CompleteMultipartUploadResult xmlns=\'http://s3.amazonaws.com/doc/2006-03-01/\'><Location>http://storage.googleapis.com/ibazulic-quay-test-push-bucket/datastorage/registry/uplo
ads/8fd2b0ef-43d0-4160-a597-607de833ea33</Location><Bucket>ibazulic-quay-test-push-bucket</Bucket><Key>datastorage/registry/uploads/8fd2b0ef-43d0-4160-a597-607de833ea33</Key><ETag>"e8d309e4916285de1adcdbff33c27cf4-1392"</ETag></CompleteMultipartUpl
oadResult>'
...
nginx stdout | 172.17.0.1 (-) - - [28/Mar/2025:14:36:23 +0000] "PATCH /v2/ibazulic/big-mirror-test/blobs/uploads/bab998d0-1bde-4ecc-ad4d-121d0caca780 HTTP/1.1" 202 0 "-" "containers/5.30.2 (github.com/containers/image)" (2641.751 145909017392 2641.750)
~~~

For uploading extremely big layers, 5 MiB as the default chunk size is not enough. The PR also enables support for user-defined chunk sizes via `minimum_chunk_size_mb` which defaults to 5 MiB unless specified otherwise.