### PR TITLE
notifications: Support slash in repository names (PROJQUAY-7538)

### DIFF
--- a/endpoints/gitlabtrigger.py
+++ b/endpoints/gitlabtrigger.py
@@ -25,7 +25,7 @@ def attach_gitlab_build_trigger():
         abort(400)
     state = state[len("repo:") :]
     try:
-        [namespace, repository] = state.split("/")
+        [namespace, repository] = state.split("/", maxsplit=1)
     except ValueError:
         abort(400)
 

--- a/util/jinjautil.py
+++ b/util/jinjautil.py
@@ -48,7 +48,7 @@ def user_reference(username):
 
 def repository_tag_reference(repository_path_and_tag):
     (repository_path, tag) = repository_path_and_tag
-    (namespace, repository) = repository_path.split("/")
+    (namespace, repository) = repository_path.split("/", maxsplit=1)
     owner = model.user.get_namespace_user(namespace)
     if not owner:
         return tag
@@ -66,7 +66,7 @@ def repository_reference(pair):
     if isinstance(pair, tuple):
         (namespace, repository) = pair
     else:
-        pair = pair.split("/")
+        pair = pair.split("/", maxsplit=1)
         namespace = pair[0]
         repository = pair[1]
 


### PR DESCRIPTION
Fix for PROJQUAY-7538 discussed in #3069 by only considering the first slash when separating namespace and repository.

I did a search for other examples where `.split("/")` was used and expecting two values, and also found one in gitlabtrigger.