### PR TITLE
db: moving get sorted matching repos and find repos to garbage collect to read replica (PROJQUAY-8792)

### DIFF
--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -655,7 +655,7 @@ def find_repository_with_garbage(limit_to_gc_policy_s):
 
     try:
         candidates = (
-            Tag.select(Tag.repository)
+            Tag.select(Tag.repository, can_use_read_replica=True)
             .join(Repository)
             .join(Namespace, on=(Repository.namespace_user == Namespace.id))
             .where(

--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -528,7 +528,7 @@ def _get_sorted_matching_repositories(
 
         select_fields.append(computed_score)
         query = (
-            Repository.select(*select_fields)
+            Repository.select(*select_fields, can_use_read_replica=True)
             .join(RepositorySearchScore)
             .where(clause)
             .where(Repository.state != RepositoryState.MARKED_FOR_DELETION)


### PR DESCRIPTION
`_get_sorted_matching_repositories` used by:
1.  /v1/search (Used by header search box)
2. /v1/find/repositories (Used in [quay.io/search](http://quay.io/search) page)
3. /v1/find/all (Used in [quay.io/search](http://quay.io/search) page)

`find_repository_with_garbage` used by:
garbage collection worker
