### PR TITLE
endpoint(web): added new automation API endpoint (PROJQUAY-7602)

### DIFF
--- a/config.py
+++ b/config.py
@@ -911,3 +911,6 @@ class DefaultConfig(ImmutableConfig):
     # Specific namespaces that be exceptions to the s3-cloudflare optimization
     # used for registry-proxy namespaces
     CDN_SPECIFIC_NAMESPACES: Optional[List[str]] = []
+
+    # Automation user config. Note: The Users need to also be in the SUPER_USERS list
+    AUTOMATION_USERS: List[str] = []

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1615,5 +1615,13 @@ CONFIG_SCHEMA = {
             "description": "Nginx read timeout for manifests endpoints used by pulls and pushes",
             "x-example": "5m",
         },
+        "AUTOMATION_USERS": {
+            "type": "array",
+            "description": "Automation names of those organizations to be granted superuser privileges",
+            "uniqueItems": True,
+            "items": {
+                "type": "string",
+            },
+        },
     },
 }


### PR DESCRIPTION
With the RFE's:

* https://issues.redhat.com/browse/PROJQUAY-7602
* https://issues.redhat.com/browse/PROJQUAY-6181

The concept for the automation and as implemented in this PR is as follows:

* we deprectate the `/api/v1/user/initialize` API
    * having a token for only two hours valid complicates bootstrapping
* we instead start to provide a `/api/v1/automation/initialize` API
    * that API endpoint takes the same input as the initialize
    * that API endpoint checks if (not in order as in the code)
        * there's an Organization or User with the name existing (if fail)
        * there's a config.yaml SUPER_USER according to the name provided (if not fail)
        * there's a config.yaml AUTOMATION_USER according to the name provided (if not fail)
    * initializes an Organization in Quay with an Application token that has superuser privileges to populate Quay through automation
    * creates an Organization and not a user as the original API endpoint to keep consistency if created through the UI
    * the token expires in 10 years not within 2 hours
* the original endpoint did had the option to either provide a token or a generated one will be returned (kept)

The concept of splitting `SUPER_USER` (still necessary to have privileges of course) and `AUTOMATION_USERS` will provide a safety net for:
* only people who are able to write the config can start automation (meaning if your OIDC/LDAP name is in the SUPER_USER list without being in AUTOMATION_USER it will fail)
* provide a possibility to have more organization SUPER_USER tokens for automation (like delegating to someone)
* provide a possibility to not need to restart Quay with a config.yaml change
* recover a lost automation token as one can initialize another one ...