### PR TITLE
reconciler: fix exception when user api is called with empty email (PROJQUAY-5698)

### DIFF
--- a/workers/reconciliationworker.py
+++ b/workers/reconciliationworker.py
@@ -61,6 +61,8 @@ class ReconciliationWorker(Worker):
                 user_api.lookup_customer_id(email) if email is not None and email != "" else None
             )
             if customer_ids is None:
+                if email is None or email == "":
+                    logger.info("Email missing or empty for user %s", user.username)
                 logger.info("No web customer ids found for %s", email)
                 if model_customer_ids:
                     # user does not have a web customer id from api and should be removed from table

--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -113,3 +113,25 @@ def test_update_same_id(initialized_db):
         worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
 
     mock.assert_not_called()
+
+
+def test_empty_email(initialized_db):
+    test_user = model.user.create_user("stripe_user", "password", "", email_required=False)
+    test_user.stripe_id = "cus_" + "".join(random.choices(string.ascii_lowercase, k=14))
+    test_user.save()
+
+    with patch.object(marketplace_users, "lookup_customer_id") as mock:
+        worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
+
+    assert "" not in mock.call_args_list
+
+
+def test_null_email(initialized_db):
+    test_user = model.user.create_user("stripe_user", "password", None, email_required=False)
+    test_user.stripe_id = "cus_" + "".join(random.choices(string.ascii_lowercase, k=14))
+    test_user.save()
+
+    with patch.object(marketplace_users, "lookup_customer_id") as mock:
+        worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
+
+    assert None not in mock.call_args_list


### PR DESCRIPTION
The user api seems to now give an error response when a lookup is called with email = `""`

```
{
    "code": "validation_error",
    "detail": "com.redhat.services.user.domain.validation.ConstraintViolationException: path=emailStartsWith rejectedValue= errorCode=required properties={}",
    "validationErrors": [
        {
            "path": "emailStartsWith",
            "value": "",
            "code": "required"
        }
    ]
}
```

This causes problems during the reconciliation loop and prevents it from completing. Adds a check for `""` as well as `None` that prevents lookup from happening. Also increases logging level for certain operations for better observability