### PR TITLE
reconciler: Remove database calls for storing/changing web customer ids (PROJQUAY-0000)

### DIFF
--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -80,39 +80,6 @@ def test_create_for_stripe_user(initialized_db):
 
     # expect that entitlment is created with account number
     mock.assert_called_with(11111, "FakeSKU")
-    # expect that entitlment is created with customer id number
-    mock.assert_called_with(model.entitlements.get_web_customer_ids(test_user.id)[0], "FakeSKU")
-
-
-def test_reconcile_different_ids(initialized_db):
-    test_user = model.user.create_user("stripe_user", "password", "stripe_user@test.com")
-    test_user.stripe_id = "cus_" + "".join(random.choices(string.ascii_lowercase, k=14))
-    test_user.save()
-    model.entitlements.save_web_customer_id(test_user, 55555)
-
-    worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
-
-    new_id = model.entitlements.get_web_customer_ids(test_user.id)
-    assert new_id != [55555]
-    assert new_id == marketplace_users.lookup_customer_id(test_user.email)
-
-    # make sure it will remove account numbers from db that do not belong
-    with patch.object(marketplace_users, "lookup_customer_id") as mock:
-        mock.return_value = None
-        worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
-    assert model.entitlements.get_web_customer_ids(test_user.id) is None
-
-
-def test_update_same_id(initialized_db):
-    test_user = model.user.create_user("stripe_user", "password", "stripe_user@test.com")
-    test_user.stripe_id = "cus_" + "".join(random.choices(string.ascii_lowercase, k=14))
-    test_user.save()
-    model.entitlements.save_web_customer_id(test_user, 11111)
-
-    with patch.object(model.entitlements, "update_web_customer_id") as mock:
-        worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
-
-    mock.assert_not_called()
 
 
 def test_empty_email(initialized_db):


### PR DESCRIPTION
Remove adding/updating web customer ids in database during the reconciler run. Using the database to reference web customer ids was removed in https://github.com/quay/quay/pull/3302