### PR TITLE
dockerfile: set GOPATH env var before running go build in dockerfile (PROJQUAY-8789)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ FROM registry.access.redhat.com/ubi8/go-toolset as config-tool
 WORKDIR /opt/app-root/src
 COPY config-tool/ ./
 COPY --from=config-editor /opt/app-root/src/static/build  /opt/app-root/src/pkg/lib/editor/static/build
-RUN go install -tags=fips ./cmd/config-tool
+RUN GOPATH=/opt/app-root/src/go go install -tags=fips ./cmd/config-tool
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS build-quaydir
 WORKDIR /quaydir


### PR DESCRIPTION
Konflux uses cachi2 to fetch dependencies for our build. Cachi2 will inject environment variables in every `RUN` step of the dockerfile so it can use the prefetched dependencies. This will cause problems during build because the `GOPATH` is overwritten for the config editor. Explicitly setting the default `GOPATH` during the go install step fixes this problem