### PR TITLE
chore: move github runners to ubuntu-22.04 (#3783)

### DIFF
--- a/.github/workflows/CI-nightly.yaml
+++ b/.github/workflows/CI-nightly.yaml
@@ -8,7 +8,7 @@ jobs:
   unit:
     if: github.repository == 'quay/quay'
     name: Run all Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       ZVSI_FP_NAME: ${{ vars.IBMZ_ZVSI_FP_NAME }}
       ZVSI_INSTANCE_NAME: ${{ vars.IBMZ_ZVSI_INSTANCE_NAME }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout
@@ -79,16 +79,37 @@ jobs:
 
   unit:
     name: Unit Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
+    - name: Install deps and OpenSSL 1.1
+      run: |
+        sudo apt-get -y update
+        sudo apt-get install -y wget build-essential
+        wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz
+        tar -xzf openssl-1.1.1w.tar.gz
+        cd openssl-1.1.1w
+        ./config --prefix=/opt/openssl-1.1 --openssldir=/opt/openssl-1.1
+        sudo make install
+
+    - name: Download Python and configure python with OpenSSL 1.1
+      run: |
+        cd /usr/local/src
+        sudo wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz
+        sudo tar -xzf Python-3.9.0.tgz
+        cd Python-3.9.0
+        sudo ./configure --prefix=/opt/python3.9-openssl1.1 \
+            --with-openssl=/opt/openssl-1.1 \
+            --enable-optimizations
+        sudo make -j$(nproc)
+        sudo make altinstall
+
+    - name: Test OpenSSL version
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
 
     - name: Install dependencies
       run: |
@@ -97,7 +118,11 @@ jobs:
         cat requirements-dev.txt | grep tox | xargs pip install
 
     - name: tox
-      run: tox -e py39-unit -- --cov=./ --cov-report=xml
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
+        /opt/python3.9-openssl1.1/bin/python3.9 -m venv .venv
+        source .venv/bin/activate
+        tox -e py39-unit -- --cov=./ --cov-report=xml
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
@@ -107,7 +132,7 @@ jobs:
 
   types:
     name: Types Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout
@@ -141,16 +166,37 @@ jobs:
 
   e2e:
     name: E2E Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
+    - name: Install deps and OpenSSL 1.1
+      run: |
+        sudo apt-get -y update
+        sudo apt-get install -y wget build-essential
+        wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz
+        tar -xzf openssl-1.1.1w.tar.gz
+        cd openssl-1.1.1w
+        ./config --prefix=/opt/openssl-1.1 --openssldir=/opt/openssl-1.1
+        sudo make install
+
+    - name: Download Python and configure python with OpenSSL 1.1
+      run: |
+        cd /usr/local/src
+        sudo wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz
+        sudo tar -xzf Python-3.9.0.tgz
+        cd Python-3.9.0
+        sudo ./configure --prefix=/opt/python3.9-openssl1.1 \
+            --with-openssl=/opt/openssl-1.1 \
+            --enable-optimizations
+        sudo make -j$(nproc)
+        sudo make altinstall
+
+    - name: Test OpenSSL version
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
 
     - name: Install dependencies
       run: |
@@ -160,20 +206,45 @@ jobs:
         cat requirements-dev.txt | grep tox | xargs pip install
 
     - name: tox
-      run: tox -e py39-e2e
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
+        /opt/python3.9-openssl1.1/bin/python3.9 -m venv .venv
+        source .venv/bin/activate
+        tox -e py39-e2e
 
   registry:
     name: E2E Registry Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
+    - name: Install deps and OpenSSL 1.1
+      run: |
+        sudo apt-get -y update
+        sudo apt-get install -y wget build-essential
+        wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz
+        tar -xzf openssl-1.1.1w.tar.gz
+        cd openssl-1.1.1w
+        ./config --prefix=/opt/openssl-1.1 --openssldir=/opt/openssl-1.1
+        sudo make install
+
+    - name: Download Python and configure python with OpenSSL 1.1
+      run: |
+        cd /usr/local/src
+        sudo wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz
+        sudo tar -xzf Python-3.9.0.tgz
+        cd Python-3.9.0
+        sudo ./configure --prefix=/opt/python3.9-openssl1.1 \
+            --with-openssl=/opt/openssl-1.1 \
+            --enable-optimizations
+        sudo make -j$(nproc)
+        sudo make altinstall
+
+    - name: Test OpenSSL version
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
 
     - name: Install dependencies
       run: |
@@ -183,7 +254,11 @@ jobs:
         cat requirements-dev.txt | grep tox | xargs pip install
 
     - name: tox
-      run: tox -e py39-registry
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
+        /opt/python3.9-openssl1.1/bin/python3.9 -m venv .venv
+        source .venv/bin/activate
+        tox -e py39-registry
 
   cypress:
     name: Cypress Tests
@@ -274,16 +349,37 @@ jobs:
 
   mysql:
     name: E2E MySQL Test
-    runs-on: ubuntu-20.04
-    steps:
+    runs-on: ubuntu-22.04
 
+    steps:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
+    - name: Install deps and OpenSSL 1.1
+      run: |
+        sudo apt-get -y update
+        sudo apt-get install -y wget build-essential
+        wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz
+        tar -xzf openssl-1.1.1w.tar.gz
+        cd openssl-1.1.1w
+        ./config --prefix=/opt/openssl-1.1 --openssldir=/opt/openssl-1.1
+        sudo make install
+
+    - name: Download Python and configure python with OpenSSL 1.1
+      run: |
+        cd /usr/local/src
+        sudo wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz
+        sudo tar -xzf Python-3.9.0.tgz
+        cd Python-3.9.0
+        sudo ./configure --prefix=/opt/python3.9-openssl1.1 \
+            --with-openssl=/opt/openssl-1.1 \
+            --enable-optimizations
+        sudo make -j$(nproc)
+        sudo make altinstall
+
+    - name: Test OpenSSL version
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
 
     - name: Install dependencies
       run: |
@@ -296,20 +392,45 @@ jobs:
         cat requirements-dev.txt | grep tox | xargs pip install
 
     - name: tox
-      run: tox -e py39-mysql
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
+        /opt/python3.9-openssl1.1/bin/python3.9 -m venv .venv
+        source .venv/bin/activate
+        tox -e py39-mysql
 
   psql:
     name: E2E Postgres Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
+    - name: Install deps and OpenSSL 1.1
+      run: |
+        sudo apt-get -y update
+        sudo apt-get install -y wget build-essential
+        wget https://www.openssl.org/source/openssl-1.1.1w.tar.gz
+        tar -xzf openssl-1.1.1w.tar.gz
+        cd openssl-1.1.1w
+        ./config --prefix=/opt/openssl-1.1 --openssldir=/opt/openssl-1.1
+        sudo make install
+
+    - name: Download Python and configure python with OpenSSL 1.1
+      run: |
+        cd /usr/local/src
+        sudo wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tgz
+        sudo tar -xzf Python-3.9.0.tgz
+        cd Python-3.9.0
+        sudo ./configure --prefix=/opt/python3.9-openssl1.1 \
+            --with-openssl=/opt/openssl-1.1 \
+            --enable-optimizations
+        sudo make -j$(nproc)
+        sudo make altinstall
+
+    - name: Test OpenSSL version
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
 
     - name: Install dependencies
       run: |
@@ -322,4 +443,8 @@ jobs:
         cat requirements-dev.txt | grep tox | xargs pip install
 
     - name: tox
-      run: tox -e py39-psql
+      run: |
+        /opt/python3.9-openssl1.1/bin/python3.9 -c "import ssl; print(ssl.OPENSSL_VERSION)"
+        /opt/python3.9-openssl1.1/bin/python3.9 -m venv .venv
+        source .venv/bin/activate
+        tox -e py39-psql


### PR DESCRIPTION
* chore: move github runners to ubuntu-22.04

* use docker image with openssl 1.1 preinstalled

* using non-interactive mode for github actions

* remove starting docker

* remove starting docker service

* install openssl 1.1 on ubuntu-22.04

* minor fixes

* compiling from source

* check openssl version

* check openssl version before running tox

* use exports when running tox

* fix typo

* overwrite OPENSSL_VERSION var

* minor fixes

* use python3.9 before installing openssl-1.1

* download python and configure openssl1.1

* adding sudo to configure

* use sudo for make

* minor fixes

* using python venv to run tox

* Apply changes to all tests