### PR TITLE
proxy: moving manifest check to after upstream manifest fetch (PROJQUAY-8536)

### DIFF
--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -254,7 +254,10 @@ class ProxyModel(OCIModel):
         if wrapped_manifest is None:
             try:
                 wrapped_manifest, _ = self._create_and_tag_manifest(
-                    repository_ref, manifest_digest, self._create_manifest_with_temp_tag
+                    repository_ref,
+                    manifest_digest,
+                    self._create_manifest_with_temp_tag,
+                    verify_manifest_exists=True,
                 )
             except (UpstreamRegistryError, ManifestDoesNotExist) as e:
                 raise ManifestDoesNotExist(str(e))
@@ -319,7 +322,6 @@ class ProxyModel(OCIModel):
             repository_ref,
             manifest_digest,
             allow_dead=True,
-            allow_hidden=True,
             require_available=False,
             raise_on_error=True,
         )
@@ -388,6 +390,7 @@ class ProxyModel(OCIModel):
         create_manifest_fn: Callable[
             [RepositoryReference, ManifestInterface, str | None], tuple[Manifest | None, Tag | None]
         ],
+        verify_manifest_exists: bool = False,
     ) -> tuple[Manifest | None, Tag | None]:
         """
         Returns the newly created manifest and tag.
@@ -399,6 +402,12 @@ class ProxyModel(OCIModel):
         """
         self._proxy.manifest_exists(manifest_ref, ACCEPTED_MEDIA_TYPES)
         upstream_manifest = self._pull_upstream_manifest(repo_ref.name, manifest_ref)
+        if verify_manifest_exists:
+            wrapped_manifest = super().lookup_manifest_by_digest(
+                repo_ref, manifest_ref, allow_dead=True, require_available=False
+            )
+            if wrapped_manifest is not None:
+                return wrapped_manifest, None
         manifest, tag = create_manifest_fn(repo_ref, upstream_manifest, manifest_ref)
         return manifest, tag
 


### PR DESCRIPTION
The check for the existing manifest was occurring before the request to the upstream registry to fetch the manifest. This caused race conditions where two requests for the same manifest would try to create the manifest at the same time, leading to registry 500's.