### PR TITLE
db: optimize _get_user_repo_permissions to send to read replica (PROJQUAY-8839)

### DIFF
--- a/data/model/permission.py
+++ b/data/model/permission.py
@@ -103,7 +103,14 @@ def _get_user_repo_permissions(
         .where(UserThroughTeam.id == user)
     )
 
-    return direct | team
+    results = []
+    for r in direct:
+        results.append(r)
+
+    for r in team:
+        results.append(r)
+
+    return results
 
 
 def delete_prototype_permission(org, uid):

--- a/endpoints/api/test/test_tag.py
+++ b/endpoints/api/test/test_tag.py
@@ -93,8 +93,8 @@ def test_move_tag(manifest_exists, test_tag, expected_status, app):
         ("devtable", "history", 6),  # +2 for converting object to and from json
         ("devtable", "complex", 6),  # +2 for converting object to and from json
         ("devtable", "gargantuan", 6),  # +2 for converting object to and from json
-        ("buynlarge", "orgrepo", 8),  # +2 for permissions checks.
-        ("buynlarge", "anotherorgrepo", 8),  # +2 for permissions checks.
+        ("buynlarge", "orgrepo", 9),  # +3 for permissions checks.
+        ("buynlarge", "anotherorgrepo", 9),  # +3 for permissions checks.
     ],
 )
 def test_list_repo_tags(repo_namespace, repo_name, query_count, app):


### PR DESCRIPTION
it uses a union query which doesn't invoke the replica selection logic. Make this into 2 seperate queries