### PR TITLE
db: use iterator chain for _get_user_repo_permissions (PROJQUAY-8839)

### DIFF
--- a/data/model/permission.py
+++ b/data/model/permission.py
@@ -1,3 +1,5 @@
+import itertools
+
 from peewee import JOIN
 
 from data.database import (
@@ -103,14 +105,7 @@ def _get_user_repo_permissions(
         .where(UserThroughTeam.id == user)
     )
 
-    results = []
-    for r in direct:
-        results.append(r)
-
-    for r in team:
-        results.append(r)
-
-    return results
+    return itertools.chain(direct, team)
 
 
 def delete_prototype_permission(org, uid):


### PR DESCRIPTION
Unwrapping can cause increase in CPU. Use iterator chain to let the caller unwrap