### PR TITLE
deps: updating nginx version to1.28.0 (PROJQUAY-8783)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,36 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS base
-# Only set variables or install packages that need to end up in the
-# final container here.
+
 ENV PATH=/app/bin/:$PATH \
-	PYTHONUNBUFFERED=1 \
-	PYTHONIOENCODING=UTF-8 \
-	LC_ALL=C.UTF-8 \
-	LANG=C.UTF-8
-ENV PYTHONUSERBASE /app
-ENV TZ UTC
-RUN set -ex\
-	; microdnf -y module enable nginx:1.22 \
-	; microdnf -y module enable python39:3.9 \
-	; microdnf update -y \
-	; microdnf -y --setopt=tsflags=nodocs install \
-		dnsmasq \
-		memcached \
-		nginx \
-		libpq-devel \
-		libjpeg-turbo \
-		openldap \
-		openssl \
-		python39 \
-		python3-gpg \
-		skopeo \
-		findutils \
-	; microdnf -y reinstall tzdata \
-	; microdnf remove platform-python-pip python39-pip \
-	; microdnf -y clean all && rm -rf /var/cache/yum
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    PYTHONUSERBASE=/app \
+    TZ=UTC
+
+RUN set -ex \
+    ; microdnf -y module enable python39:3.9 \
+    ; microdnf update -y \
+    ; microdnf -y --setopt=tsflags=nodocs install \
+        memcached \
+        libpq-devel \
+        libjpeg-turbo \
+        openldap \
+        openssl \
+        python39 \
+        python3-gpg \
+        skopeo \
+        procps-ng \
+        findutils \
+    ; microdnf -y reinstall tzdata \
+    ; microdnf remove platform-python-pip python39-pip \
+    ; microdnf -y clean all && rm -rf /var/cache/yum
+
+# Install NGINX 1.28.0 from the official NGINX repository
+RUN set -ex \
+    && curl -sSL https://nginx.org/packages/rhel/8/x86_64/RPMS/nginx-1.28.0-1.el8.ngx.x86_64.rpm -o /tmp/nginx.rpm \
+    && rpm -ivh /tmp/nginx.rpm \
+    && rm -f /tmp/nginx.rpm
 
 # Config-editor builds the javascript for the configtool.
 FROM registry.access.redhat.com/ubi8/nodejs-10 AS config-editor


### PR DESCRIPTION
Affected Versions:
Nginx version from 1.11.4 prior to 1.26.3
Nginx version from 1.27.0 prior to 1.27.4

2025-04-23	
nginx-1.28.0 stable version has been released, incorporating new features and bug fixes from the 1.27.x mainline branch  — including memory usage and CPU usage optimizations in complex SSL configurations, automatic re‑resolution of hostnames in upstream groups, performance enhancements in QUIC, OCSP validation of client SSL certificates and OCSP stapling support in the stream module, variables support in the proxy_limit_rate, fastcgi_limit_rate, scgi_limit_rate, and uwsgi_limit_rate directives, the proxy_pass_trailers directive, and more.