### PR TITLE
deploy: add anti-affinity for registry-proxy pods (PROJQUAY-8839)

### DIFF
--- a/deploy/openshift/quay-py3-app.yaml
+++ b/deploy/openshift/quay-py3-app.yaml
@@ -164,7 +164,7 @@ objects:
             - podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                  - key: app
+                  - key: part-of
                     operator: In
                     values:
                     - registry-proxy

--- a/deploy/openshift/quay-py3-app.yaml
+++ b/deploy/openshift/quay-py3-app.yaml
@@ -160,6 +160,16 @@ objects:
         serviceAccountName: ${{NAME}}
         affinity:
           podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - registry-proxy
+                namespaceSelector: {}
+              weight: 100
             preferredDuringSchedulingIgnoredDuringExecution:
               - weight: 1
                 podAffinityTerm:


### PR DESCRIPTION
the registry proxy pods compete for CPU resources. Make sure we don't schedule them with the quay pods