### PR TITLE
patch: update package-lock.json [redhat-3.11] (PROJQUAY-8804)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "elliptic": "^6.5.7",
         "file-saver": "^1.3.3",
         "highlight.js": "^9.12.0",
-        "jquery": "1.12.4",
+        "jquery": "^3.5.0",
         "moment": "^2.29",
         "ng-metadata": "^4.0.1",
         "package.json": "^2.0.1",
@@ -5418,9 +5418,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "1.12.4",
-      "resolved": "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz",
-      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "node_modules/js-base64": {
       "version": "2.1.9",


### PR DESCRIPTION
Noticing problems with a lockfile inconsistency when cherry picking https://github.com/quay/quay/pull/3817. Results of running `npm install` on 3.11 branch to fix inconsistency.