### PR TITLE
storage: Increase proxy JWT expiry to 10 minutes (PROJQUAY-8894)

### DIFF
--- a/storage/downloadproxy.py
+++ b/storage/downloadproxy.py
@@ -14,7 +14,7 @@ from util.security.registry_jwt import (
 logger = logging.getLogger(__name__)
 
 
-PROXY_STORAGE_MAX_LIFETIME_S = 30  # Seconds
+PROXY_STORAGE_MAX_LIFETIME_S = 300  # Seconds.
 STORAGE_PROXY_SUBJECT = "storageproxy"
 STORAGE_PROXY_ACCESS_TYPE = "storageproxy"
 

--- a/storage/downloadproxy.py
+++ b/storage/downloadproxy.py
@@ -14,7 +14,7 @@ from util.security.registry_jwt import (
 logger = logging.getLogger(__name__)
 
 
-PROXY_STORAGE_MAX_LIFETIME_S = 300  # Seconds.
+PROXY_STORAGE_MAX_LIFETIME_S = 600  # Seconds.
 STORAGE_PROXY_SUBJECT = "storageproxy"
 STORAGE_PROXY_ACCESS_TYPE = "storageproxy"
 


### PR DESCRIPTION
The current JWT expiry time of 30 seconds is sometimes inadequate, especially for scanning purposes when download is not as quick as one expects. This will increase the expiry time to 10 minutes allowing downloading of layers even in slower environments.