### PR TITLE
otel: fix dynatrace issue (PROJQUAY-8902)

### DIFF
--- a/util/metrics/otel.py
+++ b/util/metrics/otel.py
@@ -24,23 +24,23 @@ def init_exporter(app_config):
     tracerProvider = TracerProvider(resource=resource, sampler=sampler)
 
     if DT_API_URL is not None and DT_API_TOKEN is not None:
-        spanExporter = BatchSpanProcessor(
-            OTLPSpanExporter(
+        processor = BatchSpanProcessor(
+            OTLPHTTPSpanExporter(
                 endpoint=DT_API_URL + "/v1/traces",
                 headers={"Authorization": "Api-Token " + DT_API_TOKEN},
             )
         )
     else:
         spanExporter = OTLPSpanExporter(endpoint="http://jaeger:4317")
+        processor = BatchSpanProcessor(spanExporter)
 
-    processor = BatchSpanProcessor(spanExporter)
     tracerProvider.add_span_processor(processor)
     trace.set_tracer_provider(tracerProvider)
 
 
 def traced(span_name=None):
     """
-    Decorator for tracing functino calls using OpenTelemetry.
+    Decorator for tracing function calls using OpenTelemetry.
     """
 
     def decorate(func):

--- a/util/metrics/otel.py
+++ b/util/metrics/otel.py
@@ -25,7 +25,7 @@ def init_exporter(app_config):
 
     if DT_API_URL is not None and DT_API_TOKEN is not None:
         processor = BatchSpanProcessor(
-            OTLPHTTPSpanExporter(
+            OTLPSpanExporter(
                 endpoint=DT_API_URL + "/v1/traces",
                 headers={"Authorization": "Api-Token " + DT_API_TOKEN},
             )


### PR DESCRIPTION
Fixes exception when using dynatrace:

```
AttributeError: 'BatchSpanProcessor' object has no attribute 'export'
  File "/app/lib/python3.9/site-packages/opentelemetry/sdk/trace/export/__init__.py", line 362, in _export_batch
    self.span_exporter.export(self.spans_list[:idx])  # type: ignore
```