### PR TITLE
proxycache(permissions): CVE-2025-4374 (PROJQUAY-8892)

### DIFF
--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -126,7 +126,13 @@ class _RepositoryExistsException(Exception):
 
 
 def create_repository(
-    namespace, name, creating_user, visibility="private", repo_kind="image", description=None
+    namespace,
+    name,
+    creating_user,
+    visibility="private",
+    repo_kind="image",
+    description=None,
+    proxy_cache=False,
 ):
     namespace_user = User.get(username=namespace)
     yesterday = datetime.now() - timedelta(days=1)
@@ -154,7 +160,8 @@ def create_repository(
 
             # Note: We put the admin create permission under the transaction to ensure it is created.
             if creating_user and not creating_user.organization:
-                admin = Role.get(name="admin")
+                rolename = "admin" if proxy_cache == False else "read"
+                admin = Role.get(name=rolename)
                 RepositoryPermission.create(user=creating_user, repository=repo, role=admin)
     except _RepositoryExistsException as ree:
         try:

--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -132,7 +132,9 @@ class ProxyModel(OCIModel):
 
         visibility = "private" if app.config.get("CREATE_PRIVATE_REPO_ON_PUSH", True) else "public"
 
-        repo = create_repository(namespace_name, repo_name, self._user, visibility=visibility)
+        repo = create_repository(
+            namespace_name, repo_name, self._user, visibility=visibility, proxy_cache=True
+        )
         return RepositoryReference.for_repo_obj(
             repo,
             namespace_name,


### PR DESCRIPTION
To fix the CVE-2025-4374 reported default permission assignment of  `admin` even to unprivileged and Organization wide assigned none `admin` users, the `create_repository` method get's extended to understand if a PROXY_CACHE_FEATURE requested pull creating a repository is happening and only `read` permissions should be assigned to the user who first pulls the repo/image.
 