### PR TITLE
chore: enable source build image (PROJQUAY-0000)

### DIFF
--- a/.tekton/quay-test-pull-request.yaml
+++ b/.tekton/quay-test-pull-request.yaml
@@ -28,6 +28,8 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile
+  - name: build-source-image
+    value: "true"
   - name: hermetic
     value: "true"
   - name: prefetch-input


### PR DESCRIPTION
enable source image build in pipeline

should fix `[Violation] source_image.exists`