### PR TITLE
chore: reconciler lock match frequency (PROJQUAY-8933)

### DIFF
--- a/workers/reconciliationworker.py
+++ b/workers/reconciliationworker.py
@@ -147,7 +147,7 @@ class ReconciliationWorker(Worker):
             try:
                 with GlobalLock(
                     "RECONCILIATION_WORKER",
-                    lock_ttl=RECONCILIATION_TIMEOUT + LOCK_TIMEOUT_PADDING,
+                    lock_ttl=RECONCILIATION_FREQUENCY + LOCK_TIMEOUT_PADDING,
                 ):
                     self._perform_reconciliation(
                         user_api=marketplace_users, marketplace_api=marketplace_subscriptions

--- a/workers/reconciliationworker.py
+++ b/workers/reconciliationworker.py
@@ -147,7 +147,8 @@ class ReconciliationWorker(Worker):
             try:
                 with GlobalLock(
                     "RECONCILIATION_WORKER",
-                    lock_ttl=RECONCILIATION_FREQUENCY + LOCK_TIMEOUT_PADDING,
+                    lock_ttl=app.config.get("RECONCILIATION_FREQUENCY", RECONCILIATION_FREQUENCY)
+                    + LOCK_TIMEOUT_PADDING,
                 ):
                     self._perform_reconciliation(
                         user_api=marketplace_users, marketplace_api=marketplace_subscriptions


### PR DESCRIPTION
Lock ttl should match the frequency of the worker so only one worker runs at a time