### PR TITLE
fix: migrate to logging.warning (PROJQUAY-8996)

### DIFF
--- a/data/migrations/env.py
+++ b/data/migrations/env.py
@@ -124,7 +124,7 @@ def run_migrations_online():
                 # ignore revision error if we're running the previous release
                 releases = list(get_recent_releases(SERVICE, REGION).offset(1).limit(1))
                 if releases and releases[0].version == GIT_HEAD:
-                    logger.warn("Skipping database migration because revision not found")
+                    logger.warning("Skipping database migration because revision not found")
                 else:
                     raise
     finally:

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -391,7 +391,7 @@ class _CloudStorage(BaseStorageV2):
                     botocore.exceptions.ConnectionClosedError,
                     IOError,
                 ) as e:
-                    logger.warn(
+                    logger.warning(
                         "Error when writing to stream in stream_write_internal at path %s: %s",
                         path,
                         e,

--- a/workers/reconciliationworker.py
+++ b/workers/reconciliationworker.py
@@ -70,7 +70,7 @@ class ReconciliationWorker(Worker):
                     logger.error("Cannot connect to Stripe")
                     continue
                 except stripe.error.InvalidRequestError:
-                    logger.warn("Invalid request for stripe_id %s", user.stripe_id)
+                    logger.warning("Invalid request for stripe_id %s", user.stripe_id)
                     continue
 
             self._iterate_over_ids(stripe_customer, customer_ids, marketplace_api, user.username)


### PR DESCRIPTION
## PR Summary
The `logging.warn()` method is deprecated since Python2.7 and replaced with `logging.warning()`.