### PR TITLE
ci: Oci fix (PROJQUAY-0000)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,11 @@ RUN set -ex\
 FROM base AS build-python
 ENV PYTHONDONTWRITEBYTECODE 1
 # Enable CodeReady Builder for access to -devel packages.
-RUN microdnf config-manager --set-enabled crb
 
 RUN set -ex\
-	; microdnf -y --setopt=tsflags=nodocs install \
+	; microdnf -y \
+    --setopt=tsflags=nodocs install \
+    --enablerepo=ubi-8-codeready-builder-rpms \
 		gcc-c++ \
 		git \
 		openldap-devel \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ RUN set -ex\
 # Build-python installs the requirements for the python code.
 FROM base AS build-python
 ENV PYTHONDONTWRITEBYTECODE 1
+# Enable CodeReady Builder for access to -devel packages.
+RUN microdnf config-manager --set-enabled crb
+
 RUN set -ex\
 	; microdnf -y --setopt=tsflags=nodocs install \
 		gcc-c++ \


### PR DESCRIPTION
Testing out a fix for issue in 3.12 and up CI with oci check:
```
  > [build-python 1/7] RUN set -ex	; microdnf -y --setopt=tsflags=nodocs install 		gcc-c++ 		git 		openldap-devel 		python39-devel 		libffi-devel         openssl-devel         diffutils         file         make         libjpeg-turbo         libjpeg-turbo-devel 		wget 		rust-toolset 		libxml2-devel 		libxslt-devel 		freetype-devel 	; microdnf -y clean all:
2.564  Problem 1: package rust-toolset-1.84.1-2.module+el8.10.0+23064+1bf4ac64.noarch from ubi-8-appstream-rpms requires rust = 1.84.1-2.module+el8.10.0+23064+1bf4ac64, but none of the providers can be installed
2.564   - package rust-1.84.1-2.module+el8.10.0+23064+1bf4ac64.x86_64 from ubi-8-appstream-rpms requires rust-std-static(x86-64) = 1.84.1-2.module+el8.10.0+23064+1bf4ac64, but none of the providers can be installed
2.564   - conflicting requests
2.564   - nothing provides glibc-devel(x86-64) >= 2.17 needed by rust-std-static-1.84.1-2.module+el8.10.0+23064+1bf4ac64.x86_64 from ubi-8-appstream-rpms
2.564  Problem 2: package gcc-8.5.0-26.el8_10.x86_64 from ubi-8-appstream-rpms requires glibc-devel >= 2.2.90-12, but none of the providers can be installed
2.564   - package glibc-devel-2.28-251.el8_10.22.i686 from ubi-8-baseos-rpms requires libxcrypt-devel(x86-32) >= 4.0.0, but none of the providers can be installed
2.564   - package gcc-c++-8.5.0-26.el8_10.x86_64 from ubi-8-appstream-rpms requires gcc = 8.5.0-26.el8_10, but none of the providers can be installed
2.564   - libxcrypt-devel-4.1.1-6.el8.i686 from ubi-8-baseos-rpms  does not belong to a distupgrade repository
2.564   - conflicting requests
2.564   - nothing provides glibc-devel(x86-64) >= 2.26.9000-46 needed by libxcrypt-devel-4.1.1-6.el8.x86_64 from ubi-8-baseos-rpms
```