### PR TITLE
deps: downgrading maturin to 1.7.5

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -223,6 +223,21 @@ hatchling==1.18.0 \
     #   -r requirements-build.in
     #   hatch-fancy-pypi-readme
     #   hatch-vcs
+maturin==1.7.5 \
+    --hash=sha256:0d2d04ab5f47c1bc2b075a5d8255d9a72921e8dceebf9f9e9884f09d67f7cdd6 \
+    --hash=sha256:5563d61cfa2fcd7d1552022df6566300f229fa3aed62020c93a750fa3dca9a99 \
+    --hash=sha256:71cbcfd4a74aac3eafe99a1cd73d83af8049f572986ff4e0e5e4d8fec9c66a93 \
+    --hash=sha256:742cd76a50104fdd832b010a205199e9b02333879f750c0cfca6c93e9472623f \
+    --hash=sha256:76a78284a96c24cd2d0ac3eac865315b4b0be7a443463fd5b3ebea3c6f147703 \
+    --hash=sha256:9044e5e2eb68bbf8ad86c4ffeab365b78b54bf342ba346dc93775531d3a4e647 \
+    --hash=sha256:c1002ca9a23c45123af752d353f6b221151a6eab2b5b65d57a79298b7d8ca6d4 \
+    --hash=sha256:c38e585555be525ebc2602ea7189c7ef3e1c3001c94893e5bc71f934468ff124 \
+    --hash=sha256:c441fe54945fe8077f17cb116834980391169cf712b63631d8380c8c3de781a1 \
+    --hash=sha256:e31c4d25b56346c7872417d58cca81e52387a37469cdb79f7225bae9ad75daf9 \
+    --hash=sha256:e773ade7a1383c24eaf6b665340a91278c80ab544c18687aa69e9661b289cf48 \
+    --hash=sha256:f05ccbdfe96ad58d70dba9c3eed090726db8ccbaf07ec03852113ca2fec6d84b \
+    --hash=sha256:f6c80fa7d67f58fd2cecbcdf309e2c3c5cd6f965216191de73af6cf947ef2ab8
+    # via -r requirements-build.in
 mypy==1.15.0 \
     --hash=sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e \
     --hash=sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22 \
@@ -321,6 +336,7 @@ tomli==2.0.1 \
     #   -r requirements-build.in
     #   hatch-fancy-pypi-readme
     #   hatchling
+    #   maturin
     #   mypy
     #   setuptools-rust
     #   setuptools-scm


### PR DESCRIPTION
This version is required specifically for cryptography 44.0.1