### PR TITLE
storage(cloud): class S3Storage, endpoint build not considering manual overwrites of endpoint in configuration (PROJQUAY-9047)

### DIFF
--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -789,7 +789,7 @@ class S3Storage(_CloudStorage):
             "config": Config(signature_version=signature_version),
             "aws_session_token": aws_session_token,
         }
-        if s3_region is not None:
+        if all([s3_region is not None, endpoint_url is None, host is None]):
             connect_kwargs["region_name"] = s3_region
             connect_kwargs["endpoint_url"] = "https://s3.{region}.amazonaws.com".format(
                 region=s3_region
@@ -797,6 +797,11 @@ class S3Storage(_CloudStorage):
             # cn-north-1's endpoint has a .com.cn TLD
             if s3_region in S3Storage.REGIONS["cn"]:
                 connect_kwargs["endpoint_url"] = connect_kwargs["endpoint_url"] + ".cn"
+        elif all([s3_region is not None, any([endpoint_url is not None, host is not None])]):
+            connect_kwargs["region_name"] = s3_region
+            connect_kwargs["endpoint_url"] = endpoint_url or _build_endpoint_url(
+                host, port=port, is_secure=True
+            )
         elif host or endpoint_url:
             connect_kwargs["endpoint_url"] = endpoint_url or _build_endpoint_url(
                 host, port=port, is_secure=True

--- a/storage/test/test_cloud_storage.py
+++ b/storage/test/test_cloud_storage.py
@@ -57,6 +57,29 @@ def test_build_endpoint_url(hostname, port, is_secure, expected):
     assert _build_endpoint_url(hostname, port, is_secure) == expected
 
 
+def test_storage_engine_custom_overwrites():
+    engine = S3Storage(
+        _TEST_CONTEXT,
+        "some/path",
+        _TEST_BUCKET,
+        _TEST_USER,
+        _TEST_PASSWORD,
+        _TEST_REGION,
+        host="custom-host-overwrite.example.com",
+    )
+    assert engine._connect_kwargs["endpoint_url"] == "https://custom-host-overwrite.example.com"
+    engine = S3Storage(
+        _TEST_CONTEXT,
+        "some/path",
+        _TEST_BUCKET,
+        _TEST_USER,
+        _TEST_PASSWORD,
+        _TEST_REGION,
+        endpoint_url="http://custom-endpoint-overwrite.example.com",
+    )
+    assert engine._connect_kwargs["endpoint_url"] == "http://custom-endpoint-overwrite.example.com"
+
+
 def test_basicop(storage_engine):
     # Ensure the content exists.
     assert storage_engine.exists(_TEST_PATH)


### PR DESCRIPTION
configuring S3Storage with a manual endpoint get's `overwritten` to `awsamazon.com` even when specifying endpoint or host in the configuration
```
DISTRIBUTED_STORAGE_CONFIG:
  default:
    - S3Storage 
    - host: s3.<region>.<domain>.gov
      s3_access_key: ABCDEFGHIJKLMN
      s3_secret_key: OL3ABCDEFGHIJKLMN
      s3_bucket: quay_bucket
      s3_region: <region>
      storage_path: /datastorage/registry 
```
Expected Host and S3v4 Signature Host value `s3.<region>.<domain>.gov` 
The Class `S3Storage` does only consider `cn` for special treathment.

 

A small adjustment could make the code aware of manual overwrites
```
        if all([s3_region is not None, endpoint_url is None, host is None]):
            connect_kwargs["region_name"] = s3_region
            connect_kwargs["endpoint_url"] = "https://s3.{region}.amazonaws.com".format(
                region=s3_region
            )
            # cn-north-1's endpoint has a .com.cn TLD
            if s3_region in S3Storage.REGIONS["cn"]:
                connect_kwargs["endpoint_url"] = connect_kwargs["endpoint_url"] + ".cn"
        elif all([s3_region is not None, any([endpoint_url is not None, host is not None])]):
            connect_kwargs["region_name"] = s3_region
            connect_kwargs["endpoint_url"] = endpoint_url or _build_endpoint_url(
                host, port=port, is_secure=True
            )
        elif host or endpoint_url:
            connect_kwargs["endpoint_url"] = endpoint_url or _build_endpoint_url(
                host, port=port, is_secure=True
            ) 
```