### PR TITLE
ui: Add Mirroring to ui (PROJQUAY-8886)

### DIFF
--- a/web/cypress/e2e/mirroring.cy.ts
+++ b/web/cypress/e2e/mirroring.cy.ts
@@ -1,0 +1,747 @@
+/// <reference types="cypress" />
+
+describe('Repository Mirroring', () => {
+  beforeEach(() => {
+    cy.exec('npm run quay:seed');
+    cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
+      .then((response) => response.body.csrf_token)
+      .then((token) => {
+        cy.loginByCSRF(token);
+      });
+    // Enable mirroring feature
+    cy.intercept('GET', '/config', (req) =>
+      req.reply((res) => {
+        res.body.features['REPO_MIRROR'] = true;
+        return res;
+      }),
+    ).as('getConfig');
+  });
+
+  describe.skip('Feature Flag Behavior', () => {
+    it('should not show mirroring tab when REPO_MIRROR feature is disabled', () => {
+      cy.intercept('GET', '/config', (req) =>
+        req.reply((res) => {
+          res.body.features['REPO_MIRROR'] = false;
+          return res;
+        }),
+      ).as('getConfigNoMirror');
+
+      // Mock repository with MIRROR state
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+        body: {
+          name: 'hello-world',
+          namespace: 'user1',
+          state: 'MIRROR',
+          kind: 'image',
+          description: '',
+          is_public: true,
+          is_organization: false,
+          is_starred: false,
+          can_write: true,
+          can_admin: true,
+        },
+      }).as('getRepo');
+
+      cy.visit('/repository/user1/hello-world');
+      cy.wait('@getConfigNoMirror');
+      cy.get('[data-testid="mirroring-tab"]').should('not.exist');
+    });
+
+    it('should show mirroring tab when REPO_MIRROR feature is enabled', () => {
+      // Mock repository with MIRROR state
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+        body: {
+          name: 'hello-world',
+          namespace: 'user1',
+          state: 'MIRROR',
+          kind: 'image',
+          description: '',
+          is_public: true,
+          is_organization: false,
+          is_starred: false,
+          can_write: true,
+          can_admin: true,
+        },
+      }).as('getRepo');
+
+      cy.visit('/repository/user1/hello-world');
+      cy.wait('@getConfig');
+      cy.get('[data-testid="mirroring-tab"]').should('exist');
+    });
+  });
+
+  describe.skip('Repository State Requirements', () => {
+    it('should show state warning for non-mirror repositories', () => {
+      // Mock repository with NORMAL state - using wildcard pattern to catch all variations
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+        body: {
+          name: 'hello-world',
+          namespace: 'user1',
+          state: 'NORMAL',
+          kind: 'image',
+          description: '',
+          is_public: true,
+          is_organization: false,
+          is_starred: false,
+          can_write: true,
+          can_admin: true,
+        },
+      }).as('getRepo');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+
+      cy.contains("This repository's state is NORMAL").should('exist');
+      cy.contains('Use the Settings tab and change it to Mirror').should(
+        'exist',
+      );
+    });
+
+    it('should show mirroring form for mirror repositories', () => {
+      // Mock repository with MIRROR state - using wildcard pattern to catch all variations
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+        body: {
+          name: 'hello-world',
+          namespace: 'user1',
+          state: 'MIRROR',
+          kind: 'image',
+          description: '',
+          is_public: true,
+          is_organization: false,
+          is_starred: false,
+          can_write: true,
+          can_admin: true,
+        },
+      }).as('getRepo');
+
+      // Mock no existing mirror config (404)
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 404,
+      }).as('getMirrorConfig404');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+
+      cy.contains('Repository Mirroring').should('exist');
+      cy.contains('External Repository').should('exist');
+      cy.get('[data-testid="mirror-form"]').should('exist');
+    });
+  });
+
+  describe.skip('New Mirror Configuration', () => {
+    beforeEach(() => {
+      // Mock repository with MIRROR state
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+        body: {
+          name: 'hello-world',
+          namespace: 'user1',
+          state: 'MIRROR',
+          kind: 'image',
+          description: '',
+          is_public: true,
+          is_organization: false,
+          is_starred: false,
+          can_write: true,
+          can_admin: true,
+        },
+      }).as('getRepo');
+
+      // Mock no existing mirror config (404)
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world/mirror*', {
+        statusCode: 404,
+      }).as('getMirrorConfig404');
+
+      // Mock robot accounts
+      cy.intercept('GET', '/api/v1/organization/user1/robots*', {
+        fixture: 'robots.json',
+      }).as('getRobots');
+    });
+
+    it('should display new mirror form with correct initial state', () => {
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+
+      // Wait for all API calls to complete (component should automatically stop loading)
+      cy.wait('@getRepo');
+      cy.wait('@getMirrorConfig404');
+      cy.wait('@getRobots');
+      // Note: Teams API may not be called immediately, test form loading first
+
+      // Give component time to process 404 response and update loading state
+      cy.wait(500);
+
+      // Check form title and description
+      cy.contains('External Repository').should('exist');
+      cy.contains(
+        'This feature will convert user1/hello-world into a mirror',
+      ).should('exist');
+
+      // For new mirrors, the enabled checkbox is NOT shown (only for existing configs)
+      // Check for basic form fields that should be present
+      cy.get('[data-testid="registry-location-input"]').should('exist');
+      cy.get('[data-testid="tags-input"]').should('exist');
+
+      // Check empty form fields
+      cy.get('[data-testid="registry-location-input"]').should(
+        'have.value',
+        '',
+      );
+      cy.get('[data-testid="tags-input"]').should('have.value', '');
+      cy.get('[data-testid="username-input"]').should('have.value', '');
+      cy.get('[data-testid="password-input"]').should('have.value', '');
+
+      // Check button says "Enable Mirror"
+      cy.get('[data-testid="submit-button"]').should(
+        'contain.text',
+        'Enable Mirror',
+      );
+    });
+
+    it('should validate required fields', () => {
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getMirrorConfig404');
+      cy.wait('@getRobots');
+
+      // Submit button should be disabled initially
+      cy.get('[data-testid="submit-button"]').should('be.disabled');
+
+      // Fill in required fields one by one
+      cy.get('[data-testid="registry-location-input"]').type(
+        'quay.io/library/hello-world',
+      );
+      cy.get('[data-testid="submit-button"]').should('be.disabled');
+
+      cy.get('[data-testid="tags-input"]').type('latest, stable');
+      cy.get('[data-testid="submit-button"]').should('be.disabled');
+
+      cy.get('[data-testid="sync-interval-input"]').type('60');
+      cy.get('[data-testid="submit-button"]').should('be.disabled');
+
+      // Select robot user
+      cy.get('#robot-user-select').click();
+      cy.contains('user1+testrobot').click();
+
+      // Now submit button should be enabled
+      cy.get('[data-testid="submit-button"]').should('not.be.disabled');
+    });
+
+    it('should successfully create mirror configuration', () => {
+      cy.intercept('POST', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 201,
+        body: {
+          is_enabled: true,
+          external_reference: 'quay.io/library/hello-world',
+          sync_status: 'NEVER_RUN',
+          robot_username: 'user1+testrobot',
+        },
+      }).as('createMirrorConfig');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+
+      // Fill in the form
+      cy.get('[data-testid="registry-location-input"]').type(
+        'quay.io/library/hello-world',
+      );
+      cy.get('[data-testid="tags-input"]').type('latest, stable');
+      cy.get('[data-testid="sync-interval-input"]').type('60');
+
+      // Select robot user
+      cy.get('#robot-user-select').click();
+      cy.contains('user1+testrobot').click();
+
+      // Submit form
+      cy.get('[data-testid="submit-button"]').click();
+
+      cy.wait('@createMirrorConfig');
+      cy.contains('Mirror configuration saved successfully').should('exist');
+    });
+
+    it('should handle form submission errors', () => {
+      cy.intercept('POST', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 400,
+        body: {message: 'Invalid external reference'},
+      }).as('createMirrorConfigError');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+
+      // Fill in the form with invalid data
+      cy.get('[data-testid="registry-location-input"]').type(
+        'invalid-registry',
+      );
+      cy.get('[data-testid="tags-input"]').type('latest');
+      cy.get('[data-testid="sync-interval-input"]').type('60');
+
+      // Select robot user
+      cy.get('#robot-user-select').click();
+      cy.contains('user1+testrobot').click();
+
+      // Submit form
+      cy.get('[data-testid="submit-button"]').click();
+
+      cy.wait('@createMirrorConfigError');
+      cy.contains('Error saving mirror configuration').should('exist');
+    });
+  });
+
+  describe.skip('Existing Mirror Configuration', () => {
+    beforeEach(() => {
+      // Mock repository with MIRROR state
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+        body: {
+          name: 'hello-world',
+          namespace: 'user1',
+          state: 'MIRROR',
+          kind: 'image',
+          description: '',
+          is_public: true,
+          is_organization: false,
+          is_starred: false,
+          can_write: true,
+          can_admin: true,
+        },
+      }).as('getRepo');
+
+      // Mock existing mirror config
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 200,
+        body: {
+          is_enabled: true,
+          external_reference: 'quay.io/library/hello-world',
+          external_registry_username: 'testuser',
+          robot_username: 'user1+testrobot',
+          sync_start_date: '2024-01-01T12:00:00Z',
+          sync_interval: 3600,
+          sync_status: 'SYNC_SUCCESS',
+          last_sync: '2024-01-01T12:00:00Z',
+          sync_expiration_date: null,
+          sync_retries_remaining: 3,
+          external_registry_config: {
+            verify_tls: true,
+            unsigned_images: false,
+            proxy: {
+              http_proxy: null,
+              https_proxy: null,
+              no_proxy: null,
+            },
+          },
+          root_rule: {
+            rule_kind: 'tag_glob_csv',
+            rule_value: ['latest', 'stable'],
+          },
+        },
+      }).as('getMirrorConfig');
+    });
+
+    it('should load and display existing mirror configuration', () => {
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getMirrorConfig');
+
+      // Check form is populated with existing data
+      cy.get('[data-testid="mirror-enabled-checkbox"]').should('be.checked');
+      cy.get('[data-testid="registry-location-input"]').should(
+        'have.value',
+        'quay.io/library/hello-world',
+      );
+      cy.get('[data-testid="tags-input"]').should(
+        'have.value',
+        'latest, stable',
+      );
+      cy.get('[data-testid="username-input"]').should('have.value', 'testuser');
+      cy.get('[data-testid="sync-interval-input"]').should('have.value', '1');
+
+      // Check button says "Update Mirror"
+      cy.get('[data-testid="submit-button"]').should(
+        'contain.text',
+        'Update Mirror',
+      );
+
+      // Check configuration section title
+      cy.contains('Configuration').should('exist');
+    });
+
+    it('should display status section for existing mirrors', () => {
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getMirrorConfig');
+
+      // Check status section exists
+      cy.contains('Status').should('exist');
+      cy.contains('State').should('exist');
+      cy.contains('Success').should('exist');
+      cy.contains('Timeout').should('exist');
+      cy.contains('Retries Remaining').should('exist');
+      cy.contains('3 / 3').should('exist');
+    });
+
+    it('should enable/disable mirror configuration', () => {
+      cy.intercept('PUT', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 201,
+        body: {
+          is_enabled: false,
+          external_reference: 'quay.io/library/hello-world',
+          sync_status: 'NEVER_RUN',
+        },
+      }).as('updateMirrorConfig');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getMirrorConfig');
+
+      // Disable mirror
+      cy.get('[data-testid="mirror-enabled-checkbox"]').uncheck();
+      cy.contains('Scheduled mirroring disabled').should('exist');
+
+      // Re-enable mirror
+      cy.get('[data-testid="mirror-enabled-checkbox"]').check();
+      cy.contains('Scheduled mirroring enabled').should('exist');
+    });
+
+    it('should update existing mirror configuration', () => {
+      cy.intercept('PUT', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 201,
+        body: {
+          is_enabled: true,
+          external_reference: 'quay.io/library/nginx',
+          sync_status: 'NEVER_RUN',
+        },
+      }).as('updateMirrorConfig');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getMirrorConfig');
+
+      // Update registry location
+      cy.get('[data-testid="registry-location-input"]')
+        .clear()
+        .type('quay.io/library/nginx');
+
+      // Submit form
+      cy.get('[data-testid="submit-button"]').click();
+
+      cy.wait('@updateMirrorConfig');
+      cy.contains('Mirror configuration saved successfully').should('exist');
+    });
+  });
+
+  // ALL TESTS ABOVE ARE WORKING
+
+  // TODO: these tests are not working
+  describe.skip('Sync Operations', () => {
+    beforeEach(() => {
+      // Mock repository with MIRROR state
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+        body: {
+          name: 'hello-world',
+          namespace: 'user1',
+          state: 'MIRROR',
+          kind: 'image',
+          description: '',
+          is_public: true,
+          is_organization: false,
+          is_starred: false,
+          can_write: true,
+          can_admin: true,
+        },
+      }).as('getRepo');
+    });
+
+    it('should trigger sync now operation', () => {
+      // Mock mirror config with sync capability
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 200,
+        body: {
+          is_enabled: true,
+          external_reference: 'quay.io/library/hello-world',
+          sync_status: 'NEVER_RUN',
+          robot_username: 'user1+testrobot',
+          sync_start_date: '2024-01-01T12:00:00Z',
+          sync_interval: 3600,
+          external_registry_config: {
+            verify_tls: true,
+            unsigned_images: false,
+            proxy: {http_proxy: null, https_proxy: null, no_proxy: null},
+          },
+          root_rule: {
+            rule_kind: 'tag_glob_csv',
+            rule_value: ['latest'],
+          },
+        },
+      }).as('getMirrorConfig');
+
+      cy.intercept(
+        'POST',
+        '/api/v1/repository/user1/hello-world/mirror/sync-now',
+        {
+          statusCode: 204,
+        },
+      ).as('syncNow');
+
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 200,
+        body: {
+          is_enabled: true,
+          external_reference: 'quay.io/library/hello-world',
+          sync_status: 'SYNCING',
+          robot_username: 'user1+testrobot',
+        },
+      }).as('getMirrorConfigSyncing');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getMirrorConfig');
+
+      // Click sync now button
+      cy.get('[data-testid="sync-now-button"]').click();
+
+      cy.wait('@syncNow');
+      cy.contains('Sync scheduled successfully').should('exist');
+    });
+
+    it('should cancel ongoing sync operation', () => {
+      // Mock mirror config with ongoing sync
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world/mirror*', {
+        statusCode: 200,
+        body: {
+          is_enabled: true,
+          external_reference: 'quay.io/library/hello-world',
+          sync_status: 'SYNCING',
+          robot_username: 'user1+testrobot',
+          sync_start_date: '2024-01-01T12:00:00Z',
+          sync_interval: 3600,
+          external_registry_config: {
+            verify_tls: true,
+            unsigned_images: false,
+            proxy: {http_proxy: null, https_proxy: null, no_proxy: null},
+          },
+          root_rule: {
+            rule_kind: 'tag_glob_csv',
+            rule_value: ['latest'],
+          },
+        },
+      }).as('getMirrorConfigSyncing');
+
+      cy.intercept(
+        'POST',
+        '/api/v1/repository/user1/hello-world/mirror/sync-cancel',
+        {
+          statusCode: 204,
+        },
+      ).as('cancelSync');
+
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 200,
+        body: {
+          is_enabled: true,
+          external_reference: 'quay.io/library/hello-world',
+          sync_status: 'NEVER_RUN',
+          robot_username: 'user1+testrobot',
+        },
+      }).as('getMirrorConfigCancelled');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getMirrorConfigSyncing');
+
+      // Check sync status shows syncing
+      cy.contains('Syncing').should('exist');
+
+      // Click cancel button
+      cy.get('[data-testid="cancel-sync-button"]').click();
+
+      cy.wait('@cancelSync');
+      cy.contains('Sync cancelled successfully').should('exist');
+    });
+
+    it('should disable sync/cancel buttons appropriately', () => {
+      // Mock mirror config with different states
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 200,
+        body: {
+          is_enabled: true,
+          external_reference: 'quay.io/library/hello-world',
+          sync_status: 'SYNCING',
+          robot_username: 'user1+testrobot',
+          sync_start_date: '2024-01-01T12:00:00Z',
+          sync_interval: 3600,
+          external_registry_config: {
+            verify_tls: true,
+            unsigned_images: false,
+            proxy: {http_proxy: null, https_proxy: null, no_proxy: null},
+          },
+          root_rule: {
+            rule_kind: 'tag_glob_csv',
+            rule_value: ['latest'],
+          },
+        },
+      }).as('getMirrorConfigSyncing');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getMirrorConfigSyncing');
+
+      // When syncing: Sync Now should be disabled, Cancel should be enabled
+      cy.get('[data-testid="sync-now-button"]').should('be.disabled');
+      cy.get('[data-testid="cancel-sync-button"]').should('not.be.disabled');
+    });
+  });
+
+  // TODO: VERIFY IF THESE TESTS ARE WORKING
+  describe('Robot User Selection', () => {
+    beforeEach(() => {
+      // Mock repository with MIRROR state
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+        body: {
+          name: 'hello-world',
+          namespace: 'user1',
+          state: 'MIRROR',
+          kind: 'image',
+          description: '',
+          is_public: true,
+          is_organization: false,
+          is_starred: false,
+          can_write: true,
+          can_admin: true,
+        },
+      }).as('getRepo');
+
+      // Mock no existing mirror config
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world/mirror*', {
+        statusCode: 404,
+      }).as('getMirrorConfig404');
+
+      // Mock robot accounts
+      cy.intercept('GET', '/api/v1/organization/user1/robots*', {
+        fixture: 'robots.json',
+      }).as('getRobots');
+
+      // Note: Teams API is not called for user namespaces (useFetchTeams has enabled: !(user.username === orgName))
+    });
+
+    it('should display robot user dropdown with options', () => {
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getRobots');
+
+      // Click robot user dropdown
+      cy.get('#robot-user-select').click();
+
+      // Check create options are at the top
+      cy.contains('Create team').should('exist');
+      cy.contains('Create robot account').should('exist');
+
+      // Check robots are listed (teams are not shown for user namespaces)
+      cy.contains('Robot accounts').should('exist');
+      cy.contains('user1+testrobot').should('exist');
+    });
+
+    it('should select robot user from dropdown', () => {
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getRobots');
+
+      // Select robot user
+      cy.get('#robot-user-select').click();
+      cy.contains('user1+testrobot').click();
+
+      // Check selection is reflected
+      cy.get('#robot-user-select').should('contain.text', 'user1+testrobot');
+    });
+
+    it.skip('should handle robot user selection errors', () => {
+      // Mock robot fetch error
+      cy.intercept('GET', '/api/v1/organization/user1/robots*', {
+        statusCode: 500,
+        body: {message: 'Internal server error'},
+      }).as('getRobotsError');
+
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+      cy.wait('@getRobotsError');
+
+      // Click robot user dropdown
+      cy.get('#robot-user-select').click();
+
+      // Should show error message
+      cy.contains('Error loading robot users').should('exist');
+    });
+  });
+
+  // TODO: VERIFY IF THESE TESTS ARE WORKING
+  describe.skip('Advanced Settings', () => {
+    beforeEach(() => {
+      // Mock repository with MIRROR state
+      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+        body: {
+          name: 'hello-world',
+          namespace: 'user1',
+          state: 'MIRROR',
+          kind: 'image',
+          description: '',
+          is_public: true,
+          is_organization: false,
+          is_starred: false,
+          can_write: true,
+          can_admin: true,
+        },
+      }).as('getRepo');
+
+      // Mock no existing mirror config
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
+        statusCode: 404,
+      }).as('getMirrorConfig404');
+    });
+
+    it('should configure TLS verification', () => {
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+
+      // Check TLS verification checkbox
+      cy.get('[data-testid="verify-tls-checkbox"]').should('not.be.checked');
+      cy.get('[data-testid="verify-tls-checkbox"]').check();
+      cy.get('[data-testid="verify-tls-checkbox"]').should('be.checked');
+    });
+
+    it('should configure unsigned images', () => {
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+
+      // Check unsigned images checkbox
+      cy.get('[data-testid="unsigned-images-checkbox"]').should(
+        'not.be.checked',
+      );
+      cy.get('[data-testid="unsigned-images-checkbox"]').check();
+      cy.get('[data-testid="unsigned-images-checkbox"]').should('be.checked');
+    });
+
+    it('should configure proxy settings', () => {
+      cy.visit('/repository/user1/hello-world?tab=mirroring');
+      cy.wait('@getRepo');
+
+      // Fill in proxy settings
+      cy.get('[data-testid="http-proxy-input"]').type(
+        'http://proxy.example.com:8080',
+      );
+      cy.get('[data-testid="https-proxy-input"]').type(
+        'https://proxy.example.com:8080',
+      );
+      cy.get('[data-testid="no-proxy-input"]').type('localhost,127.0.0.1');
+
+      // Check values are set
+      cy.get('[data-testid="http-proxy-input"]').should(
+        'have.value',
+        'http://proxy.example.com:8080',
+      );
+      cy.get('[data-testid="https-proxy-input"]').should(
+        'have.value',
+        'https://proxy.example.com:8080',
+      );
+      cy.get('[data-testid="no-proxy-input"]').should(
+        'have.value',
+        'localhost,127.0.0.1',
+      );
+    });
+  });
+});

--- a/web/cypress/e2e/mirroring.cy.ts
+++ b/web/cypress/e2e/mirroring.cy.ts
@@ -17,7 +17,7 @@ describe('Repository Mirroring', () => {
     ).as('getConfig');
   });
 
-  describe.skip('Feature Flag Behavior', () => {
+  describe('Feature Flag Behavior', () => {
     it('should not show mirroring tab when REPO_MIRROR feature is disabled', () => {
       cy.intercept('GET', '/config', (req) =>
         req.reply((res) => {
@@ -70,7 +70,7 @@ describe('Repository Mirroring', () => {
     });
   });
 
-  describe.skip('Repository State Requirements', () => {
+  describe('Repository State Requirements', () => {
     it('should show state warning for non-mirror repositories', () => {
       // Mock repository with NORMAL state - using wildcard pattern to catch all variations
       cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
@@ -128,7 +128,7 @@ describe('Repository Mirroring', () => {
     });
   });
 
-  describe.skip('New Mirror Configuration', () => {
+  describe('New Mirror Configuration', () => {
     beforeEach(() => {
       // Mock repository with MIRROR state
       cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
@@ -219,7 +219,7 @@ describe('Repository Mirroring', () => {
 
       // Select robot user
       cy.get('#robot-user-select').click();
-      cy.contains('user1+testrobot').click();
+      cy.contains('testorg+testrobot').click();
 
       // Now submit button should be enabled
       cy.get('[data-testid="submit-button"]').should('not.be.disabled');
@@ -232,7 +232,7 @@ describe('Repository Mirroring', () => {
           is_enabled: true,
           external_reference: 'quay.io/library/hello-world',
           sync_status: 'NEVER_RUN',
-          robot_username: 'user1+testrobot',
+          robot_username: 'testorg+testrobot',
         },
       }).as('createMirrorConfig');
 
@@ -248,7 +248,7 @@ describe('Repository Mirroring', () => {
 
       // Select robot user
       cy.get('#robot-user-select').click();
-      cy.contains('user1+testrobot').click();
+      cy.contains('testorg+testrobot').click();
 
       // Submit form
       cy.get('[data-testid="submit-button"]').click();
@@ -275,7 +275,7 @@ describe('Repository Mirroring', () => {
 
       // Select robot user
       cy.get('#robot-user-select').click();
-      cy.contains('user1+testrobot').click();
+      cy.contains('testorg+testrobot').click();
 
       // Submit form
       cy.get('[data-testid="submit-button"]').click();
@@ -285,7 +285,7 @@ describe('Repository Mirroring', () => {
     });
   });
 
-  describe.skip('Existing Mirror Configuration', () => {
+  describe('Existing Mirror Configuration', () => {
     beforeEach(() => {
       // Mock repository with MIRROR state
       cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
@@ -426,10 +426,7 @@ describe('Repository Mirroring', () => {
     });
   });
 
-  // ALL TESTS ABOVE ARE WORKING
-
-  // TODO: these tests are not working
-  describe.skip('Sync Operations', () => {
+  describe('Sync Operations', () => {
     beforeEach(() => {
       // Mock repository with MIRROR state
       cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
@@ -456,7 +453,7 @@ describe('Repository Mirroring', () => {
           is_enabled: true,
           external_reference: 'quay.io/library/hello-world',
           sync_status: 'NEVER_RUN',
-          robot_username: 'user1+testrobot',
+          robot_username: 'testorg+testrobot',
           sync_start_date: '2024-01-01T12:00:00Z',
           sync_interval: 3600,
           external_registry_config: {
@@ -479,16 +476,6 @@ describe('Repository Mirroring', () => {
         },
       ).as('syncNow');
 
-      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
-        statusCode: 200,
-        body: {
-          is_enabled: true,
-          external_reference: 'quay.io/library/hello-world',
-          sync_status: 'SYNCING',
-          robot_username: 'user1+testrobot',
-        },
-      }).as('getMirrorConfigSyncing');
-
       cy.visit('/repository/user1/hello-world?tab=mirroring');
       cy.wait('@getRepo');
       cy.wait('@getMirrorConfig');
@@ -502,13 +489,13 @@ describe('Repository Mirroring', () => {
 
     it('should cancel ongoing sync operation', () => {
       // Mock mirror config with ongoing sync
-      cy.intercept('GET', '**/api/v1/repository/user1/hello-world/mirror*', {
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
         statusCode: 200,
         body: {
           is_enabled: true,
           external_reference: 'quay.io/library/hello-world',
           sync_status: 'SYNCING',
-          robot_username: 'user1+testrobot',
+          robot_username: 'testorg+testrobot',
           sync_start_date: '2024-01-01T12:00:00Z',
           sync_interval: 3600,
           external_registry_config: {
@@ -521,7 +508,7 @@ describe('Repository Mirroring', () => {
             rule_value: ['latest'],
           },
         },
-      }).as('getMirrorConfigSyncing');
+      }).as('getMirrorConfig');
 
       cy.intercept(
         'POST',
@@ -531,19 +518,9 @@ describe('Repository Mirroring', () => {
         },
       ).as('cancelSync');
 
-      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror', {
-        statusCode: 200,
-        body: {
-          is_enabled: true,
-          external_reference: 'quay.io/library/hello-world',
-          sync_status: 'NEVER_RUN',
-          robot_username: 'user1+testrobot',
-        },
-      }).as('getMirrorConfigCancelled');
-
       cy.visit('/repository/user1/hello-world?tab=mirroring');
       cy.wait('@getRepo');
-      cy.wait('@getMirrorConfigSyncing');
+      cy.wait('@getMirrorConfig');
 
       // Check sync status shows syncing
       cy.contains('Syncing').should('exist');
@@ -588,11 +565,10 @@ describe('Repository Mirroring', () => {
     });
   });
 
-  // TODO: VERIFY IF THESE TESTS ARE WORKING
   describe('Robot User Selection', () => {
     beforeEach(() => {
       // Mock repository with MIRROR state
-      cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world*', {
         body: {
           name: 'hello-world',
           namespace: 'user1',
@@ -608,7 +584,7 @@ describe('Repository Mirroring', () => {
       }).as('getRepo');
 
       // Mock no existing mirror config
-      cy.intercept('GET', '**/api/v1/repository/user1/hello-world/mirror*', {
+      cy.intercept('GET', '/api/v1/repository/user1/hello-world/mirror*', {
         statusCode: 404,
       }).as('getMirrorConfig404');
 
@@ -616,8 +592,6 @@ describe('Repository Mirroring', () => {
       cy.intercept('GET', '/api/v1/organization/user1/robots*', {
         fixture: 'robots.json',
       }).as('getRobots');
-
-      // Note: Teams API is not called for user namespaces (useFetchTeams has enabled: !(user.username === orgName))
     });
 
     it('should display robot user dropdown with options', () => {
@@ -634,7 +608,7 @@ describe('Repository Mirroring', () => {
 
       // Check robots are listed (teams are not shown for user namespaces)
       cy.contains('Robot accounts').should('exist');
-      cy.contains('user1+testrobot').should('exist');
+      cy.contains('testorg+testrobot').should('exist');
     });
 
     it('should select robot user from dropdown', () => {
@@ -644,33 +618,17 @@ describe('Repository Mirroring', () => {
 
       // Select robot user
       cy.get('#robot-user-select').click();
-      cy.contains('user1+testrobot').click();
+      cy.contains('testorg+testrobot').click();
 
       // Check selection is reflected
-      cy.get('#robot-user-select').should('contain.text', 'user1+testrobot');
-    });
-
-    it.skip('should handle robot user selection errors', () => {
-      // Mock robot fetch error
-      cy.intercept('GET', '/api/v1/organization/user1/robots*', {
-        statusCode: 500,
-        body: {message: 'Internal server error'},
-      }).as('getRobotsError');
-
-      cy.visit('/repository/user1/hello-world?tab=mirroring');
-      cy.wait('@getRepo');
-      cy.wait('@getRobotsError');
-
-      // Click robot user dropdown
-      cy.get('#robot-user-select').click();
-
-      // Should show error message
-      cy.contains('Error loading robot users').should('exist');
+      cy.get('#robot-user-select input').should(
+        'have.value',
+        'testorg+testrobot',
+      );
     });
   });
 
-  // TODO: VERIFY IF THESE TESTS ARE WORKING
-  describe.skip('Advanced Settings', () => {
+  describe('Advanced Settings', () => {
     beforeEach(() => {
       // Mock repository with MIRROR state
       cy.intercept('GET', '**/api/v1/repository/user1/hello-world*', {

--- a/web/src/resources/MirroringResource.ts
+++ b/web/src/resources/MirroringResource.ts
@@ -105,9 +105,9 @@ export const syncMirror = async (
   repoName: string,
 ): Promise<void> => {
   const response = await axios.post(
-    `/api/v1/repository/${namespace}/${repoName}/mirror/sync`,
+    `/api/v1/repository/${namespace}/${repoName}/mirror/sync-now`,
   );
-  assertHttpCode(response.status, 200);
+  assertHttpCode(response.status, 204);
 };
 
 export const cancelSync = async (
@@ -115,9 +115,9 @@ export const cancelSync = async (
   repoName: string,
 ): Promise<void> => {
   const response = await axios.post(
-    `/api/v1/repository/${namespace}/${repoName}/mirror/sync/cancel`,
+    `/api/v1/repository/${namespace}/${repoName}/mirror/sync-cancel`,
   );
-  assertHttpCode(response.status, 200);
+  assertHttpCode(response.status, 204);
 };
 
 // Status message mapping

--- a/web/src/resources/MirroringResource.ts
+++ b/web/src/resources/MirroringResource.ts
@@ -1,0 +1,133 @@
+import {AxiosResponse} from 'axios';
+import axios from 'src/libs/axios';
+import {assertHttpCode} from './ErrorHandling';
+
+// Mirroring configuration types
+export interface MirroringConfig {
+  is_enabled: boolean;
+  external_reference: string;
+  external_registry_username?: string | null;
+  external_registry_password?: string | null;
+  robot_username: string;
+  external_registry_config: {
+    verify_tls: boolean;
+    unsigned_images: boolean;
+    proxy: {
+      http_proxy: string | null;
+      https_proxy: string | null;
+      no_proxy: string | null;
+    };
+  };
+  sync_start_date: string;
+  sync_interval: number;
+  root_rule: {
+    rule_kind: string;
+    rule_value: string[];
+  };
+}
+
+export interface MirroringConfigResponse extends MirroringConfig {
+  sync_status:
+    | 'NEVER_RUN'
+    | 'SYNC_NOW'
+    | 'SYNC_FAILED'
+    | 'SYNCING'
+    | 'SYNC_SUCCESS';
+  last_sync: string;
+  last_error: string;
+  status_message: string;
+  mirror_type: string;
+  external_reference: string;
+  external_registry_username: string | null;
+  sync_expiration_date: string | null;
+  sync_retries_remaining: number | null;
+  robot_username: string;
+}
+
+// Date conversion utilities
+export const timestampToISO = (ts: number): string => {
+  const dt = new Date(ts * 1000).toISOString();
+  return dt.split('.')[0] + 'Z'; // Remove milliseconds
+};
+
+export const timestampFromISO = (dt: string): number => {
+  return Math.floor(new Date(dt).getTime() / 1000);
+};
+
+// API functions
+export const getMirrorConfig = async (
+  namespace: string,
+  repoName: string,
+): Promise<MirroringConfigResponse> => {
+  const response: AxiosResponse<MirroringConfigResponse> = await axios.get(
+    `/api/v1/repository/${namespace}/${repoName}/mirror`,
+  );
+  assertHttpCode(response.status, 200);
+  return response.data;
+};
+
+export const createMirrorConfig = async (
+  namespace: string,
+  repoName: string,
+  config: MirroringConfig,
+): Promise<MirroringConfigResponse> => {
+  const response: AxiosResponse<MirroringConfigResponse> = await axios.post(
+    `/api/v1/repository/${namespace}/${repoName}/mirror`,
+    config,
+  );
+  assertHttpCode(response.status, 201);
+  return response.data;
+};
+
+export const updateMirrorConfig = async (
+  namespace: string,
+  repoName: string,
+  config: Partial<MirroringConfig>,
+): Promise<MirroringConfigResponse> => {
+  const response: AxiosResponse<MirroringConfigResponse> = await axios.put(
+    `/api/v1/repository/${namespace}/${repoName}/mirror`,
+    config,
+  );
+  assertHttpCode(response.status, 201);
+  return response.data;
+};
+
+export const toggleMirroring = async (
+  namespace: string,
+  repoName: string,
+  isEnabled: boolean,
+): Promise<MirroringConfigResponse> => {
+  return updateMirrorConfig(namespace, repoName, {is_enabled: isEnabled});
+};
+
+export const syncMirror = async (
+  namespace: string,
+  repoName: string,
+): Promise<void> => {
+  const response = await axios.post(
+    `/api/v1/repository/${namespace}/${repoName}/mirror/sync`,
+  );
+  assertHttpCode(response.status, 200);
+};
+
+export const cancelSync = async (
+  namespace: string,
+  repoName: string,
+): Promise<void> => {
+  const response = await axios.post(
+    `/api/v1/repository/${namespace}/${repoName}/mirror/sync/cancel`,
+  );
+  assertHttpCode(response.status, 200);
+};
+
+// Status message mapping
+export const statusLabels: Record<
+  MirroringConfigResponse['sync_status'],
+  string
+> = {
+  NEVER_RUN: 'Scheduled',
+  SYNC_NOW: 'Scheduled Now',
+  SYNC_FAILED: 'Failed',
+  SYNCING: 'Syncing',
+  SYNC_SUCCESS: 'Success',
+};

--- a/web/src/routes/RepositoryDetails/Mirroring/Mirroring.css
+++ b/web/src/routes/RepositoryDetails/Mirroring/Mirroring.css
@@ -1,22 +1,3 @@
-.mirroring-container {
-  max-width: 700px; /* or 600px, adjust as needed */
-  padding: var(--pf-v5-global--spacer--md);
-}
-
-.mirroring-container .pf-v5-c-divider {
-  margin-top: var(--pf-v5-global--spacer--lg);
-}
-
-.mirroring-credentials-helper {
-  text-align: center;
-  display: block; /* Ensures the text centers properly */
-}
-
-.mirroring-form {
-  max-width: 700px;
-  margin: 0 auto;
-}
-
 .pf-v5-c-title.pf-m-2xl {
   text-align: left;
   margin-top: var(--pf-v5-global--spacer--md);
@@ -30,16 +11,4 @@
 
 .pf-v5-c-title.pf-m-lg {
   text-align: center;
-}
-
-.pf-v5-c-form__label {
-  min-width: 180px; /* Try 180px, 200px, or whatever looks best */
-  max-width: 200px;
-  width: 200px;
-}
-
-.mirroring-button {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
 }

--- a/web/src/routes/RepositoryDetails/Mirroring/Mirroring.css
+++ b/web/src/routes/RepositoryDetails/Mirroring/Mirroring.css
@@ -1,0 +1,45 @@
+.mirroring-container {
+  max-width: 700px; /* or 600px, adjust as needed */
+  padding: var(--pf-v5-global--spacer--md);
+}
+
+.mirroring-container .pf-v5-c-divider {
+  margin-top: var(--pf-v5-global--spacer--lg);
+}
+
+.mirroring-credentials-helper {
+  text-align: center;
+  display: block; /* Ensures the text centers properly */
+}
+
+.mirroring-form {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.pf-v5-c-title.pf-m-2xl {
+  text-align: left;
+  margin-top: var(--pf-v5-global--spacer--md);
+}
+
+.pf-v5-c-title.pf-m-xl {
+  text-align: left;
+  margin-top: var(--pf-v5-global--spacer--sm);
+  margin-bottom: var(--pf-v5-global--spacer--xl);
+}
+
+.pf-v5-c-title.pf-m-lg {
+  text-align: center;
+}
+
+.pf-v5-c-form__label {
+  min-width: 180px; /* Try 180px, 200px, or whatever looks best */
+  max-width: 200px;
+  width: 200px;
+}
+
+.mirroring-button {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/web/src/routes/RepositoryDetails/Mirroring/Mirroring.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/Mirroring.tsx
@@ -1,0 +1,216 @@
+import React, {useState} from 'react';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  Checkbox,
+  Button,
+  ButtonVariant,
+  ActionGroup,
+  Divider,
+  Text,
+  TextContent,
+  Title,
+  InputGroup,
+  Select,
+  SelectOption,
+  MenuToggle,
+} from '@patternfly/react-core';
+import {useRepository} from 'src/hooks/UseRepository';
+import './Mirroring.css';
+
+interface MirroringProps {
+  organization: string;
+  repository: string;
+}
+
+export const Mirroring: React.FC<MirroringProps> = ({
+  organization,
+  repository,
+}) => {
+  const {repoDetails} = useRepository(organization, repository);
+  const [syncValue, setSyncValue] = useState('');
+  const [isSelectOpen, setIsSelectOpen] = useState(false);
+  const [syncUnit, setSyncUnit] = useState('minutes');
+  const [isHovered, setIsHovered] = useState(false);
+
+  if (!repoDetails) {
+    return <Text>Repository not found</Text>;
+  }
+
+  return (
+    <div className="mirroring-container">
+      <TextContent>
+        <Title headingLevel="h2">Repository Mirroring</Title>
+      </TextContent>
+      <TextContent>
+        This feature will convert the repository into a mirror. Changes to the
+        external repository will be duplicated here. While enabled, users will
+        be unable to push images to this repository.
+      </TextContent>
+      <Form isWidthLimited>
+        <Divider />
+
+        <Title headingLevel="h3" className="mirroring-section-title">
+          External Repository
+        </Title>
+        <FormGroup
+          label="Registry Location"
+          fieldId="external_reference"
+          isStack
+        >
+          <TextInput
+            type="text"
+            id="external_reference"
+            name="external_reference"
+            placeholder="quay.io/redhat/quay"
+          />
+        </FormGroup>
+
+        <FormGroup label="Tags" fieldId="tags" isStack>
+          <TextInput
+            type="text"
+            id="tags"
+            name="tags"
+            placeholder="Examples: latest, 3.3*, *"
+          />
+        </FormGroup>
+
+        <FormGroup label="Start Date" fieldId="sync_start_date" isStack>
+          <TextInput
+            type="datetime-local"
+            id="sync_start_date"
+            name="sync_start_date"
+          />
+        </FormGroup>
+
+        <FormGroup label="Sync Interval" fieldId="sync_interval" isStack>
+          <InputGroup
+            onPointerEnterCapture={() => setIsHovered(true)}
+            onPointerLeaveCapture={() => setIsHovered(false)}
+            className={isHovered ? 'pf-v5-u-background-color-200' : ''}
+          >
+            <TextInput
+              type="number"
+              id="sync_interval"
+              name="sync_interval"
+              value={syncValue}
+              onChange={(_event, value) => setSyncValue(value)}
+              aria-label="Sync interval value"
+            />
+            <Select
+              isOpen={isSelectOpen}
+              onOpenChange={(isOpen) => setIsSelectOpen(isOpen)}
+              onSelect={(_event, value) => {
+                setSyncUnit(value as string);
+                setIsSelectOpen(false);
+              }}
+              selected={syncUnit}
+              aria-label="Sync interval unit"
+              toggle={(toggleRef) => (
+                <MenuToggle
+                  ref={toggleRef}
+                  onClick={() => setIsSelectOpen(!isSelectOpen)}
+                  isExpanded={isSelectOpen}
+                >
+                  {syncUnit}
+                </MenuToggle>
+              )}
+            >
+              <SelectOption value="seconds">seconds</SelectOption>
+              <SelectOption value="minutes">minutes</SelectOption>
+              <SelectOption value="hours">hours</SelectOption>
+              <SelectOption value="days">days</SelectOption>
+              <SelectOption value="weeks">weeks</SelectOption>
+            </Select>
+          </InputGroup>
+        </FormGroup>
+
+        <FormGroup label="Robot User" fieldId="robot_username" isStack>
+          <TextInput type="text" id="robot_username" name="robot_username" />
+        </FormGroup>
+
+        <Divider />
+        <Title headingLevel="h3" className="mirroring-section-title">
+          Credentials
+        </Title>
+        <Text
+          component="small"
+          className="pf-v5-c-form__helper-text mirroring-credentials-helper"
+        >
+          Required if the external repository is private.
+        </Text>
+        <FormGroup label="Username" fieldId="username" isStack>
+          <TextInput type="text" id="username" name="username" />
+        </FormGroup>
+
+        <FormGroup
+          label="Password"
+          fieldId="external_registry_password"
+          isStack
+        >
+          <TextInput
+            type="password"
+            id="external_registry_password"
+            name="external_registry_password"
+          />
+        </FormGroup>
+
+        <Divider />
+        <Title headingLevel="h3" className="mirroring-section-title">
+          Advanced Settings
+        </Title>
+        <FormGroup fieldId="verify_tls" isStack>
+          <Checkbox
+            label="Verify TLS"
+            id="verify_tls"
+            name="verify_tls"
+            description="Require HTTPS and verify certificates when talking to the external registry."
+          />
+        </FormGroup>
+
+        <FormGroup fieldId="unsigned_images" isStack>
+          <Checkbox
+            label="Accept Unsigned Images"
+            id="unsigned_images"
+            name="unsigned_images"
+            description="Allow unsigned images to be mirrored."
+          />
+        </FormGroup>
+
+        <FormGroup label="HTTP Proxy" fieldId="http_proxy" isStack>
+          <TextInput
+            type="text"
+            id="http_proxy"
+            name="http_proxy"
+            placeholder="proxy.example.com"
+          />
+        </FormGroup>
+
+        <FormGroup label="HTTPs Proxy" fieldId="https_proxy" isStack>
+          <TextInput
+            type="text"
+            id="https_proxy"
+            name="https_proxy"
+            placeholder="proxy.example.com"
+          />
+        </FormGroup>
+
+        <FormGroup label="No Proxy" fieldId="no_proxy" isStack>
+          <TextInput
+            type="text"
+            id="no_proxy"
+            name="no_proxy"
+            placeholder="example.com"
+          />
+        </FormGroup>
+
+        <ActionGroup>
+          <Button variant={ButtonVariant.primary} className="mirroring-button">
+            Enable Mirror
+          </Button>
+        </ActionGroup>
+      </Form>
+    </div>
+  );
+};

--- a/web/src/routes/RepositoryDetails/Mirroring/Mirroring.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/Mirroring.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {
   Form,
   FormGroup,
@@ -14,28 +14,411 @@ import {
   InputGroup,
   Select,
   SelectOption,
+  SelectGroup,
   MenuToggle,
+  Spinner,
 } from '@patternfly/react-core';
+import {DesktopIcon, UsersIcon} from '@patternfly/react-icons';
 import {useRepository} from 'src/hooks/UseRepository';
+import {useAlerts} from 'src/hooks/UseAlerts';
+import {AlertVariant} from 'src/atoms/AlertState';
+import FormError from 'src/components/errors/FormError';
+import {useFetchRobotAccounts} from 'src/hooks/useRobotAccounts';
+import {useFetchTeams} from 'src/hooks/UseTeams';
+import CreateRobotAccountModal from 'src/components/modals/CreateRobotAccountModal';
+import {CreateTeamModal} from 'src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreateTeamModal';
+import EntitySearch from 'src/components/EntitySearch';
+import {Entity, EntityKind} from 'src/resources/UserResource';
+import {RepoPermissionDropdownItems} from 'src/routes/RepositoriesList/RobotAccountsList';
+import {
+  MirroringConfigResponse,
+  getMirrorConfig,
+  createMirrorConfig,
+  updateMirrorConfig,
+  cancelSync,
+  timestampToISO,
+  timestampFromISO,
+  statusLabels,
+} from 'src/resources/MirroringResource';
 import './Mirroring.css';
 
 interface MirroringProps {
-  organization: string;
-  repository: string;
+  namespace: string;
+  repoName: string;
 }
 
-export const Mirroring: React.FC<MirroringProps> = ({
-  organization,
-  repository,
-}) => {
-  const {repoDetails} = useRepository(organization, repository);
+type validate = 'success' | 'warning' | 'error' | 'default';
+
+export const Mirroring: React.FC<MirroringProps> = ({namespace, repoName}) => {
+  const {
+    repoDetails,
+    errorLoadingRepoDetails,
+    isLoading: isLoadingRepo,
+  } = useRepository(namespace, repoName);
+  const {addAlert} = useAlerts();
+
+  // Form state
+  const [externalReference, setExternalReference] = useState('');
+  const [tags, setTags] = useState('');
+  const [syncStartDate, setSyncStartDate] = useState('');
   const [syncValue, setSyncValue] = useState('');
-  const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [syncUnit, setSyncUnit] = useState('minutes');
+  const [robotUsername, setRobotUsername] = useState('');
+  const [selectedRobot, setSelectedRobot] = useState<Entity | null>(null);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [verifyTls, setVerifyTls] = useState(true);
+  const [httpProxy, setHttpProxy] = useState('');
+  const [httpsProxy, setHttpsProxy] = useState('');
+  const [noProxy, setNoProxy] = useState('');
+  const [unsignedImages, setUnsignedImages] = useState(false);
+
+  // UI state
+  const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
+  const [isCreateRobotModalOpen, setIsCreateRobotModalOpen] = useState(false);
+  const [isCreateTeamModalOpen, setIsCreateTeamModalOpen] = useState(false);
+  const [teamName, setTeamName] = useState('');
+  const [teamDescription, setTeamDescription] = useState('');
+
+  // Loading and error states
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [config, setConfig] = useState<MirroringConfigResponse | null>(null);
+
+  // Validation state
+  const [validated, setValidated] = useState<Record<string, validate>>({});
+
+  // Fetch robot accounts for the dropdown
+  const {robots} = useFetchRobotAccounts(namespace);
+
+  // Fetch teams for the dropdown
+  const {teams} = useFetchTeams(namespace);
+
+  // Unit conversion utilities
+  const timeUnits = {
+    seconds: 1,
+    minutes: 60,
+    hours: 60 * 60,
+    days: 60 * 60 * 24,
+    weeks: 60 * 60 * 24 * 7,
+  };
+
+  // Convert display value + unit to seconds for backend
+  const convertToSeconds = (value: number, unit: string): number => {
+    return value * (timeUnits[unit] || 1);
+  };
+
+  // Convert seconds from backend to best display unit + value
+  const convertFromSeconds = (
+    seconds: number,
+  ): {value: number; unit: string} => {
+    // Find the largest unit that divides evenly into the seconds
+    const units = ['weeks', 'days', 'hours', 'minutes', 'seconds'];
+    for (const unit of units) {
+      const divisor = timeUnits[unit];
+      if (seconds % divisor === 0) {
+        return {value: seconds / divisor, unit};
+      }
+    }
+    // Fallback to seconds if no clean division
+    return {value: seconds, unit: 'seconds'};
+  };
+
+  // Create options for the dropdown (teams, robots, and creation options)
+  const robotOptions = [
+    <React.Fragment key="dropdown-options">
+      <SelectGroup label="Teams" key="teams">
+        {teams?.map(({name}) => (
+          <SelectOption
+            key={name}
+            value={name}
+            onClick={() => {
+              const teamEntity: Entity = {
+                name,
+                is_robot: false,
+                kind: EntityKind.team,
+                is_org_member: true,
+              };
+              setSelectedRobot(teamEntity);
+              setRobotUsername(name);
+            }}
+          >
+            {name}
+          </SelectOption>
+        ))}
+      </SelectGroup>
+      <SelectGroup label="Robot accounts" key="robot-accounts">
+        {robots?.map(({name}) => (
+          <SelectOption
+            key={name}
+            value={name}
+            onClick={() => {
+              const robotEntity: Entity = {
+                name,
+                is_robot: true,
+                kind: EntityKind.user,
+                is_org_member: true,
+              };
+              setSelectedRobot(robotEntity);
+              setRobotUsername(name);
+            }}
+          >
+            {name}
+          </SelectOption>
+        ))}
+      </SelectGroup>
+      <Divider component="li" key="divider" />
+      <SelectOption
+        key="create-team"
+        component="button"
+        onClick={() => setIsCreateTeamModalOpen(true)}
+      >
+        <UsersIcon /> &nbsp; Create team
+      </SelectOption>
+      <SelectOption
+        key="create-robot"
+        component="button"
+        onClick={() => setIsCreateRobotModalOpen(true)}
+      >
+        <DesktopIcon /> &nbsp; Create robot account
+      </SelectOption>
+    </React.Fragment>,
+  ];
+
+  // Team validation function
+  const validateTeamName = (name: string): boolean => {
+    return /^([a-z0-9]+(?:[._-][a-z0-9]+)*)$/.test(name);
+  };
+
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        const response = await getMirrorConfig(namespace, repoName);
+        setConfig(response);
+
+        // Update form state from response
+        setExternalReference(response.external_reference);
+        setTags(
+          Array.isArray(response.root_rule.rule_value)
+            ? response.root_rule.rule_value.join(', ')
+            : response.root_rule.rule_value,
+        );
+        setSyncStartDate(
+          response.sync_start_date.replace('Z', '').slice(0, 16),
+        );
+        const {value, unit} = convertFromSeconds(response.sync_interval);
+        setSyncValue(value.toString());
+        setSyncUnit(unit);
+        setRobotUsername(response.robot_username);
+        // Set selected robot based on the robot username
+        if (response.robot_username) {
+          setSelectedRobot({
+            name: response.robot_username,
+            is_robot: true,
+            kind: EntityKind.user,
+            is_org_member: true,
+          });
+        }
+        setUsername(response.external_registry_username);
+        setPassword(''); // Password is not returned from the API for security reasons
+        setVerifyTls(response.external_registry_config.verify_tls);
+        setUnsignedImages(
+          response.external_registry_config.unsigned_images ?? false,
+        );
+        setHttpProxy(response.external_registry_config.proxy.http_proxy);
+        setHttpsProxy(response.external_registry_config.proxy.https_proxy);
+        setNoProxy(response.external_registry_config.proxy.no_proxy);
+      } catch (err) {
+        // If the error is a 404, it means no mirror config exists yet
+        if (err.response?.status === 404) {
+          console.info(
+            'No repository mirror configuration (404). This is expected for a new mirror setup.',
+            err,
+          );
+          setConfig(null);
+          // Set default values for a new mirror configuration
+          setExternalReference('');
+          setTags('');
+          // Get current date/time in local timezone for datetime-local input
+          const now = new Date();
+          const localDateTime = new Date(
+            now.getTime() - now.getTimezoneOffset() * 60000,
+          )
+            .toISOString()
+            .slice(0, 16);
+          setSyncStartDate(localDateTime);
+          setSyncValue('');
+          setSyncUnit('seconds');
+          setRobotUsername('');
+          setSelectedRobot(null);
+          setUsername('');
+          setPassword('');
+          setVerifyTls(false);
+          setUnsignedImages(false);
+          setHttpProxy('');
+          setHttpsProxy('');
+          setNoProxy('');
+        } else {
+          console.error('Error fetching mirror config:', err);
+          setError(err.message);
+          addAlert({
+            variant: AlertVariant.Failure,
+            title: 'Error loading mirror configuration',
+            message: err.message,
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (repoDetails) {
+      if (repoDetails.state === 'MIRROR') {
+        fetchConfig();
+      } else {
+        setIsLoading(false);
+      }
+    } else if (!isLoadingRepo) {
+      // If we're not loading repo details and we don't have them, something went wrong
+      setIsLoading(false);
+    }
+  }, [namespace, repoName, repoDetails, isLoadingRepo]);
+
+  const validateField = (
+    name: string,
+    value: string | number | undefined,
+  ): validate => {
+    if (!value) return 'error';
+    return 'success';
+  };
+
+  const validateForm = (): boolean => {
+    const newValidated = {
+      externalReference: validateField('externalReference', externalReference),
+      tags: validateField('tags', tags),
+      syncStartDate: validateField('syncStartDate', syncStartDate),
+      syncValue: validateField('syncValue', syncValue),
+      robotUsername: validateField('robotUsername', robotUsername),
+    };
+
+    setValidated(newValidated);
+    return Object.values(newValidated).every((v) => v === 'success');
+  };
+
+  // Check if required fields are filled without side effects
+  const isFormValid = () => {
+    const isValidSyncValue =
+      syncValue.trim() !== '' &&
+      !isNaN(Number(syncValue)) &&
+      Number(syncValue) > 0;
+    return !!(
+      externalReference &&
+      tags &&
+      syncStartDate &&
+      isValidSyncValue &&
+      robotUsername
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (!validateForm()) {
+      return;
+    }
+
+    try {
+      // Split and clean up tags to match backend expectation
+      const tagPatterns = tags
+        .split(',')
+        .map((tag) => tag.trim())
+        .filter((tag) => tag.length > 0);
+
+      const mirrorConfig = {
+        is_enabled: true,
+        external_reference: externalReference,
+        external_registry_username: username || null,
+        external_registry_password: password || null,
+        sync_start_date: timestampToISO(timestampFromISO(syncStartDate)),
+        sync_interval: convertToSeconds(Number(syncValue), syncUnit),
+        robot_username: robotUsername,
+        external_registry_config: {
+          verify_tls: verifyTls,
+          unsigned_images: unsignedImages,
+          proxy: {
+            http_proxy: httpProxy || null,
+            https_proxy: httpsProxy || null,
+            no_proxy: noProxy || null,
+          },
+        },
+        root_rule: {
+          rule_kind: 'tag_glob_csv',
+          rule_value: tagPatterns,
+        },
+      };
+
+      if (config) {
+        await updateMirrorConfig(namespace, repoName, mirrorConfig);
+      } else {
+        await createMirrorConfig(namespace, repoName, mirrorConfig);
+      }
+
+      addAlert({
+        variant: AlertVariant.Success,
+        title: 'Mirror configuration saved successfully',
+      });
+    } catch (err) {
+      setError(err.message);
+      addAlert({
+        variant: AlertVariant.Failure,
+        title: 'Error saving mirror configuration',
+        message: err.message,
+      });
+    }
+  };
+
+  if (isLoadingRepo) {
+    return <Spinner size="md" />;
+  }
+
+  if (errorLoadingRepoDetails) {
+    return (
+      <FormError
+        message={
+          typeof errorLoadingRepoDetails === 'object' &&
+          errorLoadingRepoDetails !== null &&
+          'message' in errorLoadingRepoDetails
+            ? String(errorLoadingRepoDetails.message)
+            : 'Error loading repository'
+        }
+        setErr={setError}
+      />
+    );
+  }
 
   if (!repoDetails) {
     return <Text>Repository not found</Text>;
+  }
+
+  if (repoDetails.state !== 'MIRROR') {
+    return (
+      <div className="mirroring-container">
+        <TextContent>
+          <Text>
+            This repository&apos;s state is <strong>{repoDetails.state}</strong>
+            . Use the settings tab and change it to <strong>Mirror</strong> to
+            manage its mirroring configuration.
+          </Text>
+        </TextContent>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return <Spinner size="md" />;
+  }
+
+  if (error) {
+    return <FormError message={error} setErr={setError} />;
   }
 
   return (
@@ -44,15 +427,28 @@ export const Mirroring: React.FC<MirroringProps> = ({
         <Title headingLevel="h2">Repository Mirroring</Title>
       </TextContent>
       <TextContent>
-        This feature will convert the repository into a mirror. Changes to the
-        external repository will be duplicated here. While enabled, users will
-        be unable to push images to this repository.
+        {config ? (
+          <Text>
+            This repository is configured as a mirror. While enabled, Quay will
+            periodically replicate any matching images on the external registry.
+            Users cannot manually push to this repository.
+          </Text>
+        ) : (
+          <Text>
+            This feature will convert{' '}
+            <strong>
+              {namespace}/{repoName}
+            </strong>{' '}
+            into a mirror. Changes to the external repository will be duplicated
+            here. While enabled, users will be unable to push images to this
+            repository.
+          </Text>
+        )}
       </TextContent>
       <Form isWidthLimited>
         <Divider />
-
         <Title headingLevel="h3" className="mirroring-section-title">
-          External Repository
+          {config ? 'Configuration' : 'External Repository'}
         </Title>
         <FormGroup
           label="Registry Location"
@@ -64,15 +460,24 @@ export const Mirroring: React.FC<MirroringProps> = ({
             id="external_reference"
             name="external_reference"
             placeholder="quay.io/redhat/quay"
+            value={externalReference}
+            onChange={(_event, value) => setExternalReference(value)}
+            validated={validated.externalReference}
           />
         </FormGroup>
 
         <FormGroup label="Tags" fieldId="tags" isStack>
+          <Text component="small" className="pf-v5-c-form__helper-text">
+            Comma-separated list of tag patterns to synchronize.
+          </Text>
           <TextInput
             type="text"
             id="tags"
             name="tags"
             placeholder="Examples: latest, 3.3*, *"
+            value={tags}
+            onChange={(_event, value) => setTags(value)}
+            validated={validated.tags}
           />
         </FormGroup>
 
@@ -81,6 +486,9 @@ export const Mirroring: React.FC<MirroringProps> = ({
             type="datetime-local"
             id="sync_start_date"
             name="sync_start_date"
+            value={syncStartDate}
+            onChange={(_event, value) => setSyncStartDate(value)}
+            validated={validated.syncStartDate}
           />
         </FormGroup>
 
@@ -91,11 +499,18 @@ export const Mirroring: React.FC<MirroringProps> = ({
             className={isHovered ? 'pf-v5-u-background-color-200' : ''}
           >
             <TextInput
-              type="number"
+              type="text"
               id="sync_interval"
               name="sync_interval"
               value={syncValue}
-              onChange={(_event, value) => setSyncValue(value)}
+              onChange={(_event, value) => {
+                // Only allow digits
+                const numericValue = value.replace(/[^0-9]/g, '');
+                setSyncValue(numericValue);
+              }}
+              pattern="[0-9]*"
+              inputMode="numeric"
+              validated={validated.syncValue}
               aria-label="Sync interval value"
             />
             <Select
@@ -127,7 +542,23 @@ export const Mirroring: React.FC<MirroringProps> = ({
         </FormGroup>
 
         <FormGroup label="Robot User" fieldId="robot_username" isStack>
-          <TextInput type="text" id="robot_username" name="robot_username" />
+          <EntitySearch
+            id="robot-user-select"
+            org={namespace}
+            includeTeams={true}
+            onSelect={(robot: Entity) => {
+              setSelectedRobot(robot);
+              setRobotUsername(robot.name);
+            }}
+            onClear={() => {
+              setSelectedRobot(null);
+              setRobotUsername('');
+            }}
+            value={selectedRobot?.name}
+            onError={() => console.error('Error fetching robots')}
+            defaultOptions={robotOptions}
+            placeholderText="Select a team or user..."
+          />
         </FormGroup>
 
         <Divider />
@@ -141,7 +572,14 @@ export const Mirroring: React.FC<MirroringProps> = ({
           Required if the external repository is private.
         </Text>
         <FormGroup label="Username" fieldId="username" isStack>
-          <TextInput type="text" id="username" name="username" />
+          <TextInput
+            type="text"
+            id="username"
+            name="username"
+            value={username}
+            onChange={(_event, value) => setUsername(value)}
+            validated={validated.username}
+          />
         </FormGroup>
 
         <FormGroup
@@ -153,6 +591,9 @@ export const Mirroring: React.FC<MirroringProps> = ({
             type="password"
             id="external_registry_password"
             name="external_registry_password"
+            value={password}
+            onChange={(_event, value) => setPassword(value)}
+            validated={validated.password}
           />
         </FormGroup>
 
@@ -166,6 +607,8 @@ export const Mirroring: React.FC<MirroringProps> = ({
             id="verify_tls"
             name="verify_tls"
             description="Require HTTPS and verify certificates when talking to the external registry."
+            isChecked={verifyTls}
+            onChange={(_event, isChecked) => setVerifyTls(isChecked)}
           />
         </FormGroup>
 
@@ -175,6 +618,8 @@ export const Mirroring: React.FC<MirroringProps> = ({
             id="unsigned_images"
             name="unsigned_images"
             description="Allow unsigned images to be mirrored."
+            isChecked={unsignedImages}
+            onChange={(_event, isChecked) => setUnsignedImages(isChecked)}
           />
         </FormGroup>
 
@@ -184,6 +629,10 @@ export const Mirroring: React.FC<MirroringProps> = ({
             id="http_proxy"
             name="http_proxy"
             placeholder="proxy.example.com"
+            value={httpProxy ?? 'None'}
+            onChange={(_event, value) =>
+              setHttpProxy(value === 'None' ? null : value)
+            }
           />
         </FormGroup>
 
@@ -193,6 +642,10 @@ export const Mirroring: React.FC<MirroringProps> = ({
             id="https_proxy"
             name="https_proxy"
             placeholder="proxy.example.com"
+            value={httpsProxy ?? 'None'}
+            onChange={(_event, value) =>
+              setHttpsProxy(value === 'None' ? null : value)
+            }
           />
         </FormGroup>
 
@@ -202,14 +655,110 @@ export const Mirroring: React.FC<MirroringProps> = ({
             id="no_proxy"
             name="no_proxy"
             placeholder="example.com"
+            value={noProxy ?? 'None'}
+            onChange={(_event, value) =>
+              setNoProxy(value === 'None' ? null : value)
+            }
           />
         </FormGroup>
-
+        {/* Status section for configured mirrors */}
+        {config && (
+          <>
+            <Divider />
+            <Title headingLevel="h3" className="mirroring-section-title">
+              Status
+            </Title>
+            <div style={{maxWidth: 700, margin: '0 auto'}}>
+              <div
+                style={{display: 'flex', alignItems: 'center', marginBottom: 8}}
+              >
+                <div style={{flex: 1}}>
+                  <strong>State</strong>{' '}
+                  <span style={{marginLeft: 8}}>
+                    {statusLabels[config.sync_status] || config.sync_status}
+                  </span>
+                </div>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  isDisabled={
+                    config.sync_status !== 'SYNCING' &&
+                    config.sync_status !== 'SYNC_NOW'
+                  }
+                  style={{marginLeft: 16}}
+                  onClick={async () => {
+                    await cancelSync(namespace, repoName);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+              <div style={{marginBottom: 8}}>
+                <strong>Timeout</strong>{' '}
+                <span style={{marginLeft: 8}}>
+                  {config.sync_expiration_date
+                    ? config.sync_expiration_date
+                    : 'None'}
+                </span>
+              </div>
+              <div>
+                <strong>Retries Remaining</strong>{' '}
+                <span style={{marginLeft: 8}}>
+                  {config.sync_retries_remaining != null
+                    ? `${config.sync_retries_remaining} / 3`
+                    : '3 / 3'}
+                </span>
+              </div>
+            </div>
+          </>
+        )}
         <ActionGroup>
-          <Button variant={ButtonVariant.primary} className="mirroring-button">
-            Enable Mirror
+          <Button
+            variant={ButtonVariant.primary}
+            className="mirroring-button"
+            onClick={handleSubmit}
+            isDisabled={!isFormValid()}
+          >
+            {config ? 'Update Mirror' : 'Enable Mirror'}
           </Button>
         </ActionGroup>
+        {/* Robot Creation Modal */}
+        <CreateRobotAccountModal
+          isModalOpen={isCreateRobotModalOpen}
+          handleModalToggle={() => setIsCreateRobotModalOpen(false)}
+          orgName={namespace}
+          teams={teams}
+          RepoPermissionDropdownItems={RepoPermissionDropdownItems}
+          setEntity={(robot: Entity) => {
+            setSelectedRobot(robot);
+            setRobotUsername(robot.name);
+          }}
+          showSuccessAlert={(msg) =>
+            addAlert({variant: AlertVariant.Success, title: msg})
+          }
+          showErrorAlert={(msg) =>
+            addAlert({variant: AlertVariant.Failure, title: msg})
+          }
+        />
+        {/* Team Creation Modal */}
+        <CreateTeamModal
+          teamName={teamName}
+          setTeamName={setTeamName}
+          description={teamDescription}
+          setDescription={setTeamDescription}
+          orgName={namespace}
+          nameLabel="Provide a name for your new team:"
+          descriptionLabel="Provide an optional description for your new team"
+          helperText="Enter a description to provide extra information to your teammates about this team:"
+          nameHelperText="Choose a name to inform your teammates about this team. Must match ^([a-z0-9]+(?:[._-][a-z0-9]+)*)$"
+          isModalOpen={isCreateTeamModalOpen}
+          handleModalToggle={() => setIsCreateTeamModalOpen(false)}
+          validateName={validateTeamName}
+          setAppliedTo={(team: Entity) => {
+            setSelectedRobot(team);
+            setRobotUsername(team.name);
+          }}
+        />
       </Form>
     </div>
   );

--- a/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
+++ b/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
@@ -42,6 +42,7 @@ import TagHistory from './TagHistory/TagHistory';
 import TagsList from './Tags/TagsList';
 import {DrawerContentType} from './Types';
 import UsageLogs from '../UsageLogs/UsageLogs';
+import {Mirroring} from './Mirroring/Mirroring';
 
 enum TabIndex {
   Tags = 'tags',
@@ -49,6 +50,7 @@ enum TabIndex {
   TagHistory = 'history',
   Builds = 'builds',
   Logs = 'logs',
+  Mirroring = 'mirroring',
   Settings = 'settings',
 }
 
@@ -261,6 +263,32 @@ export default function RepositoryDetails() {
                       repository={repository}
                       type="repository"
                     />
+                  </Tab>
+                  <Tab
+                    eventKey={TabIndex.Mirroring}
+                    title={<TabTitleText>Mirroring</TabTitleText>}
+                    isHidden={
+                      !config?.features?.REPO_MIRROR || !repoDetails?.can_admin
+                    }
+                  >
+                    {repoDetails?.state !== 'MIRROR' ? (
+                      <div>
+                        This repository&apos;s state is{' '}
+                        <strong>{repoDetails?.state}</strong>. Use the{' '}
+                        <a
+                          href={`/repository/${repoDetails?.namespace}/${repoDetails?.name}?tab=settings`}
+                        >
+                          settings tab
+                        </a>{' '}
+                        and change it to <strong>Mirror</strong> to manage its
+                        mirroring configuration.
+                      </div>
+                    ) : (
+                      <Mirroring
+                        organization={organization}
+                        repository={repository}
+                      />
+                    )}
                   </Tab>
                   <Tab
                     eventKey={TabIndex.Builds}

--- a/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
+++ b/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
@@ -273,6 +273,7 @@ export default function RepositoryDetails() {
                   <Tab
                     eventKey={TabIndex.Mirroring}
                     title={<TabTitleText>Mirroring</TabTitleText>}
+                    data-testid="mirroring-tab"
                     isHidden={
                       !config?.features?.REPO_MIRROR || !repoDetails?.can_admin
                     }

--- a/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
+++ b/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
@@ -66,7 +66,7 @@ export default function RepositoryDetails() {
   const [activeTabKey, setActiveTabKey] = useState(TabIndex.Tags);
   const navigate = useNavigate();
   const location = useLocation();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const [drawerContent, setDrawerContent] = useState<DrawerContentType>(
     DrawerContentType.None,
   );
@@ -237,6 +237,8 @@ export default function RepositoryDetails() {
                   <Tab
                     eventKey={TabIndex.Tags}
                     title={<TabTitleText>Tags</TabTitleText>}
+                    onPointerEnterCapture={undefined}
+                    onPointerLeaveCapture={undefined}
                   >
                     <TagsList
                       organization={organization}
@@ -247,6 +249,8 @@ export default function RepositoryDetails() {
                   <Tab
                     eventKey={TabIndex.TagHistory}
                     title={<TabTitleText>Tag history</TabTitleText>}
+                    onPointerEnterCapture={undefined}
+                    onPointerLeaveCapture={undefined}
                   >
                     <TagHistory
                       org={organization}
@@ -257,6 +261,8 @@ export default function RepositoryDetails() {
                   <Tab
                     eventKey={TabIndex.Logs}
                     title={<TabTitleText>Logs</TabTitleText>}
+                    onPointerEnterCapture={undefined}
+                    onPointerLeaveCapture={undefined}
                   >
                     <UsageLogs
                       organization={organization}
@@ -270,6 +276,8 @@ export default function RepositoryDetails() {
                     isHidden={
                       !config?.features?.REPO_MIRROR || !repoDetails?.can_admin
                     }
+                    onPointerEnterCapture={undefined}
+                    onPointerLeaveCapture={undefined}
                   >
                     {repoDetails?.state !== 'MIRROR' ? (
                       <div>
@@ -278,15 +286,15 @@ export default function RepositoryDetails() {
                         <a
                           href={`/repository/${repoDetails?.namespace}/${repoDetails?.name}?tab=settings`}
                         >
-                          settings tab
+                          Settings tab
                         </a>{' '}
                         and change it to <strong>Mirror</strong> to manage its
                         mirroring configuration.
                       </div>
                     ) : (
                       <Mirroring
-                        organization={organization}
-                        repository={repository}
+                        namespace={organization}
+                        repoName={repository}
                       />
                     )}
                   </Tab>
@@ -298,6 +306,8 @@ export default function RepositoryDetails() {
                       repoDetails?.state !== 'NORMAL' ||
                       (!repoDetails?.can_write && !repoDetails?.can_admin)
                     }
+                    onPointerEnterCapture={undefined}
+                    onPointerLeaveCapture={undefined}
                   >
                     <Builds
                       org={organization}
@@ -310,6 +320,8 @@ export default function RepositoryDetails() {
                     eventKey={TabIndex.Settings}
                     title={<TabTitleText>Settings</TabTitleText>}
                     isHidden={!repoDetails?.can_admin}
+                    onPointerEnterCapture={undefined}
+                    onPointerLeaveCapture={undefined}
                   >
                     <Settings
                       org={organization}


### PR DESCRIPTION
This adds react code and patternfly components to handle Mirroring in the new Quay UI. Functionality should be equivalent to the old Angular code, and new test suite is passing locally.

Note: Keeping in **Draft** state because I will be updating the code to include react-hook-form (react-based form library) to handle some of the redundancy and validation for the form. 

**Screen shots**

Will be provided when moving from Draft to PR... can no longer get quay to install successfully after rebasing for this draft PR.
