### PR TITLE
nginx: Allow TLSv1.3 when proxying content (PROJQUAY-9125)

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -95,6 +95,11 @@ location ~ ^/_storage_proxy/([^/]+)/([^/]+)/([^/]+)/(.+) {
     proxy_ssl_name $3;
     proxy_ssl_server_name on;
 
+    # nginx prior to 1.23 does not use TLSv1.3 for proxy.,
+    # this breaks _storage_proxy pulls when only TLSv1.3 is enabled.
+    # https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_protocols
+    proxy_ssl_protocols TLSv1.2 TLSv1.3;
+
     add_header Host $3;
 
     proxy_buffering off;


### PR DESCRIPTION
Nginx versions prior to 1.23 do not use TLSv1.3 on proxy requests. This breaks `_storage_proxy` when S3 backend uses TLSv1.3 exclusively. This small change explicitly defines a list of TLS versions that `_storage_proxy` endpoint will use.