### PR TITLE
init: Refactor mirror worker init script (PROJQUAY-9098)

### DIFF
--- a/mirror-worker-init/mirror-worker-init.py
+++ b/mirror-worker-init/mirror-worker-init.py
@@ -5,7 +5,7 @@ from time import sleep
 
 import requests
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("init")
 logger.setLevel(logging.DEBUG)
 formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 handler = logging.StreamHandler()


### PR DESCRIPTION
Previous init script did not log anything in the standard output which made it difficult to understand in certain circumstances why the worker was restarting. This script is based on the current init container script but adds logging and some exception trapping. It will ensure that the mirror worker containers do not go into `CrashLoopBackoff` but instead remain in the `init` state until Quay actually responds.