### PR TITLE
alembic: Install certs during alembic migrations (PROJQUAY-9135)

### DIFF
--- a/quay-entrypoint.sh
+++ b/quay-entrypoint.sh
@@ -78,6 +78,7 @@ case "$QUAYENTRY" in
         echo ""; echo "Startup timestamp: "; date; echo ""
         : "${MIGRATION_VERSION:=$2}"
         : "${MIGRATION_VERSION:?Missing version argument}"
+        "${QUAYPATH}/conf/init/certs_install.sh" || exit
         "${QUAYPATH}/conf/init/client_certs.sh" || exit
         echo "Entering migration mode to version: ${MIGRATION_VERSION}"
         PYTHONPATH="${QUAYPATH}" alembic upgrade "${MIGRATION_VERSION}"


### PR DESCRIPTION
Currently, we don't install certs when starting alembic migrations on the db. This poses a problem when Quay is behind a proxy and proxy HTTPS connection is needed to connect to the database. This small fix will make alembic migrations take into account certificates installed in `extra_ca_certs` folder.