### PR TITLE
Increase ngnix rate limit on the auth header (PROJQUAY-9149)

### DIFF
--- a/conf/nginx/rate-limiting.conf.jnj
+++ b/conf/nginx/rate-limiting.conf.jnj
@@ -44,7 +44,7 @@ map $namespace $namespaced_http2_bucket {
 }
 
 {% if enable_rate_limits %}
-limit_req_zone $http_authorization zone=staticauth:10m rate=30r/s;
+limit_req_zone $http_authorization zone=staticauth:10m rate=60r/s;
 {% else %}
 limit_req_zone $request_id zone=staticauth:10m rate=300r/s;
 {% endif %}


### PR DESCRIPTION
Increasing ngnix rate limit to 60 req/s to alleviate frequent 429s on the auth endpoint