### PR TITLE
nginx: rate limit on namespace (PROJQUAY-9203)

### DIFF
--- a/conf/nginx/http-base.conf.jnj
+++ b/conf/nginx/http-base.conf.jnj
@@ -12,6 +12,7 @@ log_format lb_logs '$remote_addr ($proxy_protocol_addr) '
                    '- $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent '
                    '"$http_referer" "$http_user_agent" '
+                   'rate_limit_key="$auth_namespace_bucket" '
                    '($request_time $request_length $upstream_response_time)';
 
 types_hash_max_size 2048;

--- a/conf/nginx/rate-limiting.conf.jnj
+++ b/conf/nginx/rate-limiting.conf.jnj
@@ -20,14 +20,12 @@ map $arg_scope $scope_namespace {
 }
 
 # Create namespace-based rate limiting bucket for auth endpoint
-# Falls back to $request_id if no namespace is found (effectively disabling rate limiting)
 map $scope_namespace $auth_namespace_bucket {
   {% for namespace in non_rate_limited_namespaces %}
-  "{{ namespace }}" $request_id;
+  "{{ namespace }}"  $request_id;
   {% endfor %}
   {% if enable_rate_limits %}
-  ~^(.+)$ $1;  # Use namespace if found
-  default $http_authorization;  # Fallback to auth header if no namespace
+  default $http_authorization;  # Fallback to auth header
   {% else %}
   default $request_id;  # Disable rate limiting when not enabled
   {% endif %}
@@ -65,13 +63,8 @@ map $namespace $namespaced_http2_bucket {
 }
 
 {% if enable_rate_limits %}
-# Original auth rate limiting by authorization header
-limit_req_zone $http_authorization zone=staticauth:10m rate=120r/s;
-
-# New namespace-based auth rate limiting
 limit_req_zone $auth_namespace_bucket zone=namespace_auth:10m rate=120r/s;
 {% else %}
-limit_req_zone $request_id zone=staticauth:10m rate=300r/s;
 limit_req_zone $request_id zone=namespace_auth:10m rate=300r/s;
 {% endif %}
 

--- a/conf/nginx/rate-limiting.conf.jnj
+++ b/conf/nginx/rate-limiting.conf.jnj
@@ -12,6 +12,27 @@ map $http2 $http2_bucket {
   default $connection;          # HTTP2 case: use the connection serial number to limit.
 }
 
+# Extract namespace from scope query parameter
+# Docker scope format: "repository:namespace/repo:actions"
+map $arg_scope $scope_namespace {
+  ~^repository:([^/]+)/.* $1;
+  default "";
+}
+
+# Create namespace-based rate limiting bucket for auth endpoint
+# Falls back to $request_id if no namespace is found (effectively disabling rate limiting)
+map $scope_namespace $auth_namespace_bucket {
+  {% for namespace in non_rate_limited_namespaces %}
+  "{{ namespace }}" $request_id;
+  {% endfor %}
+  {% if enable_rate_limits %}
+  ~^(.+)$ $1;  # Use namespace if found
+  default $http_authorization;  # Fallback to auth header if no namespace
+  {% else %}
+  default $request_id;  # Disable rate limiting when not enabled
+  {% endif %}
+}
+
 map $uri:$http_user_agent $miner_tag_block {
     "~/api/v1/repository/team-helium/miner/tag/:curl/*" 1;
     default 0;
@@ -44,9 +65,14 @@ map $namespace $namespaced_http2_bucket {
 }
 
 {% if enable_rate_limits %}
+# Original auth rate limiting by authorization header
 limit_req_zone $http_authorization zone=staticauth:10m rate=120r/s;
+
+# New namespace-based auth rate limiting
+limit_req_zone $auth_namespace_bucket zone=namespace_auth:10m rate=120r/s;
 {% else %}
 limit_req_zone $request_id zone=staticauth:10m rate=300r/s;
+limit_req_zone $request_id zone=namespace_auth:10m rate=300r/s;
 {% endif %}
 
 limit_req_zone $http1_bucket zone=dynamicauth_very_light_http1:10m rate=60r/s;

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -275,7 +275,8 @@ location = /v2/auth {
     proxy_pass   http://registry_app_server;
 
     {% if enable_rate_limits %}
-    limit_req zone=staticauth burst=2 nodelay;
+    # Use namespace-based rate limiting extracted from scope query parameter
+    limit_req zone=namespace_auth burst=2 nodelay;
     {% endif %}
 
     keepalive_timeout 0; # Disables HTTP 1.1 keep-alive and forces round-robin.


### PR DESCRIPTION
Should extract the namespace from auth scope param and implement rate limits based on that. Should fall back to auth header if namespace cannot be extracted for some reason