### PR TITLE
Further increase ngnix rate limit on the auth header

### DIFF
--- a/conf/nginx/rate-limiting.conf.jnj
+++ b/conf/nginx/rate-limiting.conf.jnj
@@ -44,7 +44,7 @@ map $namespace $namespaced_http2_bucket {
 }
 
 {% if enable_rate_limits %}
-limit_req_zone $http_authorization zone=staticauth:10m rate=60r/s;
+limit_req_zone $http_authorization zone=staticauth:10m rate=120r/s;
 {% else %}
 limit_req_zone $request_id zone=staticauth:10m rate=300r/s;
 {% endif %}


### PR DESCRIPTION
#4133 increased the rate limit but we are still seeing some rate limiting when trying to check images in parallel. I have been making changes on the [client side](https://github.com/conforma/cli/pull/2660), but the auth 429s are still occurring.