### PR TITLE
nginx: html encoded matching for regex pattern (PROJQUAY-9203)

### DIFF
--- a/conf/nginx/rate-limiting.conf.jnj
+++ b/conf/nginx/rate-limiting.conf.jnj
@@ -15,7 +15,7 @@ map $http2 $http2_bucket {
 # Extract namespace from scope query parameter
 # Docker scope format: "repository:namespace/repo:actions"
 map $arg_scope $scope_namespace {
-  ~^repository:([^/]+)/.* $1;
+  ~^repository%3A(.+?)(%2F|%3A).* $1;
   default "";
 }
 


### PR DESCRIPTION
Nginx rate limits are not properly picking up the namespace. It appears that the scope is html encoded so adjusting the regex to properly pick up the namespace. Tested locally to validate that rate limit key is the namespace.