### PR TITLE
nginx: fix rate limiting bucket (PROJQUAY-9203)

### DIFF
--- a/conf/nginx/rate-limiting.conf.jnj
+++ b/conf/nginx/rate-limiting.conf.jnj
@@ -25,7 +25,7 @@ map $scope_namespace $auth_namespace_bucket {
   "{{ namespace }}"  $request_id;
   {% endfor %}
   {% if enable_rate_limits %}
-  default $http_authorization;  # Fallback to auth header
+  default $scope_namespace;
   {% else %}
   default $request_id;  # Disable rate limiting when not enabled
   {% endif %}


### PR DESCRIPTION
Bucket was improperly using the auth header as a key even though it should be using the namespace with the new changes.