### PR TITLE
chore: add hermetic param to run oci script (PROJQUAY-0000)

### DIFF
--- a/.tekton/quay-v3-14-pull-request.yaml
+++ b/.tekton/quay-v3-14-pull-request.yaml
@@ -204,6 +204,8 @@ spec:
         value: registry.access.redhat.com/ubi8/ubi:latest
       - name: SOURCE_ARTIFACT
         value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: HERMETIC
+        value: $(params.hermetic)
       - name: SCRIPT
         value: |
           sed \
@@ -221,8 +223,6 @@ spec:
           value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:1dcc9805bdc20708f87126455c01e0c49be9d79f0c140220a71c85e49979b96d
         - name: kind
           value: task
-        - name: hermetic
-          value: "true"
         resolver: bundles
     - name: prefetch-dependencies
       params:

--- a/.tekton/quay-v3-14-push.yaml
+++ b/.tekton/quay-v3-14-push.yaml
@@ -201,6 +201,8 @@ spec:
         value: registry.access.redhat.com/ubi8/ubi:latest
       - name: SOURCE_ARTIFACT
         value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: HERMETIC
+        value: $(params.hermetic)
       - name: SCRIPT
         value: |
           sed \


### PR DESCRIPTION
Fixes improper use of the hermetic parameter for the oci run script task. Should fix conforma test on konflux