### PR TITLE
stripe: apply trial periods for user credit card subscriptions (PROJQUAY-9253)

### DIFF
--- a/endpoints/api/billing.py
+++ b/endpoints/api/billing.py
@@ -1,6 +1,7 @@
 """
 Billing information, subscriptions, and plan information.
 """
+
 import datetime
 import json
 import time
@@ -515,6 +516,7 @@ class UserPlan(ApiResource):
                         "performer": user.username,
                         "ip": get_request_ip(),
                         "plan": price["stripeId"],
+                        "trial_period_days": price["free_trial_days"],
                     }
                 },
                 mode="subscription",


### PR DESCRIPTION
This corrects the Stripe API call to include the `trial_period_days` parameter also when non-org accounts are set up with a credit card

Signed-off-by: dmesser <dmesser@redhat.com>