### PR TITLE
konflux: add additional base images (PROJQUAY-9279)

### DIFF
--- a/.tekton/quay-v3-14-pull-request.yaml
+++ b/.tekton/quay-v3-14-pull-request.yaml
@@ -285,6 +285,9 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_BASE_IMAGES
+        value:
+          - $(tasks.modify-containerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       - name: LABELS
         value:
           - com.redhat.component="quay-registry-container"

--- a/.tekton/quay-v3-14-push.yaml
+++ b/.tekton/quay-v3-14-push.yaml
@@ -284,6 +284,9 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_BASE_IMAGES
+        value:
+          - $(tasks.modify-containerfile.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
       - name: LABELS
         value:
           - com.redhat.component="quay-registry-container"


### PR DESCRIPTION
Addresses the following conformance test by adding parameter to tekton task to add script runner image to sbom.
```
Pre-Build-Script task runner image "registry.access.redhat.com/ubi8/ubi:latest@sha256:a91cd157f699b48c7d15a8b38c77163cc8b4a1bdd7d510fcf1aa59e54c99c953" is not in the SBOM
```