### PR TITLE
deps: update cipher-base to version 1.0.6 (PROJQUAY-9051)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -264,19 +264,6 @@
         "typescript": ">=2.1.4"
       }
     },
-    "node_modules/@types/jasmine/node_modules/typescript": {
-      "version": "2.2.1",
-      "resolved": "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz",
-      "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@types/jquery": {
       "version": "2.0.40",
       "resolved": "https://registry.yarnpkg.com/@types/jquery/-/jquery-2.0.40.tgz",
@@ -1316,12 +1303,6 @@
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
-    "node_modules/buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true
-    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -1729,13 +1710,46 @@
       "dev": true
     },
     "node_modules/cipher-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz",
-      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
+    },
+    "node_modules/cipher-base/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cipher-base/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/clap": {
       "version": "1.1.2",
@@ -1910,15 +1924,6 @@
       "dev": true,
       "dependencies": {
         "color-name": "^1.0.0"
-      }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
-      "dependencies": {
-        "color-name": "^1.1.1"
       }
     },
     "node_modules/colormin": {
@@ -2510,13 +2515,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/define-property/node_modules/is-buffer": {
-      "version": "1.1.4",
-      "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-      "deprecated": "This version of 'is-buffer' is out-of-date. You must update to v1.1.6 or newer",
-      "dev": true
     },
     "node_modules/define-property/node_modules/is-data-descriptor": {
       "version": "0.1.4",
@@ -3758,27 +3756,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/findup-sync/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/findup-sync/node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
@@ -4809,15 +4786,6 @@
         "extend": "3"
       }
     },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "2.6.7",
-      "resolved": "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz",
-      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5376,29 +5344,11 @@
         "node": "*"
       }
     },
-    "node_modules/istanbul/node_modules/isexe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-      "dev": true
-    },
     "node_modules/istanbul/node_modules/resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
-    },
-    "node_modules/istanbul/node_modules/which": {
-      "version": "1.2.12",
-      "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-      "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^1.1.1"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
     },
     "node_modules/iterate-object": {
       "version": "1.3.4",
@@ -5701,24 +5651,6 @@
       "dependencies": {
         "fs-access": "^1.0.0",
         "which": "^1.2.1"
-      }
-    },
-    "node_modules/karma-chrome-launcher/node_modules/isexe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-      "dev": true
-    },
-    "node_modules/karma-chrome-launcher/node_modules/which": {
-      "version": "1.2.12",
-      "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-      "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^1.1.1"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
     "node_modules/karma-coverage": {
@@ -6151,13 +6083,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/kind-of/node_modules/is-buffer": {
-      "version": "1.1.4",
-      "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-      "deprecated": "This version of 'is-buffer' is out-of-date. You must update to v1.1.6 or newer",
-      "dev": true
-    },
     "node_modules/lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -6529,21 +6454,6 @@
       "dependencies": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/memory-fs/node_modules/readable-stream": {
-      "version": "2.2.3",
-      "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-      "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/meow": {
@@ -8070,12 +7980,6 @@
       "engines": {
         "node": ">= 0.6.0"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -9666,21 +9570,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "node_modules/stream-browserify/node_modules/readable-stream": {
-      "version": "2.2.3",
-      "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-      "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
     "node_modules/stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz",
@@ -9755,12 +9644,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "node_modules/string-width": {
       "version": "1.0.2",
@@ -11013,48 +10896,6 @@
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
-    "node_modules/watchpack/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/watchpack/node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/watchpack/node_modules/readable-stream": {
-      "version": "2.2.3",
-      "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-      "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/watchpack/node_modules/readable-stream/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
     "node_modules/watchpack/node_modules/readdirp": {
       "version": "2.2.1",
       "resolved": "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz",
@@ -12150,14 +11991,6 @@
       "dev": true,
       "requires": {
         "typescript": ">=2.1.4"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "2.2.1",
-          "resolved": "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz",
-          "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
-          "dev": true
-        }
       }
     },
     "@types/jquery": {
@@ -13072,12 +12905,6 @@
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true
-    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -13411,12 +13238,27 @@
       }
     },
     "cipher-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz",
-      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
       }
     },
     "clap": {
@@ -13533,17 +13375,6 @@
         "clone": "^1.0.2",
         "color-convert": "^1.3.0",
         "color-string": "^0.3.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "1.9.0",
-          "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz",
-          "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-          "dev": true,
-          "requires": {
-            "color-name": "^1.1.1"
-          }
-        }
       }
     },
     "color-convert": {
@@ -14058,12 +13889,6 @@
               }
             }
           }
-        },
-        "is-buffer": {
-          "version": "1.1.4",
-          "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-          "dev": true
         },
         "is-data-descriptor": {
           "version": "0.1.4",
@@ -15045,23 +14870,6 @@
         "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        }
       }
     },
     "flatted": {
@@ -15890,17 +15698,6 @@
         "agent-base": "2",
         "debug": "2",
         "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "iconv-lite": {
@@ -16340,26 +16137,11 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "isexe": {
-          "version": "1.1.2",
-          "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-          "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-          "dev": true
-        },
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
-        },
-        "which": {
-          "version": "1.2.12",
-          "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-          "dev": true,
-          "requires": {
-            "isexe": "^1.1.1"
-          }
         }
       }
     },
@@ -16850,23 +16632,6 @@
       "requires": {
         "fs-access": "^1.0.0",
         "which": "^1.2.1"
-      },
-      "dependencies": {
-        "isexe": {
-          "version": "1.1.2",
-          "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-          "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.2.12",
-          "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-          "dev": true,
-          "requires": {
-            "isexe": "^1.1.1"
-          }
-        }
       }
     },
     "karma-coverage": {
@@ -16959,14 +16724,6 @@
       "dev": true,
       "requires": {
         "is-buffer": "^1.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "1.1.4",
-          "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-          "dev": true
-        }
       }
     },
     "lazy-cache": {
@@ -17282,23 +17039,6 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.3",
-          "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "meow": {
@@ -18600,12 +18340,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
-    },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -19909,23 +19643,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.3",
-          "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "stream-each": {
@@ -19989,12 +19706,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "string-width": {
@@ -20997,44 +20708,6 @@
           "resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz",
           "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
           "dev": true
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "4.0.1",
-          "resolved": "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.3",
-          "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
-            }
-          }
         },
         "readdirp": {
           "version": "2.2.1",


### PR DESCRIPTION
Fix for CVE-2025-9287.

Commands used:
~~~
$ npm update cipher-base
$ npm list cipher-base
quay@1.0.0 /home/aroyo/quay
└─┬ webpack@4.41.0
  └─┬ node-libs-browser@2.2.1
    └─┬ crypto-browserify@3.11.0
      ├─┬ browserify-cipher@1.0.0
      │ ├─┬ browserify-aes@1.0.6
      │ │ └── cipher-base@1.0.6 deduped
      │ └─┬ browserify-des@1.0.0
      │   └── cipher-base@1.0.6 deduped
      └─┬ create-hash@1.1.2
        └── cipher-base@1.0.6
~~~