### PR TITLE
[redhat-3.10] deps: update cipher-base to version 1.0.6 (PROJQUAY-9338)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,19 +115,6 @@
         "typescript": ">=2.1.4"
       }
     },
-    "node_modules/@types/jasmine/node_modules/typescript": {
-      "version": "2.2.1",
-      "resolved": "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz",
-      "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@types/jquery": {
       "version": "2.0.40",
       "resolved": "https://registry.yarnpkg.com/@types/jquery/-/jquery-2.0.40.tgz",
@@ -590,15 +577,6 @@
       "dependencies": {
         "arr-flatten": "^1.0.1"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/anymatch/node_modules/arr-flatten": {
-      "version": "1.0.1",
-      "resolved": "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz",
-      "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1193,15 +1171,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/body-parser/node_modules/content-type": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.7",
       "resolved": "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz",
@@ -1255,19 +1224,6 @@
       "resolved": "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/body-parser/node_modules/type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.15"
-      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -1425,12 +1381,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
-      "dev": true
-    },
-    "node_modules/buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
     "node_modules/buffer-xor": {
@@ -1807,13 +1757,46 @@
       "dev": true
     },
     "node_modules/cipher-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz",
-      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
+    },
+    "node_modules/cipher-base/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cipher-base/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/clap": {
       "version": "1.1.2",
@@ -1990,15 +1973,6 @@
         "color-name": "^1.0.0"
       }
     },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
-      "dependencies": {
-        "color-name": "^1.1.1"
-      }
-    },
     "node_modules/colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.yarnpkg.com/colormin/-/colormin-1.1.2.tgz",
@@ -2125,15 +2099,6 @@
       "dev": true,
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/connect/node_modules/parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/console-browserify": {
@@ -2569,13 +2534,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/define-property/node_modules/is-buffer": {
-      "version": "1.1.4",
-      "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-      "deprecated": "This version of 'is-buffer' is out-of-date. You must update to v1.1.6 or newer",
-      "dev": true
     },
     "node_modules/define-property/node_modules/is-data-descriptor": {
       "version": "0.1.4",
@@ -3984,24 +3942,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/finalhandler/node_modules/encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/finalhandler/node_modules/parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/finalhandler/node_modules/statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz",
@@ -4190,15 +4130,6 @@
       "dependencies": {
         "for-in": "^1.0.1"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/for-own/node_modules/for-in": {
-      "version": "1.0.1",
-      "resolved": "https://registry.yarnpkg.com/for-in/-/for-in-1.0.1.tgz",
-      "integrity": "sha1-1sPjeYzqqjAQR7EJ3t8bGuN6Dvo=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5159,15 +5090,6 @@
         "extend": "3"
       }
     },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "2.6.7",
-      "resolved": "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz",
-      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5779,29 +5701,11 @@
         "node": "*"
       }
     },
-    "node_modules/istanbul/node_modules/isexe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-      "dev": true
-    },
     "node_modules/istanbul/node_modules/resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
-    },
-    "node_modules/istanbul/node_modules/which": {
-      "version": "1.2.12",
-      "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-      "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^1.1.1"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
     },
     "node_modules/iterate-object": {
       "version": "1.3.4",
@@ -6106,24 +6010,6 @@
         "which": "^1.2.1"
       }
     },
-    "node_modules/karma-chrome-launcher/node_modules/isexe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-      "dev": true
-    },
-    "node_modules/karma-chrome-launcher/node_modules/which": {
-      "version": "1.2.12",
-      "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-      "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^1.1.1"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/karma-coverage": {
       "version": "0.5.5",
       "resolved": "https://registry.yarnpkg.com/karma-coverage/-/karma-coverage-0.5.5.tgz",
@@ -6228,22 +6114,10 @@
         "node": ">= 8"
       }
     },
-    "node_modules/karma/node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-      "dev": true
-    },
     "node_modules/karma/node_modules/lodash": {
       "version": "3.10.1",
       "resolved": "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-      "dev": true
-    },
-    "node_modules/karma/node_modules/safe-buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz",
-      "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
       "dev": true
     },
     "node_modules/kind-of": {
@@ -6257,13 +6131,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/kind-of/node_modules/is-buffer": {
-      "version": "1.1.4",
-      "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-      "deprecated": "This version of 'is-buffer' is out-of-date. You must update to v1.1.6 or newer",
-      "dev": true
     },
     "node_modules/lazy-cache": {
       "version": "1.0.4",
@@ -6632,21 +6499,6 @@
       "dependencies": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/memory-fs/node_modules/readable-stream": {
-      "version": "2.2.3",
-      "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-      "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/meow": {
@@ -8263,12 +8115,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -8649,21 +8495,6 @@
       },
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/readdirp/node_modules/readable-stream": {
-      "version": "2.2.3",
-      "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-      "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/recast": {
@@ -9831,21 +9662,6 @@
       "dependencies": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/stream-browserify/node_modules/readable-stream": {
-      "version": "2.2.3",
-      "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-      "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/stream-each": {
@@ -11198,27 +11014,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/watchpack/node_modules/readable-stream": {
-      "version": "2.2.3",
-      "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-      "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/watchpack/node_modules/readable-stream/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
     "node_modules/watchpack/node_modules/readdirp": {
       "version": "2.2.1",
       "resolved": "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz",
@@ -12244,14 +12039,6 @@
       "dev": true,
       "requires": {
         "typescript": ">=2.1.4"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "2.2.1",
-          "resolved": "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz",
-          "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
-          "dev": true
-        }
       }
     },
     "@types/jquery": {
@@ -12675,12 +12462,6 @@
           "requires": {
             "arr-flatten": "^1.0.1"
           }
-        },
-        "arr-flatten": {
-          "version": "1.0.1",
-          "resolved": "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz",
-          "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
-          "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
@@ -13166,12 +12947,6 @@
         "type-is": "~1.6.15"
       },
       "dependencies": {
-        "content-type": {
-          "version": "1.0.2",
-          "resolved": "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz",
-          "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
-          "dev": true
-        },
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz",
@@ -13216,16 +12991,6 @@
           "resolved": "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz",
           "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
-        },
-        "type-is": {
-          "version": "1.6.15",
-          "resolved": "https://registry.yarnpkg.com/type-is/-/type-is-1.6.15.tgz",
-          "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-          "dev": true,
-          "requires": {
-            "media-typer": "0.3.0",
-            "mime-types": "~2.1.15"
-          }
         }
       }
     },
@@ -13370,12 +13135,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
-      "dev": true
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
       "dev": true
     },
     "buffer-xor": {
@@ -13693,12 +13452,27 @@
       }
     },
     "cipher-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz",
-      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
       }
     },
     "clap": {
@@ -13815,17 +13589,6 @@
         "clone": "^1.0.2",
         "color-convert": "^1.3.0",
         "color-string": "^0.3.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "1.9.0",
-          "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz",
-          "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-          "dev": true,
-          "requires": {
-            "color-name": "^1.1.1"
-          }
-        }
       }
     },
     "color-convert": {
@@ -13974,12 +13737,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "parseurl": {
-          "version": "1.3.1",
-          "resolved": "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz",
-          "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
-          "dev": true
         }
       }
     },
@@ -14345,12 +14102,6 @@
               }
             }
           }
-        },
-        "is-buffer": {
-          "version": "1.1.4",
-          "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-          "dev": true
         },
         "is-data-descriptor": {
           "version": "0.1.4",
@@ -15482,18 +15233,6 @@
             "ms": "2.0.0"
           }
         },
-        "encodeurl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz",
-          "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
-          "dev": true
-        },
-        "parseurl": {
-          "version": "1.3.1",
-          "resolved": "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz",
-          "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
-          "dev": true
-        },
         "statuses": {
           "version": "1.3.1",
           "resolved": "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz",
@@ -15642,14 +15381,6 @@
       "dev": true,
       "requires": {
         "for-in": "^1.0.1"
-      },
-      "dependencies": {
-        "for-in": {
-          "version": "1.0.1",
-          "resolved": "https://registry.yarnpkg.com/for-in/-/for-in-1.0.1.tgz",
-          "integrity": "sha1-1sPjeYzqqjAQR7EJ3t8bGuN6Dvo=",
-          "dev": true
-        }
       }
     },
     "forever-agent": {
@@ -16414,17 +16145,6 @@
         "agent-base": "2",
         "debug": "2",
         "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "iconv-lite": {
@@ -16901,26 +16621,11 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "isexe": {
-          "version": "1.1.2",
-          "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-          "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-          "dev": true
-        },
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
-        },
-        "which": {
-          "version": "1.2.12",
-          "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-          "dev": true,
-          "requires": {
-            "isexe": "^1.1.1"
-          }
         }
       }
     },
@@ -17169,22 +16874,10 @@
         "useragent": "^2.1.12"
       },
       "dependencies": {
-        "bluebird": {
-          "version": "3.4.7",
-          "resolved": "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz",
-          "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
-          "dev": true
-        },
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.1.0",
-          "resolved": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz",
-          "integrity": "sha1-/kyEYDl/nqqqWOc75GJzQIpF4iM=",
           "dev": true
         }
       }
@@ -17197,23 +16890,6 @@
       "requires": {
         "fs-access": "^1.0.0",
         "which": "^1.2.1"
-      },
-      "dependencies": {
-        "isexe": {
-          "version": "1.1.2",
-          "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-          "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.2.12",
-          "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-          "dev": true,
-          "requires": {
-            "isexe": "^1.1.1"
-          }
-        }
       }
     },
     "karma-coverage": {
@@ -17306,14 +16982,6 @@
       "dev": true,
       "requires": {
         "is-buffer": "^1.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "1.1.4",
-          "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-          "dev": true
-        }
       }
     },
     "lazy-cache": {
@@ -17625,23 +17293,6 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.3",
-          "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "meow": {
@@ -19024,12 +18675,6 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -19355,23 +19000,6 @@
         "minimatch": "^3.0.2",
         "readable-stream": "^2.0.2",
         "set-immediate-shim": "^1.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.3",
-          "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "recast": {
@@ -20362,23 +19990,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.3",
-          "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "stream-each": {
@@ -21475,29 +21086,6 @@
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.3",
-          "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
-            }
           }
         },
         "readdirp": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8609,15 +8609,41 @@
       "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
     },
     "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
+    },
+    "node_modules/cipher-base/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.3",
@@ -37814,14 +37840,23 @@
       "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
     },
     "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
       "peer": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "cjs-module-lexer": {


### PR DESCRIPTION
Fix for CVE-2025-9287.

Commands used:
~~~
$ npm update cipher-base
$ npm list cipher-base
quay@1.0.0 /home/aroyo/quay
└─┬ webpack@4.41.0
  └─┬ node-libs-browser@2.2.1
    └─┬ crypto-browserify@3.11.0
      ├─┬ browserify-cipher@1.0.0
      │ ├─┬ browserify-aes@1.0.6
      │ │ └── cipher-base@1.0.6 deduped
      │ └─┬ browserify-des@1.0.0
      │   └── cipher-base@1.0.6 deduped
      └─┬ create-hash@1.1.2
        └── cipher-base@1.0.6
$ cd web
$ npm install
$ npm update cipher-base
$ npm list cipher-base
quay-ui@0.1.0 /home/aroyo/quay/web
└─┬ react-docgen-typescript-loader@3.7.2
  └─┬ @webpack-contrib/schema-utils@1.0.0-beta.0
    └─┬ webpack@4.46.0
      └─┬ node-libs-browser@2.2.1
        └─┬ crypto-browserify@3.12.0
          ├─┬ browserify-cipher@1.0.1
          │ ├─┬ browserify-aes@1.2.0
          │ │ └── cipher-base@1.0.6 deduped
          │ └─┬ browserify-des@1.0.2
          │   └── cipher-base@1.0.6 deduped
          ├─┬ create-hash@1.2.0
          │ └── cipher-base@1.0.6
          ├─┬ create-hmac@1.1.7
          │ └── cipher-base@1.0.6 deduped
          └─┬ pbkdf2@3.1.3
            └─┬ create-hash@1.1.3
              └── cipher-base@1.0.6 deduped
~~~