### PR TITLE
[redhat-3.9] deps: update cipher-base to version 1.0.6 (PROJQUAY-9339)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,19 +115,6 @@
         "typescript": ">=2.1.4"
       }
     },
-    "node_modules/@types/jasmine/node_modules/typescript": {
-      "version": "2.2.1",
-      "resolved": "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz",
-      "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@types/jquery": {
       "version": "2.0.40",
       "resolved": "https://registry.yarnpkg.com/@types/jquery/-/jquery-2.0.40.tgz",
@@ -1364,12 +1351,6 @@
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
-    "node_modules/buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true
-    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -1748,13 +1729,46 @@
       "dev": true
     },
     "node_modules/cipher-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz",
-      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
+    },
+    "node_modules/cipher-base/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cipher-base/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/clap": {
       "version": "1.1.2",
@@ -1929,15 +1943,6 @@
       "dev": true,
       "dependencies": {
         "color-name": "^1.0.0"
-      }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
-      "dependencies": {
-        "color-name": "^1.1.1"
       }
     },
     "node_modules/colormin": {
@@ -2534,13 +2539,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/define-property/node_modules/is-buffer": {
-      "version": "1.1.4",
-      "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-      "deprecated": "This version of 'is-buffer' is out-of-date. You must update to v1.1.6 or newer",
-      "dev": true
     },
     "node_modules/define-property/node_modules/is-data-descriptor": {
       "version": "0.1.4",
@@ -5007,15 +5005,6 @@
         "extend": "3"
       }
     },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "2.6.7",
-      "resolved": "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz",
-      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5643,29 +5632,11 @@
         "node": "*"
       }
     },
-    "node_modules/istanbul/node_modules/isexe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-      "dev": true
-    },
     "node_modules/istanbul/node_modules/resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
-    },
-    "node_modules/istanbul/node_modules/which": {
-      "version": "1.2.12",
-      "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-      "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^1.1.1"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
     },
     "node_modules/iterate-object": {
       "version": "1.3.4",
@@ -5970,24 +5941,6 @@
         "which": "^1.2.1"
       }
     },
-    "node_modules/karma-chrome-launcher/node_modules/isexe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-      "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-      "dev": true
-    },
-    "node_modules/karma-chrome-launcher/node_modules/which": {
-      "version": "1.2.12",
-      "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-      "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^1.1.1"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/karma-coverage": {
       "version": "0.5.5",
       "resolved": "https://registry.yarnpkg.com/karma-coverage/-/karma-coverage-0.5.5.tgz",
@@ -6115,13 +6068,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/kind-of/node_modules/is-buffer": {
-      "version": "1.1.4",
-      "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-      "deprecated": "This version of 'is-buffer' is out-of-date. You must update to v1.1.6 or newer",
-      "dev": true
     },
     "node_modules/lazy-cache": {
       "version": "1.0.4",
@@ -6496,21 +6442,6 @@
       "dependencies": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/memory-fs/node_modules/readable-stream": {
-      "version": "2.2.3",
-      "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-      "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/meow": {
@@ -8119,12 +8050,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -9717,21 +9642,6 @@
       "dependencies": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/stream-browserify/node_modules/readable-stream": {
-      "version": "2.2.3",
-      "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-      "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-      "dev": true,
-      "dependencies": {
-        "buffer-shims": "^1.0.0",
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "string_decoder": "~0.10.x",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/stream-each": {
@@ -12097,14 +12007,6 @@
       "dev": true,
       "requires": {
         "typescript": ">=2.1.4"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "2.2.1",
-          "resolved": "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz",
-          "integrity": "sha1-SGK2YrmIpMj/aRzHlpYi0k23auk=",
-          "dev": true
-        }
       }
     },
     "@types/jquery": {
@@ -13178,12 +13080,6 @@
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true
-    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -13499,12 +13395,27 @@
       }
     },
     "cipher-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.3.tgz",
-      "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
       }
     },
     "clap": {
@@ -13621,17 +13532,6 @@
         "clone": "^1.0.2",
         "color-convert": "^1.3.0",
         "color-string": "^0.3.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "1.9.0",
-          "resolved": "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz",
-          "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-          "dev": true,
-          "requires": {
-            "color-name": "^1.1.1"
-          }
-        }
       }
     },
     "color-convert": {
@@ -14157,12 +14057,6 @@
               }
             }
           }
-        },
-        "is-buffer": {
-          "version": "1.1.4",
-          "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-          "dev": true
         },
         "is-data-descriptor": {
           "version": "0.1.4",
@@ -16136,17 +16030,6 @@
         "agent-base": "2",
         "debug": "2",
         "extend": "3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "iconv-lite": {
@@ -16632,26 +16515,11 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "isexe": {
-          "version": "1.1.2",
-          "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-          "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-          "dev": true
-        },
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
-        },
-        "which": {
-          "version": "1.2.12",
-          "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-          "dev": true,
-          "requires": {
-            "isexe": "^1.1.1"
-          }
         }
       }
     },
@@ -16922,23 +16790,6 @@
       "requires": {
         "fs-access": "^1.0.0",
         "which": "^1.2.1"
-      },
-      "dependencies": {
-        "isexe": {
-          "version": "1.1.2",
-          "resolved": "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz",
-          "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.2.12",
-          "resolved": "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz",
-          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-          "dev": true,
-          "requires": {
-            "isexe": "^1.1.1"
-          }
-        }
       }
     },
     "karma-coverage": {
@@ -17031,14 +16882,6 @@
       "dev": true,
       "requires": {
         "is-buffer": "^1.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "1.1.4",
-          "resolved": "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.4.tgz",
-          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-          "dev": true
-        }
       }
     },
     "lazy-cache": {
@@ -17356,23 +17199,6 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.3",
-          "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "meow": {
@@ -18743,12 +18569,6 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -20093,23 +19913,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.2.3",
-          "resolved": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "^1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        }
       }
     },
     "stream-each": {


### PR DESCRIPTION
Fix for CVE-2025-9287.

Commands used:
~~~
$ npm update cipher-base
$ npm list cipher-base
quay@1.0.0 /home/aroyo/quay
└─┬ webpack@4.41.0
  └─┬ node-libs-browser@2.2.1
    └─┬ crypto-browserify@3.11.0
      ├─┬ browserify-cipher@1.0.0
      │ ├─┬ browserify-aes@1.0.6
      │ │ └── cipher-base@1.0.6 deduped
      │ └─┬ browserify-des@1.0.0
      │   └── cipher-base@1.0.6 deduped
      └─┬ create-hash@1.1.2
        └── cipher-base@1.0.6
$ cd web
$ npm install
$ npm update cipher-base
$ npm list cipher-base
quay-ui@0.1.0 /home/aroyo/quay/web
└─┬ react-docgen-typescript-loader@3.7.2
  └─┬ @webpack-contrib/schema-utils@1.0.0-beta.0
    └─┬ webpack@4.47.0
      └─┬ node-libs-browser@2.2.1
        └─┬ crypto-browserify@3.12.1
          ├─┬ browserify-cipher@1.0.1
          │ ├─┬ browserify-aes@1.2.0
          │ │ └── cipher-base@1.0.6 deduped
          │ └─┬ browserify-des@1.0.2
          │   └── cipher-base@1.0.6 deduped
          ├─┬ create-hash@1.2.0
          │ └── cipher-base@1.0.6
          ├─┬ create-hmac@1.1.7
          │ └── cipher-base@1.0.6 deduped
          └─┬ pbkdf2@3.1.3
            └─┬ create-hash@1.1.3
              └── cipher-base@1.0.6 deduped
~~~