### PR TITLE
proxy: Drop error 403 token requests for anonymous pulls (PROJQUAY-9012)

### DIFF
--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -206,7 +206,7 @@ class Proxy:
 
         # ignore fetching a token when validating proxy cache config to allow anonymous pulls from registries,
         # since the repo name is not known during the initial proxy configuration
-        if resp.status_code == 401 and auth is None and self._repo is None:
+        if (resp.status_code == 401 or resp.status_code == 403) and auth is None and self._repo is None:
             return
 
         if not resp.ok:


### PR DESCRIPTION
ghcr.io returns 403 when attempting an anonymous pull, which causes the proxy to attempt authentication even when authentication is disabled. This change ignores 403 status codes when requesting anonymous pulls, similar to the existing behavior for 401 responses.

Fixes https://issues.redhat.com/browse/PROJQUAY-9012, the code is from the original issue poster. I tested the code myself and it appears to work and not break anything.