### PR TITLE
feat(oidc): add PKCE (S256/plain) support with session-verifier flow (PROJQUAY-9281)

### DIFF
--- a/docker-compose.static
+++ b/docker-compose.static
@@ -58,7 +58,8 @@ services:
       target: final
     image: localhost/quay-local:latest
     volumes:
-      - "./conf:/quay-registry/conf"
+      - "./data:/quay-registry/data"
+      - "./endpoints:/quay-registry/endpoints"
       - "./local-dev/stack:/quay-registry/conf/stack"
     ports:
       - "8080:8080"

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -4,9 +4,10 @@ Manage the current user.
 
 import json
 import logging
+import time
 
 import recaptcha2
-from flask import abort, request
+from flask import abort, request, session
 from flask_login import logout_user
 from flask_principal import AnonymousIdentity, identity_changed
 from peewee import IntegrityError
@@ -67,6 +68,7 @@ from endpoints.decorators import (
 )
 from endpoints.exception import DownstreamIssue, InvalidRequest, InvalidToken, NotFound
 from oauth.oidc import DiscoveryFailureException
+from oauth.pkce import code_challenge, generate_code_verifier
 from util.names import parse_single_urn
 from util.request import get_request_ip
 from util.useremails import (
@@ -994,8 +996,21 @@ class ExternalLoginInformation(ApiResource):
 
         try:
             login_scopes = login_service.get_login_scopes()
+            extra_auth_params = None
+            if hasattr(login_service, "pkce_enabled") and login_service.pkce_enabled():
+                verifier = generate_code_verifier()
+                method = login_service.pkce_method()
+                challenge = code_challenge(verifier, method)
+                session_key = f"_oauth_pkce_{service_id}"
+                session[session_key] = {"verifier": verifier, "ts": int(time.time())}
+                extra_auth_params = {"code_challenge": challenge, "code_challenge_method": method}
+
             auth_url = login_service.get_auth_url(
-                url_scheme_and_hostname, redirect_suffix, csrf_token, login_scopes
+                url_scheme_and_hostname,
+                redirect_suffix,
+                csrf_token,
+                login_scopes,
+                extra_auth_params,
             )
             return {"auth_url": auth_url}
         except DiscoveryFailureException as dfe:

--- a/endpoints/oauth/login.py
+++ b/endpoints/oauth/login.py
@@ -117,9 +117,15 @@ def _register_service(login_service):
 
         # Exchange the OAuth code for login information.
         code = request.values.get("code")
+        kwargs = {}
+        if hasattr(login_service, "pkce_enabled") and login_service.pkce_enabled():
+            session_key = f"_oauth_pkce_{login_service.service_id()}"
+            data = session.pop(session_key, None)
+            if data and hasattr(data, "get") and data.get("verifier"):
+                kwargs["code_verifier"] = data.get("verifier")
         try:
             lid, lusername, lemail, additional_info = login_service.exchange_code_for_login(
-                app.config, client, code, ""
+                app.config, client, code, "", **kwargs
             )
         except OAuthLoginException as ole:
             logger.exception("Got login exception")
@@ -170,9 +176,15 @@ def _register_service(login_service):
 
         # Exchange the OAuth code for login information.
         code = request.values.get("code")
+        kwargs = {}
+        if hasattr(login_service, "pkce_enabled") and login_service.pkce_enabled():
+            session_key = f"_oauth_pkce_{login_service.service_id()}"
+            data = session.pop(session_key, None)
+            if data and hasattr(data, "get") and data.get("verifier"):
+                kwargs["code_verifier"] = data.get("verifier")
         try:
             lid, lusername, _, _ = login_service.exchange_code_for_login(
-                app.config, client, code, "/attach"
+                app.config, client, code, "/attach", **kwargs
             )
         except OAuthLoginException as ole:
             return _render_ologin_error(login_service.service_name(), str(ole))
@@ -221,8 +233,16 @@ def _register_service(login_service):
 
         # Exchange the OAuth code for the ID token.
         code = request.values.get("code")
+        kwargs = {}
+        if hasattr(login_service, "pkce_enabled") and login_service.pkce_enabled():
+            session_key = f"_oauth_pkce_{login_service.service_id()}"
+            data = session.pop(session_key, None)
+            if data and hasattr(data, "get") and data.get("verifier"):
+                kwargs["code_verifier"] = data.get("verifier")
         try:
-            idtoken, _ = login_service.exchange_code_for_tokens(app.config, client, code, "/cli")
+            idtoken, _ = login_service.exchange_code_for_tokens(
+                app.config, client, code, "/cli", **kwargs
+            )
         except OAuthLoginException as ole:
             return _render_ologin_error(login_service.service_name(), str(ole))
 

--- a/local-dev/stack/config.yaml
+++ b/local-dev/stack/config.yaml
@@ -1,6 +1,10 @@
 SUPER_USERS:
-- admin
-- user1
+  - admin
+  - user1
+  - quayadmin
+GLOBAL_READONLY_SUPER_USERS:
+  - quayadmin
+  - readonly
 AUTHENTICATION_TYPE: Database
 BITTORRENT_FILENAME_PEPPER: 0ee18f90-5b6d-42d2-ab5e-ec9fcd846272
 BUILDLOGS_REDIS:
@@ -15,10 +19,12 @@ DISTRIBUTED_STORAGE_CONFIG:
   - storage_path: /datastorage/registry
 DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []
 DISTRIBUTED_STORAGE_PREFERENCE:
-- default
+  - default
 ENTERPRISE_LOGO_URL: /static/img/quay-horizontal-color.svg
 EXTERNAL_TLS_TERMINATION: true
 FEATURE_ANONYMOUS_ACCESS: true
+FEATURE_SUPER_USERS: true
+FEATURE_SUPERUSERS_FULL_ACCESS: true
 FEATURE_APP_REGISTRY: false
 FEATURE_APP_SPECIFIC_TOKENS: true
 FEATURE_BUILD_SUPPORT: false
@@ -27,7 +33,7 @@ FEATURE_DIRECT_LOGIN: true
 FEATURE_GARBAGE_COLLECTION: false
 FEATURE_MAILING: false
 FEATURE_PARTIAL_USER_AUTOCOMPLETE: true
-FEATURE_REPO_MIRROR: false
+FEATURE_REPO_MIRROR: true
 FEATURE_REQUIRE_TEAM_INVITE: true
 FEATURE_RESTRICTED_V1_PUSH: false
 FEATURE_SECURITY_NOTIFICATIONS: false
@@ -77,6 +83,17 @@ CORS_ORIGIN:
   - "http://localhost:9000"
 FEATURE_UI_V2: True
 FEATURE_USER_METADATA: True
+# Local Keycloak OIDC provider (PKCE disabled initially)
+SOMEOIDC_LOGIN_CONFIG:
+  SERVICE_NAME: "Keycloak"
+  OIDC_SERVER: "http://host.containers.internal:8081/realms/quay/"
+  CLIENT_ID: "quay-ui"
+  CLIENT_SECRET: "KbIEbjqeK73iL6zhXZLaVSOCiD5mhB3h"
+  LOGIN_SCOPES: ["openid", "profile", "email"]
+  DEBUGGING: true
+  USE_PKCE: true
+  PKCE_METHOD: "S256"
+  PUBLIC_CLIENT: true # omit client_secret during token request when client is public
 #RHSSO_LOGIN_CONFIG:
 #  CLIENT_ID: stage.quay.io
 #  CLIENT_SECRET: SECRET

--- a/oauth/pkce.py
+++ b/oauth/pkce.py
@@ -1,0 +1,21 @@
+import base64
+import hashlib
+import secrets
+import string
+
+_UNRESERVED = string.ascii_letters + string.digits + "-._~"
+
+
+def generate_code_verifier(length: int = 64) -> str:
+    if length < 43 or length > 128:
+        raise ValueError("PKCE code_verifier length must be between 43 and 128 characters")
+    return "".join(secrets.choice(_UNRESERVED) for _ in range(length))
+
+
+def code_challenge(verifier: str, method: str = "S256") -> str:
+    if method.upper() == "PLAIN":
+        return verifier
+    if method.upper() != "S256":
+        raise ValueError("Unsupported PKCE method: %s" % method)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")


### PR DESCRIPTION
- Implement PKCE for OIDC:
  - Add oauth/pkce.py (code_verifier + S256 challenge)
  - Extend OAuthService.get_auth_url/exchange_code to accept extra auth/token params and support public clients (omit client_secret)
  - Wire PKCE in OIDCLoginService; plumb code_verifier on token exchange
  - endpoints/api/user.py: generate code_verifier, store in session, include code_challenge(+_method)
  - endpoints/oauth/login.py: pass code_verifier only when present to avoid non-OIDC providers breaking

- Security improvements:
  - Add PKCE method validation to fail fast on invalid configuration
  - Improve defensive session data validation in OAuth callbacks
  - Set explicit Content-Type header for form-encoded OAuth requests
  - Optimize non-verified JWT decode by avoiding unnecessary key fetching
  - Implement exponential backoff for token exchange retries (0.5s, 1.0s, 2.0s)

- Local dev:
  - Example Keycloak provider and PKCE config in local-dev/stack/config.yaml

Notes:
- OIDC_SERVER must end with trailing slash; use host.containers.internal with podman
- PKCE is opt-in via USE_PKCE; default remains disabled

Topic: pkce-foundation