### PR TITLE
fix: Fix Sentry transport KeyError in exception logging initialization (PROJQUAY-9198)

### DIFF
--- a/buildman/builder.py
+++ b/buildman/builder.py
@@ -72,14 +72,6 @@ def initialize_sentry():
                     integrations=integrations,
                     default_integrations=False,
                     auto_session_tracking=True,
-                    # Fix connection pool issues
-                    transport=sentry_sdk.transport.make_transport(
-                        {
-                            "pool_connections": 10,  # Instead of 1
-                            "pool_maxsize": 20,  # Max connections per pool
-                            "max_retries": 3,  # Retry failed sends
-                        }
-                    ),
                 )
                 sentry_sdk.set_tag("service", "buildman")
                 sentry_sdk.set_tag("buildman", buildman_name)

--- a/util/saas/exceptionlog.py
+++ b/util/saas/exceptionlog.py
@@ -72,13 +72,6 @@ class Sentry(object):
                         integrations=integrations,
                         default_integrations=False,
                         auto_session_tracking=True,
-                        transport=sentry_sdk.transport.make_transport(
-                            {
-                                "pool_connections": 10,  # Instead of default 1
-                                "pool_maxsize": 20,  # Max connections per pool
-                                "max_retries": 3,  # Retry failed sends
-                            }
-                        ),
                     )
                     # Return the initialized Sentry SDK object directly
                     sentry = initialized_sentry

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -101,14 +101,6 @@ class Worker(object):
                         integrations=integrations,
                         default_integrations=False,
                         auto_session_tracking=True,
-                        # Fix connection pool issues
-                        transport=sentry_sdk.transport.make_transport(
-                            {
-                                "pool_connections": 10,  # Instead of 1
-                                "pool_maxsize": 20,  # Max connections per pool
-                                "max_retries": 3,  # Retry failed sends
-                            }
-                        ),
                     )
                     sentry_sdk.set_tag("worker", worker_name)
                 except Exception as e:


### PR DESCRIPTION
Fix Sentry transport KeyError in exception logging initialization

**Root cause:**

Custom transport configuration using `sentry_sdk.transport.make_transport()` was incompatible with the current Sentry SDK version. It did not recognize the transport keyword.


**Testing:**
- Verified Sentry initialization completes successfully
- Confirmed exception capture works correctly
- Tested both OTEL-enabled and OTEL-disabled scenarios
- OTEL/Sentry conflict resolution logic preserved and working
<img width="1264" height="652" alt="Screenshot 2025-09-16 at 2 32 54 PM" src="https://github.com/user-attachments/assets/89819a5a-7aca-4934-aaf7-7b50d07e1993" />

