### PR TITLE
fix(new ui): Move tag gives note when inputting existing tag name (PROJQUAY-9422)

### DIFF
--- a/web/src/routes/RepositoryDetails/Tags/TagsActionsAddTagModal.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsActionsAddTagModal.tsx
@@ -57,9 +57,8 @@ export default function AddTagModal(props: AddTagModalProps) {
         tagName,
         true,
       );
-      const existingTag = tagsResponse.tags.find(
-        (tag) => tag.name === tagName,
-      );
+
+      const existingTag = tagsResponse.tags.find((tag) => tag.name === tagName);
 
       if (existingTag) {
         setExistingTagInfo({
@@ -121,7 +120,8 @@ export default function AddTagModal(props: AddTagModalProps) {
         id="add-tag-modal"
         header={
           <Title headingLevel="h2">
-            {existingTagInfo?.exists ? 'Move' : 'Add'} tag to manifest {props.manifest.substring(0, 19)}
+            {existingTagInfo?.exists ? 'Move' : 'Add'} tag to manifest{' '}
+            {props.manifest.substring(0, 19)}
           </Title>
         }
         aria-label="Add tag modal"

--- a/web/src/routes/RepositoryDetails/Tags/TagsActionsAddTagModal.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsActionsAddTagModal.tsx
@@ -144,7 +144,7 @@ export default function AddTagModal(props: AddTagModalProps) {
               createTag({tag: value, manifest: props.manifest});
             }}
           >
-            {existingTagInfo?.exists ? 'Move Tag' : 'Create Tag'}
+            {existingTagInfo?.exists ? 'Move tag' : 'Create tag'}
           </Button>,
         ]}
       >

--- a/web/src/routes/RepositoryDetails/Tags/TagsActionsAddTagModal.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsActionsAddTagModal.tsx
@@ -1,52 +1,119 @@
 import {
+  Alert,
   Button,
   Modal,
   ModalVariant,
+  Spinner,
   TextInput,
   Title,
 } from '@patternfly/react-core';
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {AlertVariant} from 'src/atoms/AlertState';
 import {useAlerts} from 'src/hooks/UseAlerts';
 import {useCreateTag} from 'src/hooks/UseTags';
 import {isNullOrUndefined} from 'src/libs/utils';
+import {getTags} from 'src/resources/TagResource';
+
+// Simple debounce function
+function debounce<T extends (...args: any[]) => void>(
+  func: T,
+  wait: number,
+): T {
+  let timeout: NodeJS.Timeout;
+  return ((...args: Parameters<T>) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  }) as T;
+}
 
 export default function AddTagModal(props: AddTagModalProps) {
   const [value, setValue] = useState('');
+  const [existingTagInfo, setExistingTagInfo] = useState<{
+    exists: boolean;
+    manifest?: string;
+  } | null>(null);
+  const [isCheckingTag, setIsCheckingTag] = useState(false);
   const {addAlert} = useAlerts();
   const {createTag, successCreateTag, errorCreateTag} = useCreateTag(
     props.org,
     props.repo,
   );
 
+  // Function to check if tag exists
+  const checkTagExists = async (tagName: string) => {
+    if (!tagName.trim()) {
+      setExistingTagInfo(null);
+      return;
+    }
+
+    setIsCheckingTag(true);
+    try {
+      // Call existing tags API to check if tag exists
+      const tagsResponse = await getTags(
+        props.org,
+        props.repo,
+        1,
+        50,
+        tagName,
+        true,
+      );
+      const existingTag = tagsResponse.tags.find(
+        (tag) => tag.name === tagName,
+      );
+
+      if (existingTag) {
+        setExistingTagInfo({
+          exists: true,
+          manifest: existingTag.manifest_digest,
+        });
+      } else {
+        setExistingTagInfo({exists: false});
+      }
+    } catch (error) {
+      setExistingTagInfo({exists: false});
+    } finally {
+      setIsCheckingTag(false);
+    }
+  };
+
+  // Debounce the check to avoid too many API calls
+  const debouncedCheckTag = useCallback(
+    debounce((tagName: string) => checkTagExists(tagName), 500),
+    [props.org, props.repo],
+  );
+
   useEffect(() => {
     if (successCreateTag) {
+      const actionType = existingTagInfo?.exists ? 'moved' : 'created';
       addAlert({
         variant: AlertVariant.Success,
-        title: `Successfully created tag ${value}`,
+        title: `Successfully ${actionType} tag ${value}`,
       });
       setValue('');
+      setExistingTagInfo(null);
       props.loadTags();
       props.setIsOpen(false);
       if (!isNullOrUndefined(props.onComplete)) {
         props.onComplete();
       }
     }
-  }, [successCreateTag]);
+  }, [successCreateTag, existingTagInfo]);
 
   useEffect(() => {
     if (errorCreateTag) {
+      const actionType = existingTagInfo?.exists ? 'move' : 'create';
       addAlert({
         variant: AlertVariant.Failure,
-        title: `Could not create tag ${value}`,
+        title: `Could not ${actionType} tag ${value}`,
       });
       setValue('');
+      setExistingTagInfo(null);
       props.setIsOpen(false);
       if (!isNullOrUndefined(props.onComplete)) {
         props.onComplete();
       }
     }
-  }, [errorCreateTag]);
+  }, [errorCreateTag, existingTagInfo]);
 
   return (
     <>
@@ -54,7 +121,7 @@ export default function AddTagModal(props: AddTagModalProps) {
         id="add-tag-modal"
         header={
           <Title headingLevel="h2">
-            Add tag to manifest {props.manifest.substring(0, 19)}
+            {existingTagInfo?.exists ? 'Move' : 'Add'} tag to manifest {props.manifest.substring(0, 19)}
           </Title>
         }
         aria-label="Add tag modal"
@@ -72,21 +139,37 @@ export default function AddTagModal(props: AddTagModalProps) {
           <Button
             key="modal-action-button"
             variant="primary"
+            isDisabled={isCheckingTag || !value.trim()}
             onClick={() => {
               createTag({tag: value, manifest: props.manifest});
             }}
           >
-            Create tag
+            {existingTagInfo?.exists ? 'Move Tag' : 'Create Tag'}
           </Button>,
         ]}
       >
         <TextInput
           value={value}
           type="text"
-          onChange={(_event, value) => setValue(value)}
+          onChange={(_event, value) => {
+            setValue(value);
+            debouncedCheckTag(value);
+          }}
           aria-label="new tag name"
           placeholder="New tag name"
         />
+        {isCheckingTag && (
+          <div style={{marginTop: '16px'}}>
+            <Spinner size="sm" /> Checking tag availability...
+          </div>
+        )}
+        {existingTagInfo?.exists && (
+          <Alert
+            variant="warning"
+            title={`${value} is already applied to another image. This will move the tag.`}
+            style={{marginTop: '16px'}}
+          />
+        )}
       </Modal>
     </>
   );


### PR DESCRIPTION
This PR will fix the new UI of https://issues.redhat.com/browse/PROJQUAY-9422

**Now here're the expected behavior on new UI:**
- Check if an image tag is existed or not
- Update to change the head message to "**Move** tag to manifest *****"
- Display a note that the new image tag name is already existed, and will move the tag to another manifest.

<img width="1287" height="743" alt="image" src="https://github.com/user-attachments/assets/2ca4d132-6ce4-4df3-8f6b-a245196094a3" />
