### PR TITLE
config: add akamai config validation  (PROJQUAY-9435)

### DIFF
--- a/config-tool/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
+++ b/config-tool/pkg/lib/fieldgroups/distributedstorage/distributedstorage.go
@@ -264,6 +264,22 @@ func NewDistributedStorageArgs(storageArgs map[string]interface{}) (*shared.Dist
 		}
 	}
 
+	// Akamai provider
+	if value, ok := storageArgs["akamai_domain"]; ok {
+		newDistributedStorageArgs.AkamaiDomain, ok = value.(string)
+		if !ok {
+			return newDistributedStorageArgs, errors.New("cloudflare_domain must be of type string")
+		}
+	}
+
+	if value, ok := storageArgs["akamai_shared_secret"]; ok {
+		newDistributedStorageArgs.AkamaiSharedSecret, ok = value.(string)
+		if !ok {
+			return newDistributedStorageArgs, errors.New("cloudflare_domain must be of type string")
+		}
+	}
+
+
 	// Multi CDN provider
 	if value, ok := storageArgs["storage_config"]; ok {
 		newDistributedStorageArgs.StorageConfig, ok = value.(map[string]interface{})

--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -435,6 +435,29 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 		if ok, err := ValidateRequiredString(args.CloudflareDomain, "DISTRIBUTED_STORAGE_CONFIG."+storageName+".cloudflare_domain", fgName); !ok {
 			errors = append(errors, err)
 		}
+
+    case "AkamaiS3Storage":
+        // Check access key
+		if ok, err := ValidateRequiredString(args.S3AccessKey, "DISTRIBUTED_STORAGE_CONFIG."+storageName+".s3_access_key", fgName); !ok {
+			errors = append(errors, err)
+		}
+		// Check secret key
+		if ok, err := ValidateRequiredString(args.S3SecretKey, "DISTRIBUTED_STORAGE_CONFIG."+storageName+".s3_secret_key", fgName); !ok {
+			errors = append(errors, err)
+		}
+		// Check bucket name
+		if ok, err := ValidateRequiredString(args.S3Bucket, "DISTRIBUTED_STORAGE_CONFIG."+storageName+".s3_bucket", fgName); !ok {
+			errors = append(errors, err)
+		}
+
+    if ok, err := ValidateRequiredString(args.AkamaiDomain, "DISTRIBUTED_STORAGE_CONFIG."+storageName+".akamai_domain", fgName); !ok {
+			errors = append(errors, err)
+		}
+
+    if ok, err := ValidateRequiredString(args.AkamaiSharedSecret, "DISTRIBUTED_STORAGE_CONFIG."+storageName+".akamai_shared_secret", fgName); !ok {
+			errors = append(errors, err)
+		}
+
 	case "MultiCDNStorage":
 		// Check provider map
 		if ok, err := ValidateRequiredObject(args.Providers, "DISTRIBUTED_STORAGE_CONFIG."+storageName+".providers", fgName); !ok {

--- a/config-tool/pkg/lib/shared/structs.go
+++ b/config-tool/pkg/lib/shared/structs.go
@@ -54,6 +54,9 @@ type DistributedStorageArgs struct {
 	SwiftOsOptions   map[string]interface{} `default:"" validate:"" json:"os_options,omitempty" yaml:"os_options,omitempty"`
 	// Args for CloudFlare
 	CloudflareDomain string `default:"" validate:"" json:"cloudflare_domain,omitempty" yaml:"cloudflare_domain,omitempty"`
+	// Args for Akamai
+	AkamaiDomain string `default:"" validate:"" json:"akamai_domain,omitempty" yaml:"akamai_domain,omitempty"`
+	AkamaiSharedSecret string `default:"" validate:"" json:"akamai_shared_secret,omitempty" yaml:"akamai_shared_secret,omitempty"`
 	// Args for MultiCDNStorage
 	DefaultProvider string                 `default:"" validate:"" json:"default_provider,omitempty" yaml:"default_provider,omitempty"`
 	Providers       map[string]interface{} `default:"" validate:"" json:"providers,omitempty" yaml:"providers,omitempty"`


### PR DESCRIPTION
Akamai storage config validation was not added because we are using the multi CDN provider. However for dev, we might need to just use Akamai standalone. This adds validation so that the config works