### PR TITLE
workers(quotaregistrysize): fixed wrong condition to run quotasizeworker from PROJQUAY-8086 (PROJQUAY-9460)

### DIFF
--- a/workers/quotaregistrysizeworker.py
+++ b/workers/quotaregistrysizeworker.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
             time.sleep(100000)
 
     # Registry size is only viewable by superusers, don't calculate if not used
-    if not all(
+    if not any(
         [
             any(
                 [


### PR DESCRIPTION
As documented in `PROJQUAY-9460 [New] : Total Registry Size Calculation return 0 KB and always queued`, the logical condition is not checked correctly and needs to be adjusted as `if any (database or LDAP)` which was wrongly added as `if all (database or LDAP)` which blocks Quota calculation of all none LDAP based deployments.

Unittest have been adjusted and a note has been added as the logic has to be re-implemented in the unittests as the conditions are only evaluated during process start `__name__ == "__main__"`