### PR TITLE
web: make team name clickable in Teams View (PROJQUAY-9347)

### DIFF
--- a/web/cypress/e2e/teams-and-membership.cy.ts
+++ b/web/cypress/e2e/teams-and-membership.cy.ts
@@ -248,4 +248,38 @@ describe('Teams and membership page', () => {
     cy.get(`[data-testid="edit-team-description-btn"]`).should('not.exist');
     cy.get(`[data-testid="${user}-delete-icon"]`).should('not.exist');
   });
+
+  it('Can click team name to navigate to team management page and edit description', () => {
+    const team = 'arsenal';
+    const newDescription = 'updated team description';
+    cy.visit('/organization/testorg?tab=Teamsandmembership');
+    cy.get('#Teams').click();
+
+    // Search for a single team
+    cy.get('#teams-view-search').type(`${team}`);
+    cy.contains('1 - 1 of 1');
+
+    // Click on team name to navigate to team management page
+    cy.contains('td', team).contains('a', team).click();
+    cy.url().should('include', `teams/${team}`);
+
+    // Verify team name is displayed
+    cy.get('[data-testid="teamname-title"]').contains(team).should('exist');
+
+    // Edit team description
+    cy.get('[data-testid="edit-team-description-btn"]').click();
+    cy.get('[data-testid="team-description-text-area"]').clear();
+    cy.get('[data-testid="team-description-text-area"]').type(newDescription);
+    cy.get('[data-testid="save-team-description-btn"]').click();
+
+    // verify success alert
+    cy.get('.pf-v5-c-alert.pf-m-success')
+      .contains(`Successfully updated team:${team} description`)
+      .should('exist');
+
+    // verify description is updated
+    cy.get('[data-testid="team-description-text"]')
+      .contains(newDescription)
+      .should('exist');
+  });
 });

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
@@ -529,6 +529,9 @@ export default function ManageMembersList(props: ManageMembersListProps) {
     return (
       <>
         <Conditional if={pageInReadOnlyMode}>{teamSyncedConfig}</Conditional>
+        <PageSection variant={PageSectionVariants.light}>
+          {teamDescriptionComponent}
+        </PageSection>
         <Empty
           title="There are no viewable members for this team"
           icon={CubesIcon}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsViewList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsViewList.tsx
@@ -298,7 +298,22 @@ export default function TeamsViewList(props: TeamsViewListProps) {
                     isSelected: selectedTeams.some((t) => t.name === team.name),
                   }}
                 />
-                <Td dataLabel={teamViewColumnNames.teamName}>{team.name}</Td>
+                <Td dataLabel={teamViewColumnNames.teamName}>
+                  {team.can_view ? (
+                    <Link
+                      to={getTeamMemberPath(
+                        location.pathname,
+                        props.organizationName,
+                        team.name,
+                        searchParams.get('tab'),
+                      )}
+                    >
+                      {team.name}
+                    </Link>
+                  ) : (
+                    team.name
+                  )}
+                </Td>
                 <Td
                   dataLabel={teamViewColumnNames.members}
                   data-testid={`member-count-for-${team.name}`}


### PR DESCRIPTION
e21476eb web: show team desc if no members (PROJQUAY-9347)
b4e23a7a web: make team name clickable in Teams View (PROJQUAY-9347)

<img width="1073" height="492" alt="team-name-link" src="https://github.com/user-attachments/assets/e8f0a2be-2387-4fe8-b997-d3cb3a89ff1e" />
<img width="639" height="330" alt="team-description" src="https://github.com/user-attachments/assets/c38e14f0-1223-4c89-92f0-9c8fb3a88e0b" />
<img width="1038" height="573" alt="team-desc-no-members" src="https://github.com/user-attachments/assets/95f701f0-867f-4a36-9556-af96d85a6c16" />

