### PR TITLE
ui: show custom REGISTRY_TITLE on login page (PROJQUAY-9461)

### DIFF
--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -42,6 +42,7 @@ import SunIcon from '@patternfly/react-icons/dist/esm/icons/sun-icon';
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 
 import {ThemePreference, useTheme} from 'src/contexts/ThemeContext';
+import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 
 export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -52,6 +53,7 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
   const queryClient = useQueryClient();
   const {user} = useCurrentUser();
   const [err, setErr] = useState<string>();
+  const quayConfig = useQuayConfig();
 
   const onDropdownToggle = () => {
     setIsDropdownOpen((prev) => !prev);
@@ -220,7 +222,11 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
     />
   );
 
-  const signInButton = <Button> Sign In </Button>;
+  const signInButtonText = quayConfig?.config?.REGISTRY_TITLE_SHORT
+    ? `Sign in to ${quayConfig.config.REGISTRY_TITLE_SHORT}`
+    : 'Sign In';
+
+  const signInButton = <Button>{signInButtonText}</Button>;
 
   // Toggle between old UI and new UI
   const [isChecked, setIsChecked] = React.useState<boolean>(true);

--- a/web/src/routes/Signin/Signin.tsx
+++ b/web/src/routes/Signin/Signin.tsx
@@ -70,6 +70,10 @@ export function Signin() {
     />
   );
 
+  const loginButtonLabel = quayConfig?.config?.REGISTRY_TITLE
+    ? `Sign in to ${quayConfig.config.REGISTRY_TITLE}`
+    : 'Sign in';
+
   const loginForm = (
     <LoginForm
       showHelperText={err != null}
@@ -85,7 +89,7 @@ export function Signin() {
       isRememberMeChecked={rememberMe}
       onChangeRememberMe={(_event, v) => setRememberMe(v)}
       onLoginButtonClick={(e) => onLoginButtonClick(e)}
-      loginButtonLabel="Log in"
+      loginButtonLabel={loginButtonLabel}
     />
   );
 


### PR DESCRIPTION
the old UI shows this value in the login/sign in button

Signed-off-by: Brady Pratt <bpratt@redhat.com>

<img width="572" height="449" alt="sign-in-registry-title" src="https://github.com/user-attachments/assets/d4471c10-3e49-4fa9-a337-f07174975e77" />
