### PR TITLE
PROJQUAY-10282: feat(endpoints): add mirroring metrics

### DIFF
--- a/docs/mirroring-metrics.md
+++ b/docs/mirroring-metrics.md
@@ -1,0 +1,685 @@
+# Repository Mirror Metrics and Health Endpoints
+
+This document describes the comprehensive metrics and health endpoints available for monitoring Quay's repository mirroring functionality.
+
+## Overview
+
+Quay exposes detailed Prometheus metrics and a dedicated health endpoint for repository mirroring operations. These provide visibility into:
+
+- Synchronization status and progress per repository
+- Failure tracking and categorization
+- Performance metrics (duration, throughput)
+- Overall system health
+
+## Prometheus Metrics
+
+All metrics are exposed via the standard Quay metrics endpoint (typically available at the Prometheus PushGateway on port `9091`).
+
+**Names in this document match the worker export:** the pending-tags gauge is exported as `quay_repository_mirror_pending_tags` (internal Python name `repo_mirror_tags_pending` in `workers/repomirrorworker`). There is no `quay_repository_mirror_tags_pending` symbol.
+
+**`quay_repository_mirror_last_sync_status`:** the implementation uses labels `namespace`, `repository`, and `last_error_reason` only—there is no `status` label and values are **0** (failed), **1** (success), and **2** (in progress), not a −2..3 range. The canonical series uses `last_error_reason=""`; failures may also set a second series with `last_error_reason=<category>` for the same value.
+
+### Core Mirroring Metrics
+
+#### 1. Tags Pending Synchronization
+
+```text
+quay_repository_mirror_pending_tags{namespace="org1",repository="repo1"} 5
+```
+
+**Type:** Gauge
+**Labels:**
+- `namespace`: Organization or user namespace
+- `repository`: Repository name
+
+**Description:** Total number of tags pending synchronization for each mirrored repository. This decreases as tags are synced during a mirroring operation.
+
+**Use Cases:**
+- Monitor synchronization progress in real-time
+- Identify repositories with large numbers of pending tags
+- Track workload distribution across mirrors
+
+---
+
+#### 2. Last Synchronization Status
+
+```text
+quay_repository_mirror_last_sync_status{namespace="org1",repository="repo1",last_error_reason=""} 1
+quay_repository_mirror_last_sync_status{namespace="org2",repository="repo2",last_error_reason="auth_failed"} 0
+```
+
+**Type:** Gauge
+**Labels:**
+- `namespace`: Organization or user namespace
+- `repository`: Repository name
+- `last_error_reason`: Empty string (`""`) on the **canonical** time series for each repository (use this for counts and high-level alerts). When a sync fails, the worker also emits a **detail** time series with the same `namespace` / `repository` and `last_error_reason=<category>` for drill-down.
+
+**Values:**
+- `0` = Failed
+- `1` = Success
+- `2` = In Progress
+
+**Description:** Status of the last synchronization attempt. The canonical series (`last_error_reason=""`) always reflects the current status for that repo. On failure, a second series with a non-empty `last_error_reason` is set to the same value so you can attribute failures by category without double-counting repos—use the canonical label for `sum` / `count`, and the specific reason label for breakdowns.
+
+**Error Reason Categories:**
+- `auth_failed`: Authentication or authorization failures
+- `network_timeout`: Network timeout errors
+- `connection_error`: General connection issues
+- `not_found`: Repository or resource not found (404)
+- `tls_error`: TLS/SSL certificate errors
+- `decryption_failed`: Failed to decrypt credentials
+- `preempted`: Mirror job was preempted by another worker
+- `unknown_error`: Other unclassified errors
+
+**Use Cases:**
+- Alert on failed synchronizations
+- Identify patterns in failure types
+- Quickly determine current sync state without checking multiple metrics
+
+**Example Queries:**
+```promql
+# Failing repositories (canonical series only — one sample per repo)
+quay_repository_mirror_last_sync_status{last_error_reason=""} == 0
+
+# Successful repositories by namespace
+sum by (namespace) (quay_repository_mirror_last_sync_status{last_error_reason=""} == 1)
+
+# Failures attributed to auth (detail series)
+quay_repository_mirror_last_sync_status{last_error_reason="auth_failed"} == 0
+```
+
+---
+
+#### 3. Complete Synchronization Status
+
+```text
+quay_repository_mirror_sync_complete{namespace="org1",repository="repo1"} 1
+quay_repository_mirror_sync_complete{namespace="org2",repository="repo2"} 0
+```
+
+**Type:** Gauge
+**Labels:**
+- `namespace`: Organization or user namespace
+- `repository`: Repository name
+
+**Values:**
+- `0` = Incomplete (some tags failed to sync)
+- `1` = Complete (all tags successfully synchronized)
+
+**Description:** Indicates if all tags have been successfully synchronized in the last sync operation.
+
+**Use Cases:**
+- Alert on incomplete synchronizations
+- Track overall mirror health
+- Distinguish between complete failures and partial successes
+
+---
+
+#### 4. Synchronization Failure Counter
+
+```text
+quay_repository_mirror_sync_failures_total{namespace="org1",repository="repo1",reason="network_timeout"} 3
+quay_repository_mirror_sync_failures_total{namespace="org2",repository="repo2",reason="auth_failed"} 7
+```
+
+**Type:** Counter
+**Labels:**
+- `namespace`: Organization or user namespace
+- `repository`: Repository name
+- `reason`: Categorized failure reason (see error reasons above)
+
+**Description:** Cumulative counter of synchronization failures per repository. Increments on each failed sync attempt, with failures categorized by reason.
+
+**Use Cases:**
+- Set up alerts based on failure thresholds
+- Track failure rates over time
+- Identify consistently problematic repositories
+- Analyze failure patterns by type
+
+**Example Queries:**
+```promql
+# Failure rate per repository over 5 minutes
+rate(quay_repository_mirror_sync_failures_total[5m])
+
+# Repositories with more than 10 total failures
+quay_repository_mirror_sync_failures_total > 10
+
+# Most common failure types
+topk(5, sum by (reason) (quay_repository_mirror_sync_failures_total))
+```
+
+---
+
+### Supporting Metrics
+
+#### 5. Active Mirror Workers
+
+```text
+quay_repository_mirror_workers_active 5
+```
+
+**Type:** Gauge
+**Description:** Set to **1** in each Quay process while a `RepoMirrorWorker` is running (see `workers/repomirrorworker/repomirrorworker.py`). Prometheus should scrape every mirror worker target; **`sum(quay_repository_mirror_workers_active)`** across those targets approximates the number of active worker processes.
+
+**Use Cases:**
+- Verify worker processes are running
+- Monitor worker scaling
+- Alert when no workers are active
+
+---
+
+#### 6. Last Synchronization Timestamp
+
+```text
+quay_repository_mirror_last_sync_timestamp{namespace="org1",repository="repo1"} 1697385600
+```
+
+**Type:** Gauge
+**Labels:**
+- `namespace`: Organization or user namespace
+- `repository`: Repository name
+
+**Description:** Unix timestamp of when the last synchronization attempt started.
+
+**Use Cases:**
+- Alert on stale synchronizations
+- Track sync frequency
+- Identify mirrors that haven't run recently
+
+**Example Query:**
+```promql
+# Repositories that haven't synced in over an hour
+(time() - quay_repository_mirror_last_sync_timestamp) > 3600
+```
+
+---
+
+#### 7. Synchronization Duration
+
+```text
+quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",repository="repo1",le="30"} 45
+quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",repository="repo1",le="60"} 82
+quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",repository="repo1",le="+Inf"} 100
+```
+
+**Type:** Histogram
+**Labels:**
+- `namespace`: Organization or user namespace
+- `repository`: Repository name
+
+**Buckets:** 30s, 60s, 120s, 300s (5m), 600s (10m), 1200s (20m), 1800s (30m), 3600s (1h), 7200s (2h), +Inf
+
+**Description:** Duration of synchronization operations, allowing percentile calculations and performance analysis.
+
+**Use Cases:**
+- Calculate 95th/99th percentile sync times
+- Identify slow mirrors
+- Track performance trends over time
+- Capacity planning
+
+**Example Queries:**
+```promql
+# 95th percentile sync duration
+histogram_quantile(0.95, rate(quay_repository_mirror_sync_duration_seconds_bucket[5m]))
+
+# Average sync duration per repository
+rate(quay_repository_mirror_sync_duration_seconds_sum[5m]) /
+rate(quay_repository_mirror_sync_duration_seconds_count[5m])
+```
+
+---
+
+### Legacy Metric
+
+#### Unmirrored Repositories
+
+```text
+quay_repository_rows_unmirrored 42
+```
+
+**Type:** Gauge
+**Description:** Number of repositories in the database that have not yet been mirrored. This metric is maintained for backward compatibility.
+
+---
+
+## Health Endpoint
+
+### Endpoint Details
+
+**Path:** `/v1/repository/mirror/health`
+**Method:** GET
+**Authentication:** Required (fresh login)
+**Response Format:** JSON
+
+### HTTP Status Codes
+
+- `200 OK`: System is healthy
+- `503 Service Unavailable`: System is unhealthy (critical issues detected)
+- `401 Unauthorized`: Authentication required
+- `403 Forbidden`: Insufficient permissions
+- `404 Not Found`: `namespace` query parameter names a user or organization that does not exist
+
+### Query Parameters
+
+- `namespace` (optional): Filter health check to specific namespace
+- `detailed` (optional, boolean): Include per-repository breakdown (default: false)
+- `limit` (optional, integer): Maximum repositories returned in `repositories.details` when `detailed=true` (default: 100, max: 1000)
+- `offset` (optional, integer): Offset into the sorted mirror list for paginated details (default: 0)
+
+The JSON field `tags_pending` is the sum of `quay_repository_mirror_pending_tags` samples in **this** process’s Prometheus registry. On typical deployments the API does not run the mirror worker, so that sum is often `0` unless metrics are shared with the worker process.
+
+The `workers.active` field is `quay_repository_mirror_workers_active` from **this** process’s registry (again often `0` on API-only pods). `workers.configured` is **`REPO_MIRROR_WORKER_REPLICAS`** when that config is set; otherwise it mirrors `workers.active` (both from the same in-process gauge). When `REPO_MIRROR_WORKER_REPLICAS` is set and exceeds `workers.active` while at least one enabled mirror exists, the response includes a warning issue and `healthy` may be `false` (HTTP **503**).
+
+All `repositories` totals (`total`, `syncing`, `completed`, `failed`, `never_run`) and the optional `repositories.details` list include **enabled** mirror configurations only; disabled mirrors are omitted.
+
+### Response Schema
+
+#### Basic Response
+
+```json
+{
+  "healthy": true,
+  "workers": {
+    "active": 1,
+    "configured": 1,
+    "status": "healthy"
+  },
+  "repositories": {
+    "total": 150,
+    "syncing": 3,
+    "completed": 145,
+    "failed": 2,
+    "never_run": 0
+  },
+  "tags_pending": 47,
+  "last_check": "2025-12-09T10:30:00Z",
+  "issues": []
+}
+```
+
+#### Unhealthy Response
+
+```json
+{
+  "healthy": false,
+  "workers": {
+    "active": 3,
+    "configured": 5,
+    "status": "degraded"
+  },
+  "repositories": {
+    "total": 100,
+    "syncing": 2,
+    "completed": 54,
+    "failed": 19,
+    "never_run": 25
+  },
+  "tags_pending": 234,
+  "last_check": "2025-12-09T10:30:00Z",
+  "issues": [
+    {
+      "severity": "critical",
+      "message": "25.3% of repositories are failing (threshold: 20.0%)",
+      "timestamp": "2025-12-09T10:30:00Z"
+    },
+    {
+      "severity": "error",
+      "message": "Repository org2/repo2 has exhausted all retry attempts",
+      "timestamp": "2025-12-09T10:20:00Z"
+    },
+    {
+      "severity": "warning",
+      "message": "Repository org1/repo1 hasn't synced in over 24 hours",
+      "timestamp": "2025-12-09T10:25:00Z"
+    }
+  ]
+}
+```
+
+#### Detailed Response
+
+When `detailed=true` is specified:
+
+Each `repositories.details[]` item includes `last_sync`, which is either an ISO-8601 UTC timestamp string ending in `Z` or **`null`**. The API reads `quay_repository_mirror_last_sync_timestamp` from the in-process Prometheus registry in `endpoints/api/mirrorhealth.py`; when that metric has no sample for the repo in this process (typical when the mirror worker runs elsewhere), `last_sync` is `null`. Clients must treat the field as nullable.
+
+The `workers.status` field reflects aggregate health: repository mirror row state plus optional replica mismatch when `REPO_MIRROR_WORKER_REPLICAS` is configured.
+
+```json
+{
+  "healthy": true,
+  "workers": {
+    "active": 1,
+    "configured": 1,
+    "status": "healthy"
+  },
+  "repositories": {
+    "total": 150,
+    "syncing": 3,
+    "completed": 145,
+    "failed": 2,
+    "never_run": 0,
+    "details": [
+      {
+        "namespace": "org1",
+        "repository": "repo1",
+        "sync_status": "SUCCESS",
+        "is_enabled": true,
+        "last_sync": "2025-12-09T10:15:00Z",
+        "retries_remaining": 3
+      },
+      {
+        "namespace": "org2",
+        "repository": "repo2",
+        "sync_status": "FAIL",
+        "is_enabled": true,
+        "last_sync": null,
+        "retries_remaining": 0
+      }
+    ],
+    "pagination": {
+      "limit": 100,
+      "offset": 0,
+      "has_more": false
+    }
+  },
+  "tags_pending": 47,
+  "last_check": "2025-12-09T10:30:00Z",
+  "issues": []
+}
+```
+
+### Health Determination Logic
+
+The `healthy` field and HTTP status (`503` when unhealthy) are driven by repository **failure rate** over **enabled** mirrors only: more than **20%** of enabled mirrors that have left `NEVER_RUN` are in `FAIL`, i.e. `failed / (total - never_run) > 0.2` when `(total - never_run) > 0`. Mirrors still in `NEVER_RUN` are counted in `repositories.never_run` and are excluded from that denominator so new configurations do not count as failures.
+
+The `issues` array may additionally include **warnings** (stale sync, never synced), **errors** (retry exhaustion), and **critical** entries when the failure-rate threshold is exceeded. Other health services may apply further rules (for example long-running `SYNCING` states).
+
+### Example Usage
+
+```bash
+# Basic health check
+curl -X GET "https://quay.example.com/v1/repository/mirror/health" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Health check for specific namespace
+curl -X GET "https://quay.example.com/v1/repository/mirror/health?namespace=myorg" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Detailed health check
+curl -X GET "https://quay.example.com/v1/repository/mirror/health?detailed=true" \
+  -H "Authorization: Bearer $TOKEN"
+
+# Paginated detailed view
+curl -X GET "https://quay.example.com/v1/repository/mirror/health?detailed=true&limit=50&offset=50" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## Example Prometheus Alert Rules
+
+### Critical Alerts
+
+```yaml
+groups:
+  - name: quay_mirror_critical
+    interval: 30s
+    rules:
+      - alert: QuayMirrorWorkersDown
+        expr: quay_repository_mirror_workers_active == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No active mirror workers"
+          description: "All mirror workers are down or not responding"
+
+      - alert: QuayMirrorHighFailureCount
+        expr: quay_repository_mirror_sync_failures_total > 10
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High number of mirror synchronization failures"
+          description: "Repository {{ $labels.namespace }}/{{ $labels.repository }} has {{ $value }} total failures"
+```
+
+### Warning Alerts
+
+```yaml
+      - alert: QuayMirrorSyncFailures
+        expr: rate(quay_repository_mirror_sync_failures_total[5m]) > 0.1
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Repository mirroring failures detected"
+          description: "Repository {{ $labels.namespace }}/{{ $labels.repository }} has {{ $value }} failures per second (reason: {{ $labels.reason }})"
+
+      - alert: QuayMirrorSyncStale
+        expr: time() - quay_repository_mirror_last_sync_timestamp > 3600
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Mirror synchronization is stale"
+          description: "Repository {{ $labels.namespace }}/{{ $labels.repository }} hasn't synced in over an hour"
+
+      - alert: QuayMirrorHighPendingTags
+        expr: sum(quay_repository_mirror_pending_tags) > 1000
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High number of pending tags"
+          description: "There are {{ $value }} tags pending synchronization across all repositories"
+
+      - alert: QuayMirrorAuthFailures
+        expr: increase(quay_repository_mirror_sync_failures_total{reason="auth_failed"}[1h]) > 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Mirror authentication failures"
+          description: "Repository {{ $labels.namespace }}/{{ $labels.repository }} has had {{ $value }} authentication failures in the last hour"
+```
+
+---
+
+## Example Grafana Dashboard Queries
+
+### Panel 1: Synchronization Status Overview
+
+```promql
+# Count of repositories by sync status (canonical series: last_error_reason="")
+sum by(namespace) (quay_repository_mirror_last_sync_status{last_error_reason=""} == 1)  # Success
+sum by(namespace) (quay_repository_mirror_last_sync_status{last_error_reason=""} == 0)  # Failed
+sum by(namespace) (quay_repository_mirror_last_sync_status{last_error_reason=""} == 2)  # In Progress
+```
+
+**Visualization:** Pie chart or time series
+
+---
+
+### Panel 2: Failure Rate
+
+```promql
+# Failures per second by repository
+rate(quay_repository_mirror_sync_failures_total[5m])
+
+# Total failure rate
+sum(rate(quay_repository_mirror_sync_failures_total[5m]))
+```
+
+**Visualization:** Time series
+
+---
+
+### Panel 3: Failures by Reason
+
+```promql
+# Count failures by reason
+sum by (reason) (quay_repository_mirror_sync_failures_total)
+
+# Failure rate by reason
+sum by (reason) (rate(quay_repository_mirror_sync_failures_total[5m]))
+```
+
+**Visualization:** Bar chart or table
+
+---
+
+### Panel 4: Pending Tags by Repository
+
+```promql
+# Top 10 repositories by pending tags
+topk(10, quay_repository_mirror_pending_tags)
+
+# Total pending tags
+sum(quay_repository_mirror_pending_tags)
+```
+
+**Visualization:** Bar chart or gauge
+
+---
+
+### Panel 5: Active Mirror Workers
+
+```promql
+quay_repository_mirror_workers_active
+```
+
+**Visualization:** Gauge or single stat
+
+---
+
+### Panel 6: Synchronization Duration
+
+```promql
+# 95th percentile sync duration
+histogram_quantile(0.95, rate(quay_repository_mirror_sync_duration_seconds_bucket[5m]))
+
+# 99th percentile sync duration
+histogram_quantile(0.99, rate(quay_repository_mirror_sync_duration_seconds_bucket[5m]))
+
+# Average duration by repository
+rate(quay_repository_mirror_sync_duration_seconds_sum{namespace="myorg"}[5m]) /
+rate(quay_repository_mirror_sync_duration_seconds_count{namespace="myorg"}[5m])
+```
+
+**Visualization:** Time series or heatmap
+
+---
+
+### Panel 7: Incomplete Syncs
+
+```promql
+# Count of incomplete synchronizations
+count(quay_repository_mirror_sync_complete == 0)
+
+# List of repositories with incomplete syncs
+quay_repository_mirror_sync_complete == 0
+```
+
+**Visualization:** Single stat and table
+
+---
+
+## Best Practices
+
+### Metric Collection
+
+1. **Scrape Interval**: Set Prometheus scrape interval to 30-60 seconds for mirror metrics
+2. **Retention**: Keep at least 30 days of history for trend analysis
+3. **Cardinality Management**: Monitor the number of mirrored repositories; consider aggregating by namespace for very large deployments (100+ mirrors)
+
+### Alerting
+
+1. **Failure Thresholds**: Set alerts based on your SLA requirements
+2. **Notification Routing**: Route auth failures to security teams, network failures to infrastructure
+3. **Alert Fatigue**: Use appropriate `for` durations to avoid transient alert noise
+4. **Escalation**: Set up tiered alerts (warning → critical) based on failure count and duration
+
+### Monitoring
+
+1. **Dashboard Organization**: Create separate dashboards for:
+   - Overview (system-wide health)
+   - Per-namespace views
+   - Troubleshooting (detailed failure analysis)
+2. **Correlate Metrics**: Combine mirror metrics with system metrics (CPU, memory, network) for root cause analysis
+3. **Regular Review**: Weekly review of failure patterns and trends
+
+### Capacity Planning
+
+1. Monitor sync duration trends to predict when additional workers are needed
+2. Track total pending tags to understand workload
+3. Use histogram metrics to identify performance degradation before it impacts SLAs
+
+---
+
+## Troubleshooting Guide
+
+### High Failure Rate
+
+1. Check `quay_repository_mirror_sync_failures_total` broken down by `reason`
+2. For auth failures: Verify credentials, check token expiration
+3. For network timeouts: Check network connectivity, consider increasing `skopeo_timeout_interval`
+4. For TLS errors: Verify certificate validity, check `verify_tls` settings
+
+### Stale Synchronizations
+
+1. Query `quay_repository_mirror_last_sync_timestamp` to find affected repositories
+2. Check if `sync_interval` is appropriate for the repository update frequency
+3. Verify mirror workers are running and processing jobs
+4. Check if repositories are disabled
+
+### Slow Synchronization
+
+1. Use `quay_repository_mirror_sync_duration_seconds` histogram to identify slow mirrors
+2. Check repository size (number of tags, layer sizes)
+3. Verify network bandwidth between Quay and external registry
+4. Consider adjusting `skopeo_timeout_interval` for large images
+
+### Incomplete Synchronizations
+
+1. Query `quay_repository_mirror_sync_complete == 0` to find affected repositories
+2. Check logs for specific tag failures
+3. Review `quay_repository_mirror_sync_failures_total` by reason
+4. Verify tag patterns in mirror configuration are correct
+
+---
+
+## Integration with Existing Health Checks
+
+The mirror health service is automatically integrated into Quay's existing health check infrastructure:
+
+- Available via `/health/endtoend` endpoint (includes all services)
+- Can be monitored separately via the dedicated `/v1/repository/mirror/health` endpoint
+- Follows the same patterns as other Quay health services
+
+---
+
+## Backward Compatibility
+
+All existing metrics remain unchanged:
+- `quay_repository_rows_unmirrored` continues to function as before
+- New metrics are additive and don't affect existing monitoring setups
+- Old monitoring configurations will continue to work without modification
+
+---
+
+## Security Considerations
+
+1. **Authentication**: Both metrics and health endpoints require authentication
+2. **Namespace Filtering**: Users can only view health for namespaces they have access to
+3. **Sensitive Information**: Credentials and passwords are never exposed in metrics or health responses
+4. **Error Messages**: Failure reasons are categorized generically to avoid leaking sensitive details
+
+---
+
+## Additional Resources
+
+- [Prometheus Best Practices](https://prometheus.io/docs/practices/naming/)
+- [Grafana Dashboard Examples](https://grafana.com/grafana/dashboards/)
+- [Quay Configuration Documentation](https://docs.projectquay.io/)
+- [Repository Mirroring Guide](https://docs.projectquay.io/repo_mirror.html)

--- a/docs/mirroring-metrics.md
+++ b/docs/mirroring-metrics.md
@@ -118,31 +118,29 @@ quay_repository_mirror_sync_complete{namespace="org2",repository="repo2"} 0
 #### 4. Synchronization Failure Counter
 
 ```text
-quay_repository_mirror_sync_failures_total{namespace="org1",repository="repo1",reason="network_timeout"} 3
-quay_repository_mirror_sync_failures_total{namespace="org2",repository="repo2",reason="auth_failed"} 7
+quay_repository_mirror_sync_failures_total{namespace="org1",reason="network_timeout"} 3
+quay_repository_mirror_sync_failures_total{namespace="org2",reason="auth_failed"} 7
 ```
 
 **Type:** Counter
 **Labels:**
 - `namespace`: Organization or user namespace
-- `repository`: Repository name
 - `reason`: Categorized failure reason (see error reasons above)
 
-**Description:** Cumulative counter of synchronization failures per repository. Increments on each failed sync attempt, with failures categorized by reason.
+**Description:** Cumulative counter of synchronization failures aggregated by namespace. Increments on each failed sync attempt, with failures categorized by reason. Per-repository failure detail is available via the health endpoint.
 
 **Use Cases:**
 - Set up alerts based on failure thresholds
-- Track failure rates over time
-- Identify consistently problematic repositories
+- Track failure rates over time per namespace
 - Analyze failure patterns by type
 
 **Example Queries:**
 ```promql
-# Failure rate per repository over 5 minutes
+# Failure rate per namespace over 5 minutes
 rate(quay_repository_mirror_sync_failures_total[5m])
 
-# Repositories with more than 10 total failures
-quay_repository_mirror_sync_failures_total > 10
+# Namespaces with more than 10 total failures
+sum by (namespace) (quay_repository_mirror_sync_failures_total) > 10
 
 # Most common failure types
 topk(5, sum by (reason) (quay_repository_mirror_sync_failures_total))
@@ -197,23 +195,21 @@ quay_repository_mirror_last_sync_timestamp{namespace="org1",repository="repo1"} 
 #### 7. Synchronization Duration
 
 ```text
-quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",repository="repo1",le="30"} 45
-quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",repository="repo1",le="60"} 82
-quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",repository="repo1",le="+Inf"} 100
+quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",le="60"} 45
+quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",le="300"} 82
+quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",le="+Inf"} 100
 ```
 
 **Type:** Histogram
 **Labels:**
 - `namespace`: Organization or user namespace
-- `repository`: Repository name
 
-**Buckets:** 30s, 60s, 120s, 300s (5m), 600s (10m), 1200s (20m), 1800s (30m), 3600s (1h), 7200s (2h), +Inf
+**Buckets:** 60s (1m), 300s (5m), 900s (15m), 3600s (1h), +Inf
 
-**Description:** Duration of synchronization operations, allowing percentile calculations and performance analysis.
+**Description:** Duration of synchronization operations aggregated by namespace, allowing percentile calculations and performance analysis. Per-repository granularity is omitted to control time series cardinality at scale.
 
 **Use Cases:**
-- Calculate 95th/99th percentile sync times
-- Identify slow mirrors
+- Calculate 95th/99th percentile sync times per namespace
 - Track performance trends over time
 - Capacity planning
 
@@ -222,7 +218,7 @@ quay_repository_mirror_sync_duration_seconds_bucket{namespace="org1",repository=
 # 95th percentile sync duration
 histogram_quantile(0.95, rate(quay_repository_mirror_sync_duration_seconds_bucket[5m]))
 
-# Average sync duration per repository
+# Average sync duration per namespace
 rate(quay_repository_mirror_sync_duration_seconds_sum[5m]) /
 rate(quay_repository_mirror_sync_duration_seconds_count[5m])
 ```
@@ -504,7 +500,7 @@ sum by(namespace) (quay_repository_mirror_last_sync_status{last_error_reason=""}
 ### Panel 2: Failure Rate
 
 ```promql
-# Failures per second by repository
+# Failures per second by namespace
 rate(quay_repository_mirror_sync_failures_total[5m])
 
 # Total failure rate
@@ -562,7 +558,7 @@ histogram_quantile(0.95, rate(quay_repository_mirror_sync_duration_seconds_bucke
 # 99th percentile sync duration
 histogram_quantile(0.99, rate(quay_repository_mirror_sync_duration_seconds_bucket[5m]))
 
-# Average duration by repository
+# Average duration by namespace
 rate(quay_repository_mirror_sync_duration_seconds_sum{namespace="myorg"}[5m]) /
 rate(quay_repository_mirror_sync_duration_seconds_count{namespace="myorg"}[5m])
 ```

--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -844,6 +844,7 @@ import endpoints.api.immutability_policy
 import endpoints.api.logs
 import endpoints.api.manifest
 import endpoints.api.mirror
+import endpoints.api.mirrorhealth
 import endpoints.api.namespacequota
 import endpoints.api.org_mirror
 import endpoints.api.organization

--- a/endpoints/api/discovery.py
+++ b/endpoints/api/discovery.py
@@ -31,6 +31,7 @@ PARAM_REGEX = re.compile(r"<([^:>]+:)*([\w]+)>")
 
 TYPE_CONVERTER = {
     truthy_bool: "boolean",
+    bool: "boolean",
     str: "string",
     reqparse.text_type: "string",
     int: "integer",

--- a/endpoints/api/mirrorhealth.py
+++ b/endpoints/api/mirrorhealth.py
@@ -1,0 +1,486 @@
+# -*- coding: utf-8 -*-
+"""
+Repository Mirror Health Endpoint
+
+Provides health status and monitoring information for repository mirroring operations.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from peewee import Case, fn
+from prometheus_client import REGISTRY
+
+import features
+from app import app
+from auth.auth_context import get_authenticated_user
+from auth.permissions import OrganizationMemberPermission, UserAdminPermission
+from data import model
+from data.database import (
+    RepoMirrorConfig,
+    RepoMirrorStatus,
+    Repository,
+    RepositoryState,
+    User,
+)
+from endpoints.api import (
+    ApiResource,
+    allow_if_global_readonly_superuser,
+    allow_if_superuser,
+    nickname,
+    parse_args,
+    query_param,
+    require_fresh_login,
+    resource,
+    show_if,
+)
+from endpoints.exception import NotFound, Unauthorized
+from util.parsing import truthy_bool
+
+logger = logging.getLogger(__name__)
+
+_MAX_DETAIL_PAGE = 1000
+_ISSUE_SAMPLE_CAP = 5
+
+_CACHE_CONTROL_NO_STORE = "no-cache, no-store, must-revalidate"
+
+
+def _utc_z_timestamp(when: datetime) -> str:
+    """Format an aware UTC datetime as ISO-8601 with Z suffix."""
+    utc = when.astimezone(timezone.utc)
+    return utc.isoformat().replace("+00:00", "Z")
+
+
+def _get_last_sync_timestamps():
+    """
+    Retrieve last sync timestamps from the Prometheus registry in this process.
+
+    Mirror timestamps are emitted by the repository mirror worker. API/gunicorn processes
+    typically do not run that worker, so REGISTRY often has no samples and this returns {}.
+    In that case stale-mirror warnings are skipped (not treated as errors).
+
+    Returns a dict keyed by (namespace, repository) with unix timestamps as values.
+    If the metric is not present in this process, returns an empty dict.
+    """
+    timestamps = {}
+    try:
+        for metric in REGISTRY.collect():
+            if metric.name != "quay_repository_mirror_last_sync_timestamp":
+                continue
+            for sample in metric.samples:
+                if sample.name != "quay_repository_mirror_last_sync_timestamp":
+                    continue
+                namespace = sample.labels.get("namespace")
+                repository = sample.labels.get("repository")
+                if namespace and repository:
+                    timestamps[(namespace, repository)] = sample.value
+            break
+    except Exception as ex:
+        logger.debug("Unable to read last sync timestamps from registry: %s", ex)
+    return timestamps
+
+
+def _get_pending_tags_total(namespace=None):
+    """
+    Sum quay_repository_mirror_pending_tags gauge values from this process's registry.
+
+    Same limitation as _get_last_sync_timestamps: values exist only if the mirror worker
+    registers metrics in this process; otherwise this returns 0.
+    """
+    total = 0.0
+    try:
+        for metric in REGISTRY.collect():
+            if metric.name != "quay_repository_mirror_pending_tags":
+                continue
+            for sample in metric.samples:
+                if sample.name != "quay_repository_mirror_pending_tags":
+                    continue
+                if namespace is not None and sample.labels.get("namespace") != namespace:
+                    continue
+                total += float(sample.value)
+            break
+    except Exception as ex:
+        logger.debug("Unable to read pending tags from registry: %s", ex)
+    return int(total) if total == int(total) else total
+
+
+def _get_mirror_workers_active_value():
+    """
+    Read quay_repository_mirror_workers_active from this process's Prometheus registry.
+
+    The repository mirror worker sets this to 1 while RepoMirrorWorker is running; API
+    processes typically report 0 unless they embed the worker.
+    """
+    try:
+        for metric in REGISTRY.collect():
+            if metric.name != "quay_repository_mirror_workers_active":
+                continue
+            for sample in metric.samples:
+                if sample.name != "quay_repository_mirror_workers_active":
+                    continue
+                return int(sample.value)
+            break
+    except Exception as ex:
+        logger.debug("Unable to read mirror workers active gauge from registry: %s", ex)
+    return 0
+
+
+def _mirror_rows_query(namespace=None):
+    """
+    Enabled RepoMirrorConfig rows with Repository and namespace User joined and selected
+    so repository.namespace_user is populated (avoids N+1 on .username).
+
+    Health aggregates and issue sampling use enabled configs only; disabled mirrors
+    are omitted from totals and from this listing.
+    """
+    q = (
+        RepoMirrorConfig.select(RepoMirrorConfig, Repository, User)
+        .join(Repository)
+        .switch(Repository)
+        .join(User, on=(Repository.namespace_user == User.id))
+        .where(
+            Repository.state == RepositoryState.MIRROR,
+            RepoMirrorConfig.is_enabled == True,
+        )
+    )
+    if namespace:
+        q = q.where(User.username == namespace)
+    return q.order_by(Repository.namespace_user_id, Repository.name)
+
+
+def _mirror_status_counts(namespace=None):
+    """Aggregated status counts for enabled mirror configs only (no row load)."""
+    syncing_sum = fn.SUM(
+        Case(None, [(RepoMirrorConfig.sync_status == RepoMirrorStatus.SYNCING, 1)], 0)
+    )
+    completed_sum = fn.SUM(
+        Case(None, [(RepoMirrorConfig.sync_status == RepoMirrorStatus.SUCCESS, 1)], 0)
+    )
+    failed_sum = fn.SUM(Case(None, [(RepoMirrorConfig.sync_status == RepoMirrorStatus.FAIL, 1)], 0))
+    never_run_sum = fn.SUM(
+        Case(None, [(RepoMirrorConfig.sync_status == RepoMirrorStatus.NEVER_RUN, 1)], 0)
+    )
+    q = (
+        RepoMirrorConfig.select(
+            fn.COUNT(RepoMirrorConfig.id).alias("total"),
+            syncing_sum.alias("syncing"),
+            completed_sum.alias("completed"),
+            failed_sum.alias("failed"),
+            never_run_sum.alias("never_run"),
+        )
+        .join(Repository)
+        .switch(Repository)
+        .join(User, on=(Repository.namespace_user == User.id))
+        .where(
+            Repository.state == RepositoryState.MIRROR,
+            RepoMirrorConfig.is_enabled == True,
+        )
+    )
+    if namespace:
+        q = q.where(User.username == namespace)
+    dict_rows = list(q.dicts())
+    row = dict_rows[0] if dict_rows else {}
+    return {
+        "total": int(row["total"] or 0),
+        "syncing": int(row["syncing"] or 0),
+        "completed": int(row["completed"] or 0),
+        "failed": int(row["failed"] or 0),
+        "never_run": int(row["never_run"] or 0),
+    }
+
+
+def get_mirror_health_data(
+    namespace=None,
+    detailed=False,
+    detail_limit=100,
+    detail_offset=0,
+):
+    """
+    Gather health data for repository mirroring operations.
+
+    Args:
+        namespace: Optional namespace to filter results
+        detailed: If true, include paginated per-repository rows under repositories.details
+        detail_limit: Max repositories in detailed view (clamped 1..1000)
+        detail_offset: Pagination offset into the sorted mirror list (SQL LIMIT/OFFSET)
+
+    Returns:
+        Dictionary with health status information. Totals and `details` use enabled
+        mirror configs only.
+    """
+    counts = _mirror_status_counts(namespace)
+    total_repos = counts["total"]
+    syncing = counts["syncing"]
+    completed = counts["completed"]
+    failed = counts["failed"]
+    never_run = counts["never_run"]
+
+    # From in-process Prometheus registry when mirror worker shares this process; else 0.
+    tags_pending = _get_pending_tags_total(namespace)
+
+    # Determine overall health status
+    now = datetime.now(timezone.utc)
+    issues = []
+
+    # Stale detection: last sync from quay_repository_mirror_last_sync_timestamp in REGISTRY—not
+    # mirror.sync_start_date (that field is the next scheduled run). Missing samples: skip stale
+    # (never-synced NEVER_RUN handled separately); enabled repos with no metric are not flagged stale.
+    stale_threshold = now - timedelta(hours=24)
+    last_sync_timestamps = _get_last_sync_timestamps()
+    stale_repos = []
+    never_synced_repos = []
+    failing_repos = []
+    repos_detail = []
+    has_more = False
+    lim = max(1, min(int(detail_limit), _MAX_DETAIL_PAGE)) if detailed else 0
+    off = max(0, int(detail_offset)) if detailed else 0
+
+    # Sample up to _ISSUE_SAMPLE_CAP of each issue type; stop early once all caps are reached.
+    scan_query = _mirror_rows_query(namespace)
+    for mirror in scan_query.iterator():
+        namespace_name = mirror.repository.namespace_user.username
+        repo_name = mirror.repository.name
+        last_sync_ts = last_sync_timestamps.get((namespace_name, repo_name))
+
+        if (
+            mirror.sync_status == RepoMirrorStatus.FAIL
+            and mirror.sync_retries_remaining == 0
+            and len(failing_repos) < _ISSUE_SAMPLE_CAP
+        ):
+            failing_repos.append(mirror)
+
+        if mirror.sync_status != RepoMirrorStatus.SYNCING:
+            if last_sync_ts is None:
+                if (
+                    mirror.sync_status == RepoMirrorStatus.NEVER_RUN
+                    and len(never_synced_repos) < _ISSUE_SAMPLE_CAP
+                ):
+                    never_synced_repos.append(mirror)
+            elif len(stale_repos) < _ISSUE_SAMPLE_CAP:
+                last_sync_dt = datetime.fromtimestamp(last_sync_ts, tz=timezone.utc)
+                if last_sync_dt < stale_threshold:
+                    stale_repos.append(mirror)
+
+        if (
+            len(stale_repos) >= _ISSUE_SAMPLE_CAP
+            and len(never_synced_repos) >= _ISSUE_SAMPLE_CAP
+            and len(failing_repos) >= _ISSUE_SAMPLE_CAP
+        ):
+            break
+
+    if detailed:
+        page_query = _mirror_rows_query(namespace).limit(lim + 1).offset(off)
+        page_rows = list(page_query)
+        has_more = len(page_rows) > lim
+        page_rows = page_rows[:lim]
+        for mirror in page_rows:
+            namespace_name = mirror.repository.namespace_user.username
+            repo_name = mirror.repository.name
+            last_sync_ts = last_sync_timestamps.get((namespace_name, repo_name))
+            last_sync_value = None
+            if last_sync_ts is not None:
+                last_sync_value = (
+                    datetime.fromtimestamp(last_sync_ts, tz=timezone.utc)
+                    .isoformat()
+                    .replace("+00:00", "Z")
+                )
+            repos_detail.append(
+                {
+                    "namespace": namespace_name,
+                    "repository": repo_name,
+                    "sync_status": mirror.sync_status.name,
+                    "is_enabled": mirror.is_enabled,
+                    "last_sync": last_sync_value,
+                    "retries_remaining": mirror.sync_retries_remaining,
+                }
+            )
+
+    if stale_repos:
+        for repo in stale_repos[:5]:  # Limit to first 5 for brevity
+            issues.append(
+                {
+                    "severity": "warning",
+                    "message": f"Repository {repo.repository.namespace_user.username}/{repo.repository.name} hasn't synced in over 24 hours",
+                    "timestamp": _utc_z_timestamp(now),
+                }
+            )
+    if never_synced_repos:
+        for repo in never_synced_repos[:5]:  # Limit to first 5 for brevity
+            issues.append(
+                {
+                    "severity": "warning",
+                    "message": f"Repository {repo.repository.namespace_user.username}/{repo.repository.name} has never been synced",
+                    "timestamp": _utc_z_timestamp(now),
+                }
+            )
+
+    if failing_repos:
+        for repo in failing_repos[:5]:  # Limit to first 5
+            issues.append(
+                {
+                    "severity": "error",
+                    "message": f"Repository {repo.repository.namespace_user.username}/{repo.repository.name} has exhausted all retry attempts",
+                    "timestamp": _utc_z_timestamp(now),
+                }
+            )
+
+    # Determine if system is healthy
+    # System is unhealthy if:
+    # - More than 20% of repos that have run (non-NEVER_RUN) are failing
+    # - Any critical errors exist
+    critical_threshold = 0.2
+    healthy = True
+
+    mirrors_for_failure_rate = total_repos - never_run
+    if mirrors_for_failure_rate > 0:
+        failure_rate = failed / mirrors_for_failure_rate
+        if failure_rate > critical_threshold:
+            healthy = False
+            issues.insert(
+                0,
+                {
+                    "severity": "critical",
+                    "message": (
+                        f"{failure_rate * 100:.1f}% of repositories are failing "
+                        f"(threshold: {critical_threshold * 100:.1f}%)"
+                    ),
+                    "timestamp": _utc_z_timestamp(now),
+                },
+            )
+
+    replicas = app.config.get("REPO_MIRROR_WORKER_REPLICAS")
+    active_workers = _get_mirror_workers_active_value()
+    configured_workers = replicas if replicas is not None else active_workers
+
+    if replicas is not None and total_repos > 0 and active_workers < replicas:
+        healthy = False
+        issues.insert(
+            0,
+            {
+                "severity": "warning",
+                "message": (
+                    f"{replicas - active_workers} mirror worker(s) are not reporting in this "
+                    f"process (REPO_MIRROR_WORKER_REPLICAS={replicas}, "
+                    f"quay_repository_mirror_workers_active={active_workers})"
+                ),
+                "timestamp": _utc_z_timestamp(now),
+            },
+        )
+
+    # workers.status: aggregate health (repository states and optional replica mismatch).
+    workers_status = "healthy" if healthy else "degraded"
+
+    result = {
+        "healthy": healthy,
+        "workers": {
+            "active": active_workers,
+            "configured": configured_workers,
+            "status": workers_status,
+        },
+        "repositories": {
+            "total": total_repos,
+            "syncing": syncing,
+            "completed": completed,
+            "failed": failed,
+            "never_run": never_run,
+        },
+        "tags_pending": tags_pending,
+        "last_check": _utc_z_timestamp(now),
+        "issues": issues,
+    }
+
+    if detailed:
+        result["repositories"]["details"] = repos_detail
+        result["repositories"]["pagination"] = {
+            "limit": lim,
+            "offset": off,
+            "has_more": has_more,
+        }
+
+    return result
+
+
+@resource("/v1/repository/mirror/health")
+@show_if(features.REPO_MIRROR)
+class RepositoryMirrorHealth(ApiResource):
+    """
+    Resource for checking the health of repository mirroring operations.
+    """
+
+    @require_fresh_login
+    @nickname("getRepositoryMirrorHealth")
+    @parse_args()
+    @query_param(
+        "namespace",
+        "Filter health check to specific namespace",
+        type=str,
+        default=None,
+    )
+    @query_param(
+        "detailed",
+        "Include per-repository breakdown",
+        type=truthy_bool,
+        default=False,
+    )
+    @query_param(
+        "limit",
+        "Maximum repositories in detailed view (when detailed=true)",
+        type=int,
+        default=100,
+    )
+    @query_param(
+        "offset",
+        "Offset into the sorted mirror list for detailed view",
+        type=int,
+        default=0,
+    )
+    def get(self, parsed_args):
+        """
+        Get the health status of repository mirroring operations.
+
+        Returns overall health status, `workers.status` (repository-derived summary),
+        and any issues. HTTP status reflects health: 200 for healthy, 503 for unhealthy.
+        """
+        namespace = parsed_args.get("namespace")
+        detailed = parsed_args.get("detailed", False)
+        detail_limit = parsed_args.get("limit", 100)
+        detail_offset = parsed_args.get("offset", 0)
+
+        authed_user = get_authenticated_user()
+        if not authed_user:
+            raise Unauthorized()
+
+        # Global access requires superuser or global readonly superuser
+        if namespace is None:
+            if not (allow_if_superuser() or allow_if_global_readonly_superuser()):
+                raise Unauthorized()
+        else:
+            namespace_user = model.user.get_namespace_user(namespace)
+            if not namespace_user:
+                raise NotFound()
+            if not (allow_if_superuser() or allow_if_global_readonly_superuser()):
+                if namespace_user.organization:
+                    if not OrganizationMemberPermission(namespace).can():
+                        raise Unauthorized()
+                else:
+                    if (
+                        authed_user.username != namespace
+                        and not UserAdminPermission(namespace).can()
+                    ):
+                        raise Unauthorized()
+
+        health_data = get_mirror_health_data(
+            namespace=namespace,
+            detailed=detailed,
+            detail_limit=detail_limit,
+            detail_offset=detail_offset,
+        )
+
+        # Return 503 if unhealthy, 200 if healthy
+        status_code = 200 if health_data["healthy"] else 503
+
+        return (
+            health_data,
+            status_code,
+            {"Cache-Control": _CACHE_CONTROL_NO_STORE},
+        )

--- a/endpoints/api/mirrorhealth.py
+++ b/endpoints/api/mirrorhealth.py
@@ -235,38 +235,31 @@ def get_mirror_health_data(
     lim = max(1, min(int(detail_limit), _MAX_DETAIL_PAGE)) if detailed else 0
     off = max(0, int(detail_offset)) if detailed else 0
 
-    # Sample up to _ISSUE_SAMPLE_CAP of each issue type; stop early once all caps are reached.
-    scan_query = _mirror_rows_query(namespace)
-    for mirror in scan_query.iterator():
-        namespace_name = mirror.repository.namespace_user.username
-        repo_name = mirror.repository.name
-        last_sync_ts = last_sync_timestamps.get((namespace_name, repo_name))
+    # Bounded queries: sample up to _ISSUE_SAMPLE_CAP of each issue type via SQL LIMIT.
+    failing_repos = list(
+        _mirror_rows_query(namespace)
+        .where(
+            RepoMirrorConfig.sync_status == RepoMirrorStatus.FAIL,
+            RepoMirrorConfig.sync_retries_remaining == 0,
+        )
+        .limit(_ISSUE_SAMPLE_CAP)
+    )
 
-        if (
-            mirror.sync_status == RepoMirrorStatus.FAIL
-            and mirror.sync_retries_remaining == 0
-            and len(failing_repos) < _ISSUE_SAMPLE_CAP
-        ):
-            failing_repos.append(mirror)
+    never_synced_repos = list(
+        _mirror_rows_query(namespace)
+        .where(RepoMirrorConfig.sync_status == RepoMirrorStatus.NEVER_RUN)
+        .limit(_ISSUE_SAMPLE_CAP)
+    )
 
-        if mirror.sync_status != RepoMirrorStatus.SYNCING:
-            if last_sync_ts is None:
-                if (
-                    mirror.sync_status == RepoMirrorStatus.NEVER_RUN
-                    and len(never_synced_repos) < _ISSUE_SAMPLE_CAP
-                ):
-                    never_synced_repos.append(mirror)
-            elif len(stale_repos) < _ISSUE_SAMPLE_CAP:
-                last_sync_dt = datetime.fromtimestamp(last_sync_ts, tz=timezone.utc)
-                if last_sync_dt < stale_threshold:
-                    stale_repos.append(mirror)
-
-        if (
-            len(stale_repos) >= _ISSUE_SAMPLE_CAP
-            and len(never_synced_repos) >= _ISSUE_SAMPLE_CAP
-            and len(failing_repos) >= _ISSUE_SAMPLE_CAP
-        ):
+    # Stale detection uses in-process Prometheus timestamps (bounded by registry size).
+    for (ns, repo), ts in last_sync_timestamps.items():
+        if len(stale_repos) >= _ISSUE_SAMPLE_CAP:
             break
+        if namespace and ns != namespace:
+            continue
+        last_sync_dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        if last_sync_dt < stale_threshold:
+            stale_repos.append({"namespace": ns, "repository": repo})
 
     if detailed:
         page_query = _mirror_rows_query(namespace).limit(lim + 1).offset(off)
@@ -296,11 +289,13 @@ def get_mirror_health_data(
             )
 
     if stale_repos:
-        for repo in stale_repos[:5]:  # Limit to first 5 for brevity
+        for repo in stale_repos[:_ISSUE_SAMPLE_CAP]:
+            ns = repo["namespace"] if isinstance(repo, dict) else repo.repository.namespace_user.username
+            name = repo["repository"] if isinstance(repo, dict) else repo.repository.name
             issues.append(
                 {
                     "severity": "warning",
-                    "message": f"Repository {repo.repository.namespace_user.username}/{repo.repository.name} hasn't synced in over 24 hours",
+                    "message": f"Repository {ns}/{name} hasn't synced in over 24 hours",
                     "timestamp": _utc_z_timestamp(now),
                 }
             )

--- a/endpoints/api/mirrorhealth.py
+++ b/endpoints/api/mirrorhealth.py
@@ -290,7 +290,11 @@ def get_mirror_health_data(
 
     if stale_repos:
         for repo in stale_repos[:_ISSUE_SAMPLE_CAP]:
-            ns = repo["namespace"] if isinstance(repo, dict) else repo.repository.namespace_user.username
+            ns = (
+                repo["namespace"]
+                if isinstance(repo, dict)
+                else repo.repository.namespace_user.username
+            )
             name = repo["repository"] if isinstance(repo, dict) else repo.repository.name
             issues.append(
                 {

--- a/endpoints/api/test/test_mirrorhealth.py
+++ b/endpoints/api/test/test_mirrorhealth.py
@@ -1,0 +1,561 @@
+import time
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import pytest
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+
+from app import app as quay_app
+from endpoints.api.mirrorhealth import (
+    RepositoryMirrorHealth,
+    _get_last_sync_timestamps,
+    _get_mirror_workers_active_value,
+    _get_pending_tags_total,
+    _mirror_status_counts,
+    get_mirror_health_data,
+)
+from endpoints.api.test.shared import conduct_api_call
+from endpoints.test.shared import client_with_identity
+from test.fixtures import *
+
+
+# =============================================================================
+# Unit tests for Prometheus registry reader helpers
+# =============================================================================
+
+
+class TestGetLastSyncTimestamps:
+    def test_returns_empty_when_metric_absent(self):
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.return_value = []
+            result = _get_last_sync_timestamps()
+            assert result == {}
+
+    def test_parses_samples_correctly(self):
+        sample = mock.Mock()
+        sample.name = "quay_repository_mirror_last_sync_timestamp"
+        sample.labels = {"namespace": "ns1", "repository": "repo1"}
+        sample.value = 1700000000.0
+
+        metric = mock.Mock()
+        metric.name = "quay_repository_mirror_last_sync_timestamp"
+        metric.samples = [sample]
+
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.return_value = [metric]
+            result = _get_last_sync_timestamps()
+            assert result == {("ns1", "repo1"): 1700000000.0}
+
+    def test_skips_samples_missing_labels(self):
+        sample = mock.Mock()
+        sample.name = "quay_repository_mirror_last_sync_timestamp"
+        sample.labels = {"namespace": "ns1"}
+        sample.value = 1700000000.0
+
+        metric = mock.Mock()
+        metric.name = "quay_repository_mirror_last_sync_timestamp"
+        metric.samples = [sample]
+
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.return_value = [metric]
+            result = _get_last_sync_timestamps()
+            assert result == {}
+
+    def test_handles_registry_exception(self):
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.side_effect = RuntimeError("boom")
+            result = _get_last_sync_timestamps()
+            assert result == {}
+
+
+class TestGetPendingTagsTotal:
+    def test_returns_zero_when_metric_absent(self):
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.return_value = []
+            result = _get_pending_tags_total()
+            assert result == 0
+
+    def test_sums_across_namespaces(self):
+        s1 = mock.Mock()
+        s1.name = "quay_repository_mirror_pending_tags"
+        s1.labels = {"namespace": "ns1", "repository": "r1"}
+        s1.value = 5.0
+
+        s2 = mock.Mock()
+        s2.name = "quay_repository_mirror_pending_tags"
+        s2.labels = {"namespace": "ns2", "repository": "r2"}
+        s2.value = 3.0
+
+        metric = mock.Mock()
+        metric.name = "quay_repository_mirror_pending_tags"
+        metric.samples = [s1, s2]
+
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.return_value = [metric]
+            assert _get_pending_tags_total() == 8
+
+    def test_filters_by_namespace(self):
+        s1 = mock.Mock()
+        s1.name = "quay_repository_mirror_pending_tags"
+        s1.labels = {"namespace": "ns1", "repository": "r1"}
+        s1.value = 5.0
+
+        s2 = mock.Mock()
+        s2.name = "quay_repository_mirror_pending_tags"
+        s2.labels = {"namespace": "ns2", "repository": "r2"}
+        s2.value = 3.0
+
+        metric = mock.Mock()
+        metric.name = "quay_repository_mirror_pending_tags"
+        metric.samples = [s1, s2]
+
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.return_value = [metric]
+            assert _get_pending_tags_total(namespace="ns1") == 5
+
+    def test_returns_int_for_whole_numbers(self):
+        s1 = mock.Mock()
+        s1.name = "quay_repository_mirror_pending_tags"
+        s1.labels = {"namespace": "ns1", "repository": "r1"}
+        s1.value = 7.0
+
+        metric = mock.Mock()
+        metric.name = "quay_repository_mirror_pending_tags"
+        metric.samples = [s1]
+
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.return_value = [metric]
+            result = _get_pending_tags_total()
+            assert result == 7
+            assert isinstance(result, int)
+
+
+class TestGetMirrorWorkersActiveValue:
+    def test_returns_zero_when_metric_absent(self):
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.return_value = []
+            assert _get_mirror_workers_active_value() == 0
+
+    def test_returns_sample_value(self):
+        sample = mock.Mock()
+        sample.name = "quay_repository_mirror_workers_active"
+        sample.value = 1
+
+        metric = mock.Mock()
+        metric.name = "quay_repository_mirror_workers_active"
+        metric.samples = [sample]
+
+        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
+            mock_reg.collect.return_value = [metric]
+            assert _get_mirror_workers_active_value() == 1
+
+
+# =============================================================================
+# Unit tests for get_mirror_health_data
+# =============================================================================
+
+
+class TestGetMirrorHealthData:
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_healthy_with_no_mirrors(self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk):
+        mock_counts.return_value = {
+            "total": 0,
+            "syncing": 0,
+            "completed": 0,
+            "failed": 0,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+
+        result = get_mirror_health_data()
+
+        assert result["healthy"] is True
+        assert result["repositories"]["total"] == 0
+        assert result["tags_pending"] == 0
+        assert result["issues"] == []
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_healthy_all_succeeded(self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk):
+        mock_counts.return_value = {
+            "total": 10,
+            "syncing": 0,
+            "completed": 10,
+            "failed": 0,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+
+        result = get_mirror_health_data()
+
+        assert result["healthy"] is True
+        assert result["repositories"]["total"] == 10
+        assert result["repositories"]["completed"] == 10
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_unhealthy_high_failure_rate(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
+    ):
+        mock_counts.return_value = {
+            "total": 10,
+            "syncing": 0,
+            "completed": 5,
+            "failed": 5,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+
+        result = get_mirror_health_data()
+
+        assert result["healthy"] is False
+        assert result["workers"]["status"] == "degraded"
+        critical_issues = [i for i in result["issues"] if i["severity"] == "critical"]
+        assert len(critical_issues) == 1
+        assert "50.0%" in critical_issues[0]["message"]
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_healthy_at_threshold_boundary(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
+    ):
+        mock_counts.return_value = {
+            "total": 10,
+            "syncing": 0,
+            "completed": 8,
+            "failed": 2,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+
+        result = get_mirror_health_data()
+
+        assert result["healthy"] is True
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_never_run_excluded_from_failure_rate(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
+    ):
+        mock_counts.return_value = {
+            "total": 10,
+            "syncing": 0,
+            "completed": 4,
+            "failed": 1,
+            "never_run": 5,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+
+        result = get_mirror_health_data()
+
+        assert result["healthy"] is True
+
+    @mock.patch("endpoints.api.mirrorhealth.app")
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=1)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_unhealthy_worker_replica_mismatch(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk, mock_app
+    ):
+        mock_counts.return_value = {
+            "total": 5,
+            "syncing": 0,
+            "completed": 5,
+            "failed": 0,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_app.config.get.return_value = 3
+
+        result = get_mirror_health_data()
+
+        assert result["healthy"] is False
+        warning_issues = [i for i in result["issues"] if i["severity"] == "warning"]
+        worker_warnings = [w for w in warning_issues if "worker" in w["message"].lower()]
+        assert len(worker_warnings) == 1
+        assert "2 mirror worker" in worker_warnings[0]["message"]
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_stale_repos_generate_warnings(self, mock_counts, mock_rows, mock_pending, mock_wk):
+        mock_counts.return_value = {
+            "total": 2,
+            "syncing": 0,
+            "completed": 2,
+            "failed": 0,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+
+        stale_ts = (datetime.now(timezone.utc) - timedelta(hours=48)).timestamp()
+        with mock.patch(
+            "endpoints.api.mirrorhealth._get_last_sync_timestamps",
+            return_value={("ns1", "repo1"): stale_ts},
+        ):
+            result = get_mirror_health_data()
+
+        stale_warnings = [
+            i for i in result["issues"] if "hasn't synced" in i.get("message", "")
+        ]
+        assert len(stale_warnings) == 1
+        assert "ns1/repo1" in stale_warnings[0]["message"]
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_stale_cap_limits_issue_samples(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
+    ):
+        mock_counts.return_value = {
+            "total": 10,
+            "syncing": 0,
+            "completed": 10,
+            "failed": 0,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+
+        stale_ts = (datetime.now(timezone.utc) - timedelta(hours=48)).timestamp()
+        many_stale = {(f"ns{i}", f"repo{i}"): stale_ts for i in range(20)}
+        with mock.patch(
+            "endpoints.api.mirrorhealth._get_last_sync_timestamps",
+            return_value=many_stale,
+        ):
+            result = get_mirror_health_data()
+
+        stale_warnings = [
+            i for i in result["issues"] if "hasn't synced" in i.get("message", "")
+        ]
+        assert len(stale_warnings) <= 5
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_response_structure(self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk):
+        mock_counts.return_value = {
+            "total": 3,
+            "syncing": 1,
+            "completed": 1,
+            "failed": 1,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+
+        result = get_mirror_health_data()
+
+        assert "healthy" in result
+        assert "workers" in result
+        assert "active" in result["workers"]
+        assert "configured" in result["workers"]
+        assert "status" in result["workers"]
+        assert "repositories" in result
+        assert "total" in result["repositories"]
+        assert "syncing" in result["repositories"]
+        assert "completed" in result["repositories"]
+        assert "failed" in result["repositories"]
+        assert "never_run" in result["repositories"]
+        assert "tags_pending" in result
+        assert "last_check" in result
+        assert "issues" in result
+        assert result["last_check"].endswith("Z")
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_detailed_includes_pagination(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
+    ):
+        mock_counts.return_value = {
+            "total": 0,
+            "syncing": 0,
+            "completed": 0,
+            "failed": 0,
+            "never_run": 0,
+        }
+        page_query = mock.Mock()
+        page_query.limit.return_value = mock.Mock(offset=mock.Mock(return_value=[]))
+        rows_q = mock.Mock()
+        rows_q.where.return_value = mock.Mock(limit=mock.Mock(return_value=[]))
+        rows_q.limit.return_value = mock.Mock(offset=mock.Mock(return_value=[]))
+
+        mock_rows.return_value = rows_q
+
+        result = get_mirror_health_data(detailed=True)
+
+        assert "details" in result["repositories"]
+        assert "pagination" in result["repositories"]
+        assert "limit" in result["repositories"]["pagination"]
+        assert "offset" in result["repositories"]["pagination"]
+        assert "has_more" in result["repositories"]["pagination"]
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_no_details_without_detailed_flag(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
+    ):
+        mock_counts.return_value = {
+            "total": 0,
+            "syncing": 0,
+            "completed": 0,
+            "failed": 0,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+
+        result = get_mirror_health_data(detailed=False)
+
+        assert "details" not in result["repositories"]
+        assert "pagination" not in result["repositories"]
+
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_detail_limit_clamped_to_max(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
+    ):
+        mock_counts.return_value = {
+            "total": 0,
+            "syncing": 0,
+            "completed": 0,
+            "failed": 0,
+            "never_run": 0,
+        }
+        rows_q = mock.Mock()
+        rows_q.where.return_value = mock.Mock(limit=mock.Mock(return_value=[]))
+        rows_q.limit.return_value = mock.Mock(offset=mock.Mock(return_value=[]))
+        mock_rows.return_value = rows_q
+
+        result = get_mirror_health_data(detailed=True, detail_limit=5000)
+
+        assert result["repositories"]["pagination"]["limit"] == 1000
+
+
+# =============================================================================
+# API endpoint integration tests
+# =============================================================================
+
+
+class TestMirrorHealthEndpoint:
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_superuser_global_access(self, mock_health, app, initialized_db):
+        mock_health.return_value = {
+            "healthy": True,
+            "workers": {"active": 0, "configured": 0, "status": "healthy"},
+            "repositories": {
+                "total": 0, "syncing": 0, "completed": 0, "failed": 0, "never_run": 0,
+            },
+            "tags_pending": 0,
+            "last_check": "2024-01-01T00:00:00Z",
+            "issues": [],
+        }
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 200)
+            assert resp.json["healthy"] is True
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_anonymous_returns_401(self, mock_health, app, initialized_db):
+        with client_with_identity(None, app) as cl:
+            conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 401)
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_unhealthy_returns_503(self, mock_health, app, initialized_db):
+        mock_health.return_value = {
+            "healthy": False,
+            "workers": {"active": 0, "configured": 0, "status": "degraded"},
+            "repositories": {
+                "total": 10, "syncing": 0, "completed": 5, "failed": 5, "never_run": 0,
+            },
+            "tags_pending": 0,
+            "last_check": "2024-01-01T00:00:00Z",
+            "issues": [{"severity": "critical", "message": "high failure rate", "timestamp": "2024-01-01T00:00:00Z"}],
+        }
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 503)
+            assert resp.json["healthy"] is False
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_cache_control_header(self, mock_health, app, initialized_db):
+        mock_health.return_value = {
+            "healthy": True,
+            "workers": {"active": 0, "configured": 0, "status": "healthy"},
+            "repositories": {
+                "total": 0, "syncing": 0, "completed": 0, "failed": 0, "never_run": 0,
+            },
+            "tags_pending": 0,
+            "last_check": "2024-01-01T00:00:00Z",
+            "issues": [],
+        }
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 200)
+            assert "no-cache" in resp.headers.get("Cache-Control", "")
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_namespace_passed_to_health_data(self, mock_health, app, initialized_db):
+        mock_health.return_value = {
+            "healthy": True,
+            "workers": {"active": 0, "configured": 0, "status": "healthy"},
+            "repositories": {
+                "total": 0, "syncing": 0, "completed": 0, "failed": 0, "never_run": 0,
+            },
+            "tags_pending": 0,
+            "last_check": "2024-01-01T00:00:00Z",
+            "issues": [],
+        }
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(
+                cl,
+                RepositoryMirrorHealth,
+                "GET",
+                {"namespace": "devtable"},
+                None,
+                200,
+            )
+            mock_health.assert_called_once()
+            call_kwargs = mock_health.call_args
+            assert call_kwargs[1].get("namespace") or call_kwargs[0][0] == "devtable"
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_global_readonly_superuser_access(self, mock_health, app, initialized_db):
+        mock_health.return_value = {
+            "healthy": True,
+            "workers": {"active": 0, "configured": 0, "status": "healthy"},
+            "repositories": {
+                "total": 0, "syncing": 0, "completed": 0, "failed": 0, "never_run": 0,
+            },
+            "tags_pending": 0,
+            "last_check": "2024-01-01T00:00:00Z",
+            "issues": [],
+        }
+        with client_with_identity("globalreadonlysuperuser", app) as cl:
+            conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 200)

--- a/endpoints/api/test/test_mirrorhealth.py
+++ b/endpoints/api/test/test_mirrorhealth.py
@@ -18,7 +18,6 @@ from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
 from test.fixtures import *
 
-
 # =============================================================================
 # Unit tests for Prometheus registry reader helpers
 # =============================================================================
@@ -169,7 +168,9 @@ class TestGetMirrorHealthData:
             "failed": 0,
             "never_run": 0,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
 
         result = get_mirror_health_data()
 
@@ -191,7 +192,9 @@ class TestGetMirrorHealthData:
             "failed": 0,
             "never_run": 0,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
 
         result = get_mirror_health_data()
 
@@ -214,7 +217,9 @@ class TestGetMirrorHealthData:
             "failed": 5,
             "never_run": 0,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
 
         result = get_mirror_health_data()
 
@@ -239,7 +244,9 @@ class TestGetMirrorHealthData:
             "failed": 2,
             "never_run": 0,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
 
         result = get_mirror_health_data()
 
@@ -260,7 +267,9 @@ class TestGetMirrorHealthData:
             "failed": 1,
             "never_run": 5,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
 
         result = get_mirror_health_data()
 
@@ -282,7 +291,9 @@ class TestGetMirrorHealthData:
             "failed": 0,
             "never_run": 0,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
         mock_app.config.get.return_value = 3
 
         result = get_mirror_health_data()
@@ -305,7 +316,9 @@ class TestGetMirrorHealthData:
             "failed": 0,
             "never_run": 0,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
 
         stale_ts = (datetime.now(timezone.utc) - timedelta(hours=48)).timestamp()
         with mock.patch(
@@ -314,9 +327,7 @@ class TestGetMirrorHealthData:
         ):
             result = get_mirror_health_data()
 
-        stale_warnings = [
-            i for i in result["issues"] if "hasn't synced" in i.get("message", "")
-        ]
+        stale_warnings = [i for i in result["issues"] if "hasn't synced" in i.get("message", "")]
         assert len(stale_warnings) == 1
         assert "ns1/repo1" in stale_warnings[0]["message"]
 
@@ -335,7 +346,9 @@ class TestGetMirrorHealthData:
             "failed": 0,
             "never_run": 0,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
 
         stale_ts = (datetime.now(timezone.utc) - timedelta(hours=48)).timestamp()
         many_stale = {(f"ns{i}", f"repo{i}"): stale_ts for i in range(20)}
@@ -345,9 +358,7 @@ class TestGetMirrorHealthData:
         ):
             result = get_mirror_health_data()
 
-        stale_warnings = [
-            i for i in result["issues"] if "hasn't synced" in i.get("message", "")
-        ]
+        stale_warnings = [i for i in result["issues"] if "hasn't synced" in i.get("message", "")]
         assert len(stale_warnings) <= 5
 
     @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
@@ -363,7 +374,9 @@ class TestGetMirrorHealthData:
             "failed": 1,
             "never_run": 0,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
 
         result = get_mirror_health_data()
 
@@ -429,7 +442,9 @@ class TestGetMirrorHealthData:
             "failed": 0,
             "never_run": 0,
         }
-        mock_rows.return_value = mock.Mock(where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[]))))
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
 
         result = get_mirror_health_data(detailed=False)
 
@@ -473,7 +488,11 @@ class TestMirrorHealthEndpoint:
             "healthy": True,
             "workers": {"active": 0, "configured": 0, "status": "healthy"},
             "repositories": {
-                "total": 0, "syncing": 0, "completed": 0, "failed": 0, "never_run": 0,
+                "total": 0,
+                "syncing": 0,
+                "completed": 0,
+                "failed": 0,
+                "never_run": 0,
             },
             "tags_pending": 0,
             "last_check": "2024-01-01T00:00:00Z",
@@ -494,11 +513,21 @@ class TestMirrorHealthEndpoint:
             "healthy": False,
             "workers": {"active": 0, "configured": 0, "status": "degraded"},
             "repositories": {
-                "total": 10, "syncing": 0, "completed": 5, "failed": 5, "never_run": 0,
+                "total": 10,
+                "syncing": 0,
+                "completed": 5,
+                "failed": 5,
+                "never_run": 0,
             },
             "tags_pending": 0,
             "last_check": "2024-01-01T00:00:00Z",
-            "issues": [{"severity": "critical", "message": "high failure rate", "timestamp": "2024-01-01T00:00:00Z"}],
+            "issues": [
+                {
+                    "severity": "critical",
+                    "message": "high failure rate",
+                    "timestamp": "2024-01-01T00:00:00Z",
+                }
+            ],
         }
         with client_with_identity("devtable", app) as cl:
             resp = conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 503)
@@ -510,7 +539,11 @@ class TestMirrorHealthEndpoint:
             "healthy": True,
             "workers": {"active": 0, "configured": 0, "status": "healthy"},
             "repositories": {
-                "total": 0, "syncing": 0, "completed": 0, "failed": 0, "never_run": 0,
+                "total": 0,
+                "syncing": 0,
+                "completed": 0,
+                "failed": 0,
+                "never_run": 0,
             },
             "tags_pending": 0,
             "last_check": "2024-01-01T00:00:00Z",
@@ -526,7 +559,11 @@ class TestMirrorHealthEndpoint:
             "healthy": True,
             "workers": {"active": 0, "configured": 0, "status": "healthy"},
             "repositories": {
-                "total": 0, "syncing": 0, "completed": 0, "failed": 0, "never_run": 0,
+                "total": 0,
+                "syncing": 0,
+                "completed": 0,
+                "failed": 0,
+                "never_run": 0,
             },
             "tags_pending": 0,
             "last_check": "2024-01-01T00:00:00Z",
@@ -551,7 +588,11 @@ class TestMirrorHealthEndpoint:
             "healthy": True,
             "workers": {"active": 0, "configured": 0, "status": "healthy"},
             "repositories": {
-                "total": 0, "syncing": 0, "completed": 0, "failed": 0, "never_run": 0,
+                "total": 0,
+                "syncing": 0,
+                "completed": 0,
+                "failed": 0,
+                "never_run": 0,
             },
             "tags_pending": 0,
             "last_check": "2024-01-01T00:00:00Z",

--- a/endpoints/api/test/test_security.py
+++ b/endpoints/api/test/test_security.py
@@ -22,6 +22,7 @@ from endpoints.api.immutability_policy import *
 from endpoints.api.logs import *  # type: ignore[no-redef]
 from endpoints.api.manifest import *
 from endpoints.api.mirror import *  # type: ignore[no-redef]
+from endpoints.api.mirrorhealth import RepositoryMirrorHealth
 from endpoints.api.namespacequota import *
 from endpoints.api.org_mirror import *  # type: ignore[no-redef]
 from endpoints.api.organization import *  # type: ignore[assignment,no-redef]
@@ -5963,6 +5964,11 @@ SECURITY_TESTS: List[
         "globalreadonlysuperuser",
         404,
     ),
+    (RepositoryMirrorHealth, "GET", None, None, None, 401),
+    (RepositoryMirrorHealth, "GET", None, None, "devtable", 200),
+    (RepositoryMirrorHealth, "GET", None, None, "globalreadonlysuperuser", 200),
+    (RepositoryMirrorHealth, "GET", None, None, "freshuser", 403),
+    (RepositoryMirrorHealth, "GET", None, None, "reader", 403),
     (RepoMirrorResource, "POST", {"repository": "devtable/simple"}, None, None, 401),
     (RepoMirrorResource, "POST", {"repository": "devtable/simple"}, None, "devtable", 400),
     (RepoMirrorResource, "POST", {"repository": "devtable/simple"}, None, "freshuser", 403),

--- a/endpoints/common.py
+++ b/endpoints/common.py
@@ -69,6 +69,10 @@ def _list_files(path, extension, contains=""):
         return os.path.join(dp, f)[len("static/") :]
 
     filepath = os.path.join("static/", path)
+    if not os.path.isdir(filepath):
+        # Volume mounts of the repo (e.g. CI, local dev) often omit gitignored `static/build`;
+        # walking a missing path raises FileNotFoundError and yields 500 on every Angular UI route.
+        return []
     return [join_path(dp, f) for dp, _, files in os.walk(filepath) for f in files if matches(f)]
 
 

--- a/web/cypress/test/quay-db-data.txt
+++ b/web/cypress/test/quay-db-data.txt
@@ -7404,6 +7404,7 @@ COPY public.quotarepositorysize (id, repository_id, size_bytes, backfill_start_m
 154	155	3948	1769004376921	t
 155	2	0	1769004377002	t
 156	1	52054	1769004377022	t
+157	3	0	1769004377042	t
 \.
 
 
@@ -8175,160 +8176,6 @@ COPY public.repositorysearchscore (id, repository_id, score, last_updated) FROM 
 --
 
 COPY public.repositorysize (id, repository_id, size_bytes) FROM stdin;
-1	1	2479
-3	3	0
-6	6	0
-7	7	0
-8	8	0
-9	9	0
-10	10	0
-11	11	0
-12	12	0
-13	13	0
-14	14	0
-15	15	0
-2	2	0
-19	19	0
-5	5	0
-16	16	0
-17	17	0
-18	18	0
-20	20	0
-21	21	0
-22	22	0
-23	23	0
-24	24	0
-25	25	0
-26	26	0
-27	27	0
-28	28	0
-29	29	0
-30	30	0
-31	31	0
-32	32	0
-33	33	0
-34	34	0
-35	35	0
-36	36	0
-37	37	0
-38	38	0
-39	39	0
-40	40	0
-41	41	0
-42	42	0
-43	43	0
-44	44	0
-45	45	0
-46	46	0
-47	47	0
-48	48	0
-49	49	0
-50	50	0
-51	51	0
-52	52	0
-53	53	0
-54	54	0
-55	55	0
-56	56	0
-57	57	0
-58	58	0
-59	59	0
-60	60	0
-61	61	0
-62	62	0
-63	63	0
-64	64	0
-65	65	0
-66	66	0
-67	67	0
-68	68	0
-69	69	0
-70	70	0
-71	71	0
-72	72	0
-73	73	0
-74	74	0
-75	75	0
-76	76	0
-77	77	0
-78	78	0
-79	79	0
-80	80	0
-81	81	0
-82	82	0
-83	83	0
-84	84	0
-85	85	0
-86	86	0
-87	87	0
-88	88	0
-89	89	0
-90	90	0
-91	91	0
-92	92	0
-93	93	0
-94	94	0
-95	95	0
-96	96	0
-97	97	0
-98	98	0
-99	99	0
-100	100	0
-101	101	0
-102	102	0
-103	103	0
-104	104	0
-105	105	0
-106	106	0
-107	107	0
-108	108	0
-109	109	0
-110	110	0
-111	111	0
-112	112	0
-113	113	0
-114	114	0
-115	115	0
-116	116	0
-117	117	0
-118	118	0
-119	119	0
-120	120	0
-121	121	0
-122	122	0
-123	123	0
-124	124	0
-125	125	0
-126	126	0
-127	127	0
-128	128	0
-129	129	0
-130	130	0
-131	131	0
-132	132	0
-133	133	0
-134	134	0
-135	135	0
-136	136	0
-137	137	0
-138	138	0
-139	139	0
-140	140	0
-141	141	0
-142	142	0
-143	143	0
-144	144	0
-145	145	0
-146	146	0
-147	147	0
-148	148	0
-149	149	0
-150	150	0
-151	151	0
-152	152	0
-153	153	0
-154	154	0
-4	4	0
 \.
 
 
@@ -9213,7 +9060,7 @@ SELECT pg_catalog.setval('public.quotaregistrysize_id_seq', 1, true);
 -- Name: quotarepositorysize_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.quotarepositorysize_id_seq', 156, true);
+SELECT pg_catalog.setval('public.quotarepositorysize_id_seq', 157, true);
 
 
 --
@@ -9325,7 +9172,7 @@ SELECT pg_catalog.setval('public.repositorysearchscore_id_seq', 157, true);
 -- Name: repositorysize_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.repositorysize_id_seq', 154, true);
+SELECT pg_catalog.setval('public.repositorysize_id_seq', 1, false);
 
 
 --

--- a/web/playwright/e2e/api/api-v1-mirror-health.spec.ts
+++ b/web/playwright/e2e/api/api-v1-mirror-health.spec.ts
@@ -174,9 +174,7 @@ test.describe(
       }) => {
         const org = await superuserApi.organization('mhealthtest');
 
-        const r = await userClient.get(
-          `${HEALTH_URL}?namespace=${org.name}`,
-        );
+        const r = await userClient.get(`${HEALTH_URL}?namespace=${org.name}`);
         // Should be denied — user is not a member of this org
         expect([401, 403]).toContain(r.status());
       });

--- a/web/playwright/e2e/api/api-v1-mirror-health.spec.ts
+++ b/web/playwright/e2e/api/api-v1-mirror-health.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * Mirror Health API Tests
+ *
+ * Tests the /api/v1/repository/mirror/health endpoint across three roles:
+ *   - adminClient  : superuser (full access, global + namespace-scoped)
+ *   - userClient   : normal user (namespace-scoped only)
+ *   - readonlyClient : global readonly superuser (read-only global access)
+ *   - anonClient   : unauthenticated (should get 401)
+ *
+ * Validates:
+ *   - Authorization: superuser global, readonly superuser global,
+ *     normal user namespace-scoped, anonymous rejection
+ *   - Response structure: top-level fields, nested objects
+ *   - HTTP status codes: 200 for healthy, 503 for unhealthy
+ *   - Cache-Control header: no-store
+ *   - Query parameters: namespace, detailed, limit, offset
+ */
+
+import {test, expect} from '../../fixtures';
+import {RawApiClient} from '../../utils/api';
+import {API_URL} from '../../utils/config';
+import {TEST_USERS, TEST_USERS_OIDC} from '../../global-setup';
+
+const HEALTH_URL = '/api/v1/repository/mirror/health';
+
+test.describe(
+  'Mirror Health API',
+  {tag: ['@api', '@feature:REPO_MIRROR']},
+  () => {
+    let readonlyClient: RawApiClient;
+    let anonClient: RawApiClient;
+    let normalUsername: string;
+
+    test.beforeAll(async ({playwright, cachedQuayConfig}) => {
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      anonClient = new RawApiClient(request, API_URL);
+
+      const users =
+        cachedQuayConfig?.config?.AUTHENTICATION_TYPE === 'OIDC'
+          ? TEST_USERS_OIDC
+          : TEST_USERS;
+      normalUsername = users.user.username;
+
+      // Build readonly superuser client
+      const roRequest = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      readonlyClient = new RawApiClient(roRequest, API_URL);
+      try {
+        await readonlyClient.signIn(
+          users.readonly.username,
+          users.readonly.password,
+        );
+      } catch {
+        // If readonly user not configured, tests using it will skip individually
+        readonlyClient = null as unknown as RawApiClient;
+      }
+    });
+
+    // ========================================================================
+    // Section 1 -- Superuser access (global)
+    // ========================================================================
+
+    test.describe('Superuser global access', () => {
+      test('superuser can GET mirror health globally', async ({
+        adminClient,
+      }) => {
+        const r = await adminClient.get(HEALTH_URL);
+        // 200 (healthy) or 503 (unhealthy) are both valid
+        expect([200, 503]).toContain(r.status());
+
+        const body = await r.json();
+        expect(body).toHaveProperty('healthy');
+        expect(body).toHaveProperty('workers');
+        expect(body).toHaveProperty('repositories');
+        expect(body).toHaveProperty('tags_pending');
+        expect(body).toHaveProperty('last_check');
+        expect(body).toHaveProperty('issues');
+      });
+
+      test('response has correct structure', async ({adminClient}) => {
+        const r = await adminClient.get(HEALTH_URL);
+        expect([200, 503]).toContain(r.status());
+
+        const body = await r.json();
+
+        // workers object
+        expect(body.workers).toHaveProperty('active');
+        expect(body.workers).toHaveProperty('configured');
+        expect(body.workers).toHaveProperty('status');
+        expect(['healthy', 'degraded']).toContain(body.workers.status);
+
+        // repositories object
+        expect(body.repositories).toHaveProperty('total');
+        expect(body.repositories).toHaveProperty('syncing');
+        expect(body.repositories).toHaveProperty('completed');
+        expect(body.repositories).toHaveProperty('failed');
+        expect(body.repositories).toHaveProperty('never_run');
+
+        // Counts are non-negative integers
+        expect(body.repositories.total).toBeGreaterThanOrEqual(0);
+        expect(body.repositories.syncing).toBeGreaterThanOrEqual(0);
+        expect(body.repositories.completed).toBeGreaterThanOrEqual(0);
+        expect(body.repositories.failed).toBeGreaterThanOrEqual(0);
+        expect(body.repositories.never_run).toBeGreaterThanOrEqual(0);
+
+        // tags_pending is a number
+        expect(typeof body.tags_pending).toBe('number');
+
+        // last_check is an ISO timestamp ending in Z
+        expect(body.last_check).toMatch(/Z$/);
+
+        // issues is an array
+        expect(Array.isArray(body.issues)).toBe(true);
+      });
+
+      test('Cache-Control header is no-store', async ({adminClient}) => {
+        const r = await adminClient.get(HEALTH_URL);
+        expect([200, 503]).toContain(r.status());
+
+        const cacheControl = r.headers()['cache-control'] || '';
+        expect(cacheControl).toContain('no-cache');
+        expect(cacheControl).toContain('no-store');
+      });
+    });
+
+    // ========================================================================
+    // Section 2 -- Readonly superuser access (global)
+    // ========================================================================
+
+    test.describe('Readonly superuser global access', () => {
+      test('readonly superuser can GET mirror health globally', async () => {
+        test.skip(!readonlyClient, 'Readonly superuser not configured');
+
+        const r = await readonlyClient.get(HEALTH_URL);
+        expect([200, 503]).toContain(r.status());
+
+        const body = await r.json();
+        expect(body).toHaveProperty('healthy');
+        expect(body).toHaveProperty('repositories');
+      });
+    });
+
+    // ========================================================================
+    // Section 3 -- Normal user access
+    // ========================================================================
+
+    test.describe('Normal user access', () => {
+      test('normal user cannot GET mirror health globally', async ({
+        userClient,
+      }) => {
+        const r = await userClient.get(HEALTH_URL);
+        // Should be denied — 401 (Unauthorized) or 403 (Forbidden)
+        expect([401, 403]).toContain(r.status());
+      });
+
+      test('normal user can GET mirror health for own namespace', async ({
+        userClient,
+      }) => {
+        const r = await userClient.get(
+          `${HEALTH_URL}?namespace=${normalUsername}`,
+        );
+        expect([200, 503]).toContain(r.status());
+
+        const body = await r.json();
+        expect(body).toHaveProperty('healthy');
+      });
+
+      test('normal user cannot GET mirror health for other namespace', async ({
+        userClient,
+        superuserApi,
+      }) => {
+        const org = await superuserApi.organization('mhealthtest');
+
+        const r = await userClient.get(
+          `${HEALTH_URL}?namespace=${org.name}`,
+        );
+        // Should be denied — user is not a member of this org
+        expect([401, 403]).toContain(r.status());
+      });
+    });
+
+    // ========================================================================
+    // Section 4 -- Anonymous access
+    // ========================================================================
+
+    test.describe('Anonymous access', () => {
+      test('anonymous user gets 401', async () => {
+        const r = await anonClient.get(HEALTH_URL);
+        expect(r.status()).toBe(401);
+      });
+    });
+
+    // ========================================================================
+    // Section 5 -- Query parameters
+    // ========================================================================
+
+    test.describe('Query parameters', () => {
+      test('namespace parameter filters results', async ({adminClient}) => {
+        const r = await adminClient.get(
+          `${HEALTH_URL}?namespace=${normalUsername}`,
+        );
+        expect([200, 503]).toContain(r.status());
+
+        const body = await r.json();
+        expect(body).toHaveProperty('healthy');
+        expect(body).toHaveProperty('repositories');
+      });
+
+      test('detailed=true includes details and pagination', async ({
+        adminClient,
+      }) => {
+        const r = await adminClient.get(`${HEALTH_URL}?detailed=true`);
+        expect([200, 503]).toContain(r.status());
+
+        const body = await r.json();
+        expect(body.repositories).toHaveProperty('details');
+        expect(Array.isArray(body.repositories.details)).toBe(true);
+        expect(body.repositories).toHaveProperty('pagination');
+        expect(body.repositories.pagination).toHaveProperty('limit');
+        expect(body.repositories.pagination).toHaveProperty('offset');
+        expect(body.repositories.pagination).toHaveProperty('has_more');
+      });
+
+      test('detailed=false omits details and pagination', async ({
+        adminClient,
+      }) => {
+        const r = await adminClient.get(`${HEALTH_URL}?detailed=false`);
+        expect([200, 503]).toContain(r.status());
+
+        const body = await r.json();
+        expect(body.repositories).not.toHaveProperty('details');
+        expect(body.repositories).not.toHaveProperty('pagination');
+      });
+
+      test('limit and offset params accepted in detailed mode', async ({
+        adminClient,
+      }) => {
+        const r = await adminClient.get(
+          `${HEALTH_URL}?detailed=true&limit=5&offset=0`,
+        );
+        expect([200, 503]).toContain(r.status());
+
+        const body = await r.json();
+        expect(body.repositories.pagination.limit).toBe(5);
+        expect(body.repositories.pagination.offset).toBe(0);
+      });
+
+      test('limit is clamped to max 1000', async ({adminClient}) => {
+        const r = await adminClient.get(
+          `${HEALTH_URL}?detailed=true&limit=9999`,
+        );
+        expect([200, 503]).toContain(r.status());
+
+        const body = await r.json();
+        expect(body.repositories.pagination.limit).toBeLessThanOrEqual(1000);
+      });
+    });
+
+    // ========================================================================
+    // Section 6 -- healthy vs unhealthy status codes
+    // ========================================================================
+
+    test.describe('Status code semantics', () => {
+      test('healthy=true returns 200, healthy=false returns 503', async ({
+        adminClient,
+      }) => {
+        const r = await adminClient.get(HEALTH_URL);
+        const body = await r.json();
+
+        if (body.healthy) {
+          expect(r.status()).toBe(200);
+        } else {
+          expect(r.status()).toBe(503);
+        }
+      });
+    });
+  },
+);

--- a/web/playwright/e2e/repository/mirroring.spec.ts
+++ b/web/playwright/e2e/repository/mirroring.spec.ts
@@ -621,5 +621,81 @@ test.describe(
       const tags = await api.raw.getTags(org.name, repo.name);
       expect(tags.tags.some((t) => t.name === 'latest')).toBe(true);
     });
+
+    test('mirror health endpoint reflects completed sync', async ({
+      api,
+      adminClient,
+    }) => {
+      test.setTimeout(180_000);
+
+      const org = await api.organization('mhealthsyncorg');
+      const repo = await api.repository(org.name, 'mhealthsyncrepo');
+      const robot = await api.robot(org.name, 'mhealthsyncbot');
+      await api.setMirrorState(org.name, repo.name);
+
+      const syncStartDate = new Date();
+      syncStartDate.setMinutes(syncStartDate.getMinutes() + 5);
+      await api.raw.createMirrorConfig(org.name, repo.name, {
+        external_reference: 'quay.io/quay/busybox',
+        sync_interval: 86400,
+        sync_start_date: syncStartDate.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        root_rule: {rule_kind: 'tag_glob_csv', rule_value: ['latest']},
+        robot_username: robot.fullName,
+        skopeo_timeout_interval: 300,
+        is_enabled: true,
+        verify_tls: true,
+      });
+
+      await api.raw.triggerMirrorSync(org.name, repo.name);
+
+      await expect
+        .poll(
+          async () => {
+            const cfg = await api.raw.getMirrorConfig(org.name, repo.name);
+            const status = cfg?.sync_status ?? 'UNKNOWN';
+            if (status === 'FAIL') {
+              throw new Error(`Mirror sync failed with status: ${status}`);
+            }
+            return status;
+          },
+          {
+            timeout: 120_000,
+            intervals: [5_000, 10_000, 15_000],
+            message:
+              'Mirror sync did not complete successfully within 2 minutes',
+          },
+        )
+        .toBe('SUCCESS');
+
+      // Validate the health endpoint reflects the synced mirror
+      const healthResp = await adminClient.get(
+        `/api/v1/repository/mirror/health?namespace=${org.name}`,
+      );
+      expect([200, 503]).toContain(healthResp.status());
+
+      const health = await healthResp.json();
+      expect(health).toHaveProperty('healthy');
+      expect(health).toHaveProperty('repositories');
+      expect(health.repositories.total).toBeGreaterThanOrEqual(1);
+      expect(health.repositories.completed).toBeGreaterThanOrEqual(1);
+
+      // Detailed mode should list the synced repository
+      const detailedResp = await adminClient.get(
+        `/api/v1/repository/mirror/health?namespace=${org.name}&detailed=true`,
+      );
+      expect([200, 503]).toContain(detailedResp.status());
+
+      const detailed = await detailedResp.json();
+      expect(detailed.repositories.details).toBeDefined();
+      expect(Array.isArray(detailed.repositories.details)).toBe(true);
+
+      const syncedRepo = detailed.repositories.details.find(
+        (d: {namespace: string; repository: string}) =>
+          d.namespace === org.name && d.repository === repo.name,
+      );
+      expect(syncedRepo).toBeDefined();
+      expect(syncedRepo.sync_status).toBe('SUCCESS');
+      expect(syncedRepo.is_enabled).toBe(true);
+    });
   },
 );

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -70,6 +70,51 @@ unmirrored_repositories = Gauge(
     "number of repositories in the database that have not yet been mirrored",
 )
 
+# Repository mirroring metrics
+repo_mirror_tags_pending = Gauge(
+    "quay_repository_mirror_pending_tags",
+    "Total number of tags pending synchronization for each mirrored repository",
+    labelnames=["namespace", "repository"],
+)
+
+repo_mirror_last_sync_status = Gauge(
+    "quay_repository_mirror_last_sync_status",
+    "Status of the last synchronization attempt (0=failed, 1=success, 2=in_progress)",
+    labelnames=["namespace", "repository", "last_error_reason"],
+)
+
+repo_mirror_sync_complete = Gauge(
+    "quay_repository_mirror_sync_complete",
+    "Indicates if all tags have been successfully synchronized (0=incomplete, 1=complete)",
+    labelnames=["namespace", "repository"],
+)
+
+repo_mirror_sync_failures_total = Counter(
+    "quay_repository_mirror_sync_failures_total",
+    "Total number of synchronization failures per repository",
+    labelnames=["namespace", "repository", "reason"],
+)
+
+# Additional supporting metrics
+repo_mirror_last_sync_timestamp = Gauge(
+    "quay_repository_mirror_last_sync_timestamp",
+    "Unix timestamp of the last synchronization attempt",
+    labelnames=["namespace", "repository"],
+)
+
+repo_mirror_sync_duration_seconds = Histogram(
+    "quay_repository_mirror_sync_duration_seconds",
+    "Duration of the last synchronization operation",
+    labelnames=["namespace", "repository"],
+    buckets=(30, 60, 120, 300, 600, 1200, 1800, 3600, 7200, float("inf")),
+)
+
+repo_mirror_workers_active = Gauge(
+    "quay_repository_mirror_workers_active",
+    "Number of repository mirror worker processes reporting from this Quay process (1 while a "
+    "RepoMirrorWorker is running; scrape all mirror worker targets and sum for cluster total)",
+)
+
 unmirrored_org_repositories = Gauge(
     "quay_org_mirror_repositories_unmirrored",
     "number of org-level mirror repositories in the database that have not yet been mirrored",
@@ -114,6 +159,29 @@ org_mirror_repo_sync_duration_seconds = Histogram(
 
 # Used only for testing - should not be set in production
 TAG_ROLLBACK_PAGE_SIZE = app.config.get("REPO_MIRROR_TAG_ROLLBACK_PAGE_SIZE", 100)
+
+
+def _map_failure_to_reason(error_message):
+    """
+    Map error messages to standardized failure reasons for metrics.
+    This helps categorize failures for better alerting and troubleshooting.
+    """
+    error_lower = str(error_message).lower()
+
+    if "auth" in error_lower or "unauthorized" in error_lower or "forbidden" in error_lower:
+        return "auth_failed"
+    elif "timeout" in error_lower or "timed out" in error_lower:
+        return "network_timeout"
+    elif "connection" in error_lower or "network" in error_lower:
+        return "connection_error"
+    elif "not found" in error_lower or "404" in error_lower:
+        return "not_found"
+    elif "tls" in error_lower or "certificate" in error_lower or "ssl" in error_lower:
+        return "tls_error"
+    elif "decrypt" in error_lower:
+        return "decryption_failed"
+    else:
+        return "unknown_error"
 
 
 class PreemptedException(Exception):
@@ -181,6 +249,24 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     if not mirror:
         raise PreemptedException
 
+    # Track start time for duration metric
+    sync_start_time = time.time()
+    namespace = mirror.repository.namespace_user.username
+    repository_name = mirror.repository.name
+
+    # Set sync status to in_progress (2)
+    repo_mirror_last_sync_status.labels(
+        namespace=namespace,
+        repository=repository_name,
+        last_error_reason="",
+    ).set(2)
+
+    # Update timestamp
+    repo_mirror_last_sync_timestamp.labels(
+        namespace=namespace,
+        repository=repository_name,
+    ).set(sync_start_time)
+
     emit_log(
         mirror,
         "repo_mirror_sync_started",
@@ -192,9 +278,12 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     # Fetch the tags to mirror, being careful to handle exceptions. The 'Exception' is safety net only, allowing
     # easy communication by user through bug report.
     tags = []
+    failure_reason = None
+
     try:
         tags = tags_to_mirror(skopeo, mirror)
     except RepoMirrorSkopeoException as e:
+        failure_reason = _map_failure_to_reason(str(e))
         emit_log(
             mirror,
             "repo_mirror_sync_failed",
@@ -205,9 +294,14 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             stdout=e.stdout,
             stderr=e.stderr,
         )
+        # Update metrics for early failure
+        _update_mirror_metrics_on_failure(
+            namespace, repository_name, failure_reason, sync_start_time
+        )
         release_mirror(mirror, RepoMirrorStatus.FAIL)
         return
-    except Exception:
+    except Exception as e:
+        failure_reason = _map_failure_to_reason(str(e))
         emit_log(
             mirror,
             "repo_mirror_sync_failed",
@@ -217,6 +311,10 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             tags=", ".join(tags),
             stdout="Not applicable",
             stderr=traceback.format_exc(),
+        )
+        # Update metrics for early failure
+        _update_mirror_metrics_on_failure(
+            namespace, repository_name, failure_reason, sync_start_time
         )
         release_mirror(mirror, RepoMirrorStatus.FAIL)
         return
@@ -229,6 +327,25 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             % (mirror.external_reference, ",".join(mirror.root_rule.rule_value)),
             tags="No tags matched",
         )
+        # Set metrics for empty tag list - this is a success
+        sync_duration = time.time() - sync_start_time
+        repo_mirror_tags_pending.labels(
+            namespace=namespace,
+            repository=repository_name,
+        ).set(0)
+        repo_mirror_last_sync_status.labels(
+            namespace=namespace,
+            repository=repository_name,
+            last_error_reason="",
+        ).set(1)
+        repo_mirror_sync_complete.labels(
+            namespace=namespace,
+            repository=repository_name,
+        ).set(1)
+        repo_mirror_sync_duration_seconds.labels(
+            namespace=namespace,
+            repository=repository_name,
+        ).observe(sync_duration)
         release_mirror(mirror, RepoMirrorStatus.SUCCESS)
         return
 
@@ -236,6 +353,12 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     now_ms = database.get_epoch_timestamp_ms()
     overall_status = RepoMirrorStatus.SUCCESS
     failed_tags = []
+
+    # Set initial pending tags metric
+    repo_mirror_tags_pending.labels(
+        namespace=namespace,
+        repository=repository_name,
+    ).set(len(tags))
     try:
         try:
             username = (
@@ -271,7 +394,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
                 architecture_filter,
             )
 
-        for tag in tags:
+        for tag_index, tag in enumerate(tags):
             src_image = "docker://%s:%s" % (mirror.external_reference, tag)
             dest_image = "docker://%s/%s/%s:%s" % (
                 dest_server,
@@ -307,6 +430,13 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
                         ),
                     )
 
+            # Update pending tags metric after processing each tag
+            remaining_tags = len(tags) - (tag_index + 1)
+            repo_mirror_tags_pending.labels(
+                namespace=namespace,
+                repository=repository_name,
+            ).set(remaining_tags)
+
             if check_repo_mirror_sync_status(mirror) == RepoMirrorStatus.CANCEL:
                 logger.info(
                     "Sync cancelled on repo %s/%s.",
@@ -319,6 +449,11 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             if not result.success:
                 overall_status = RepoMirrorStatus.FAIL
                 failed_tags.append(tag)
+                # Track the first failure reason for metrics
+                if failure_reason is None:
+                    failure_reason = _map_failure_to_reason(
+                        result.stderr or result.stdout or "unknown"
+                    )
                 emit_log(
                     mirror,
                     "repo_mirror_sync_tag_failed",
@@ -345,6 +480,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
 
     except PreemptedException:
         overall_status = RepoMirrorStatus.FAIL
+        failure_reason = "preempted"
         emit_log(
             mirror,
             "repo_mirror_sync_failed",
@@ -354,11 +490,12 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             stdout="Not applicable",
             stderr="Not applicable",
         )
-        release_mirror(mirror, overall_status)
         return
 
-    except Exception:
+    except Exception as e:
         overall_status = RepoMirrorStatus.FAIL
+        if failure_reason is None:
+            failure_reason = _map_failure_to_reason(str(e))
         emit_log(
             mirror,
             "repo_mirror_sync_failed",
@@ -369,9 +506,10 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             stdout="Not applicable",
             stderr=traceback.format_exc(),
         )
-        release_mirror(mirror, overall_status)
         return
     finally:
+        sync_duration = time.time() - sync_start_time
+
         if overall_status == RepoMirrorStatus.FAIL:
             log_tags = []
             log_message = "'%s' with tag pattern '%s'"
@@ -404,7 +542,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
                 rollback(mirror, now_ms)
             else:
                 rollback(mirror, now_ms, failed_tags)
-        if overall_status == RepoMirrorStatus.CANCEL:
+        elif overall_status == RepoMirrorStatus.CANCEL:
             log_message = "'%s' with tag pattern '%s'"
             emit_log(
                 mirror,
@@ -414,7 +552,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
                 stdout="Not applicable",
                 stderr="Not applicable",
             )
-        else:
+        elif overall_status == RepoMirrorStatus.SUCCESS:
             emit_log(
                 mirror,
                 "repo_mirror_sync_success",
@@ -423,6 +561,54 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
                 % (mirror.external_reference, ",".join(mirror.root_rule.rule_value)),
                 tags=", ".join(tags),
             )
+
+        # Update mirroring metrics
+        # Set complete sync metric (1 if all tags synced successfully, 0 otherwise)
+        is_complete = (
+            1 if (overall_status == RepoMirrorStatus.SUCCESS and len(failed_tags) == 0) else 0
+        )
+        repo_mirror_sync_complete.labels(
+            namespace=namespace,
+            repository=repository_name,
+        ).set(is_complete)
+
+        # Set last sync status metric based on final status
+        if overall_status == RepoMirrorStatus.SUCCESS:
+            status_value = 1
+            error_reason = ""
+        elif overall_status == RepoMirrorStatus.SYNCING:
+            status_value = 2
+            error_reason = ""
+        else:  # FAIL or CANCEL
+            status_value = 0
+            error_reason = failure_reason or "unknown_error"
+
+        repo_mirror_last_sync_status.labels(
+            namespace=namespace,
+            repository=repository_name,
+            last_error_reason="",
+        ).set(status_value)
+        if error_reason:
+            repo_mirror_last_sync_status.labels(
+                namespace=namespace,
+                repository=repository_name,
+                last_error_reason=error_reason,
+            ).set(status_value)
+
+        # Record sync duration
+        repo_mirror_sync_duration_seconds.labels(
+            namespace=namespace,
+            repository=repository_name,
+        ).observe(sync_duration)
+
+        # Increment failure counter on failures with reason
+        if overall_status == RepoMirrorStatus.FAIL:
+            repo_mirror_sync_failures_total.labels(
+                namespace=namespace,
+                repository=repository_name,
+                reason=failure_reason or "unknown_error",
+            ).inc()
+
         release_mirror(mirror, overall_status)
 
     return overall_status
@@ -914,6 +1100,47 @@ def emit_log(mirror, log_kind, verb, message, tag=None, tags=None, stdout=None, 
         "repo_mirror_sync_success",
     ):
         spawn_notification(wrap_repository(mirror.repository), log_kind, {"message": message})
+
+
+def _update_mirror_metrics_on_failure(namespace, repository_name, failure_reason, sync_start_time):
+    """
+    Helper function to update metrics when a mirror sync fails.
+    """
+    reason = failure_reason or "unknown_error"
+    repo_mirror_tags_pending.labels(
+        namespace=namespace,
+        repository=repository_name,
+    ).set(0)
+
+    repo_mirror_last_sync_status.labels(
+        namespace=namespace,
+        repository=repository_name,
+        last_error_reason="",
+    ).set(0)
+    repo_mirror_last_sync_status.labels(
+        namespace=namespace,
+        repository=repository_name,
+        last_error_reason=reason,
+    ).set(0)
+
+    repo_mirror_sync_complete.labels(
+        namespace=namespace,
+        repository=repository_name,
+    ).set(0)
+
+    repo_mirror_sync_failures_total.labels(
+        namespace=namespace,
+        repository=repository_name,
+        reason=reason,
+    ).inc()
+
+    # Record duration if available
+    if sync_start_time:
+        sync_duration = time.time() - sync_start_time
+        repo_mirror_sync_duration_seconds.labels(
+            namespace=namespace,
+            repository=repository_name,
+        ).observe(sync_duration)
 
 
 # ==============================================================================

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -91,8 +91,8 @@ repo_mirror_sync_complete = Gauge(
 
 repo_mirror_sync_failures_total = Counter(
     "quay_repository_mirror_sync_failures_total",
-    "Total number of synchronization failures per repository",
-    labelnames=["namespace", "repository", "reason"],
+    "Total number of synchronization failures aggregated by namespace",
+    labelnames=["namespace", "reason"],
 )
 
 # Additional supporting metrics
@@ -104,9 +104,9 @@ repo_mirror_last_sync_timestamp = Gauge(
 
 repo_mirror_sync_duration_seconds = Histogram(
     "quay_repository_mirror_sync_duration_seconds",
-    "Duration of the last synchronization operation",
-    labelnames=["namespace", "repository"],
-    buckets=(30, 60, 120, 300, 600, 1200, 1800, 3600, 7200, float("inf")),
+    "Duration of synchronization operations aggregated by namespace",
+    labelnames=["namespace"],
+    buckets=(60, 300, 900, 3600, float("inf")),
 )
 
 repo_mirror_workers_active = Gauge(
@@ -344,7 +344,6 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
         ).set(1)
         repo_mirror_sync_duration_seconds.labels(
             namespace=namespace,
-            repository=repository_name,
         ).observe(sync_duration)
         release_mirror(mirror, RepoMirrorStatus.SUCCESS)
         return
@@ -598,14 +597,12 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
         # Record sync duration
         repo_mirror_sync_duration_seconds.labels(
             namespace=namespace,
-            repository=repository_name,
         ).observe(sync_duration)
 
         # Increment failure counter on failures with reason
         if overall_status == RepoMirrorStatus.FAIL:
             repo_mirror_sync_failures_total.labels(
                 namespace=namespace,
-                repository=repository_name,
                 reason=failure_reason or "unknown_error",
             ).inc()
 
@@ -1130,7 +1127,6 @@ def _update_mirror_metrics_on_failure(namespace, repository_name, failure_reason
 
     repo_mirror_sync_failures_total.labels(
         namespace=namespace,
-        repository=repository_name,
         reason=reason,
     ).inc()
 
@@ -1139,7 +1135,6 @@ def _update_mirror_metrics_on_failure(namespace, repository_name, failure_reason
         sync_duration = time.time() - sync_start_time
         repo_mirror_sync_duration_seconds.labels(
             namespace=namespace,
-            repository=repository_name,
         ).observe(sync_duration)
 
 

--- a/workers/repomirrorworker/repomirrorworker.py
+++ b/workers/repomirrorworker/repomirrorworker.py
@@ -13,6 +13,7 @@ from workers.repomirrorworker import (
     process_mirrors,
     process_org_mirror_discovery,
     process_org_mirrors,
+    repo_mirror_workers_active,
 )
 from workers.worker import Worker
 
@@ -40,6 +41,9 @@ class RepoMirrorWorker(Worker):
         org_interval = app.config.get("ORG_MIRROR_INTERVAL", DEFAULT_MIRROR_INTERVAL)
         self.add_operation(self._process_org_mirror_discovery, org_interval)
         self.add_operation(self._process_org_mirrors, org_interval)
+
+        if features.REPO_MIRROR:
+            repo_mirror_workers_active.set(1)
 
     def _process_mirrors(self):
         while True:

--- a/workers/repomirrorworker/test/test_mirror_metrics.py
+++ b/workers/repomirrorworker/test/test_mirror_metrics.py
@@ -10,7 +10,6 @@ from workers.repomirrorworker import (
     _update_mirror_metrics_on_failure,
 )
 
-
 # =============================================================================
 # Tests for _map_failure_to_reason
 # =============================================================================

--- a/workers/repomirrorworker/test/test_mirror_metrics.py
+++ b/workers/repomirrorworker/test/test_mirror_metrics.py
@@ -1,0 +1,195 @@
+import time
+from unittest import mock
+
+import pytest
+from prometheus_client import REGISTRY, CollectorRegistry, Counter, Gauge, Histogram
+
+from test.fixtures import *
+from workers.repomirrorworker import (
+    _map_failure_to_reason,
+    _update_mirror_metrics_on_failure,
+)
+
+
+# =============================================================================
+# Tests for _map_failure_to_reason
+# =============================================================================
+
+
+class TestMapFailureToReason:
+    @pytest.mark.parametrize(
+        "error_message, expected_reason",
+        [
+            ("unauthorized access denied", "auth_failed"),
+            ("HTTP 401 Unauthorized", "auth_failed"),
+            ("403 Forbidden", "auth_failed"),
+            ("authentication required", "auth_failed"),
+            ("connection timed out after 30s", "network_timeout"),
+            ("request timeout exceeded", "network_timeout"),
+            ("connection refused by remote host", "connection_error"),
+            ("network unreachable", "connection_error"),
+            ("repository not found", "not_found"),
+            ("HTTP 404 error", "not_found"),
+            ("TLS handshake failure", "tls_error"),
+            ("certificate has expired", "tls_error"),
+            ("SSL verification failed", "tls_error"),
+            ("unable to decrypt credentials", "decryption_failed"),
+            ("something completely unexpected happened", "unknown_error"),
+            ("", "unknown_error"),
+        ],
+    )
+    def test_error_categorization(self, error_message, expected_reason):
+        assert _map_failure_to_reason(error_message) == expected_reason
+
+    def test_case_insensitive(self):
+        assert _map_failure_to_reason("UNAUTHORIZED") == "auth_failed"
+        assert _map_failure_to_reason("CONNECTION REFUSED") == "connection_error"
+        assert _map_failure_to_reason("TLS Error") == "tls_error"
+
+    def test_non_string_input(self):
+        assert _map_failure_to_reason(None) == "unknown_error"
+        assert _map_failure_to_reason(42) == "unknown_error"
+        assert _map_failure_to_reason(Exception("timeout")) == "network_timeout"
+
+
+# =============================================================================
+# Tests for _update_mirror_metrics_on_failure
+# =============================================================================
+
+
+class TestUpdateMirrorMetricsOnFailure:
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_duration_seconds")
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_failures_total")
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_complete")
+    @mock.patch("workers.repomirrorworker.repo_mirror_last_sync_status")
+    @mock.patch("workers.repomirrorworker.repo_mirror_tags_pending")
+    def test_sets_all_failure_metrics(
+        self, mock_pending, mock_status, mock_complete, mock_failures, mock_duration
+    ):
+        mock_pending_labeled = mock.Mock()
+        mock_pending.labels.return_value = mock_pending_labeled
+
+        mock_status_labeled = mock.Mock()
+        mock_status.labels.return_value = mock_status_labeled
+
+        mock_complete_labeled = mock.Mock()
+        mock_complete.labels.return_value = mock_complete_labeled
+
+        mock_failures_labeled = mock.Mock()
+        mock_failures.labels.return_value = mock_failures_labeled
+
+        _update_mirror_metrics_on_failure("myns", "myrepo", "auth_failed", time.time() - 10)
+
+        mock_pending.labels.assert_called_with(namespace="myns", repository="myrepo")
+        mock_pending_labeled.set.assert_called_with(0)
+
+        mock_complete.labels.assert_called_with(namespace="myns", repository="myrepo")
+        mock_complete_labeled.set.assert_called_with(0)
+
+        mock_failures.labels.assert_called_with(namespace="myns", reason="auth_failed")
+        mock_failures_labeled.inc.assert_called_once()
+
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_duration_seconds")
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_failures_total")
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_complete")
+    @mock.patch("workers.repomirrorworker.repo_mirror_last_sync_status")
+    @mock.patch("workers.repomirrorworker.repo_mirror_tags_pending")
+    def test_records_duration_when_start_time_provided(
+        self, mock_pending, mock_status, mock_complete, mock_failures, mock_duration
+    ):
+        mock_pending.labels.return_value = mock.Mock()
+        mock_status.labels.return_value = mock.Mock()
+        mock_complete.labels.return_value = mock.Mock()
+        mock_failures.labels.return_value = mock.Mock()
+
+        mock_duration_labeled = mock.Mock()
+        mock_duration.labels.return_value = mock_duration_labeled
+
+        start = time.time() - 60
+        _update_mirror_metrics_on_failure("myns", "myrepo", "timeout", start)
+
+        mock_duration.labels.assert_called_with(namespace="myns")
+        mock_duration_labeled.observe.assert_called_once()
+        observed = mock_duration_labeled.observe.call_args[0][0]
+        assert 59 < observed < 62
+
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_duration_seconds")
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_failures_total")
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_complete")
+    @mock.patch("workers.repomirrorworker.repo_mirror_last_sync_status")
+    @mock.patch("workers.repomirrorworker.repo_mirror_tags_pending")
+    def test_skips_duration_when_no_start_time(
+        self, mock_pending, mock_status, mock_complete, mock_failures, mock_duration
+    ):
+        mock_pending.labels.return_value = mock.Mock()
+        mock_status.labels.return_value = mock.Mock()
+        mock_complete.labels.return_value = mock.Mock()
+        mock_failures.labels.return_value = mock.Mock()
+
+        _update_mirror_metrics_on_failure("myns", "myrepo", "auth_failed", None)
+
+        mock_duration.labels.assert_not_called()
+
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_duration_seconds")
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_failures_total")
+    @mock.patch("workers.repomirrorworker.repo_mirror_sync_complete")
+    @mock.patch("workers.repomirrorworker.repo_mirror_last_sync_status")
+    @mock.patch("workers.repomirrorworker.repo_mirror_tags_pending")
+    def test_defaults_to_unknown_error_reason(
+        self, mock_pending, mock_status, mock_complete, mock_failures, mock_duration
+    ):
+        mock_pending.labels.return_value = mock.Mock()
+        mock_status.labels.return_value = mock.Mock()
+        mock_complete.labels.return_value = mock.Mock()
+        mock_failures.labels.return_value = mock.Mock()
+
+        _update_mirror_metrics_on_failure("myns", "myrepo", None, None)
+
+        mock_failures.labels.assert_called_with(namespace="myns", reason="unknown_error")
+
+
+# =============================================================================
+# Tests for metric cardinality: Counter and Histogram use namespace-only labels
+# =============================================================================
+
+
+class TestMetricCardinality:
+    def test_sync_failures_counter_has_namespace_and_reason_labels(self):
+        from workers.repomirrorworker import repo_mirror_sync_failures_total
+
+        assert repo_mirror_sync_failures_total._labelnames == ("namespace", "reason")
+
+    def test_sync_duration_histogram_has_namespace_only_label(self):
+        from workers.repomirrorworker import repo_mirror_sync_duration_seconds
+
+        assert repo_mirror_sync_duration_seconds._labelnames == ("namespace",)
+
+    def test_sync_duration_histogram_has_trimmed_buckets(self):
+        from workers.repomirrorworker import repo_mirror_sync_duration_seconds
+
+        expected = [60.0, 300.0, 900.0, 3600.0, float("inf")]
+        assert list(repo_mirror_sync_duration_seconds._upper_bounds) == expected
+
+    def test_tags_pending_gauge_has_per_repo_labels(self):
+        from workers.repomirrorworker import repo_mirror_tags_pending
+
+        assert repo_mirror_tags_pending._labelnames == ("namespace", "repository")
+
+    def test_last_sync_status_gauge_has_per_repo_labels(self):
+        from workers.repomirrorworker import repo_mirror_last_sync_status
+
+        assert repo_mirror_last_sync_status._labelnames == (
+            "namespace",
+            "repository",
+            "last_error_reason",
+        )
+
+    def test_sync_complete_gauge_has_per_repo_labels(self):
+        from workers.repomirrorworker import repo_mirror_sync_complete
+
+        assert repo_mirror_sync_complete._labelnames == ("namespace", "repository")
+
+    def test_last_sync_timestamp_gauge_has_per_repo_labels(self):
+        from workers.repomirrorworker import repo_mirror_last_sync_timestamp
+
+        assert repo_mirror_last_sync_timestamp._labelnames == ("namespace", "repository")


### PR DESCRIPTION
Add Prometheus metrics for repository mirroring

Add four new metrics to monitor mirroring operations:
- quay_repository_mirror_pending_tags: Track tags pending sync
- quay_repository_mirror_last_sync_status: Last sync status indicator
- quay_repository_mirror_sync_complete: Boolean for complete sync
- quay_repository_mirror_sync_failures_total: Failure counter for alerting

Includes comprehensive documentation with alerting examples and troubleshooting guides.
Relates to enhancement Additional mirror metrics https://github.com/quay/enhancements/pull/35 , to: [RFE-6452](https://issues.redhat.com//browse/RFE-6452) and to: [PROJQUAY-10282](https://redhat.atlassian.net/browse/PROJQUAY-10282)
Does not cover Implement a health endpoint, mentioned as well in the enhancement, as it has not been discussed yet.

## Automation
- **Session ID**: 84d0e6d5-c78d-4105-a730-29f1cdd00086