### PR TITLE
fix: Quay new UI global readonly superuser can't see all organizations and image repos (PROJQUAY-6882)

### DIFF
--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -78,7 +78,7 @@ def team_view(orgname, team):
         "description": team.description,
         "role": team.role_name,
         "avatar": avatar.get_data_for_team(team),
-        "can_view": ViewTeamPermission(orgname, team.name).can(),
+        "can_view": ViewTeamPermission(orgname, team.name).can() or allow_if_global_readonly_superuser(),
         "repo_count": team.repo_count,
         "member_count": team.member_count,
         "is_synced": team.is_synced,

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -78,7 +78,8 @@ def team_view(orgname, team):
         "description": team.description,
         "role": team.role_name,
         "avatar": avatar.get_data_for_team(team),
-        "can_view": ViewTeamPermission(orgname, team.name).can() or allow_if_global_readonly_superuser(),
+        "can_view": ViewTeamPermission(orgname, team.name).can() 
+        or allow_if_global_readonly_superuser(),
         "repo_count": team.repo_count,
         "member_count": team.member_count,
         "is_synced": team.is_synced,

--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -226,9 +226,9 @@ class OrgRobotList(ApiResource):
                 AdministerOrganizationPermission(orgname).can()
                 or allow_if_global_readonly_superuser()
             ) and parsed_args.get("token", True)
-            include_permissions = AdministerOrganizationPermission(
-                orgname
-            ).can() and parsed_args.get("permissions", False)
+            include_permissions = (
+                AdministerOrganizationPermission(orgname).can() or allow_if_global_readonly_superuser()
+            ) and parsed_args.get("permissions", False)
             return robots_list(
                 orgname,
                 include_permissions=include_permissions,

--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -227,7 +227,8 @@ class OrgRobotList(ApiResource):
                 or allow_if_global_readonly_superuser()
             ) and parsed_args.get("token", True)
             include_permissions = (
-                AdministerOrganizationPermission(orgname).can() or allow_if_global_readonly_superuser()
+                AdministerOrganizationPermission(orgname).can() 
+                or allow_if_global_readonly_superuser()
             ) and parsed_args.get("permissions", False)
             return robots_list(
                 orgname,

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -31,6 +31,7 @@ from auth.permissions import (
     SuperUserPermission,
     UserAdminPermission,
     UserReadPermission,
+    GlobalReadOnlySuperUserPermission,
 )
 from data import model
 from data.billing import get_plan
@@ -214,12 +215,12 @@ def user_view(user, previous_username=None):
             }
         )
 
-    if features.SUPER_USERS and SuperUserPermission().can():
+    if features.SUPER_USERS and (SuperUserPermission().can() or GlobalReadOnlySuperUserPermission().can()):
         user_response.update(
             {
                 "super_user": user
                 and user == get_authenticated_user()
-                and SuperUserPermission().can()
+                and (SuperUserPermission().can() or GlobalReadOnlySuperUserPermission().can())
             }
         )
 

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -215,7 +215,9 @@ def user_view(user, previous_username=None):
             }
         )
 
-    if features.SUPER_USERS and (SuperUserPermission().can() or GlobalReadOnlySuperUserPermission().can()):
+    if features.SUPER_USERS and (
+        SuperUserPermission().can() or GlobalReadOnlySuperUserPermission().can()
+    ):
         user_response.update(
             {
                 "super_user": user

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -28,10 +28,10 @@ from auth.auth_context import get_authenticated_user
 from auth.permissions import (
     AdministerOrganizationPermission,
     CreateRepositoryPermission,
+    GlobalReadOnlySuperUserPermission,
     SuperUserPermission,
     UserAdminPermission,
     UserReadPermission,
-    GlobalReadOnlySuperUserPermission,
 )
 from data import model
 from data.billing import get_plan


### PR DESCRIPTION
With this fix, now **Quay global readonly superuser** can see all organizations and image repos of other normal users
<img width="2416" height="1183" alt="image" src="https://github.com/user-attachments/assets/60f13361-c6dd-4a0d-8769-71558f940661" />
