### PR TITLE
config: Make health endpoint instance skips configurable

### DIFF
--- a/health/healthcheck.py
+++ b/health/healthcheck.py
@@ -121,10 +121,12 @@ class HealthCheck(object):
 
 
 class LocalHealthCheck(HealthCheck):
-    def __init__(self, app, config_provider, instance_keys):
-        super(LocalHealthCheck, self).__init__(
-            app, config_provider, instance_keys, ["redis", "storage"]
-        )
+    def __init__(self, app, config_provider, instance_keys, instance_skips=None):
+
+        if instance_skips is None:
+            instance_skips = ["redis", "storage"]
+
+        super(LocalHealthCheck, self).__init__(app, config_provider, instance_keys, instance_skips)
 
     @classmethod
     def check_names(cls):
@@ -141,11 +143,16 @@ class RDSAwareHealthCheck(HealthCheck):
         secret_key=None,
         db_instance="quay",
         region="us-east-1",
+        instance_skips=None,
     ):
         # Note: We skip the redis check because if redis is down, we don't want ELB taking the
         # machines out of service. Redis is not considered a high avaliability-required service.
+
+        if instance_skips is None:
+            instance_skips = ["redis", "storage"]
+
         super(RDSAwareHealthCheck, self).__init__(
-            app, config_provider, instance_keys, ["redis", "storage"]
+            app, config_provider, instance_keys, instance_skips
         )
 
         self.access_key = access_key


### PR DESCRIPTION
We use ldap auth and now it defaults to pinging the backend for every health check. We run quay as a kubernetes deployment and have /health configured as the probe endpoints and it generates a bit of traffic. We also have had some issues with our internal ldap, and since quay defaults to pinging it for its health endpoint the whole app gets killed since the auth check fails. We use robot accounts for pulling images to our cluster and in our ci/cd pipeline to push and these work fine without the ldap backend. So we would like to have the options of checking the other services and exclude auth.