### PR TITLE
chore(deps): upgrade redis version, remove redis-py-cluster (PROJQUAY-9314)

### DIFF
--- a/data/cache/redis_cache.py
+++ b/data/cache/redis_cache.py
@@ -89,11 +89,13 @@ def redis_cache_from_config(cache_config):
     if driver == "rediscluster":
         redis_config = redis_config.copy()
         if "startup_nodes" in redis_config:
+            # redis-py expects a different format from redis-py-cluster hence this conversion is required
             redis_config["startup_nodes"] = [
                 ClusterNode(host=node["host"], port=int(node["port"]))
                 for node in redis_config["startup_nodes"]
             ]
         if "readonly_mode" in redis_config:
+            # `readonly_mode` was renamed to `read_from_replicas` in redis-py
             redis_config["read_from_replicas"] = redis_config.pop("readonly_mode")
 
     return driver_cls(**redis_config)

--- a/data/cache/redis_cache.py
+++ b/data/cache/redis_cache.py
@@ -1,5 +1,5 @@
 from redis import RedisError, StrictRedis
-from rediscluster import RedisCluster
+from redis.cluster import RedisCluster
 
 
 class ReadEndpointSupportedRedis(object):

--- a/data/cache/redis_cache.py
+++ b/data/cache/redis_cache.py
@@ -1,5 +1,5 @@
 from redis import RedisError, StrictRedis
-from redis.cluster import RedisCluster
+from redis.cluster import ClusterNode, RedisCluster
 
 
 class ReadEndpointSupportedRedis(object):
@@ -68,14 +68,13 @@ def redis_cache_from_config(cache_config):
           startup_nodes:
           - host: "test"
             port: 6379
-          readonly_mode: true
+          read_from_replicas: true
 
     rediscluster uses the same client as redis internally for commands.
-    Anything that can be set in StricRedis() can also be set under the redis_config structure.
+    Anything that can be set in RedisCluster() can also be set under the redis_config structure.
 
-    NOTE: Known issue - To allow read from replicas in redis cluster mode, set read_from_replicas instead
-          of readonly_mode.
-          Ref: https://github.com/Grokzen/redis-py-cluster/issues/339
+    NOTE: The legacy 'readonly_mode' parameter is automatically converted to 'read_from_replicas'
+          for backwards compatibility.
     """
     driver = cache_config.get("engine", None)
     if driver is None or driver.lower() not in REDIS_DRIVERS.keys():
@@ -86,5 +85,15 @@ def redis_cache_from_config(cache_config):
     redis_config = cache_config.get("redis_config", None)
     if not redis_config:
         raise ValueError("Invalid Redis config for %s" % driver)
+
+    if driver == "rediscluster":
+        redis_config = redis_config.copy()
+        if "startup_nodes" in redis_config:
+            redis_config["startup_nodes"] = [
+                ClusterNode(host=node["host"], port=int(node["port"]))
+                for node in redis_config["startup_nodes"]
+            ]
+        if "readonly_mode" in redis_config:
+            redis_config["read_from_replicas"] = redis_config.pop("readonly_mode")
 
     return driver_cls(**redis_config)

--- a/mypy.ini
+++ b/mypy.ini
@@ -153,9 +153,6 @@ ignore_missing_imports = True
 [mypy-redis_lock]
 ignore_missing_imports = True
 
-[mypy-rediscluster.*]
-ignore_missing_imports = True
-
 [mypy-rehash]
 ignore_missing_imports = True
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ bencode.py==4.0.0
 black==24.4.2
 flake8==4.0.1
 boto3-stubs==1.14.9.0
-fakeredis==1.6.1
+fakeredis==2.26.2
 freezegun==0.3.12
 httmock==1.4.0
 ipdb
@@ -50,7 +50,7 @@ types-pyOpenSSL==20.0.9
 types-python-dateutil==2.8.19.14
 types-pytz==2023.3.1.1
 types-PyYAML==5.4.12
-types-redis==3.5.14
+types-redis==4.6.0.20241004
 types-requests==2.25.11
 types-setuptools==68.2.0.0
 types-six==1.16.21.20240513

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,14 +98,13 @@ python-gitlab==2.0.0
 python-keystoneclient==3.22.0
 python-ldap==3.4.3
 python-magic==0.4.27
-python-redis-lock==3.7.0
+python-redis-lock==4.0.0
 python-swiftclient==4.4.0
 pytz==2019.3
 PyYAML==6.0.2
 sentry-sdk[flask]==1.40.0
 recaptcha2==0.1
-redis==3.5.3
-redis-py-cluster==2.1.3
+redis==7.1.0
 rehash==1.0.1
 requests==2.32.3
 requests-aws4auth==1.2.3


### PR DESCRIPTION
- Upgrade `redis` package used by Quay
- Remove `redis-py-cluster` since this functionality is in the base Redis package now
- Update imports

Work required for [PROJQUAY-9314](https://issues.redhat.com/browse/PROJQUAY-9314)