### PR TITLE
feat(ldap): LDAP pooling

### DIFF
--- a/app.py
+++ b/app.py
@@ -173,7 +173,7 @@ if features.LDAPPOOL:  # type: ignore
             params=app.config.get(
                 "LDAP_POOL_PARAMS",
                 {
-                    "referrals": app.config.get("LDAP_POOL_PARAMS", {}).get("referrals"),
+                    "referrals": app.config.get("LDAP_POOL_PARAMS", {}).get("referrals", False),
                     "network_timeout": float(
                         app.config.get("LDAP_POOL_PARAMS", {}).get("network_timeout", 10.0)
                     ),
@@ -191,7 +191,7 @@ if features.LDAPPOOL:  # type: ignore
                         "allow_tls_fallback", False
                     ),
                     "lock_timeout": float(
-                        app.config.get("LDAP_POOL_PARAMS", {}).get("lock_timeoout", 15.0)
+                        app.config.get("LDAP_POOL_PARAMS", {}).get("lock_timeout", 15.0)
                     ),
                 },
             ),

--- a/config.py
+++ b/config.py
@@ -951,3 +951,9 @@ class DefaultConfig(ImmutableConfig):
     # 2. Dict format: {"bucket_name": ["namespace1", "namespace2"]} - multiple namespaces share a bucket
     # Example: {"critical": ["redhat", "internal"], "customers": ["customer1", "customer2"]}
     TRACKED_NAMESPACES: Union[List[str], Dict[str, Union[List[str], str]]] = []
+
+    # LDAPPool Config and Feature
+    FEATURE_LDAPPOOL = False
+    # Params can be used to pre-warm connections
+    LDAP_POOL_PARAMS = {"prewarm": False}
+    LDAP_POOL_MAX = 50

--- a/ldappool/__init__.py
+++ b/ldappool/__init__.py
@@ -1,0 +1,460 @@
+import logging
+import sys
+import threading
+from time import perf_counter
+from typing import Any, List
+from urllib.parse import urlparse
+
+import ldap
+from ldapurl import LDAPUrl  # type: ignore
+
+from util.metrics.prometheus import (
+    ldappool_auth_calls_failure,
+    ldappool_auth_calls_success,
+    ldappool_close_calls,
+    ldappool_connect_calls,
+    ldappool_connections_max,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LDAPPoolExhausted(Exception):
+    pass
+
+
+class LDAPPoolDown(Exception):
+    pass
+
+
+class LDAPLockTimeout(Exception):
+    pass
+
+
+class Connection(object):
+    # OPTIMIZATION: Use __slots__ to prevent creation of __dict__ per instance
+    __slots__ = (
+        "uri",
+        "binddn",
+        "bindpw",
+        "params",
+        "established",
+        "inUse",
+        "_whoami",
+        "_conn",
+        "_lock",
+        "_lock_timeout",
+        "_pool",
+        "_health",
+    )
+
+    def __init__(self, uri: LDAPUrl, binddn: str, bindpw: str, params: dict = None):  # type: ignore
+        self.uri = (
+            LDAPUrl(uri, scope=ldap.SCOPE_SUBTREE, dn=binddn, cred=bindpw)
+            if not isinstance(uri, LDAPUrl)
+            else uri
+        )
+        self.binddn = binddn
+        self.bindpw = bindpw
+        self.params = params if params is not None else {"prewarm": False, "lock_timeout": 15.0}
+        self.established = False
+        self.inUse = False
+        self._whoami = None
+        self._conn = False
+        self._lock = threading.Lock()
+        self._lock_timeout = float(self.params.get("lock_timeout", 15.0))
+        self._pool = None
+        self._health = 0.0
+
+        # Converted implicit string expression to log to avoid dead code
+        logging.debug("ConnectionPool new Connection %s", self)
+
+        if self.params.get("prewarm", False):
+            self.__enter__()
+
+    def __locktime(self):
+        if self._health == 0.0:
+            self._health = perf_counter()
+            return True
+        if (perf_counter() - self._health) < self._lock_timeout:
+            return False
+        return True
+
+    def whoami(self):
+        return self._whoami
+
+    def __whoami(self):
+        # do not stress the connection too often
+        if not self.__locktime():
+            return
+        for r in range(self.params.get("retries", 3)):
+            try:
+                self._whoami = self._conn.whoami_s()
+                return
+            except ldap.SERVER_DOWN as ldaperr:
+                logging.exception("__whoami ConnectionPool %s", ldaperr)
+                self.established = False
+                # just catch that error until we finished iterating
+                try:
+                    self.__enter__()
+                except ldap.LDAPError:
+                    continue
+        raise ldap.SERVER_DOWN(f"max retries {self.params.get('retries', 3)} reached") from None
+
+    @property
+    def conn(self):
+        if self._conn is False:
+            self.__enter__()
+        try:
+            if self.established:
+                self.__whoami()
+        except ldap.SERVER_DOWN as ldaperr:
+            self.established = False
+            raise LDAPPoolDown(
+                f"could not establish connection with {self.uri.initializeUrl()}"
+                + f" with max retries of {self.params.get('retries', 3)}"
+            ) from ldaperr
+        return self._conn
+
+    def __lock_acquire(self):
+        try:
+            if self._lock.acquire(blocking=True, timeout=1):
+                return True
+        except Exception as lockerr:
+            return False
+
+    def __lock_release(self):
+        try:
+            self._lock.release()
+            return True
+        except Exception as lockerr:
+            return False
+
+    def authenticate(self, binddn: str, bindpw: str):
+        if not self.__lock_acquire():
+            raise LDAPLockTimeout()
+
+        try:
+            self.conn.simple_bind_s(binddn, bindpw)
+            ldappool_auth_calls_success.inc()
+            if not self.__lock_release():
+                raise LDAPLockTimeout()
+        except ldap.INVALID_CREDENTIALS as ldaperr:
+            # rollback auth anyway
+            ldappool_auth_calls_failure.inc()
+            self.__lock_release()
+            self.__authenticate__()
+            raise ldap.INVALID_CREDENTIALS
+        # rollback auth anyway
+        self.__authenticate__()
+        return True
+
+    def __authenticate__(self):
+        try:
+            self.conn.simple_bind_s(self.binddn, self.bindpw)
+            ldappool_auth_calls_success.inc()
+            logging.debug("__whoami from __authenticate__")
+            self.__whoami()
+        except ldap.INVALID_CREDENTIALS as ldaperr:
+            ldappool_auth_calls_failure.inc()
+            logging.info(ldaperr)
+            raise ldap.INVALID_CREDENTIALS
+
+    def __set_connection_parameters__(self):
+        try:
+            self._conn.set_option(ldap.OPT_REFERRALS, self.params.get("referrals", False))
+            self._conn.set_option(
+                ldap.OPT_NETWORK_TIMEOUT, self.params.get("network_timeout", 10.0)
+            )
+            self._conn.set_option(ldap.OPT_TIMEOUT, self.params.get("timeout", 10.0))
+            self._conn.set_option(ldap.OPT_X_KEEPALIVE_IDLE, self.params.get("keepalive_idle", 10))
+            self._conn.set_option(
+                ldap.OPT_X_KEEPALIVE_INTERVAL, self.params.get("keepalive_interval", 5)
+            )
+            self._conn.set_option(
+                ldap.OPT_X_KEEPALIVE_PROBES, self.params.get("keepalive_probes", 3)
+            )
+            self._conn.set_option(ldap.OPT_RESTART, ldap.OPT_ON)
+            if self.params.get("allow_tls_fallback", False):
+                self._conn.set_option(ldap.OPT_X_TLS_TRY, 1)
+            self._conn.set_option(ldap.OPT_X_TLS_NEWCTX, ldap.OPT_OFF)
+        except Exception as connerr:
+            logging.error("cannot set LDAP option %s", connerr)
+
+    def __enter__(self):
+        self.inUse = True
+        if not self.established:
+            logging.debug("ConnectionPool %s initializin LDAP %s", self, self.uri.initializeUrl())
+            try:
+                ldappool_connect_calls.inc()
+                self._conn = ldap.initialize(self.uri.initializeUrl())
+                self.__set_connection_parameters__()
+                if self.params.get("autoBind", False):
+                    # Fixed implicit string to log
+                    logging.debug(
+                        "ConnectionPool %s autoBind with %s password %s",
+                        self,
+                        self.binddn,
+                        "x" * len(self.bindpw),
+                    )
+                self.__authenticate__()
+            except Exception as ldaperr:
+                logging.error(ldaperr)  # Fixed implicit string to log
+                raise ldaperr
+        self.established = True
+        return self.conn
+
+    def giveback(self, force=False):
+        try:
+            if force:
+                try:
+                    self._conn.unbind_s()
+                except Exception as ldaperr:
+                    logging.error("ConnectionPool unbind connection %s exception %s", self, ldaperr)
+                self.inUse = False
+                return
+
+            if self.params.get("autoBind", False):
+                if not self.params.get("keep", False):
+                    logging.debug("ConnectionPool unbind connection %s", self)
+                    try:
+                        self._conn.unbind_s()
+                    except Exception as ldaperr:
+                        logging.error(
+                            "ConnectionPool unbind connection %s exception %s", self, ldaperr
+                        )
+            self.inUse = False
+        except AttributeError:
+            self.inUse = False
+
+    def __del__(self):
+        try:
+            self.giveback()
+        except Exception:
+            pass
+
+    def __exit__(self, type, value, traceback):
+        self.giveback()
+        if self._pool is not None and not self.params.get("keep", False):
+            self._pool.delete(self)
+
+    def __eq__(self, other):
+        if isinstance(other, Connection):
+            return self.uri.initializeUrl() == other.uri.initializeUrl()
+        return False
+
+    def __hash__(self):
+        return hash(self.uri.initializeUrl())
+
+    def set_uri(self, uri: LDAPUrl):
+        self.uri = LDAPUrl(uri) if not isinstance(uri, LDAPUrl) else uri
+        return True
+
+    def set_binddn(self, binddn: str):
+        self.binddn = binddn
+        return True
+
+    def set_bindpw(self, bindpw: str):
+        self.bindpw = bindpw
+        return True
+
+    def set_credentials(self, binddn: str, bindpw: str):
+        self.set_binddn(binddn)
+        self.set_bindpw(bindpw)
+        return True
+
+
+class ConnectionPool(object):
+    # OPTIMIZATION: Use __slots__
+    __slots__ = ("uri", "binddn", "bindpw", "params", "max", "_lock", "_pool", "_context_conn")
+
+    def __init__(
+        self,
+        uri: LDAPUrl = None,  # Avoid mutable default, handled below or in field def
+        binddn: str = "",
+        bindpw: str = "",
+        params: dict = None,  # type: ignore
+        max: int = 50,
+    ):
+        uri = (
+            LDAPUrl(uri, scope=ldap.SCOPE_SUBTREE, dn=binddn, cred=bindpw)
+            if not isinstance(uri, LDAPUrl)
+            else uri
+        )
+        self.uri = uri if isinstance(uri, LDAPUrl) else LDAPUrl("ldap:///")
+        self.binddn = binddn
+        self.bindpw = bindpw
+        self.params = params if params is not None else {}
+        self.max = int(max)
+        self._lock = threading.Lock()
+        self._pool: List[Any] = []
+        logging.debug("ConnectionPool %s starting with %s connections", self, self.max)
+        ldappool_connections_max.set(self.max)
+        if self.params.get("prewarm", False):
+            self.scale()
+
+    @property
+    def basedn(self):
+        return self.uri.dn
+
+    @property
+    def scope(self):
+        return self.uri.scope
+
+    @property
+    def filter(self):
+        return self.uri.filterstr
+
+    @property
+    def attributes(self):
+        return self.uri.attrs
+
+    @property
+    def extensions(self):
+        return self.uri.extensions
+
+    def set_uri(self, uri: LDAPUrl):
+        if not isinstance(uri, LDAPUrl):
+            uri = LDAPUrl(uri)
+
+        if not self._lock.acquire(timeout=1):
+            raise LDAPLockTimeout("Could not acquire pool lock")
+        try:
+            # OPTIMIZATION: Replace map/lambda/filter with explicit loop
+            # This avoids creating a temporary list in memory just for side effects
+            if len(self._pool) > 0:
+                for cp in self._pool:
+                    if cp.uri != uri:
+                        cp.set_uri(uri)
+                        cp.giveback(force=True)
+        finally:
+            self._lock.release()
+
+        self.uri = uri
+        return True
+
+    def set_binddn(self, binddn: str):
+        # OPTIMIZATION: Replace map/lambda/filter with explicit loop
+        if len(self._pool) > 0:
+            for cp in self._pool:
+                if cp.binddn != binddn:
+                    cp.set_binddn(binddn)
+                    cp.giveback(force=True)
+
+        self.binddn = binddn
+        return True
+
+    def set_bindpw(self, bindpw: str):
+        # OPTIMIZATION: Replace map/lambda/filter with explicit loop
+        if len(self._pool) > 0:
+            for cp in self._pool:
+                if cp.bindpw != bindpw:
+                    cp.set_bindpw(bindpw)
+                    cp.giveback(force=True)
+
+        self.bindpw = bindpw
+        return True
+
+    def set_credentials(self, binddn: str, bindpw: str):
+        self.set_binddn(binddn)
+        self.set_bindpw(bindpw)
+        return True
+
+    def scale(self):
+        for _ in range(self.max - len(self._pool)):
+            self.put(
+                Connection(
+                    uri=self.uri,
+                    binddn=self.binddn,
+                    bindpw=self.bindpw,
+                    params=self.params,
+                )
+            )
+
+    def __enter__(self):
+        if len(self._pool) == 0:
+            self.scale()
+        self._context_conn = self.get()
+        return self._context_conn
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if hasattr(self, "_context_conn") and self._context_conn is not None:
+            self.put(self._context_conn)
+            self._context_conn = None
+            ldappool_close_calls.inc()
+        return False
+
+    def ping(self):
+        conn = self.get()
+        try:
+            # whoami_s is a lightweight operation to verify connectivity
+            conn.conn.whoami_s()
+            return True
+        except ldap.LDAPError as e:
+            logging.exception("LDAP ping failed for %s", self.uri.initializeUrl())
+            raise LDAPPoolDown(f"Server unreachable: {self.uri.initializeUrl()}") from e
+        finally:
+            self.put(conn)
+
+    def get(self, binddn: str = "", bindpw: str = ""):
+        if len(self._pool) == 0:
+            self.scale()
+        if not self._lock.acquire(timeout=1):
+            raise LDAPLockTimeout("Could not acquire pool lock")
+        if len(self._pool) == 0:
+            self._lock.release()
+            logging.warning("max connections %s reached, consider increasing pool size", self.max)
+            raise LDAPPoolExhausted(f"max connections {self.max} reached")
+        try:
+            con = next((c for c in self._pool if not c.inUse), None)
+            if con is None:
+                raise IndexError()
+        except IndexError:
+            self._lock.release()
+            logging.warning("all connections %s in use, consider increasing pool size", self.max)
+            raise LDAPPoolExhausted(
+                f"all connections {self.max} in use, consider increasing pool size"
+            )
+        con.inUse = True
+        self._lock.release()
+        if all([binddn != "", bindpw != ""]):
+            try:
+                con.authenticate(binddn, bindpw)
+            except ldap.INVALID_CREDENTIALS:
+                self.put(con)
+                raise ldap.INVALID_CREDENTIALS
+        return con
+
+    def put(self, connection):
+        if not self._lock.acquire(timeout=1):
+            raise LDAPLockTimeout("Could not acquire pool lock")
+        if connection.inUse:
+            connection.giveback()
+        if not connection in self._pool:
+            self._pool.append(connection)
+        connection._pool = self
+        self._lock.release()
+        return True
+
+    def status(self):
+        if not self._lock.acquire(timeout=1):
+            raise LDAPLockTimeout("Could not acquire pool lock")
+        for p in self._pool:
+            if p.inUse:
+                if sys.getrefcount(p) < 4:
+                    p.giveback()
+            logging.info("Id %s inUse %s %s %s", p, p.inUse, p.established, p.whoami())
+        self._lock.release()
+
+    def delete(self, connection, force=True):
+        if not self._lock.acquire(timeout=1):
+            raise LDAPLockTimeout("Could not acquire pool lock")
+        if connection in self._pool:
+            if any([not self.params.get("keep", False), force]):
+                self._pool.remove(connection)
+                ldappool_close_calls.inc()
+                del connection
+        self._lock.release()
+
+    def __len__(self):
+        return len(self._pool)

--- a/test/test_ldappool.py
+++ b/test/test_ldappool.py
@@ -1,0 +1,247 @@
+from time import sleep, time
+
+import ldap
+import pytest
+
+
+class MockLDAPPool:
+    def __init__(self):
+        self.directory = {
+            "uid=quay,ou=users,dc=example,dc=com": {
+                "cn": ["Quay binduser"],
+                "sn": ["Quay"],
+                "uid": ["quay"],
+                "mail": ["quay@example.com"],
+                "objectClass": ["inetOrgPerson"],
+                "userPassword": ["special"],
+            },
+            "uid=jdoe,ou=users,dc=example,dc=com": {
+                "cn": ["John Doe"],
+                "sn": ["Doe"],
+                "uid": ["jdoe"],
+                "mail": ["jdoe@example.com"],
+                "objectClass": ["inetOrgPerson"],
+                "userPassword": ["changeme"],
+            },
+        }
+        self.bound_user = None
+
+    def initialize(self, uri, trace_level=0):
+        self.simple_bind_s("uid=quay,ou=users,dc=example,dc=com", "special")
+        return self
+
+    def set_option(self, key, value):
+        return
+
+    def simple_bind_s(self, who, cred):
+        if who in self.directory and self.directory[who].get("userPassword")[0] == cred:
+            self.bound_user = who
+            return (97, [])  # LDAP success code
+        raise ldap.INVALID_CREDENTIALS("Invalid Credentials")
+
+    def search_s(self, base, scope, filterstr="(objectClass=*)", attrlist=None):
+        results = []
+        for dn, attrs in self.directory.items():
+            if dn.endswith(base):
+                if "=" in filterstr:
+                    attr, value = filterstr.strip("()").split("=")
+                    if attr in attrs and value in attrs[attr]:
+                        results.append((dn, attrs))
+                else:
+                    results.append((dn, attrs))
+        return results
+
+    def whoami_s(self):
+        return self.bound_user
+
+    def unbind_s(self):
+        return (97, [])
+
+
+import ldappool
+from ldappool import Connection, ConnectionPool, LDAPLockTimeout, LDAPPoolExhausted
+
+
+@pytest.fixture
+def mock_ldap(monkeypatch):
+    """Fixture to provide a fresh MockLDAPPool instance for each test."""
+    mock = MockLDAPPool()
+    monkeypatch.setattr(ldappool.ldap, "initialize", mock.initialize)
+    return mock
+
+
+@pytest.fixture
+def mock_ldap_server_down(monkeypatch):
+    """Fixture to provide a fresh MockLDAPPool instance for each test."""
+
+    def server_down(*args, **kwargs):
+        raise ldap.SERVER_DOWN()
+
+    mock = MockLDAPPool()
+    monkeypatch.setattr(ldappool.ldap, "initialize", mock.initialize)
+    monkeypatch.setattr(ldappool.Connection, "_Connection__whoami", server_down)
+    monkeypatch.setattr(ldappool.Connection, "authenticate", server_down)
+    return mock
+
+
+def test_pool_authentication(mock_ldap):
+    pool = ConnectionPool(
+        "ldaps://ldap.example.com:636/dc=example,dc=com?uid,mail,memberOf?sub?(objectClass=*)",
+        binddn="uid=quay,ou=users,dc=example,dc=com",
+        bindpw="special",
+        max=1,
+    )
+    assert len(pool) == 0
+    conn = pool.get()
+    assert len(pool) == 1
+    assert conn.inUse == True
+    assert conn.established == False
+    assert conn._lock.locked() == False
+    assert conn.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+
+    assert conn.authenticate("uid=jdoe,ou=users,dc=example,dc=com", "changeme") == True
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        conn.authenticate("uid=jdoe,ou=users,dc=example,dc=com", "changemeXXX")
+    assert conn.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+    assert len(pool) == 1
+    assert conn.inUse == True
+    assert conn.established == True
+    assert conn._lock.locked() == False
+
+
+def test_pool_exhausted(mock_ldap):
+    pool = ConnectionPool(
+        "ldaps://ldap.example.com:636/dc=example,dc=com?uid,mail,memberOf?sub?(objectClass=*)",
+        binddn="uid=quay,ou=users,dc=example,dc=com",
+        bindpw="special",
+        max=1,
+    )
+    assert len(pool) == 0
+    conn1 = pool.get()
+    assert len(pool) == 1
+    assert conn1.inUse == True
+    assert conn1.established == False
+    assert conn1._lock.locked() == False
+    assert conn1.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+
+    with pytest.raises(LDAPPoolExhausted):
+        conn2 = pool.get()
+
+
+def test_pool_exhausted_butnotblocked(mock_ldap):
+    pool = ConnectionPool(
+        "ldaps://ldap.example.com:636/dc=example,dc=com?uid,mail,memberOf?sub?(objectClass=*)",
+        binddn="uid=quay,ou=users,dc=example,dc=com",
+        bindpw="special",
+        max=1,
+    )
+    assert len(pool) == 0
+    conn1 = pool.get()
+    assert len(pool) == 1
+    assert conn1.inUse == True
+    assert conn1.established == False
+    assert conn1._lock.locked() == False
+    assert conn1.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+
+    with pytest.raises(LDAPPoolExhausted):
+        conn2 = pool.get()
+
+    assert conn1.authenticate("uid=jdoe,ou=users,dc=example,dc=com", "changeme") == True
+    assert conn1.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+    conn1.giveback()
+    conn2 = pool.get()
+    assert conn2.authenticate("uid=jdoe,ou=users,dc=example,dc=com", "changeme") == True
+    assert conn2.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+
+
+def test_pool_exhausted_butnotblocked_even_on_autherror(mock_ldap):
+    pool = ConnectionPool(
+        "ldaps://ldap.example.com:636/dc=example,dc=com?uid,mail,memberOf?sub?(objectClass=*)",
+        binddn="uid=quay,ou=users,dc=example,dc=com",
+        bindpw="special",
+        max=1,
+    )
+    assert len(pool) == 0
+    conn1 = pool.get()
+    assert len(pool) == 1
+    assert conn1.inUse == True
+    assert conn1.established == False
+    assert conn1._lock.locked() == False
+    assert conn1.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+
+    with pytest.raises(LDAPPoolExhausted):
+        conn2 = pool.get()
+
+    assert conn1.authenticate("uid=jdoe,ou=users,dc=example,dc=com", "changeme") == True
+    assert conn1.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+    conn1.giveback()
+    conn2 = pool.get()
+    with pytest.raises(ldap.INVALID_CREDENTIALS):
+        conn2.authenticate("uid=jdoe,ou=users,dc=example,dc=com", "changemeXXX")
+    conn2.giveback()
+    conn3 = pool.get()
+    assert conn3.authenticate("uid=jdoe,ou=users,dc=example,dc=com", "changeme") == True
+    assert conn3.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+    assert len(pool) == 1
+    assert conn3.inUse == True
+    assert conn3.established == True
+    assert conn3._lock.locked() == False
+
+
+def test_pool_prewarm(mock_ldap):
+    pool = ConnectionPool(
+        "ldaps://ldap.example.com:636/dc=example,dc=com?uid,mail,memberOf?sub?(objectClass=*)",
+        binddn="uid=quay,ou=users,dc=example,dc=com",
+        bindpw="special",
+        max=3,
+        params={"prewarm": True},
+    )
+    assert len(pool) == 1
+    conn = pool.get()
+    assert conn.inUse == True
+    assert conn.established == True
+    assert conn._lock.locked() == False
+    assert conn.conn.whoami_s() == "uid=quay,ou=users,dc=example,dc=com"
+
+
+def test_connection_locking(mock_ldap):
+    pool = ConnectionPool(
+        "ldaps://ldap.example.com:636/dc=example,dc=com?uid,mail,memberOf?sub?(objectClass=*)",
+        binddn="uid=quay,ou=users,dc=example,dc=com",
+        bindpw="special",
+        max=1,
+        params={"prewarm": True, "lock_timeout": 3},
+    )
+    conn = pool.get()
+    assert conn._Connection__lock_acquire() == True
+    locktimestart = time()
+    with pytest.raises(LDAPLockTimeout):
+        conn.authenticate("invalid", "invalid")
+    locktimeend = time()
+    assert locktimeend - locktimestart < 3
+    assert conn._Connection__lock_release() == True
+    assert conn.authenticate("uid=jdoe,ou=users,dc=example,dc=com", "changeme")
+
+
+def test_connection_server_down_prewarm(mock_ldap_server_down):
+    with pytest.raises(ldap.SERVER_DOWN):
+        pool = ConnectionPool(
+            "ldaps://ldap.example.com:636/dc=example,dc=com?uid,mail,memberOf?sub?(objectClass=*)",
+            binddn="uid=quay,ou=users,dc=example,dc=com",
+            bindpw="special",
+            max=1,
+            params={"prewarm": True, "lock_timeout": 3},
+        )
+
+
+def test_connection_server_down(mock_ldap_server_down):
+    with pytest.raises(ldap.SERVER_DOWN):
+        pool = ConnectionPool(
+            "ldaps://ldap.example.com:636/dc=example,dc=com?uid,mail,memberOf?sub?(objectClass=*)",
+            binddn="uid=quay,ou=users,dc=example,dc=com",
+            bindpw="special",
+            max=1,
+            params={"prewarm": False, "lock_timeout": 3},
+        )
+        conn = pool.get()
+        conn.authenticate("", "")

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1708,7 +1708,7 @@ CONFIG_SCHEMA = {
         },
         "LDAP_POOL_MAX": {
             "type": "number",
-            "description": "Maximum connection per worker in pool. Defaults to 50",
+            "description": "Maximum connections per worker in pool. Defaults to 50",
             "x-example": 50,
             "x-reference": None,
         },
@@ -1723,22 +1723,22 @@ CONFIG_SCHEMA = {
                 },
                 "network_timeout": {
                     "type": "number",
-                    "description": "Connection timeout in seconds. Defaults to 10.0 seconds",
+                    "description": "Connection timeout in seconds. Defaults to 10.0",
                     "x-example": 10.0,
                 },
                 "timeout": {
                     "type": "number",
-                    "description": "LDAP Statement timeout in seconds. Defaults to 10.0 seconds",
+                    "description": "LDAP Statement timeout in seconds. Defaults to 10.0",
                     "x-example": 10.0,
                 },
                 "keepalive_idle": {
                     "type": "integer",
-                    "description": "Keepalive idle setting for LDAP connections. Defaults to 10 seconds",
+                    "description": "Keepalive idle setting for LDAP connections. Defaults to 10",
                     "x-example": 10,
                 },
                 "keepalive_interval": {
                     "type": "integer",
-                    "description": "Keepalive interval setting for LDAP connections. Defaults to 5 seconds",
+                    "description": "Keepalive interval setting for LDAP connections. Defaults to 5",
                     "x-example": 5,
                 },
                 "keepalive_probes": {

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1701,6 +1701,63 @@ CONFIG_SCHEMA = {
             "description": "Comma separated list of urls to exclude from tracing",
             "x-example": "api/v1/.*,v2/([^/]+(/[^/]+)+)/(tags|blobs),v2/_catalog,v2/auth",
         },
+        "FEATURE_LDAPPOOL": {
+            "type": "boolean",
+            "description": "Whether to enable LDAP connection pooling on quay. Defaults to False",
+            "x-example": False,
+        },
+        "LDAP_POOL_MAX": {
+            "type": "number",
+            "description": "Maximum connection per worker in pool. Defaults to 50",
+            "x-example": 50,
+            "x-reference": None,
+        },
+        "LDAP_POOL_PARAMS": {
+            "type": "object",
+            "description": "LDAP pool connection parameters",
+            "properties": {
+                "referrals": {
+                    "type": "boolean",
+                    "description": "Follow LDAP referrals. Defaults to False as the authentication is not reliable by RFC definition",
+                    "x-example": False,
+                },
+                "network_timeout": {
+                    "type": "number",
+                    "description": "Connection timeout in seconds. Defaults to 10.0 seconds",
+                    "x-example": 10.0,
+                },
+                "timeout": {
+                    "type": "number",
+                    "description": "LDAP Statement timeout in seconds. Defaults to 10.0 seconds",
+                    "x-example": 10.0,
+                },
+                "keepalive_idle": {
+                    "type": "integer",
+                    "description": "Keepalive idle setting for LDAP connections. Defaults to 10 seconds",
+                    "x-example": 10,
+                },
+                "keepalive_interval": {
+                    "type": "integer",
+                    "description": "Keepalive interval setting for LDAP connections. Defaults to 5 seconds",
+                    "x-example": 5,
+                },
+                "keepalive_probes": {
+                    "type": "integer",
+                    "description": "Keepalive probes before considering connection stale. Defaults to 3",
+                    "x-example": 3,
+                },
+                "allow_tls_fallback": {
+                    "type": "boolean",
+                    "description": "Allow TLS fallback on LDAP connections. Defaults to False",
+                    "x-example": False,
+                },
+                "lock_timeout": {
+                    "type": "number",
+                    "description": "Locking timeout in seconds. Do not set unless instructed by Support. Defaults to 15.0 seconds",
+                    "x-example": 15.0,
+                },
+            },
+        },
     },
     "DEBUG": {
         "type": "boolean",

--- a/util/metrics/prometheus.py
+++ b/util/metrics/prometheus.py
@@ -303,3 +303,25 @@ def timed_blueprint(bp, get_app=None):
 
     bp.after_request(_time_after_request())
     return bp
+
+
+# LDAP Pool connections
+ldappool_connections_max = Gauge(
+    "quay_ldappool_connections_max", "max number of LDAPpool connections configured"
+)
+ldappool_connect_calls = Counter(
+    "quay_ldappool_connect_calls",
+    "number of connect() calls made by LDAPpool",
+)
+ldappool_auth_calls_success = Counter(
+    "quay_ldappool_auth_calls_success",
+    "number of successful authentication calls made by LDAPpool",
+)
+ldappool_auth_calls_failure = Counter(
+    "quay_ldappool_auth_calls_failure",
+    "number of failed authentication calls made by LDAPpool",
+)
+ldappool_close_calls = Counter(
+    "quay_ldappool_close_calls",
+    "number of close() calls made by LDAPpool",
+)


### PR DESCRIPTION
With the object oriented model, the code generates a connection per object and doesn't re-use connections.

As discussed in https://github.com/quay/quay/discussions/3539 and a try to push the pool upstream towards python-ldap, we have been told that connection pooling is not a feature the base module wants to handle.

Since we have no other option available, we consider to implement and maintain this module inside the Quay code.

Here's the initial push to get coderabbit and unittests going.
