### PR TITLE
fix(proxy-cache): proxying failure for manifests with duplicate child manifests (PROJQUAY-10068)

### DIFF
--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -531,7 +531,7 @@ class ProxyModel(OCIModel):
                     self._create_placeholder_blobs(manifest, db_manifest.id, repository_ref.id)
                     return wrapped_manifest, wrapped_tag
 
-                manifests_to_connect = set()
+                manifests_to_connect = []
                 for child in manifest.child_manifests(content_retriever=None):
                     m = oci.manifest.lookup_manifest(
                         repository_ref.id, child.digest, allow_dead=True
@@ -544,11 +544,10 @@ class ProxyModel(OCIModel):
                     try:
                         ManifestChild.get(manifest=db_manifest.id, child_manifest=m.id)
                     except ManifestChild.DoesNotExist:
-                        manifests_to_connect.add(m)
+                        if m not in manifests_to_connect:
+                            manifests_to_connect.append(m)
 
-                oci.manifest.connect_manifests(
-                    list(manifests_to_connect), db_manifest, repository_ref.id
-                )
+                oci.manifest.connect_manifests(manifests_to_connect, db_manifest, repository_ref.id)
 
                 return wrapped_manifest, wrapped_tag
 

--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -531,7 +531,7 @@ class ProxyModel(OCIModel):
                     self._create_placeholder_blobs(manifest, db_manifest.id, repository_ref.id)
                     return wrapped_manifest, wrapped_tag
 
-                manifests_to_connect = []
+                manifests_to_connect = set()
                 for child in manifest.child_manifests(content_retriever=None):
                     m = oci.manifest.lookup_manifest(
                         repository_ref.id, child.digest, allow_dead=True
@@ -544,9 +544,11 @@ class ProxyModel(OCIModel):
                     try:
                         ManifestChild.get(manifest=db_manifest.id, child_manifest=m.id)
                     except ManifestChild.DoesNotExist:
-                        manifests_to_connect.append(m)
+                        manifests_to_connect.add(m)
 
-                oci.manifest.connect_manifests(manifests_to_connect, db_manifest, repository_ref.id)
+                oci.manifest.connect_manifests(
+                    list(manifests_to_connect), db_manifest, repository_ref.id
+                )
 
                 return wrapped_manifest, wrapped_tag
 


### PR DESCRIPTION
In `registry_proxy_model:_create_manifest_and_retarget_tag` (line 535), the `manifests_to_connect` list could contain duplicate child manifests when processing index manifests with identical children ( OCI model does not say that a fat manifest (an image index) must have unique entries). This caused `oci.manifest.connect_manifests` to raise the `UniqueViolation` exception:

~~~
gunicorn-registry stdout | 2025-12-18 07:48:06,052 [356] [ERROR] [gunicorn.error] Error handling request /v2/ghcr-proxy/ghcr.io/berriai/litellm-non_root/manifests/main-v1.80.10.rc.4
gunicorn-registry stdout | Traceback (most recent call last):
gunicorn-registry stdout |   File "/app/lib/python3.12/site-packages/peewee.py", line 3057, in execute_sql
gunicorn-registry stdout |     cursor.execute(sql, params or ())
gunicorn-registry stdout | psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "manifestchild_manifest_id_child_manifest_id"
gunicorn-registry stdout | DETAIL:  Key (manifest_id, child_manifest_id)=(10, 11) already exists.
~~~

Changed 

~~~
'manifests_to_connect = []' -> 'manifests_to_connect = set()' 
~~~

to ensure uniqueness. Convert to `list(manifests_to_connect)` before calling `oci.manifest.connect_manifests`.