### PR TITLE
feat(config): add Python config validation framework (PROJQUAY-10125)

### DIFF
--- a/util/config/validation/__init__.py
+++ b/util/config/validation/__init__.py
@@ -1,0 +1,61 @@
+"""
+Config validation framework
+
+This module provides config validation that can be run on startup and via API
+against arbitrary config dictionaries.
+
+Usage:
+    from util.config.validation import validate_config, validate_config_or_raise
+
+    # Get list of errors (empty list = valid)
+    errors = validate_config(config_dict)
+
+    # Or raise ValueError if invalid
+    validate_config_or_raise(config_dict)
+"""
+
+from typing import Any, Dict, List
+
+from .errors import ValidationError
+from .fieldgroups import FIELD_GROUP_VALIDATORS
+
+__all__ = [
+    "ValidationError",
+    "validate_config",
+    "validate_config_or_raise",
+]
+
+
+def validate_config(config: Dict[str, Any]) -> List[ValidationError]:
+    """
+    Validate a configuration dictionary against all field groups.
+
+    Args:
+        config: The configuration dictionary loaded from YAML
+
+    Returns:
+        List of ValidationError objects. Empty list means validation passed.
+    """
+    all_errors: List[ValidationError] = []
+
+    for validator_func in FIELD_GROUP_VALIDATORS:
+        errors = validator_func(config)
+        all_errors.extend(errors)
+
+    return all_errors
+
+
+def validate_config_or_raise(config: Dict[str, Any]) -> None:
+    """
+    Validate configuration and raise an exception if invalid.
+
+    Args:
+        config: The configuration dictionary loaded from YAML
+
+    Raises:
+        ValueError: If validation fails, with all error messages
+    """
+    errors = validate_config(config)
+    if errors:
+        error_messages = "\n".join(f"  - [{e.field_group}] {e.message}" for e in errors)
+        raise ValueError(f"Configuration validation failed:\n{error_messages}")

--- a/util/config/validation/errors.py
+++ b/util/config/validation/errors.py
@@ -1,0 +1,20 @@
+"""
+Validation error types for config validation.
+"""
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class ValidationError:
+    """
+    Represents a validation error for a config field group.
+    """
+
+    field_group: str
+    tags: List[str]  # Field names involved in the error
+    message: str
+
+    def __str__(self) -> str:
+        return self.message

--- a/util/config/validation/fieldgroups.py
+++ b/util/config/validation/fieldgroups.py
@@ -1,0 +1,460 @@
+"""
+Field group validators for config validation.
+
+Each field group validator takes a config dict and returns a list of ValidationErrors.
+"""
+
+from typing import Any, Callable, Dict, List
+
+from .errors import ValidationError
+from .validators import (
+    validate_at_least_one_of_string,
+    validate_is_hostname,
+    validate_is_list,
+    validate_is_one_of,
+    validate_is_positive_int,
+    validate_is_type,
+    validate_is_url,
+    validate_port,
+    validate_required_object,
+    validate_required_string,
+    validate_time_pattern,
+)
+
+
+def validate_database(config: Dict[str, Any]) -> List[ValidationError]:
+    """Validate Database field group."""
+    errors = []
+    fg_name = "Database"
+
+    # DB_URI is required
+    err = validate_required_string(config.get("DB_URI"), "DB_URI", fg_name)
+    if err:
+        errors.append(err)
+
+    # DB_CONNECTION_ARGS validation (optional)
+    db_args = config.get("DB_CONNECTION_ARGS")
+    if db_args is not None:
+        if not isinstance(db_args, dict):
+            errors.append(
+                ValidationError(
+                    field_group=fg_name,
+                    tags=["DB_CONNECTION_ARGS"],
+                    message="DB_CONNECTION_ARGS must be an object",
+                )
+            )
+        else:
+            # Validate sslmode if present
+            sslmode = db_args.get("sslmode")
+            if sslmode is not None:
+                valid_sslmodes = [
+                    "disable",
+                    "allow",
+                    "prefer",
+                    "require",
+                    "verify-ca",
+                    "verify-full",
+                ]
+                err = validate_is_one_of(
+                    sslmode, valid_sslmodes, "DB_CONNECTION_ARGS.sslmode", fg_name
+                )
+                if err:
+                    errors.append(err)
+
+    return errors
+
+
+def validate_hostsettings(config: Dict[str, Any]) -> List[ValidationError]:
+    """Validate HostSettings field group."""
+    errors = []
+    fg_name = "HostSettings"
+
+    # SERVER_HOSTNAME is required
+    hostname = config.get("SERVER_HOSTNAME")
+    err = validate_required_string(hostname, "SERVER_HOSTNAME", fg_name)
+    if err:
+        errors.append(err)
+    else:
+        err = validate_is_hostname(hostname, "SERVER_HOSTNAME", fg_name)
+        if err:
+            errors.append(err)
+
+    # PREFERRED_URL_SCHEME must be http or https
+    scheme = config.get("PREFERRED_URL_SCHEME")
+    if scheme is not None:
+        err = validate_is_one_of(scheme, ["http", "https"], "PREFERRED_URL_SCHEME", fg_name)
+        if err:
+            errors.append(err)
+
+    # EXTERNAL_TLS_TERMINATION type check
+    ext_tls = config.get("EXTERNAL_TLS_TERMINATION")
+    if ext_tls is not None:
+        err = validate_is_type(ext_tls, bool, "EXTERNAL_TLS_TERMINATION", fg_name)
+        if err:
+            errors.append(err)
+
+    return errors
+
+
+def _validate_redis_struct(
+    redis_config: Dict[str, Any],
+    field_name: str,
+    fg_name: str,
+) -> List[ValidationError]:
+    """Validate a Redis configuration structure."""
+    errors = []
+
+    # host is required
+    err = validate_required_string(
+        redis_config.get("host"),
+        f"{field_name}.host",
+        fg_name,
+    )
+    if err:
+        errors.append(err)
+
+    # port validation
+    port = redis_config.get("port")
+    if port is not None:
+        err = validate_port(port, f"{field_name}.port", fg_name)
+        if err:
+            errors.append(err)
+
+    # password type check
+    password = redis_config.get("password")
+    if password is not None:
+        err = validate_is_type(password, str, f"{field_name}.password", fg_name)
+        if err:
+            errors.append(err)
+
+    # ssl type check
+    ssl = redis_config.get("ssl")
+    if ssl is not None:
+        err = validate_is_type(ssl, bool, f"{field_name}.ssl", fg_name)
+        if err:
+            errors.append(err)
+
+    return errors
+
+
+def validate_redis(config: Dict[str, Any]) -> List[ValidationError]:
+    """Validate Redis field group."""
+    errors = []
+    fg_name = "Redis"
+
+    # BUILDLOGS_REDIS is required
+    buildlogs = config.get("BUILDLOGS_REDIS")
+    err = validate_required_object(buildlogs, "BUILDLOGS_REDIS", fg_name)
+    if err:
+        errors.append(err)
+    elif isinstance(buildlogs, dict):
+        errors.extend(_validate_redis_struct(buildlogs, "BUILDLOGS_REDIS", fg_name))
+
+    # USER_EVENTS_REDIS is required
+    user_events = config.get("USER_EVENTS_REDIS")
+    err = validate_required_object(user_events, "USER_EVENTS_REDIS", fg_name)
+    if err:
+        errors.append(err)
+    elif isinstance(user_events, dict):
+        errors.extend(_validate_redis_struct(user_events, "USER_EVENTS_REDIS", fg_name))
+
+    # PULL_METRICS_REDIS is optional
+    pull_metrics = config.get("PULL_METRICS_REDIS")
+    if pull_metrics is not None:
+        if not isinstance(pull_metrics, dict):
+            errors.append(
+                ValidationError(
+                    field_group=fg_name,
+                    tags=["PULL_METRICS_REDIS"],
+                    message="PULL_METRICS_REDIS must be an object",
+                )
+            )
+        else:
+            errors.extend(_validate_redis_struct(pull_metrics, "PULL_METRICS_REDIS", fg_name))
+
+    return errors
+
+
+def validate_distributedstorage(config: Dict[str, Any]) -> List[ValidationError]:
+    """Validate DistributedStorage field group."""
+    errors: List[ValidationError] = []
+    fg_name = "DistributedStorage"
+
+    # DISTRIBUTED_STORAGE_CONFIG is required
+    storage_config = config.get("DISTRIBUTED_STORAGE_CONFIG")
+    err = validate_required_object(storage_config, "DISTRIBUTED_STORAGE_CONFIG", fg_name)
+    if err:
+        errors.append(err)
+        return errors
+
+    # At this point storage_config is guaranteed to be a dict
+    if not isinstance(storage_config, dict):
+        return errors
+
+    # DISTRIBUTED_STORAGE_PREFERENCE is required
+    storage_pref = config.get("DISTRIBUTED_STORAGE_PREFERENCE")
+    if storage_pref is None:
+        errors.append(
+            ValidationError(
+                field_group=fg_name,
+                tags=["DISTRIBUTED_STORAGE_PREFERENCE"],
+                message="DISTRIBUTED_STORAGE_PREFERENCE is required",
+            )
+        )
+    elif not isinstance(storage_pref, list):
+        errors.append(
+            ValidationError(
+                field_group=fg_name,
+                tags=["DISTRIBUTED_STORAGE_PREFERENCE"],
+                message="DISTRIBUTED_STORAGE_PREFERENCE must be a list",
+            )
+        )
+    elif len(storage_pref) == 0:
+        errors.append(
+            ValidationError(
+                field_group=fg_name,
+                tags=["DISTRIBUTED_STORAGE_PREFERENCE"],
+                message="DISTRIBUTED_STORAGE_PREFERENCE must have at least one storage location",
+            )
+        )
+    else:
+        # Validate that all preferences exist in config
+        for pref in storage_pref:
+            if pref not in storage_config:
+                errors.append(
+                    ValidationError(
+                        field_group=fg_name,
+                        tags=["DISTRIBUTED_STORAGE_PREFERENCE"],
+                        message=f"Storage location '{pref}' not found in DISTRIBUTED_STORAGE_CONFIG",
+                    )
+                )
+
+    # Validate each storage engine configuration
+    valid_storage_types = [
+        "LocalStorage",
+        "S3Storage",
+        "GoogleCloudStorage",
+        "AzureStorage",
+        "RadosGWStorage",
+        "RHOCSStorage",
+        "SwiftStorage",
+        "CloudFrontedS3Storage",
+        "IBMCloudStorage",
+        "STSS3Storage",
+        "MultiCDNStorage",
+    ]
+
+    for location, engine_config in storage_config.items():
+        if not isinstance(engine_config, list) or len(engine_config) < 2:
+            errors.append(
+                ValidationError(
+                    field_group=fg_name,
+                    tags=[f"DISTRIBUTED_STORAGE_CONFIG.{location}"],
+                    message=f"Storage location '{location}' must be a list with [engine_type, config]",
+                )
+            )
+            continue
+
+        engine_type = engine_config[0]
+        if engine_type not in valid_storage_types:
+            errors.append(
+                ValidationError(
+                    field_group=fg_name,
+                    tags=[f"DISTRIBUTED_STORAGE_CONFIG.{location}"],
+                    message=f"Unknown storage engine type: {engine_type}",
+                )
+            )
+
+    return errors
+
+
+def validate_accesssettings(config: Dict[str, Any]) -> List[ValidationError]:
+    """Validate AccessSettings field group."""
+    errors = []
+    fg_name = "AccessSettings"
+
+    # AUTHENTICATION_TYPE validation
+    auth_type = config.get("AUTHENTICATION_TYPE")
+    if auth_type is not None:
+        valid_auth_types = [
+            "Database",
+            "LDAP",
+            "JWT",
+            "Keystone",
+            "OIDC",
+            "AppToken",
+        ]
+        err = validate_is_one_of(auth_type, valid_auth_types, "AUTHENTICATION_TYPE", fg_name)
+        if err:
+            errors.append(err)
+
+    # Feature flags type validation
+    feature_flags = [
+        "FEATURE_DIRECT_LOGIN",
+        "FEATURE_GITHUB_LOGIN",
+        "FEATURE_GOOGLE_LOGIN",
+        "FEATURE_ANONYMOUS_ACCESS",
+        "FEATURE_INVITE_ONLY_USER_CREATION",
+        "FEATURE_USER_CREATION",
+        "FEATURE_USER_LAST_ACCESSED",
+        "FEATURE_PARTIAL_USER_AUTOCOMPLETE",
+        "FEATURE_REQUIRE_TEAM_INVITE",
+        "FEATURE_USERNAME_CONFIRMATION",
+    ]
+
+    for flag in feature_flags:
+        val = config.get(flag)
+        if val is not None:
+            err = validate_is_type(val, bool, flag, fg_name)
+            if err:
+                errors.append(err)
+
+    return errors
+
+
+def validate_timemachine(config: Dict[str, Any]) -> List[ValidationError]:
+    """Validate TimeMachine field group."""
+    errors = []
+    fg_name = "TimeMachine"
+
+    # DEFAULT_TAG_EXPIRATION validation
+    default_exp = config.get("DEFAULT_TAG_EXPIRATION")
+    if default_exp is not None:
+        err = validate_time_pattern(default_exp, "DEFAULT_TAG_EXPIRATION", fg_name)
+        if err:
+            errors.append(err)
+
+    # TAG_EXPIRATION_OPTIONS validation
+    exp_options = config.get("TAG_EXPIRATION_OPTIONS")
+    if exp_options is not None:
+        err = validate_is_list(exp_options, "TAG_EXPIRATION_OPTIONS", fg_name)
+        if err:
+            errors.append(err)
+        else:
+            for i, opt in enumerate(exp_options):
+                err = validate_time_pattern(opt, f"TAG_EXPIRATION_OPTIONS[{i}]", fg_name)
+                if err:
+                    errors.append(err)
+
+            # Validate that default is in options
+            if default_exp and default_exp not in exp_options:
+                errors.append(
+                    ValidationError(
+                        field_group=fg_name,
+                        tags=["DEFAULT_TAG_EXPIRATION", "TAG_EXPIRATION_OPTIONS"],
+                        message="DEFAULT_TAG_EXPIRATION must be one of TAG_EXPIRATION_OPTIONS",
+                    )
+                )
+
+    return errors
+
+
+def validate_email(config: Dict[str, Any]) -> List[ValidationError]:
+    """Validate Email field group."""
+    errors: List[ValidationError] = []
+    fg_name = "Email"
+
+    # Only validate if mailing feature is enabled
+    if not config.get("FEATURE_MAILING"):
+        return errors
+
+    # MAIL_SERVER is required when mailing is enabled
+    mail_server = config.get("MAIL_SERVER")
+    err = validate_required_string(mail_server, "MAIL_SERVER", fg_name)
+    if err:
+        errors.append(err)
+
+    # MAIL_PORT validation
+    mail_port = config.get("MAIL_PORT")
+    if mail_port is not None:
+        err = validate_port(mail_port, "MAIL_PORT", fg_name)
+        if err:
+            errors.append(err)
+
+    # MAIL_USE_TLS type check
+    mail_tls = config.get("MAIL_USE_TLS")
+    if mail_tls is not None:
+        err = validate_is_type(mail_tls, bool, "MAIL_USE_TLS", fg_name)
+        if err:
+            errors.append(err)
+
+    # MAIL_USE_AUTH type check
+    mail_auth = config.get("MAIL_USE_AUTH")
+    if mail_auth is not None:
+        err = validate_is_type(mail_auth, bool, "MAIL_USE_AUTH", fg_name)
+        if err:
+            errors.append(err)
+
+    # If auth is enabled, validate username/password
+    if mail_auth:
+        err = validate_required_string(config.get("MAIL_USERNAME"), "MAIL_USERNAME", fg_name)
+        if err:
+            errors.append(err)
+        err = validate_required_string(config.get("MAIL_PASSWORD"), "MAIL_PASSWORD", fg_name)
+        if err:
+            errors.append(err)
+
+    return errors
+
+
+def validate_securityscanner(config: Dict[str, Any]) -> List[ValidationError]:
+    """Validate SecurityScanner field group."""
+    errors: List[ValidationError] = []
+    fg_name = "SecurityScanner"
+
+    # Only validate if security scanner is enabled
+    if not config.get("FEATURE_SECURITY_SCANNER"):
+        return errors
+
+    # SECURITY_SCANNER_V4_ENDPOINT is required when enabled
+    endpoint = config.get("SECURITY_SCANNER_V4_ENDPOINT")
+    err = validate_required_string(endpoint, "SECURITY_SCANNER_V4_ENDPOINT", fg_name)
+    if err:
+        errors.append(err)
+    else:
+        err = validate_is_url(endpoint, "SECURITY_SCANNER_V4_ENDPOINT", fg_name)
+        if err:
+            errors.append(err)
+
+    return errors
+
+
+def validate_repomirror(config: Dict[str, Any]) -> List[ValidationError]:
+    """Validate RepoMirror field group."""
+    errors: List[ValidationError] = []
+    fg_name = "RepoMirror"
+
+    # Only validate if repo mirror is enabled
+    if not config.get("FEATURE_REPO_MIRROR"):
+        return errors
+
+    # REPO_MIRROR_TLS_VERIFY type check
+    tls_verify = config.get("REPO_MIRROR_TLS_VERIFY")
+    if tls_verify is not None:
+        err = validate_is_type(tls_verify, bool, "REPO_MIRROR_TLS_VERIFY", fg_name)
+        if err:
+            errors.append(err)
+
+    # REPO_MIRROR_SERVER_HOSTNAME validation
+    server_hostname = config.get("REPO_MIRROR_SERVER_HOSTNAME")
+    if server_hostname is not None:
+        err = validate_is_hostname(server_hostname, "REPO_MIRROR_SERVER_HOSTNAME", fg_name)
+        if err:
+            errors.append(err)
+
+    return errors
+
+
+# Registry of all field group validators
+# Order matters - more fundamental validators first
+FIELD_GROUP_VALIDATORS: List[Callable[[Dict[str, Any]], List[ValidationError]]] = [
+    validate_hostsettings,
+    validate_database,
+    validate_redis,
+    validate_distributedstorage,
+    validate_accesssettings,
+    validate_timemachine,
+    validate_email,
+    validate_securityscanner,
+    validate_repomirror,
+]

--- a/util/config/validation/test/test_validation.py
+++ b/util/config/validation/test/test_validation.py
@@ -1,0 +1,709 @@
+"""
+Tests for config validation framework.
+"""
+
+import pytest
+
+from util.config.validation import (
+    ValidationError,
+    validate_config,
+    validate_config_or_raise,
+)
+from util.config.validation.fieldgroups import (
+    validate_accesssettings,
+    validate_database,
+    validate_distributedstorage,
+    validate_email,
+    validate_hostsettings,
+    validate_redis,
+    validate_repomirror,
+    validate_securityscanner,
+    validate_timemachine,
+)
+from util.config.validation.validators import (
+    validate_at_least_one_of_bool,
+    validate_at_least_one_of_string,
+    validate_is_email,
+    validate_is_hostname,
+    validate_is_list,
+    validate_is_one_of,
+    validate_is_positive_int,
+    validate_is_type,
+    validate_is_url,
+    validate_port,
+    validate_required_object,
+    validate_required_string,
+    validate_time_pattern,
+)
+
+
+class TestValidators:
+    """Tests for shared validator functions."""
+
+    def test_validate_required_string_missing(self):
+        err = validate_required_string(None, "FIELD", "TestGroup")
+        assert err is not None
+        assert err.field_group == "TestGroup"
+        assert err.tags == ["FIELD"]
+        assert "is required" in err.message
+
+    def test_validate_required_string_empty(self):
+        err = validate_required_string("", "FIELD", "TestGroup")
+        assert err is not None
+
+    def test_validate_required_string_valid(self):
+        err = validate_required_string("value", "FIELD", "TestGroup")
+        assert err is None
+
+    def test_validate_is_hostname_valid(self):
+        assert validate_is_hostname("quay.io", "H", "G") is None
+        assert validate_is_hostname("quay.io:443", "H", "G") is None
+        assert validate_is_hostname("localhost", "H", "G") is None
+        assert validate_is_hostname("my-host.example.com", "H", "G") is None
+
+    def test_validate_is_hostname_invalid(self):
+        err = validate_is_hostname("http://quay.io", "H", "G")
+        assert err is not None
+        assert "Hostname" in err.message
+
+    def test_validate_is_url_valid(self):
+        assert validate_is_url("https://quay.io", "U", "G") is None
+        assert validate_is_url("http://localhost:8080/path", "U", "G") is None
+
+    def test_validate_is_url_invalid(self):
+        err = validate_is_url("not-a-url", "U", "G")
+        assert err is not None
+
+    def test_validate_is_one_of_valid(self):
+        assert validate_is_one_of("http", ["http", "https"], "F", "G") is None
+
+    def test_validate_is_one_of_invalid(self):
+        err = validate_is_one_of("ftp", ["http", "https"], "F", "G")
+        assert err is not None
+        assert "must be one of" in err.message
+
+    def test_validate_time_pattern_valid(self):
+        assert validate_time_pattern("2w", "F", "G") is None
+        assert validate_time_pattern("30d", "F", "G") is None
+        assert validate_time_pattern("1h", "F", "G") is None
+        assert validate_time_pattern("0s", "F", "G") is None
+
+    def test_validate_time_pattern_invalid(self):
+        err = validate_time_pattern("2weeks", "F", "G")
+        assert err is not None
+
+    # validate_required_object tests
+    def test_validate_required_object_missing(self):
+        err = validate_required_object(None, "FIELD", "TestGroup")
+        assert err is not None
+        assert "is required" in err.message
+
+    def test_validate_required_object_not_dict(self):
+        err = validate_required_object("not a dict", "FIELD", "TestGroup")
+        assert err is not None
+
+    def test_validate_required_object_valid(self):
+        err = validate_required_object({"key": "value"}, "FIELD", "TestGroup")
+        assert err is None
+
+    # validate_at_least_one_of_string tests
+    def test_validate_at_least_one_of_string_none_present(self):
+        err = validate_at_least_one_of_string([None, "", None], ["A", "B", "C"], "G")
+        assert err is not None
+        assert "At least one of" in err.message
+
+    def test_validate_at_least_one_of_string_one_present(self):
+        err = validate_at_least_one_of_string([None, "value", None], ["A", "B", "C"], "G")
+        assert err is None
+
+    # validate_at_least_one_of_bool tests
+    def test_validate_at_least_one_of_bool_none_true(self):
+        err = validate_at_least_one_of_bool([False, False], ["A", "B"], "G")
+        assert err is not None
+        assert "must be enabled" in err.message
+
+    def test_validate_at_least_one_of_bool_one_true(self):
+        err = validate_at_least_one_of_bool([False, True], ["A", "B"], "G")
+        assert err is None
+
+    # validate_is_type tests
+    def test_validate_is_type_correct(self):
+        assert validate_is_type(True, bool, "F", "G") is None
+        assert validate_is_type("string", str, "F", "G") is None
+        assert validate_is_type(123, int, "F", "G") is None
+
+    def test_validate_is_type_incorrect(self):
+        err = validate_is_type("not a bool", bool, "F", "G")
+        assert err is not None
+        assert "must be of type bool" in err.message
+
+    def test_validate_is_type_none(self):
+        assert validate_is_type(None, bool, "F", "G") is None
+
+    # validate_port tests
+    def test_validate_port_valid(self):
+        assert validate_port(80, "F", "G") is None
+        assert validate_port(443, "F", "G") is None
+        assert validate_port(6379, "F", "G") is None
+        assert validate_port(65535, "F", "G") is None
+
+    def test_validate_port_invalid_type(self):
+        err = validate_port("80", "F", "G")
+        assert err is not None
+        assert "port number" in err.message
+
+    def test_validate_port_out_of_range(self):
+        err = validate_port(0, "F", "G")
+        assert err is not None
+        err = validate_port(70000, "F", "G")
+        assert err is not None
+
+    def test_validate_port_none(self):
+        assert validate_port(None, "F", "G") is None
+
+    # validate_is_positive_int tests
+    def test_validate_is_positive_int_valid(self):
+        assert validate_is_positive_int(0, "F", "G") is None
+        assert validate_is_positive_int(100, "F", "G") is None
+
+    def test_validate_is_positive_int_negative(self):
+        err = validate_is_positive_int(-1, "F", "G")
+        assert err is not None
+        assert "positive integer" in err.message
+
+    def test_validate_is_positive_int_not_int(self):
+        err = validate_is_positive_int("5", "F", "G")
+        assert err is not None
+
+    # validate_is_list tests
+    def test_validate_is_list_valid(self):
+        assert validate_is_list([], "F", "G") is None
+        assert validate_is_list([1, 2, 3], "F", "G") is None
+
+    def test_validate_is_list_invalid(self):
+        err = validate_is_list("not a list", "F", "G")
+        assert err is not None
+        assert "must be a list" in err.message
+
+    def test_validate_is_list_none(self):
+        assert validate_is_list(None, "F", "G") is None
+
+    # validate_is_email tests
+    def test_validate_is_email_valid(self):
+        assert validate_is_email("user@example.com", "F", "G") is None
+        assert validate_is_email("test.user@domain.org", "F", "G") is None
+
+    def test_validate_is_email_invalid(self):
+        err = validate_is_email("not-an-email", "F", "G")
+        assert err is not None
+        assert "valid email" in err.message
+
+    def test_validate_is_email_empty(self):
+        assert validate_is_email("", "F", "G") is None
+        assert validate_is_email(None, "F", "G") is None
+
+
+class TestFieldGroupValidators:
+    """Tests for field group validators."""
+
+    def test_validate_database_missing_uri(self):
+        errors = validate_database({})
+        assert len(errors) == 1
+        assert errors[0].tags == ["DB_URI"]
+
+    def test_validate_database_valid(self):
+        errors = validate_database({"DB_URI": "postgresql://localhost/quay"})
+        assert len(errors) == 0
+
+    def test_validate_database_invalid_sslmode(self):
+        errors = validate_database(
+            {
+                "DB_URI": "postgresql://localhost/quay",
+                "DB_CONNECTION_ARGS": {"sslmode": "invalid"},
+            }
+        )
+        assert len(errors) == 1
+        assert "sslmode" in errors[0].tags[0]
+
+    def test_validate_hostsettings_missing_hostname(self):
+        errors = validate_hostsettings({})
+        assert len(errors) == 1
+        assert errors[0].tags == ["SERVER_HOSTNAME"]
+
+    def test_validate_hostsettings_valid(self):
+        errors = validate_hostsettings(
+            {
+                "SERVER_HOSTNAME": "quay.example.com",
+                "PREFERRED_URL_SCHEME": "https",
+            }
+        )
+        assert len(errors) == 0
+
+    def test_validate_hostsettings_invalid_scheme(self):
+        errors = validate_hostsettings(
+            {
+                "SERVER_HOSTNAME": "quay.example.com",
+                "PREFERRED_URL_SCHEME": "ftp",
+            }
+        )
+        assert len(errors) == 1
+        assert "PREFERRED_URL_SCHEME" in errors[0].tags
+
+    def test_validate_redis_missing_required(self):
+        errors = validate_redis({})
+        assert len(errors) == 2  # BUILDLOGS_REDIS and USER_EVENTS_REDIS
+
+    def test_validate_redis_valid(self):
+        errors = validate_redis(
+            {
+                "BUILDLOGS_REDIS": {"host": "redis.example.com"},
+                "USER_EVENTS_REDIS": {"host": "redis.example.com"},
+            }
+        )
+        assert len(errors) == 0
+
+    def test_validate_redis_missing_host(self):
+        errors = validate_redis(
+            {
+                "BUILDLOGS_REDIS": {"port": 6379},
+                "USER_EVENTS_REDIS": {"host": "redis.example.com"},
+            }
+        )
+        assert len(errors) == 1
+        assert "BUILDLOGS_REDIS.host" in errors[0].tags[0]
+
+    # Edge case tests for existing validators
+    def test_validate_database_connection_args_not_dict(self):
+        errors = validate_database(
+            {
+                "DB_URI": "postgresql://localhost/quay",
+                "DB_CONNECTION_ARGS": "not a dict",
+            }
+        )
+        assert len(errors) == 1
+        assert "must be an object" in errors[0].message
+
+    def test_validate_redis_pull_metrics_not_dict(self):
+        errors = validate_redis(
+            {
+                "BUILDLOGS_REDIS": {"host": "redis.example.com"},
+                "USER_EVENTS_REDIS": {"host": "redis.example.com"},
+                "PULL_METRICS_REDIS": "not a dict",
+            }
+        )
+        assert len(errors) == 1
+        assert "PULL_METRICS_REDIS" in errors[0].tags[0]
+        assert "must be an object" in errors[0].message
+
+    def test_validate_redis_invalid_port(self):
+        errors = validate_redis(
+            {
+                "BUILDLOGS_REDIS": {"host": "redis.example.com", "port": "invalid"},
+                "USER_EVENTS_REDIS": {"host": "redis.example.com"},
+            }
+        )
+        assert len(errors) == 1
+        assert "port" in errors[0].tags[0]
+
+    def test_validate_redis_invalid_password_type(self):
+        errors = validate_redis(
+            {
+                "BUILDLOGS_REDIS": {"host": "redis.example.com", "password": 12345},
+                "USER_EVENTS_REDIS": {"host": "redis.example.com"},
+            }
+        )
+        assert len(errors) == 1
+        assert "password" in errors[0].tags[0]
+
+    def test_validate_redis_invalid_ssl_type(self):
+        errors = validate_redis(
+            {
+                "BUILDLOGS_REDIS": {"host": "redis.example.com", "ssl": "yes"},
+                "USER_EVENTS_REDIS": {"host": "redis.example.com"},
+            }
+        )
+        assert len(errors) == 1
+        assert "ssl" in errors[0].tags[0]
+
+    def test_validate_hostsettings_invalid_tls_type(self):
+        errors = validate_hostsettings(
+            {
+                "SERVER_HOSTNAME": "quay.example.com",
+                "EXTERNAL_TLS_TERMINATION": "yes",
+            }
+        )
+        assert len(errors) == 1
+        assert "EXTERNAL_TLS_TERMINATION" in errors[0].tags[0]
+
+    def test_validate_hostsettings_invalid_hostname_format(self):
+        errors = validate_hostsettings({"SERVER_HOSTNAME": "http://invalid"})
+        assert len(errors) == 1
+        assert "Hostname" in errors[0].message
+
+    def test_validate_redis_pull_metrics_valid(self):
+        errors = validate_redis(
+            {
+                "BUILDLOGS_REDIS": {"host": "redis.example.com"},
+                "USER_EVENTS_REDIS": {"host": "redis.example.com"},
+                "PULL_METRICS_REDIS": {"host": "metrics-redis.example.com", "port": 6380},
+            }
+        )
+        assert len(errors) == 0
+
+
+class TestValidateConfig:
+    """Tests for the main validate_config entry point."""
+
+    def test_valid_minimal_config(self):
+        config = {
+            "SERVER_HOSTNAME": "quay.example.com",
+            "DB_URI": "postgresql://localhost/quay",
+            "BUILDLOGS_REDIS": {"host": "redis.example.com"},
+            "USER_EVENTS_REDIS": {"host": "redis.example.com"},
+            "DISTRIBUTED_STORAGE_CONFIG": {
+                "default": ["LocalStorage", {"storage_path": "/storage"}],
+            },
+            "DISTRIBUTED_STORAGE_PREFERENCE": ["default"],
+        }
+        errors = validate_config(config)
+        assert len(errors) == 0
+
+    def test_multiple_validation_errors(self):
+        config = {}
+        errors = validate_config(config)
+        # Should have errors from multiple field groups
+        field_groups = set(e.field_group for e in errors)
+        assert len(field_groups) > 1
+
+    def test_validate_config_or_raise_valid(self):
+        config = {
+            "SERVER_HOSTNAME": "quay.example.com",
+            "DB_URI": "postgresql://localhost/quay",
+            "BUILDLOGS_REDIS": {"host": "redis.example.com"},
+            "USER_EVENTS_REDIS": {"host": "redis.example.com"},
+            "DISTRIBUTED_STORAGE_CONFIG": {
+                "default": ["LocalStorage", {"storage_path": "/storage"}],
+            },
+            "DISTRIBUTED_STORAGE_PREFERENCE": ["default"],
+        }
+        # Should not raise
+        validate_config_or_raise(config)
+
+    def test_validate_config_or_raise_invalid(self):
+        with pytest.raises(ValueError) as exc_info:
+            validate_config_or_raise({})
+        assert "Configuration validation failed" in str(exc_info.value)
+
+
+class TestDistributedStorageValidator:
+    """Tests for validate_distributedstorage."""
+
+    def test_validate_distributedstorage_missing_config(self):
+        errors = validate_distributedstorage({})
+        assert len(errors) == 1
+        assert "DISTRIBUTED_STORAGE_CONFIG" in errors[0].tags[0]
+
+    def test_validate_distributedstorage_missing_preference(self):
+        errors = validate_distributedstorage(
+            {
+                "DISTRIBUTED_STORAGE_CONFIG": {
+                    "default": ["LocalStorage", {"storage_path": "/storage"}],
+                },
+            }
+        )
+        assert len(errors) == 1
+        assert "DISTRIBUTED_STORAGE_PREFERENCE" in errors[0].tags[0]
+
+    def test_validate_distributedstorage_preference_not_list(self):
+        errors = validate_distributedstorage(
+            {
+                "DISTRIBUTED_STORAGE_CONFIG": {
+                    "default": ["LocalStorage", {"storage_path": "/storage"}],
+                },
+                "DISTRIBUTED_STORAGE_PREFERENCE": "default",
+            }
+        )
+        assert len(errors) == 1
+        assert "must be a list" in errors[0].message
+
+    def test_validate_distributedstorage_preference_empty(self):
+        errors = validate_distributedstorage(
+            {
+                "DISTRIBUTED_STORAGE_CONFIG": {
+                    "default": ["LocalStorage", {"storage_path": "/storage"}],
+                },
+                "DISTRIBUTED_STORAGE_PREFERENCE": [],
+            }
+        )
+        assert len(errors) == 1
+        assert "at least one" in errors[0].message
+
+    def test_validate_distributedstorage_preference_not_in_config(self):
+        errors = validate_distributedstorage(
+            {
+                "DISTRIBUTED_STORAGE_CONFIG": {
+                    "default": ["LocalStorage", {"storage_path": "/storage"}],
+                },
+                "DISTRIBUTED_STORAGE_PREFERENCE": ["nonexistent"],
+            }
+        )
+        assert len(errors) == 1
+        assert "not found" in errors[0].message
+
+    def test_validate_distributedstorage_invalid_engine_config(self):
+        errors = validate_distributedstorage(
+            {
+                "DISTRIBUTED_STORAGE_CONFIG": {
+                    "default": "not a list",
+                },
+                "DISTRIBUTED_STORAGE_PREFERENCE": ["default"],
+            }
+        )
+        assert len(errors) == 1
+        assert "must be a list" in errors[0].message
+
+    def test_validate_distributedstorage_engine_config_too_short(self):
+        errors = validate_distributedstorage(
+            {
+                "DISTRIBUTED_STORAGE_CONFIG": {
+                    "default": ["LocalStorage"],
+                },
+                "DISTRIBUTED_STORAGE_PREFERENCE": ["default"],
+            }
+        )
+        assert len(errors) == 1
+        assert "must be a list with" in errors[0].message
+
+    def test_validate_distributedstorage_unknown_engine_type(self):
+        errors = validate_distributedstorage(
+            {
+                "DISTRIBUTED_STORAGE_CONFIG": {
+                    "default": ["UnknownStorage", {}],
+                },
+                "DISTRIBUTED_STORAGE_PREFERENCE": ["default"],
+            }
+        )
+        assert len(errors) == 1
+        assert "Unknown storage engine" in errors[0].message
+
+    def test_validate_distributedstorage_valid(self):
+        errors = validate_distributedstorage(
+            {
+                "DISTRIBUTED_STORAGE_CONFIG": {
+                    "default": ["LocalStorage", {"storage_path": "/storage"}],
+                    "s3": ["S3Storage", {"bucket": "my-bucket"}],
+                },
+                "DISTRIBUTED_STORAGE_PREFERENCE": ["default", "s3"],
+            }
+        )
+        assert len(errors) == 0
+
+
+class TestAccessSettingsValidator:
+    """Tests for validate_accesssettings."""
+
+    def test_validate_accesssettings_valid_auth_type(self):
+        errors = validate_accesssettings({"AUTHENTICATION_TYPE": "Database"})
+        assert len(errors) == 0
+
+    def test_validate_accesssettings_invalid_auth_type(self):
+        errors = validate_accesssettings({"AUTHENTICATION_TYPE": "InvalidType"})
+        assert len(errors) == 1
+        assert "must be one of" in errors[0].message
+
+    def test_validate_accesssettings_feature_flag_invalid_type(self):
+        errors = validate_accesssettings({"FEATURE_DIRECT_LOGIN": "not a bool"})
+        assert len(errors) == 1
+        assert "must be of type bool" in errors[0].message
+
+    def test_validate_accesssettings_multiple_feature_flags(self):
+        errors = validate_accesssettings(
+            {
+                "FEATURE_DIRECT_LOGIN": True,
+                "FEATURE_GITHUB_LOGIN": False,
+                "FEATURE_USER_CREATION": True,
+            }
+        )
+        assert len(errors) == 0
+
+
+class TestTimeMachineValidator:
+    """Tests for validate_timemachine."""
+
+    def test_validate_timemachine_valid(self):
+        errors = validate_timemachine(
+            {
+                "DEFAULT_TAG_EXPIRATION": "2w",
+                "TAG_EXPIRATION_OPTIONS": ["1d", "1w", "2w", "4w"],
+            }
+        )
+        assert len(errors) == 0
+
+    def test_validate_timemachine_invalid_default_pattern(self):
+        errors = validate_timemachine({"DEFAULT_TAG_EXPIRATION": "invalid"})
+        assert len(errors) == 1
+        assert "regex pattern" in errors[0].message
+
+    def test_validate_timemachine_options_not_list(self):
+        errors = validate_timemachine({"TAG_EXPIRATION_OPTIONS": "not a list"})
+        assert len(errors) == 1
+        assert "must be a list" in errors[0].message
+
+    def test_validate_timemachine_invalid_option_pattern(self):
+        errors = validate_timemachine({"TAG_EXPIRATION_OPTIONS": ["1d", "invalid"]})
+        assert len(errors) == 1
+        assert "TAG_EXPIRATION_OPTIONS[1]" in errors[0].tags[0]
+
+    def test_validate_timemachine_default_not_in_options(self):
+        errors = validate_timemachine(
+            {
+                "DEFAULT_TAG_EXPIRATION": "3w",
+                "TAG_EXPIRATION_OPTIONS": ["1d", "1w", "2w"],
+            }
+        )
+        assert len(errors) == 1
+        assert "must be one of TAG_EXPIRATION_OPTIONS" in errors[0].message
+
+
+class TestEmailValidator:
+    """Tests for validate_email."""
+
+    def test_validate_email_disabled(self):
+        errors = validate_email({"FEATURE_MAILING": False})
+        assert len(errors) == 0
+
+    def test_validate_email_not_configured(self):
+        errors = validate_email({})
+        assert len(errors) == 0
+
+    def test_validate_email_enabled_missing_server(self):
+        errors = validate_email({"FEATURE_MAILING": True})
+        assert len(errors) == 1
+        assert "MAIL_SERVER" in errors[0].tags[0]
+
+    def test_validate_email_invalid_port(self):
+        errors = validate_email(
+            {
+                "FEATURE_MAILING": True,
+                "MAIL_SERVER": "smtp.example.com",
+                "MAIL_PORT": "not an int",
+            }
+        )
+        assert len(errors) == 1
+        assert "port number" in errors[0].message
+
+    def test_validate_email_invalid_tls_type(self):
+        errors = validate_email(
+            {
+                "FEATURE_MAILING": True,
+                "MAIL_SERVER": "smtp.example.com",
+                "MAIL_USE_TLS": "yes",
+            }
+        )
+        assert len(errors) == 1
+        assert "must be of type bool" in errors[0].message
+
+    def test_validate_email_auth_missing_credentials(self):
+        errors = validate_email(
+            {
+                "FEATURE_MAILING": True,
+                "MAIL_SERVER": "smtp.example.com",
+                "MAIL_USE_AUTH": True,
+            }
+        )
+        assert len(errors) == 2
+        tags = [e.tags[0] for e in errors]
+        assert "MAIL_USERNAME" in tags
+        assert "MAIL_PASSWORD" in tags
+
+    def test_validate_email_valid(self):
+        errors = validate_email(
+            {
+                "FEATURE_MAILING": True,
+                "MAIL_SERVER": "smtp.example.com",
+                "MAIL_PORT": 587,
+                "MAIL_USE_TLS": True,
+                "MAIL_USE_AUTH": True,
+                "MAIL_USERNAME": "user",
+                "MAIL_PASSWORD": "pass",
+            }
+        )
+        assert len(errors) == 0
+
+
+class TestSecurityScannerValidator:
+    """Tests for validate_securityscanner."""
+
+    def test_validate_securityscanner_disabled(self):
+        errors = validate_securityscanner({"FEATURE_SECURITY_SCANNER": False})
+        assert len(errors) == 0
+
+    def test_validate_securityscanner_not_configured(self):
+        errors = validate_securityscanner({})
+        assert len(errors) == 0
+
+    def test_validate_securityscanner_enabled_missing_endpoint(self):
+        errors = validate_securityscanner({"FEATURE_SECURITY_SCANNER": True})
+        assert len(errors) == 1
+        assert "SECURITY_SCANNER_V4_ENDPOINT" in errors[0].tags[0]
+
+    def test_validate_securityscanner_invalid_url(self):
+        errors = validate_securityscanner(
+            {
+                "FEATURE_SECURITY_SCANNER": True,
+                "SECURITY_SCANNER_V4_ENDPOINT": "not-a-url",
+            }
+        )
+        assert len(errors) == 1
+        assert "URL" in errors[0].message
+
+    def test_validate_securityscanner_valid(self):
+        errors = validate_securityscanner(
+            {
+                "FEATURE_SECURITY_SCANNER": True,
+                "SECURITY_SCANNER_V4_ENDPOINT": "https://clair.example.com",
+            }
+        )
+        assert len(errors) == 0
+
+
+class TestRepoMirrorValidator:
+    """Tests for validate_repomirror."""
+
+    def test_validate_repomirror_disabled(self):
+        errors = validate_repomirror({"FEATURE_REPO_MIRROR": False})
+        assert len(errors) == 0
+
+    def test_validate_repomirror_not_configured(self):
+        errors = validate_repomirror({})
+        assert len(errors) == 0
+
+    def test_validate_repomirror_invalid_tls_verify_type(self):
+        errors = validate_repomirror(
+            {
+                "FEATURE_REPO_MIRROR": True,
+                "REPO_MIRROR_TLS_VERIFY": "yes",
+            }
+        )
+        assert len(errors) == 1
+        assert "must be of type bool" in errors[0].message
+
+    def test_validate_repomirror_invalid_hostname(self):
+        errors = validate_repomirror(
+            {
+                "FEATURE_REPO_MIRROR": True,
+                "REPO_MIRROR_SERVER_HOSTNAME": "http://invalid",
+            }
+        )
+        assert len(errors) == 1
+        assert "Hostname" in errors[0].message
+
+    def test_validate_repomirror_valid(self):
+        errors = validate_repomirror(
+            {
+                "FEATURE_REPO_MIRROR": True,
+                "REPO_MIRROR_TLS_VERIFY": True,
+                "REPO_MIRROR_SERVER_HOSTNAME": "mirror.example.com",
+            }
+        )
+        assert len(errors) == 0

--- a/util/config/validation/validators.py
+++ b/util/config/validation/validators.py
@@ -1,0 +1,317 @@
+"""
+Shared validator functions for config validation.
+"""
+
+import re
+from typing import Any, List, Optional, Type
+from urllib.parse import urlparse
+
+from .errors import ValidationError
+
+
+def validate_required_string(
+    value: Any,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a value is a non-empty string.
+
+    Equivalent to Go's ValidateRequiredString.
+    """
+    if not value or not isinstance(value, str):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} is required",
+        )
+    return None
+
+
+def validate_required_object(
+    value: Any,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a value is a non-None dict.
+
+    Equivalent to Go's ValidateRequiredObject.
+    """
+    if value is None or not isinstance(value, dict):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} is required",
+        )
+    return None
+
+
+def validate_is_hostname(
+    value: Any,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a string is a valid hostname with optional port.
+
+    Equivalent to Go's ValidateIsHostname.
+    """
+    if not value:
+        return None  # Let required validator handle empty
+
+    if not isinstance(value, str):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be a string",
+        )
+
+    # Pattern from Go: ^[a-zA-Z-0-9\.]+(:[0-9]+)?$
+    pattern = r"^[a-zA-Z0-9\.\-]+(:[0-9]+)?$"
+    if not re.match(pattern, value.strip()):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be of type Hostname",
+        )
+    return None
+
+
+def validate_is_url(
+    value: Any,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a string is a valid URL.
+
+    Equivalent to Go's ValidateIsURL.
+    """
+    if not value:
+        return None
+
+    if not isinstance(value, str):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be a string",
+        )
+
+    try:
+        parsed = urlparse(value)
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError("Missing scheme or netloc")
+    except Exception:
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be of type URL",
+        )
+    return None
+
+
+def validate_is_one_of(
+    value: Any,
+    options: List[str],
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a value is one of the allowed options.
+
+    Equivalent to Go's ValidateIsOneOfString.
+    """
+    if value is None:
+        return None  # Let required validator handle missing
+
+    if value not in options:
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be one of {', '.join(options)}.",
+        )
+    return None
+
+
+def validate_at_least_one_of_string(
+    values: List[Any],
+    fields: List[str],
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that at least one of the given values is a non-empty string.
+
+    Equivalent to Go's ValidateAtLeastOneOfString.
+    """
+    for val in values:
+        if val and isinstance(val, str):
+            return None
+
+    return ValidationError(
+        field_group=field_group,
+        tags=fields,
+        message=f"At least one of {', '.join(fields)} must be present",
+    )
+
+
+def validate_at_least_one_of_bool(
+    values: List[bool],
+    fields: List[str],
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that at least one of the given boolean values is True.
+
+    Equivalent to Go's ValidateAtLeastOneOfBool.
+    """
+    for val in values:
+        if val is True:
+            return None
+
+    return ValidationError(
+        field_group=field_group,
+        tags=fields,
+        message=f"At least one of {', '.join(fields)} must be enabled",
+    )
+
+
+def validate_time_pattern(
+    value: Any,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate time pattern like '2w', '30d', '1h'.
+
+    Pattern: ^[0-9]+(w|m|d|h|s)$
+    Equivalent to Go's ValidateTimePattern.
+    """
+    if not value:
+        return None
+
+    if not isinstance(value, str):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be a string",
+        )
+
+    pattern = r"^[0-9]+(w|m|d|h|s)$"
+    if not re.match(pattern, value):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must have the regex pattern ^[0-9]+(w|m|d|h|s)$",
+        )
+    return None
+
+
+def validate_is_type(
+    value: Any,
+    expected_type: Type,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a value is of the expected type.
+    """
+    if value is None:
+        return None
+
+    if not isinstance(value, expected_type):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be of type {expected_type.__name__}",
+        )
+    return None
+
+
+def validate_port(
+    value: Any,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a value is a valid port number (1-65535).
+    """
+    if value is None:
+        return None
+
+    if not isinstance(value, int) or value < 1 or value > 65535:
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be a port number between 1 and 65535",
+        )
+    return None
+
+
+def validate_is_positive_int(
+    value: Any,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a value is a positive integer.
+    """
+    if value is None:
+        return None
+
+    if not isinstance(value, int) or value < 0:
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be a positive integer",
+        )
+    return None
+
+
+def validate_is_list(
+    value: Any,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a value is a list.
+    """
+    if value is None:
+        return None
+
+    if not isinstance(value, list):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be a list",
+        )
+    return None
+
+
+def validate_is_email(
+    value: Any,
+    field: str,
+    field_group: str,
+) -> Optional[ValidationError]:
+    """
+    Validate that a string is a valid email address format.
+    """
+    if not value:
+        return None
+
+    if not isinstance(value, str):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be a string",
+        )
+
+    # Simple email pattern - not exhaustive but catches common issues
+    pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+    if not re.match(pattern, value):
+        return ValidationError(
+            field_group=field_group,
+            tags=[field],
+            message=f"{field} must be a valid email address",
+        )
+    return None


### PR DESCRIPTION
Add a Python-based config validation framework that replaces the Go
config-tool validation. The framework provides:

- ValidationError dataclass matching the Go struct
- Shared validators: required, hostname, url, one-of, time-pattern, etc.
- Field group validators: Database, HostSettings, Redis, DistributedStorage,
  AccessSettings, TimeMachine, Email, SecurityScanner, RepoMirror
- Entry point functions: validate_config() and validate_config_or_raise()
- Comprehensive test suite (24 tests)

The framework can be run on startup and via API against arbitrary configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
Signed-off-by: Brady Pratt <bpratt@redhat.com>
