### PR TITLE
feat(web): add column management to list tables (PROJQUAY-10133)

### DIFF
--- a/web/src/components/ManageColumns/ManageColumnsButton.tsx
+++ b/web/src/components/ManageColumns/ManageColumnsButton.tsx
@@ -1,0 +1,46 @@
+import React, {useState, useCallback} from 'react';
+import {Button, ToolbarItem} from '@patternfly/react-core';
+import {ColumnsIcon} from '@patternfly/react-icons';
+import ManageColumnsModal from './ManageColumnsModal';
+import type {ColumnConfig} from './types';
+
+interface ManageColumnsButtonProps {
+  columns: ColumnConfig[];
+  onSave: (columns: ColumnConfig[]) => void;
+  maxVisibleColumns?: number;
+}
+
+export const ManageColumnsButton: React.FC<ManageColumnsButtonProps> = ({
+  columns,
+  onSave,
+  maxVisibleColumns,
+}) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpen = useCallback(() => setIsModalOpen(true), []);
+  const handleClose = useCallback(() => setIsModalOpen(false), []);
+
+  return (
+    <ToolbarItem>
+      <Button
+        variant="plain"
+        aria-label="Manage columns"
+        onClick={handleOpen}
+        data-testid="manage-columns-button"
+      >
+        <ColumnsIcon />
+      </Button>
+      {isModalOpen && (
+        <ManageColumnsModal
+          isOpen={isModalOpen}
+          onClose={handleClose}
+          columns={columns}
+          onSave={onSave}
+          maxVisibleColumns={maxVisibleColumns}
+        />
+      )}
+    </ToolbarItem>
+  );
+};
+
+export default ManageColumnsButton;

--- a/web/src/components/ManageColumns/ManageColumnsModal.tsx
+++ b/web/src/components/ManageColumns/ManageColumnsModal.tsx
@@ -1,0 +1,209 @@
+import React, {useState, useMemo, useCallback, useEffect} from 'react';
+import {
+  Modal,
+  ModalVariant,
+  Button,
+  Alert,
+  Split,
+  SplitItem,
+  DataList,
+  DataListItem,
+  DataListItemRow,
+  DataListItemCells,
+  DataListCell,
+  DataListCheck,
+  Title,
+  Divider,
+} from '@patternfly/react-core';
+import type {ColumnConfig, ManageColumnsModalProps} from './types';
+
+const MAX_COLUMNS = 9;
+
+export const ManageColumnsModal: React.FC<ManageColumnsModalProps> = ({
+  isOpen,
+  onClose,
+  columns,
+  onSave,
+  maxVisibleColumns = MAX_COLUMNS,
+  title = 'Manage columns',
+}) => {
+  // Local state for editing (only committed on Save)
+  const [editedColumns, setEditedColumns] = useState<ColumnConfig[]>(columns);
+
+  // Reset local state when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setEditedColumns(columns);
+    }
+  }, [isOpen, columns]);
+
+  // Separate columns into default and additional
+  const {defaultColumns, additionalColumns} = useMemo(() => {
+    const defaults = editedColumns.filter((col) => col.isDefault);
+    const additional = editedColumns.filter((col) => !col.isDefault);
+    return {defaultColumns: defaults, additionalColumns: additional};
+  }, [editedColumns]);
+
+  const visibleCount = useMemo(
+    () => editedColumns.filter((c) => c.isVisible).length,
+    [editedColumns],
+  );
+
+  const isAtMaxColumns = visibleCount >= maxVisibleColumns;
+
+  // Toggle column visibility
+  const handleToggle = useCallback(
+    (columnId: string) => {
+      setEditedColumns((prev) =>
+        prev.map((col) => {
+          if (col.id !== columnId || col.isDisabled) {
+            return col;
+          }
+          // Prevent enabling more columns if at max
+          if (!col.isVisible && isAtMaxColumns) {
+            return col;
+          }
+          return {...col, isVisible: !col.isVisible};
+        }),
+      );
+    },
+    [isAtMaxColumns],
+  );
+
+  // Restore defaults - make all default columns visible, hide additional
+  const handleRestoreDefaults = useCallback(() => {
+    setEditedColumns((prev) =>
+      prev.map((col) => ({
+        ...col,
+        isVisible: col.isDefault || col.isDisabled,
+      })),
+    );
+  }, []);
+
+  // Save and close
+  const handleSave = useCallback(() => {
+    onSave(editedColumns);
+    onClose();
+  }, [editedColumns, onSave, onClose]);
+
+  // Cancel without saving
+  const handleCancel = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  // Render column list section
+  const renderColumnList = (
+    columnList: ColumnConfig[],
+    sectionTitle: string,
+  ) => (
+    <div style={{flex: 1, minWidth: '200px'}}>
+      <Title headingLevel="h4" size="md" style={{marginBottom: '16px'}}>
+        {sectionTitle}
+      </Title>
+      {columnList.length === 0 ? (
+        <div style={{color: 'var(--pf-v5-global--Color--200)'}}>
+          No columns in this section
+        </div>
+      ) : (
+        <DataList aria-label={`${sectionTitle} columns`} isCompact>
+          {columnList.map((column) => {
+            // Disable checkbox if column is disabled OR if at max and trying to enable
+            const isCheckboxDisabled =
+              column.isDisabled || (!column.isVisible && isAtMaxColumns);
+
+            return (
+              <DataListItem
+                key={column.id}
+                aria-labelledby={`column-${column.id}`}
+              >
+                <DataListItemRow>
+                  <DataListCheck
+                    aria-labelledby={`column-${column.id}`}
+                    name={`column-${column.id}`}
+                    checked={column.isVisible}
+                    isDisabled={isCheckboxDisabled}
+                    onChange={() => handleToggle(column.id)}
+                  />
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell key={column.id}>
+                        <span id={`column-${column.id}`}>{column.title}</span>
+                        {column.isDisabled && (
+                          <span
+                            style={{
+                              color: 'var(--pf-v5-global--Color--200)',
+                              marginLeft: '8px',
+                            }}
+                          >
+                            (Required)
+                          </span>
+                        )}
+                      </DataListCell>,
+                    ]}
+                  />
+                </DataListItemRow>
+              </DataListItem>
+            );
+          })}
+        </DataList>
+      )}
+    </div>
+  );
+
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      title={title}
+      description="Selected columns will appear in the table."
+      isOpen={isOpen}
+      onClose={handleCancel}
+      actions={[
+        <Button
+          key="save"
+          variant="primary"
+          onClick={handleSave}
+          data-testid="manage-columns-save"
+        >
+          Save
+        </Button>,
+        <Button
+          key="cancel"
+          variant="link"
+          onClick={handleCancel}
+          data-testid="manage-columns-cancel"
+        >
+          Cancel
+        </Button>,
+      ]}
+    >
+      <Alert
+        variant="info"
+        isInline
+        title={`You can select up to ${maxVisibleColumns} columns`}
+        style={{marginBottom: '16px'}}
+      />
+
+      <Split hasGutter>
+        <SplitItem isFilled>
+          {renderColumnList(defaultColumns, 'Default columns')}
+        </SplitItem>
+        <Divider orientation={{default: 'vertical'}} />
+        <SplitItem isFilled>
+          {renderColumnList(additionalColumns, 'Additional columns')}
+        </SplitItem>
+      </Split>
+
+      <div style={{marginTop: '24px'}}>
+        <Button
+          variant="link"
+          onClick={handleRestoreDefaults}
+          data-testid="manage-columns-restore"
+        >
+          Restore default columns
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+export default ManageColumnsModal;

--- a/web/src/components/ManageColumns/index.ts
+++ b/web/src/components/ManageColumns/index.ts
@@ -1,0 +1,8 @@
+export {ManageColumnsModal} from './ManageColumnsModal';
+export {ManageColumnsButton} from './ManageColumnsButton';
+export type {
+  ColumnConfig,
+  ManageColumnsModalProps,
+  UseColumnManagementReturn,
+  UseColumnManagementOptions,
+} from './types';

--- a/web/src/components/ManageColumns/types.ts
+++ b/web/src/components/ManageColumns/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Configuration for a single column in a table
+ */
+export interface ColumnConfig {
+  /** Unique identifier for the column */
+  id: string;
+  /** Display name shown in the table header and modal */
+  title: string;
+  /** Whether this column is currently visible */
+  isVisible: boolean;
+  /** Whether this is a default column (shown in left section of modal) */
+  isDefault: boolean;
+  /** Whether the column can be hidden (some columns like "Name" should always be visible) */
+  isDisabled?: boolean;
+  /** Sort index for the column (for use with usePaginatedSortableTable) */
+  sortIndex?: number;
+}
+
+/**
+ * Props for the ManageColumnsModal component
+ */
+export interface ManageColumnsModalProps {
+  /** Whether the modal is open */
+  isOpen: boolean;
+  /** Callback when the modal should close */
+  onClose: () => void;
+  /** Current column configurations */
+  columns: ColumnConfig[];
+  /** Callback when columns are saved - receives updated column configs */
+  onSave: (columns: ColumnConfig[]) => void;
+  /** Maximum number of visible columns (displays info alert) */
+  maxVisibleColumns?: number;
+  /** Title for the modal (defaults to "Manage columns") */
+  title?: string;
+}
+
+/**
+ * Return type for the useColumnManagement hook
+ */
+export interface UseColumnManagementReturn {
+  /** Current column configurations */
+  columns: ColumnConfig[];
+  /** Get visible columns only */
+  visibleColumns: ColumnConfig[];
+  /** Check if a specific column is visible */
+  isColumnVisible: (columnId: string) => boolean;
+  /** Toggle visibility of a single column */
+  toggleColumn: (columnId: string) => void;
+  /** Set visibility for a specific column */
+  setColumnVisibility: (columnId: string, isVisible: boolean) => void;
+  /** Restore all columns to their default visibility */
+  restoreDefaults: () => void;
+  /** Save column configuration (persists to localStorage) */
+  saveColumns: (columns: ColumnConfig[]) => void;
+  /** Count of currently visible columns */
+  visibleCount: number;
+}
+
+/**
+ * Options for the useColumnManagement hook
+ */
+export interface UseColumnManagementOptions {
+  /** Unique storage key for localStorage persistence */
+  storageKey: string;
+  /** Default column configurations (used on first load and for restore) */
+  defaultColumns: ColumnConfig[];
+}

--- a/web/src/hooks/useColumnManagement.ts
+++ b/web/src/hooks/useColumnManagement.ts
@@ -1,0 +1,127 @@
+import {useState, useCallback, useMemo, useEffect} from 'react';
+import type {
+  ColumnConfig,
+  UseColumnManagementReturn,
+  UseColumnManagementOptions,
+} from 'src/components/ManageColumns/types';
+
+/**
+ * Merge stored config with defaults to handle schema changes.
+ * Preserves visibility from stored config but updates other properties from defaults.
+ */
+function mergeWithDefaults(
+  stored: ColumnConfig[],
+  defaults: ColumnConfig[],
+): ColumnConfig[] {
+  const storedMap = new Map(stored.map((c) => [c.id, c]));
+  return defaults.map((def) => {
+    const storedCol = storedMap.get(def.id);
+    if (storedCol) {
+      return {...def, isVisible: storedCol.isVisible};
+    }
+    return def;
+  });
+}
+
+/**
+ * Hook for managing table column visibility with localStorage persistence.
+ *
+ * @example
+ * const {columns, visibleColumns, saveColumns, restoreDefaults, isColumnVisible} = useColumnManagement({
+ *   storageKey: 'repositories-list',
+ *   defaultColumns: [
+ *     {id: 'name', title: 'Name', isVisible: true, isDefault: true, isDisabled: true},
+ *     {id: 'visibility', title: 'Visibility', isVisible: true, isDefault: true},
+ *     {id: 'size', title: 'Size', isVisible: true, isDefault: false},
+ *     {id: 'lastModified', title: 'Last Modified', isVisible: true, isDefault: true},
+ *   ],
+ * });
+ */
+export function useColumnManagement(
+  options: UseColumnManagementOptions,
+): UseColumnManagementReturn {
+  const {storageKey, defaultColumns} = options;
+  const fullStorageKey = `quay-columns-${storageKey}`;
+
+  // Initialize state from localStorage or defaults
+  const [columns, setColumns] = useState<ColumnConfig[]>(() => {
+    try {
+      const stored = localStorage.getItem(fullStorageKey);
+      if (stored) {
+        const parsed = JSON.parse(stored) as ColumnConfig[];
+        return mergeWithDefaults(parsed, defaultColumns);
+      }
+    } catch (e) {
+      console.warn('Failed to parse stored column config:', e);
+    }
+    return defaultColumns;
+  });
+
+  // Persist to localStorage when columns change
+  useEffect(() => {
+    try {
+      localStorage.setItem(fullStorageKey, JSON.stringify(columns));
+    } catch (e) {
+      console.warn('Failed to save column config:', e);
+    }
+  }, [columns, fullStorageKey]);
+
+  // Computed: visible columns only
+  const visibleColumns = useMemo(
+    () => columns.filter((col) => col.isVisible),
+    [columns],
+  );
+
+  const visibleCount = visibleColumns.length;
+
+  // Check if specific column is visible
+  const isColumnVisible = useCallback(
+    (columnId: string) =>
+      columns.find((c) => c.id === columnId)?.isVisible ?? false,
+    [columns],
+  );
+
+  // Toggle single column visibility
+  const toggleColumn = useCallback((columnId: string) => {
+    setColumns((prev) =>
+      prev.map((col) =>
+        col.id === columnId && !col.isDisabled
+          ? {...col, isVisible: !col.isVisible}
+          : col,
+      ),
+    );
+  }, []);
+
+  // Set specific column visibility
+  const setColumnVisibility = useCallback(
+    (columnId: string, isVisible: boolean) => {
+      setColumns((prev) =>
+        prev.map((col) =>
+          col.id === columnId && !col.isDisabled ? {...col, isVisible} : col,
+        ),
+      );
+    },
+    [],
+  );
+
+  // Restore to default configuration
+  const restoreDefaults = useCallback(() => {
+    setColumns(defaultColumns);
+  }, [defaultColumns]);
+
+  // Save columns (for modal save action)
+  const saveColumns = useCallback((newColumns: ColumnConfig[]) => {
+    setColumns(newColumns);
+  }, []);
+
+  return {
+    columns,
+    visibleColumns,
+    isColumnVisible,
+    toggleColumn,
+    setColumnVisibility,
+    restoreDefaults,
+    saveColumns,
+    visibleCount,
+  };
+}

--- a/web/src/routes/OrganizationsList/ColumnNames.ts
+++ b/web/src/routes/OrganizationsList/ColumnNames.ts
@@ -1,3 +1,5 @@
+import type {ColumnConfig} from 'src/components/ManageColumns';
+
 const ColumnNames = {
   name: 'Name',
   adminEmail: 'Admin Email',
@@ -9,5 +11,78 @@ const ColumnNames = {
   size: 'Size',
   options: 'Settings',
 };
+
+/**
+ * Default column configurations for the Organizations List table.
+ * Note: Some columns have additional visibility controlled by feature flags
+ * (MAILING, QUOTA_MANAGEMENT, EDIT_QUOTA) and user permissions (isSuperUser)
+ * in OrganizationsList.tsx and OrganizationsListTableData.tsx
+ */
+export const organizationDefaultColumns: ColumnConfig[] = [
+  {
+    id: 'name',
+    title: ColumnNames.name,
+    isVisible: true,
+    isDefault: true,
+    isDisabled: true, // Name column cannot be hidden
+    sortIndex: 0,
+  },
+  {
+    id: 'adminEmail',
+    title: ColumnNames.adminEmail,
+    isVisible: true,
+    isDefault: true, // Default for superusers when MAILING feature enabled
+    sortIndex: 1,
+  },
+  {
+    id: 'repoCount',
+    title: ColumnNames.repoCount,
+    isVisible: true,
+    isDefault: true,
+    sortIndex: 2,
+  },
+  {
+    id: 'teamsCount',
+    title: ColumnNames.teamsCount,
+    isVisible: true,
+    isDefault: true,
+    sortIndex: 3,
+  },
+  {
+    id: 'membersCount',
+    title: ColumnNames.membersCount,
+    isVisible: true,
+    isDefault: true,
+    sortIndex: 4,
+  },
+  {
+    id: 'robotsCount',
+    title: ColumnNames.robotsCount,
+    isVisible: true,
+    isDefault: true,
+    sortIndex: 5,
+  },
+  {
+    id: 'lastModified',
+    title: ColumnNames.lastModified,
+    isVisible: true,
+    isDefault: true,
+    sortIndex: 6,
+  },
+  {
+    id: 'size',
+    title: ColumnNames.size,
+    isVisible: true,
+    isDefault: false, // Additional column (requires QUOTA_MANAGEMENT + EDIT_QUOTA)
+    sortIndex: 7,
+  },
+  {
+    id: 'options',
+    title: ColumnNames.options,
+    isVisible: true,
+    isDefault: true, // Default for superusers
+    sortIndex: 8,
+  },
+];
 
 export default ColumnNames;

--- a/web/src/routes/OrganizationsList/OrganizationToolBar.tsx
+++ b/web/src/routes/OrganizationsList/OrganizationToolBar.tsx
@@ -8,6 +8,7 @@ import {DropdownCheckbox} from 'src/components/toolbar/DropdownCheckbox';
 import {Kebab} from 'src/components/toolbar/Kebab';
 import {ToolbarButton} from 'src/components/toolbar/ToolbarButton';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
+import {ManageColumnsButton, ColumnConfig} from 'src/components/ManageColumns';
 
 import * as React from 'react';
 import {useState} from 'react';
@@ -66,6 +67,10 @@ export function OrganizationToolBar(props: OrganizationToolBarProps) {
             ) : null}
             {props.deleteKebabIsOpen ? props.deleteModal : null}
           </ToolbarItem>
+          <ManageColumnsButton
+            columns={props.columns}
+            onSave={props.onSaveColumns}
+          />
           <ToolbarPagination
             itemsList={props.organizationsList}
             perPage={props.perPage}
@@ -114,4 +119,6 @@ type OrganizationToolBarProps = {
   paginatedOrganizationsList: any[];
   onSelectOrganization: (Org, rowIndex, isSelecting) => void;
   isExternalAuth: boolean;
+  columns: ColumnConfig[];
+  onSaveColumns: (columns: ColumnConfig[]) => void;
 };

--- a/web/src/routes/RepositoriesList/ColumnNames.ts
+++ b/web/src/routes/RepositoriesList/ColumnNames.ts
@@ -1,9 +1,48 @@
+import type {ColumnConfig} from 'src/components/ManageColumns';
+
 export const RepositoryListColumnNames = {
   name: 'Name',
   visibility: 'Visibility',
   size: 'Size',
   lastModified: 'Last Modified',
 };
+
+/**
+ * Default column configurations for the Repository List table.
+ * Note: The 'size' column visibility is also controlled by feature flags
+ * (QUOTA_MANAGEMENT && EDIT_QUOTA) in RepositoriesList.tsx
+ */
+export const repositoryDefaultColumns: ColumnConfig[] = [
+  {
+    id: 'name',
+    title: RepositoryListColumnNames.name,
+    isVisible: true,
+    isDefault: true,
+    isDisabled: true, // Name column cannot be hidden
+    sortIndex: 0,
+  },
+  {
+    id: 'visibility',
+    title: RepositoryListColumnNames.visibility,
+    isVisible: true,
+    isDefault: true,
+    sortIndex: 1,
+  },
+  {
+    id: 'size',
+    title: RepositoryListColumnNames.size,
+    isVisible: true,
+    isDefault: false, // Size is an additional column (requires feature flags)
+    sortIndex: 2,
+  },
+  {
+    id: 'lastModified',
+    title: RepositoryListColumnNames.lastModified,
+    isVisible: true,
+    isDefault: true,
+    sortIndex: 3,
+  },
+];
 
 export const RobotAccountColumnNames = {
   robotAccountName: 'Robot account name',

--- a/web/src/routes/RepositoriesList/RepositoryToolBar.tsx
+++ b/web/src/routes/RepositoriesList/RepositoryToolBar.tsx
@@ -7,6 +7,7 @@ import {Kebab} from 'src/components/toolbar/Kebab';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
 import {ToolbarButton} from 'src/components/toolbar/ToolbarButton';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
+import {ManageColumnsButton, ColumnConfig} from 'src/components/ManageColumns';
 
 export function RepositoryToolBar(props: RepositoryToolBarProps) {
   const fetchConfirmationModalText = () => {
@@ -71,6 +72,10 @@ export function RepositoryToolBar(props: RepositoryToolBarProps) {
           ) : null}
           {props.deleteKebabIsOpen ? props.deleteModal : null}
         </ToolbarItem>
+        <ManageColumnsButton
+          columns={props.columns}
+          onSave={props.onSaveColumns}
+        />
         <ToolbarPagination
           itemsList={props.repositoryList}
           perPage={props.perPage}
@@ -135,4 +140,6 @@ type RepositoryToolBarProps = {
   setSelectedRepoNames: (selectedRepoList) => void;
   paginatedRepositoryList: any[];
   onSelectRepo: (Repo, rowIndex, isSelecting) => void;
+  columns: ColumnConfig[];
+  onSaveColumns: (columns: ColumnConfig[]) => void;
 };


### PR DESCRIPTION
Add ManageColumnsModal component that allows users to show/hide
table columns with preferences persisted to localStorage.

Changes:
- Add ManageColumnsModal and ManageColumnsButton components
- Add useColumnManagement hook for localStorage persistence
- Integrate column management into RepositoriesList table
- Integrate column management into OrganizationsList table
- Add Playwright e2e tests for column management on both tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<img width="1001" height="754" alt="image" src="https://github.com/user-attachments/assets/4cc1885c-495f-4dd8-8972-8e5600bb8d1a" />
<img width="1267" height="404" alt="image" src="https://github.com/user-attachments/assets/14ea046c-a4e9-452e-8322-6a8db500c4dd" />

