### PR TITLE
PROJQUAY-9516: fix(endpoints): block image push to proxy cache organizations

### DIFF
--- a/endpoints/v2/test/test_v2auth.py
+++ b/endpoints/v2/test/test_v2auth.py
@@ -277,6 +277,61 @@ def get_robot_password(username):
             "private",
             False,
         ),
+        # Proxy cache org: push should be blocked for org admin (devtable is proxyorg owner)
+        (
+            "repository:proxyorg/somerepo:push",
+            "devtable",
+            "password",
+            200,
+            ["proxyorg/somerepo:"],
+            True,
+            "private",
+            False,
+        ),
+        # Proxy cache org: pull+push should only grant pull
+        (
+            "repository:proxyorg/somerepo:pull,push",
+            "devtable",
+            "password",
+            200,
+            ["proxyorg/somerepo:pull"],
+            True,
+            "private",
+            False,
+        ),
+        # Proxy cache org: admin scope should be blocked
+        (
+            "repository:proxyorg/somerepo:pull,push,*",
+            "devtable",
+            "password",
+            200,
+            ["proxyorg/somerepo:pull"],
+            True,
+            "private",
+            False,
+        ),
+        # Proxy cache org: new repo creation via push should be blocked
+        (
+            "repository:proxyorg/newrepo:push",
+            "devtable",
+            "password",
+            200,
+            ["proxyorg/newrepo:"],
+            True,
+            "private",
+            False,
+        ),
+        # Proxy cache org: member user push should also be blocked
+        (
+            "repository:proxyorg/newrepo:push",
+            "member",
+            "password",
+            200,
+            ["proxyorg/newrepo:"],
+            True,
+            "private",
+            False,
+        ),
         # Organization repository, freshuser
         (
             "repository:buynlarge/orgrepo:pull,push,*",

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -243,6 +243,19 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
         msg = "Namespace %s has been disabled. Please contact a system administrator." % namespace
         raise NamespaceDisabled(message=msg)
 
+    # Lazy-load proxy cache config check to avoid DB hit on pull-only requests
+    _proxy_cache_checked = False
+    _is_proxy_cache_org = False
+
+    def is_proxy_cache_org():
+        nonlocal _proxy_cache_checked, _is_proxy_cache_org
+        if not _proxy_cache_checked:
+            _is_proxy_cache_org = features.PROXY_CACHE and model.proxy_cache.has_proxy_cache_config(
+                namespace
+            )
+            _proxy_cache_checked = True
+        return _is_proxy_cache_org
+
     final_actions = []
 
     repository_ref = registry_model.lookup_repository(namespace, reponame)
@@ -286,9 +299,14 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
                     if repository_ref is not None and repository_ref.kind != "image":
                         raise Unsupported(message=invalid_repo_message)
 
-                    # Check for different repository states.
-                    if repository_ref.state == RepositoryState.NORMAL:
-                        # In NORMAL mode, if the user has permission, then they can push.
+                    # Proxy cache orgs are read-only — block push regardless of repo state
+                    if is_proxy_cache_org():
+                        logger.debug(
+                            "Push denied to proxy cache organization %s/%s",
+                            namespace,
+                            reponame,
+                        )
+                    elif repository_ref.state == RepositoryState.NORMAL:
                         final_actions.append("push")
                     elif repository_ref.state == RepositoryState.MIRROR:
                         # In MIRROR mode, only the repo-level mirroring robot can push.
@@ -351,7 +369,14 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
                 logger.debug("Restricted users cannot create repository %s/%s", namespace, reponame)
 
             else:
-                if (
+                # Block repository creation in proxy cache organizations
+                if is_proxy_cache_org():
+                    logger.debug(
+                        "Repository creation denied in proxy cache organization %s/%s",
+                        namespace,
+                        reponame,
+                    )
+                elif (
                     app.config.get("CREATE_NAMESPACE_ON_PUSH", False)
                     and model.user.get_namespace_user(namespace) is None
                 ):
@@ -420,7 +445,7 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
             user = get_authenticated_user()
 
         can_pullthru = False
-        if features.PROXY_CACHE and model.proxy_cache.has_proxy_cache_config(namespace):
+        if is_proxy_cache_org():
             can_pullthru = OrganizationMemberPermission(namespace).can() and user is not None
 
         if (
@@ -445,7 +470,14 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
             if repository_ref is not None and repository_ref.kind != "image":
                 raise Unsupported(message=invalid_repo_message)
 
-            if repository_ref and repository_ref.state in (
+            # Block admin scope for proxy cache orgs
+            if is_proxy_cache_org():
+                logger.debug(
+                    "No permission to administer repository in proxy cache org %s/%s",
+                    namespace,
+                    reponame,
+                )
+            elif repository_ref and repository_ref.state in (
                 RepositoryState.MIRROR,
                 RepositoryState.ORG_MIRROR,
                 RepositoryState.READ_ONLY,
@@ -460,9 +492,13 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
     # Final sanity checks.
     if "push" in final_actions:
         assert repository_ref.state != RepositoryState.READ_ONLY
+        # Ensure not pushing to proxy cache org
+        assert not is_proxy_cache_org()
 
     if "*" in final_actions:
         assert repository_ref.state == RepositoryState.NORMAL
+        # Ensure not admin in proxy cache org
+        assert not is_proxy_cache_org()
 
     return scopeResult(
         actions=final_actions,

--- a/web/playwright/e2e/organization/proxy-cache.spec.ts
+++ b/web/playwright/e2e/organization/proxy-cache.spec.ts
@@ -1,5 +1,6 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
+import {tryPushImage} from '../../utils/container';
 
 test.describe(
   'Organization Proxy Cache',
@@ -177,5 +178,65 @@ test.describe(
         authenticatedPage.getByText('Proxy Cache'),
       ).not.toBeVisible();
     });
+
+    test(
+      'push to proxy cache organization is blocked',
+      {tag: ['@container', '@PROJQUAY-9516']},
+      async ({api}) => {
+        // Create organization and configure as proxy cache
+        const org = await api.organization('pushblock');
+        await api.raw.createProxyCacheConfig(org.name, {
+          upstream_registry: 'docker.io',
+        });
+
+        await api.repositoryWithName(org.name, 'testpush');
+
+        // Attempt to push an image to the proxy cache org
+        // This should fail because proxy cache orgs are read-only
+        const result = await tryPushImage(
+          org.name,
+          'testpush',
+          'latest',
+          TEST_USERS.user.username,
+          TEST_USERS.user.password,
+        );
+
+        // Push should fail
+        expect(result.success).toBe(false);
+
+        // Error should indicate access was denied
+        // The registry returns "denied" or "unauthorized" when push permissions are blocked
+        expect(result.error?.toLowerCase()).toMatch(
+          /denied|unauthorized|access/,
+        );
+      },
+    );
+
+    test(
+      'repository creation via push is blocked for proxy cache organizations',
+      {tag: ['@container', '@PROJQUAY-9516']},
+      async ({api}) => {
+        // Create organization and configure as proxy cache
+        const org = await api.organization('repocreateblock');
+        await api.raw.createProxyCacheConfig(org.name, {
+          upstream_registry: 'docker.io',
+        });
+
+        // Attempt to push to a non-existent repo (would create it normally)
+        const result = await tryPushImage(
+          org.name,
+          'newrepo',
+          'v1.0.0',
+          TEST_USERS.user.username,
+          TEST_USERS.user.password,
+        );
+
+        // Push should fail - can't create repos in proxy cache orgs
+        expect(result.success).toBe(false);
+        expect(result.error?.toLowerCase()).toMatch(
+          /denied|unauthorized|access/,
+        );
+      },
+    );
   },
 );

--- a/web/playwright/utils/api/client.ts
+++ b/web/playwright/utils/api/client.ts
@@ -1776,11 +1776,12 @@ export class ApiClient {
           'X-CSRF-Token': token,
         },
         data: {
+          org_name: orgName, // Required by the API endpoint
           upstream_registry: config.upstream_registry,
           expiration_s: config.expiration_s ?? 86400,
           insecure: config.insecure ?? false,
-          upstream_registry_username: config.upstream_registry_username,
-          upstream_registry_password: config.upstream_registry_password,
+          upstream_registry_username: config.upstream_registry_username ?? null,
+          upstream_registry_password: config.upstream_registry_password ?? null,
         },
       },
     );

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -244,6 +244,88 @@ export async function isContainerRuntimeAvailable(): Promise<boolean> {
 }
 
 /**
+ * Result of attempting to push an image
+ */
+export interface PushResult {
+  success: boolean;
+  error?: string;
+  stdout?: string;
+  stderr?: string;
+}
+
+/**
+ * Attempt to push an image and return the result (success/failure).
+ *
+ * Unlike `pushImage`, this function does not throw on failure.
+ * Use this when testing scenarios where push should be blocked.
+ *
+ * @example
+ * ```typescript
+ * const result = await tryPushImage('myorg', 'myrepo', 'latest', 'user', 'pass');
+ * expect(result.success).toBe(false);
+ * expect(result.error).toContain('denied');
+ * ```
+ */
+export async function tryPushImage(
+  namespace: string,
+  repo: string,
+  tag: string,
+  username: string,
+  password: string,
+): Promise<PushResult> {
+  const runtime = await detectContainerRuntime();
+  if (!runtime) {
+    return {
+      success: false,
+      error: 'No container runtime available (podman or docker)',
+    };
+  }
+
+  const image = `${REGISTRY_HOST}/${namespace}/${repo}:${tag}`;
+  const tlsFlag = runtime === 'podman' ? '--tls-verify=false' : '';
+
+  try {
+    // Login to registry
+    await execAsync(
+      `${runtime} login ${REGISTRY_HOST} -u ${username} -p ${password} ${tlsFlag}`.trim(),
+    );
+
+    const busyboxImage = 'quay.io/prometheus/busybox:latest';
+
+    // Pull busybox and tag it
+    await execAsync(`${runtime} pull ${busyboxImage}`);
+    await execAsync(`${runtime} tag ${busyboxImage} ${image}`);
+
+    // Push to registry
+    const {stdout, stderr} = await execAsync(
+      `${runtime} push ${image} ${tlsFlag}`.trim(),
+    );
+
+    // Cleanup local image
+    try {
+      await execAsync(`${runtime} rmi ${image}`);
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    return {success: true, stdout, stderr};
+  } catch (error) {
+    // Extract error message
+    const err = error as Error & {
+      stdout?: string;
+      stderr?: string;
+      message?: string;
+    };
+    return {
+      success: false,
+      error: err.stderr || err.message || String(error),
+      stdout: err.stdout,
+      stderr: err.stderr,
+    };
+  }
+}
+
+/**
  * Push a multi-architecture manifest list to the registry.
  *
  * Uses quay.io/prometheus/busybox:latest as the source image.


### PR DESCRIPTION
Proxy cache organizations should be read-only from the client perspective.
Users with write/admin permissions were incorrectly able to push images to
these organizations. This fix blocks:
- Push to existing repos in proxy cache orgs
- New repository creation in proxy cache orgs
- Admin (*) scope for proxy cache orgs

The implementation follows the existing pattern for MIRROR and READ_ONLY
repository states by silently downscoping permissions.

Co-authored-by: Claude <noreply@anthropic.com>

```
❯ podman push localhost:8080/proxycachetest/alpine:latest --tls-verify=false
Getting image source signatures
Copying blob 7bb20cf5ef67 [--------------------------------------] 8.0b / 8.3MiB | 1.3 MiB/s
Error: writing blob: initiating layer upload to /v2/proxycachetest/alpine/blobs/uploads/ in localhost:8080: unauthorized: access to the requested resource is not authorized
```

pulls still working

```
❯ podman pull localhost:8080/proxycachetest/alpine:latest --tls-verify=false
Trying to pull localhost:8080/proxycachetest/alpine:latest...
Getting image source signatures
Copying blob 1074353eec0d skipped: already exists
Copying config e7b39c54cd done   |
Writing manifest to image destination
e7b39c54cdeca0d2aae83114bb605753a5f5bc511fe8be7590e38f6d9f915dad
```

<img width="946" height="428" alt="image" src="https://github.com/user-attachments/assets/e1059bb7-a324-404b-9d56-473f0c4e341a" />
