### PR TITLE
fix(api): superuser org visibility (PROJQUAY-10152)

### DIFF
--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -95,6 +95,11 @@ def org_view(o, teams):
         features.SUPERUSERS_FULL_ACCESS and allow_if_superuser()
     )
 
+    # Grant superusers effective admin/member status for UI visibility
+    if can_view_as_superuser:
+        is_admin = True
+        is_member = True
+
     view = {
         "name": o.username,
         "email": o.email if is_admin or can_view_as_superuser else "",

--- a/web/playwright/e2e/organization/org-list.spec.ts
+++ b/web/playwright/e2e/organization/org-list.spec.ts
@@ -407,6 +407,30 @@ test.describe(
         );
 
         test(
+          'shows organization management tabs to full-access superusers',
+          {tag: ['@superuser', '@PROJQUAY-10152']},
+          async ({superuserPage, api}) => {
+            const org = await api.organization('superuserorg');
+            await superuserPage.goto(`/organization/${org.name}`);
+            await expect(
+              superuserPage.getByRole('heading', {name: org.name, exact: true}),
+            ).toBeVisible();
+
+            for (const tabName of [
+              'Teams and membership',
+              'Robot accounts',
+              'Default permissions',
+              'OAuth Applications',
+              'Logs',
+              'Settings',
+            ]) {
+              await expect(
+                superuserPage.getByRole('tab', {name: tabName, exact: true}),
+              ).toBeVisible();
+            }
+          },
+        );
+        test(
           'shows user orgs when superuser API fails',
           {tag: '@superuser'},
           async ({superuserPage, superuserApi}) => {


### PR DESCRIPTION
Superusers with SUPERUSERS_FULL_ACCESS enabled could not see org details
(Teams, Robot accounts, Settings, etc.) for organizations they weren't
members of. The UI hid tabs because the API returned is_admin: false and
is_member: false.

This fix grants superusers effective admin/member status in org_view()
when can_view_as_superuser is true, enabling full org visibility in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
