### PR TITLE
chore: fix broken Types Tests

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,6 +22,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.12
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |
@@ -89,6 +93,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.12
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |
@@ -118,6 +126,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.12
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
         cache: 'pip'
         cache-dependency-path: |
           requirements.txt
@@ -152,6 +164,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.12
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |
@@ -176,6 +192,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.12
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |
@@ -220,6 +240,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.12
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |
@@ -290,6 +314,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.12
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |
@@ -317,6 +345,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.12
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements-dev.txt
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
To fix broken CI tests because of python version.
 
Automated & manual cherry-pick for  [#4586](https://github.com/quay/quay/pull/4586) Failed !!