### PR TITLE
db: Add an index to manifest_subject (PROJQUAY-0000)

### DIFF
--- a/data/migrations/versions/5c69e7934f0f_add_index_on_manifest_subject.py
+++ b/data/migrations/versions/5c69e7934f0f_add_index_on_manifest_subject.py
@@ -1,22 +1,21 @@
 """Add index on manifest_subject
 
 Revision ID: 5c69e7934f0f
-Revises: 9307c3d604b4
+Revises: 27d0df099ac4
 Create Date: 2026-01-13 10:01:12.710515
 
 """
 
 # revision identifiers, used by Alembic.
 revision = "5c69e7934f0f"
-down_revision = "9307c3d604b4"
+down_revision = "27d0df099ac4"
 
 import sqlalchemy as sa
-from sqlalchemy.engine.reflection import Inspector
 
 
 def upgrade(op, tables, tester):
     bind = op.get_bind()
-    inspector = Inspector.from_engine(bind)
+    inspector = sa.inspect(bind)
     manifest_indexes = inspector.get_indexes("manifest")
     if "manifest_subject" not in [i["name"] for i in manifest_indexes]:
         with op.get_context().autocommit_block():
@@ -30,4 +29,13 @@ def upgrade(op, tables, tester):
 
 
 def downgrade(op, tables, tester):
-    op.drop_index("manifest_subject", table_name="manifest")
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    manifest_indexes = inspector.get_indexes("manifest")
+    if "manifest_subject" in [i["name"] for i in manifest_indexes]:
+        with op.get_context().autocommit_block():
+            op.drop_index(
+                "manifest_subject",
+                table_name="manifest",
+                postgresql_concurrently=True,
+            )

--- a/data/migrations/versions/5c69e7934f0f_add_index_on_manifest_subject.py
+++ b/data/migrations/versions/5c69e7934f0f_add_index_on_manifest_subject.py
@@ -1,0 +1,33 @@
+"""Add index on manifest_subject
+
+Revision ID: 5c69e7934f0f
+Revises: 9307c3d604b4
+Create Date: 2026-01-13 10:01:12.710515
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "5c69e7934f0f"
+down_revision = "9307c3d604b4"
+
+import sqlalchemy as sa
+from sqlalchemy.engine.reflection import Inspector
+
+
+def upgrade(op, tables, tester):
+    bind = op.get_bind()
+    inspector = Inspector.from_engine(bind)
+    manifest_indexes = inspector.get_indexes("manifest")
+    if "manifest_subject" not in [i["name"] for i in manifest_indexes]:
+        with op.get_context().autocommit_block():
+            op.create_index(
+                "manifest_subject",
+                "manifest",
+                ["subject"],
+                unique=False,
+                postgresql_concurrently=True,
+            )
+
+
+def downgrade(op, tables, tester):
+    op.drop_index("manifest_subject", table_name="manifest")


### PR DESCRIPTION
Index to improve this GC related query: 
```sql
SELECT 
    "t1"."id", "t1"."repository_id", "t1"."digest", "t1"."media_type_id", 
    "t1"."manifest_bytes", "t1"."config_media_type", "t1"."layers_compressed_size", 
    "t1"."subject", "t1"."subject_backfilled", "t1"."artifact_type", 
    "t1"."artifact_type_backfilled" 
FROM "manifest" AS "t1" 
INNER JOIN "manifest" AS "t2" ON ("t2"."subject" = "t1"."digest") 
WHERE ("t1"."id" = 296853380) 
LIMIT 1 OFFSET 0;
```