### PR TITLE
chore: Deprecate TLS 1.0 and TLS 1.1 support (PROJQUAY-9620)

### DIFF
--- a/config-tool/pkg/lib/fieldgroups/database/database.go
+++ b/config-tool/pkg/lib/fieldgroups/database/database.go
@@ -68,11 +68,10 @@ func NewDatabaseFieldGroup(fullConfig map[string]interface{}) (*DatabaseFieldGro
 }
 
 // function to ensure supported TLS versions are used in Postgres connection URI
+// Note: TLSv1 and TLSv1.1 are deprecated and no longer supported
 func IsValidTLS(version string) bool {
 	switch version {
 	case
-		"TLSv1",
-		"TLSv1.1",
 		"TLSv1.2",
 		"TLSv1.3":
 		return true
@@ -141,7 +140,7 @@ func NewDbConnectionArgsStruct(fullConfig map[string]interface{}) (*DbConnection
 			return newDbConnectionArgsStruct, errors.New("ssl_min_protoclversion must be of type string")
 		}
 		if !IsValidTLS(value.(string)) {
-			return newDbConnectionArgsStruct, errors.New("ssl_min_protoclversion invalid value (supported TLSv1,TLSv1.1-TLSv1.3)")
+			return newDbConnectionArgsStruct, errors.New("ssl_min_protocolversion invalid value (supported: TLSv1.2, TLSv1.3)")
 		}
 	}
 	if value, ok := fullConfig["ssl_max_protocolversion"]; ok {
@@ -150,7 +149,7 @@ func NewDbConnectionArgsStruct(fullConfig map[string]interface{}) (*DbConnection
 			return newDbConnectionArgsStruct, errors.New("ssl_max_protoclversion must be of type string")
 		}
 		if !IsValidTLS(value.(string)) {
-			return newDbConnectionArgsStruct, errors.New("ssl_max_protoclversion invalid value (supported TLSv1,TLSv1.1-TLSv1.3)")
+			return newDbConnectionArgsStruct, errors.New("ssl_max_protocolversion invalid value (supported: TLSv1.2, TLSv1.3)")
 		}
 	}
 	if value, ok := fullConfig["sslcrl"]; ok {

--- a/config-tool/utils/generate/not-done.json
+++ b/config-tool/utils/generate/not-done.json
@@ -125,9 +125,9 @@
       "description": "If set to true, build logs may be read by those with read access to the repo, rather than only write access or admin access. Defaults to False"
     },
     "SSL_PROTOCOLS": {
-      "x-example": ["TLSv1.1", "TLSv1.2"],
+      "x-example": ["TLSv1.2", "TLSv1.3"],
       "type": "array",
-      "description": "If specified, the nginx-defined list of SSL protocols to enabled and disabled",
+      "description": "If specified, the nginx-defined list of SSL protocols to enabled and disabled. TLSv1 and TLSv1.1 are deprecated.",
       "x-reference": "http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
     },
     "WEBHOOK_HOSTNAME_BLACKLIST": {

--- a/config-tool/utils/scripts/dumpschema.py
+++ b/config-tool/utils/scripts/dumpschema.py
@@ -48,8 +48,8 @@ CONFIG_SCHEMA = {
         },
         "SSL_PROTOCOLS": {
             "type": "array",
-            "description": "If specified, the nginx-defined list of SSL protocols to enabled and disabled",
-            "x-example": ["TLSv1.1", "TLSv1.2"],
+            "description": "If specified, the nginx-defined list of SSL protocols to enabled and disabled. TLSv1 and TLSv1.1 are deprecated.",
+            "x-example": ["TLSv1.2", "TLSv1.3"],
             "x-reference": "http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols",
         },
         # User-visible configuration.

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -150,8 +150,8 @@ CONFIG_SCHEMA = {
         },
         "SSL_PROTOCOLS": {
             "type": "array",
-            "description": "If specified, the nginx-defined list of SSL protocols to enabled and disabled",
-            "x-example": ["TLSv1.1", "TLSv1.2"],
+            "description": "If specified, the nginx-defined list of SSL protocols to enabled and disabled. TLSv1 and TLSv1.1 are deprecated.",
+            "x-example": ["TLSv1.2", "TLSv1.3"],
             "x-reference": "http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols",
         },
         # User-visible configuration.

--- a/util/security/ssl.py
+++ b/util/security/ssl.py
@@ -48,7 +48,7 @@ class SSLCertificate(object):
 
         Raises a KeyInvalidException on failure.
         """
-        context = OpenSSL.SSL.Context(OpenSSL.SSL.TLSv1_METHOD)
+        context = OpenSSL.SSL.Context(OpenSSL.SSL.TLS_METHOD)
         context.use_certificate(self.openssl_cert)
 
         try:


### PR DESCRIPTION
- Update IsValidTLS() to only accept TLSv1.2 and TLSv1.3 for PostgreSQL connections
- Update error messages to reflect supported TLS versions
- Update SSL_PROTOCOLS examples and descriptions in schema documentation

TLSv1 and TLSv1.1 are deprecated due to known security vulnerabilities.