### PR TITLE
PROJQUAY-10610: fix(web): enable anonymous browsing of public repos in React UI

### DIFF
--- a/web/playwright/e2e/auth/anonymous-access.spec.ts
+++ b/web/playwright/e2e/auth/anonymous-access.spec.ts
@@ -1,0 +1,98 @@
+import {test, expect} from '../../fixtures';
+
+test.describe(
+  'Anonymous access',
+  {
+    tag: ['@auth', '@critical', '@feature:ANONYMOUS_ACCESS', '@PROJQUAY-10610'],
+  },
+  () => {
+    test('renders public repository page for unauthenticated user', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('anon');
+      const repo = await api.repository(org.name, 'public', 'public');
+
+      await unauthenticatedPage.goto(`/repository/${repo.fullName}`);
+
+      // Should NOT redirect to /signin
+      await expect(unauthenticatedPage).toHaveURL(
+        new RegExp(`/repository/${repo.fullName}`),
+      );
+
+      // Repo title should be visible on the page
+      await expect(unauthenticatedPage.getByTestId('repo-title')).toContainText(
+        repo.name,
+        {timeout: 10000},
+      );
+
+      // Sign In link should be visible instead of user menu
+      await expect(
+        unauthenticatedPage.getByRole('link', {name: /sign in/i}),
+      ).toBeVisible();
+      await expect(
+        unauthenticatedPage.getByTestId('user-menu-toggle'),
+      ).not.toBeVisible();
+    });
+
+    test('renders organization list page for unauthenticated user', async ({
+      unauthenticatedPage,
+    }) => {
+      await unauthenticatedPage.goto('/organization');
+
+      // Should render without redirecting to /signin
+      await expect(unauthenticatedPage).toHaveURL(/\/organization/);
+      await expect(
+        unauthenticatedPage.getByRole('heading', {name: /organizations/i}),
+      ).toBeVisible({timeout: 10000});
+    });
+
+    test('redirects shorthand URL to repository page for unauthenticated user', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('anon');
+      const repo = await api.repository(org.name, 'public', 'public');
+
+      // Use shorthand URL (/:org/:repo instead of /repository/:org/:repo)
+      await unauthenticatedPage.goto(`/${org.name}/${repo.name}`);
+
+      // Should redirect to /repository/org/repo (not /signin)
+      await expect(unauthenticatedPage).toHaveURL(
+        new RegExp(`/repository/${repo.fullName}`),
+      );
+    });
+
+    test('lists public repos on /repository page for unauthenticated user', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('anon');
+      const repo = await api.repository(org.name, 'public', 'public');
+
+      await unauthenticatedPage.goto('/repository');
+
+      // Should NOT redirect to /signin
+      await expect(unauthenticatedPage).toHaveURL(/\/repository/);
+
+      // Public repo should appear in the list
+      await expect(
+        unauthenticatedPage.getByRole('link', {name: repo.fullName}),
+      ).toBeVisible({timeout: 10000});
+    });
+
+    test('navigates to signin page via Sign In link', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('anon');
+      const repo = await api.repository(org.name, 'public', 'public');
+
+      await unauthenticatedPage.goto(`/repository/${repo.fullName}`);
+
+      await unauthenticatedPage.getByRole('link', {name: /sign in/i}).click();
+
+      await expect(unauthenticatedPage).toHaveURL(/\/signin/);
+    });
+  },
+);

--- a/web/playwright/e2e/auth/logout.spec.ts
+++ b/web/playwright/e2e/auth/logout.spec.ts
@@ -124,7 +124,11 @@ test.describe('Logout functionality', {tag: ['@auth', '@critical']}, () => {
   test('clears session and prevents access to protected pages', async ({
     logoutPage,
     logoutUsername,
+    quayConfig,
   }) => {
+    const anonymousAccessEnabled =
+      quayConfig?.features?.ANONYMOUS_ACCESS === true;
+
     // Navigate to organization page
     await logoutPage.goto('/organization');
     await expect(logoutPage.getByTestId('user-menu-toggle')).toBeVisible();
@@ -143,16 +147,25 @@ test.describe('Logout functionality', {tag: ['@auth', '@critical']}, () => {
       logoutPage.getByRole('textbox', {name: /username/i}),
     ).toBeVisible();
 
-    // Try to navigate to a protected page (use the temp user's namespace)
+    // Try to navigate to a page (use the temp user's namespace)
     await logoutPage.goto(`/organization/${logoutUsername}`);
 
-    // Should redirect back to signin (not authenticated)
-    await expect(logoutPage).toHaveURL(/\/signin/);
-
-    // Verify still on login page
-    await expect(
-      logoutPage.getByRole('textbox', {name: /username/i}),
-    ).toBeVisible();
+    if (anonymousAccessEnabled) {
+      // When ANONYMOUS_ACCESS is enabled, anonymous users stay on the page
+      // and see a Sign In link instead of user menu
+      await expect(
+        logoutPage.getByTestId('user-menu-toggle'),
+      ).not.toBeVisible();
+      await expect(
+        logoutPage.getByRole('link', {name: /sign in/i}),
+      ).toBeVisible();
+    } else {
+      // When ANONYMOUS_ACCESS is disabled, should redirect to signin
+      await expect(logoutPage).toHaveURL(/\/signin/);
+      await expect(
+        logoutPage.getByRole('textbox', {name: /username/i}),
+      ).toBeVisible();
+    }
   });
 
   test('logout menu item has danger styling', async ({authenticatedPage}) => {

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -728,6 +728,7 @@ export class TestApi {
  * Known Quay feature flags that can be enabled/disabled
  */
 export type QuayFeature =
+  | 'ANONYMOUS_ACCESS'
   | 'BILLING'
   | 'QUOTA_MANAGEMENT'
   | 'EDIT_QUOTA'

--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -64,7 +64,6 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
   const queryClient = useQueryClient();
   const {user} = useCurrentUser();
   const [err, setErr] = useState<string>();
-  const quayConfig = useQuayConfig();
 
   const onDropdownToggle = () => {
     setIsDropdownOpen((prev) => !prev);
@@ -322,13 +321,14 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
     </div>
   );
 
-  const signInButtonText = quayConfig?.config?.REGISTRY_TITLE_SHORT
-    ? `Sign in to ${quayConfig.config.REGISTRY_TITLE_SHORT}`
-    : 'Sign In';
+  const signInButton = (
+    <Button component="a" href="/signin">
+      Sign In
+    </Button>
+  );
 
-  const signInButton = <Button>{signInButtonText}</Button>;
-
-  const {unreadCount} = useAppNotifications();
+  const isAuthenticated = !!user?.username;
+  const {unreadCount} = useAppNotifications(isAuthenticated);
 
   return (
     <>
@@ -340,30 +340,32 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
             align={{default: 'alignRight'}}
             spacer={{default: 'spacerNone', md: 'spacerMd'}}
           >
-            <ToolbarItem
-              spacer={{
-                default: 'spacerNone',
-                md: 'spacerSm',
-                lg: 'spacerMd',
-                xl: 'spacerLg',
-              }}
-            >
-              <NotificationBadge
-                variant={
-                  unreadCount > 0
-                    ? NotificationBadgeVariant.unread
-                    : NotificationBadgeVariant.read
-                }
-                count={unreadCount}
-                onClick={toggleDrawer}
-                aria-label="Notifications"
-                data-testid="notification-bell"
+            {isAuthenticated && (
+              <ToolbarItem
+                spacer={{
+                  default: 'spacerNone',
+                  md: 'spacerSm',
+                  lg: 'spacerMd',
+                  xl: 'spacerLg',
+                }}
               >
-                <BellIcon />
-              </NotificationBadge>
-            </ToolbarItem>
+                <NotificationBadge
+                  variant={
+                    unreadCount > 0
+                      ? NotificationBadgeVariant.unread
+                      : NotificationBadgeVariant.read
+                  }
+                  count={unreadCount}
+                  onClick={toggleDrawer}
+                  aria-label="Notifications"
+                  data-testid="notification-bell"
+                >
+                  <BellIcon />
+                </NotificationBadge>
+              </ToolbarItem>
+            )}
             <ToolbarItem>
-              {user.username ? menuContainer : signInButton}
+              {isAuthenticated ? menuContainer : signInButton}
             </ToolbarItem>
           </ToolbarGroup>
         </ToolbarContent>

--- a/web/src/components/notifications/NotificationDrawerList.tsx
+++ b/web/src/components/notifications/NotificationDrawerList.tsx
@@ -11,11 +11,15 @@ import {TimesIcon} from '@patternfly/react-icons';
 import {useState} from 'react';
 
 import {useAppNotifications} from 'src/hooks/useAppNotifications';
+import {useCurrentUser} from 'src/hooks/UseCurrentUser';
 import {getNotificationMessage} from './notificationTemplates';
 import {formatDate} from 'src/libs/utils';
 
 export function NotificationDrawerListComponent() {
-  const {notifications, dismissNotification, loading} = useAppNotifications();
+  const {user} = useCurrentUser();
+  const {notifications, dismissNotification, loading} = useAppNotifications(
+    !!user?.username,
+  );
 
   const [readNotifications, setReadNotifications] = useState<string[]>(() => {
     const stored = localStorage.getItem('notification-read-status');

--- a/web/src/hooks/UseRepositories.ts
+++ b/web/src/hooks/UseRepositories.ts
@@ -8,6 +8,7 @@ import {
 import {OrgSearchState} from 'src/components/toolbar/SearchTypes';
 import {
   fetchAllRepos,
+  fetchRepositories,
   fetchRepositoriesForNamespace,
   IRepository,
 } from 'src/resources/RepositoryResource';
@@ -26,7 +27,9 @@ export function useRepositories(organization?: string) {
 
   const listOfOrgNames: string[] = currentOrganization
     ? [currentOrganization]
-    : user?.organizations.map((org) => org.name).concat(user.username);
+    : user?.anonymous
+    ? [] // Anonymous users have no namespaces to fetch
+    : user?.organizations?.map((org) => org.name).concat(user.username) || [];
 
   const handlePartialResults = useCallback((newRepos: IRepository[]) => {
     setPartialResults((prev) => [...prev, ...newRepos]);
@@ -44,6 +47,11 @@ export function useRepositories(organization?: string) {
     queryFn: async ({signal}): Promise<IRepository[]> => {
       // Reset partial results at the start of a new query
       setPartialResults([]);
+
+      // Anonymous users without a specific org: show all public repos
+      if (user?.anonymous && !currentOrganization) {
+        return fetchRepositories();
+      }
 
       const result = currentOrganization
         ? fetchRepositoriesForNamespace(currentOrganization, {

--- a/web/src/hooks/useAppNotifications.ts
+++ b/web/src/hooks/useAppNotifications.ts
@@ -40,7 +40,7 @@ function mapAngularLevelToPF(
   }
 }
 
-export function useAppNotifications() {
+export function useAppNotifications(enabled = true) {
   const queryClient = useQueryClient();
 
   const {data: notifications = [], isLoading: loading} = useQuery({
@@ -53,6 +53,7 @@ export function useAppNotifications() {
       }));
     },
     refetchInterval: 5 * 60 * 1000, // refetch every 5 minutes
+    enabled, // Skip fetch for anonymous users (PROJQUAY-10610)
   });
 
   const dismissMutation = useMutation({

--- a/web/src/libs/axios.ts
+++ b/web/src/libs/axios.ts
@@ -6,6 +6,15 @@ if (process.env.MOCK_API === 'true') {
   require('src/tests/fake-db/ApiMock');
 }
 
+// Track whether user is browsing anonymously. When true, 401 responses
+// from other endpoints (e.g. /api/v1/user/notifications) won't trigger
+// a redirect to /signin. Set by fetchUser() in UserResource.ts.
+let _anonymousMode = false;
+
+export function setAnonymousMode(enabled: boolean) {
+  _anonymousMode = enabled;
+}
+
 axios.defaults.withCredentials = true;
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
@@ -92,7 +101,18 @@ axiosIns.interceptors.response.use(
 
       // Handle regular session expiry
       if (!isFreshLoginRequired) {
-        if (window?.insights?.chrome?.auth) {
+        // Don't redirect on 401 from /api/v1/user/ (let fetchUser() return
+        // an anonymous user object instead — PROJQUAY-10610), or when already
+        // in anonymous mode (other endpoints like /api/v1/user/notifications
+        // will also 401 for anonymous users).
+        const requestUrl = error.config?.url || '';
+        const isUserEndpoint =
+          requestUrl === '/api/v1/user/' ||
+          requestUrl.endsWith('/api/v1/user/');
+
+        if (isUserEndpoint || _anonymousMode) {
+          // Skip redirect — handled by fetchUser or component error boundaries
+        } else if (window?.insights?.chrome?.auth) {
           // Refresh token for plugin
           GlobalAuthState.bearerToken =
             await window.insights.chrome.auth.getToken();

--- a/web/src/resources/UserResource.ts
+++ b/web/src/resources/UserResource.ts
@@ -1,5 +1,5 @@
 import {AxiosResponse, AxiosError} from 'axios';
-import axios from 'src/libs/axios';
+import axios, {setAnonymousMode} from 'src/libs/axios';
 import {assertHttpCode} from './ErrorHandling';
 import {IAvatar, IOrganization} from './OrganizationResource';
 import {IQuotaReport} from 'src/libs/quotaUtils';
@@ -10,22 +10,20 @@ export interface IUserResource {
   avatar: IAvatar;
   can_create_repo: boolean;
   is_me: boolean;
-  verified: true;
+  verified: boolean;
   email: string;
-  logins: [
-    {
-      service: string;
-      service_identifier: string;
-      metadata: {
-        service_username: string;
-      };
-    },
-  ];
+  logins: Array<{
+    service: string;
+    service_identifier: string;
+    metadata: {
+      service_username: string;
+    };
+  }>;
   invoice_email: boolean;
   invoice_email_address: string;
   preferred_namespace: boolean;
   tag_expiration_s: number;
-  prompts: [];
+  prompts: string[];
   super_user: boolean;
   global_readonly_super_user?: boolean;
   enabled?: boolean; // User enabled/disabled status (for superuser user management)
@@ -39,11 +37,49 @@ export interface IUserResource {
   quota_report?: IQuotaReport; // Quota report for the user's namespace
 }
 
+// Sentinel anonymous user object returned when the backend returns 401.
+// Matches the Angular UI pattern from static/js/services/user-service.js.
+const ANONYMOUS_USER: IUserResource = {
+  anonymous: true,
+  username: '',
+  avatar: {name: '', hash: '', color: '', kind: 'user'},
+  can_create_repo: false,
+  is_me: false,
+  verified: false,
+  email: '',
+  logins: [],
+  invoice_email: false,
+  invoice_email_address: '',
+  preferred_namespace: false,
+  tag_expiration_s: 0,
+  prompts: [],
+  super_user: false,
+  company: '',
+  family_name: '',
+  given_name: '',
+  location: '',
+  is_free_account: true,
+  has_password_set: false,
+  organizations: [],
+};
+
 export async function fetchUser() {
-  const response: AxiosResponse<IUserResource> =
-    await axios.get('/api/v1/user/');
-  assertHttpCode(response.status, 200);
-  return response.data;
+  try {
+    const response: AxiosResponse<IUserResource> =
+      await axios.get('/api/v1/user/');
+    assertHttpCode(response.status, 200);
+    setAnonymousMode(false);
+    return response.data;
+  } catch (error) {
+    if ((error as AxiosError)?.response?.status === 401) {
+      // Not authenticated — return anonymous user object instead of throwing.
+      // This matches Angular UI behavior and enables anonymous browsing of
+      // public repos when FEATURE_ANONYMOUS_ACCESS is enabled (PROJQUAY-10610).
+      setAnonymousMode(true);
+      return ANONYMOUS_USER;
+    }
+    throw error;
+  }
 }
 
 export interface AllUsers {

--- a/web/src/routes/OrganizationsList/OrganizationToolBar.tsx
+++ b/web/src/routes/OrganizationsList/OrganizationToolBar.tsx
@@ -25,25 +25,29 @@ export function OrganizationToolBar(props: OrganizationToolBarProps) {
     <>
       <Toolbar>
         <ToolbarContent>
-          <DropdownCheckbox
-            selectedItems={props.selectedOrganization}
-            deSelectAll={props.setSelectedOrganization}
-            allItemsList={props.organizationsList}
-            itemsPerPageList={props.paginatedOrganizationsList}
-            onItemSelect={props.onSelectOrganization}
-          />
+          {props.isAuthenticated !== false && (
+            <DropdownCheckbox
+              selectedItems={props.selectedOrganization}
+              deSelectAll={props.setSelectedOrganization}
+              allItemsList={props.organizationsList}
+              itemsPerPageList={props.paginatedOrganizationsList}
+              onItemSelect={props.onSelectOrganization}
+            />
+          )}
           <FilterInput
             id="orgslist-search-input"
             searchState={props.search}
             onChange={props.setSearch}
           />
-          <ToolbarButton
-            id="create-organization-button"
-            buttonValue="Create Organization"
-            Modal={props.createOrgModal}
-            isModalOpen={props.isOrganizationModalOpen}
-            setModalOpen={props.setOrganizationModalOpen}
-          />
+          {props.isAuthenticated !== false && (
+            <ToolbarButton
+              id="create-organization-button"
+              buttonValue="Create Organization"
+              Modal={props.createOrgModal}
+              isModalOpen={props.isOrganizationModalOpen}
+              setModalOpen={props.setOrganizationModalOpen}
+            />
+          )}
           {canModify && !props.isExternalAuth && (
             <ToolbarItem>
               <Button
@@ -114,4 +118,5 @@ type OrganizationToolBarProps = {
   paginatedOrganizationsList: any[];
   onSelectOrganization: (Org, rowIndex, isSelecting) => void;
   isExternalAuth: boolean;
+  isAuthenticated?: boolean;
 };

--- a/web/src/routes/OrganizationsList/OrganizationsList.tsx
+++ b/web/src/routes/OrganizationsList/OrganizationsList.tsx
@@ -448,6 +448,8 @@ export default function OrganizationsList() {
     );
   }
 
+  const isAuthenticated = !!user?.username;
+
   // Return component Empty state
   if (!loading && !organizationsTableDetails?.length) {
     return (
@@ -465,15 +467,21 @@ export default function OrganizationsList() {
         <Empty
           icon={CubesIcon}
           title="Collaborate and share projects across teams"
-          body="Create a shared space of public and private repositories for your developers to collaborate in. Organizations make it easy to add and manage people and permissions"
+          body={
+            isAuthenticated
+              ? 'Create a shared space of public and private repositories for your developers to collaborate in. Organizations make it easy to add and manage people and permissions'
+              : 'Sign in to create organizations and manage repositories.'
+          }
           button={
-            <ToolbarButton
-              id="create-organization-button"
-              buttonValue="Create Organization"
-              Modal={createOrgModal}
-              isModalOpen={isOrganizationModalOpen}
-              setModalOpen={setOrganizationModalOpen}
-            />
+            isAuthenticated ? (
+              <ToolbarButton
+                id="create-organization-button"
+                buttonValue="Create Organization"
+                Modal={createOrgModal}
+                isModalOpen={isOrganizationModalOpen}
+                setModalOpen={setOrganizationModalOpen}
+              />
+            ) : null
           }
         />
       </>
@@ -518,7 +526,7 @@ export default function OrganizationsList() {
           isKebabOpen={isKebabOpen}
           setKebabOpen={setKebabOpen}
           kebabItems={kebabItems}
-          selectedOrganization={selectedOrganization}
+          selectedOrganization={isAuthenticated ? selectedOrganization : []}
           deleteKebabIsOpen={deleteModalIsOpen}
           deleteModal={deleteModal}
           organizationsList={sortedOrgs}
@@ -530,11 +538,12 @@ export default function OrganizationsList() {
           paginatedOrganizationsList={paginatedOrganizationsList}
           onSelectOrganization={onSelectOrganization}
           isExternalAuth={!!isExternalAuth}
+          isAuthenticated={isAuthenticated}
         />
         <Table aria-label="Selectable table" variant="compact">
           <Thead>
             <Tr>
-              <Th />
+              {isAuthenticated && <Th />}
               <Th sort={getSortableSort(1)} modifier="wrap">
                 {ColumnNames.name}
               </Th>
@@ -556,18 +565,19 @@ export default function OrganizationsList() {
           <Tbody>
             {paginatedOrganizationsList?.map((org, rowIndex) => (
               <Tr key={org.name}>
-                {isOrgSelectable(org) ? (
-                  <Td
-                    select={{
-                      rowIndex,
-                      onSelect: (_event, isSelecting) =>
-                        onSelectOrganization(org, rowIndex, isSelecting),
-                      isSelected: isOrganizationSelected(org),
-                    }}
-                  />
-                ) : (
-                  <Td />
-                )}
+                {isAuthenticated &&
+                  (isOrgSelectable(org) ? (
+                    <Td
+                      select={{
+                        rowIndex,
+                        onSelect: (_event, isSelecting) =>
+                          onSelectOrganization(org, rowIndex, isSelecting),
+                        isSelected: isOrganizationSelected(org),
+                      }}
+                    />
+                  ) : (
+                    <Td />
+                  ))}
                 <OrgTableData
                   name={org.name}
                   isUser={org.isUser}

--- a/web/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/web/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -292,6 +292,8 @@ export default function RepositoriesList(props: RepositoriesListProps) {
     );
   }
 
+  const isAuthenticated = !!user?.username;
+
   // Return component Empty state - only if there are truly no repositories
   // If filtered results are empty but repos exist, show the table with toolbar
   if (!loading && !repos?.length) {
@@ -299,15 +301,21 @@ export default function RepositoriesList(props: RepositoriesListProps) {
       <Empty
         icon={CubesIcon}
         title="There are no viewable repositories"
-        body="Either no repositories exist yet or you may not have permission to view any. If you have permission, try creating a new repository."
+        body={
+          isAuthenticated
+            ? 'Either no repositories exist yet or you may not have permission to view any. If you have permission, try creating a new repository.'
+            : 'No public repositories found. Sign in to view your private repositories.'
+        }
         button={
-          <ToolbarButton
-            id=""
-            buttonValue="Create Repository"
-            Modal={createRepoModal}
-            isModalOpen={isCreateRepoModalOpen}
-            setModalOpen={setCreateRepoModalOpen}
-          />
+          isAuthenticated ? (
+            <ToolbarButton
+              id=""
+              buttonValue="Create Repository"
+              Modal={createRepoModal}
+              isModalOpen={isCreateRepoModalOpen}
+              setModalOpen={setCreateRepoModalOpen}
+            />
+          ) : null
         }
       />
     );
@@ -336,15 +344,15 @@ export default function RepositoriesList(props: RepositoriesListProps) {
           setSearch={setSearch}
           total={paginationProps.total}
           currentOrg={currentOrg}
-          pageModal={createRepoModal}
-          showPageButton={true}
+          pageModal={isAuthenticated ? createRepoModal : null}
+          showPageButton={isAuthenticated}
           buttonText="Create Repository"
           isModalOpen={isCreateRepoModalOpen}
           setModalOpen={setCreateRepoModalOpen}
           isKebabOpen={isKebabOpen}
           setKebabOpen={setKebabOpen}
-          kebabItems={kebabItems}
-          selectedRepoNames={selectedRepoNames}
+          kebabItems={isAuthenticated ? kebabItems : []}
+          selectedRepoNames={isAuthenticated ? selectedRepoNames : []}
           deleteModal={deleteRepositoryModal}
           deleteKebabIsOpen={isDeleteModalOpen}
           makePublicModalOpen={makePublicModalOpen}
@@ -364,7 +372,7 @@ export default function RepositoriesList(props: RepositoriesListProps) {
         <Table aria-label="Selectable table" variant="compact">
           <Thead>
             <Tr>
-              <Th />
+              {isAuthenticated && <Th />}
               <Th modifier="wrap" sort={getSortableSort(0)}>
                 {RepositoryListColumnNames.name}
               </Th>
@@ -395,15 +403,17 @@ export default function RepositoriesList(props: RepositoriesListProps) {
             ) : (
               paginatedRepositoryList.map((repo, rowIndex) => (
                 <Tr key={rowIndex}>
-                  <Td
-                    select={{
-                      rowIndex,
-                      onSelect: (_event, isSelecting) =>
-                        onSelectRepo(repo, rowIndex, isSelecting),
-                      isSelected: isRepoSelected(repo),
-                      isDisabled: !isRepoSelectable(repo),
-                    }}
-                  />
+                  {isAuthenticated && (
+                    <Td
+                      select={{
+                        rowIndex,
+                        onSelect: (_event, isSelecting) =>
+                          onSelectRepo(repo, rowIndex, isSelecting),
+                        isSelected: isRepoSelected(repo),
+                        isDisabled: !isRepoSelectable(repo),
+                      }}
+                    />
+                  )}
                   <Td dataLabel={RepositoryListColumnNames.name}>
                     <Flex alignItems={{default: 'alignItemsCenter'}}>
                       <FlexItem spacer={{default: 'spacerSm'}}>

--- a/web/src/routes/RepositoriesList/RepositoryToolBar.tsx
+++ b/web/src/routes/RepositoriesList/RepositoryToolBar.tsx
@@ -41,25 +41,29 @@ export function RepositoryToolBar(props: RepositoryToolBarProps) {
   return (
     <Toolbar>
       <ToolbarContent>
-        <DropdownCheckbox
-          selectedItems={props.selectedRepoNames}
-          deSelectAll={props.setSelectedRepoNames}
-          allItemsList={props.repositoryList}
-          itemsPerPageList={props.paginatedRepositoryList}
-          onItemSelect={props.onSelectRepo}
-        />
+        {props.showPageButton && (
+          <DropdownCheckbox
+            selectedItems={props.selectedRepoNames}
+            deSelectAll={props.setSelectedRepoNames}
+            allItemsList={props.repositoryList}
+            itemsPerPageList={props.paginatedRepositoryList}
+            onItemSelect={props.onSelectRepo}
+          />
+        )}
         <FilterInput
           id="repositorylist-search-input"
           searchState={props.search}
           onChange={props.setSearch}
         />
-        <ToolbarButton
-          id="create-repository-button"
-          buttonValue={props.buttonText}
-          Modal={props.pageModal}
-          isModalOpen={props.isModalOpen}
-          setModalOpen={props.setModalOpen}
-        />
+        {props.showPageButton && (
+          <ToolbarButton
+            id="create-repository-button"
+            buttonValue={props.buttonText}
+            Modal={props.pageModal}
+            isModalOpen={props.isModalOpen}
+            setModalOpen={props.setModalOpen}
+          />
+        )}
         <ToolbarItem>
           {props.selectedRepoNames?.length !== 0 ? (
             <Kebab

--- a/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
+++ b/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
@@ -275,6 +275,9 @@ export default function RepositoryDetails() {
                   <Tab
                     eventKey={TabIndex.Logs}
                     title={<TabTitleText>Logs</TabTitleText>}
+                    isHidden={
+                      !repoDetails?.can_write && !repoDetails?.can_admin
+                    }
                     {...({} as any)}
                   >
                     <UsageLogs

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -24,7 +24,7 @@ import {NavigationPath} from './NavigationPath';
 
 import {useEffect, useState, lazy, Suspense} from 'react';
 import ErrorBoundary from 'src/components/errors/ErrorBoundary';
-import {useQuayConfig} from 'src/hooks/UseQuayConfig';
+import {useQuayConfigWithLoading} from 'src/hooks/UseQuayConfig';
 import SiteUnavailableError from 'src/components/errors/SiteUnavailableError';
 import NotFound from 'src/components/errors/404';
 import {useCurrentUser} from 'src/hooks/UseCurrentUser';
@@ -39,7 +39,6 @@ import {GlobalMessages} from 'src/components/GlobalMessages';
 import {LoadingPage} from 'src/components/LoadingPage';
 import {useUI} from 'src/contexts/UIContext';
 import {useExternalScripts} from 'src/hooks/UseExternalScripts';
-import {AxiosError} from 'axios';
 
 // Lazy load route components for better performance
 const OrganizationsList = lazy(
@@ -217,8 +216,12 @@ const NavigationRoutes = [
 ];
 
 export function StandaloneMain() {
-  const quayConfig = useQuayConfig();
-  const {loading, error} = useCurrentUser();
+  const {
+    config: quayConfig,
+    isLoading: configLoading,
+    error: configError,
+  } = useQuayConfigWithLoading();
+  const {user, loading: userLoading, error: userError} = useCurrentUser();
   const location = useLocation();
   const {clearAllAlerts} = useUI();
 
@@ -251,17 +254,24 @@ export function StandaloneMain() {
     }
   }, [quayConfig]);
 
-  // Don't render anything while loading, or if there's a 401 error
-  // (401 errors trigger a redirect to /signin via axios interceptor, so we shouldn't
-  // flash the SiteUnavailableError during the redirect - fixes PROJQUAY-10089)
-  const is401Error = error && (error as AxiosError)?.response?.status === 401;
-  if (loading || is401Error) {
+  // Wait for both user data and config to load before rendering
+  if (userLoading || configLoading) {
     return null;
   }
 
-  // Only show SiteUnavailableError for non-401 errors (real server errors)
+  // If user is anonymous and ANONYMOUS_ACCESS is not enabled, redirect to
+  // signin (preserves existing behavior when anonymous access is disabled).
+  // When ANONYMOUS_ACCESS is enabled, let anonymous users browse public repos
+  // (PROJQUAY-10610).
+  if (user?.anonymous && quayConfig?.features?.ANONYMOUS_ACCESS !== true) {
+    window.location.href = '/signin';
+    return null;
+  }
+
+  // Surface config or user fetch errors via the ErrorBoundary
+  const hasError = !!configError || !!userError;
   return (
-    <ErrorBoundary hasError={!!error} fallback={<SiteUnavailableError />}>
+    <ErrorBoundary hasError={hasError} fallback={<SiteUnavailableError />}>
       <Page
         header={<QuayHeader toggleDrawer={toggleDrawer} />}
         sidebar={<QuaySidebar />}


### PR DESCRIPTION
The new React UI redirected all unauthenticated users to /signin, even
when FEATURE_ANONYMOUS_ACCESS was enabled. The Angular UI allowed
anonymous browsing of public repos by catching the 401 from /api/v1/user/
and continuing as an anonymous user.

- Modify axios interceptor to skip 401 redirect for /api/v1/user/ and
  when in anonymous browsing mode
- Handle 401 in fetchUser() by returning an anonymous user object
- Render the app for anonymous users when ANONYMOUS_ACCESS is enabled,
  redirect to /signin when disabled
- Fix Sign In button to actually navigate to /signin
- Hide authenticated-only UI: create repo/org buttons, selection
  checkboxes, kebab actions, notification bell, and Logs tab
- Show public repos on /repository page for anonymous users
- Disable notification API calls for anonymous users
- Add Playwright e2e tests for anonymous access flows
- Update logout test to handle both ANONYMOUS_ACCESS enabled/disabled

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
