### PR TITLE
PROJQUAY-9951: fix(web): add OIDC team sync support to Legacy Angular UI

### DIFF
--- a/static/partials/team-view.html
+++ b/static/partials/team-view.html
@@ -42,6 +42,9 @@
               <div ng-if="syncInfo.service == 'keystone'">
                 <code>{{ syncInfo.config.group_id }}</code>
               </div>
+              <div ng-if="syncInfo.service == 'oidc'">
+                <code>{{ syncInfo.config.group_name }}</code>
+              </div>
             </td>
           </tr>
           <tr>
@@ -182,6 +185,10 @@
       <div ng-switch-when="keystone">
         Enter the Keystone group ID:
         <input type="text" class="form-control" placeholder="Group ID" ng-model="enableSyncingInfo.config.group_id" required>
+      </div>
+      <div ng-switch-when="oidc">
+        Enter the group name (Object ID for Microsoft EntraID):
+        <input type="text" class="form-control" placeholder="Group Name" ng-model="enableSyncingInfo.config.group_name" required>
       </div>
      </div>
    </form>


### PR DESCRIPTION
The team sync dialog only handled LDAP and Keystone cases, missing the
OIDC case entirely. This prevented EntraID customers from enabling team
sync in the Legacy UI. Add ng-switch-when="oidc" for the group name
input and display the bound group name when sync is already enabled.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
