### PR TITLE
PROJQUAY-10591: feat(api): expose contact_email in organization endpoints

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -843,6 +843,7 @@ class User(BaseModel):
                 ManifestPullStatistics,
                 OrgMirrorConfig,
                 OrgMirrorRepository,
+                OrganizationContactEmail,
             } | v22_classes
             delete_instance_filtered(self, User, delete_nullable, skip_transitive_deletes)
 
@@ -2055,6 +2056,15 @@ class OrgMirrorRepository(BaseModel):
             # Composite index for efficient status counting per org mirror config
             (("org_mirror_config", "sync_status"), False),
         )
+
+
+class OrganizationContactEmail(BaseModel):
+    organization = QuayUserField(index=True, allows_robots=False, unique=True)
+    contact_email = CharField(null=True, index=True)
+
+    class Meta:
+        database = db
+        read_only_config = read_only_config
 
 
 @unique

--- a/data/migrations/versions/414c5e2fc487_add_organization_contact_email.py
+++ b/data/migrations/versions/414c5e2fc487_add_organization_contact_email.py
@@ -1,0 +1,75 @@
+"""add organization contact email
+
+Revision ID: 414c5e2fc487
+Revises: 285f36ce97fd
+Create Date: 2026-02-25 00:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "414c5e2fc487"
+down_revision = "285f36ce97fd"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.create_table(
+        "organizationcontactemail",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("organization_id", sa.Integer(), nullable=False),
+        sa.Column("contact_email", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["user.id"],
+            name=op.f("fk_organizationcontactemail_organization_id_user"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_organizationcontactemail")),
+    )
+
+    op.create_index(
+        "organizationcontactemail_organization_id",
+        "organizationcontactemail",
+        ["organization_id"],
+        unique=True,
+    )
+
+    op.create_index(
+        "organizationcontactemail_contact_email",
+        "organizationcontactemail",
+        ["contact_email"],
+        unique=False,
+    )
+
+    # Data migration: copy existing org emails to new table
+    conn = op.get_bind()
+    orgs_with_real_email = conn.execute(
+        sa.text("""
+            SELECT id, email FROM "user"
+            WHERE organization = true
+              AND email NOT LIKE '%placeholder.invalid'
+              AND email IS NOT NULL
+              AND length(email) < 64
+        """)
+    )
+    for org_id, email in orgs_with_real_email:
+        conn.execute(
+            sa.text("""
+                INSERT INTO organizationcontactemail (organization_id, contact_email)
+                VALUES (:org_id, :email)
+                ON CONFLICT (organization_id) DO NOTHING
+            """),
+            {"org_id": org_id, "email": email},
+        )
+
+    tester.populate_table(
+        "organizationcontactemail",
+        [
+            ("organization_id", tester.TestDataType.Foreign("user")),
+            ("contact_email", tester.TestDataType.String),
+        ],
+    )
+
+
+def downgrade(op, tables, tester):
+    op.drop_table("organizationcontactemail")

--- a/data/model/organization.py
+++ b/data/model/organization.py
@@ -1,7 +1,10 @@
+import uuid
+
 from data.database import (
     DeletedNamespace,
     FederatedLogin,
     Namespace,
+    OrganizationContactEmail,
     Repository,
     RepositoryPermission,
     Team,
@@ -20,15 +23,24 @@ from data.model import (
 )
 
 
-def create_organization(name, email, creating_user, email_required=True, is_possible_abuser=False):
+def create_organization(
+    name, email, creating_user, email_required=True, is_possible_abuser=False, contact_email=None
+):
     with db_transaction():
         try:
-            # Create the org
+            # Auto-generate internal email — never shown to users
+            internal_email = str(uuid.uuid4())
             new_org = user.create_user_noverify(
-                name, email, email_required=email_required, is_possible_abuser=is_possible_abuser
+                name, internal_email, email_required=False, is_possible_abuser=is_possible_abuser
             )
             new_org.organization = True
             new_org.save()
+
+            # Store contact_email in separate table if provided
+            if contact_email:
+                OrganizationContactEmail.create(
+                    organization=new_org, contact_email=contact_email
+                )
 
             # Create a team for the owners
             owners_team = team.create_team("owners", new_org, "admin")
@@ -209,4 +221,44 @@ def is_org_admin(user, org):
         .join(TeamRole)
         .where(Team.organization == org, TeamRole.name == "admin", TeamMember.user == user)
         .exists()
+    )
+
+
+def get_contact_email(org):
+    """Returns contact_email string or None."""
+    try:
+        record = OrganizationContactEmail.get(OrganizationContactEmail.organization == org)
+        return record.contact_email
+    except OrganizationContactEmail.DoesNotExist:
+        return None
+
+
+def set_contact_email(org, contact_email):
+    """Upserts contact_email (get_or_create + update)."""
+    record, created = OrganizationContactEmail.get_or_create(
+        organization=org,
+        defaults={"contact_email": contact_email},
+    )
+    if not created:
+        record.contact_email = contact_email
+        record.save()
+    return record
+
+
+def delete_contact_email(org):
+    """Removes the contact_email record."""
+    OrganizationContactEmail.delete().where(
+        OrganizationContactEmail.organization == org
+    ).execute()
+
+
+def find_organizations_by_contact_email(contact_email):
+    """Returns query of User records (orgs) matching a contact_email."""
+    return (
+        User.select()
+        .join(OrganizationContactEmail)
+        .where(
+            OrganizationContactEmail.contact_email == contact_email,
+            User.organization == True,
+        )
     )

--- a/data/model/test/test_organization.py
+++ b/data/model/test/test_organization.py
@@ -1,6 +1,8 @@
 import pytest
+from peewee import IntegrityError
 from playhouse.test_utils import assert_query_count
 
+from data.database import OrganizationContactEmail
 from data.model.organization import (
     create_organization,
     get_organization,
@@ -175,3 +177,49 @@ class TestGetOrganizationMemberSet:
             members = get_organization_member_set(org)
 
         assert len(members) > 0
+
+
+class TestOrganizationContactEmail:
+    """Tests for the OrganizationContactEmail model."""
+
+    def test_create_with_email(self, initialized_db):
+        """Test creating an OrganizationContactEmail with a contact email."""
+        org = get_organization("buynlarge")
+        record = OrganizationContactEmail.create(
+            organization=org, contact_email="contact@example.com"
+        )
+        assert record.contact_email == "contact@example.com"
+        assert record.organization_id == org.id
+
+    def test_create_with_null_email(self, initialized_db):
+        """Test creating an OrganizationContactEmail with a null contact email."""
+        org = get_organization("buynlarge")
+        record = OrganizationContactEmail.create(organization=org, contact_email=None)
+        assert record.contact_email is None
+        assert record.organization_id == org.id
+
+    def test_unique_constraint_on_organization(self, initialized_db):
+        """Test that only one contact email record can exist per organization."""
+        org = get_organization("buynlarge")
+        OrganizationContactEmail.create(organization=org, contact_email="first@example.com")
+
+        with pytest.raises(IntegrityError):
+            OrganizationContactEmail.create(organization=org, contact_email="second@example.com")
+
+    def test_multiple_orgs_can_share_email(self, initialized_db):
+        """Test that multiple organizations can have the same contact email."""
+        org1 = get_organization("buynlarge")
+        admin = get_user("devtable")
+        org2 = create_organization("testsharedorg", "shared@example.com", admin)
+
+        shared_email = "shared@example.com"
+        record1 = OrganizationContactEmail.create(
+            organization=org1, contact_email=shared_email
+        )
+        record2 = OrganizationContactEmail.create(
+            organization=org2, contact_email=shared_email
+        )
+
+        assert record1.contact_email == shared_email
+        assert record2.contact_email == shared_email
+        assert record1.organization_id != record2.organization_id

--- a/data/model/test/test_organization.py
+++ b/data/model/test/test_organization.py
@@ -5,10 +5,14 @@ from playhouse.test_utils import assert_query_count
 from data.database import OrganizationContactEmail
 from data.model.organization import (
     create_organization,
+    delete_contact_email,
+    find_organizations_by_contact_email,
+    get_contact_email,
     get_organization,
     get_organization_member_set,
     get_organizations,
     is_org_admin,
+    set_contact_email,
 )
 from data.model.team import add_user_to_team, get_organization_team
 from data.model.user import (
@@ -223,3 +227,116 @@ class TestOrganizationContactEmail:
         assert record1.contact_email == shared_email
         assert record2.contact_email == shared_email
         assert record1.organization_id != record2.organization_id
+
+
+class TestContactEmailCRUD:
+    """Tests for contact_email CRUD functions."""
+
+    def test_get_contact_email_returns_none_when_no_record(self, initialized_db):
+        """Test get_contact_email returns None when no record exists."""
+        org = get_organization("buynlarge")
+        assert get_contact_email(org) is None
+
+    def test_get_contact_email_returns_email(self, initialized_db):
+        """Test get_contact_email returns the stored email."""
+        org = get_organization("buynlarge")
+        OrganizationContactEmail.create(organization=org, contact_email="test@example.com")
+        assert get_contact_email(org) == "test@example.com"
+
+    def test_set_contact_email_creates_record(self, initialized_db):
+        """Test set_contact_email creates a new record."""
+        org = get_organization("buynlarge")
+        record = set_contact_email(org, "new@example.com")
+        assert record.contact_email == "new@example.com"
+        assert get_contact_email(org) == "new@example.com"
+
+    def test_set_contact_email_updates_existing(self, initialized_db):
+        """Test set_contact_email updates an existing record."""
+        org = get_organization("buynlarge")
+        set_contact_email(org, "first@example.com")
+        set_contact_email(org, "updated@example.com")
+        assert get_contact_email(org) == "updated@example.com"
+
+    def test_delete_contact_email(self, initialized_db):
+        """Test delete_contact_email removes the record."""
+        org = get_organization("buynlarge")
+        set_contact_email(org, "delete-me@example.com")
+        assert get_contact_email(org) == "delete-me@example.com"
+
+        delete_contact_email(org)
+        assert get_contact_email(org) is None
+
+    def test_delete_contact_email_no_record(self, initialized_db):
+        """Test delete_contact_email is safe when no record exists."""
+        org = get_organization("buynlarge")
+        delete_contact_email(org)  # Should not raise
+
+    def test_find_organizations_by_contact_email_single(self, initialized_db):
+        """Test find_organizations_by_contact_email returns matching org."""
+        admin = get_user("devtable")
+        org = create_organization("findorg1", None, admin, contact_email="find@example.com")
+        results = list(find_organizations_by_contact_email("find@example.com"))
+        assert len(results) == 1
+        assert results[0].username == "findorg1"
+
+    def test_find_organizations_by_contact_email_multiple(self, initialized_db):
+        """Test find_organizations_by_contact_email returns multiple matching orgs."""
+        admin = get_user("devtable")
+        create_organization("findorg2", None, admin, contact_email="shared@example.com")
+        create_organization("findorg3", None, admin, contact_email="shared@example.com")
+        results = list(find_organizations_by_contact_email("shared@example.com"))
+        assert len(results) == 2
+        names = {r.username for r in results}
+        assert names == {"findorg2", "findorg3"}
+
+    def test_find_organizations_by_contact_email_no_match(self, initialized_db):
+        """Test find_organizations_by_contact_email returns empty for no match."""
+        results = list(find_organizations_by_contact_email("nonexistent@example.com"))
+        assert len(results) == 0
+
+
+class TestCreateOrganizationContactEmail:
+    """Tests for create_organization() with contact_email support."""
+
+    def test_create_org_generates_uuid_email(self, initialized_db):
+        """Test that create_organization generates a UUID for User.email."""
+        admin = get_user("devtable")
+        org = create_organization("uuidorg", "ignored@example.com", admin)
+        # User.email should be a UUID, not the passed email
+        assert org.email != "ignored@example.com"
+        # UUID format: 8-4-4-4-12 hex chars
+        assert len(org.email) == 36
+        assert org.email.count("-") == 4
+
+    def test_create_org_no_contact_email(self, initialized_db):
+        """Test creating org without contact_email."""
+        admin = get_user("devtable")
+        org = create_organization("nocontactorg", None, admin)
+        assert get_contact_email(org) is None
+
+    def test_create_org_with_contact_email(self, initialized_db):
+        """Test creating org with contact_email stores it in separate table."""
+        admin = get_user("devtable")
+        org = create_organization(
+            "contactorg", None, admin, contact_email="contact@example.com"
+        )
+        assert get_contact_email(org) == "contact@example.com"
+
+    def test_create_two_orgs_same_contact_email(self, initialized_db):
+        """Test two orgs can share the same contact_email."""
+        admin = get_user("devtable")
+        org1 = create_organization(
+            "shareorg1", None, admin, contact_email="same@example.com"
+        )
+        org2 = create_organization(
+            "shareorg2", None, admin, contact_email="same@example.com"
+        )
+        assert get_contact_email(org1) == "same@example.com"
+        assert get_contact_email(org2) == "same@example.com"
+
+    def test_create_org_backward_compat(self, initialized_db):
+        """Test that existing callers (without contact_email) still work."""
+        admin = get_user("devtable")
+        org = create_organization("compatorg", "compat@example.com", admin)
+        assert org.organization is True
+        assert org.username == "compatorg"

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -96,9 +96,15 @@ def org_view(o, teams):
         features.SUPERUSERS_FULL_ACCESS and allow_if_superuser()
     )
 
+    # Fetch contact_email from separate table
+    contact_email = None
+    if is_admin or can_view_as_superuser:
+        contact_email = model.organization.get_contact_email(o)
+
     view = {
         "name": o.username,
-        "email": o.email if is_admin or can_view_as_superuser else "",
+        "email": contact_email or "" if (is_admin or can_view_as_superuser) else "",
+        "contact_email": contact_email if (is_admin or can_view_as_superuser) else None,
         "avatar": avatar.get_data_for_user(o),
         "is_admin": is_admin,
         "is_member": is_member,
@@ -143,7 +149,11 @@ class OrganizationList(ApiResource):
                 },
                 "email": {
                     "type": "string",
-                    "description": "Organization contact email",
+                    "description": "Organization contact email (backward compat)",
+                },
+                "contact_email": {
+                    "type": "string",
+                    "description": "Optional contact email for organization recovery and notifications",
                 },
                 "recaptcha_response": {
                     "type": "string",
@@ -186,8 +196,13 @@ class OrganizationList(ApiResource):
             msg = "A user or organization with this name already exists"
             raise request_error(message=msg)
 
-        if features.MAILING and not org_data.get("email"):
-            raise request_error(message="Email address is required")
+        # Extract contact_email (prefer contact_email, fall back to email for backward compat)
+        contact_email = org_data.get("contact_email") or org_data.get("email")
+        if contact_email:
+            from util.validation import validate_email
+
+            if not validate_email(contact_email):
+                raise request_error(message="Invalid email address")
 
         # If recaptcha is enabled, then verify the user is a human.
         if features.RECAPTCHA:
@@ -206,13 +221,13 @@ class OrganizationList(ApiResource):
                 org_data["name"],
                 org_data.get("email"),
                 user,
-                email_required=features.MAILING,
                 is_possible_abuser=is_possible_abuser,
+                contact_email=contact_email,
             )
             log_action(
                 "org_create",
                 org_data["name"],
-                {"email": org_data.get("email"), "namespace": org_data["name"]},
+                {"contact_email": contact_email, "namespace": org_data["name"]},
             )
             return "Created", 201
         except model.DataModelException as ex:
@@ -234,7 +249,11 @@ class Organization(ApiResource):
             "properties": {
                 "email": {
                     "type": "string",
-                    "description": "Organization contact email",
+                    "description": "Organization contact email (backward compat)",
+                },
+                "contact_email": {
+                    "type": "string",
+                    "description": "Contact email for organization recovery and notifications",
                 },
                 "invoice_email": {
                     "type": "boolean",
@@ -312,20 +331,27 @@ class Organization(ApiResource):
                     {"invoice_email_address": new_email, "namespace": orgname},
                 )
 
-            if "email" in org_data and org_data["email"] != org.email:
-                new_email = org_data["email"]
-                old_email = org.email
+            new_contact = org_data.get("contact_email") or org_data.get("email")
+            if new_contact is not None:
+                current_contact = model.organization.get_contact_email(org)
+                if new_contact != current_contact:
+                    if new_contact:
+                        from util.validation import validate_email
 
-                if model.user.find_user_by_email(new_email):
-                    raise request_error(message="E-mail address already used")
+                        if not validate_email(new_contact):
+                            raise request_error(message="Invalid email address")
 
-                logger.debug("Changing email address for organization: %s", org.username)
-                model.user.update_email(org, new_email)
-                log_action(
-                    "org_change_email",
-                    orgname,
-                    {"email": new_email, "namespace": orgname, "old_email": old_email},
-                )
+                    logger.debug("Changing contact email for organization: %s", org.username)
+                    model.organization.set_contact_email(org, new_contact)
+                    log_action(
+                        "org_change_email",
+                        orgname,
+                        {
+                            "contact_email": new_contact,
+                            "namespace": orgname,
+                            "old_email": current_contact or "",
+                        },
+                    )
 
             if features.CHANGE_TAG_EXPIRATION and "tag_expiration_s" in org_data:
                 logger.debug(

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -237,3 +237,121 @@ class TestProxyCacheConfigWithImmutableTags:
         has_immutable = namespace_has_immutable_tags(org.id)
         # Initially there should be no immutable tags
         assert isinstance(has_immutable, bool)
+
+
+class TestContactEmail:
+    """Tests for contact_email in organization API endpoints."""
+
+    def test_create_org_with_contact_email(self, app):
+        """Test creating org with contact_email field."""
+        body = {"name": "contactorg1", "contact_email": "contact@example.com"}
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
+
+        # Verify contact_email is returned in GET
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(
+                cl, Organization, "GET", {"orgname": "contactorg1"}, expected_code=200
+            )
+            assert resp.json["contact_email"] == "contact@example.com"
+            assert resp.json["email"] == "contact@example.com"
+
+    def test_create_org_without_email(self, app):
+        """Test creating org without any email succeeds."""
+        body = {"name": "noemailorg"}
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
+
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(
+                cl, Organization, "GET", {"orgname": "noemailorg"}, expected_code=200
+            )
+            assert resp.json["contact_email"] is None
+            assert resp.json["email"] == ""
+
+    def test_create_org_with_email_backward_compat(self, app):
+        """Test creating org with email field maps to contact_email."""
+        body = {"name": "backcompatorg", "email": "compat@example.com"}
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
+
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(
+                cl, Organization, "GET", {"orgname": "backcompatorg"}, expected_code=200
+            )
+            assert resp.json["contact_email"] == "compat@example.com"
+
+    def test_update_contact_email(self, app):
+        """Test updating org contact_email via PUT."""
+        body = {"name": "updateemailorg", "contact_email": "old@example.com"}
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
+
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(
+                cl,
+                Organization,
+                "PUT",
+                {"orgname": "updateemailorg"},
+                body={"contact_email": "new@example.com"},
+                expected_code=200,
+            )
+            assert resp.json["contact_email"] == "new@example.com"
+            assert resp.json["email"] == "new@example.com"
+
+    def test_update_email_backward_compat(self, app):
+        """Test updating org via email field maps to contact_email."""
+        body = {"name": "updatecompat", "contact_email": "old@example.com"}
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
+
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(
+                cl,
+                Organization,
+                "PUT",
+                {"orgname": "updatecompat"},
+                body={"email": "updated@example.com"},
+                expected_code=200,
+            )
+            assert resp.json["contact_email"] == "updated@example.com"
+
+    def test_duplicate_contact_email_allowed(self, app):
+        """Test that two orgs can share the same contact_email."""
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(
+                cl,
+                OrganizationList,
+                "POST",
+                None,
+                body={"name": "dupeorg1", "contact_email": "shared@example.com"},
+                expected_code=201,
+            )
+            conduct_api_call(
+                cl,
+                OrganizationList,
+                "POST",
+                None,
+                body={"name": "dupeorg2", "contact_email": "shared@example.com"},
+                expected_code=201,
+            )
+
+    def test_create_org_with_invalid_email(self, app):
+        """Test creating org with invalid email format returns error."""
+        body = {"name": "invalidemail", "contact_email": "not-an-email"}
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=400)
+
+    def test_get_org_non_admin_no_contact_email(self, app):
+        """Test that non-admin users cannot see contact_email."""
+        # Use buynlarge which has freshuser as non-admin member
+        # Set contact_email on buynlarge first
+        org = model.organization.get_organization("buynlarge")
+        model.organization.set_contact_email(org, "hidden@example.com")
+
+        with client_with_identity("freshuser", app) as cl:
+            resp = conduct_api_call(
+                cl, Organization, "GET", {"orgname": "buynlarge"}, expected_code=200
+            )
+            assert resp.json["contact_email"] is None
+            assert resp.json["email"] == ""

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -1116,16 +1116,31 @@ class Recovery(ApiResource):
 
         email = recovery_data["email"]
         user = model.user.find_user_by_email(email)
+
         if not user:
+            # Try to find org by contact_email (new orgs have UUID internal emails)
+            orgs = list(model.organization.find_organizations_by_contact_email(email))
+            if orgs:
+                for org in orgs:
+                    contact_email = model.organization.get_contact_email(org)
+                    admin_users = model.organization.get_admin_users(org)
+                    send_org_recovery_email(org, admin_users, contact_email=contact_email)
+                return {
+                    "status": "org",
+                    "orgemail": email,
+                    "orgname": redact(orgs[0].username),
+                }
             return {
                 "status": "sent",
             }
 
         if user.organization:
-            send_org_recovery_email(user, model.organization.get_admin_users(user))
+            contact_email = model.organization.get_contact_email(user)
+            admin_users = model.organization.get_admin_users(user)
+            send_org_recovery_email(user, admin_users, contact_email=contact_email)
             return {
                 "status": "org",
-                "orgemail": email,
+                "orgemail": contact_email or email,
                 "orgname": redact(user.username),
             }
 

--- a/endpoints/webhooks.py
+++ b/endpoints/webhooks.py
@@ -69,12 +69,21 @@ def stripe_webhook():
                 invoice = stripe.Invoice.retrieve(invoice_id)
                 if invoice:
                     invoice_html = renderInvoiceToHtml(invoice, namespace)
-                    send_invoice_email(
-                        namespace.invoice_email_address or namespace.email, invoice_html
-                    )
+                    recipient = namespace.invoice_email_address
+                    if not recipient and namespace.organization:
+                        from data.model.organization import get_contact_email
+
+                        recipient = get_contact_email(namespace)
+                    if not recipient:
+                        recipient = namespace.email
+                    send_invoice_email(recipient, invoice_html)
 
     elif event_type.startswith("customer.subscription."):
         cust_email = namespace.email if namespace is not None else "unknown@domain.com"
+        if namespace and namespace.organization:
+            from data.model.organization import get_contact_email
+
+            cust_email = get_contact_email(namespace) or cust_email
         quay_username = namespace.username if namespace is not None else "unknown"
 
         change_type = ""
@@ -98,7 +107,12 @@ def stripe_webhook():
 
     elif event_type == "invoice.payment_failed":
         if namespace:
-            send_payment_failed(namespace.email, namespace.username)
+            recipient = namespace.email
+            if namespace.organization:
+                from data.model.organization import get_contact_email
+
+                recipient = get_contact_email(namespace) or recipient
+            send_payment_failed(recipient, namespace.username)
 
     elif event_type == "checkout.session.completed":
         mode = request_data["data"]["object"]["mode"]

--- a/util/test/test_useremails.py
+++ b/util/test/test_useremails.py
@@ -3,7 +3,7 @@ from test.fixtures import *
 import mock
 import pytest
 
-from util.useremails import render_email, send_recovery_email
+from util.useremails import render_email, send_org_recovery_email, send_recovery_email
 
 
 def test_render_email():
@@ -109,3 +109,56 @@ def test_send_recovery_email(mock_send_email, initialized_db):
     mock_send_email.assert_called_once_with(
         email, subject, template_file, parameters, action=action
     )
+
+
+@mock.patch("util.useremails.send_email")
+def test_send_org_recovery_email_with_contact_email(mock_send_email, initialized_db):
+    """Test that send_org_recovery_email sends to contact_email when provided."""
+    org = mock.MagicMock()
+    org.username = "testorg"
+    admin1 = mock.MagicMock()
+    admin1.username = "admin1"
+    admin1.email = "admin1@example.com"
+
+    send_org_recovery_email(org, [admin1], contact_email="contact@example.com")
+
+    mock_send_email.assert_called_once_with(
+        "contact@example.com",
+        "Organization testorg recovery",
+        "orgrecovery",
+        {"organization": "testorg", "admin_usernames": ["admin1"]},
+    )
+
+
+@mock.patch("util.useremails.send_email")
+def test_send_org_recovery_email_fallback_to_admins(mock_send_email, initialized_db):
+    """Test that send_org_recovery_email falls back to admin emails when no contact_email."""
+    org = mock.MagicMock()
+    org.username = "testorg"
+    admin1 = mock.MagicMock()
+    admin1.username = "admin1"
+    admin1.email = "admin1@example.com"
+    admin2 = mock.MagicMock()
+    admin2.username = "admin2"
+    admin2.email = "admin2@example.com"
+
+    send_org_recovery_email(org, [admin1, admin2])
+
+    assert mock_send_email.call_count == 2
+    calls = mock_send_email.call_args_list
+    assert calls[0][0][0] == "admin1@example.com"
+    assert calls[1][0][0] == "admin2@example.com"
+
+
+@mock.patch("util.useremails.send_email")
+def test_send_org_recovery_email_no_contact_no_admins(mock_send_email, initialized_db):
+    """Test that no emails are sent when no contact_email and no admin emails."""
+    org = mock.MagicMock()
+    org.username = "testorg"
+    admin = mock.MagicMock()
+    admin.username = "admin1"
+    admin.email = None
+
+    send_org_recovery_email(org, [admin])
+
+    mock_send_email.assert_not_called()

--- a/util/useremails.py
+++ b/util/useremails.py
@@ -167,17 +167,20 @@ def send_repo_authorization_email(namespace, repository, email, token):
     )
 
 
-def send_org_recovery_email(org, admin_users):
+def send_org_recovery_email(org, admin_users, contact_email=None):
     subject = "Organization %s recovery" % (org.username)
-    send_email(
-        org.email,
-        subject,
-        "orgrecovery",
-        {
-            "organization": org.username,
-            "admin_usernames": [user.username for user in admin_users],
-        },
-    )
+    params = {
+        "organization": org.username,
+        "admin_usernames": [user.username for user in admin_users],
+    }
+
+    if contact_email:
+        send_email(contact_email, subject, "orgrecovery", params)
+    else:
+        # Fallback: send to each admin user's personal email
+        for admin in admin_users:
+            if admin.email:
+                send_email(admin.email, subject, "orgrecovery", params)
 
 
 def send_recovery_email(email, token):


### PR DESCRIPTION
## Summary
- Update org `GET`/`POST`/`PUT` API endpoints to use `contact_email` from `OrganizationContactEmail` table
- Remove `FEATURE_MAILING` email requirement for org creation
- Remove `User.email` uniqueness check from org update (contact_email is non-unique)
- Maintain backward compat: `email` field in requests maps to `contact_email`, responses include both fields

## Test plan
- [x] 8 new API tests passing locally (19 total in test_organization.py)
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)