### PR TITLE
NO-ISSUE: feat(serve): add -config flag to load Quay config for registry server

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -17,10 +17,13 @@ import (
 
 	// Registers the filesystem storage driver with the distribution driver factory.
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/filesystem"
+
+	"github.com/quay/quay/internal/config"
 )
 
 func runServe(args []string) int {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	configPath := fs.String("config", "", "path to Quay config.yaml or config directory")
 	addr := fs.String("addr", "127.0.0.1:5000", "listen address (host:port)")
 	root := fs.String("root", "/var/lib/registry", "root directory for image storage")
 	if err := fs.Parse(args); err != nil {
@@ -30,20 +33,18 @@ func runServe(args []string) int {
 		return 1
 	}
 
-	// Minimal distribution config: filesystem storage with delete support.
-	// Auth, TLS, and metrics are left unconfigured for local use.
-	cfg := &configuration.Configuration{
-		Storage: configuration.Storage{
-			"filesystem": configuration.Parameters{
-				"rootdirectory": *root,
-			},
-			"delete": configuration.Parameters{
-				"enabled": true,
-			},
-		},
+	// Track which flags were explicitly set so CLI overrides only apply
+	// when the user actually provided them.
+	explicit := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) { explicit[f.Name] = true })
+
+	cfg, err := buildConfig(*configPath, *addr, *root, explicit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
 	}
 
-	cfg.HTTP.Addr = *addr
+	listenAddr, storageRoot := resolveListenConfig(cfg, *root)
 
 	// Root context canceled on SIGINT/SIGTERM; propagates to the
 	// distribution app and all in-flight HTTP requests.
@@ -55,7 +56,7 @@ func runServe(args []string) int {
 	app := handlers.NewApp(ctx, cfg)
 
 	srv := &http.Server{
-		Addr:              *addr,
+		Addr:              listenAddr,
 		Handler:           app,
 		ReadHeaderTimeout: 10 * time.Second,
 
@@ -65,7 +66,7 @@ func runServe(args []string) int {
 
 	errCh := make(chan error, 1)
 	go func() {
-		fmt.Fprintf(os.Stderr, "registry listening on %s (storage: %s)\n", *addr, *root)
+		fmt.Fprintf(os.Stderr, "registry listening on %s (storage: %s)\n", listenAddr, storageRoot)
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}
@@ -93,4 +94,60 @@ func runServe(args []string) int {
 
 	fmt.Fprintln(os.Stderr, "stopped")
 	return 0
+}
+
+// buildConfig constructs a distribution Configuration from a Quay config file
+// (if provided) or falls back to a minimal hardcoded config. CLI flags in
+// explicit override the corresponding config values.
+func buildConfig(configPath, addr, root string, explicit map[string]bool) (*configuration.Configuration, error) {
+	if configPath != "" {
+		quayCfg, err := config.Load(configPath)
+		if err != nil {
+			return nil, err
+		}
+
+		cfg, err := config.ToDistribution(quayCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		// CLI flags override config file values when explicitly set.
+		if explicit["addr"] {
+			cfg.HTTP.Addr = addr
+		}
+		if explicit["root"] {
+			if fsCfg, ok := cfg.Storage["filesystem"]; ok {
+				fsCfg["rootdirectory"] = root
+				cfg.Storage["filesystem"] = fsCfg
+			}
+		}
+		return cfg, nil
+	}
+
+	// No config file: minimal hardcoded config (original behavior).
+	cfg := &configuration.Configuration{
+		Storage: configuration.Storage{
+			"filesystem": configuration.Parameters{
+				"rootdirectory": root,
+			},
+			"delete": configuration.Parameters{
+				"enabled": true,
+			},
+		},
+	}
+	cfg.HTTP.Addr = addr
+	return cfg, nil
+}
+
+// resolveListenConfig extracts the listen address and storage root from a
+// resolved configuration.
+func resolveListenConfig(cfg *configuration.Configuration, rootDefault string) (listenAddr, storageRoot string) {
+	listenAddr = cfg.HTTP.Addr
+	storageRoot = rootDefault
+	if fsCfg, ok := cfg.Storage["filesystem"]; ok {
+		if dir, ok := fsCfg["rootdirectory"].(string); ok {
+			storageRoot = dir
+		}
+	}
+	return listenAddr, storageRoot
 }

--- a/internal/config/distribution.go
+++ b/internal/config/distribution.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/distribution/distribution/v3/configuration"
+)
+
+// ToDistribution translates a Quay Config into a distribution Configuration.
+// Only LocalStorage is currently supported.
+func ToDistribution(cfg *Config) (*configuration.Configuration, error) {
+	storagePath, err := ResolveStoragePath(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	distCfg := &configuration.Configuration{
+		Storage: configuration.Storage{
+			"filesystem": configuration.Parameters{
+				"rootdirectory": storagePath,
+			},
+			"delete": configuration.Parameters{
+				"enabled": true,
+			},
+		},
+	}
+
+	distCfg.HTTP.Addr = ResolveAddr(cfg.ServerHostname)
+
+	return distCfg, nil
+}
+
+// ResolveStoragePath extracts the filesystem storage_path from the Quay config.
+// It uses the first preference or the sole entry when only one is defined.
+func ResolveStoragePath(cfg *Config) (string, error) {
+	if len(cfg.DistributedStorageConfig) == 0 {
+		return "", fmt.Errorf("no DISTRIBUTED_STORAGE_CONFIG defined")
+	}
+
+	var entry StorageEntry
+
+	switch {
+	case len(cfg.DistributedStoragePreference) > 0:
+		id := cfg.DistributedStoragePreference[0]
+		e, ok := cfg.DistributedStorageConfig[id]
+		if !ok {
+			return "", fmt.Errorf("preferred storage %q not found in DISTRIBUTED_STORAGE_CONFIG", id)
+		}
+		entry = e
+
+	case len(cfg.DistributedStorageConfig) == 1:
+		for _, e := range cfg.DistributedStorageConfig {
+			entry = e
+		}
+
+	default:
+		return "", fmt.Errorf("multiple storage entries defined but no DISTRIBUTED_STORAGE_PREFERENCE set")
+	}
+
+	if entry.Driver != "LocalStorage" {
+		return "", fmt.Errorf("unsupported storage driver %q; only LocalStorage is currently supported", entry.Driver)
+	}
+
+	path, ok := entry.Params["storage_path"]
+	if !ok {
+		return "", fmt.Errorf("LocalStorage entry missing storage_path parameter")
+	}
+
+	pathStr, ok := path.(string)
+	if !ok {
+		return "", fmt.Errorf("storage_path must be a string, got %T", path)
+	}
+
+	return pathStr, nil
+}
+
+// ResolveAddr normalizes a SERVER_HOSTNAME value into a listen address.
+// If the hostname includes a port it is used as-is; otherwise ":5000" is
+// appended as a default.
+func ResolveAddr(hostname string) string {
+	if hostname == "" {
+		return "127.0.0.1:5000"
+	}
+	_, _, err := net.SplitHostPort(hostname)
+	if err != nil {
+		return net.JoinHostPort(hostname, "5000")
+	}
+	return hostname
+}

--- a/internal/config/distribution_test.go
+++ b/internal/config/distribution_test.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToDistribution_LocalStorage(t *testing.T) {
+	cfg := &Config{
+		Server: Server{ServerHostname: "localhost:9090"},
+		Storage: Storage{
+			DistributedStorageConfig: StorageEntries{
+				"default": {Driver: "LocalStorage", Params: map[string]any{"storage_path": "/data/registry"}},
+			},
+			DistributedStoragePreference: []string{"default"},
+		},
+	}
+
+	distCfg, err := ToDistribution(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "localhost:9090", distCfg.HTTP.Addr)
+	assert.Equal(t, "/data/registry", distCfg.Storage["filesystem"]["rootdirectory"])
+	assert.Equal(t, true, distCfg.Storage["delete"]["enabled"])
+}
+
+func TestToDistribution_UnsupportedDriver(t *testing.T) {
+	cfg := &Config{
+		Storage: Storage{
+			DistributedStorageConfig: StorageEntries{
+				"s3": {Driver: "S3Storage", Params: map[string]any{"s3_bucket": "mybucket"}},
+			},
+			DistributedStoragePreference: []string{"s3"},
+		},
+	}
+
+	_, err := ToDistribution(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported storage driver")
+}
+
+func TestToDistribution_NoStorageConfig(t *testing.T) {
+	cfg := &Config{}
+
+	_, err := ToDistribution(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no DISTRIBUTED_STORAGE_CONFIG")
+}
+
+func TestToDistribution_MissingStoragePath(t *testing.T) {
+	cfg := &Config{
+		Storage: Storage{
+			DistributedStorageConfig: StorageEntries{
+				"default": {Driver: "LocalStorage", Params: map[string]any{}},
+			},
+			DistributedStoragePreference: []string{"default"},
+		},
+	}
+
+	_, err := ToDistribution(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing storage_path")
+}
+
+func TestResolveAddr(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"localhost:8080", "localhost:8080"},
+		{"quay.example.com", "quay.example.com:5000"},
+		{"", "127.0.0.1:5000"},
+		{"0.0.0.0:5000", "0.0.0.0:5000"},
+		{"::1", "[::1]:5000"},
+		{"[::1]:8080", "[::1]:8080"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, ResolveAddr(tt.input))
+		})
+	}
+}
+
+func TestResolveStoragePath_PreferenceOverride(t *testing.T) {
+	cfg := &Config{
+		Storage: Storage{
+			DistributedStorageConfig: StorageEntries{
+				"primary":   {Driver: "LocalStorage", Params: map[string]any{"storage_path": "/primary"}},
+				"secondary": {Driver: "LocalStorage", Params: map[string]any{"storage_path": "/secondary"}},
+			},
+			DistributedStoragePreference: []string{"secondary"},
+		},
+	}
+
+	path, err := ResolveStoragePath(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "/secondary", path)
+}
+
+func TestResolveStoragePath_SingleEntryNoPreference(t *testing.T) {
+	cfg := &Config{
+		Storage: Storage{
+			DistributedStorageConfig: StorageEntries{
+				"only": {Driver: "LocalStorage", Params: map[string]any{"storage_path": "/only"}},
+			},
+		},
+	}
+
+	path, err := ResolveStoragePath(cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "/only", path)
+}
+
+func TestResolveStoragePath_MultipleNoPreference(t *testing.T) {
+	cfg := &Config{
+		Storage: Storage{
+			DistributedStorageConfig: StorageEntries{
+				"a": {Driver: "LocalStorage", Params: map[string]any{"storage_path": "/a"}},
+				"b": {Driver: "LocalStorage", Params: map[string]any{"storage_path": "/b"}},
+			},
+		},
+	}
+
+	_, err := ResolveStoragePath(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no DISTRIBUTED_STORAGE_PREFERENCE")
+}


### PR DESCRIPTION
Add config-to-distribution translation in internal/config so the serve
command can read a Quay config.yaml and map LocalStorage and
SERVER_HOSTNAME to the distribution registry. CLI flags (-addr, -root)
override config values when explicitly provided.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
