### PR TITLE
poc: add database migration rollback POC and tooling (QUAYIO-1605)

### DIFF
--- a/agent_docs/database_rollback_sop.md
+++ b/agent_docs/database_rollback_sop.md
@@ -1,0 +1,275 @@
+# Database Migration Rollback — Standard Operating Procedure
+
+## Overview
+
+This document covers how to safely roll back (downgrade) an Alembic database migration in Quay. It was created as part of a POC using a dummy `poc_rollback_demo` table and the `tools/db_rollback.py` automation script.
+
+## Table of Contents
+
+1. [Background](#background)
+2. [POC Walkthrough](#poc-walkthrough)
+3. [Manual Rollback Steps](#manual-rollback-steps)
+4. [Automated Rollback (Recommended)](#automated-rollback-recommended)
+5. [Stage Environment Procedure](#stage-environment-procedure)
+6. [Troubleshooting](#troubleshooting)
+
+---
+
+## Background
+
+- Quay uses **Alembic** for schema migrations (`data/migrations/versions/`).
+- CICD automatically runs `alembic upgrade head` on deployment.
+- There is **no automated downgrade path** — rollbacks are manual.
+- Every migration file must implement both `upgrade()` and `downgrade()`.
+- The current revision is stored in the `alembic_version` table (single row).
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `alembic.ini` | Alembic configuration |
+| `data/migrations/env.py` | Runtime environment (DB URL resolution, engine creation) |
+| `data/migrations/versions/` | Migration scripts |
+| `tools/db_rollback.py` | Rollback automation script (this POC) |
+
+---
+
+## POC Walkthrough
+
+### What we're doing
+
+1. A dummy migration (`a1b2c3d4e5f7`) creates a `poc_rollback_demo` table.
+2. CICD deploys to stage → `alembic upgrade head` runs → table is created.
+3. We then manually execute a downgrade to remove the table, verifying the full rollback process.
+
+### The dummy migration
+
+**File:** `data/migrations/versions/a1b2c3d4e5f7_add_poc_rollback_demo_table.py`
+
+- **upgrade:** Creates `poc_rollback_demo` table with `id`, `name`, `description`, `created_at` columns and a unique index on `name`.
+- **downgrade:** Drops the index and then the table.
+- **Depends on:** `15f06d00c4b3` (the current head at time of writing).
+
+### Step-by-step POC execution
+
+```
+1. Merge the migration to main/master
+2. CICD deploys to stage (alembic upgrade head runs automatically)
+3. Verify: connect to stage DB and confirm the table exists
+4. Run the rollback (see sections below)
+5. Verify: confirm the table is gone and alembic_version is reverted
+```
+
+---
+
+## Manual Rollback Steps
+
+Use these when you cannot run the automation script (e.g., restricted environments).
+
+### Prerequisites
+
+- Shell access to a Quay pod or a host that can reach the database.
+- `PYTHONPATH` set to the Quay repo root.
+- Quay config available (typically at `conf/stack/config.yaml`).
+
+### 1. Check current state
+
+```bash
+# From inside the Quay container / pod:
+PYTHONPATH=. alembic current
+```
+
+Expected output includes the current revision hash, e.g., `a1b2c3d4e5f7 (head)`.
+
+You can also check directly in PostgreSQL:
+
+```sql
+SELECT version_num FROM alembic_version;
+```
+
+### 2. Verify the downgrade target
+
+Look at the migration file to confirm what `down_revision` points to:
+
+```bash
+head -12 data/migrations/versions/a1b2c3d4e5f7_add_poc_rollback_demo_table.py
+```
+
+You should see `down_revision = "15f06d00c4b3"`.
+
+### 3. Preview the downgrade SQL (dry run)
+
+```bash
+PYTHONPATH=. alembic downgrade -1 --sql
+```
+
+This prints the SQL without executing it. Review carefully.
+
+### 4. Execute the downgrade
+
+```bash
+# Roll back 1 step
+PYTHONPATH=. alembic downgrade -1
+
+# OR roll back to a specific revision
+PYTHONPATH=. alembic downgrade 15f06d00c4b3
+```
+
+### 5. Verify
+
+```bash
+PYTHONPATH=. alembic current
+# Should show: 15f06d00c4b3
+```
+
+```sql
+-- Confirm the table is gone
+SELECT tablename FROM pg_tables WHERE tablename = 'poc_rollback_demo';
+-- Should return 0 rows
+
+-- Confirm alembic_version
+SELECT version_num FROM alembic_version;
+-- Should return: 15f06d00c4b3
+```
+
+---
+
+## Automated Rollback (Recommended)
+
+The `tools/db_rollback.py` script wraps the manual steps with safety checks, a confirmation prompt, dry-run support, and post-rollback verification.
+
+### Quick reference
+
+```bash
+# All commands assume PYTHONPATH=. and are run from the Quay repo root.
+
+# 1. Check current migration state
+PYTHONPATH=. python tools/db_rollback.py --status
+
+# 2. View full migration history
+PYTHONPATH=. python tools/db_rollback.py --history
+
+# 3. Dry-run (preview SQL, no changes)
+PYTHONPATH=. python tools/db_rollback.py --dry-run --steps 1
+
+# 4. Roll back 1 migration (with confirmation prompt)
+PYTHONPATH=. python tools/db_rollback.py --steps 1
+
+# 5. Roll back to a specific revision
+PYTHONPATH=. python tools/db_rollback.py --target 15f06d00c4b3
+
+# 6. Roll back without confirmation (for scripted pipelines)
+PYTHONPATH=. python tools/db_rollback.py --steps 1 --yes
+
+# 7. Override DB connection string
+PYTHONPATH=. python tools/db_rollback.py --steps 1 --db-uri 'postgresql://user:pass@host:5432/quay'
+```
+
+### What the script does
+
+1. **Pre-flight checks** — reads `alembic_version`, resolves the target revision, prints a summary.
+2. **Confirmation prompt** — requires `y` to proceed (skip with `--yes`).
+3. **Downgrade execution** — calls `alembic.command.downgrade()`.
+4. **Post-rollback verification** — re-reads `alembic_version` and confirms it matches the target.
+
+### Dry-run output example
+
+```
+  DRY-RUN — SQL that would be executed:
+  ============================================================
+  DROP INDEX poc_rollback_demo_name;
+  DROP TABLE poc_rollback_demo;
+  UPDATE alembic_version SET version_num='15f06d00c4b3' WHERE ...;
+  ============================================================
+```
+
+---
+
+## Stage Environment Procedure
+
+### Before you start
+
+1. **Notify the team** — post in the relevant channel that you're performing a DB rollback on stage.
+2. **Confirm no active deployments** — ensure CICD is not mid-deploy (it would re-run `upgrade head` and undo your downgrade).
+3. **Take a DB snapshot** — if your stage environment supports it, snapshot the RDS/CloudSQL instance first.
+
+### Execution (from a Quay pod)
+
+```bash
+# 1. Exec into a Quay pod
+oc rsh <quay-pod-name>
+# or
+kubectl exec -it <quay-pod-name> -- /bin/bash
+
+# 2. Check current state
+PYTHONPATH=/quay-registry python /quay-registry/tools/db_rollback.py --status
+
+# 3. Dry-run
+PYTHONPATH=/quay-registry python /quay-registry/tools/db_rollback.py --dry-run --steps 1
+
+# 4. Execute rollback
+PYTHONPATH=/quay-registry python /quay-registry/tools/db_rollback.py --steps 1
+
+# 5. Verify (also check directly in psql if possible)
+PYTHONPATH=/quay-registry python /quay-registry/tools/db_rollback.py --status
+```
+
+### After rollback
+
+1. **Prevent CICD from re-upgrading.** The next deployment will run `alembic upgrade head` and re-apply the migration you just rolled back. Options:
+   - Revert the migration file from the branch/release before redeploying.
+   - Or gate the deployment until the migration fix is merged.
+2. **Verify application health** — confirm Quay pods are running, API responds, and no errors in logs related to missing tables/columns.
+
+---
+
+## Troubleshooting
+
+### `alembic_version` table is missing
+
+The database was never initialized with Alembic. You'll need to stamp it:
+
+```bash
+PYTHONPATH=. alembic stamp <known_good_revision>
+```
+
+### Downgrade fails mid-way
+
+The `transactional_ddl` setting in `env.py` is `False` for online mode, meaning **DDL statements are not wrapped in a transaction on PostgreSQL** (PostgreSQL actually supports transactional DDL, but Quay disables it). If a downgrade fails partway:
+
+1. Check which DDL statements already executed (inspect the schema).
+2. Manually complete or revert the remaining steps.
+3. Update `alembic_version` to the correct revision:
+   ```sql
+   UPDATE alembic_version SET version_num = '<correct_revision>';
+   ```
+
+### CICD re-applied the migration after rollback
+
+The deployment pipeline runs `alembic upgrade head`. If you rolled back but a new deploy happened, the migration is re-applied. To prevent this:
+- Remove or revert the migration file from the release branch before deploying.
+
+### "No such revision" error
+
+This happens when the `alembic_version` table references a revision that doesn't exist in the codebase (e.g., you rolled back to a revision from a different branch). Fix by stamping:
+
+```bash
+PYTHONPATH=. alembic stamp <revision_that_exists>
+```
+
+---
+
+## Cleanup
+
+After the POC is validated, remove the dummy migration:
+
+```bash
+rm data/migrations/versions/a1b2c3d4e5f7_add_poc_rollback_demo_table.py
+```
+
+If the table was created in any environment, drop it manually:
+
+```sql
+DROP TABLE IF EXISTS poc_rollback_demo;
+UPDATE alembic_version SET version_num = '15f06d00c4b3';
+```

--- a/data/migrations/versions/a1b2c3d4e5f7_add_poc_rollback_demo_table.py
+++ b/data/migrations/versions/a1b2c3d4e5f7_add_poc_rollback_demo_table.py
@@ -1,0 +1,35 @@
+"""add poc_rollback_demo table
+
+Revision ID: a1b2c3d4e5f7
+Revises: 15f06d00c4b3
+Create Date: 2026-03-16 00:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f7"
+down_revision = "15f06d00c4b3"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    op.create_table(
+        "poc_rollback_demo",
+        sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_poc_rollback_demo")),
+    )
+    op.create_index(
+        "poc_rollback_demo_name",
+        "poc_rollback_demo",
+        ["name"],
+        unique=True,
+    )
+
+
+def downgrade(op, tables, tester):
+    op.drop_index("poc_rollback_demo_name", table_name="poc_rollback_demo")
+    op.drop_table("poc_rollback_demo")

--- a/tools/db_rollback.py
+++ b/tools/db_rollback.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""
+Database Migration Rollback Tool for Quay
+
+Automates safe Alembic downgrades with pre-flight checks, dry-run support,
+and post-rollback verification. Designed to be run from inside a Quay
+container or a pod with access to the Quay database.
+
+Usage:
+    # Show current migration state
+    python tools/db_rollback.py --status
+
+    # Show migration history (chain)
+    python tools/db_rollback.py --history
+
+    # Dry-run: preview the SQL that would be executed to roll back 1 migration
+    python tools/db_rollback.py --dry-run --steps 1
+
+    # Roll back the most recent migration
+    python tools/db_rollback.py --steps 1
+
+    # Roll back to a specific revision
+    python tools/db_rollback.py --target <revision_id>
+
+    # Roll back with explicit DB URI (overrides config.yaml)
+    python tools/db_rollback.py --steps 1 --db-uri 'postgresql://user:pass@host/db'
+
+Environment:
+    PYTHONPATH must include the Quay repo root.
+    Quay config.yaml must be loadable (or pass --db-uri).
+"""
+
+import argparse
+import io
+import logging
+import os
+import sys
+import textwrap
+from contextlib import redirect_stdout
+from datetime import datetime
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger("db_rollback")
+
+ALEMBIC_INI = os.path.join(os.path.dirname(__file__), "..", "alembic.ini")
+
+
+def _get_alembic_config(db_uri_override=None):
+    """Build an Alembic Config object, optionally overriding the DB URI."""
+    from alembic.config import Config
+
+    cfg = Config(os.path.abspath(ALEMBIC_INI))
+
+    if db_uri_override:
+        os.environ["QUAY_OVERRIDE_CONFIG"] = '{"DB_URI":"%s"}' % db_uri_override
+
+    return cfg
+
+
+def _get_engine(db_uri_override=None):
+    """Create a SQLAlchemy engine using Quay's config chain."""
+    if db_uri_override:
+        from sqlalchemy import create_engine
+
+        return create_engine(db_uri_override)
+
+    from app import app
+
+    db_url = app.config.get("DB_URI", "sqlite:///test/data/test.db")
+    from sqlalchemy import create_engine
+
+    return create_engine(db_url)
+
+
+def _get_current_head(engine):
+    """Read the current revision from alembic_version table."""
+    from sqlalchemy import text
+
+    with engine.connect() as conn:
+        result = conn.execute(text("SELECT version_num FROM alembic_version"))
+        rows = list(result)
+        if not rows:
+            return None
+        return rows[0][0]
+
+
+def _get_script_directory(cfg):
+    """Return Alembic's ScriptDirectory for walking the revision graph."""
+    from alembic.script import ScriptDirectory
+
+    return ScriptDirectory.from_config(cfg)
+
+
+def _table_exists(engine, table_name):
+    """Check whether a table exists in the database."""
+    from sqlalchemy import inspect
+
+    inspector = inspect(engine)
+    return table_name in inspector.get_table_names()
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_status(engine, cfg):
+    """Print the current database migration revision."""
+    current = _get_current_head(engine)
+    script = _get_script_directory(cfg)
+
+    if current is None:
+        logger.info("No alembic_version row found — database may be uninitialized.")
+        return
+
+    try:
+        rev = script.get_revision(current)
+        desc = rev.doc if rev else "(unknown)"
+    except Exception:
+        desc = "(unable to resolve)"
+
+    head = script.get_current_head()
+    at_head = current == head
+
+    print()
+    print(f"  Current revision : {current}")
+    print(f"  Description      : {desc}")
+    print(f"  Alembic head     : {head}")
+    print(f"  Up to date       : {'YES' if at_head else 'NO — upgrades pending'}")
+    print()
+
+
+def cmd_history(engine, cfg):
+    """Print the linear migration history (newest first)."""
+    script = _get_script_directory(cfg)
+    current = _get_current_head(engine)
+
+    print()
+    print("  Migration history (newest → oldest):")
+    print("  " + "-" * 60)
+
+    for rev in script.walk_revisions():
+        marker = " ◀ current" if rev.revision == current else ""
+        print(f"  {rev.revision}  {rev.doc}{marker}")
+
+    print()
+
+
+def cmd_dry_run(cfg, target):
+    """
+    Generate the SQL that a downgrade would execute without touching the DB.
+    Uses Alembic's offline mode.
+    """
+    from alembic.command import downgrade
+
+    print()
+    print("  DRY-RUN — SQL that would be executed:")
+    print("  " + "=" * 60)
+
+    buf = io.StringIO()
+    cfg.output_buffer = buf
+
+    downgrade(cfg, target, sql=True)
+
+    sql_output = buf.getvalue()
+    if sql_output.strip():
+        for line in sql_output.strip().splitlines():
+            print(f"  {line}")
+    else:
+        print("  (no SQL generated — target may already be current)")
+
+    print("  " + "=" * 60)
+    print()
+
+
+def cmd_downgrade(engine, cfg, target, skip_confirm=False):
+    """
+    Execute a downgrade with pre-flight checks, confirmation prompt, and
+    post-rollback verification.
+    """
+    from alembic.command import downgrade
+
+    current = _get_current_head(engine)
+    script = _get_script_directory(cfg)
+
+    if current is None:
+        logger.error("Cannot downgrade: no alembic_version found.")
+        sys.exit(1)
+
+    head = script.get_current_head()
+
+    # Resolve the target revision for display
+    if target.startswith("-"):
+        steps = int(target[1:])
+        rev = script.get_revision(current)
+        walk_target = current
+        for _ in range(steps):
+            r = script.get_revision(walk_target)
+            if r is None or r.down_revision is None:
+                logger.error("Cannot step back %d — only %d revisions above base.", steps, _)
+                sys.exit(1)
+            walk_target = r.down_revision
+        target_display = walk_target
+    else:
+        target_display = target
+
+    try:
+        target_rev = script.get_revision(target_display)
+        target_desc = target_rev.doc if target_rev else "(unknown)"
+    except Exception:
+        target_desc = "(unable to resolve)"
+
+    # --- Pre-flight summary ---
+    print()
+    print("  " + "=" * 60)
+    print("  DATABASE MIGRATION ROLLBACK")
+    print("  " + "=" * 60)
+    print(f"  Timestamp       : {datetime.utcnow().isoformat()}Z")
+    print(f"  Current revision: {current}")
+    print(f"  Target revision : {target_display}  ({target_desc})")
+    print(f"  Alembic head    : {head}")
+    print(
+        f"  alembic_version : {'exists' if _table_exists(engine, 'alembic_version') else 'MISSING'}"
+    )
+    print("  " + "-" * 60)
+
+    if current == target_display:
+        logger.info("Database is already at the target revision. Nothing to do.")
+        return
+
+    # --- Confirmation ---
+    if not skip_confirm:
+        answer = input("\n  Proceed with downgrade? [y/N]: ").strip().lower()
+        if answer != "y":
+            logger.info("Aborted by user.")
+            sys.exit(0)
+
+    # --- Execute ---
+    logger.info("Starting downgrade to %s ...", target_display)
+
+    try:
+        downgrade(cfg, target)
+    except Exception:
+        logger.exception("Downgrade FAILED. Database may be in an inconsistent state.")
+        logger.error("Investigate the alembic_version table and the schema manually.")
+        sys.exit(2)
+
+    # --- Post-rollback verification ---
+    new_current = _get_current_head(engine)
+    if new_current == target_display:
+        logger.info("Downgrade succeeded.")
+    else:
+        logger.warning(
+            "Unexpected state after downgrade: expected %s, got %s",
+            target_display,
+            new_current,
+        )
+
+    print()
+    print(f"  Post-rollback revision: {new_current}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Quay Database Migration Rollback Tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+            Examples:
+              %(prog)s --status
+              %(prog)s --history
+              %(prog)s --dry-run --steps 1
+              %(prog)s --steps 1
+              %(prog)s --target 15f06d00c4b3
+              %(prog)s --steps 1 --db-uri 'postgresql://user:pass@host/db'
+              %(prog)s --steps 1 --yes   # skip confirmation prompt
+        """
+        ),
+    )
+
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--status", action="store_true", help="Show current migration state")
+    action.add_argument("--history", action="store_true", help="Show migration history")
+    action.add_argument("--steps", type=int, metavar="N", help="Roll back N migrations")
+    action.add_argument(
+        "--target", type=str, metavar="REV", help="Roll back to a specific revision"
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print SQL without executing (requires --steps or --target)",
+    )
+    parser.add_argument(
+        "--db-uri", type=str, metavar="URI", help="Override DB URI (instead of config.yaml)"
+    )
+    parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    cfg = _get_alembic_config(db_uri_override=args.db_uri)
+    engine = _get_engine(db_uri_override=args.db_uri)
+
+    if args.status:
+        cmd_status(engine, cfg)
+        return
+
+    if args.history:
+        cmd_history(engine, cfg)
+        return
+
+    # Determine target string for Alembic
+    if args.steps:
+        target = f"-{args.steps}"
+    else:
+        target = args.target
+
+    if args.dry_run:
+        cmd_dry_run(cfg, target)
+    else:
+        cmd_downgrade(engine, cfg, target, skip_confirm=args.yes)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add dummy migration (poc_rollback_demo table) to test downgrade flow
- Add tools/db_rollback.py automation script with dry-run, status, history, and safe downgrade with pre-flight checks
- Add database_rollback_sop.md documenting manual and automated rollback procedures for stage/prod environments
- Fix pre-commit config: rename invalid stage 'pre-commit' to 'commit'
