### PR TITLE
NO-ISSUE: feat: Add container build timestamp to the UI

### DIFF
--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -35,6 +35,10 @@ from image.docker.schema1 import (
     DockerSchema1Manifest,
     MalformedSchema1Manifest,
 )
+from image.docker.schema2.list import DOCKER_SCHEMA2_MANIFESTLIST_CONTENT_TYPE
+from image.docker.schema2.manifest import DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE
+from image.oci.index import OCI_IMAGE_INDEX_CONTENT_TYPE
+from image.oci.manifest import OCI_IMAGE_MANIFEST_CONTENT_TYPE
 from util.bytes import Bytes
 from util.timedeltastring import convert_to_timedelta
 
@@ -193,13 +197,16 @@ def list_repository_tag_history(
     specific_tag_name is given, the tags are further filtered by name. If since is given, tags are
     further filtered to newer than that date.
 
-    Returns the full manifest row including manifest bytes. The manifest bytes are needed to parse config
-    layer information but to maintain same query number.
+    Note that the returned Manifest will not contain the manifest contents.
     """
     query = (
         Tag.select(
             Tag,
-            Manifest,
+            Manifest.id,
+            Manifest.digest,
+            Manifest.media_type,
+            Manifest.layers_compressed_size,
+            Manifest.config_media_type,
             can_use_read_replica=True,
         )
         .join(Manifest)

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -193,16 +193,13 @@ def list_repository_tag_history(
     specific_tag_name is given, the tags are further filtered by name. If since is given, tags are
     further filtered to newer than that date.
 
-    Note that the returned Manifest will not contain the manifest contents.
+    Returns the full manifest row including manifest bytes. The manifest bytes are needed to parse config
+    layer information but to maintain same query number.
     """
     query = (
         Tag.select(
             Tag,
-            Manifest.id,
-            Manifest.digest,
-            Manifest.media_type,
-            Manifest.layers_compressed_size,
-            Manifest.config_media_type,
+            Manifest,
             can_use_read_replica=True,
         )
         .join(Manifest)

--- a/endpoints/api/manifest.py
+++ b/endpoints/api/manifest.py
@@ -10,6 +10,7 @@ from flask import request
 
 import features
 from app import app, label_validator, storage
+from data.database import Manifest as ManifestTable
 from data.model import InvalidLabelKeyException, InvalidMediaTypeException
 from data.model.oci.retriever import RepositoryContentRetriever
 from data.model.pull_statistics import get_manifest_pull_statistics
@@ -78,6 +79,87 @@ def _layer_dict(manifest_layer, index):
     }
 
 
+def _enrich_child_manifests(manifest_list, repository_id):
+    """
+    Parses the manifest list and extracts the child manifest information. For each child, reads the
+    config layer and extracts the image built timestamp if it exists.
+    """
+    try:
+        manifest_json = json.loads(manifest_list.internal_manifest_bytes.as_unicode())
+        child_entries = manifest_json.get("manifests", [])
+    except Exception as e:
+        logger.debug("Could not parse manifest list %s: %s", manifest_list.digest, e)
+        return []
+
+    if not child_entries:
+        return []
+
+    # Collect child digests and batch process them
+    child_digests = [entry.get("digest") for entry in child_entries if entry.get("digest")]
+    child_manifests = ManifestTable.select(
+        ManifestTable.digest,
+        ManifestTable.manifest_bytes,
+    ).where(
+        ManifestTable.digest << child_digests,
+        ManifestTable.repository == repository_id,
+    )
+
+    child_by_digest = {child.digest: child for child in child_manifests}
+
+    # Extract config digests from children
+    config_digests_by_child = {}
+    for entry in child_entries:
+        child_digest = entry.get("digest")
+        if not child_digest:
+            continue
+        child = child_by_digest.get(child_digest)
+        if not child or not child.manifest_bytes:
+            continue
+
+        try:
+            child_manifest_json = json.loads(child.manifest_bytes)
+            config_obj = child_manifest_json.get("config")
+            if config_obj and config_obj.get("digest"):
+                config_digests_by_child[child_digest] = config_obj["digest"]
+        except Exception as e:
+            logger.debug("Failed to parse child manifest %s: %s", child_digest, e)
+
+    # Construct the timestamp cache for all child manifests
+    timestamp_cache = {}
+    if config_digests_by_child:
+        retriever = RepositoryContentRetriever(repository_id, storage)
+        for child_digest, config_digest in config_digests_by_child.items():
+            try:
+                config_bytes = retriever.get_blob_bytes_with_digest(config_digest)
+                if config_bytes:
+                    config_json = json.loads(config_bytes.decode("utf-8"))
+                    created = config_json.get("created")
+                    if created:
+                        timestamp_cache[child_digest] = created
+            except Exception as e:
+                logger.debug(
+                    "Failed to fetch config digest %s for child digest %s: %s",
+                    config_digest,
+                    child_digest,
+                    e,
+                )
+
+    # build enriched child manifest list
+    enriched_children = []
+    for entry in child_entries:
+        child_digest = entry.get("digest")
+        enriched = {
+            "digest": child_digest,
+            "mediaType": entry.get("mediaType"),
+            "size": entry.get("size"),
+            "platform": entry.get("platform", {}),
+        }
+        if child_digest in timestamp_cache:
+            enriched["image_built"] = timestamp_cache[child_digest]
+        enriched_children.append(enriched)
+    return enriched_children
+
+
 def _manifest_dict(manifest):
     layers = None
     if not manifest.is_manifest_list:
@@ -86,7 +168,7 @@ def _manifest_dict(manifest):
             logger.debug("Missing layers for manifest `%s`", manifest.digest)
             abort(404)
 
-    return {
+    manifest_dict = {
         "digest": manifest.digest,
         "is_manifest_list": manifest.is_manifest_list,
         "manifest_data": manifest.internal_manifest_bytes.as_unicode(),
@@ -98,6 +180,14 @@ def _manifest_dict(manifest):
             [_layer_dict(lyr.layer_info, idx) for idx, lyr in enumerate(layers)] if layers else None
         ),
     }
+
+    # Enrich manifest list return to contain timestamps when images were built
+    if manifest.is_manifest_list:
+        manifest_dict["manifests"] = _enrich_child_manifests(
+            manifest,
+            manifest.repository._db_id,
+        )
+    return manifest_dict
 
 
 def _find_modelcard_layer(parsed):

--- a/endpoints/api/tag.py
+++ b/endpoints/api/tag.py
@@ -3,6 +3,8 @@ Manage the tags of a repository.
 """
 
 import json
+import logging
+import traceback
 from datetime import datetime
 
 from flask import abort, request
@@ -14,6 +16,7 @@ from auth.permissions import AdministerRepositoryPermission
 from data.database import Manifest as ManifestTable
 from data.model import ImmutableTagException
 from data.model.oci.manifest import is_manifest_present
+from data.model.oci.retriever import RepositoryContentRetriever
 from data.model.oci.tag import RetargetTagException
 from data.model.pull_statistics import (
     get_manifest_pull_statistics,
@@ -38,8 +41,70 @@ from endpoints.api import (
     validate_json_request,
 )
 from endpoints.exception import InvalidRequest, NotFound, TagImmutable, Unauthorized
+from image.docker.schema1 import DOCKER_SCHEMA1_CONTENT_TYPES
 from util.names import TAG_ERROR, TAG_REGEX
 from util.parsing import truthy_bool
+
+logger = logging.getLogger(__name__)
+
+
+def _load_image_built_timestamp(tags: list, repository_id: int) -> dict[int, str]:
+    """
+    Loads the image_built property for all tags in a repository which are not manifest lists. Returns
+    a dictionary mapping between the manifest id and its creation date.
+    """
+    config_digests_by_manifest = {}
+    timestamp_cache = {}
+    manifest_bytes_str = None
+
+    for tag in tags:
+        if tag.manifest.is_manifest_list:
+            continue
+        try:
+            if tag.manifest.internal_manifest_bytes is None:
+                logger.warning("Manifest %s has no internal_manifest_bytes.", tag.manifest._db_id)
+                continue
+            manifest_bytes_str = tag.manifest.internal_manifest_bytes.as_unicode()
+            media_type = tag.manifest.media_type
+            manifest_json = json.loads(manifest_bytes_str)
+
+            # handle schema 1 images separately
+            if media_type in list(DOCKER_SCHEMA1_CONTENT_TYPES):
+                history = manifest_json.get("history", [])
+                if history and len(history) > 0:
+                    v1_compat_str = history[0].get("v1Compatibility")
+                    if v1_compat_str:
+                        v1_compat_json = json.loads(v1_compat_str)
+                        created = v1_compat_json.get("created")
+                        if created:
+                            timestamp_cache[tag.manifest._db_id] = created
+
+            # If image is Docker v2 schema 2 or OCI:
+            else:
+                config_obj = manifest_json.get("config")
+                if config_obj and config_obj.get("digest"):
+                    config_digests_by_manifest[tag.manifest._db_id] = config_obj["digest"]
+        except Exception as e:
+            logger.debug(
+                "Failed to parse manifest %s for batch loading: %s", tag.manifest.digest, e
+            )
+            continue
+
+    if not config_digests_by_manifest:
+        return timestamp_cache
+
+    retriever = RepositoryContentRetriever(repository_id, storage)
+    for manifest_id, config_digest in config_digests_by_manifest.items():
+        try:
+            config_bytes = retriever.get_blob_bytes_with_digest(config_digest)
+            if config_bytes:
+                config_json = json.loads(config_bytes.decode("utf-8"))
+                created = config_json.get("created")
+                if created:
+                    timestamp_cache[manifest_id] = created
+        except Exception as e:
+            logger.debug("Failed to fetch config layer %s: %s", config_digest, e)
+    return timestamp_cache
 
 
 def _get_sparse_manifest_info(manifest_id, repository_id):
@@ -108,7 +173,7 @@ def _get_sparse_manifest_info(manifest_id, repository_id):
     return is_sparse, child_manifest_count, present_child_count, child_presence_map
 
 
-def _tag_dict(tag):
+def _tag_dict(tag, image_built_cache):
     tag_info = {
         "name": tag.name,
         "reversion": tag.reversion,
@@ -144,6 +209,9 @@ def _tag_dict(tag):
         tag_info["child_manifest_count"] = child_count
         tag_info["present_child_count"] = present_count
         tag_info["child_manifests_presence"] = presence_map
+    else:
+        if image_built_cache is not None and tag.manifest._db_id in image_built_cache:
+            tag_info["image_built"] = image_built_cache[tag.manifest._db_id]
 
     return tag_info
 
@@ -194,8 +262,10 @@ class ListRepositoryTags(RepositoryParamResource):
             print("error", error)
             custom_abort(400, message=str(error))
 
+        image_built_cache = _load_image_built_timestamp(history, repo_ref.id)
+
         return {
-            "tags": [_tag_dict(tag) for tag in history],
+            "tags": [_tag_dict(tag, image_built_cache) for tag in history],
             "page": page,
             "has_additional": has_more,
         }

--- a/endpoints/api/tag.py
+++ b/endpoints/api/tag.py
@@ -8,12 +8,14 @@ import traceback
 from datetime import datetime
 
 from flask import abort, request
+from peewee import SQL
 
 import features
 from app import app, docker_v2_signing_key, model_cache, storage
 from auth.auth_context import get_authenticated_user
 from auth.permissions import AdministerRepositoryPermission
 from data.database import Manifest as ManifestTable
+from data.database import db
 from data.model import ImmutableTagException
 from data.model.oci.manifest import is_manifest_present
 from data.model.oci.retriever import RepositoryContentRetriever
@@ -42,10 +44,29 @@ from endpoints.api import (
 )
 from endpoints.exception import InvalidRequest, NotFound, TagImmutable, Unauthorized
 from image.docker.schema1 import DOCKER_SCHEMA1_CONTENT_TYPES
+from image.docker.schema2.list import DOCKER_SCHEMA2_MANIFESTLIST_CONTENT_TYPE
+from image.docker.schema2.manifest import DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE
+from image.oci.index import OCI_IMAGE_INDEX_CONTENT_TYPE
+from image.oci.manifest import OCI_IMAGE_MANIFEST_CONTENT_TYPE
 from util.names import TAG_ERROR, TAG_REGEX
 from util.parsing import truthy_bool
 
 logger = logging.getLogger(__name__)
+
+
+def _fetch_config_timestamp(config_digest: str, retriever) -> str | None:
+    """
+    Fetches a config blob from storage and extracts the 'created' timestamp.
+    Returns the timestamp string or None if not found.
+    """
+    try:
+        config_bytes = retriever.get_blob_bytes_with_digest(config_digest)
+        if config_bytes:
+            config_json = json.loads(config_bytes.decode("utf-8"))
+            return config_json.get("created")
+    except Exception as e:
+        logger.debug("Failed to fetch config layer %s: %s", config_digest, e)
+    return None
 
 
 def _load_image_built_timestamp(tags: list, repository_id: int) -> dict[int, str]:
@@ -53,23 +74,36 @@ def _load_image_built_timestamp(tags: list, repository_id: int) -> dict[int, str
     Loads the image_built property for all tags in a repository which are not manifest lists. Returns
     a dictionary mapping between the manifest id and its creation date.
     """
-    config_digests_by_manifest = {}
     timestamp_cache = {}
-    manifest_bytes_str = None
+
+    # lists of ids for batch loading
+    v1_list = []
+    v2_list = []
 
     for tag in tags:
         if tag.manifest.is_manifest_list:
             continue
-        try:
-            if tag.manifest.internal_manifest_bytes is None:
-                logger.warning("Manifest %s has no internal_manifest_bytes.", tag.manifest._db_id)
-                continue
-            manifest_bytes_str = tag.manifest.internal_manifest_bytes.as_unicode()
-            media_type = tag.manifest.media_type
-            manifest_json = json.loads(manifest_bytes_str)
+        # Check what kind of image the tag is
+        if tag.manifest.media_type in (
+            OCI_IMAGE_MANIFEST_CONTENT_TYPE,
+            DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE,
+        ):
+            v2_list.append(tag.manifest._db_id)
+            continue
+        if tag.manifest.media_type in DOCKER_SCHEMA1_CONTENT_TYPES:
+            v1_list.append(tag.manifest._db_id)
+            continue
 
-            # handle schema 1 images separately
-            if media_type in list(DOCKER_SCHEMA1_CONTENT_TYPES):
+    # batch load all collected manifests in one fell swoop
+    if v1_list:
+        schema_v1_manifests = ManifestTable.select(
+            ManifestTable.id,
+            ManifestTable.digest,
+            ManifestTable.manifest_bytes,
+        ).where(ManifestTable.id << v1_list)
+        for manifest in schema_v1_manifests:
+            try:
+                manifest_json = json.loads(manifest.manifest_bytes)
                 history = manifest_json.get("history", [])
                 if history and len(history) > 0:
                     v1_compat_str = history[0].get("v1Compatibility")
@@ -77,33 +111,50 @@ def _load_image_built_timestamp(tags: list, repository_id: int) -> dict[int, str
                         v1_compat_json = json.loads(v1_compat_str)
                         created = v1_compat_json.get("created")
                         if created:
-                            timestamp_cache[tag.manifest._db_id] = created
-
-            # If image is Docker v2 schema 2 or OCI:
-            else:
-                config_obj = manifest_json.get("config")
-                if config_obj and config_obj.get("digest"):
-                    config_digests_by_manifest[tag.manifest._db_id] = config_obj["digest"]
-        except Exception as e:
-            logger.debug(
-                "Failed to parse manifest %s for batch loading: %s", tag.manifest.digest, e
-            )
-            continue
-
-    if not config_digests_by_manifest:
-        return timestamp_cache
+                            timestamp_cache[manifest.id] = created
+            except Exception as e:
+                logger.debug("Could not parse schema 1 manifest %s: %s", manifest.digest, e)
 
     retriever = RepositoryContentRetriever(repository_id, storage)
-    for manifest_id, config_digest in config_digests_by_manifest.items():
-        try:
-            config_bytes = retriever.get_blob_bytes_with_digest(config_digest)
-            if config_bytes:
-                config_json = json.loads(config_bytes.decode("utf-8"))
-                created = config_json.get("created")
-                if created:
-                    timestamp_cache[manifest_id] = created
-        except Exception as e:
-            logger.debug("Failed to fetch config layer %s: %s", config_digest, e)
+
+    if v2_list:
+        # Check if we're using PostgreSQL (supports JSONB operators)
+        is_postgres = db.obj.database.startswith("postgres")
+
+        if is_postgres:
+            # Optimized: Extract config digest using PostgreSQL JSONB operators
+            schema_v2_config_digests = (
+                ManifestTable.select(
+                    ManifestTable.id,
+                    SQL("manifest_bytes::jsonb->'config'->>'digest'").alias("config_digest"),
+                )
+                .where(ManifestTable.id << v2_list)
+                .dicts()
+            )
+
+            for row in schema_v2_config_digests:
+                config_digest = row.get("config_digest")
+                if config_digest:
+                    created = _fetch_config_timestamp(config_digest, retriever)
+                    if created:
+                        timestamp_cache[row["id"]] = created
+        else:
+            # Fallback for SQLite: Load manifest_bytes and parse in Python
+            schema_v2_manifests = ManifestTable.select(
+                ManifestTable.id,
+                ManifestTable.manifest_bytes,
+            ).where(ManifestTable.id << v2_list)
+
+            for manifest in schema_v2_manifests:
+                try:
+                    manifest_json = json.loads(manifest.manifest_bytes)
+                    config_digest = manifest_json.get("config", {}).get("digest")
+                    if config_digest:
+                        created = _fetch_config_timestamp(config_digest, retriever)
+                        if created:
+                            timestamp_cache[manifest.id] = created
+                except json.JSONDecodeError as e:
+                    logger.debug("Failed to parse manifest %d: %s", manifest.id, e)
     return timestamp_cache
 
 

--- a/endpoints/api/test/test_manifest.py
+++ b/endpoints/api/test/test_manifest.py
@@ -1,17 +1,29 @@
+import json
+import random
 from datetime import datetime
 
 from mock import patch
 
 from app import app as realapp
-from data.database import ManifestPullStatistics, TagPullStatistics
+from app import storage as app_storage
+from data.database import ImageStorage, ImageStorageLocation
+from data.database import Manifest as ManifestTable
+from data.database import ManifestPullStatistics, MediaType, TagPullStatistics
+from data.model import oci
+from data.model import storage as storage_model
+from data.model.blob import store_blob_record_and_temp_link
 from data.model.repository import create_repository
 from data.model.user import get_user
 from data.registry_model import registry_model
+from digest.digest_tools import sha256_digest
 from endpoints.api.manifest import RepositoryManifest, _get_modelcard_layer_digest
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
 from features import FeatureNameValue
-from image.oci.manifest import OCIManifest
+from image.docker.schema2.list import DockerSchema2ManifestListBuilder
+from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
+from image.oci.index import OCIIndexBuilder
+from image.oci.manifest import OCIManifest, OCIManifestBuilder
 from test.fixtures import *
 from util.bytes import Bytes
 
@@ -245,3 +257,359 @@ def test_repository_manifest_pull_statistics_multiple_pulls(app, initialized_db)
     assert stats is not None
     assert stats["pull_count"] == 150
     assert stats["last_pull_date"] is not None
+
+
+def _generate_config_layer(arch, layer_digest):
+    """
+    Helper function for generating config layer. Returns a config layer bytes and config layer digest
+    tuple to the main test function.
+    """
+    config = {
+        "architecture": arch,
+        "os": "linux",
+        "created": "2024-02-20T14:25:30.987654321Z",
+        "config": {"Env": ["PATH=/usr/local/bin:/usr/bin"]},
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": [
+                layer_digest,
+            ],
+        },
+        "history": [
+            {
+                "created": "2024-02-20T14:25:30.987654321Z",
+                "created_by": '/bin/sh -c # (NOP) CMD ["sh"]',
+            },
+        ],
+    }
+    config_bytes = json.dumps(config).encode("utf-8")
+    return config_bytes, sha256_digest(config_bytes)
+
+
+def test_enrich_child_manifests_with_timestamps(app, initialized_db):
+    """
+    Verifies that the API is returning the enriched manifest list data with built timestamps for each
+    individual child manifest.
+    """
+    layer_bytes = random.randbytes(1024)
+    layer_digest = sha256_digest(layer_bytes)
+
+    user = get_user("devtable")
+    repo = create_repository("devtable", "test-manifest-list-parsing", user)
+    assert repo is not None
+
+    location = ImageStorageLocation.get(name="local_us")
+
+    # Generate config layers
+    config_amd64_bytes, config_amd64_digest = _generate_config_layer("amd64", layer_digest)
+    config_arm64_bytes, config_arm64_digest = _generate_config_layer("arm64", layer_digest)
+
+    # Store shared layer between two manifests
+    shared_layer = ImageStorage.create(
+        content_checksum=layer_digest,
+        image_size=len(layer_bytes),
+        compressed_size=len(layer_bytes),
+    )
+    layer_blob = store_blob_record_and_temp_link(
+        "devtable",
+        "test-manifest-list-parsing",
+        layer_digest,
+        location,
+        len(layer_bytes),
+        3600,
+    )
+    app_storage.put_content(
+        ["local_us"],
+        storage_model.get_layer_path(layer_blob),
+        layer_bytes,
+    )
+
+    # Store config blobs
+    blob_amd64 = store_blob_record_and_temp_link(
+        "devtable",
+        "test-manifest-list-parsing",
+        config_amd64_digest,
+        location,
+        len(config_amd64_bytes),
+        3600,
+    )
+    blob_arm64 = store_blob_record_and_temp_link(
+        "devtable",
+        "test-manifest-list-parsing",
+        config_arm64_digest,
+        location,
+        len(config_arm64_bytes),
+        3600,
+    )
+
+    # Write both config blobs to storage
+    app_storage.put_content(
+        ["local_us"],
+        storage_model.get_layer_path(blob_amd64),
+        config_amd64_bytes,
+    )
+    app_storage.put_content(
+        ["local_us"],
+        storage_model.get_layer_path(blob_arm64),
+        config_arm64_bytes,
+    )
+
+    # Define builders
+    builder_amd64_docker = DockerSchema2ManifestBuilder()
+    builder_arm64_docker = DockerSchema2ManifestBuilder()
+    builder_amd64_oci = OCIManifestBuilder()
+    builder_arm64_oci = OCIManifestBuilder()
+
+    # First we'll build a Docker v2 schema 2 image
+    # for AMD64
+    builder_amd64_docker.set_config_digest(config_amd64_digest, len(config_amd64_bytes))
+    builder_amd64_docker.add_layer(layer_digest, len(layer_digest))
+    child_amd64_docker_manifest_obj = builder_amd64_docker.build()
+    created_amd64 = oci.manifest.get_or_create_manifest(
+        repo.id,
+        child_amd64_docker_manifest_obj,
+        app_storage,
+        raise_on_error=True,
+    )
+    assert created_amd64 is not None
+
+    # for Arm64
+    builder_arm64_docker.set_config_digest(config_arm64_digest, len(config_arm64_bytes))
+    builder_arm64_docker.add_layer(layer_digest, len(layer_digest))
+    child_arm64_docker_manifest_obj = builder_arm64_docker.build()
+    created_arm64 = oci.manifest.get_or_create_manifest(
+        repo.id,
+        child_arm64_docker_manifest_obj,
+        app_storage,
+        raise_on_error=True,
+    )
+    assert created_arm64 is not None
+
+    # Build Docker v2 manifest list from the two manifests
+    list_builder_docker = DockerSchema2ManifestListBuilder()
+    list_builder_docker.add_manifest(child_amd64_docker_manifest_obj, "amd64", "linux")
+    list_builder_docker.add_manifest(child_arm64_docker_manifest_obj, "arm64", "linux")
+    manifest_list = list_builder_docker.build()
+    assert manifest_list is not None
+
+    # Create manifest list in db
+    created_list = oci.manifest.get_or_create_manifest(repo.id, manifest_list, app_storage)
+    assert created_list is not None
+
+    # Add tag for the manifest list
+    tag = oci.tag.retarget_tag("latest", created_list.manifest.id, raise_on_error=True)
+    assert tag is not None
+
+    # call api
+    with client_with_identity("devtable", app) as cl:
+        params = {
+            "repository": "devtable/test-manifest-list-parsing",
+            "manifestref": created_list.manifest.digest,
+        }
+        result = conduct_api_call(cl, RepositoryManifest, "GET", params, None, 200).json
+        # Verify basic properties
+        assert result["digest"] == created_list.manifest.digest
+        assert result["is_manifest_list"] is True
+        assert "manifests" in result
+
+        # verify child manifests
+        manifests = result["manifests"]
+        assert len(manifests) == 2
+        amd64_entry = next((m for m in manifests if m["platform"]["architecture"] == "amd64"), None)
+        arm64_entry = next((m for m in manifests if m["platform"]["architecture"] == "arm64"), None)
+
+        assert amd64_entry is not None
+        assert arm64_entry is not None
+
+        # verify we have timestamps and other attributes
+        # for amd64 image
+        assert "image_built" in amd64_entry
+        assert amd64_entry["image_built"] == "2024-02-20T14:25:30.987654321Z"
+        assert amd64_entry["platform"]["os"] == "linux"
+        assert amd64_entry["digest"] == created_amd64.manifest.digest
+
+        # for arm64 image
+        assert "image_built" in arm64_entry
+        assert arm64_entry["image_built"] == "2024-02-20T14:25:30.987654321Z"
+        assert arm64_entry["platform"]["os"] == "linux"
+        assert arm64_entry["digest"] == created_arm64.manifest.digest
+
+    # reset all variables to None
+    created_amd64 = None
+    created_arm64 = None
+    created_list = None
+
+    # create OCI image and then repoint "latest" to the new OCI image
+    # for AMD64
+    builder_amd64_oci.set_config_digest(config_amd64_digest, len(config_amd64_bytes))
+    builder_amd64_oci.add_layer(layer_digest, len(layer_digest))
+    child_amd64_oci_manifest_obj = builder_amd64_oci.build()
+    created_amd64 = oci.manifest.get_or_create_manifest(
+        repo.id,
+        child_amd64_oci_manifest_obj,
+        app_storage,
+        raise_on_error=True,
+    )
+    assert created_amd64 is not None
+
+    # for Arm64
+    builder_arm64_oci.set_config_digest(config_arm64_digest, len(config_arm64_bytes))
+    builder_arm64_oci.add_layer(layer_digest, len(layer_digest))
+    child_arm64_oci_manifest_obj = builder_arm64_oci.build()
+    created_arm64 = oci.manifest.get_or_create_manifest(
+        repo.id,
+        child_arm64_oci_manifest_obj,
+        app_storage,
+        raise_on_error=True,
+    )
+    assert created_arm64 is not None
+
+    # build OCI image index
+    index_builder = OCIIndexBuilder()
+    index_builder.add_manifest(child_amd64_oci_manifest_obj, "amd64", "linux")
+    index_builder.add_manifest(child_arm64_oci_manifest_obj, "arm64", "linux")
+    index_manifest = index_builder.build()
+    assert index_manifest is not None
+
+    # Create manifest list in db
+    created_list = oci.manifest.get_or_create_manifest(repo.id, index_manifest, app_storage)
+    assert created_list is not None
+
+    # Add tag for the manifest list
+    tag = oci.tag.retarget_tag("latest", created_list.manifest.id, raise_on_error=True)
+    assert tag is not None
+
+    # call api
+    with client_with_identity("devtable", app) as cl:
+        params = {
+            "repository": "devtable/test-manifest-list-parsing",
+            "manifestref": created_list.manifest.digest,
+        }
+        result = conduct_api_call(cl, RepositoryManifest, "GET", params, None, 200).json
+        # Verify basic properties
+        assert result["digest"] == created_list.manifest.digest
+        assert result["is_manifest_list"] is True
+        assert "manifests" in result
+
+        # verify child manifests
+        manifests = result["manifests"]
+        assert len(manifests) == 2
+        amd64_entry = next((m for m in manifests if m["platform"]["architecture"] == "amd64"), None)
+        arm64_entry = next((m for m in manifests if m["platform"]["architecture"] == "arm64"), None)
+
+        assert amd64_entry is not None
+        assert arm64_entry is not None
+
+        # verify we have timestamps and other attributes
+        # for amd64 image
+        assert "image_built" in amd64_entry
+        assert amd64_entry["image_built"] == "2024-02-20T14:25:30.987654321Z"
+        assert amd64_entry["platform"]["os"] == "linux"
+        assert amd64_entry["digest"] == created_amd64.manifest.digest
+
+        # for arm64 image
+        assert "image_built" in arm64_entry
+        assert arm64_entry["image_built"] == "2024-02-20T14:25:30.987654321Z"
+        assert arm64_entry["platform"]["os"] == "linux"
+        assert arm64_entry["digest"] == created_arm64.manifest.digest
+
+
+def test_manifest_list_sparse_no_timestamps(app, initialized_db):
+    """
+    Test that sparse manifest list (missing child manifests) still returns platform info without timestamps.
+    This simulates proxy cache scenarios where the manifest list exists but children haven't been pulled.
+    """
+    user = get_user("devtable")
+    repo = create_repository("devtable", "test-sparse-manifest-list", user)
+
+    # Build manifest list with non-existent child manifests
+    list_builder = DockerSchema2ManifestListBuilder()
+
+    # These digests don't exist in the database - simulating sparse manifest list
+    fake_digest_amd64 = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    fake_digest_arm64 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    fake_digest_ppc64le = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+    list_builder.add_manifest_digest(
+        fake_digest_amd64,
+        1234,
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "amd64",
+        "linux",
+    )
+    list_builder.add_manifest_digest(
+        fake_digest_arm64,
+        5678,
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "arm64",
+        "linux",
+    )
+    list_builder.add_manifest_digest(
+        fake_digest_ppc64le,
+        9012,
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "ppc64le",
+        "linux",
+    )
+
+    manifest_list = list_builder.build()
+    manifest_list_bytes = manifest_list.bytes.as_encoded_str()
+    manifest_list_digest = sha256_digest(manifest_list_bytes)
+
+    # We need to inject the manifest directly to the database
+    media_type = MediaType.get(name="application/vnd.docker.distribution.manifest.list.v2+json")
+    created_manifest = ManifestTable.create(
+        digest=manifest_list_digest,
+        manifest_bytes=manifest_list_bytes,
+        media_type=media_type,
+        repository=repo.id,
+    )
+
+    tag = oci.tag.retarget_tag("latest", created_manifest.id, raise_on_error=True)
+    assert tag is not None
+
+    # Call the API endpoint
+    with client_with_identity("devtable", app) as cl:
+        params = {
+            "repository": "devtable/test-sparse-manifest-list",
+            "manifestref": manifest_list_digest,
+        }
+        result = conduct_api_call(cl, RepositoryManifest, "GET", params, None, 200).json
+
+        # Verify manifest list properties
+        assert result["digest"] == manifest_list_digest
+        assert result["is_manifest_list"] is True
+        assert "manifests" in result
+
+        # Verify child manifests are returned with platform info
+        manifests = result["manifests"]
+        assert len(manifests) == 3
+
+        # Find each architecture entry
+        amd64_entry = next((m for m in manifests if m["platform"]["architecture"] == "amd64"), None)
+        arm64_entry = next((m for m in manifests if m["platform"]["architecture"] == "arm64"), None)
+        ppc64le_entry = next(
+            (m for m in manifests if m["platform"]["architecture"] == "ppc64le"), None
+        )
+
+        assert amd64_entry is not None
+        assert arm64_entry is not None
+        assert ppc64le_entry is not None
+
+        # Verify platform info is present
+        assert amd64_entry["platform"]["os"] == "linux"
+        assert amd64_entry["digest"] == fake_digest_amd64
+        assert amd64_entry["size"] == 1234
+
+        assert arm64_entry["platform"]["os"] == "linux"
+        assert arm64_entry["digest"] == fake_digest_arm64
+        assert arm64_entry["size"] == 5678
+
+        assert ppc64le_entry["platform"]["os"] == "linux"
+        assert ppc64le_entry["digest"] == fake_digest_ppc64le
+        assert ppc64le_entry["size"] == 9012
+
+        # Verify NO timestamps are present (child manifests don't exist in DB)
+        assert "image_built" not in amd64_entry
+        assert "image_built" not in arm64_entry
+        assert "image_built" not in ppc64le_entry

--- a/endpoints/api/test/test_manifest.py
+++ b/endpoints/api/test/test_manifest.py
@@ -363,7 +363,7 @@ def test_enrich_child_manifests_with_timestamps(app, initialized_db):
     # First we'll build a Docker v2 schema 2 image
     # for AMD64
     builder_amd64_docker.set_config_digest(config_amd64_digest, len(config_amd64_bytes))
-    builder_amd64_docker.add_layer(layer_digest, len(layer_digest))
+    builder_amd64_docker.add_layer(layer_digest, len(layer_bytes))
     child_amd64_docker_manifest_obj = builder_amd64_docker.build()
     created_amd64 = oci.manifest.get_or_create_manifest(
         repo.id,
@@ -375,7 +375,7 @@ def test_enrich_child_manifests_with_timestamps(app, initialized_db):
 
     # for Arm64
     builder_arm64_docker.set_config_digest(config_arm64_digest, len(config_arm64_bytes))
-    builder_arm64_docker.add_layer(layer_digest, len(layer_digest))
+    builder_arm64_docker.add_layer(layer_digest, len(layer_bytes))
     child_arm64_docker_manifest_obj = builder_arm64_docker.build()
     created_arm64 = oci.manifest.get_or_create_manifest(
         repo.id,
@@ -442,7 +442,7 @@ def test_enrich_child_manifests_with_timestamps(app, initialized_db):
     # create OCI image and then repoint "latest" to the new OCI image
     # for AMD64
     builder_amd64_oci.set_config_digest(config_amd64_digest, len(config_amd64_bytes))
-    builder_amd64_oci.add_layer(layer_digest, len(layer_digest))
+    builder_amd64_oci.add_layer(layer_digest, len(layer_bytes))
     child_amd64_oci_manifest_obj = builder_amd64_oci.build()
     created_amd64 = oci.manifest.get_or_create_manifest(
         repo.id,
@@ -454,7 +454,7 @@ def test_enrich_child_manifests_with_timestamps(app, initialized_db):
 
     # for Arm64
     builder_arm64_oci.set_config_digest(config_arm64_digest, len(config_arm64_bytes))
-    builder_arm64_oci.add_layer(layer_digest, len(layer_digest))
+    builder_arm64_oci.add_layer(layer_digest, len(layer_bytes))
     child_arm64_oci_manifest_obj = builder_arm64_oci.build()
     created_arm64 = oci.manifest.get_or_create_manifest(
         repo.id,

--- a/endpoints/api/test/test_tag.py
+++ b/endpoints/api/test/test_tag.py
@@ -1,17 +1,29 @@
 import json
-from unittest.mock import patch
+import random
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 import pytest
 from playhouse.test_utils import assert_query_count
 
-from data.database import Manifest
-from data.model import DataModelException, ImmutableTagException
+from app import storage
+from data.database import ImageStorage, ImageStorageLocation, Manifest, ManifestBlob
+from data.model import DataModelException, ImmutableTagException, oci
+from data.model.blob import store_blob_record_and_temp_link
 from data.model.oci.tag import change_tag_expiration, set_tag_immutable
+from data.model.repository import create_repository
+from data.model.storage import get_layer_path
+from data.model.user import get_user
 from data.registry_model import registry_model
+from digest import digest_tools
 from endpoints.api.tag import ListRepositoryTags, RepositoryTag, RestoreTag
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity, toggle_feature
+from image.docker.schema1 import DockerSchema1Manifest
+from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
+from image.oci.manifest import OCIManifestBuilder
 from test.fixtures import *
+from util.bytes import Bytes
 
 
 @pytest.mark.parametrize(
@@ -712,3 +724,284 @@ def test_set_tag_immutable_allowed_when_config_permits():
         # Clean up
         set_tag_immutable(repo_ref.id, "latest", False)
         change_tag_expiration(tag_ref.id, None)
+
+
+def test_tag_created_timestamp_schema1(app, initialized_db):
+    """
+    Verifies that the created timestamp can be extracted from the Docker v2 schema 1 manifest. The value
+    is embedded into the v1Compatibility field.
+    """
+    layer_bytes = random.randbytes(1024)
+    layer_digest = digest_tools.sha256_digest(layer_bytes)
+
+    user = get_user("devtable")
+    repo = create_repository("devtable", "test-image-built-schema1", user)
+    assert repo is not None
+
+    layer_blob = ImageStorage.create(
+        content_checksum=layer_digest,
+        image_size=len(layer_bytes),
+        compressed_size=len(layer_bytes),
+    )
+
+    location = ImageStorageLocation.get(name="local_us")
+    store_blob_record_and_temp_link(
+        "devtable",
+        "test-image-built-schema1",
+        layer_digest,
+        location,
+        len(layer_bytes),
+        120,
+    )
+
+    schema1_manifest_json = {
+        "schemaVersion": 1,
+        "name": "devtable/test-image-built-schema1",
+        "tag": "schema1-tag",
+        "architecture": "amd64",
+        "fsLayers": [
+            {
+                "blobSum": layer_digest,
+            },
+        ],
+        "history": [
+            {
+                "v1Compatibility": json.dumps(
+                    {
+                        "id": "abc123",
+                        "created": "2024-01-15T10:30:45.123456789Z",
+                        "container_config": {
+                            "Cmd": ["/bin/sh"],
+                        },
+                        "architecture": "amd64",
+                        "os": "linux",
+                    }
+                ),
+            },
+        ],
+    }
+    manifest_bytes = Bytes.for_string_or_unicode(json.dumps(schema1_manifest_json))
+
+    manifest = DockerSchema1Manifest(manifest_bytes)
+    created_manifest = oci.manifest.get_or_create_manifest(
+        repo.id,
+        manifest,
+        storage,
+    )
+
+    test_tag_name = "schema1-tag"
+    tag = oci.tag.retarget_tag(test_tag_name, created_manifest.manifest.id, raise_on_error=True)
+    assert tag is not None
+
+    # call the tag api and check if image_built is available
+    with client_with_identity("devtable", app) as cl:
+        params = {
+            "repository": "devtable/test-image-built-schema1",
+        }
+        result = conduct_api_call(cl, ListRepositoryTags, "GET", params, None, 200).json
+        test_tag = next((t for t in result["tags"] if t["name"] == test_tag_name), None)
+        assert test_tag is not None
+        assert "image_built" in test_tag
+        assert test_tag["image_built"] == "2024-01-15T10:30:45.123456789Z"
+
+
+def test_tag_created_timestamp_schema2(app, initialized_db):
+    """
+    Verifies that the created timestamp can be extracted from the Docker v2 schema 2 manifest. The value, if exists,
+    is part of the config blob.
+    """
+    user = get_user("devtable")
+    repo = create_repository("devtable", "test-image-built-schema2", user)
+    assert repo is not None
+
+    layer_bytes = random.randbytes(1024)
+    layer_digest = digest_tools.sha256_digest(layer_bytes)
+
+    config_json = {
+        "architecture": "amd64",
+        "os": "linux",
+        "created": "2024-02-20T14:25:30.987654321Z",
+        "config": {"Env": ["PATH=/usr/local/bin:/usr/bin"]},
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": [
+                layer_digest,
+            ],
+        },
+        "history": [
+            {
+                "created": "2024-02-20T14:25:30.987654321Z",
+                "created_by": '/bin/sh -c # (NOP) CMD ["sh"]',
+            },
+        ],
+    }
+
+    config_bytes = json.dumps(config_json).encode("utf-8")
+    config_digest = digest_tools.sha256_digest(config_bytes)
+    location = ImageStorageLocation.get(name="local_us")
+
+    # create blob records in the database
+    config_blob = store_blob_record_and_temp_link(
+        "devtable",
+        "test-image-built-schema2",
+        config_digest,
+        location,
+        len(config_bytes),
+        120,
+    )
+    layer_blob = store_blob_record_and_temp_link(
+        "devtable",
+        "test-image-built-schema2",
+        layer_digest,
+        location,
+        len(layer_bytes),
+        120,
+    )
+
+    # store created blobs
+    storage.put_content(
+        ["local_us"],
+        get_layer_path(config_blob),
+        config_bytes,
+    )
+    storage.put_content(
+        ["local_us"],
+        get_layer_path(layer_blob),
+        layer_bytes,
+    )
+
+    # build manifest
+    builder = DockerSchema2ManifestBuilder()
+    builder.set_config_digest(config_digest, len(config_bytes))
+    builder.add_layer(layer_digest, len(layer_bytes))
+    manifest_obj = builder.build()
+
+    # create manifest
+    created_manifest = oci.manifest.get_or_create_manifest(
+        repo.id,
+        manifest_obj,
+        storage,
+        raise_on_error=True,
+    )
+    assert created_manifest is not None
+
+    # create test tag based on provided manifest
+    test_tag_name = "schema2-created-tag"
+    tag = oci.tag.retarget_tag(
+        test_tag_name,
+        created_manifest.manifest.id,
+        raise_on_error=True,
+    )
+    assert tag is not None
+
+    # call API and verify that build timestamp can be read
+    params = {
+        "repository": "devtable/test-image-built-schema2",
+    }
+    with client_with_identity("devtable", app) as cl:
+        result = conduct_api_call(cl, ListRepositoryTags, "GET", params, None, 200).json
+        test_tag = next((t for t in result["tags"] if t["name"] == test_tag_name), None)
+        assert test_tag is not None
+        assert "image_built" in test_tag
+        assert test_tag["image_built"] == "2024-02-20T14:25:30.987654321Z"
+
+
+def test_tag_created_timestamp_oci_image(app, initialized_db):
+    """
+    Verifies that the created timestamp can be extracted from the OCI image manifest. The value, if exists,
+    is part of the config blob.
+    """
+    user = get_user("devtable")
+    repo = create_repository("devtable", "test-image-built-oci", user)
+    assert repo is not None
+
+    layer_bytes = random.randbytes(1024)
+    layer_digest = digest_tools.sha256_digest(layer_bytes)
+
+    config_json = {
+        "architecture": "amd64",
+        "os": "linux",
+        "created": "2024-02-20T14:25:30.987654321Z",
+        "config": {"Env": ["PATH=/usr/local/bin:/usr/bin"]},
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": [
+                layer_digest,
+            ],
+        },
+        "history": [
+            {
+                "created": "2024-02-20T14:25:30.987654321Z",
+                "created_by": '/bin/sh -c # (NOP) CMD ["sh"]',
+            },
+        ],
+    }
+
+    config_bytes = json.dumps(config_json).encode("utf-8")
+    config_digest = digest_tools.sha256_digest(config_bytes)
+    location = ImageStorageLocation.get(name="local_us")
+
+    # create blob records in the database
+    config_blob = store_blob_record_and_temp_link(
+        "devtable",
+        "test-image-built-oci",
+        config_digest,
+        location,
+        len(config_bytes),
+        120,
+    )
+    layer_blob = store_blob_record_and_temp_link(
+        "devtable",
+        "test-image-built-oci",
+        layer_digest,
+        location,
+        len(layer_bytes),
+        120,
+    )
+
+    # store created blobs
+    storage.put_content(
+        ["local_us"],
+        get_layer_path(config_blob),
+        config_bytes,
+    )
+    storage.put_content(
+        ["local_us"],
+        get_layer_path(layer_blob),
+        layer_bytes,
+    )
+
+    # build manifest
+    builder = OCIManifestBuilder()
+    builder.set_config_digest(config_digest, len(config_bytes))
+    builder.add_layer(layer_digest, len(layer_bytes))
+    manifest_obj = builder.build()
+
+    # create manifest
+    created_manifest = oci.manifest.get_or_create_manifest(
+        repo.id,
+        manifest_obj,
+        storage,
+        raise_on_error=True,
+    )
+    assert created_manifest is not None
+
+    # create test tag based on provided manifest
+    test_tag_name = "schema2-created-tag"
+    tag = oci.tag.retarget_tag(
+        test_tag_name,
+        created_manifest.manifest.id,
+        raise_on_error=True,
+    )
+    assert tag is not None
+
+    # call API and verify that build timestamp can be read
+    params = {
+        "repository": "devtable/test-image-built-oci",
+    }
+    with client_with_identity("devtable", app) as cl:
+        result = conduct_api_call(cl, ListRepositoryTags, "GET", params, None, 200).json
+        test_tag = next((t for t in result["tags"] if t["name"] == test_tag_name), None)
+        assert test_tag is not None
+        assert "image_built" in test_tag
+        assert test_tag["image_built"] == "2024-02-20T14:25:30.987654321Z"

--- a/endpoints/api/test/test_tag.py
+++ b/endpoints/api/test/test_tag.py
@@ -106,12 +106,36 @@ def test_move_tag(manifest_exists, test_tag, expected_status, app):
 @pytest.mark.parametrize(
     "repo_namespace, repo_name, query_count",
     [
-        ("devtable", "simple", 5),  # +2 for converting object to and from json
-        ("devtable", "history", 5),  # +2 for converting object to and from json
-        ("devtable", "complex", 5),  # +2 for converting object to and from json
-        ("devtable", "gargantuan", 5),  # +2 for converting object to and from json
-        ("buynlarge", "orgrepo", 7),  # +2 for permissions checks (uses UNION).
-        ("buynlarge", "anotherorgrepo", 7),  # +2 for permissions checks (uses UNION).
+        (
+            "devtable",
+            "simple",
+            6,
+        ),  # +2 for converting object to and from json, +1 for config digest extraction
+        (
+            "devtable",
+            "history",
+            6,
+        ),  # +2 for converting object to and from json, +1 for config digest extraction
+        (
+            "devtable",
+            "complex",
+            6,
+        ),  # +2 for converting object to and from json, +1 for config digest extraction
+        (
+            "devtable",
+            "gargantuan",
+            6,
+        ),  # +2 for converting object to and from json, +1 for config digest extraction
+        (
+            "buynlarge",
+            "orgrepo",
+            8,
+        ),  # +2 for permissions checks (uses UNION), +1 for config digest extraction
+        (
+            "buynlarge",
+            "anotherorgrepo",
+            8,
+        ),  # +2 for permissions checks (uses UNION), +1 for config digest extraction
     ],
 )
 def test_list_repo_tags(repo_namespace, repo_name, query_count, app):
@@ -131,7 +155,11 @@ def test_list_repo_tags(repo_namespace, repo_name, query_count, app):
 @pytest.mark.parametrize(
     "repo_namespace, repo_name, query_count",
     [
-        ("devtable", "gargantuan", 5),  # +2 for converting object to and from json
+        (
+            "devtable",
+            "gargantuan",
+            6,
+        ),  # +2 for converting object to and from json, +1 for config digest extraction
     ],
 )
 def test_list_repo_tags_filter(repo_namespace, repo_name, query_count, app):

--- a/image/oci/manifest.py
+++ b/image/oci/manifest.py
@@ -262,7 +262,19 @@ class OCIManifest(ManifestInterface):
 
     @property
     def is_image_manifest(self):
-        return self.manifest_dict["config"]["mediaType"] == OCI_IMAGE_CONFIG_CONTENT_TYPE
+        # check config media type
+        if self.manifest_dict["config"]["mediaType"] == OCI_IMAGE_CONFIG_CONTENT_TYPE:
+            # Check if layers are filesystem layers and not attestations or artifacts.
+            # Attestation can have the same config media type but different layer mime type
+            layers = self._parsed.get(OCI_MANIFEST_LAYERS_KEY, [])
+            if not layers:
+                return True  # Empty manifest is valid
+            # Check if the first layer in the image is a normal filesystem layer.
+            # Manifests don't mix filesystem and non-filesystem layers so this is safe.
+            layer_mediatype = layers[0].get(OCI_MANIFEST_MEDIATYPE_KEY)
+            return layer_mediatype in OCI_IMAGE_LAYER_CONTENT_TYPES
+
+        return False
 
     @property
     def blob_digests(self):

--- a/image/oci/test/test_oci_manifest.py
+++ b/image/oci/test/test_oci_manifest.py
@@ -424,3 +424,37 @@ def test_manifest_layer_annotations():
                 "com.example.layerkey1": "value1",
                 "com.example.layerkey2": "value2",
             }
+
+
+def test_is_image_manifest_true_on_image():
+    """
+    Checks if is_image_manifest returns true on a valid manifest with image layers.
+    """
+    manifest = OCIManifest(Bytes.for_string_or_unicode(SAMPLE_MANIFEST))
+    assert not manifest.is_manifest_list
+    assert manifest.is_image_manifest
+
+
+def test_is_image_manifest_false_on_attestation_manifest():
+    """
+    Checks whether is_image_manifest returns false on a valid attestation manifest.
+    """
+    ATTESTATION_MANIFEST = """{
+        "schemaVersion": 2,
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "size": 7023,
+            "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"
+        },
+        "layers": [
+            {
+            "mediaType": "application/vnd.in-toto+json",
+            "size": 32654,
+            "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0"
+            }
+        ]
+    }"""
+
+    manifest = OCIManifest(Bytes.for_string_or_unicode(ATTESTATION_MANIFEST))
+    assert not manifest.is_manifest_list
+    assert not manifest.is_image_manifest

--- a/web/playwright/e2e/tags/image-built-timestamp-manifest-list.spec.ts
+++ b/web/playwright/e2e/tags/image-built-timestamp-manifest-list.spec.ts
@@ -1,0 +1,103 @@
+import {test, expect} from '../../fixtures';
+import {TEST_USERS} from '../../global-setup';
+import {ApiClient} from '../../utils/api';
+import {pushMultiArchImage} from '../../utils/container';
+
+test.describe(
+  'Tags - Manifest List Child Timestamps',
+  {tag: ['@tags', '@container']},
+  () => {
+    let testRepo: {namespace: string; name: string; fullName: string};
+
+    test.beforeAll(async ({userContext, cachedContainerAvailable}) => {
+      if (!cachedContainerAvailable) return;
+      const api = new ApiClient(userContext.request);
+      const repoName = `manifest-list-${Date.now()}`;
+      await api.createRepository(TEST_USERS.user.username, repoName, 'private');
+
+      testRepo = {
+        namespace: TEST_USERS.user.username,
+        name: repoName,
+        fullName: `${TEST_USERS.user.username}/${repoName}`,
+      };
+
+      // Push multi-arch image
+      await pushMultiArchImage(
+        testRepo.namespace,
+        testRepo.name,
+        'v1.0',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+    });
+
+    test.afterAll(async ({userContext}) => {
+      if (!testRepo) return;
+      const api = new ApiClient(userContext.request);
+      try {
+        await api.deleteRepository(testRepo.namespace, testRepo.name);
+      } catch {
+        // ignore cleanup errors
+      }
+    });
+
+    test('displays image built timestamp for child manifests', async ({
+      authenticatedPage,
+    }) => {
+      await authenticatedPage.goto(`/repository/${testRepo.fullName}?tab=tags`);
+
+      // Find manifest list row
+      const tagRow = authenticatedPage
+        .getByRole('row')
+        .filter({hasText: 'v1.0'});
+      await expect(tagRow).toBeVisible();
+
+      // expand the row
+      const expandButton = tagRow.getByRole('button', {name: /toggle row/i});
+      await expandButton.click();
+
+      // wait for child manifests to be visible
+      const childManifest = authenticatedPage.getByText(
+        /linux on (amd64|arm64)/,
+      );
+      await expect(childManifest.first()).toBeVisible();
+
+      // verify that timestamps are showing
+      const expandedRows = authenticatedPage.locator(
+        'tr[class*="pf-m-expanded"]',
+      );
+      const firstExpandedRow = expandedRows.first();
+
+      // look for a timestamp pattern
+      const imageBuiltText = await firstExpandedRow
+        .locator('td')
+        .filter({hasText: /\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}/})
+        .textContent();
+
+      expect(imageBuiltText).toBeTruthy();
+      expect(imageBuiltText).not.toBe('n/a');
+    });
+
+    test('displays platform correctly (not "unknown on unknown")', async ({
+      authenticatedPage,
+    }) => {
+      await authenticatedPage.goto(`/repository/${testRepo.fullName}?tab=tags`);
+
+      const tagRow = authenticatedPage
+        .getByRole('row')
+        .filter({hasText: 'v1.0'});
+      const expandButton = tagRow.getByRole('button', {name: /toggle row/i});
+      await expandButton.click();
+
+      // verify platform shows correctly
+      const platformText = authenticatedPage.getByText(
+        /linux on (amd64|arm64)/,
+      );
+      await expect(platformText.first()).toBeVisible();
+
+      // verify "unknown on unknown" is not shown
+      const unknownPlatform = authenticatedPage.getByText('unknown on unknown');
+      await expect(unknownPlatform).not.toBeVisible();
+    });
+  },
+);

--- a/web/playwright/e2e/tags/image-built-timestamp-manifest-list.spec.ts
+++ b/web/playwright/e2e/tags/image-built-timestamp-manifest-list.spec.ts
@@ -41,54 +41,41 @@ test.describe(
       }
     });
 
+    test.beforeEach(async ({authenticatedPage}) => {
+      // Navigate to the page
+      await authenticatedPage.goto(`/repository/${testRepo.fullName}?tab=tags`);
+
+      // Find row
+      const tagRow = authenticatedPage
+        .getByRole('row')
+        .filter({has: authenticatedPage.getByText('v1.0', {exact: true})});
+
+      // Expand row
+      await expect(tagRow).toBeVisible();
+      await tagRow.getByRole('button', {name: /toggle row/i}).click();
+    });
+
     test('displays image built timestamp for child manifests', async ({
       authenticatedPage,
     }) => {
-      await authenticatedPage.goto(`/repository/${testRepo.fullName}?tab=tags`);
-
-      // Find manifest list row
-      const tagRow = authenticatedPage
+      // We are already expanded so we just find the child row
+      const childRow = authenticatedPage
         .getByRole('row')
-        .filter({hasText: 'v1.0'});
-      await expect(tagRow).toBeVisible();
+        .filter({hasText: /linux on (amd64|arm64)/})
+        .first();
 
-      // expand the row
-      const expandButton = tagRow.getByRole('button', {name: /toggle row/i});
-      await expandButton.click();
+      // find the cell with the timestamp
+      const imageBuiltCell = childRow
+        .getByRole('cell')
+        .filter({hasText: /[A-Z][a-z]{2}\s\d{1,2},\s\d{4}/});
 
-      // wait for child manifests to be visible
-      const childManifest = authenticatedPage.getByText(
-        /linux on (amd64|arm64)/,
-      );
-      await expect(childManifest.first()).toBeVisible();
-
-      // verify that timestamps are showing
-      const expandedRows = authenticatedPage.locator(
-        'tr[class*="pf-m-expanded"]',
-      );
-      const firstExpandedRow = expandedRows.first();
-
-      // look for a timestamp pattern
-      const imageBuiltText = await firstExpandedRow
-        .locator('td')
-        .filter({hasText: /\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}/})
-        .textContent();
-
-      expect(imageBuiltText).toBeTruthy();
-      expect(imageBuiltText).not.toBe('n/a');
+      await expect(imageBuiltCell).toBeVisible();
+      await expect(imageBuiltCell).not.toHaveText(/n\/a/i);
     });
 
     test('displays platform correctly (not "unknown on unknown")', async ({
       authenticatedPage,
     }) => {
-      await authenticatedPage.goto(`/repository/${testRepo.fullName}?tab=tags`);
-
-      const tagRow = authenticatedPage
-        .getByRole('row')
-        .filter({hasText: 'v1.0'});
-      const expandButton = tagRow.getByRole('button', {name: /toggle row/i});
-      await expandButton.click();
-
       // verify platform shows correctly
       const platformText = authenticatedPage.getByText(
         /linux on (amd64|arm64)/,

--- a/web/playwright/e2e/tags/image-built-timestamp-manifest-list.spec.ts
+++ b/web/playwright/e2e/tags/image-built-timestamp-manifest-list.spec.ts
@@ -45,14 +45,23 @@ test.describe(
       // Navigate to the page
       await authenticatedPage.goto(`/repository/${testRepo.fullName}?tab=tags`);
 
-      // Find row
+      // Wait for the tag to appear in the table
+      await expect(
+        authenticatedPage.getByText('v1.0', {exact: true}),
+      ).toBeVisible();
+
+      // Find and expand the manifest list row
       const tagRow = authenticatedPage
-        .getByRole('row')
+        .getByTestId('table-entry')
         .filter({has: authenticatedPage.getByText('v1.0', {exact: true})});
 
-      // Expand row
-      await expect(tagRow).toBeVisible();
-      await tagRow.getByRole('button', {name: /toggle row/i}).click();
+      // Click the expand button (first button in the row)
+      await tagRow.getByRole('button').first().click();
+
+      // Wait for child manifests to appear after expansion
+      await expect(
+        authenticatedPage.getByText(/linux on (amd64|arm64)/).first(),
+      ).toBeVisible();
     });
 
     test('displays image built timestamp for child manifests', async ({
@@ -64,12 +73,14 @@ test.describe(
         .filter({hasText: /linux on (amd64|arm64)/})
         .first();
 
-      // find the cell with the timestamp
-      const imageBuiltCell = childRow
-        .getByRole('cell')
-        .filter({hasText: /[A-Z][a-z]{2}\s\d{1,2},\s\d{4}/});
+      // Find the Image Built cell using data-label attribute
+      const imageBuiltCell = childRow.locator('[data-label="Image Built"]');
 
+      // Verify the timestamp is visible and contains a date (not n/a)
       await expect(imageBuiltCell).toBeVisible();
+      await expect(imageBuiltCell).toContainText(
+        /[A-Z][a-z]{2}\s\d{1,2},\s\d{4}/,
+      );
       await expect(imageBuiltCell).not.toHaveText(/n\/a/i);
     });
 

--- a/web/playwright/e2e/tags/image-built-timestamp.spec.ts
+++ b/web/playwright/e2e/tags/image-built-timestamp.spec.ts
@@ -58,8 +58,8 @@ test.describe(
         .getByRole('row')
         .filter({has: latestTagLink});
 
-      // Target the image built cell. 'Image Built' column should be column 4 in the output.
-      const imageBuiltCell = targetRow.getByRole('cell').nth(4);
+      // Target the image built cell using data-label attribute
+      const imageBuiltCell = targetRow.locator('[data-label="Image Built"]');
 
       // Verify that the timestamp is visible
       await expect(imageBuiltCell).toBeVisible();

--- a/web/playwright/e2e/tags/image-built-timestamp.spec.ts
+++ b/web/playwright/e2e/tags/image-built-timestamp.spec.ts
@@ -1,0 +1,66 @@
+import {test, expect} from '../../fixtures';
+import {TEST_USERS} from '../../global-setup';
+import {ApiClient} from '../../utils/api';
+import {pushImage} from '../../utils/container';
+
+test.describe(
+  'Tags - Image Built Timestamp',
+  {tag: ['@tags', '@container']},
+  () => {
+    let testRepo: {namespace: string; name: string; fullName: string};
+    test.beforeAll(async ({userContext, cachedContainerAvailable}) => {
+      if (!cachedContainerAvailable) return;
+      const api = new ApiClient(userContext.request);
+      const repoName = `image-built-${Date.now()}`;
+      await api.createRepository(TEST_USERS.user.username, repoName, 'private');
+
+      testRepo = {
+        namespace: TEST_USERS.user.username,
+        name: repoName,
+        fullName: `${TEST_USERS.user.username}/${repoName}`,
+      };
+
+      // push test image
+      await pushImage(
+        testRepo.namespace,
+        testRepo.name,
+        'latest',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+    });
+
+    test.afterAll(async ({userContext}) => {
+      if (!testRepo) return;
+      const api = new ApiClient(userContext.request);
+      try {
+        await api.deleteRepository(testRepo.namespace, testRepo.name);
+      } catch {
+        // ignore cleanup errors
+      }
+    });
+
+    test('displays image built timestamp column', async ({
+      authenticatedPage,
+    }) => {
+      await authenticatedPage.goto(`/repository/${testRepo.fullName}?tab=tags`);
+      // Verify that column header exists
+      await expect(
+        authenticatedPage.getByRole('columnheader', {name: `Image Built`}),
+      ).toBeVisible();
+
+      // Verify at least one tag shows a built timestamp (not n/a)
+      // The pushed image should have a built timestamp from Docker
+      const imageBuiltCell = authenticatedPage
+        .getByRole('row')
+        .filter({hasText: 'latest'})
+        .getByRole('cell', {name: /Image Built/});
+
+      await expect(imageBuiltCell).toBeVisible();
+
+      // Check that it's not n/a (pushed images from Docker should have a timestamp)
+      const cellText = await imageBuiltCell.textContent();
+      expect(cellText).not.toBe('N/A');
+    });
+  },
+);

--- a/web/playwright/e2e/tags/image-built-timestamp.spec.ts
+++ b/web/playwright/e2e/tags/image-built-timestamp.spec.ts
@@ -43,24 +43,27 @@ test.describe(
     test('displays image built timestamp column', async ({
       authenticatedPage,
     }) => {
+      // Load the page
       await authenticatedPage.goto(`/repository/${testRepo.fullName}?tab=tags`);
-      // Verify that column header exists
-      await expect(
-        authenticatedPage.getByRole('columnheader', {name: `Image Built`}),
-      ).toBeVisible();
 
-      // Verify at least one tag shows a built timestamp (not n/a)
-      // The pushed image should have a built timestamp from Docker
-      const imageBuiltCell = authenticatedPage
+      // Wait for the latest tag to appear
+      const latestTagLink = authenticatedPage.getByRole('link', {
+        name: 'latest',
+        exact: true,
+      });
+      await expect(latestTagLink).toBeVisible();
+
+      // Find row that contains the latest tag
+      const targetRow = authenticatedPage
         .getByRole('row')
-        .filter({hasText: 'latest'})
-        .getByRole('cell', {name: /Image Built/});
+        .filter({has: latestTagLink});
 
+      // Target the image built cell. 'Image Built' column should be column 4 in the output.
+      const imageBuiltCell = targetRow.getByRole('cell').nth(4);
+
+      // Verify that the timestamp is visible
       await expect(imageBuiltCell).toBeVisible();
-
-      // Check that it's not n/a (pushed images from Docker should have a timestamp)
-      const cellText = await imageBuiltCell.textContent();
-      expect(cellText).not.toBe('N/A');
+      await expect(imageBuiltCell).not.toHaveText(/n\/a/i);
     });
   },
 );

--- a/web/playwright/e2e/tags/sparse-manifest.spec.ts
+++ b/web/playwright/e2e/tags/sparse-manifest.spec.ts
@@ -436,7 +436,7 @@ test.describe('Sparse Manifest Visualization', {tag: ['@tags']}, () => {
     await expect(sparseLabel).not.toBeVisible();
   });
 
-  test('shows N/A for security and size of missing architectures', async ({
+  test('shows n/a for security and size of missing architectures', async ({
     authenticatedPage,
     api,
   }) => {
@@ -504,9 +504,9 @@ test.describe('Sparse Manifest Visualization', {tag: ['@tags']}, () => {
     await expect(expandButton).toBeVisible({timeout: 10000});
     await expandButton.click();
 
-    // Wait for expanded content and check for N/A text
-    // The N/A appears for security and size columns on missing manifests
-    await expect(authenticatedPage.getByText('N/A').first()).toBeVisible({
+    // Wait for expanded content and check for n/a text
+    // The n/a appears for security and size columns on missing manifests
+    await expect(authenticatedPage.getByText('n/a').first()).toBeVisible({
       timeout: 10000,
     });
   });

--- a/web/src/components/Table/ManifestListSize.tsx
+++ b/web/src/components/Table/ManifestListSize.tsx
@@ -1,6 +1,6 @@
 import {Skeleton} from '@patternfly/react-core';
 import prettyBytes from 'pretty-bytes';
-import {Manifest} from 'src/resources/TagResource';
+import {ManifestDescriptor} from 'src/resources/TagResource';
 import {useRecoilValue} from 'recoil';
 import {childManifestSizeState} from 'src/atoms/TagListState';
 
@@ -34,5 +34,5 @@ export default function ManifestListSize(props: ManifestListSizeProps) {
 }
 
 interface ManifestListSizeProps {
-  manifests: Manifest[];
+  manifests: ManifestDescriptor[];
 }

--- a/web/src/libs/utils.ts
+++ b/web/src/libs/utils.ts
@@ -25,7 +25,7 @@ export function formatDate(
   timeStyle: 'short' | 'medium' | 'long' = 'short',
 ) {
   if (!date || date == -1) {
-    return 'N/A';
+    return 'n/a';
   }
 
   const adjustedDate = typeof date === 'number' ? date * 1000 : date;
@@ -39,7 +39,7 @@ export function formatDate(
 export function formatSize(sizeInBytes: number) {
   // Handle null/undefined but allow 0 as a valid value
   if (sizeInBytes === null || sizeInBytes === undefined) {
-    return 'N/A';
+    return 'n/a';
   }
 
   // Handle 0 explicitly to avoid Math.log(0) = -Infinity

--- a/web/src/resources/TagResource.ts
+++ b/web/src/resources/TagResource.ts
@@ -43,9 +43,28 @@ export interface Tag {
 export interface ManifestList {
   schemaVersion: number;
   mediaType: string;
-  manifests: Manifest[];
+  manifests: ManifestDescriptor[];
 }
 
+/**
+ * ManifestDescriptor reporesents a child manifest entry in a manifest list.
+ * Contains descriptor fields plus optional enriched fields.
+ */
+export interface ManifestDescriptor {
+  mediaType: string;
+  size: number;
+  digest: string;
+  platform: Platform;
+  // whether manifest context is available locally (not sparse)
+  is_present?: boolean;
+  // child manifest built timestamp if applicable
+  image_built?: string;
+}
+
+/**
+ * Manifest represents the full manifest with security and layer information.
+ * Used for single arch manifests and when fetching complete manifest details.
+ */
 export interface Manifest {
   mediaType: string;
   size: number;
@@ -98,7 +117,7 @@ export interface ManifestByDigestResponse {
   layers?: Layer[];
   layers_compressed_size?: number;
   modelcard?: string;
-  manifests?: Manifest[]; // Enriched child manifests (for manifest lists)
+  manifests?: ManifestDescriptor[]; // Enriched child manifests (for manifest lists)
 }
 
 export interface SecurityDetailsResponse {

--- a/web/src/resources/TagResource.ts
+++ b/web/src/resources/TagResource.ts
@@ -24,6 +24,8 @@ export interface Tag {
   manifest_list: ManifestList;
   expiration?: string;
   end_ts?: number;
+  // Image built date
+  image_built?: string;
   modelcard?: string;
   cosign_signature_tag?: string;
   cosign_signature_manifest_digest?: string;
@@ -53,6 +55,8 @@ export interface Manifest {
   layers: Layer[];
   // Whether manifest content is available locally (not sparse)
   is_present?: boolean;
+  // Read child manifest built timestamp if applicable
+  image_built?: string;
 }
 
 export interface Layer {
@@ -94,6 +98,7 @@ export interface ManifestByDigestResponse {
   layers?: Layer[];
   layers_compressed_size?: number;
   modelcard?: string;
+  manifests?: Manifest[]; // Enriched child manifests (for manifest lists)
 }
 
 export interface SecurityDetailsResponse {

--- a/web/src/routes/RepositoryDetails/Tags/ColumnNames.ts
+++ b/web/src/routes/RepositoryDetails/Tags/ColumnNames.ts
@@ -3,6 +3,7 @@ const ColumnNames = {
   security: 'Security',
   size: 'Size',
   lastModified: 'Last Modified',
+  imageBuilt: 'Image Built',
   expires: 'Expires',
   digest: 'Digest',
   lastPulled: 'Last Pulled',

--- a/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
@@ -1,5 +1,5 @@
 import {PageSection, PanelFooter} from '@patternfly/react-core';
-import {CubesIcon} from '@patternfly/react-icons';
+import {CubesIcon, InfoCircleIcon} from '@patternfly/react-icons';
 import {useEffect, useState} from 'react';
 import {useRecoilState, useRecoilValue, useResetRecoilState} from 'recoil';
 import {
@@ -175,6 +175,21 @@ export default function TagsList(props: TagsProps) {
           selectTag={selectTag}
           repoDetails={props.repoDetails}
         />
+        {sortedTags.some((tag) => tag.is_manifest_list) && (
+          <div
+            style={{
+              fontSize: '0.875rem',
+              color: 'var(--pf-t--global--text--color--subtle)',
+              padding: '12px 16px',
+              backgroundColor:
+                'var(--pf-t--global--background--color--primary--default)',
+            }}
+          >
+            <InfoCircleIcon style={{marginRight: '6px'}} aria-label="Note" />
+            Note: Child manifest build dates represent when the container image
+            was created.
+          </div>
+        )}
         <TagsTable
           org={props.organization}
           repo={props.repository}

--- a/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
@@ -86,6 +86,11 @@ export default function TagsList(props: TagsProps) {
         true, // include_modelcard
       );
       const manifestList = JSON.parse(manifestResp.manifest_data);
+      // if we have enriched data, use that data
+      if (manifestResp.manifests && manifestResp.manifests.length > 0) {
+        manifestList.manifests = manifestResp.manifests;
+      }
+
       // Map is_present onto each child manifest using child_manifests_presence
       if (manifestList.manifests && tag.child_manifests_presence) {
         manifestList.manifests = manifestList.manifests.map(

--- a/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
@@ -11,7 +11,11 @@ import {
 } from '@patternfly/react-table';
 import prettyBytes from 'pretty-bytes';
 import {useState} from 'react';
-import {Tag, Manifest, Label as ManifestLabel} from 'src/resources/TagResource';
+import {
+  Tag,
+  Label as ManifestLabel,
+  ManifestDescriptor,
+} from 'src/resources/TagResource';
 import {useRecoilValue} from 'recoil';
 import {Link, useLocation} from 'react-router-dom';
 import {getTagDetailPath} from 'src/routes/NavigationPath';
@@ -28,7 +32,6 @@ import {
   TagIcon,
   CubeIcon,
   CopyIcon,
-  InfoCircleIcon,
 } from '@patternfly/react-icons';
 import {ChildManifestSize} from 'src/components/Table/ImageSize';
 import Labels from 'src/components/labels/Labels';
@@ -252,96 +255,78 @@ function TagsTableRow(props: RowProps) {
           onMouseLeave={() => setIsTagHovered(false)}
         >
           <div>
-            <div>
-              <Link
-                to={getTagDetailPath(
-                  location.pathname,
-                  props.org,
-                  props.repo,
-                  tag.name,
-                )}
-              >
-                {tag.name}
-              </Link>
-              {tag.cosign_signature_tag && (
-                <Tooltip content="This tag has been signed via cosign.">
-                  <ShieldAltIcon
-                    style={{marginLeft: '8px'}}
-                    aria-label="Cosign signed"
-                  />
-                </Tooltip>
+            <Link
+              to={getTagDetailPath(
+                location.pathname,
+                props.org,
+                props.repo,
+                tag.name,
               )}
-              {config?.features?.IMMUTABLE_TAGS && tag.immutable && (
-                <Tooltip content="This tag is immutable and cannot be modified or deleted">
-                  <LockIcon
-                    style={{
-                      marginLeft: '8px',
-                      color: 'var(--pf-t--global--icon-color--status--info--default)',
-                    }}
-                    aria-label="Immutable tag"
-                    data-testid="immutable-tag-icon"
-                  />
-                </Tooltip>
-              )}
-              {tag.is_sparse && (
-                <Tooltip content="This is a sparse manifest list - not all architectures are present locally">
-                  <Label
-                    color="orange"
-                    isCompact
-                    style={{marginLeft: '8px'}}
-                    data-testid="sparse-manifest-label"
-                  >
-                    Sparse ({tag.present_child_count}/{tag.child_manifest_count}
-                    )
-                  </Label>
-                </Tooltip>
-              )}
-              <span
-                className="copy-icon"
-                style={{visibility: isTagHovered ? 'visible' : 'hidden'}}
-              >
-                <Tooltip
-                  content={
-                    <div>
-                      {isTagCopied ? 'Copied to clipboard!' : `Copy pull spec`}
-                    </div>
-                  }
-                  position="top"
-                >
-                  <Button
-                    icon={<CopyIcon />}
-                    variant="plain"
-                    aria-label="Copy pull spec to clipboard"
-                    onClick={() => {
-                      const hostname =
-                        config?.config?.SERVER_HOSTNAME || window.location.host;
-                      props.copyToClipboard(
-                        `${hostname}/${props.org}/${props.repo}:${tag.name}`,
-                        `tag-${tag.name}`,
-                      );
-                    }}
-                  >
-                    <CopyIcon />
-                  </Button>
-                </Tooltip>
-              </span>
-            </div>
-            {tag.is_manifest_list && (
-              <div
-                style={{
-                  fontSize: '0.875rem',
-                  color: 'var(--pf-t--global--text--color--subtle)',
-                  marginTop: '4px',
-                }}
-              >
-                <InfoCircleIcon
-                  style={{marginRight: '6px'}}
-                  aria-label="Note"
+            >
+              {tag.name}
+            </Link>
+            {tag.cosign_signature_tag && (
+              <Tooltip content="This tag has been signed via cosign.">
+                <ShieldAltIcon
+                  style={{marginLeft: '8px'}}
+                  aria-label="Cosign signed"
                 />
-                Note: Child manifest build dates represent when the container
-                image was created.
-              </div>
+              </Tooltip>
             )}
+            {config?.features?.IMMUTABLE_TAGS && tag.immutable && (
+              <Tooltip content="This tag is immutable and cannot be modified or deleted">
+                <LockIcon
+                  style={{
+                    marginLeft: '8px',
+                    color:
+                      'var(--pf-t--global--icon-color--status--info--default)',
+                  }}
+                  aria-label="Immutable tag"
+                  data-testid="immutable-tag-icon"
+                />
+              </Tooltip>
+            )}
+            {tag.is_sparse && (
+              <Tooltip content="This is a sparse manifest list - not all architectures are present locally">
+                <Label
+                  color="orange"
+                  isCompact
+                  style={{marginLeft: '8px'}}
+                  data-testid="sparse-manifest-label"
+                >
+                  Sparse ({tag.present_child_count}/{tag.child_manifest_count})
+                </Label>
+              </Tooltip>
+            )}
+            <span
+              className="copy-icon"
+              style={{visibility: isTagHovered ? 'visible' : 'hidden'}}
+            >
+              <Tooltip
+                content={
+                  <div>
+                    {isTagCopied ? 'Copied to clipboard!' : `Copy pull spec`}
+                  </div>
+                }
+                position="top"
+              >
+                <Button
+                  icon={<CopyIcon />}
+                  variant="plain"
+                  aria-label="Copy pull spec to clipboard"
+                  onClick={() => {
+                    const hostname =
+                      config?.config?.SERVER_HOSTNAME || window.location.host;
+                    props.copyToClipboard(
+                      `${hostname}/${props.org}/${props.repo}:${tag.name}`,
+                      `tag-${tag.name}`,
+                    );
+                  }}
+                >
+                  <CopyIcon />
+                </Button>
+              </Tooltip>
+            </span>
           </div>
         </Td>
         <Conditional if={config?.features?.SECURITY_SCANNER}>
@@ -616,7 +601,7 @@ export default function TagsTable(props: TableProps) {
   };
 
   // Calculate manifest tracks for visual grouping of tags sharing the same digest
-  const {tracks, getTrackEntry, getLineClass, trackCount} = useManifestTracks(
+  const {getTrackEntry, getLineClass, trackCount} = useManifestTracks(
     props.allTags,
   );
 
@@ -761,7 +746,7 @@ interface SubRowProps {
   repo: string;
   tag: Tag;
   rowIndex: number;
-  manifest: Manifest;
+  manifest: ManifestDescriptor;
   isTagExpanded: (tag: Tag) => boolean;
   config: {
     features?: {

--- a/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
@@ -28,6 +28,7 @@ import {
   TagIcon,
   CubeIcon,
   CopyIcon,
+  InfoCircleIcon,
 } from '@patternfly/react-icons';
 import {ChildManifestSize} from 'src/components/Table/ImageSize';
 import Labels from 'src/components/labels/Labels';
@@ -65,7 +66,10 @@ function SubRow(props: SubRowProps) {
                     style={{marginRight: '4px'}}
                     aria-label="Missing architecture"
                   />
-                  {`${props.manifest.platform.os} on ${props.manifest.platform.architecture}`}
+                  {props.manifest.platform.os === 'unknown' &&
+                  props.manifest.platform.architecture === 'unknown'
+                    ? 'Build Artifact'
+                    : `${props.manifest.platform.os} on ${props.manifest.platform.architecture}`}
                   <Label
                     color="grey"
                     isCompact
@@ -86,7 +90,10 @@ function SubRow(props: SubRowProps) {
                   new Map([['digest', props.manifest.digest]]),
                 )}
               >
-                {`${props.manifest.platform.os} on ${props.manifest.platform.architecture}`}
+                {props.manifest.platform.os === 'unknown' &&
+                props.manifest.platform.architecture === 'unknown'
+                  ? 'Build Artifact'
+                  : `${props.manifest.platform.os} on ${props.manifest.platform.architecture}`}
               </Link>
             )}
           </ExpandableRowContent>
@@ -99,7 +106,7 @@ function SubRow(props: SubRowProps) {
           <ExpandableRowContent>
             {isMissing ? (
               <span style={{color: 'var(--pf-t--global--text--color--subtle)'}}>
-                N/A
+                n/a
               </span>
             ) : (
               <SecurityDetails
@@ -117,7 +124,7 @@ function SubRow(props: SubRowProps) {
         <ExpandableRowContent>
           {isMissing ? (
             <span style={{color: 'var(--pf-t--global--text--color--subtle)'}}>
-              N/A
+              n/a
             </span>
           ) : (
             <ChildManifestSize
@@ -145,6 +152,18 @@ function SubRow(props: SubRowProps) {
       ) : (
         <Td />
       )}
+      {/* Add image built column for child manifests */}
+      <Td dataLabel={ColumnNames.imageBuilt} noPadding={false} colSpan={1}>
+        <ExpandableRowContent>
+          {isMissing ? (
+            <span style={{color: 'var(--pf-v5-global--Color--200)'}}>n/a</span>
+          ) : props.manifest.image_built ? (
+            formatDate(props.manifest.image_built)
+          ) : (
+            'n/a'
+          )}
+        </ExpandableRowContent>
+      </Td>
       {props.trackCount > 0 && (
         <Td className="manifest-track-cell">
           <ManifestTrackCell
@@ -158,7 +177,7 @@ function SubRow(props: SubRowProps) {
       )}
       <Td
         colSpan={
-          (props.config?.features?.IMAGE_PULL_STATS ? 4 : 2) +
+          (props.config?.features?.IMAGE_PULL_STATS ? 3 : 1) +
           (props.config?.features?.SECURITY_SCANNER ? 0 : 1)
         }
       />
@@ -232,76 +251,98 @@ function TagsTableRow(props: RowProps) {
           onMouseEnter={() => setIsTagHovered(true)}
           onMouseLeave={() => setIsTagHovered(false)}
         >
-          <Link
-            to={getTagDetailPath(
-              location.pathname,
-              props.org,
-              props.repo,
-              tag.name,
-            )}
-          >
-            {tag.name}
-          </Link>
-          {tag.cosign_signature_tag && (
-            <Tooltip content="This tag has been signed via cosign.">
-              <ShieldAltIcon
-                style={{marginLeft: '8px'}}
-                aria-label="Cosign signed"
-              />
-            </Tooltip>
-          )}
-          {config?.features?.IMMUTABLE_TAGS && tag.immutable && (
-            <Tooltip content="This tag is immutable and cannot be modified or deleted">
-              <LockIcon
-                style={{
-                  marginLeft: '8px',
-                  color:
-                    'var(--pf-t--global--icon--color--status--info--default)',
-                }}
-                aria-label="Immutable tag"
-                data-testid="immutable-tag-icon"
-              />
-            </Tooltip>
-          )}
-          {tag.is_sparse && (
-            <Tooltip content="This is a sparse manifest list - not all architectures are present locally">
-              <Label
-                color="orange"
-                isCompact
-                style={{marginLeft: '8px'}}
-                data-testid="sparse-manifest-label"
+          <div>
+            <div>
+              <Link
+                to={getTagDetailPath(
+                  location.pathname,
+                  props.org,
+                  props.repo,
+                  tag.name,
+                )}
               >
-                Sparse ({tag.present_child_count}/{tag.child_manifest_count})
-              </Label>
-            </Tooltip>
-          )}
-          <span
-            className="copy-icon"
-            style={{visibility: isTagHovered ? 'visible' : 'hidden'}}
-          >
-            <Tooltip
-              content={
-                <div>
-                  {isTagCopied ? 'Copied to clipboard!' : `Copy pull spec`}
-                </div>
-              }
-              position="top"
-            >
-              <Button
-                icon={<CopyIcon />}
-                variant="plain"
-                aria-label="Copy pull spec to clipboard"
-                onClick={() => {
-                  const hostname =
-                    config?.config?.SERVER_HOSTNAME || window.location.host;
-                  props.copyToClipboard(
-                    `${hostname}/${props.org}/${props.repo}:${tag.name}`,
-                    `tag-${tag.name}`,
-                  );
+                {tag.name}
+              </Link>
+              {tag.cosign_signature_tag && (
+                <Tooltip content="This tag has been signed via cosign.">
+                  <ShieldAltIcon
+                    style={{marginLeft: '8px'}}
+                    aria-label="Cosign signed"
+                  />
+                </Tooltip>
+              )}
+              {config?.features?.IMMUTABLE_TAGS && tag.immutable && (
+                <Tooltip content="This tag is immutable and cannot be modified or deleted">
+                  <LockIcon
+                    style={{
+                      marginLeft: '8px',
+                      color: 'var(--pf-t--global--icon-color--status--info--default)',
+                    }}
+                    aria-label="Immutable tag"
+                    data-testid="immutable-tag-icon"
+                  />
+                </Tooltip>
+              )}
+              {tag.is_sparse && (
+                <Tooltip content="This is a sparse manifest list - not all architectures are present locally">
+                  <Label
+                    color="orange"
+                    isCompact
+                    style={{marginLeft: '8px'}}
+                    data-testid="sparse-manifest-label"
+                  >
+                    Sparse ({tag.present_child_count}/{tag.child_manifest_count}
+                    )
+                  </Label>
+                </Tooltip>
+              )}
+              <span
+                className="copy-icon"
+                style={{visibility: isTagHovered ? 'visible' : 'hidden'}}
+              >
+                <Tooltip
+                  content={
+                    <div>
+                      {isTagCopied ? 'Copied to clipboard!' : `Copy pull spec`}
+                    </div>
+                  }
+                  position="top"
+                >
+                  <Button
+                    icon={<CopyIcon />}
+                    variant="plain"
+                    aria-label="Copy pull spec to clipboard"
+                    onClick={() => {
+                      const hostname =
+                        config?.config?.SERVER_HOSTNAME || window.location.host;
+                      props.copyToClipboard(
+                        `${hostname}/${props.org}/${props.repo}:${tag.name}`,
+                        `tag-${tag.name}`,
+                      );
+                    }}
+                  >
+                    <CopyIcon />
+                  </Button>
+                </Tooltip>
+              </span>
+            </div>
+            {tag.is_manifest_list && (
+              <div
+                style={{
+                  fontSize: '0.875rem',
+                  color: 'var(--pf-t--global--text--color--subtle)',
+                  marginTop: '4px',
                 }}
-              />
-            </Tooltip>
-          </span>
+              >
+                <InfoCircleIcon
+                  style={{marginRight: '6px'}}
+                  aria-label="Note"
+                />
+                Note: Child manifest build dates represent when the container
+                image was created.
+              </div>
+            )}
+          </div>
         </Td>
         <Conditional if={config?.features?.SECURITY_SCANNER}>
           <Td dataLabel={ColumnNames.security}>
@@ -327,6 +368,11 @@ function TagsTableRow(props: RowProps) {
         </Td>
         <Td dataLabel={ColumnNames.lastModified}>
           {formatDate(tag.last_modified)}
+        </Td>
+        <Td dataLabel={ColumnNames.imageBuilt}>
+          {tag.is_manifest_list
+            ? formatDate(tag.last_modified)
+            : formatDate(tag.image_built)}
         </Td>
         <Td dataLabel={ColumnNames.expires}>
           <TagExpiration
@@ -609,9 +655,12 @@ export default function TagsTable(props: TableProps) {
               Last Modified
             </Th>
             <Th modifier="wrap" sort={props.getSortableSort?.(6)}>
-              Expires
+              Image Built
             </Th>
             <Th modifier="wrap" sort={props.getSortableSort?.(7)}>
+              Expires
+            </Th>
+            <Th modifier="wrap" sort={props.getSortableSort?.(8)}>
               Manifest
             </Th>
             {trackCount > 0 && (
@@ -621,10 +670,10 @@ export default function TagsTable(props: TableProps) {
               />
             )}
             <Conditional if={config?.features?.IMAGE_PULL_STATS}>
-              <Th modifier="wrap" sort={props.getSortableSort?.(8)}>
+              <Th modifier="wrap" sort={props.getSortableSort?.(9)}>
                 Last Pulled
               </Th>
-              <Th modifier="wrap" sort={props.getSortableSort?.(9)}>
+              <Th modifier="wrap" sort={props.getSortableSort?.(10)}>
                 Pull Count
               </Th>
             </Conditional>

--- a/web/src/routes/TagDetails/Details/Details.tsx
+++ b/web/src/routes/TagDetails/Details/Details.tsx
@@ -65,6 +65,14 @@ export default function Details(props: DetailsProps) {
               )}
             </DescriptionListDescription>
           </DescriptionListGroup>
+          <DescriptionListGroup data-testid="image-built">
+            <DescriptionListTerm>Image Built</DescriptionListTerm>
+            <DescriptionListDescription>
+              {props.tag.is_manifest_list
+                ? formatDate(props.tag.last_modified)
+                : formatDate(props.tag.image_built)}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Digest</DescriptionListTerm>
             <DescriptionListDescription>

--- a/web/src/routes/TagDetails/TagDetailsArchSelect.tsx
+++ b/web/src/routes/TagDetails/TagDetailsArchSelect.tsx
@@ -8,7 +8,7 @@ import {
   SelectList,
 } from '@patternfly/react-core';
 import {Select, SelectOption} from '@patternfly/react-core';
-import {Manifest} from 'src/resources/TagResource';
+import {ManifestDescriptor} from 'src/resources/TagResource';
 
 export default function ArchSelect(props: ArchSelectProps) {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -80,12 +80,12 @@ export default function ArchSelect(props: ArchSelectProps) {
   );
 }
 
-const getPlatformValue = (manifest: Manifest) =>
+const getPlatformValue = (manifest: ManifestDescriptor) =>
   `${manifest.platform.os} on ${manifest.platform.architecture}`;
 
 type ArchSelectProps = {
   digest: string;
-  options: Manifest[];
+  options: ManifestDescriptor[];
   setDigest: (digest: string) => void;
   render: boolean;
   style?: React.CSSProperties;

--- a/web/src/routes/TagDetails/TagDetailsTabs.tsx
+++ b/web/src/routes/TagDetails/TagDetailsTabs.tsx
@@ -53,6 +53,10 @@ export default function TagTabs(props: TagTabsProps) {
       <Tab
         eventKey={TabIndex.Layers}
         title={<TabTitleText>Layers</TabTitleText>}
+        isHidden={
+          props.tag.is_manifest_list &&
+          props.digest === props.tag.manifest_digest
+        }
       >
         <Layers org={props.org} repo={props.repo} digest={props.digest} />
       </Tab>

--- a/web/src/tests/fake-db/data/tag/manifest.ts
+++ b/web/src/tests/fake-db/data/tag/manifest.ts
@@ -1,6 +1,6 @@
 import {mock} from 'src/tests/fake-db/MockAxios';
 import {AxiosRequestConfig} from 'axios';
-import {ManifestByDigestResponse, Manifest} from 'src/resources/TagResource';
+import {ManifestByDigestResponse} from 'src/resources/TagResource';
 
 const manifest = {
   schemaVersion: 2,


### PR DESCRIPTION
The UI now shows build timestamps for all container images. If an image is a manifest list, the UI will show the last modified timestamp instead (as manifest lists are created and modified at the same time), while container images might have different build dates.

Co-authored-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Display "Image Built" timestamps for tags and container images, showing when container images were created.
  * Enrich manifest list children with creation timestamps and platform/architecture information (Linux/amd64, Linux/arm64, etc.).
  * Add "Image Built" column in tags table and tag details view.

* **Bug Fixes**
  * Improve OCI manifest validation to correctly distinguish image manifests from artifacts.
  * Standardize placeholder text formatting across the UI.

* **Tests**
  * Add comprehensive test coverage for image built timestamp extraction and display across single images, multi-arch manifests, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->