### PR TITLE
NO-ISSUE: feat(buildman): enable container builds in CI with PopenExecutor

### DIFF
--- a/.github/actions/setup-quay/action.yaml
+++ b/.github/actions/setup-quay/action.yaml
@@ -57,6 +57,11 @@ inputs:
     required: false
     default: 'false'
 
+  with-builds:
+    description: 'Enable container build support with PopenExecutor'
+    required: false
+    default: 'false'
+
   with-mailpit:
     description: 'Start Mailpit email testing server'
     required: false
@@ -172,6 +177,30 @@ runs:
         rm -f "${INLINE_CONFIG}"
         echo "Inline config merged successfully"
 
+    - name: Extract quay-builder binary
+      if: inputs.with-builds == 'true'
+      shell: bash
+      run: |
+        echo "Extracting quay-builder binary..."
+        docker create --name quay-builder-extract quay.io/projectquay/quay-builder:3.17-unstable
+        docker cp quay-builder-extract:/usr/local/bin/quay-builder ./local-dev/quay-builder
+        docker rm quay-builder-extract
+        chmod +x ./local-dev/quay-builder
+        echo "quay-builder binary extracted successfully"
+
+    - name: Configure build support
+      if: inputs.with-builds == 'true'
+      shell: bash
+      run: |
+        BASE_CONFIG="local-dev/stack/config.yaml"
+        BUILDS_CONFIG="local-dev/builds/builds-config.yaml"
+
+        pip install pyyaml -q
+        python3 ${{ github.action_path }}/merge-yaml.py \
+          "${BASE_CONFIG}" "${BUILDS_CONFIG}" > "${BASE_CONFIG}.tmp"
+        mv "${BASE_CONFIG}.tmp" "${BASE_CONFIG}"
+        echo "Build support configuration merged"
+
     - name: Start database services
       shell: bash
       run: |
@@ -207,7 +236,19 @@ runs:
     - name: Start Quay container
       shell: bash
       run: |
-        DOCKER_USER="1001:0" docker compose up -d --no-build quay
+        if [ "${{ inputs.with-builds }}" == "true" ]; then
+          cat > /tmp/docker-compose.builds.yaml << 'EOF'
+        services:
+          quay:
+            volumes:
+              - "/var/run/docker.sock:/var/run/docker.sock"
+            environment:
+              DOCKER_HOST: "unix:///var/run/docker.sock"
+        EOF
+          DOCKER_USER="1001:0" docker compose -f docker-compose.yaml -f /tmp/docker-compose.builds.yaml up -d --no-build quay
+        else
+          DOCKER_USER="1001:0" docker compose up -d --no-build quay
+        fi
 
     - name: Wait for Quay to be ready
       id: healthcheck

--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -5,6 +5,8 @@ on:
       - "*"
     paths:
       - "web/**"
+      - "buildman/**"
+      - "local-dev/builds/**"
       - ".github/workflows/web-playwright-ci.yaml"
       - ".github/actions/setup-quay/**"
 
@@ -21,6 +23,7 @@ jobs:
         with:
           with-clair: true
           with-keycloak: true
+          with-builds: true
           extra-config: |
             FEATURE_MAILING: true
             FEATURE_SECURITY_SCANNER: true

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ web/.playwright/
 local-dev/stack/quay-marketplace-api.crt
 local-dev/stack/quay-marketplace-api.key
 
+# quay-builder binary (extracted from container image)
+local-dev/quay-builder
+
 # Go build output
 bin/
 

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,28 @@ local-dev-up: local-dev-clean node_modules | build-image-quay
 	while ! test -e ./static/build/main-quay-frontend.bundle.js; do sleep 2; done
 	@echo "You can now access the frontend at http://localhost:8080"
 
+QUAY_BUILDER_IMAGE ?= quay.io/projectquay/quay-builder:3.17-unstable
+
+.PHONY: local-dev-extract-builder
+local-dev-extract-builder:
+	@if [ ! -f ./local-dev/quay-builder ]; then \
+	  echo "Extracting quay-builder binary from $(QUAY_BUILDER_IMAGE)..."; \
+	  $(DOCKER) create --name quay-builder-extract $(QUAY_BUILDER_IMAGE) 2>/dev/null || true; \
+	  $(DOCKER) cp quay-builder-extract:/usr/local/bin/quay-builder ./local-dev/quay-builder; \
+	  $(DOCKER) rm -f quay-builder-extract; \
+	  chmod +x ./local-dev/quay-builder; \
+	else \
+	  echo "quay-builder binary already exists, skipping extraction"; \
+	fi
+
+.PHONY: enable-builds
+enable-builds: local-dev-extract-builder
+	~/.local/bin/yq eval-all 'select(fileIndex==0) * select(fileIndex==1)' \
+	    local-dev/stack/config.yaml local-dev/builds/builds-config.yaml > /tmp/merged-builds.yaml
+	yes | cp /tmp/merged-builds.yaml local-dev/stack/config.yaml
+	@echo "Build support enabled in local-dev/stack/config.yaml"
+
+
 .PHONY: update-testdata
 update-testdata: local-dev-clean node_modules | build-image-quay
 	$(DOCKER_COMPOSE) rm -fsv quay-db quay

--- a/buildman/manager/executor.py
+++ b/buildman/manager/executor.py
@@ -22,7 +22,7 @@ import release
 from _init import OVERRIDE_CONFIG_DIRECTORY, ROOT_DIR
 from app import app
 from buildman.container_cloud_config import CloudConfigContext
-from buildman.server import SECURE_GRPC_SERVER_PORT
+from buildman.server import DEFAULT_GRPC_SERVER_PORT, SECURE_GRPC_SERVER_PORT
 
 logger = logging.getLogger(__name__)
 
@@ -368,43 +368,90 @@ class EC2Executor(BuilderExecutor):
 class PopenExecutor(BuilderExecutor):
     """
     Implementation of BuilderExecutor which uses Popen to fork a quay-builder process.
+
+    The quay-builder binary communicates with the build manager via gRPC. Environment
+    variables passed to the subprocess:
+      TOKEN              - JWT registration token
+      BUILD_UUID         - Build UUID
+      SERVER             - gRPC server address (host:port)
+      REGISTRY_HOSTNAME  - Registry to push built images to
+      CONTAINER_RUNTIME  - 'docker' or 'podman'
+      BUILDAH_ISOLATION  - 'chroot', 'rootless', or 'oci'
+      INSECURE           - 'true' to skip TLS verification
+      DOCKER_HOST        - Container runtime socket path
+
+    Executor config options:
+      BUILDER_BINARY_LOCATION - Path to quay-builder binary (default: /usr/local/bin/quay-builder)
+      CONTAINER_RUNTIME       - 'docker' or 'podman' (default: docker)
+      BUILDAH_ISOLATION       - Buildah isolation mode (default: chroot)
+      INSECURE                - Skip TLS for gRPC (default: false)
+      DEBUG                   - Enable debug logging in builder (default: false)
     """
 
-    def __init__(self, executor_config, manager_hostname):
+    def __init__(self, executor_config, registry_hostname, manager_hostname):
         self._jobs = {}
-        super(PopenExecutor, self).__init__(executor_config, manager_hostname)
+        super(PopenExecutor, self).__init__(executor_config, registry_hostname, manager_hostname)
+
+    def _get_grpc_server_addr(self):
+        """Return the gRPC server address for the builder to connect to."""
+        if self.executor_config.get("INSECURE", False):
+            return "localhost:%s" % DEFAULT_GRPC_SERVER_PORT
+        return "%s:%s" % (self.manager_hostname, SECURE_GRPC_SERVER_PORT)
 
     @property
     def running_builders_count(self):
-        return len([i for i in [v[0].poll() for k, v in self._jobs] if i is not None])
+        return sum(1 for _, (proc, _) in self._jobs.items() if proc.poll() is None)
 
-    @observe(build_start_duration, "fork")
+    @observe(build_start_duration, "popen")
     def start_builder(self, token, build_uuid):
-        # Now start a machine for this job, adding the machine id to the etcd information
-        logger.debug("Forking process for build")
+        logger.debug("Forking quay-builder process for build %s", build_uuid)
 
-        ws_host = os.environ.get("BUILDMAN_WS_HOST", "localhost")
-        ws_port = os.environ.get("BUILDMAN_WS_PORT", "8787")
+        grpc_server_addr = self._get_grpc_server_addr()
         builder_env = {
             "TOKEN": token,
-            "ENDPOINT": "ws://%s:%s" % (ws_host, ws_port),
-            "DOCKER_TLS_VERIFY": os.environ.get("DOCKER_TLS_VERIFY", ""),
-            "DOCKER_CERT_PATH": os.environ.get("DOCKER_CERT_PATH", ""),
-            "DOCKER_HOST": os.environ.get("DOCKER_HOST", ""),
+            "BUILD_UUID": build_uuid,
+            "SERVER": grpc_server_addr,
+            "REGISTRY_HOSTNAME": self.registry_hostname,
+            "CONTAINER_RUNTIME": self.executor_config.get("CONTAINER_RUNTIME", "docker"),
+            "BUILDAH_ISOLATION": self.executor_config.get("BUILDAH_ISOLATION", "chroot"),
+            "INSECURE": str(self.executor_config.get("INSECURE", False)).lower(),
+            "DOCKER_HOST": os.environ.get("DOCKER_HOST", "unix:///var/run/docker.sock"),
             "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         }
 
-        logpipe = LogPipe(logging.INFO)
-        spawned = subprocess.Popen(
-            os.environ.get("BUILDER_BINARY_LOCATION", "/usr/local/bin/quay-builder"),
-            stdout=logpipe,
-            stderr=logpipe,
-            env=builder_env,
+        if self.executor_config.get("DEBUG", False):
+            builder_env["DEBUG"] = "true"
+
+        # Pass through proxy settings if present
+        for proxy_var in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"):
+            val = os.environ.get(proxy_var)
+            if val:
+                builder_env[proxy_var] = val
+
+        binary_location = self.executor_config.get(
+            "BUILDER_BINARY_LOCATION", "/usr/local/bin/quay-builder"
         )
+
+        logpipe = LogPipe(logging.INFO)
+        try:
+            spawned = subprocess.Popen(
+                binary_location,
+                stdout=logpipe,
+                stderr=logpipe,
+                env=builder_env,
+            )
+        except Exception as e:
+            logpipe.close()
+            raise ExecutorException("Failed to spawn quay-builder: %s" % e)
 
         builder_id = str(uuid.uuid4())
         self._jobs[builder_id] = (spawned, logpipe)
-        logger.debug("Builder spawned with id: %s", builder_id)
+        logger.debug(
+            "Builder spawned with id: %s, build_uuid: %s, server: %s",
+            builder_id,
+            build_uuid,
+            grpc_server_addr,
+        )
         return builder_id
 
     def stop_builder(self, builder_id):
@@ -417,6 +464,7 @@ class PopenExecutor(BuilderExecutor):
         if spawned.poll() is None:
             spawned.kill()
         logpipe.close()
+        del self._jobs[builder_id]
 
 
 class KubernetesExecutor(BuilderExecutor):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -167,6 +167,7 @@ services:
     ports:
       - "8080:8080"
       - "8443:8443"
+      - "50051:50051"
     environment:
       QUAY_VERSION: local-dev
       QUAY_HOTRELOAD: "true"

--- a/local-dev/builds/builds-config.yaml
+++ b/local-dev/builds/builds-config.yaml
@@ -1,0 +1,14 @@
+FEATURE_BUILD_SUPPORT: true
+BUILD_MANAGER:
+  - ephemeral
+  - ORCHESTRATOR:
+      REDIS_HOST: quay-redis
+      REDIS_PORT: 6379
+    EXECUTORS:
+      - EXECUTOR: popen
+        BUILDER_BINARY_LOCATION: /quay-registry/local-dev/quay-builder
+        NAME: ci-builder
+        CONTAINER_RUNTIME: docker
+        INSECURE: true
+        DEBUG: true
+        SETUP_TIME: 120

--- a/web/playwright/e2e/repository/builds.spec.ts
+++ b/web/playwright/e2e/repository/builds.spec.ts
@@ -1,0 +1,162 @@
+import {test, expect} from '../../fixtures';
+
+test.describe(
+  'Repository Builds',
+  {tag: ['@repository', '@feature:BUILD_SUPPORT']},
+  () => {
+    // Real builds take time — extend timeout for all tests in this describe
+    test.setTimeout(180_000);
+
+    test('triggered build appears in builds list', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('builds');
+      const repo = await api.repository(org.name, 'build-list');
+
+      // Trigger a build
+      const build = await api.build(org.name, repo.name);
+
+      // Navigate to Builds tab
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}?tab=builds`,
+      );
+
+      // The build ID should appear in the table
+      await expect(
+        authenticatedPage.getByText(build.buildId.substring(0, 8)),
+      ).toBeVisible();
+    });
+
+    test('build completes successfully', async ({api}) => {
+      const org = await api.organization('buildcomplete');
+      const repo = await api.repository(org.name, 'build-success');
+
+      // Trigger a build with a simple Dockerfile
+      const build = await api.build(
+        org.name,
+        repo.name,
+        'FROM scratch\nLABEL test="e2e-build"\n',
+      );
+
+      // Wait for build to reach a terminal phase
+      const result = await api.raw.waitForBuildPhase(
+        org.name,
+        repo.name,
+        build.buildId,
+      );
+
+      expect(result.phase).toBe('complete');
+    });
+
+    test('build creates expected tag in repository', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('buildtag');
+      const repo = await api.repository(org.name, 'build-tags');
+      const tagName = 'e2e-test';
+
+      // Trigger a build with a specific tag
+      const build = await api.build(
+        org.name,
+        repo.name,
+        'FROM scratch\nLABEL test="e2e-tag"\n',
+        [tagName],
+      );
+
+      // Wait for build to complete
+      const result = await api.raw.waitForBuildPhase(
+        org.name,
+        repo.name,
+        build.buildId,
+      );
+      expect(result.phase).toBe('complete');
+
+      // Navigate to Tags tab and verify the tag exists
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}?tab=tags`,
+      );
+
+      await expect(authenticatedPage.getByText(tagName)).toBeVisible();
+    });
+
+    test('build logs are visible', async ({authenticatedPage, api}) => {
+      const org = await api.organization('buildlogs');
+      const repo = await api.repository(org.name, 'build-logs');
+
+      // Trigger a build
+      const build = await api.build(
+        org.name,
+        repo.name,
+        'FROM scratch\nLABEL test="e2e-logs"\n',
+      );
+
+      // Wait for build to complete (or at least start building)
+      await api.raw.waitForBuildPhase(org.name, repo.name, build.buildId);
+
+      // Navigate to the build detail page
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}/build/${build.buildId}`,
+      );
+
+      // Build logs page should show some content
+      await expect(
+        authenticatedPage
+          .locator('[data-testid="build-logs"]')
+          .or(authenticatedPage.getByText('Build Logs')),
+      ).toBeVisible();
+    });
+
+    test('build with invalid Dockerfile shows error state', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('builderror');
+      const repo = await api.repository(org.name, 'build-error');
+
+      // Trigger a build with invalid Dockerfile content
+      const build = await api.build(
+        org.name,
+        repo.name,
+        'INVALID DOCKERFILE CONTENT\n',
+      );
+
+      // Wait for build to reach terminal phase (should error)
+      const result = await api.raw.waitForBuildPhase(
+        org.name,
+        repo.name,
+        build.buildId,
+      );
+
+      expect(['error', 'internal_error']).toContain(result.phase);
+
+      // Navigate to builds tab and verify error is shown
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}?tab=builds`,
+      );
+
+      await expect(
+        authenticatedPage.getByText(build.buildId.substring(0, 8)),
+      ).toBeVisible();
+    });
+
+    test('shows empty state when no builds exist', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('nobilds');
+      const repo = await api.repository(org.name, 'empty-builds');
+
+      // Navigate to Builds tab
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}?tab=builds`,
+      );
+
+      // Should show empty state
+      await expect(
+        authenticatedPage.getByText('No builds have been run'),
+      ).toBeVisible();
+    });
+  },
+);

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -625,11 +625,13 @@ export class TestApi {
     namespace: string,
     repoName: string,
     dockerfileContent = 'FROM scratch\n',
+    dockerTags: string[] = [],
   ): Promise<CreatedBuild> {
     const result = await this.client.startDockerfileBuild(
       namespace,
       repoName,
       dockerfileContent,
+      dockerTags,
     );
 
     // No cleanup needed - builds are deleted when the repository is deleted

--- a/web/playwright/utils/api/client.ts
+++ b/web/playwright/utils/api/client.ts
@@ -1491,6 +1491,7 @@ export class ApiClient {
     namespace: string,
     repo: string,
     dockerfileContent = 'FROM scratch\n',
+    dockerTags: string[] = [],
   ): Promise<{id: string}> {
     const token = await this.fetchToken();
 
@@ -1545,6 +1546,7 @@ export class ApiClient {
         },
         data: {
           file_id: fileId,
+          ...(dockerTags.length > 0 && {docker_tags: dockerTags}),
         },
       },
     );
@@ -1557,6 +1559,106 @@ export class ApiClient {
     }
 
     return buildResponse.json();
+  }
+
+  /**
+   * Get build status for a specific build.
+   */
+  async getBuildStatus(
+    namespace: string,
+    repo: string,
+    buildId: string,
+  ): Promise<{id: string; phase: string; error?: string}> {
+    const response = await this.request.get(
+      `${API_URL}/api/v1/repository/${namespace}/${repo}/build/${buildId}/status`,
+      {timeout: 10000},
+    );
+
+    if (!response.ok()) {
+      const body = await response.text();
+      throw new Error(
+        `Failed to get build status: ${response.status()} - ${body}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Get build logs for a specific build.
+   */
+  async getBuildLogs(
+    namespace: string,
+    repo: string,
+    buildId: string,
+  ): Promise<{start: number; total: number; logs: Array<{message: string}>}> {
+    const response = await this.request.get(
+      `${API_URL}/api/v1/repository/${namespace}/${repo}/build/${buildId}/logs`,
+      {timeout: 10000},
+    );
+
+    if (!response.ok()) {
+      const body = await response.text();
+      throw new Error(
+        `Failed to get build logs: ${response.status()} - ${body}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  /**
+   * List builds for a repository.
+   */
+  async getBuilds(
+    namespace: string,
+    repo: string,
+  ): Promise<{builds: Array<{id: string; phase: string; started: string}>}> {
+    const response = await this.request.get(
+      `${API_URL}/api/v1/repository/${namespace}/${repo}/build/`,
+      {timeout: 10000},
+    );
+
+    if (!response.ok()) {
+      const body = await response.text();
+      throw new Error(`Failed to get builds: ${response.status()} - ${body}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Poll build status until it reaches a terminal phase or timeout.
+   * Returns the final phase.
+   */
+  async waitForBuildPhase(
+    namespace: string,
+    repo: string,
+    buildId: string,
+    terminalPhases = [
+      'complete',
+      'error',
+      'internal_error',
+      'cancelled',
+      'expired',
+    ],
+    timeoutMs = 180000,
+    pollIntervalMs = 3000,
+  ): Promise<{phase: string; error?: string}> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const status = await this.getBuildStatus(namespace, repo, buildId);
+      if (terminalPhases.includes(status.phase)) {
+        return {phase: status.phase, error: status.error};
+      }
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+    }
+
+    const finalStatus = await this.getBuildStatus(namespace, repo, buildId);
+    throw new Error(
+      `Build ${buildId} did not reach terminal phase within ${timeoutMs}ms. Current phase: ${finalStatus.phase}`,
+    );
   }
 
   // Proxy cache methods


### PR DESCRIPTION
Fix broken PopenExecutor (wrong constructor signature, deprecated WebSocket
protocol, broken running_builders_count) and wire up real container builds
in GitHub Actions CI using the quay-builder binary.

- Fix PopenExecutor to use gRPC instead of WebSocket, match base class
  constructor signature, add error handling and job cleanup
- Add build config (local-dev/builds/builds-config.yaml) with popen
  executor targeting Docker runtime
- Extend setup-quay action with `with-builds` input to extract
  quay-builder binary and mount Docker socket
- Add Playwright e2e tests for real builds: trigger, completion,
  tag creation, logs, error states
- Add Makefile targets for extracting quay-builder binary
- Expose gRPC port 50051 in docker-compose for build manager

Co-authored-by: Claude <noreply@anthropic.com>
