### PR TITLE
NO-ISSUE: fix(web): add cross-domain script guard in jQuery ajax converter (CVE-2015-9251)

### DIFF
--- a/static/ldn/jquery.js-3c5c5966471e.js
+++ b/static/ldn/jquery.js-3c5c5966471e.js
@@ -8768,6 +8768,12 @@ function ajaxConvert( s, response, jqXHR, isSuccess ) {
 			} else if ( prev !== "*" && prev !== current ) {
 
 				// Seek a direct converter
+
+				// Mitigate possible XSS vulnerability (gh-2432)
+				if ( s.crossDomain && current === "script" ) {
+					continue;
+				}
+
 				conv = converters[ prev + " " + current ] || converters[ "* " + current ];
 
 				// If none found, seek a pair


### PR DESCRIPTION
## Summary
This change mitigates CVE-2015-9251 behavior in a vendored jQuery clone at `static/ldn/jquery.js-3c5c5966471e.js`.
It mirrors the upstream jQuery security intent to avoid implicit cross-domain script execution during ajax response conversion.

## Changes
- Adds a cross-domain script guard in `ajaxConvert(...)`.
- Preserves normal conversion flow for other data types.

## Impact
This reduces XSS risk from cross-domain ajax responses being interpreted as script implicitly.

## References
- Upstream fix: https://github.com/jquery/jquery/commit/2546bb35b89413da5198d54a4539e4ed0aaf6e49
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2015-9251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cross-domain script requests would incorrectly attempt unnecessary data conversions, which could result in request failures or unexpected behavior. This improves stability when loading external scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->