### PR TITLE
QUAYIO-1629: kinesis: using ExplicitHashKey for even shard distribution

### DIFF
--- a/data/logs_model/logs_producer/kinesis_stream_logs_producer.py
+++ b/data/logs_model/logs_producer/kinesis_stream_logs_producer.py
@@ -18,26 +18,31 @@ DEFAULT_READ_TIMEOUT = 5
 MAX_RETRY_ATTEMPTS = 5
 DEFAULT_MAX_POOL_CONNECTIONS = 10
 
+# Kinesis hash space: 0 to 2^128 - 1
+KINESIS_HASH_SPACE = 2**128
 
-def _partition_key(number_of_shards=None):
+
+def _partition_key():
     """
-    Generate a partition key for AWS Kinesis stream.
-
-    If the number of shards is specified, generate keys where the size of the key space is the
-    number of shards.
+    Generate a random partition key for AWS Kinesis stream.
     """
-    key = None
-    if number_of_shards is not None:
-        shard_number = random.randrange(0, number_of_shards)
-        key = hashlib.sha1(
-            (KINESIS_PARTITION_KEY_PREFIX + str(shard_number)).encode("utf-8")
-        ).hexdigest()
-    else:
-        key = hashlib.sha1(
-            (KINESIS_PARTITION_KEY_PREFIX + str(random.getrandbits(256))).encode("utf-8")
-        ).hexdigest()
+    return hashlib.sha1(
+        (KINESIS_PARTITION_KEY_PREFIX + str(random.getrandbits(256))).encode("utf-8")
+    ).hexdigest()
 
-    return key
+
+def _explicit_hash_key(number_of_shards):
+    """
+    Generate an ExplicitHashKey that targets a random shard evenly.
+
+    Divides the Kinesis hash space (0 to 2^128 - 1) into equal slices,
+    one per shard, and returns a random point within a randomly chosen slice.
+    This bypasses Kinesis's internal MD5 hashing and guarantees even distribution.
+    """
+    shard_number = random.randrange(0, number_of_shards)
+    slice_size = KINESIS_HASH_SPACE // number_of_shards
+    shard_start = slice_size * shard_number
+    return str(shard_start + random.randrange(0, slice_size))
 
 
 class KinesisStreamLogsProducer(LogProducerInterface):
@@ -79,13 +84,36 @@ class KinesisStreamLogsProducer(LogProducerInterface):
             aws_secret_access_key=self._aws_secret_key,
             config=client_config,
         )
+        self._number_of_shards = self._get_open_shard_count()
+
+    def _get_open_shard_count(self):
+        """
+        Query Kinesis for the current number of open shards in the stream.
+        """
+        try:
+            response = self._producer.describe_stream_summary(StreamName=self._stream_name)
+            count = response["StreamDescriptionSummary"]["OpenShardCount"]
+            logger.info("Kinesis stream %s has %d open shards", self._stream_name, count)
+            return count
+        except ClientError as ce:
+            logger.exception(
+                "Failed to get shard count for stream %s, falling back to random partition keys: %s",
+                self._stream_name,
+                ce,
+            )
+            return None
 
     def send(self, logentry):
         try:
             data = logs_json_serializer(logentry)
-            self._producer.put_record(
-                StreamName=self._stream_name, Data=data, PartitionKey=_partition_key()
-            )
+            put_kwargs = {
+                "StreamName": self._stream_name,
+                "Data": data,
+                "PartitionKey": _partition_key(),
+            }
+            if self._number_of_shards is not None:
+                put_kwargs["ExplicitHashKey"] = _explicit_hash_key(self._number_of_shards)
+            self._producer.put_record(**put_kwargs)
         except ClientError as ce:
             logger.exception(
                 "KinesisStreamLogsProducer client error sending log to Kinesis: %s", ce

--- a/data/logs_model/test/test_logs_producer.py
+++ b/data/logs_model/test/test_logs_producer.py
@@ -2,6 +2,7 @@ import logging
 
 import botocore
 import pytest
+from botocore.exceptions import ClientError
 from dateutil.parser import parse
 from mock import Mock, patch
 
@@ -14,6 +15,10 @@ from .test_elasticsearch import (
     mock_elasticsearch,
 )
 from data.logs_model import configure
+from data.logs_model.logs_producer.kinesis_stream_logs_producer import (
+    KINESIS_HASH_SPACE,
+    _explicit_hash_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -87,9 +92,18 @@ def test_kinesis_logs_producers(
     mock_elasticsearch.template = Mock(return_value=DEFAULT_TEMPLATE_RESPONSE)
 
     producer_config = kinesis_logs_producer_config
+    describe_response = {
+        "StreamDescriptionSummary": {"OpenShardCount": 4},
+    }
+
+    def mock_api_call(operation_name, kwargs):
+        if operation_name == "DescribeStreamSummary":
+            return describe_response
+        return {}
+
     with (
         patch("botocore.endpoint.EndpointCreator.create_endpoint"),
-        patch("botocore.client.BaseClient._make_api_call") as mock_send,
+        patch("botocore.client.BaseClient._make_api_call", side_effect=mock_api_call) as mock_send,
     ):
         configure(producer_config)
         logs_model.log_action(
@@ -103,6 +117,124 @@ def test_kinesis_logs_producers(
             parse("2019-01-01T03:30"),
         )
 
-        # Check that a PutRecord api call is made.
-        # NOTE: The second arg of _make_api_call uses a randomized PartitionKey
-        mock_send.assert_called_once_with("PutRecord", mock_send.call_args_list[0][0][1])
+        # Should have 2 calls: DescribeStreamSummary (init) + PutRecord (send)
+        assert mock_send.call_count == 2
+        assert mock_send.call_args_list[0][0][0] == "DescribeStreamSummary"
+        assert mock_send.call_args_list[1][0][0] == "PutRecord"
+        put_kwargs = mock_send.call_args_list[1][0][1]
+        assert "ExplicitHashKey" in put_kwargs
+        assert "PartitionKey" in put_kwargs
+
+
+def test_kinesis_logs_producer_with_explicit_hash_key(
+    logs_model, mock_elasticsearch, mock_db_model, kinesis_logs_producer_config
+):
+    """Test that ExplicitHashKey is used when shard count is auto-detected."""
+    mock_elasticsearch.template = Mock(return_value=DEFAULT_TEMPLATE_RESPONSE)
+
+    producer_config = kinesis_logs_producer_config
+    describe_response = {
+        "StreamDescriptionSummary": {"OpenShardCount": 4},
+    }
+
+    def mock_api_call(operation_name, kwargs):
+        if operation_name == "DescribeStreamSummary":
+            return describe_response
+        return {}
+
+    with (
+        patch("botocore.endpoint.EndpointCreator.create_endpoint"),
+        patch("botocore.client.BaseClient._make_api_call", side_effect=mock_api_call) as mock_send,
+    ):
+        configure(producer_config)
+        logs_model.log_action(
+            "pull_repo",
+            "user1",
+            Mock(id=1),
+            "192.168.1.1",
+            {"key": "value"},
+            None,
+            "repo1",
+            parse("2019-01-01T03:30"),
+        )
+
+        # Should have 2 calls: DescribeStreamSummary (init) + PutRecord (send)
+        assert mock_send.call_count == 2
+        assert mock_send.call_args_list[0][0][0] == "DescribeStreamSummary"
+        assert mock_send.call_args_list[1][0][0] == "PutRecord"
+        put_kwargs = mock_send.call_args_list[1][0][1]
+        assert "ExplicitHashKey" in put_kwargs
+
+
+def test_explicit_hash_key_within_hash_space():
+    """Test that _explicit_hash_key returns values within the Kinesis hash space."""
+    for _ in range(100):
+        key = int(_explicit_hash_key(128))
+        assert 0 <= key < KINESIS_HASH_SPACE
+
+
+def test_explicit_hash_key_distributes_across_shards():
+    """Test that _explicit_hash_key distributes evenly across all shards."""
+    number_of_shards = 4
+    slice_size = KINESIS_HASH_SPACE // number_of_shards
+    shard_hits = {i: 0 for i in range(number_of_shards)}
+
+    for _ in range(1000):
+        key = int(_explicit_hash_key(number_of_shards))
+        shard = key // slice_size
+        shard_hits[shard] += 1
+
+    # Each shard should get roughly 250 hits out of 1000
+    for shard, count in shard_hits.items():
+        assert count > 100, f"Shard {shard} only got {count} hits, expected ~250"
+
+
+def test_explicit_hash_key_single_shard():
+    """Test that _explicit_hash_key with 1 shard always targets shard 0's range."""
+    for _ in range(100):
+        key = int(_explicit_hash_key(1))
+        assert 0 <= key < KINESIS_HASH_SPACE
+
+
+def test_kinesis_fallback_when_shard_count_unavailable(
+    logs_model, mock_elasticsearch, mock_db_model, kinesis_logs_producer_config
+):
+    """Test that when describe_stream_summary fails, ExplicitHashKey is not set
+    and the old _partition_key() logic is used as PartitionKey."""
+    mock_elasticsearch.template = Mock(return_value=DEFAULT_TEMPLATE_RESPONSE)
+
+    producer_config = kinesis_logs_producer_config
+
+    def mock_api_call(operation_name, kwargs):
+        if operation_name == "DescribeStreamSummary":
+            raise ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "Not authorized"}},
+                "DescribeStreamSummary",
+            )
+        return {}
+
+    with (
+        patch("botocore.endpoint.EndpointCreator.create_endpoint"),
+        patch("botocore.client.BaseClient._make_api_call", side_effect=mock_api_call) as mock_send,
+    ):
+        configure(producer_config)
+        logs_model.log_action(
+            "pull_repo",
+            "user1",
+            Mock(id=1),
+            "192.168.1.1",
+            {"key": "value"},
+            None,
+            "repo1",
+            parse("2019-01-01T03:30"),
+        )
+
+        # Should have 2 calls: DescribeStreamSummary (failed) + PutRecord (send)
+        assert mock_send.call_count == 2
+        assert mock_send.call_args_list[0][0][0] == "DescribeStreamSummary"
+        assert mock_send.call_args_list[1][0][0] == "PutRecord"
+        put_kwargs = mock_send.call_args_list[1][0][1]
+        assert "ExplicitHashKey" not in put_kwargs
+        assert "PartitionKey" in put_kwargs
+        # PartitionKey should be a 40-char SHA1 hex digest from _partition_key()
+        assert len(put_kwargs["PartitionKey"]) == 40


### PR DESCRIPTION
 Problem: Kinesis ProvisionedThroughputExceededException — hot shards caused by uneven record distribution. The old code
  used random PartitionKey values that get MD5-hashed by Kinesis, with no control over which shard receives the record.

  Fix: Use ExplicitHashKey to bypass Kinesis's MD5 hashing and directly target shards evenly.

  How it works:
  1. On startup, auto-detect the stream's shard count via describe_stream_summary()
  2. On each send(), divide the Kinesis hash space (0 to 2^128-1) into equal slices per shard, pick a random shard, and
  generate an ExplicitHashKey within that shard's range
  3. If shard detection fails, fall back to the original _partition_key() behavior (no regression)