### PR TITLE
PROJQUAY-10931: fix(ui): allow selecting None in robot wizard permission dropdown

### DIFF
--- a/web/playwright/e2e/organization/robot-accounts.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts.spec.ts
@@ -563,17 +563,92 @@ test.describe(
 
       // Verify changing the dropdown works
       await authenticatedPage.locator('#toggle-descriptions').click();
-      await authenticatedPage.getByRole('menuitem', {name: 'Read'}).click();
+      await authenticatedPage.getByTestId('Read-permission-type').click();
       await expect(
         authenticatedPage.locator('#toggle-descriptions'),
       ).toContainText('Read');
 
       // Change back to None and verify
       await authenticatedPage.locator('#toggle-descriptions').click();
-      await authenticatedPage.getByRole('menuitem', {name: 'None'}).click();
+      await authenticatedPage.getByTestId('None-permission-type').click();
       await expect(
         authenticatedPage.locator('#toggle-descriptions'),
       ).toContainText('None');
+    });
+
+    test('robot wizard: selecting None permission deselects the repository (PROJQUAY-10931)', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('nonepermorg');
+      const repo = await api.repository(org.name, 'nonerepo');
+
+      await authenticatedPage.goto(
+        `/organization/${org.name}?tab=Robotaccounts`,
+      );
+
+      // Open the create robot account wizard
+      await authenticatedPage
+        .getByRole('button', {name: 'Create robot account'})
+        .click();
+      await expect(
+        authenticatedPage.locator('#create-robot-account-modal'),
+      ).toBeVisible();
+
+      // Fill in robot name to enable navigation
+      await authenticatedPage
+        .getByTestId('robot-wizard-form-name')
+        .fill('nonebot');
+
+      // Navigate to "Add to repository" step
+      const wizardNav = authenticatedPage.locator(
+        'nav[aria-label="Wizard steps"]',
+      );
+      await wizardNav.getByText('Add to repository (optional)').click();
+
+      // Select the repository checkbox
+      await authenticatedPage
+        .getByTestId(`checkbox-row-${repo.name}`)
+        .locator('input[type="checkbox"]')
+        .click();
+
+      // Verify it defaults to "Read" when selected
+      await expect(
+        authenticatedPage.getByTestId(
+          `${repo.name}-permission-dropdown-toggle`,
+        ),
+      ).toContainText('Read');
+
+      // Change permission to "None"
+      await authenticatedPage
+        .getByTestId(`${repo.name}-permission-dropdown-toggle`)
+        .click();
+      await authenticatedPage.getByTestId('None-permission-type').click();
+
+      // Verify the dropdown shows "None" (not reverting to "Read")
+      await expect(
+        authenticatedPage.getByTestId(
+          `${repo.name}-permission-dropdown-toggle`,
+        ),
+      ).toContainText('None');
+
+      // Verify the row checkbox is now unchecked
+      await expect(
+        authenticatedPage
+          .getByTestId(`checkbox-row-${repo.name}`)
+          .locator('input[type="checkbox"]'),
+      ).not.toBeChecked();
+
+      // Re-select the row and verify it defaults back to "Read"
+      await authenticatedPage
+        .getByTestId(`checkbox-row-${repo.name}`)
+        .locator('input[type="checkbox"]')
+        .click();
+      await expect(
+        authenticatedPage.getByTestId(
+          `${repo.name}-permission-dropdown-toggle`,
+        ),
+      ).toContainText('Read');
     });
 
     test.describe(

--- a/web/src/components/toolbar/DropdownWithDescription.tsx
+++ b/web/src/components/toolbar/DropdownWithDescription.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {
   Dropdown,
   DropdownItem,
@@ -14,13 +14,30 @@ export function DropdownWithDescription(props: DropdownWithDescriptionProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [dropdownToggle, setDropdownToggle] = useState('');
 
+  // Refs for callback props so the useEffect always reads fresh values
+  // without re-triggering when parent recreates function/object references.
+  const onSelectRef = useRef(props.onSelect);
+  const onRowSelectRef = useRef(props.OnRowSelect);
+  const setUserEntryRef = useRef(props.setUserEntry);
+  const repoRef = useRef(props.repo);
+  const rowIndexRef = useRef(props.rowIndex);
+  onSelectRef.current = props.onSelect;
+  onRowSelectRef.current = props.OnRowSelect;
+  setUserEntryRef.current = props.setUserEntry;
+  repoRef.current = props.repo;
+  rowIndexRef.current = props.rowIndex;
+
   const dropdownOnSelect = (name, userEntry) => {
     if (!props.wizarStep) {
       props.setUserEntry(userEntry);
-      if (name == defaultUnSelectedVal) {
+      if (name === defaultUnSelectedVal) {
         props.OnRowSelect(props.repo, props?.rowIndex, false);
-      } else if (name != defaultUnSelectedVal && !props?.isItemSelected) {
+      } else if (name !== defaultUnSelectedVal && !props?.isItemSelected) {
         props.OnRowSelect(props.repo, props?.rowIndex, true);
+      }
+    } else {
+      if (name === defaultUnSelectedVal && props.OnRowSelect) {
+        props.OnRowSelect(props.repo, props?.rowIndex, false);
       }
     }
     setDropdownToggle(name);
@@ -29,13 +46,33 @@ export function DropdownWithDescription(props: DropdownWithDescriptionProps) {
   };
 
   useEffect(() => {
+    // Uses refs for callback props to avoid stale closures without
+    // re-triggering the effect when parent recreates references.
+    const applySelection = (name: string, userEntry: boolean) => {
+      if (!props.wizarStep) {
+        setUserEntryRef.current?.(userEntry);
+        if (name === defaultUnSelectedVal) {
+          onRowSelectRef.current?.(repoRef.current, rowIndexRef.current, false);
+        } else if (name !== defaultUnSelectedVal && !props?.isItemSelected) {
+          onRowSelectRef.current?.(repoRef.current, rowIndexRef.current, true);
+        }
+      } else {
+        if (name === defaultUnSelectedVal && onRowSelectRef.current) {
+          onRowSelectRef.current(repoRef.current, rowIndexRef.current, false);
+        }
+      }
+      setDropdownToggle(name);
+      onSelectRef.current(name, repoRef.current);
+      setIsOpen(false);
+    };
+
     if (props.wizarStep) {
       // Wizard step mode: always default to 'Read' when a row is selected
-      if (props.selectedVal && props.selectedVal != 'None') {
-        dropdownOnSelect(props.selectedVal, true);
+      if (props.selectedVal && props.selectedVal !== 'None') {
+        applySelection(props.selectedVal, true);
       } else if (props?.isItemSelected) {
         // Row is selected but no permission set yet - default to 'Read'
-        dropdownOnSelect(defaultSelectedVal, true);
+        applySelection(defaultSelectedVal, true);
       } else if (props.selectedVal === 'None') {
         setDropdownToggle('None');
       }
@@ -43,9 +80,9 @@ export function DropdownWithDescription(props: DropdownWithDescriptionProps) {
     }
     // Non-wizard mode: only show actual values, be careful about defaulting
     // If we have a valid permission value, always use it first
-    if (props.selectedVal && props.selectedVal != 'None') {
-      if (props.selectedVal != dropdownToggle) {
-        dropdownOnSelect(props.selectedVal, props?.isUserEntry || false);
+    if (props.selectedVal && props.selectedVal !== 'None') {
+      if (props.selectedVal !== dropdownToggle) {
+        applySelection(props.selectedVal, props?.isUserEntry || false);
       }
       return;
     }
@@ -53,13 +90,13 @@ export function DropdownWithDescription(props: DropdownWithDescriptionProps) {
     // not when rows are auto-selected during loading of existing permissions
     if (
       props?.isItemSelected &&
-      (!props.selectedVal || props.selectedVal == 'None')
+      (!props.selectedVal || props.selectedVal === 'None')
     ) {
       if (props?.isUserEntry) {
-        dropdownOnSelect(defaultSelectedVal, true);
+        applySelection(defaultSelectedVal, true);
       }
     } else if (!props?.isItemSelected) {
-      dropdownOnSelect(defaultUnSelectedVal, props?.isUserEntry || false);
+      applySelection(defaultUnSelectedVal, props?.isUserEntry || false);
     }
   }, [
     props?.isItemSelected,


### PR DESCRIPTION

In wizard mode, selecting "None" from the repository permission dropdown immediately reverted to "Read" because the row remained checked, causing the useEffect to re-default the permission. Fix by deselecting the row when "None" is chosen in wizard mode, matching the non-wizard behavior.

Also fix stale closure in useEffect by using refs for callback props, and replace loose equality (==) with strict equality (===) throughout.