### PR TITLE
PROJQUAY-11218: fix(ui): permission dropdowns navigate away in Firefox

### DIFF
--- a/web/playwright/e2e/organization/permission-dropdown-navigation.spec.ts
+++ b/web/playwright/e2e/organization/permission-dropdown-navigation.spec.ts
@@ -24,9 +24,6 @@ test.describe(
       const settingsUrl = `/repository/${org.name}/${repo.name}?tab=settings`;
       await authenticatedPage.goto(settingsUrl);
 
-      // Get the URL before clicking the dropdown
-      const urlBefore = authenticatedPage.url();
-
       // Click the permission dropdown to change role
       const teamRow = authenticatedPage.locator('tr', {hasText: team.name});
       await teamRow.getByText('read').click();
@@ -35,7 +32,7 @@ test.describe(
       await authenticatedPage.getByRole('menuitem', {name: 'Write'}).click();
 
       // Verify we stayed on the same page (no navigation occurred)
-      await expect(authenticatedPage).toHaveURL(new RegExp(settingsUrl));
+      await expect(authenticatedPage).toHaveURL(settingsUrl);
 
       // Verify the permission was actually updated
       await expect(teamRow.locator('[data-label="role"]')).toHaveText('write');
@@ -74,12 +71,10 @@ test.describe(
         .click();
 
       // Click a permission option — this is where Firefox would navigate away
-      await authenticatedPage
-        .getByTestId(`${robot.fullName}-WRITE`)
-        .click();
+      await authenticatedPage.getByTestId(`${robot.fullName}-WRITE`).click();
 
       // Verify we stayed on the same page
-      await expect(authenticatedPage).toHaveURL(new RegExp(defaultPermsUrl));
+      await expect(authenticatedPage).toHaveURL(defaultPermsUrl);
 
       // Verify success alert confirms the change worked
       await expect(
@@ -123,7 +118,7 @@ test.describe(
         .click();
 
       // Verify we stayed on the same page
-      await expect(authenticatedPage).toHaveURL(new RegExp(defaultPermsUrl));
+      await expect(authenticatedPage).toHaveURL(defaultPermsUrl);
 
       // Verify the dropdown shows the selected value
       await expect(

--- a/web/playwright/e2e/organization/permission-dropdown-navigation.spec.ts
+++ b/web/playwright/e2e/organization/permission-dropdown-navigation.spec.ts
@@ -1,0 +1,136 @@
+import {test, expect} from '../../fixtures';
+
+test.describe(
+  'Permission dropdown does not navigate away',
+  {tag: ['@organization', '@critical']},
+  () => {
+    test('inline permission change stays on page', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      // Setup: org with repo, team, and a read permission
+      const org = await api.organization('dropnav');
+      const repo = await api.repository(org.name, 'navrepo');
+      const team = await api.team(org.name, 'navteam');
+      await api.repositoryPermission(
+        org.name,
+        repo.name,
+        'team',
+        team.name,
+        'read',
+      );
+
+      // Navigate to repository settings
+      const settingsUrl = `/repository/${org.name}/${repo.name}?tab=settings`;
+      await authenticatedPage.goto(settingsUrl);
+
+      // Get the URL before clicking the dropdown
+      const urlBefore = authenticatedPage.url();
+
+      // Click the permission dropdown to change role
+      const teamRow = authenticatedPage.locator('tr', {hasText: team.name});
+      await teamRow.getByText('read').click();
+
+      // Click a permission option — this is where Firefox would navigate away
+      await authenticatedPage.getByRole('menuitem', {name: 'Write'}).click();
+
+      // Verify we stayed on the same page (no navigation occurred)
+      await expect(authenticatedPage).toHaveURL(new RegExp(settingsUrl));
+
+      // Verify the permission was actually updated
+      await expect(teamRow.locator('[data-label="role"]')).toHaveText('write');
+    });
+
+    test('default permission dropdown stays on page', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      // Setup: org with team, robot, and a default permission
+      const org = await api.organization('dropnav2');
+      const team = await api.team(org.name, 'navteam');
+      const robot = await api.robot(org.name, 'navbot');
+      await api.prototype(
+        org.name,
+        'read',
+        {name: team.name, kind: 'team'},
+        {name: robot.fullName},
+      );
+
+      // Navigate to default permissions tab
+      const defaultPermsUrl = `/organization/${org.name}?tab=Defaultpermissions`;
+      await authenticatedPage.goto(defaultPermsUrl);
+
+      // Wait for data to load
+      const tabPanel = authenticatedPage.getByRole('tabpanel', {
+        name: 'Default permissions',
+      });
+      await expect(
+        tabPanel.locator('.pf-v6-c-pagination__total-items').first(),
+      ).toContainText('1 - 1 of 1', {timeout: 15000});
+
+      // Click permission dropdown toggle
+      await authenticatedPage
+        .getByTestId(`${robot.fullName}-permission-dropdown-toggle`)
+        .click();
+
+      // Click a permission option — this is where Firefox would navigate away
+      await authenticatedPage
+        .getByTestId(`${robot.fullName}-WRITE`)
+        .click();
+
+      // Verify we stayed on the same page
+      await expect(authenticatedPage).toHaveURL(new RegExp(defaultPermsUrl));
+
+      // Verify success alert confirms the change worked
+      await expect(
+        authenticatedPage.locator('.pf-v6-c-alert.pf-m-success').last(),
+      ).toContainText('Permission updated successfully');
+    });
+
+    test('create default permission dropdown stays on page', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      // Setup: org with team
+      const org = await api.organization('dropnav3');
+      const team = await api.team(org.name, 'navteam');
+
+      // Navigate to default permissions tab
+      const defaultPermsUrl = `/organization/${org.name}?tab=Defaultpermissions`;
+      await authenticatedPage.goto(defaultPermsUrl);
+
+      // Open create default permission drawer
+      await authenticatedPage
+        .getByTestId('create-default-permissions-btn')
+        .click();
+
+      // Select "Anyone" type
+      await authenticatedPage.getByTestId('Anyone').click();
+
+      // Select team
+      await authenticatedPage.locator('#applied-to-dropdown').click();
+      await authenticatedPage.getByTestId(`${team.name}-team`).click();
+
+      // Click the permission level dropdown
+      await authenticatedPage
+        .getByTestId('create-default-permission-dropdown-toggle')
+        .click();
+
+      // Click "Write" — this is where Firefox would navigate away
+      await authenticatedPage
+        .getByTestId('create-default-permission-dropdown')
+        .getByText('Write')
+        .click();
+
+      // Verify we stayed on the same page
+      await expect(authenticatedPage).toHaveURL(new RegExp(defaultPermsUrl));
+
+      // Verify the dropdown shows the selected value
+      await expect(
+        authenticatedPage.getByTestId(
+          'create-default-permission-dropdown-toggle',
+        ),
+      ).toContainText('Write');
+    });
+  },
+);

--- a/web/src/components/modals/robotAccountWizard/AddToRepository.tsx
+++ b/web/src/components/modals/robotAccountWizard/AddToRepository.tsx
@@ -187,6 +187,7 @@ export default function AddToRepository(props: AddToRepositoryProps) {
 
   const kebabItems = props.dropdownItems.map((item) => (
     <DropdownItem
+      component="button"
       key={item.name}
       description={item.description}
       onClick={() => dropdownOnSelect(item)}

--- a/web/src/components/toolbar/DropdownWithDescription.tsx
+++ b/web/src/components/toolbar/DropdownWithDescription.tsx
@@ -127,6 +127,7 @@ export function DropdownWithDescription(props: DropdownWithDescriptionProps) {
       <DropdownList>
         {props.dropdownItems.map((item) => (
           <DropdownItem
+            component="button"
             data-testid={`${item.name}-permission-type`}
             key={item.name}
             description={item.description}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsDropDown.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsDropDown.tsx
@@ -65,6 +65,7 @@ export default function DefaultPermissionsDropDown(
       <DropdownList>
         {Object.keys(repoPermissions).map((key) => (
           <DropdownItem
+            component="button"
             data-testid={`${props.defaultPermission.createdBy}-${key}`}
             key={repoPermissions[key]}
             onClick={() =>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreatePermissionDrawer.tsx
@@ -337,6 +337,7 @@ export default function CreatePermissionDrawer(
 
   const optionsForPermission = Object.keys(repoPermissions).map((key) => (
     <DropdownItem
+      component="button"
       data-testid={`repoPermissions-${key}`}
       key={repoPermissions[key]}
       value={repoPermissions[key]}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/SetRepoPermissionsModal/SetRepoPermForTeamRoleDropDown.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/SetRepoPermissionsModal/SetRepoPermForTeamRoleDropDown.tsx
@@ -54,6 +54,7 @@ export function SetRepoPermForTeamRoleDropDown(
       <DropdownList>
         {RepoPermissionDropdownItems.map((item) => (
           <DropdownItem
+            component="button"
             data-testid={`${props.repoPerm.repoName}-${item.name}`}
             key={item.name}
             description={item.description}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/SetRepoPermissionsModal/SetRepoPermissionsForTeamToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/SetRepoPermissionsModal/SetRepoPermissionsForTeamToolbar.tsx
@@ -59,6 +59,7 @@ export default function SetRepoPermissionsForTeamModalToolbar(
                 setKebabOpen={props.setKebabOpen}
                 kebabItems={RepoPermissionDropdownItems.map((item) => (
                   <DropdownItem
+                    component="button"
                     key={item.name}
                     data-testid={`bulk-perm-${item.name}`}
                     description={item.description}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsRoleDropDown.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/TeamsRoleDropDown.tsx
@@ -66,6 +66,7 @@ export function TeamsRoleDropDown(props: TeamsRoleDropDownProps) {
       <DropdownList>
         {Object.keys(teamPermissions).map((key) => (
           <DropdownItem
+            component="button"
             data-testid={`${props.teamName}-${key}`}
             key={key}
             onClick={() =>

--- a/web/src/routes/RepositoryDetails/Settings/PermissionsDropdown.tsx
+++ b/web/src/routes/RepositoryDetails/Settings/PermissionsDropdown.tsx
@@ -55,6 +55,7 @@ export default function PermissionsDropdown({
         <DropdownList>
           {roles.map((role) => (
             <DropdownItem
+              component="button"
               key={role.name}
               description={role.description}
               onClick={() =>


### PR DESCRIPTION
## Summary
- In Firefox, clicking a permission in dropdown lists (create team, create robot popups, repo settings) navigates to a "This site is temporarily unavailable" page instead of selecting the permission
- Root cause: PatternFly `DropdownItem` defaults to rendering as `<a>` tags, and Firefox navigates when clicking `<a>` without a proper href
- Fix: Add `component="button"` to all permission-related `DropdownItem` components so they render as `<button>` instead of `<a>`

## Demo
[pr-5690-firefox-dropdown-fix.webm](https://github.com/user-attachments/assets/2284e9e2-ddee-4d4a-9030-2b5106078a23)

## Files changed
- `DropdownWithDescription.tsx` — shared permission dropdown component
- `PermissionsDropdown.tsx` — repo settings permissions
- `DefaultPermissionsDropDown.tsx` — org default permissions
- `SetRepoPermForTeamRoleDropDown.tsx` — team repo permissions
- `SetRepoPermissionsForTeamToolbar.tsx` — bulk team repo permissions
- `CreatePermissionDrawer.tsx` — create permission drawer
- `AddToRepository.tsx` — robot account repo permissions
- `TeamsRoleDropDown.tsx` — team role dropdown

## Test plan
- [ ] In Firefox, open create team popup and verify permission dropdown works without navigation
- [ ] In Firefox, open create robot account wizard and verify permission dropdown works
- [ ] In Firefox, change repo permissions in repo settings and verify dropdown works
- [ ] In Firefox, change default permissions in org settings and verify dropdown works
- [ ] Verify Chrome/Safari behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)