### PR TITLE
PROJQUAY-11216: fix(mirror): accept skopeo_timeout_interval from React UI

### DIFF
--- a/endpoints/api/mirror.py
+++ b/endpoints/api/mirror.py
@@ -69,6 +69,12 @@ common_properties = {
         },
         "description": "A list of glob-patterns used to determine which tags should be synchronized.",
     },
+    "skopeo_timeout_interval": {
+        "type": "integer",
+        "minimum": 300,
+        "maximum": 43200,
+        "description": "Skopeo timeout interval in seconds. Accepted for compatibility but not persisted.",
+    },
     "external_registry_config": {
         "type": "object",
         "properties": {

--- a/endpoints/api/test/test_mirror.py
+++ b/endpoints/api/test/test_mirror.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from test.fixtures import *
 
 import pytest
 
@@ -7,6 +6,7 @@ from data import model
 from endpoints.api.mirror import RepoMirrorResource
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
+from test.fixtures import *
 
 
 def _setup_mirror():
@@ -249,3 +249,22 @@ def test_change_credentials(request_body, expected_status, app):
     with client_with_identity("devtable", app) as cl:
         params = {"repository": "devtable/simple"}
         conduct_api_call(cl, RepoMirrorResource, "PUT", params, request_body, expected_status)
+
+
+def test_create_mirror_with_skopeo_timeout_interval(app):
+    """
+    Verify that sending skopeo_timeout_interval (as the React UI does) does not
+    cause a 500 error. The field should pass validation and be stripped before
+    reaching the model layer.
+    """
+    with client_with_identity("devtable", app) as cl:
+        params = {"repository": "devtable/simple"}
+        request_body = {
+            "external_reference": "quay.io/foobar/barbaz",
+            "sync_interval": 100,
+            "sync_start_date": "2019-08-20T17:51:00Z",
+            "root_rule": {"rule_kind": "tag_glob_csv", "rule_value": ["latest"]},
+            "robot_username": "devtable+dtrobot",
+            "skopeo_timeout_interval": 300,
+        }
+        conduct_api_call(cl, RepoMirrorResource, "POST", params, request_body, 201)


### PR DESCRIPTION
## Summary
- Fixes the remaining issue from #5683 where mirroring still fails when using the React UI
- The previous fix added `additionalProperties: false` to the `CreateMirrorConfig` schema, which rejects `skopeo_timeout_interval` at validation time (400 error). However, the React UI **always sends** this field, so users still cannot enable mirroring
- Adds `skopeo_timeout_interval` to `common_properties` so it passes schema validation. The existing `data.pop()` then strips it before calling the model layer

### Root cause
The React UI (`web/src/hooks/UseMirroringConfig.ts`) includes `skopeo_timeout_interval` in the POST payload. On `redhat-3.14`, this field doesn't exist in the database or model — it was added on `master` but not backported. PR #5683's `additionalProperties: false` made validation reject the field (400) before the `data.pop()` workaround could strip it, so the request still fails.

## Demo
[mirroring-bug-fix-validation.webm](https://github.com/user-attachments/assets/a3c9ba85-c227-4b68-8f76-16918dd6902c)


## Test plan
- [x] All 59 mirror unit tests pass (58 existing + 1 new)
- [x] New test `test_create_mirror_with_skopeo_timeout_interval` verifies POST with this field returns 201
- [x] Full e2e test with Playwright using React UI (`make local-dev-up-static`): filled mirroring form, clicked "Enable Mirror" → POST returned 201, mirror config persisted

Fixes: https://issues.redhat.com/browse/PROJQUAY-11216

🤖 Generated with [Claude Code](https://claude.com/claude-code)