### PR TITLE
PROJQUAY-11274: fix(api): enforce fresh login on all sensitive mutation endpoints

### DIFF
--- a/endpoints/api/billing.py
+++ b/endpoints/api/billing.py
@@ -29,6 +29,7 @@ from endpoints.api import (
     nickname,
     path_param,
     related_user_resource,
+    require_fresh_login,
     require_scope,
     require_user_admin,
     resource,
@@ -298,6 +299,7 @@ class UserCard(ApiResource):
         return get_card(user)
 
     @require_user_admin()
+    @require_fresh_login
     @nickname("setUserCard")
     @validate_json_request("UserCard")
     def post(self):
@@ -389,6 +391,7 @@ class OrganizationCard(ApiResource):
 
         raise Unauthorized()
 
+    @require_fresh_login
     @nickname("setOrgCard")
     @validate_json_request("OrgCard")
     def post(self, orgname):
@@ -474,6 +477,7 @@ class UserPlan(ApiResource):
     }
 
     @require_user_admin()
+    @require_fresh_login
     @nickname("createUserSubscription")
     @validate_json_request("UserSubscription")
     def post(self):
@@ -532,6 +536,7 @@ class UserPlan(ApiResource):
             abort(500, message=str(e))
 
     @require_user_admin()
+    @require_fresh_login
     @nickname("updateUserSubscription")
     @validate_json_request("UserSubscription")
     def put(self):
@@ -612,6 +617,7 @@ class OrganizationPlan(ApiResource):
     }
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("createOrgSubscription")
     @validate_json_request("OrgSubscription")
     def post(self, orgname):
@@ -675,6 +681,7 @@ class OrganizationPlan(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("updateOrgSubscription")
     @validate_json_request("OrgSubscription")
     def put(self, orgname):
@@ -996,6 +1003,7 @@ class OrganizationRhSku(ApiResource):
         abort(401)
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("bindSkuToOrg")
     def post(self, orgname):
         """
@@ -1063,6 +1071,7 @@ class OrganizationRhSku(ApiResource):
 @show_if(features.BILLING)
 class OrganizationRhSkuBatchRemoval(ApiResource):
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("batchRemoveSku")
     def post(self, orgname):
         """
@@ -1097,6 +1106,7 @@ class OrganizationRhSkuSubscriptionField(ApiResource):
     """
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("removeSkuFromOrg")
     def delete(self, orgname, subscription_id):
         """

--- a/endpoints/api/mirror.py
+++ b/endpoints/api/mirror.py
@@ -17,6 +17,7 @@ from endpoints.api import (
     format_date,
     nickname,
     path_param,
+    require_fresh_login,
     require_repo_admin,
     resource,
     show_if,
@@ -292,6 +293,7 @@ class RepoMirrorResource(RepositoryParamResource):
         }
 
     @require_repo_admin(allow_for_superuser=True)
+    @require_fresh_login
     @nickname("createRepoMirrorConfig")
     @validate_json_request("CreateMirrorConfig")
     def post(self, namespace_name, repository_name):
@@ -367,6 +369,7 @@ class RepoMirrorResource(RepositoryParamResource):
             return {"detail": "RepoMirrorConfig already exists for this repository."}, 409
 
     @require_repo_admin(allow_for_superuser=True)
+    @require_fresh_login
     @validate_json_request("UpdateMirrorConfig")
     @nickname("changeRepoMirrorConfig")
     def put(self, namespace_name, repository_name):

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -182,6 +182,7 @@ class OrganizationList(ApiResource):
     }
 
     @require_user_admin(disallow_for_restricted_users=features.RESTRICTED_USERS)
+    @require_fresh_login
     @nickname("createOrganization")
     @validate_json_request("NewOrg")
     def post(self):
@@ -304,6 +305,7 @@ class Organization(ApiResource):
         return org_view(org, teams)
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("changeOrganizationDetails")
     @validate_json_request("UpdateOrg")
     def put(self, orgname):
@@ -640,6 +642,7 @@ class OrganizationMember(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("removeOrganizationMember")
     def delete(self, orgname, membername):
         """
@@ -774,6 +777,7 @@ class OrganizationApplications(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("createOrganizationApplication")
     @validate_json_request("NewApp")
     def post(self, orgname):
@@ -871,6 +875,7 @@ class OrganizationApplicationResource(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("updateOrganizationApplication")
     @validate_json_request("UpdateApp")
     def put(self, orgname, client_id):
@@ -906,6 +911,7 @@ class OrganizationApplicationResource(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("deleteOrganizationApplication")
     def delete(self, orgname, client_id):
         """
@@ -941,6 +947,8 @@ class OrganizationApplicationResetClientSecret(ApiResource):
     Custom verb for resetting the client secret of an application.
     """
 
+    @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("resetOrganizationApplicationClientSecret")
     def post(self, orgname, client_id):
         """

--- a/endpoints/api/permission.py
+++ b/endpoints/api/permission.py
@@ -14,6 +14,7 @@ from endpoints.api import (
     nickname,
     path_param,
     request_error,
+    require_fresh_login,
     require_repo_admin,
     resource,
     validate_json_request,
@@ -126,6 +127,7 @@ class RepositoryUserPermission(RepositoryParamResource):
         return perm.to_dict()
 
     @require_repo_admin(allow_for_superuser=True)
+    @require_fresh_login
     @nickname("changeUserPermissions")
     @validate_json_request("UserPermission")
     def put(self, namespace_name, repository_name, username):  # Also needs to respond to post
@@ -159,6 +161,7 @@ class RepositoryUserPermission(RepositoryParamResource):
         return resp, 200
 
     @require_repo_admin(allow_for_superuser=True)
+    @require_fresh_login
     @nickname("deleteUserPermissions")
     def delete(self, namespace_name, repository_name, username):
         """
@@ -221,6 +224,7 @@ class RepositoryTeamPermission(RepositoryParamResource):
         return role.to_dict()
 
     @require_repo_admin(allow_for_superuser=True)
+    @require_fresh_login
     @nickname("changeTeamPermissions")
     @validate_json_request("TeamPermission")
     def put(self, namespace_name, repository_name, teamname):
@@ -248,6 +252,7 @@ class RepositoryTeamPermission(RepositoryParamResource):
         return resp, 200
 
     @require_repo_admin(allow_for_superuser=True)
+    @require_fresh_login
     @nickname("deleteTeamPermissions")
     def delete(self, namespace_name, repository_name, teamname):
         """

--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -38,6 +38,7 @@ from endpoints.api import (
     query_param,
     related_user_resource,
     request_error,
+    require_fresh_login,
     require_scope,
     require_user_admin,
     resource,
@@ -151,6 +152,7 @@ class UserRobot(ApiResource):
         return robot.to_dict(include_metadata=True, include_token=True)
 
     @require_user_admin(disallow_for_restricted_users=True)
+    @require_fresh_login
     @nickname("createUserRobot")
     @max_json_size(ROBOT_MAX_SIZE)
     @validate_json_request("CreateRobot", optional=True)
@@ -182,6 +184,7 @@ class UserRobot(ApiResource):
         return robot.to_dict(include_metadata=True, include_token=True), 201
 
     @require_user_admin(disallow_for_restricted_users=True)
+    @require_fresh_login
     @nickname("deleteUserRobot")
     def delete(self, robot_shortname):
         """
@@ -282,6 +285,7 @@ class OrgRobot(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("createOrgRobot")
     @max_json_size(ROBOT_MAX_SIZE)
     @validate_json_request("CreateRobot", optional=True)
@@ -316,6 +320,7 @@ class OrgRobot(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("deleteOrgRobot")
     def delete(self, orgname, robot_shortname):
         """
@@ -398,6 +403,7 @@ class RegenerateUserRobot(ApiResource):
     """
 
     @require_user_admin(disallow_for_restricted_users=True)
+    @require_fresh_login
     @nickname("regenerateUserRobotToken")
     def post(self, robot_shortname):
         """
@@ -421,6 +427,7 @@ class RegenerateOrgRobot(ApiResource):
     """
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("regenerateOrgRobotToken")
     def post(self, orgname, robot_shortname):
         """
@@ -464,6 +471,7 @@ class OrgRobotFederation(ApiResource):
 
     @require_scope(scopes.ORG_ADMIN)
     @validate_json_request("CreateRobotFederation", optional=False)
+    @require_fresh_login
     def post(self, orgname, robot_shortname):
         permission = AdministerOrganizationPermission(orgname)
         if permission.can() or allow_if_superuser_with_full_access():
@@ -482,6 +490,7 @@ class OrgRobotFederation(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     def delete(self, orgname, robot_shortname):
         permission = AdministerOrganizationPermission(orgname)
         if permission.can() or allow_if_superuser_with_full_access():

--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -38,6 +38,7 @@ from endpoints.api import (
     query_param,
     related_user_resource,
     request_error,
+    require_fresh_login,
     require_scope,
     require_user_admin,
     resource,
@@ -151,6 +152,7 @@ class UserRobot(ApiResource):
         return robot.to_dict(include_metadata=True, include_token=True)
 
     @require_user_admin(disallow_for_restricted_users=True)
+    @require_fresh_login
     @nickname("createUserRobot")
     @max_json_size(ROBOT_MAX_SIZE)
     @validate_json_request("CreateRobot", optional=True)
@@ -182,6 +184,7 @@ class UserRobot(ApiResource):
         return robot.to_dict(include_metadata=True, include_token=True), 201
 
     @require_user_admin(disallow_for_restricted_users=True)
+    @require_fresh_login
     @nickname("deleteUserRobot")
     def delete(self, robot_shortname):
         """
@@ -282,6 +285,7 @@ class OrgRobot(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("createOrgRobot")
     @max_json_size(ROBOT_MAX_SIZE)
     @validate_json_request("CreateRobot", optional=True)
@@ -316,6 +320,7 @@ class OrgRobot(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("deleteOrgRobot")
     def delete(self, orgname, robot_shortname):
         """
@@ -398,6 +403,7 @@ class RegenerateUserRobot(ApiResource):
     """
 
     @require_user_admin(disallow_for_restricted_users=True)
+    @require_fresh_login
     @nickname("regenerateUserRobotToken")
     def post(self, robot_shortname):
         """
@@ -421,6 +427,7 @@ class RegenerateOrgRobot(ApiResource):
     """
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("regenerateOrgRobotToken")
     def post(self, orgname, robot_shortname):
         """
@@ -489,6 +496,7 @@ class UserRobotFederation(ApiResource):
         return get_robot_federation_config(robot)
 
     @require_user_admin(disallow_for_restricted_users=True)
+    @require_fresh_login
     @nickname("createUserRobotFederation")
     @validate_json_request("CreateRobotFederation", optional=False)
     def post(self, robot_shortname):
@@ -509,6 +517,7 @@ class UserRobotFederation(ApiResource):
         return fed_config
 
     @require_user_admin(disallow_for_restricted_users=True)
+    @require_fresh_login
     @nickname("deleteUserRobotFederation")
     def delete(self, robot_shortname):
         """
@@ -560,6 +569,7 @@ class OrgRobotFederation(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("createOrgRobotFederation")
     @validate_json_request("CreateRobotFederation", optional=False)
     def post(self, orgname, robot_shortname):
@@ -583,6 +593,7 @@ class OrgRobotFederation(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("deleteOrgRobotFederation")
     def delete(self, orgname, robot_shortname):
         """

--- a/endpoints/api/team.py
+++ b/endpoints/api/team.py
@@ -206,6 +206,7 @@ class OrganizationTeam(ApiResource):
     }
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("updateOrganizationTeam")
     @validate_json_request("TeamDescription")
     def put(self, orgname, teamname):
@@ -257,6 +258,7 @@ class OrganizationTeam(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("deleteOrganizationTeam")
     def delete(self, orgname, teamname):
         """
@@ -421,6 +423,7 @@ class TeamMember(ApiResource):
     """
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("updateOrganizationTeamMember")
     @disallow_nonrobots_for_synced_team
     def put(self, orgname, teamname, membername):
@@ -461,6 +464,7 @@ class TeamMember(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("deleteOrganizationTeamMember")
     @disallow_nonrobots_for_synced_team
     def delete(self, orgname, teamname, membername):
@@ -513,6 +517,7 @@ class InviteTeamMember(ApiResource):
     """
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("inviteTeamMemberEmail")
     @disallow_all_for_synced_team
     def put(self, orgname, teamname, email):
@@ -542,6 +547,7 @@ class InviteTeamMember(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @require_fresh_login
     @nickname("deleteTeamMemberEmailInvite")
     def delete(self, orgname, teamname, email):
         """

--- a/endpoints/api/test/test_fresh_login.py
+++ b/endpoints/api/test/test_fresh_login.py
@@ -1,0 +1,240 @@
+"""
+Tests that verify @require_fresh_login is enforced on all sensitive mutation endpoints.
+
+Each test verifies two things:
+1. With a fresh session, the endpoint does NOT return 401 (control assertion)
+2. With a stale session (past FRESH_LOGIN_TIMEOUT), the endpoint returns 401
+   with a FreshLoginRequired error
+"""
+
+import datetime
+
+import pytest
+
+from endpoints.api import FRESH_LOGIN_TIMEOUT, api
+from endpoints.api.billing import (
+    OrganizationCard,
+    OrganizationPlan,
+    OrganizationRhSku,
+    OrganizationRhSkuBatchRemoval,
+    OrganizationRhSkuSubscriptionField,
+    UserCard,
+    UserPlan,
+)
+from endpoints.api.mirror import RepoMirrorResource
+from endpoints.api.organization import (
+    Organization,
+    OrganizationApplicationResetClientSecret,
+    OrganizationApplicationResource,
+    OrganizationApplications,
+    OrganizationList,
+    OrganizationMember,
+)
+from endpoints.api.permission import RepositoryTeamPermission, RepositoryUserPermission
+from endpoints.api.team import InviteTeamMember, OrganizationTeam, TeamMember
+from endpoints.api.test.shared import conduct_api_call
+from endpoints.api.user import ClientKey, ConvertToOrganization, User, UserAuthorization
+from endpoints.test.shared import client_with_identity
+from test.fixtures import *
+
+# Margin beyond FRESH_LOGIN_TIMEOUT to ensure the session is stale
+_STALE_MARGIN = datetime.timedelta(minutes=10)
+
+
+def _stale_session(cl):
+    """Set session login_time past FRESH_LOGIN_TIMEOUT so the session is stale."""
+    with cl.session_transaction() as sess:
+        sess["login_time"] = datetime.datetime.now() - FRESH_LOGIN_TIMEOUT - _STALE_MARGIN
+
+
+def _assert_fresh_login_required(response):
+    """Assert the response is a 401 FreshLoginRequired error."""
+    assert response.status_code == 401
+    data = response.json
+    assert (
+        data.get("title") == "fresh_login_required"
+        or data.get("error_type") == "fresh_login_required"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Organization endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (OrganizationList, "POST", {}, {"name": "freshorg", "email": "f@e.com"}),
+        (
+            Organization,
+            "PUT",
+            {"orgname": "buynlarge"},
+            {"email": "new@example.com"},
+        ),
+        (
+            OrganizationMember,
+            "DELETE",
+            {"orgname": "buynlarge", "membername": "reader"},
+            None,
+        ),
+        (
+            OrganizationApplications,
+            "POST",
+            {"orgname": "buynlarge"},
+            {"name": "testapp"},
+        ),
+    ],
+)
+def test_organization_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# Permission endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (
+            RepositoryUserPermission,
+            "PUT",
+            {"repository": "devtable/simple", "username": "public"},
+            {"role": "read"},
+        ),
+        (
+            RepositoryUserPermission,
+            "DELETE",
+            {"repository": "devtable/simple", "username": "public"},
+            None,
+        ),
+        (
+            RepositoryTeamPermission,
+            "PUT",
+            {"repository": "buynlarge/orgrepo", "teamname": "owners"},
+            {"role": "admin"},
+        ),
+        (
+            RepositoryTeamPermission,
+            "DELETE",
+            {"repository": "buynlarge/orgrepo", "teamname": "owners"},
+            None,
+        ),
+    ],
+)
+def test_permission_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# Team endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (
+            OrganizationTeam,
+            "PUT",
+            {"orgname": "buynlarge", "teamname": "newteam"},
+            {"role": "member"},
+        ),
+        (
+            OrganizationTeam,
+            "DELETE",
+            {"orgname": "buynlarge", "teamname": "readers"},
+            None,
+        ),
+        (
+            TeamMember,
+            "PUT",
+            {"orgname": "buynlarge", "teamname": "owners", "membername": "reader"},
+            None,
+        ),
+        (
+            TeamMember,
+            "DELETE",
+            {"orgname": "buynlarge", "teamname": "owners", "membername": "devtable"},
+            None,
+        ),
+    ],
+)
+def test_team_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# User endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (User, "PUT", {}, {"email": "new@example.com"}),
+        (User, "DELETE", {}, None),
+        (ClientKey, "POST", {}, {"password": "password"}),
+    ],
+)
+def test_user_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# Billing endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (UserCard, "POST", {}, {"token": "tok_test"}),
+        (OrganizationCard, "POST", {"orgname": "buynlarge"}, {"token": "tok_test"}),
+        (UserPlan, "POST", {}, {"plan": "free"}),
+        (UserPlan, "PUT", {}, {"plan": "free"}),
+        (OrganizationPlan, "POST", {"orgname": "buynlarge"}, {"plan": "free"}),
+        (OrganizationPlan, "PUT", {"orgname": "buynlarge"}, {"plan": "free"}),
+    ],
+)
+def test_billing_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# Mirror endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (
+            RepoMirrorResource,
+            "POST",
+            {"repository": "devtable/simple"},
+            {
+                "external_reference": "docker.io/library/alpine",
+                "sync_interval": 3600,
+                "sync_start_date": "2025-01-01T00:00:00Z",
+                "root_rule": {"rule_kind": "tag_glob_csv", "rule_value": ["latest"]},
+            },
+        ),
+        (
+            RepoMirrorResource,
+            "PUT",
+            {"repository": "devtable/simple"},
+            {"sync_interval": 7200},
+        ),
+    ],
+)
+def test_mirror_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)

--- a/endpoints/api/test/test_fresh_login.py
+++ b/endpoints/api/test/test_fresh_login.py
@@ -1,0 +1,318 @@
+"""
+Tests that verify @require_fresh_login is enforced on sensitive mutation endpoints.
+
+Each test sets the session login_time past FRESH_LOGIN_TIMEOUT and verifies that
+the endpoint returns 401 with a FreshLoginRequired error before performing the
+underlying mutation.
+"""
+
+import datetime
+
+import pytest
+
+from endpoints.api import FRESH_LOGIN_TIMEOUT, api
+from endpoints.api.billing import (
+    OrganizationCard,
+    OrganizationPlan,
+    OrganizationRhSku,
+    OrganizationRhSkuBatchRemoval,
+    OrganizationRhSkuSubscriptionField,
+    UserCard,
+    UserPlan,
+)
+from endpoints.api.mirror import RepoMirrorResource
+from endpoints.api.organization import (
+    Organization,
+    OrganizationApplicationResetClientSecret,
+    OrganizationApplicationResource,
+    OrganizationApplications,
+    OrganizationList,
+    OrganizationMember,
+)
+from endpoints.api.permission import RepositoryTeamPermission, RepositoryUserPermission
+from endpoints.api.team import InviteTeamMember, OrganizationTeam, TeamMember
+from endpoints.api.test.shared import conduct_api_call
+from endpoints.api.user import (
+    ClientKey,
+    ConvertToOrganization,
+    DetachExternal,
+    User,
+    UserAuthorization,
+)
+from endpoints.test.shared import client_with_identity
+from test.fixtures import *
+
+# Margin beyond FRESH_LOGIN_TIMEOUT to ensure the session is stale
+_STALE_MARGIN = datetime.timedelta(minutes=10)
+
+
+def _stale_session(cl):
+    """Set session login_time past FRESH_LOGIN_TIMEOUT so the session is stale."""
+    with cl.session_transaction() as sess:
+        sess["login_time"] = datetime.datetime.now() - FRESH_LOGIN_TIMEOUT - _STALE_MARGIN
+
+
+def _assert_fresh_login_required(response):
+    """Assert the response is a 401 FreshLoginRequired error."""
+    assert response.status_code == 401
+    data = response.json
+    assert (
+        data.get("title") == "fresh_login_required"
+        or data.get("error_type") == "fresh_login_required"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Organization endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (OrganizationList, "POST", {}, {"name": "freshorg", "email": "f@e.com"}),
+        (
+            Organization,
+            "PUT",
+            {"orgname": "buynlarge"},
+            {"email": "new@example.com"},
+        ),
+        (
+            OrganizationMember,
+            "DELETE",
+            {"orgname": "buynlarge", "membername": "reader"},
+            None,
+        ),
+        (
+            OrganizationApplications,
+            "POST",
+            {"orgname": "buynlarge"},
+            {"name": "testapp"},
+        ),
+        (
+            OrganizationApplicationResource,
+            "PUT",
+            {"orgname": "buynlarge", "client_id": "fakeclientid"},
+            {
+                "name": "updated-app",
+                "redirect_uri": "http://example.com/callback",
+                "application_uri": "http://example.com",
+            },
+        ),
+        (
+            OrganizationApplicationResource,
+            "DELETE",
+            {"orgname": "buynlarge", "client_id": "fakeclientid"},
+            None,
+        ),
+        (
+            OrganizationApplicationResetClientSecret,
+            "POST",
+            {"orgname": "buynlarge", "client_id": "fakeclientid"},
+            None,
+        ),
+    ],
+)
+def test_organization_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# Permission endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (
+            RepositoryUserPermission,
+            "PUT",
+            {"repository": "devtable/simple", "username": "public"},
+            {"role": "read"},
+        ),
+        (
+            RepositoryUserPermission,
+            "DELETE",
+            {"repository": "devtable/simple", "username": "public"},
+            None,
+        ),
+        (
+            RepositoryTeamPermission,
+            "PUT",
+            {"repository": "buynlarge/orgrepo", "teamname": "owners"},
+            {"role": "admin"},
+        ),
+        (
+            RepositoryTeamPermission,
+            "DELETE",
+            {"repository": "buynlarge/orgrepo", "teamname": "owners"},
+            None,
+        ),
+    ],
+)
+def test_permission_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# Team endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (
+            OrganizationTeam,
+            "PUT",
+            {"orgname": "buynlarge", "teamname": "newteam"},
+            {"role": "member"},
+        ),
+        (
+            OrganizationTeam,
+            "DELETE",
+            {"orgname": "buynlarge", "teamname": "readers"},
+            None,
+        ),
+        (
+            TeamMember,
+            "PUT",
+            {"orgname": "buynlarge", "teamname": "owners", "membername": "reader"},
+            None,
+        ),
+        (
+            TeamMember,
+            "DELETE",
+            {"orgname": "buynlarge", "teamname": "owners", "membername": "devtable"},
+            None,
+        ),
+        (
+            InviteTeamMember,
+            "PUT",
+            {
+                "orgname": "buynlarge",
+                "teamname": "owners",
+                "email": "fresh@example.com",
+            },
+            None,
+        ),
+        (
+            InviteTeamMember,
+            "DELETE",
+            {
+                "orgname": "buynlarge",
+                "teamname": "owners",
+                "email": "fresh@example.com",
+            },
+            None,
+        ),
+    ],
+)
+def test_team_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# User endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (User, "PUT", {}, {"email": "new@example.com"}),
+        (User, "DELETE", {}, None),
+        (ClientKey, "POST", {}, {"password": "password"}),
+        (
+            ConvertToOrganization,
+            "POST",
+            {},
+            {"adminUser": "devtable", "adminPassword": "password"},
+        ),
+        (DetachExternal, "POST", {"service_id": "github"}, None),
+        (
+            UserAuthorization,
+            "DELETE",
+            {"access_token_uuid": "00000000-0000-0000-0000-000000000000"},
+            None,
+        ),
+    ],
+)
+def test_user_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# Billing endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (UserCard, "POST", {}, {"token": "tok_test"}),
+        (OrganizationCard, "POST", {"orgname": "buynlarge"}, {"token": "tok_test"}),
+        (UserPlan, "POST", {}, {"plan": "free"}),
+        (UserPlan, "PUT", {}, {"plan": "free"}),
+        (OrganizationPlan, "POST", {"orgname": "buynlarge"}, {"plan": "free"}),
+        (OrganizationPlan, "PUT", {"orgname": "buynlarge"}, {"plan": "free"}),
+        (
+            OrganizationRhSku,
+            "POST",
+            {"orgname": "buynlarge"},
+            {"subscriptions": [{"subscription_id": 1}]},
+        ),
+        (
+            OrganizationRhSkuBatchRemoval,
+            "POST",
+            {"orgname": "buynlarge"},
+            {"subscriptions": [{"subscription_id": 1}]},
+        ),
+        (
+            OrganizationRhSkuSubscriptionField,
+            "DELETE",
+            {"orgname": "buynlarge", "subscription_id": 1},
+            None,
+        ),
+    ],
+)
+def test_billing_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)
+
+
+# ---------------------------------------------------------------------------
+# Mirror endpoints
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (
+            RepoMirrorResource,
+            "POST",
+            {"repository": "devtable/simple"},
+            {
+                "external_reference": "docker.io/library/alpine",
+                "sync_interval": 3600,
+                "sync_start_date": "2025-01-01T00:00:00Z",
+                "root_rule": {"rule_kind": "tag_glob_csv", "rule_value": ["latest"]},
+            },
+        ),
+        (
+            RepoMirrorResource,
+            "PUT",
+            {"repository": "devtable/simple"},
+            {"sync_interval": 7200},
+        ),
+    ],
+)
+def test_mirror_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    with client_with_identity("devtable", app) as cl:
+        _stale_session(cl)
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        _assert_fresh_login_required(result)

--- a/endpoints/api/test/test_robot.py
+++ b/endpoints/api/test/test_robot.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from unittest.mock import Mock
 
@@ -5,11 +6,13 @@ import pytest
 import requests
 
 from data import model
-from endpoints.api import api
+from endpoints.api import FRESH_LOGIN_TIMEOUT, api
 from endpoints.api.robot import (
     OrgRobot,
     OrgRobotFederation,
     OrgRobotList,
+    RegenerateOrgRobot,
+    RegenerateUserRobot,
     UserRobot,
     UserRobotList,
 )
@@ -266,3 +269,47 @@ def test_parse_federation_config(app, fed_config, raises_error, error_message):
             assert error_message in str(ex.value)
         else:
             parsed = OrgRobotFederation()._parse_federation_config(request)
+
+
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (UserRobot, "PUT", {"robot_shortname": "newbot"}, None),
+        (UserRobot, "DELETE", {"robot_shortname": "dtrobot"}, None),
+        (OrgRobot, "PUT", {"orgname": "buynlarge", "robot_shortname": "newbot"}, None),
+        (OrgRobot, "DELETE", {"orgname": "buynlarge", "robot_shortname": "coolrobot"}, None),
+        (RegenerateUserRobot, "POST", {"robot_shortname": "dtrobot"}, None),
+        (
+            RegenerateOrgRobot,
+            "POST",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            None,
+        ),
+        (
+            OrgRobotFederation,
+            "POST",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            [{"issuer": "https://test.example.com", "subject": "test"}],
+        ),
+        (
+            OrgRobotFederation,
+            "DELETE",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            None,
+        ),
+    ],
+)
+def test_robot_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    """Verify that all robot mutation endpoints require a fresh login session."""
+    with client_with_identity("devtable", app) as cl:
+        with cl.session_transaction() as sess:
+            sess["login_time"] = (
+                datetime.datetime.now() - FRESH_LOGIN_TIMEOUT - datetime.timedelta(minutes=10)
+            )
+
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        data = result.json
+        assert (
+            data.get("title") == "fresh_login_required"
+            or data.get("error_type") == "fresh_login_required"
+        )

--- a/endpoints/api/test/test_robot.py
+++ b/endpoints/api/test/test_robot.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from unittest.mock import Mock
 
@@ -5,11 +6,13 @@ import pytest
 import requests
 
 from data import model
-from endpoints.api import api
+from endpoints.api import FRESH_LOGIN_TIMEOUT, api
 from endpoints.api.robot import (
     OrgRobot,
     OrgRobotFederation,
     OrgRobotList,
+    RegenerateOrgRobot,
+    RegenerateUserRobot,
     UserRobot,
     UserRobotFederation,
     UserRobotList,
@@ -388,3 +391,65 @@ def test_parse_federation_config(app, fed_config, raises_error, error_message):
             assert error_message in str(ex.value)
         else:
             parsed = _parse_federation_config(request)
+
+
+@pytest.mark.parametrize(
+    "endpoint, method, params, body",
+    [
+        (UserRobot, "PUT", {"robot_shortname": "newbot"}, None),
+        (UserRobot, "DELETE", {"robot_shortname": "dtrobot"}, None),
+        (OrgRobot, "PUT", {"orgname": "buynlarge", "robot_shortname": "newbot"}, None),
+        (OrgRobot, "DELETE", {"orgname": "buynlarge", "robot_shortname": "coolrobot"}, None),
+        (RegenerateUserRobot, "POST", {"robot_shortname": "dtrobot"}, None),
+        (
+            RegenerateOrgRobot,
+            "POST",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            None,
+        ),
+        (
+            UserRobotFederation,
+            "POST",
+            {"robot_shortname": "dtrobot"},
+            [{"issuer": "https://test.example.com", "subject": "test"}],
+        ),
+        (
+            UserRobotFederation,
+            "DELETE",
+            {"robot_shortname": "dtrobot"},
+            None,
+        ),
+        (
+            OrgRobotFederation,
+            "POST",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            [{"issuer": "https://test.example.com", "subject": "test"}],
+        ),
+        (
+            OrgRobotFederation,
+            "POST",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            None,
+        ),
+        (
+            OrgRobotFederation,
+            "DELETE",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            None,
+        ),
+    ],
+)
+def test_robot_mutation_requires_fresh_login(endpoint, method, params, body, app):
+    """Verify protected robot mutation endpoints require a fresh login session."""
+    with client_with_identity("devtable", app) as cl:
+        with cl.session_transaction() as sess:
+            sess["login_time"] = (
+                datetime.datetime.now() - FRESH_LOGIN_TIMEOUT - datetime.timedelta(minutes=10)
+            )
+
+        result = conduct_api_call(cl, endpoint, method, params, body, expected_code=401)
+        data = result.json
+        assert (
+            data.get("title") == "fresh_login_required"
+            or data.get("error_type") == "fresh_login_required"
+        )

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -700,6 +700,7 @@ class ClientKey(ApiResource):
     }
 
     @require_user_admin()
+    @require_fresh_login
     @nickname("generateUserClientKey")
     @validate_json_request("GenerateClientKey")
     def post(self):
@@ -807,6 +808,7 @@ class ConvertToOrganization(ApiResource):
     }
 
     @require_user_admin()
+    @require_fresh_login
     @nickname("convertUserToOrganization")
     @validate_json_request("ConvertUser")
     def post(self):
@@ -1046,6 +1048,7 @@ class DetachExternal(ApiResource):
     """
 
     @require_user_admin()
+    @require_fresh_login
     @nickname("detachExternalLogin")
     def post(self, service_id):
         """
@@ -1273,6 +1276,7 @@ class UserAuthorization(ApiResource):
         return authorization_view(access_token)
 
     @require_user_admin()
+    @require_fresh_login
     @nickname("deleteUserAuthorization")
     def delete(self, access_token_uuid):
         access_token = model.oauth.lookup_access_token_for_user(

--- a/web/playwright/e2e/auth/fresh-login-db.spec.ts
+++ b/web/playwright/e2e/auth/fresh-login-db.spec.ts
@@ -1,0 +1,149 @@
+import {test, expect} from '../../fixtures';
+
+test.describe(
+  'Fresh Login - Database auth behavior',
+  {tag: ['@auth', '@auth:Database']},
+  () => {
+    test('shows password modal (not redirect) on fresh_login_required', async ({
+      superuserPage: page,
+    }) => {
+      // Mock the superuser endpoint to return fresh_login_required
+      await page.route('**/api/v1/superuser/logs*', (route) =>
+        route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            title: 'fresh_login_required',
+            error_type: 'fresh_login_required',
+            detail: 'The action requires a fresh login to succeed.',
+          }),
+        }),
+      );
+
+      await page.goto('/usage-logs');
+
+      // For Database auth, should show password modal (not redirect to /signin)
+      await expect(page.getByText('Please Verify', {exact: true})).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByPlaceholder('Current Password')).toBeVisible();
+
+      // Should NOT have redirected to /signin (that's OIDC behavior)
+      await expect(page).not.toHaveURL(/\/signin/);
+    });
+
+    test('wrong password closes modal and shows error alert', async ({
+      superuserPage: page,
+    }) => {
+      // Mock the superuser endpoint to return fresh_login_required
+      await page.route('**/api/v1/superuser/logs*', (route) =>
+        route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            title: 'fresh_login_required',
+            error_type: 'fresh_login_required',
+            detail: 'The action requires a fresh login to succeed.',
+          }),
+        }),
+      );
+
+      // Mock verify endpoint to reject wrong password
+      await page.route('**/api/v1/signin/verify', (route) =>
+        route.fulfill({
+          status: 403,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            message: 'Invalid password',
+            invalidCredentials: true,
+          }),
+        }),
+      );
+
+      await page.goto('/usage-logs');
+
+      // Wait for the fresh login modal
+      await expect(page.getByText('Please Verify', {exact: true})).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Enter wrong password and click Verify
+      await page.getByPlaceholder('Current Password').fill('wrongpassword');
+      await page.getByRole('button', {name: 'Verify'}).click();
+
+      // Modal should close
+      await expect(
+        page.getByText('Please Verify', {exact: true}),
+      ).not.toBeVisible({
+        timeout: 5000,
+      });
+
+      // Error alert should be visible
+      await expect(
+        page.getByText('Invalid verification credentials'),
+      ).toBeVisible({timeout: 5000});
+    });
+
+    test('correct password retries the queued operation', async ({
+      superuserPage: page,
+    }) => {
+      let logsCallCount = 0;
+
+      // First call returns fresh_login_required, subsequent calls pass through
+      await page.route('**/api/v1/superuser/logs*', (route) => {
+        logsCallCount++;
+        if (logsCallCount === 1) {
+          return route.fulfill({
+            status: 401,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              title: 'fresh_login_required',
+              error_type: 'fresh_login_required',
+              detail: 'The action requires a fresh login to succeed.',
+            }),
+          });
+        }
+        // Second call (retry after verification): pass through to real server
+        return route.continue();
+      });
+
+      // Mock verify endpoint to accept password
+      await page.route('**/api/v1/signin/verify', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({success: true}),
+          headers: {
+            'x-next-csrf-token': 'new-csrf-token',
+          },
+        }),
+      );
+
+      await page.goto('/usage-logs');
+
+      // Fresh login modal should appear
+      await expect(page.getByText('Please Verify', {exact: true})).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Enter correct password and verify
+      await page.getByPlaceholder('Current Password').fill('password');
+      await page.getByRole('button', {name: 'Verify'}).click();
+
+      // Modal should close after successful verification
+      await expect(
+        page.getByText('Please Verify', {exact: true}),
+      ).not.toBeVisible({
+        timeout: 5000,
+      });
+
+      // The page should have retried and loaded (no error alert)
+      await expect(
+        page.getByText('Invalid verification credentials'),
+      ).not.toBeVisible();
+
+      // Verify two calls were made (original + retry)
+      expect(logsCallCount).toBe(2);
+    });
+  },
+);

--- a/web/playwright/e2e/auth/fresh-login.spec.ts
+++ b/web/playwright/e2e/auth/fresh-login.spec.ts
@@ -1,6 +1,13 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
 
+const freshLoginRequiredBody = {
+  title: 'fresh_login_required',
+  error_type: 'fresh_login_required',
+  detail: 'The action requires a fresh login to succeed.',
+  status: 401,
+};
+
 test.describe(
   'Fresh Login - Database auth password modal',
   {tag: ['@auth', '@auth:Database']},
@@ -12,12 +19,7 @@ test.describe(
         route.fulfill({
           status: 401,
           contentType: 'application/json',
-          body: JSON.stringify({
-            title: 'fresh_login_required',
-            error_type: 'fresh_login_required',
-            detail: 'The action requires a fresh login to succeed.',
-            status: 401,
-          }),
+          body: JSON.stringify(freshLoginRequiredBody),
         }),
       );
 
@@ -40,12 +42,7 @@ test.describe(
         route.fulfill({
           status: 401,
           contentType: 'application/json',
-          body: JSON.stringify({
-            title: 'fresh_login_required',
-            error_type: 'fresh_login_required',
-            detail: 'The action requires a fresh login to succeed.',
-            status: 401,
-          }),
+          body: JSON.stringify(freshLoginRequiredBody),
         }),
       );
 
@@ -54,6 +51,31 @@ test.describe(
 
       await page.getByRole('button', {name: 'Cancel'}).click();
       await expect(page.getByText('Please Verify').first()).not.toBeVisible();
+    });
+
+    test('wrong password dismisses modal and shows error alert', async ({
+      superuserPage: page,
+    }) => {
+      await page.route('**/api/v1/superuser/logs*', (route) =>
+        route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify(freshLoginRequiredBody),
+        }),
+      );
+
+      await page.goto('/usage-logs');
+      await expect(page.getByText('Please Verify').first()).toBeVisible();
+
+      await page.locator('#fresh-password').fill('definitely-not-password');
+      await page.getByRole('button', {name: 'Verify'}).click();
+
+      await expect(page.getByText('Please Verify').first()).not.toBeVisible({
+        timeout: 10000,
+      });
+      await expect(
+        page.getByText('Invalid verification credentials'),
+      ).toBeVisible();
     });
 
     test('successful password verification dismisses modal and retries', async ({
@@ -66,12 +88,7 @@ test.describe(
           await route.fulfill({
             status: 401,
             contentType: 'application/json',
-            body: JSON.stringify({
-              title: 'fresh_login_required',
-              error_type: 'fresh_login_required',
-              detail: 'The action requires a fresh login to succeed.',
-              status: 401,
-            }),
+            body: JSON.stringify(freshLoginRequiredBody),
           });
         } else {
           await route.continue();


### PR DESCRIPTION
Add @require_fresh_login decorator to 40 mutation endpoints across 7 API
files that were missing session re-authentication checks. This closes an
authentication bypass where operations like robot account creation, org
management, billing changes, and permission modifications could succeed
with a stale session.

Affected endpoints:
- robot.py: robot CRUD, token regeneration, federation (8 endpoints)
- organization.py: org creation, OAuth apps, member removal (7 endpoints)
- billing.py: credit cards, subscriptions, marketplace SKUs (9 endpoints)
- permission.py: repo user/team permission changes (4 endpoints)
- team.py: team CRUD, member/invite management (6 endpoints)
- user.py: client keys, account conversion, OAuth tokens (4 endpoints)
- mirror.py: mirror config create/update (2 endpoints)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
