### PR TITLE
PROJQUAY-11319: api: Fix improper generation of history on multilayer images

### DIFF
--- a/image/oci/manifest.py
+++ b/image/oci/manifest.py
@@ -304,16 +304,17 @@ class OCIManifest(ManifestInterface):
         for image_layer in self._manifest_image_layers(content_retriever):
             is_remote = image_layer.blob_layer.is_remote if image_layer.blob_layer else False
             urls = image_layer.blob_layer.urls if image_layer.blob_layer else None
+            history = image_layer.history
             yield ManifestImageLayer(
                 layer_id=image_layer.v1_id,
                 compressed_size=image_layer.compressed_size,
                 is_remote=is_remote,
                 urls=urls,
-                command=image_layer.history.command,
+                command=history.command if history else None,
                 blob_digest=image_layer.blob_digest,
-                created_datetime=image_layer.history.created_datetime,
-                author=image_layer.history.author,
-                comment=image_layer.history.comment,
+                created_datetime=history.created_datetime if history else None,
+                author=history.author if history else None,
+                comment=history.comment if history else None,
                 internal_layer=image_layer,
             )
 


### PR DESCRIPTION
If a multi-layered OCI image does not have a properly formatted history, Quay automatically generates it for only the last layer listed. All other layers get a history of `None`, which causes an exception during layer read and causes the UI to render a 404 instead of real image metadata. For images that have only one layer (squashed images), this does not happen, because that one layer **is** the last layer so it always gets history generated.

This PR adds explicit check on provided history, we only access it if it exists for a given layer, otherwise we return `None` for the listed properties.