### PR TITLE
PROJQUAY-10983: Add isRequired indicator to Robot User field in mirror config

### DIFF
--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringRobotUser.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringRobotUser.tsx
@@ -30,7 +30,7 @@ export const OrgMirroringRobotUser: React.FC<OrgMirroringRobotUserProps> = ({
   addAlert,
 }) => {
   return (
-    <FormGroup label="Robot User" fieldId="robot_username" isStack>
+    <FormGroup label="Robot User" fieldId="robot_username" isStack isRequired>
       <Controller
         name="robotUsername"
         control={control}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/__tests__/OrgMirroringRobotUser.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/__tests__/OrgMirroringRobotUser.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {useForm} from 'react-hook-form';
+import {OrgMirroringRobotUser} from '../OrgMirroringRobotUser';
+import {OrgMirroringFormData} from '../types';
+
+jest.mock('src/components/EntitySearch', () => ({
+  __esModule: true,
+  default: (props: any) => <div data-testid="entity-search" />,
+}));
+
+jest.mock('src/contexts/UIContext', () => ({
+  AlertVariant: {Failure: 'danger'},
+}));
+
+function TestWrapper() {
+  const {control, formState} = useForm<OrgMirroringFormData>({
+    defaultValues: {
+      isEnabled: false,
+      externalRegistryType: '',
+      externalRegistryUrl: '',
+      externalNamespace: '',
+      robotUsername: '',
+      visibility: 'public',
+      repositoryFilters: '',
+      syncStartDate: '',
+      syncValue: '',
+      syncUnit: 'minutes',
+      username: '',
+      password: '',
+      verifyTls: true,
+      httpProxy: '',
+      httpsProxy: '',
+      noProxy: '',
+      skopeoTimeout: null,
+    },
+  });
+
+  return (
+    <OrgMirroringRobotUser
+      control={control}
+      errors={formState.errors}
+      orgName="testorg"
+      selectedRobot={null}
+      setSelectedRobot={jest.fn()}
+      robotOptions={[]}
+      addAlert={jest.fn()}
+    />
+  );
+}
+
+describe('OrgMirroringRobotUser', () => {
+  it('renders the Robot User label', () => {
+    render(<TestWrapper />);
+    expect(screen.getByText('Robot User')).toBeInTheDocument();
+  });
+
+  it('renders the required asterisk indicator on the Robot User field', () => {
+    const {container} = render(<TestWrapper />);
+    const requiredIndicator = container.querySelector(
+      '.pf-v6-c-form__label-required',
+    );
+    expect(requiredIndicator).toBeInTheDocument();
+    expect(requiredIndicator).toHaveTextContent('*');
+  });
+
+  it('renders the entity search input', () => {
+    render(<TestWrapper />);
+    expect(screen.getByTestId('entity-search')).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx
@@ -383,7 +383,7 @@ export const MirroringConfiguration: React.FC<MirroringConfigurationProps> = ({
         </FormHelperText>
       </FormGroup>
 
-      <FormGroup label="Robot User" fieldId="robot_username" isStack>
+      <FormGroup label="Robot User" fieldId="robot_username" isStack isRequired>
         <Controller
           name="robotUsername"
           control={control}


### PR DESCRIPTION
## Summary

- Adds `isRequired` prop to the `FormGroup` wrapping the Robot User field in org mirror configuration (`OrgMirroringRobotUser.tsx`)
- Applies the same fix to `MirroringConfiguration.tsx` (repo mirror config), which had the identical issue
- PatternFly automatically renders the red asterisk required-field indicator when `isRequired` is set
- The field already had validation rules marking it required; this fix adds the missing visual indicator

## Jira
[PROJQUAY-10983](https://redhat.atlassian.net/browse/PROJQUAY-10983)

## Test Plan
- [ ] Jest unit test verifies the required indicator renders on the Robot User FormGroup (`pf-v6-c-form__label-required` class present with `*` content)
- [ ] Manual: navigate to org mirror configuration, confirm red asterisk appears next to "Robot User" label
- [ ] Manual: navigate to repo mirror configuration, confirm red asterisk appears next to "Robot User" label

🤖 Generated with Claude Code