### PR TITLE
PROJQUAY-10795: Fix Load More Logs button flashing during data fetch

### DIFF
--- a/web/__mocks__/fileMock.js
+++ b/web/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/web/babel.config.js
+++ b/web/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react', {runtime: 'automatic'}],
+    '@babel/preset-typescript',
+  ],
+};

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/__mocks__/fileMock.js',
+    '^src/(.*)$': '<rootDir>/src/$1',
+  },
+  transform: {
+    '^.+\\.(ts|tsx|js|jsx)$': 'babel-jest',
+  },
+  testMatch: ['**/__tests__/**/*.(test|spec).(ts|tsx|js|jsx)'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+};

--- a/web/src/routes/UsageLogs/UsageLogsTable.tsx
+++ b/web/src/routes/UsageLogs/UsageLogsTable.tsx
@@ -304,13 +304,21 @@ export function UsageLogsTable(props: UsageLogsTableProps) {
         <div ref={loadMoreRef} style={{height: '20px'}} />
 
         {/* Load More button and loading indicator */}
-        {hasNextPage && (
+        {(hasNextPage || isFetchingNextPage) && (
           <FlexItem>
             <div style={{textAlign: 'center', margin: '20px'}}>
               {isFetchingNextPage ? (
-                <Spinner size="lg" />
+                <Spinner
+                  size="lg"
+                  aria-label="Loading more logs"
+                  data-testid="load-more-spinner"
+                />
               ) : (
-                <Button variant="secondary" onClick={() => fetchNextPage()}>
+                <Button
+                  variant="secondary"
+                  onClick={() => fetchNextPage()}
+                  data-testid="load-more-button"
+                >
                   Load More Logs
                 </Button>
               )}

--- a/web/src/routes/UsageLogs/__tests__/UsageLogsTable.test.tsx
+++ b/web/src/routes/UsageLogs/__tests__/UsageLogsTable.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import {UsageLogsTable} from '../UsageLogsTable';
+
+jest.mock('@tanstack/react-query', () => ({
+  useInfiniteQuery: jest.fn(),
+}));
+jest.mock('src/hooks/UseUsageLogs', () => ({getLogs: jest.fn()}));
+jest.mock('src/hooks/UseLogDescriptions', () => ({
+  useLogDescriptions: () => ({}),
+}));
+jest.mock('src/hooks/usePaginatedSortableTable', () => ({
+  usePaginatedSortableTable: (data: any[]) => ({
+    paginatedData: data,
+    getSortableSort: () => undefined,
+    paginationProps: {
+      itemCount: data.length,
+      perPage: 20,
+      page: 1,
+      onSetPage: jest.fn(),
+      onPerPageSelect: jest.fn(),
+    },
+  }),
+}));
+
+import {useInfiniteQuery} from '@tanstack/react-query';
+const mockUseInfiniteQuery = useInfiniteQuery as jest.Mock;
+
+const baseQueryReturn = {
+  data: {pages: [{logs: []}]},
+  isLoading: false,
+  isError: false,
+  fetchNextPage: jest.fn(),
+  hasNextPage: false,
+  isFetchingNextPage: false,
+};
+
+const defaultProps = {
+  starttime: '2026-04-01',
+  endtime: '2026-04-14',
+  org: 'myorg',
+  repo: '',
+  type: 'org',
+};
+
+// jsdom does not implement IntersectionObserver — provide a no-op stub
+const mockIntersectionObserver = jest.fn(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));
+
+describe('UsageLogsTable — Load More footer', () => {
+  beforeEach(() => {
+    mockUseInfiniteQuery.mockReturnValue({...baseQueryReturn});
+    window.IntersectionObserver = mockIntersectionObserver as any;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows spinner when isFetchingNextPage is true and hasNextPage is true', () => {
+    mockUseInfiniteQuery.mockReturnValue({
+      ...baseQueryReturn,
+      hasNextPage: true,
+      isFetchingNextPage: true,
+    });
+
+    render(<UsageLogsTable {...defaultProps} />);
+
+    expect(screen.getByTestId('load-more-spinner')).toBeInTheDocument();
+    expect(screen.queryByTestId('load-more-button')).not.toBeInTheDocument();
+  });
+
+  it('shows spinner when isFetchingNextPage is true even if hasNextPage is false', () => {
+    mockUseInfiniteQuery.mockReturnValue({
+      ...baseQueryReturn,
+      hasNextPage: false,
+      isFetchingNextPage: true,
+    });
+
+    render(<UsageLogsTable {...defaultProps} />);
+
+    expect(screen.getByTestId('load-more-spinner')).toBeInTheDocument();
+    expect(screen.queryByTestId('load-more-button')).not.toBeInTheDocument();
+  });
+
+  it('shows Load More button when hasNextPage is true and not fetching', () => {
+    mockUseInfiniteQuery.mockReturnValue({
+      ...baseQueryReturn,
+      hasNextPage: true,
+      isFetchingNextPage: false,
+    });
+
+    render(<UsageLogsTable {...defaultProps} />);
+
+    expect(screen.getByTestId('load-more-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('load-more-spinner')).not.toBeInTheDocument();
+  });
+
+  it('shows nothing when hasNextPage is false and not fetching', () => {
+    mockUseInfiniteQuery.mockReturnValue({
+      ...baseQueryReturn,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    render(<UsageLogsTable {...defaultProps} />);
+
+    expect(screen.queryByTestId('load-more-button')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('load-more-spinner')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- The "Load More Logs" button was flashing (appearing briefly then disappearing) during log data fetching
- Root cause: the intersection observer fires asynchronously after render, so the button appeared for one render cycle before the observer triggered `fetchNextPage()` and `isFetchingNextPage` became `true`
- Fix: expand the footer visibility condition from `hasNextPage` to `hasNextPage || isFetchingNextPage`, keeping the spinner visible throughout the entire fetch cycle
- Added `data-testid` attributes to `load-more-spinner` and `load-more-button` for testability

## Jira
[PROJQUAY-10795](https://redhat.atlassian.net/browse/PROJQUAY-10795)

## Test Plan
- [ ] Jest tests verify spinner shows when `isFetchingNextPage=true` (with or without `hasNextPage`)
- [ ] Jest tests verify button shows only when `hasNextPage=true` and not fetching
- [ ] Manual: scroll to bottom of Usage Logs — spinner shows smoothly without button flash

🤖 Generated with Claude Code