### PR TITLE
PROJQUAY-10862: fix(web): use props.organizationName instead of URL extraction in Settings

### DIFF
--- a/web/playwright/e2e/user/account-settings.spec.ts
+++ b/web/playwright/e2e/user/account-settings.spec.ts
@@ -687,6 +687,38 @@ test.describe('Account Settings', {tag: ['@user']}, () => {
     });
   });
 
+  test.describe('Navigation from org context (PROJQUAY-10862)', () => {
+    test('account settings shows user settings, not the org just visited', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      // Create an org so we can visit its page first
+      const org = await api.organization('navctx');
+
+      // Visit the org page
+      await authenticatedPage.goto(`/organization/${org.name}`);
+      await expect(
+        authenticatedPage.getByRole('heading', {name: org.name}),
+      ).toBeVisible();
+
+      // Click Account Settings via the user menu
+      await authenticatedPage.getByTestId('user-menu-toggle').click();
+      await authenticatedPage
+        .getByRole('menuitem', {name: 'Account Settings'})
+        .click();
+
+      // Should land on the USER's settings, not the org's
+      await expect(authenticatedPage).toHaveURL(
+        new RegExp(`/(user|organization)/${username}.*tab=Settings`),
+      );
+
+      // Verify the page shows the user's username, not the org name
+      await expect(authenticatedPage.locator('#form-name')).toHaveValue(
+        username,
+      );
+    });
+  });
+
   test.describe('URL Normalization', () => {
     test('normalizes lowercase "settings" to correct tab', async ({
       authenticatedPage,

--- a/web/playwright/e2e/user/account-settings.spec.ts
+++ b/web/playwright/e2e/user/account-settings.spec.ts
@@ -708,8 +708,9 @@ test.describe('Account Settings', {tag: ['@user']}, () => {
         .click();
 
       // Should land on the USER's settings, not the org's
+      const escaped = username.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       await expect(authenticatedPage).toHaveURL(
-        new RegExp(`/(user|organization)/${username}.*tab=Settings`),
+        new RegExp(`/(user|organization)/${escaped}\\?.*\\btab=Settings\\b`),
       );
 
       // Verify the page shows the user's username, not the org name

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/Settings.tsx
@@ -15,8 +15,7 @@ import {ProxyCacheConfig} from './ProxyCacheConfig';
 import {QuotaManagement} from './QuotaManagement';
 
 export default function Settings(props: SettingsProps) {
-  const organizationName = location.pathname.split('/')[2];
-  const {isUserOrganization} = useOrganization(organizationName);
+  const {isUserOrganization} = useOrganization(props.organizationName);
 
   const [activeTabId, setActiveTabId] = useState('generalsettings');
   const quayConfig = useQuayConfig();


### PR DESCRIPTION
## Summary

- Fixes account settings navigation bug where clicking "Account Settings" from an org page would show the wrong org's settings
- Root cause: `Settings.tsx` extracted the org name from `location.pathname.split('/')[2]` instead of using `props.organizationName` passed by the parent component
- Removed the URL path extraction and updated `useOrganization()` to use the prop, consistent with all other hooks in the component

## Test plan

- [ ] Navigate to an organization page (e.g., `/organization/someorg`)
- [ ] Click "Account Settings" from the user dropdown
- [ ] Verify the Settings page loads YOUR account settings, not the org you came from
- [ ] Verify org settings still load correctly when navigating directly to `/organization/someorg?tab=Settings`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)