### PR TITLE
PROJQUAY-10606: fix(web): increase Usage Logs default page size from 20 to 50

### DIFF
--- a/web/src/routes/UsageLogs/UsageLogsTable.tsx
+++ b/web/src/routes/UsageLogs/UsageLogsTable.tsx
@@ -177,7 +177,7 @@ export function UsageLogsTable(props: UsageLogsTableProps) {
       3: (log: LogEntry) => log.ip || '', // IP Address
     },
     filter: searchFilter,
-    initialPerPage: 20,
+    initialPerPage: 50,
     initialSort: {columnIndex: 0, direction: 'desc'}, // Default sort: newest first
   });
 


### PR DESCRIPTION
## Summary

- Increases the default page size for the Usage Logs table from 20 to 50 items
- The previous value of 20 caused the page to feel sparse and required excessive pagination
- Aligns with the precedent set by `BuildHistory.tsx` which already uses `initialPerPage: 50`
- No backend coupling — the backend `LOGS_PER_PAGE` constant is unused dead code; pagination is cursor-based

## Test plan

- [ ] Navigate to Usage Logs page
- [ ] Verify 50 items are shown per page by default (when sufficient logs exist)
- [ ] Verify pagination controls still work (next page, previous page, per-page selector)
- [ ] Verify the table renders correctly with the increased row count

🤖 Generated with [Claude Code](https://claude.ai/claude-code)