### PR TITLE
PROJQUAY-10982: fix(data): exclude deleted repos from org mirror validation

### DIFF
--- a/data/model/org_mirror.py
+++ b/data/model/org_mirror.py
@@ -153,7 +153,14 @@ def create_org_mirror_config(
         # Lock the org row to serialize against concurrent repo creation
         db_for_update(User.select().where(User.id == organization.id)).get()
 
-        if Repository.select().where(Repository.namespace_user == organization).exists():
+        if (
+            Repository.select()
+            .where(
+                (Repository.namespace_user == organization)
+                & (Repository.state != RepositoryState.MARKED_FOR_DELETION)
+            )
+            .exists()
+        ):
             raise DataModelException(
                 "Cannot create organization mirror: the organization already contains "
                 "repositories. Organization mirroring requires an empty organization."

--- a/data/model/test/test_org_mirror.py
+++ b/data/model/test/test_org_mirror.py
@@ -449,9 +449,7 @@ class TestCreateOrgMirrorConfig:
         deleted_repo.save()
 
         # Create a normal repo
-        model.repository.create_repository(
-            org.username, "normal-repo", None, visibility="private"
-        )
+        model.repository.create_repository(org.username, "normal-repo", None, visibility="private")
 
         # Should still reject — a NORMAL repo exists
         with pytest.raises(DataModelException) as excinfo:

--- a/data/model/test/test_org_mirror.py
+++ b/data/model/test/test_org_mirror.py
@@ -14,6 +14,8 @@ from data.database import (
     OrgMirrorRepository,
     OrgMirrorRepoStatus,
     OrgMirrorStatus,
+    Repository,
+    RepositoryState,
     SourceRegistryType,
     User,
     Visibility,
@@ -385,6 +387,86 @@ class TestCreateOrgMirrorConfig:
         assert retrieved is not None
         assert retrieved.id == created.id
         assert retrieved.external_registry_url == created.external_registry_url
+
+    def test_create_org_mirror_config_allows_deleted_repos(self, initialized_db):
+        """
+        Creating org mirror config should succeed when the organization only has
+        repositories in MARKED_FOR_DELETION state (pending garbage collection).
+
+        Regression test for PROJQUAY-10982.
+        """
+        org, robot = _create_org_and_robot("create_test_deleted_repos")
+        visibility = Visibility.get(name="private")
+
+        # Create a repo and mark it for deletion (simulating user-deleted repos
+        # that haven't been garbage collected yet)
+        repo = model.repository.create_repository(
+            org.username, "deleted-repo", None, visibility="private"
+        )
+        repo.state = RepositoryState.MARKED_FOR_DELETION
+        repo.save()
+
+        # Verify the repo exists in the DB but is marked for deletion
+        assert (
+            Repository.select()
+            .where(
+                (Repository.namespace_user == org)
+                & (Repository.state == RepositoryState.MARKED_FOR_DELETION)
+            )
+            .exists()
+        )
+
+        # Should succeed — MARKED_FOR_DELETION repos should not block creation
+        config = create_org_mirror_config(
+            organization=org,
+            internal_robot=robot,
+            external_registry_type=SourceRegistryType.HARBOR,
+            external_registry_url="https://harbor.example.com",
+            external_namespace="my-project",
+            visibility=visibility,
+            sync_interval=3600,
+            sync_start_date=datetime.utcnow(),
+        )
+
+        assert config is not None
+        assert config.organization == org
+
+    def test_create_org_mirror_config_rejects_normal_repos_with_deleted(self, initialized_db):
+        """
+        Creating org mirror config should still be rejected when the organization
+        has NORMAL-state repositories, even if it also has MARKED_FOR_DELETION ones.
+
+        Regression test for PROJQUAY-10982.
+        """
+        org, robot = _create_org_and_robot("create_test_mixed_repos")
+        visibility = Visibility.get(name="private")
+
+        # Create a repo marked for deletion
+        deleted_repo = model.repository.create_repository(
+            org.username, "deleted-repo", None, visibility="private"
+        )
+        deleted_repo.state = RepositoryState.MARKED_FOR_DELETION
+        deleted_repo.save()
+
+        # Create a normal repo
+        model.repository.create_repository(
+            org.username, "normal-repo", None, visibility="private"
+        )
+
+        # Should still reject — a NORMAL repo exists
+        with pytest.raises(DataModelException) as excinfo:
+            create_org_mirror_config(
+                organization=org,
+                internal_robot=robot,
+                external_registry_type=SourceRegistryType.HARBOR,
+                external_registry_url="https://harbor.example.com",
+                external_namespace="my-project",
+                visibility=visibility,
+                sync_interval=3600,
+                sync_start_date=datetime.utcnow(),
+            )
+
+        assert "already contains repositories" in str(excinfo.value)
 
 
 class TestDeleteOrgMirrorConfig:


### PR DESCRIPTION
## Summary

- Fix `create_org_mirror_config` to exclude repositories in `MARKED_FOR_DELETION` state when checking if an organization already contains repositories
- Previously, deleted repos pending garbage collection would block re-enabling organization mirroring with a 400 error
- Aligns the validation query with the existing pattern used by `get_org_mirror_repos`, `get_org_mirror_repo_status_counts`, and `count_active_org_mirror_repos`

## Root Cause

The repository existence check at `data/model/org_mirror.py:156` used:
```python
Repository.select().where(Repository.namespace_user == organization).exists()
```
This included repos in `MARKED_FOR_DELETION` state (state=3) that haven't been garbage collected yet. Users who deleted all repos and tried to re-enable org mirroring would get a misleading "organization already contains repositories" error.

## Fix

Added `& (Repository.state != RepositoryState.MARKED_FOR_DELETION)` to the query, matching the pattern already used throughout the same file.

## Test plan

- [x] Added `test_create_org_mirror_config_allows_deleted_repos` — verifies org mirror creation succeeds when only `MARKED_FOR_DELETION` repos exist
- [x] Added `test_create_org_mirror_config_rejects_normal_repos_with_deleted` — verifies creation is still rejected when NORMAL repos exist alongside deleted ones
- [ ] CI test suite passes

Fixes: [PROJQUAY-10982](https://redhat.atlassian.net/browse/PROJQUAY-10982)

🤖 Generated with [Claude Code](https://claude.com/claude-code)