### PR TITLE
PROJQUAY-11024: fix(web): display specific API error message when enabling org mirror fails

### DIFF
--- a/web/playwright/e2e/organization/org-mirroring.spec.ts
+++ b/web/playwright/e2e/organization/org-mirroring.spec.ts
@@ -542,13 +542,18 @@ test.describe(
 
       await authenticatedPage.getByTestId('submit-button').click();
 
-      // Verify the specific API error message is shown, not the generic HTTP error
-      await expect(
-        authenticatedPage.getByText(specificErrorMessage).first(),
-      ).toBeVisible();
-      await expect(
-        authenticatedPage.getByText('Request failed with status code 400'),
-      ).not.toBeVisible();
+      // Wait for the error alert to appear
+      const errorAlert = authenticatedPage
+        .locator('.pf-v6-c-alert')
+        .filter({hasText: 'Error saving organization mirror configuration'});
+      await expect(errorAlert).toBeVisible({timeout: 10000});
+
+      // The alert message is in a collapsed expandable section; verify the
+      // specific API error text is present in the alert (not the generic HTTP error)
+      await expect(errorAlert).toContainText(specificErrorMessage);
+      await expect(errorAlert).not.toContainText(
+        'Request failed with status code 400',
+      );
     });
 
     test('shows discovered repositories table when config exists', async ({

--- a/web/playwright/e2e/organization/org-mirroring.spec.ts
+++ b/web/playwright/e2e/organization/org-mirroring.spec.ts
@@ -545,7 +545,8 @@ test.describe(
       // Wait for the error alert to appear
       const errorAlert = authenticatedPage
         .locator('.pf-v6-c-alert')
-        .filter({hasText: 'Error saving organization mirror configuration'});
+        .filter({hasText: 'Error saving organization mirror configuration'})
+        .first();
       await expect(errorAlert).toBeVisible({timeout: 10000});
 
       // The alert message is in a collapsed expandable section; verify the

--- a/web/playwright/e2e/organization/org-mirroring.spec.ts
+++ b/web/playwright/e2e/organization/org-mirroring.spec.ts
@@ -498,6 +498,56 @@ test.describe(
       ).toBeVisible();
     });
 
+    test('displays specific API error_message when enabling mirror on org with repositories', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('orgmirrspecificerr');
+      const robot = await api.robot(org.name, 'specbot');
+
+      const specificErrorMessage =
+        'Cannot create organization mirror: the organization already contains repositories. Organization mirroring requires an empty organization.';
+
+      // Mock the 400 response that the API sends when the org has existing repos
+      await authenticatedPage.route(
+        `**/api/v1/organization/${org.name}/mirror`,
+        async (route) => {
+          if (route.request().method() === 'POST') {
+            await route.fulfill({
+              status: 400,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                error_message: specificErrorMessage,
+                error_type: 'invalid_request',
+                status: 400,
+              }),
+            });
+          } else {
+            await route.continue();
+          }
+        },
+      );
+
+      await authenticatedPage.goto(
+        `/organization/${org.name}?tab=Mirroring&setup=true`,
+      );
+
+      await expect(
+        authenticatedPage.getByTestId('org-mirror-form'),
+      ).toBeVisible();
+
+      await fillRequiredFields(authenticatedPage, robot.fullName, {
+        namespace: 'testns',
+      });
+
+      await authenticatedPage.getByTestId('submit-button').click();
+
+      // Verify the specific API error message is shown, not the generic HTTP error
+      await expect(
+        authenticatedPage.getByText(specificErrorMessage).first(),
+      ).toBeVisible();
+    });
+
     test('shows discovered repositories table when config exists', async ({
       authenticatedPage,
       api,

--- a/web/playwright/e2e/organization/org-mirroring.spec.ts
+++ b/web/playwright/e2e/organization/org-mirroring.spec.ts
@@ -546,6 +546,9 @@ test.describe(
       await expect(
         authenticatedPage.getByText(specificErrorMessage).first(),
       ).toBeVisible();
+      await expect(
+        authenticatedPage.getByText('Request failed with status code 400'),
+      ).not.toBeVisible();
     });
 
     test('shows discovered repositories table when config exists', async ({

--- a/web/playwright/e2e/organization/org-mirroring.spec.ts
+++ b/web/playwright/e2e/organization/org-mirroring.spec.ts
@@ -549,8 +549,14 @@ test.describe(
         .first();
       await expect(errorAlert).toBeVisible({timeout: 10000});
 
-      // The alert message is in a collapsed expandable section; verify the
-      // specific API error text is present in the alert (not the generic HTTP error)
+      // Expand the alert to reveal the detailed error message.
+      // Use dispatchEvent because the toast alert's icon SVG overlaps the toggle button,
+      // intercepting pointer events.
+      await errorAlert
+        .locator('.pf-v6-c-alert__toggle button')
+        .dispatchEvent('click');
+
+      // Verify the specific API error text is shown, not the generic HTTP error
       await expect(errorAlert).toContainText(specificErrorMessage);
       await expect(errorAlert).not.toContainText(
         'Request failed with status code 400',

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.tsx
@@ -30,6 +30,7 @@ import {
 import {DesktopIcon} from '@patternfly/react-icons';
 import {useUI, AlertVariant} from 'src/contexts/UIContext';
 import FormError from 'src/components/errors/FormError';
+import {getErrorMessageFromUnknown} from 'src/resources/ErrorHandling';
 import {useFetchRobotAccounts} from 'src/hooks/useRobotAccounts';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {Entity} from 'src/resources/UserResource';
@@ -86,7 +87,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
       addAlert({
         variant: AlertVariant.Failure,
         title: 'Error saving organization mirror configuration',
-        message: (err as Error).message,
+        message: getErrorMessageFromUnknown(err),
       });
     }
   };
@@ -174,7 +175,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
       addAlert({
         variant: AlertVariant.Failure,
         title: 'Error deleting organization mirror configuration',
-        message: (err as Error).message,
+        message: getErrorMessageFromUnknown(err),
       });
     } finally {
       setIsDeleteModalOpen(false);
@@ -211,7 +212,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
               addAlert({
                 variant: AlertVariant.Failure,
                 title: 'Error scheduling sync',
-                message: (err as Error).message,
+                message: getErrorMessageFromUnknown(err),
               });
             }
           }}
@@ -229,7 +230,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
               addAlert({
                 variant: AlertVariant.Failure,
                 title: 'Error toggling organization mirror',
-                message: (err as Error).message,
+                message: getErrorMessageFromUnknown(err),
               });
             }
           }}
@@ -264,7 +265,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
               addAlert({
                 variant: AlertVariant.Failure,
                 title: 'Error cancelling sync',
-                message: (err as Error).message,
+                message: getErrorMessageFromUnknown(err),
               });
             }
           }}
@@ -288,7 +289,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
               addAlert({
                 variant: AlertVariant.Failure,
                 title: 'Error verifying connection',
-                message: (err as Error).message,
+                message: getErrorMessageFromUnknown(err),
               });
             }
           }}


### PR DESCRIPTION
## Summary
- Replace `(err as Error).message` with `getErrorMessageFromUnknown(err)` in all six catch blocks of `OrgMirroring.tsx`
- Ensures the specific API error body (`error_message`, `detail`, `message` fields) is surfaced to the user instead of the generic Axios HTTP error string

## Root Cause
`OrgMirroring.tsx` caught errors but accessed `.message` directly on the caught value cast to `Error`. For Axios errors, this yields the generic `"Request failed with status code 400"` string. The `getErrorMessageFromUnknown()` helper in `ErrorHandling.ts` already knows how to extract the specific `error_message`/`detail` fields from the API response body, but was not being used.

## Changes
- `web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.tsx`: import `getErrorMessageFromUnknown` and use it in all six error-handling catch blocks (save, delete, sync-now, toggle-enabled, cancel-sync, verify-connection)
- `web/playwright/e2e/organization/org-mirroring.spec.ts`: add test that mocks the real 400 `error_message` payload and asserts the actionable message appears in the alert

## Test Plan
- [x] Frontend tests pass (Playwright E2E — new test added)
- [x] Manual testing performed (error message now shows the specific API text)

## JIRA
https://issues.redhat.com/browse/PROJQUAY-11024

## Backport
- [x] No backport needed (Target Version not set on ticket)