### PR TITLE
NO-ISSUE: test(api): port immutability policy API tests to Playwright

### DIFF
--- a/web/playwright/e2e/api/api-v1-immutability.spec.ts
+++ b/web/playwright/e2e/api/api-v1-immutability.spec.ts
@@ -6,7 +6,7 @@
  * organization and repository levels.
  */
 
-import {test, expect, uniqueName} from '../../fixtures';
+import {test, expect} from '../../fixtures';
 
 test.describe(
   'Immutability Policies',

--- a/web/playwright/e2e/api/api-v1-immutability.spec.ts
+++ b/web/playwright/e2e/api/api-v1-immutability.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Immutability Policy API tests.
+ *
+ * Ported from Cypress: quay_api_testing_all_new_ui.cy.js (lines 2289-2423).
+ * Validates CRUD lifecycle for immutability policies at both
+ * organization and repository levels.
+ */
+
+import {test, expect, uniqueName} from '../../fixtures';
+
+test.describe(
+  'Immutability Policies',
+  {tag: ['@api', '@auth:Database', '@feature:IMMUTABLE_TAGS']},
+  () => {
+    test.describe('Organization immutability policies', () => {
+      test('create org immutability policy', async ({
+        adminClient,
+        superuserApi,
+      }) => {
+        const org = await superuserApi.organization('immut');
+
+        const create = await adminClient.post(
+          `/api/v1/organization/${org.name}/immutabilitypolicy/`,
+          {tagPattern: 'stable*', tagPatternMatches: true},
+        );
+        expect(create.status()).toBe(201);
+        const body = await create.json();
+        expect(body.uuid).toBeTruthy();
+      });
+
+      test('get org immutability policy', async ({
+        adminClient,
+        superuserApi,
+      }) => {
+        const org = await superuserApi.organization('immut');
+        const policy = await superuserApi.orgImmutabilityPolicy(
+          org.name,
+          'stable*',
+        );
+
+        const get = await adminClient.get(
+          `/api/v1/organization/${org.name}/immutabilitypolicy/${policy.uuid}`,
+        );
+        expect(get.status()).toBe(200);
+        const body = await get.json();
+        expect(body.uuid).toContain(policy.uuid);
+      });
+
+      test('update org immutability policy', async ({
+        adminClient,
+        superuserApi,
+      }) => {
+        const org = await superuserApi.organization('immut');
+        const policy = await superuserApi.orgImmutabilityPolicy(
+          org.name,
+          'stable*',
+        );
+
+        const update = await adminClient.put(
+          `/api/v1/organization/${org.name}/immutabilitypolicy/${policy.uuid}`,
+          {tagPattern: 'nightly*', tagPatternMatches: true},
+        );
+        expect(update.status()).toBe(204);
+      });
+
+      test('delete org immutability policy', async ({
+        adminClient,
+        superuserApi,
+      }) => {
+        const org = await superuserApi.organization('immut');
+        const policy = await superuserApi.orgImmutabilityPolicy(
+          org.name,
+          'stable*',
+        );
+
+        const del = await adminClient.delete(
+          `/api/v1/organization/${org.name}/immutabilitypolicy/${policy.uuid}`,
+        );
+        expect(del.status()).toBe(200);
+        const body = await del.json();
+        expect(body.uuid).toContain(policy.uuid);
+      });
+    });
+
+    test.describe('Repository immutability policies', () => {
+      test('create repo immutability policy', async ({
+        adminClient,
+        superuserApi,
+      }) => {
+        const org = await superuserApi.organization('immut_repo');
+        const repo = await superuserApi.repository(org.name, 'immut', 'public');
+
+        const create = await adminClient.post(
+          `/api/v1/repository/${repo.namespace}/${repo.name}/immutabilitypolicy/`,
+          {tagPattern: 'latest*', tagPatternMatches: true},
+        );
+        expect(create.status()).toBe(201);
+        const body = await create.json();
+        expect(body.uuid).toBeTruthy();
+      });
+
+      test('get repo immutability policy', async ({
+        adminClient,
+        superuserApi,
+      }) => {
+        const org = await superuserApi.organization('immut_repo');
+        const repo = await superuserApi.repository(org.name, 'immut', 'public');
+        const policy = await superuserApi.repoImmutabilityPolicy(
+          repo.namespace,
+          repo.name,
+          'latest*',
+        );
+
+        const get = await adminClient.get(
+          `/api/v1/repository/${repo.namespace}/${repo.name}/immutabilitypolicy/${policy.uuid}`,
+        );
+        expect(get.status()).toBe(200);
+        const body = await get.json();
+        expect(body.uuid).toContain(policy.uuid);
+      });
+
+      test('update repo immutability policy', async ({
+        adminClient,
+        superuserApi,
+      }) => {
+        const org = await superuserApi.organization('immut_repo');
+        const repo = await superuserApi.repository(org.name, 'immut', 'public');
+        const policy = await superuserApi.repoImmutabilityPolicy(
+          repo.namespace,
+          repo.name,
+          'latest*',
+        );
+
+        const update = await adminClient.put(
+          `/api/v1/repository/${repo.namespace}/${repo.name}/immutabilitypolicy/${policy.uuid}`,
+          {tagPattern: 'stable*', tagPatternMatches: true},
+        );
+        expect(update.status()).toBe(204);
+      });
+
+      test('delete repo immutability policy', async ({
+        adminClient,
+        superuserApi,
+      }) => {
+        const org = await superuserApi.organization('immut_repo');
+        const repo = await superuserApi.repository(org.name, 'immut', 'public');
+        const policy = await superuserApi.repoImmutabilityPolicy(
+          repo.namespace,
+          repo.name,
+          'latest*',
+        );
+
+        const del = await adminClient.delete(
+          `/api/v1/repository/${repo.namespace}/${repo.name}/immutabilitypolicy/${policy.uuid}`,
+        );
+        expect(del.status()).toBe(200);
+        const body = await del.json();
+        expect(body.uuid).toContain(policy.uuid);
+      });
+    });
+  },
+);

--- a/web/playwright/e2e/api/api-v1-immutability.spec.ts
+++ b/web/playwright/e2e/api/api-v1-immutability.spec.ts
@@ -43,7 +43,7 @@ test.describe(
         );
         expect(get.status()).toBe(200);
         const body = await get.json();
-        expect(body.uuid).toContain(policy.uuid);
+        expect(body.uuid).toBe(policy.uuid);
       });
 
       test('update org immutability policy', async ({
@@ -61,6 +61,14 @@ test.describe(
           {tagPattern: 'nightly*', tagPatternMatches: true},
         );
         expect(update.status()).toBe(204);
+
+        const verify = await adminClient.get(
+          `/api/v1/organization/${org.name}/immutabilitypolicy/${policy.uuid}`,
+        );
+        expect(verify.status()).toBe(200);
+        const updated = await verify.json();
+        expect(updated.tagPattern).toBe('nightly*');
+        expect(updated.tagPatternMatches).toBe(true);
       });
 
       test('delete org immutability policy', async ({
@@ -78,7 +86,7 @@ test.describe(
         );
         expect(del.status()).toBe(200);
         const body = await del.json();
-        expect(body.uuid).toContain(policy.uuid);
+        expect(body.uuid).toBe(policy.uuid);
       });
     });
 
@@ -116,7 +124,7 @@ test.describe(
         );
         expect(get.status()).toBe(200);
         const body = await get.json();
-        expect(body.uuid).toContain(policy.uuid);
+        expect(body.uuid).toBe(policy.uuid);
       });
 
       test('update repo immutability policy', async ({
@@ -136,6 +144,14 @@ test.describe(
           {tagPattern: 'stable*', tagPatternMatches: true},
         );
         expect(update.status()).toBe(204);
+
+        const verify = await adminClient.get(
+          `/api/v1/repository/${repo.namespace}/${repo.name}/immutabilitypolicy/${policy.uuid}`,
+        );
+        expect(verify.status()).toBe(200);
+        const updated = await verify.json();
+        expect(updated.tagPattern).toBe('stable*');
+        expect(updated.tagPatternMatches).toBe(true);
       });
 
       test('delete repo immutability policy', async ({
@@ -155,7 +171,7 @@ test.describe(
         );
         expect(del.status()).toBe(200);
         const body = await del.json();
-        expect(body.uuid).toContain(policy.uuid);
+        expect(body.uuid).toBe(policy.uuid);
       });
     });
   },


### PR DESCRIPTION
## Summary
- Port 8 immutability policy CRUD API tests from the Cypress suite to Playwright
- Cover both organization-level and repository-level immutability policies (create, get, update, delete)

## Source Tests (Cypress)
Ported from `quay/quay-tests` (private):
- `quay-api-tests/cypress/e2e/quay_api_testing_all_new_ui.cy.js`
  - Organization immutability policy: create, get, update, delete (4 tests)
  - Repository immutability policy: create, get, update, delete (4 tests)

## Root Cause / Rationale
The existing Cypress API tests need to be migrated to Playwright to consolidate the test infrastructure. These tests validate the immutability policy endpoints introduced in Quay 3.17.

## Changes
- Added `web/playwright/e2e/api/api-v1-immutability.spec.ts` with 8 tests
- Each test is self-contained using `superuserApi` fixtures for setup/auto-cleanup
- Tagged with `@api`, `@auth:Database`, `@feature:IMMUTABLE_TAGS` for automatic skip when the feature is not enabled

## Test Plan
- [ ] Frontend tests pass (Playwright/Cypress)
- [x] No backend changes — test-only PR

## JIRA
N/A — test migration, no associated ticket

## Backport
- [x] No backport needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)