### PR TITLE
NO-ISSUE: test(api): port repository features API tests to Playwright

### DIFF
--- a/web/playwright/e2e/api/api-v1-repo-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-repo-features.spec.ts
@@ -7,7 +7,7 @@
  * and auto-cleanup via TestApi fixtures.
  */
 
-import {test, expect, uniqueName} from '../../fixtures';
+import {test, expect} from '../../fixtures';
 
 test.describe(
   'Repository Features API',
@@ -81,9 +81,7 @@ test.describe(
         expect(list.status()).toBe(200);
         const body = await list.json();
         expect(body.collaborators).toBeDefined();
-        const names = body.collaborators.map(
-          (c: {name: string}) => c.name,
-        );
+        const names = body.collaborators.map((c: {name: string}) => c.name);
         expect(names).toContain(user.username);
       });
     });
@@ -247,8 +245,7 @@ test.describe(
           `/api/v1/organization/${org.name}/robots/${robot.shortname}/federation`,
           [
             {
-              issuer:
-                'sts.windows.net/250926f3-c788-4a52-acfa-e3aac5386ac1',
+              issuer: 'sts.windows.net/250926f3-c788-4a52-acfa-e3aac5386ac1',
               subject: '93VEQl60c7JtJIV9r3gS0FCPTkcpwCDtfEUtD-lgdP4',
               isExpanded: true,
             },

--- a/web/playwright/e2e/api/api-v1-repo-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-repo-features.spec.ts
@@ -249,7 +249,7 @@ test.describe(
               subject: '93VEQl60c7JtJIV9r3gS0FCPTkcpwCDtfEUtD-lgdP4',
               isExpanded: true,
             },
-          ] as unknown as Record<string, unknown>,
+          ],
         );
         expect(resp.status()).toBe(400);
         const body = await resp.json();
@@ -273,7 +273,7 @@ test.describe(
               subject: '93VEQl60c7JtJIV9r3gS0FCPTkcpwCDtfEUtD-lgdP4',
               isExpanded: true,
             },
-          ] as unknown as Record<string, unknown>,
+          ],
         );
         expect(create.status()).toBe(200);
 
@@ -333,41 +333,45 @@ test.describe(
     // Repository State Changes
     // ========================================================================
 
-    test.describe('Repository State Changes', () => {
-      test('transition repo through MIRROR, READ_ONLY, and NORMAL states', async ({
-        superuserApi,
-        adminClient,
-      }) => {
-        const org = await superuserApi.organization();
-        const repo = await superuserApi.repository(org.name);
+    test.describe(
+      'Repository State Changes',
+      {tag: ['@feature:REPO_MIRROR']},
+      () => {
+        test('transition repo through MIRROR, READ_ONLY, and NORMAL states', async ({
+          superuserApi,
+          adminClient,
+        }) => {
+          const org = await superuserApi.organization();
+          const repo = await superuserApi.repository(org.name);
 
-        // Change to MIRROR
-        const toMirror = await adminClient.put(
-          `/api/v1/repository/${org.name}/${repo.name}/changestate`,
-          {state: 'MIRROR'},
-        );
-        expect(toMirror.status()).toBe(200);
-        const mirrorBody = await toMirror.json();
-        expect(mirrorBody.success).toBe(true);
+          // Change to MIRROR
+          const toMirror = await adminClient.put(
+            `/api/v1/repository/${org.name}/${repo.name}/changestate`,
+            {state: 'MIRROR'},
+          );
+          expect(toMirror.status()).toBe(200);
+          const mirrorBody = await toMirror.json();
+          expect(mirrorBody.success).toBe(true);
 
-        // Change to READ_ONLY
-        const toReadOnly = await adminClient.put(
-          `/api/v1/repository/${org.name}/${repo.name}/changestate`,
-          {state: 'READ_ONLY'},
-        );
-        expect(toReadOnly.status()).toBe(200);
-        const readOnlyBody = await toReadOnly.json();
-        expect(readOnlyBody.success).toBe(true);
+          // Change to READ_ONLY
+          const toReadOnly = await adminClient.put(
+            `/api/v1/repository/${org.name}/${repo.name}/changestate`,
+            {state: 'READ_ONLY'},
+          );
+          expect(toReadOnly.status()).toBe(200);
+          const readOnlyBody = await toReadOnly.json();
+          expect(readOnlyBody.success).toBe(true);
 
-        // Change back to NORMAL
-        const toNormal = await adminClient.put(
-          `/api/v1/repository/${org.name}/${repo.name}/changestate`,
-          {state: 'NORMAL'},
-        );
-        expect(toNormal.status()).toBe(200);
-        const normalBody = await toNormal.json();
-        expect(normalBody.success).toBe(true);
-      });
-    });
+          // Change back to NORMAL
+          const toNormal = await adminClient.put(
+            `/api/v1/repository/${org.name}/${repo.name}/changestate`,
+            {state: 'NORMAL'},
+          );
+          expect(toNormal.status()).toBe(200);
+          const normalBody = await toNormal.json();
+          expect(normalBody.success).toBe(true);
+        });
+      },
+    );
   },
 );

--- a/web/playwright/e2e/api/api-v1-repo-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-repo-features.spec.ts
@@ -7,7 +7,7 @@
  * and auto-cleanup via TestApi fixtures.
  */
 
-import {test, expect} from '../../fixtures';
+import {test, expect, skipUnlessFeature} from '../../fixtures';
 
 test.describe(
   'Repository Features API',
@@ -340,7 +340,10 @@ test.describe(
         test('transition repo through MIRROR, READ_ONLY, and NORMAL states', async ({
           superuserApi,
           adminClient,
+          quayConfig,
         }) => {
+          test.skip(...skipUnlessFeature(quayConfig, 'REPO_MIRROR'));
+
           const org = await superuserApi.organization();
           const repo = await superuserApi.repository(org.name);
 

--- a/web/playwright/e2e/api/api-v1-repo-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-repo-features.spec.ts
@@ -7,7 +7,7 @@
  * and auto-cleanup via TestApi fixtures.
  */
 
-import {test, expect, skipUnlessFeature} from '../../fixtures';
+import {test, expect} from '../../fixtures';
 
 test.describe(
   'Repository Features API',
@@ -340,10 +340,7 @@ test.describe(
         test('transition repo through MIRROR, READ_ONLY, and NORMAL states', async ({
           superuserApi,
           adminClient,
-          quayConfig,
         }) => {
-          test.skip(...skipUnlessFeature(quayConfig, 'REPO_MIRROR'));
-
           const org = await superuserApi.organization();
           const repo = await superuserApi.repository(org.name);
 

--- a/web/playwright/e2e/api/api-v1-repo-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-repo-features.spec.ts
@@ -1,0 +1,376 @@
+/**
+ * Repository Features API Tests
+ *
+ * Covers permissions, collaborators, teams, notifications, robot accounts,
+ * robot federation, default permissions (prototypes), and repository state
+ * changes. Each test.describe block is self-contained with its own setup
+ * and auto-cleanup via TestApi fixtures.
+ */
+
+import {test, expect, uniqueName} from '../../fixtures';
+
+test.describe(
+  'Repository Features API',
+  {tag: ['@api', '@smoke', '@auth:Database']},
+  () => {
+    // ========================================================================
+    // Permissions
+    // ========================================================================
+
+    test.describe('Permissions', () => {
+      test('add write permission, update to admin, then remove', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const repo = await superuserApi.repository(org.name);
+        const user = await superuserApi.user();
+
+        // Add write permission
+        const addWrite = await adminClient.put(
+          `/api/v1/repository/${org.name}/${repo.name}/permissions/user/${user.username}`,
+          {role: 'write'},
+        );
+        expect(addWrite.status()).toBe(200);
+        const addWriteBody = await addWrite.json();
+        expect(addWriteBody.role).toBe('write');
+        expect(addWriteBody.name).toBe(user.username);
+
+        // Update to admin
+        const updateAdmin = await adminClient.put(
+          `/api/v1/repository/${org.name}/${repo.name}/permissions/user/${user.username}`,
+          {role: 'admin'},
+        );
+        expect(updateAdmin.status()).toBe(200);
+        const updateAdminBody = await updateAdmin.json();
+        expect(updateAdminBody.role).toBe('admin');
+        expect(updateAdminBody.name).toBe(user.username);
+
+        // Remove permission
+        const remove = await adminClient.delete(
+          `/api/v1/repository/${org.name}/${repo.name}/permissions/user/${user.username}`,
+        );
+        expect(remove.status()).toBe(204);
+      });
+    });
+
+    // ========================================================================
+    // Collaborators
+    // ========================================================================
+
+    test.describe('Collaborators', () => {
+      test('list collaborators under organization', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const repo = await superuserApi.repository(org.name);
+        const user = await superuserApi.user();
+
+        // Add the user as a collaborator with write permission
+        const addPerm = await adminClient.put(
+          `/api/v1/repository/${org.name}/${repo.name}/permissions/user/${user.username}`,
+          {role: 'write'},
+        );
+        expect(addPerm.status()).toBe(200);
+
+        // List collaborators
+        const list = await adminClient.get(
+          `/api/v1/organization/${org.name}/collaborators`,
+        );
+        expect(list.status()).toBe(200);
+        const body = await list.json();
+        expect(body.collaborators).toBeDefined();
+        const names = body.collaborators.map(
+          (c: {name: string}) => c.name,
+        );
+        expect(names).toContain(user.username);
+      });
+    });
+
+    // ========================================================================
+    // Teams
+    // ========================================================================
+
+    test.describe('Teams', () => {
+      test('create team, add repo permission, add member', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const repo = await superuserApi.repository(org.name);
+        const team = await superuserApi.team(org.name);
+        const user = await superuserApi.user();
+
+        // Add repository write permission to team
+        const addTeamPerm = await adminClient.put(
+          `/api/v1/repository/${org.name}/${repo.name}/permissions/team/${team.name}`,
+          {role: 'write'},
+        );
+        expect(addTeamPerm.status()).toBe(200);
+        const teamPermBody = await addTeamPerm.json();
+        expect(teamPermBody.name).toContain(team.name);
+
+        // Add team member
+        const addMember = await adminClient.put(
+          `/api/v1/organization/${org.name}/team/${team.name}/members/${user.username}`,
+        );
+        expect(addMember.status()).toBe(200);
+        const memberBody = await addMember.json();
+        expect(memberBody.name).toContain(user.username);
+      });
+    });
+
+    // ========================================================================
+    // Notifications CRUD
+    // ========================================================================
+
+    test.describe('Notifications', () => {
+      test('list notifications on empty repo returns 200', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const repo = await superuserApi.repository(org.name);
+
+        const list = await adminClient.get(
+          `/api/v1/repository/${org.name}/${repo.name}/notification/`,
+        );
+        expect(list.status()).toBe(200);
+      });
+
+      test('create, test, reset, get by uuid, and delete notification', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const repo = await superuserApi.repository(org.name);
+
+        // Create a repo_push notification targeting the owners team
+        const create = await adminClient.post(
+          `/api/v1/repository/${org.name}/${repo.name}/notification/`,
+          {
+            event: 'repo_push',
+            method: 'quay_notification',
+            config: {
+              target: {
+                name: 'owners',
+                kind: 'team',
+                is_robot: false,
+                avatar: {
+                  name: 'owners',
+                  hash: 'b132392a317588e56460e77a8fd74229',
+                  color: '#1f77b4',
+                  kind: 'team',
+                },
+                is_org_member: true,
+              },
+            },
+            eventConfig: {},
+            title: 'new image pushed',
+          },
+        );
+        expect(create.status()).toBe(201);
+        const createBody = await create.json();
+        const notificationUuid = createBody.uuid;
+        expect(notificationUuid).toBeDefined();
+
+        // Test the notification
+        const testNotif = await adminClient.post(
+          `/api/v1/repository/${org.name}/${repo.name}/notification/${notificationUuid}/test`,
+        );
+        expect(testNotif.status()).toBe(200);
+
+        // Reset notification failure count
+        const reset = await adminClient.post(
+          `/api/v1/repository/${org.name}/${repo.name}/notification/${notificationUuid}`,
+        );
+        expect(reset.status()).toBe(204);
+
+        // Get notification by UUID
+        const getByUuid = await adminClient.get(
+          `/api/v1/repository/${org.name}/${repo.name}/notification/${notificationUuid}`,
+        );
+        expect(getByUuid.status()).toBe(200);
+        const getBody = await getByUuid.json();
+        expect(getBody.uuid).toBe(notificationUuid);
+
+        // Delete notification
+        const del = await adminClient.delete(
+          `/api/v1/repository/${org.name}/${repo.name}/notification/${notificationUuid}`,
+        );
+        expect(del.status()).toBe(204);
+      });
+    });
+
+    // ========================================================================
+    // Robot Accounts CRUD
+    // ========================================================================
+
+    test.describe('Robot Accounts', () => {
+      test('create, get, and list robot accounts under org', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const robot = await superuserApi.robot(org.name);
+
+        // Get specific robot
+        const getBot = await adminClient.get(
+          `/api/v1/organization/${org.name}/robots/${robot.shortname}`,
+        );
+        expect(getBot.status()).toBe(200);
+
+        // List all robots in the org
+        const listBots = await adminClient.get(
+          `/api/v1/organization/${org.name}/robots?permissions=true&token=false`,
+        );
+        expect(listBots.status()).toBe(200);
+        const listBody = await listBots.json();
+        expect(listBody.robots.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    // ========================================================================
+    // Robot Federation CRUD
+    // ========================================================================
+
+    test.describe('Robot Federation', () => {
+      test('create with invalid issuer URL returns 400', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const robot = await superuserApi.robot(org.name);
+
+        const resp = await adminClient.post(
+          `/api/v1/organization/${org.name}/robots/${robot.shortname}/federation`,
+          [
+            {
+              issuer:
+                'sts.windows.net/250926f3-c788-4a52-acfa-e3aac5386ac1',
+              subject: '93VEQl60c7JtJIV9r3gS0FCPTkcpwCDtfEUtD-lgdP4',
+              isExpanded: true,
+            },
+          ] as unknown as Record<string, unknown>,
+        );
+        expect(resp.status()).toBe(400);
+        const body = await resp.json();
+        expect(body.error_message).toContain('Issuer must be a URL');
+      });
+
+      test('create, get, and delete federation with valid issuer URL', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const robot = await superuserApi.robot(org.name);
+
+        // Create federation with valid URL
+        const create = await adminClient.post(
+          `/api/v1/organization/${org.name}/robots/${robot.shortname}/federation`,
+          [
+            {
+              issuer:
+                'https://sts.windows.net/250926f3-c788-4a52-acfa-e3aac5386ac1/',
+              subject: '93VEQl60c7JtJIV9r3gS0FCPTkcpwCDtfEUtD-lgdP4',
+              isExpanded: true,
+            },
+          ] as unknown as Record<string, unknown>,
+        );
+        expect(create.status()).toBe(200);
+
+        // Get federation
+        const getFed = await adminClient.get(
+          `/api/v1/organization/${org.name}/robots/${robot.shortname}/federation`,
+        );
+        expect(getFed.status()).toBe(200);
+        const fedBody = await getFed.json();
+        expect(Array.isArray(fedBody)).toBe(true);
+        expect(fedBody[0].issuer).toContain(
+          'sts.windows.net/250926f3-c788-4a52-acfa-e3aac5386ac1',
+        );
+        expect(fedBody[0].subject).toContain(
+          '93VEQl60c7JtJIV9r3gS0FCPTkcpwCDtfEUtD-lgdP4',
+        );
+
+        // Delete federation
+        const del = await adminClient.delete(
+          `/api/v1/organization/${org.name}/robots/${robot.shortname}/federation`,
+        );
+        expect(del.status()).toBe(204);
+      });
+    });
+
+    // ========================================================================
+    // Default Permissions / Prototypes
+    // ========================================================================
+
+    test.describe('Default Permissions (Prototypes)', () => {
+      test('create default permission for robot account', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const robot = await superuserApi.robot(org.name);
+
+        const resp = await adminClient.post(
+          `/api/v1/organization/${org.name}/prototypes`,
+          {
+            delegate: {
+              name: robot.fullName,
+              kind: 'user',
+              is_robot: true,
+              is_org_member: true,
+            },
+            role: 'read',
+          },
+        );
+        expect(resp.status()).toBe(200);
+        const body = await resp.json();
+        expect(body.delegate.name).toBe(robot.fullName);
+      });
+    });
+
+    // ========================================================================
+    // Repository State Changes
+    // ========================================================================
+
+    test.describe('Repository State Changes', () => {
+      test('transition repo through MIRROR, READ_ONLY, and NORMAL states', async ({
+        superuserApi,
+        adminClient,
+      }) => {
+        const org = await superuserApi.organization();
+        const repo = await superuserApi.repository(org.name);
+
+        // Change to MIRROR
+        const toMirror = await adminClient.put(
+          `/api/v1/repository/${org.name}/${repo.name}/changestate`,
+          {state: 'MIRROR'},
+        );
+        expect(toMirror.status()).toBe(200);
+        const mirrorBody = await toMirror.json();
+        expect(mirrorBody.success).toBe(true);
+
+        // Change to READ_ONLY
+        const toReadOnly = await adminClient.put(
+          `/api/v1/repository/${org.name}/${repo.name}/changestate`,
+          {state: 'READ_ONLY'},
+        );
+        expect(toReadOnly.status()).toBe(200);
+        const readOnlyBody = await toReadOnly.json();
+        expect(readOnlyBody.success).toBe(true);
+
+        // Change back to NORMAL
+        const toNormal = await adminClient.put(
+          `/api/v1/repository/${org.name}/${repo.name}/changestate`,
+          {state: 'NORMAL'},
+        );
+        expect(toNormal.status()).toBe(200);
+        const normalBody = await toNormal.json();
+        expect(normalBody.success).toBe(true);
+      });
+    });
+  },
+);

--- a/web/playwright/e2e/api/api-v1-repo-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-repo-features.spec.ts
@@ -284,6 +284,7 @@ test.describe(
         expect(getFed.status()).toBe(200);
         const fedBody = await getFed.json();
         expect(Array.isArray(fedBody)).toBe(true);
+        expect(fedBody.length).toBeGreaterThan(0);
         expect(fedBody[0].issuer).toContain(
           'sts.windows.net/250926f3-c788-4a52-acfa-e3aac5386ac1',
         );
@@ -304,13 +305,14 @@ test.describe(
     // ========================================================================
 
     test.describe('Default Permissions (Prototypes)', () => {
-      test('create default permission for robot account', async ({
+      test('create, list, update, and delete default permission for robot account', async ({
         superuserApi,
         adminClient,
       }) => {
         const org = await superuserApi.organization();
         const robot = await superuserApi.robot(org.name);
 
+        // Create
         const resp = await adminClient.post(
           `/api/v1/organization/${org.name}/prototypes`,
           {
@@ -326,6 +328,33 @@ test.describe(
         expect(resp.status()).toBe(200);
         const body = await resp.json();
         expect(body.delegate.name).toBe(robot.fullName);
+        const prototypeId = body.id;
+
+        // List
+        const list = await adminClient.get(
+          `/api/v1/organization/${org.name}/prototypes`,
+        );
+        expect(list.status()).toBe(200);
+        const listBody = await list.json();
+        const found = listBody.prototypes.find(
+          (p: {id: string}) => p.id === prototypeId,
+        );
+        expect(found).toBeTruthy();
+
+        // Update role from read to write
+        const update = await adminClient.put(
+          `/api/v1/organization/${org.name}/prototypes/${prototypeId}`,
+          {role: 'write'},
+        );
+        expect(update.status()).toBe(200);
+        const updateBody = await update.json();
+        expect(updateBody.role).toBe('write');
+
+        // Delete
+        const del = await adminClient.delete(
+          `/api/v1/organization/${org.name}/prototypes/${prototypeId}`,
+        );
+        expect(del.status()).toBe(204);
       });
     });
 

--- a/web/playwright/utils/api/raw-client.ts
+++ b/web/playwright/utils/api/raw-client.ts
@@ -71,7 +71,7 @@ export class RawApiClient {
    */
   async post(
     path: string,
-    data?: Record<string, unknown>,
+    data?: Record<string, unknown> | unknown[],
   ): Promise<APIResponse> {
     const token = await this.fetchCsrfToken();
     return this.request.post(`${this.baseUrl}${path}`, {


### PR DESCRIPTION
## Summary
- Port repository features API tests from the legacy Cypress suite to the Playwright API test infrastructure
- Covers: permissions (add/update/remove), collaborators listing, teams (create/permissions/members), notifications CRUD, robot accounts CRUD, robot federation CRUD, default permissions/prototypes, and repository state changes

## Source Tests (Cypress)
Ported from `quay/quay-tests` (private):
- `quay-api-tests/cypress/e2e/quay_api_testing_all.cy.js`
  - Repository permissions: add user permission, update role, remove permission (~3 tests)
  - Collaborators: list collaborators (~1 test)
  - Teams: create team, add team permission, add team member (~3 tests)
  - Notifications: list, create, test, reset, get, delete (~6 tests)
  - Robot accounts: create, get, list (~3 tests)
  - Robot federation: invalid URL 400, create, get, delete (~4 tests)
  - Default permissions (prototypes): create, list, update, delete (~4 tests)
  - Repository state: set MIRROR, set READ_ONLY, restore NORMAL (~3 tests)

## Root Cause / Rationale
Continuing the migration from Cypress to Playwright for better parallelism, reliability, and integration with the Playwright test infrastructure.

## Changes
- Added `web/playwright/e2e/api/api-v1-repo-features.spec.ts` with ~9 test groups
- All tests use `superuserApi` and `adminClient` fixtures with automatic cleanup

## Test plan
- [ ] All tests pass against a running Quay instance with Database auth
- [ ] Tests are self-contained and can run in parallel
- [ ] Cleanup runs automatically even on test failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)