### PR TITLE
NO-ISSUE: test(web): add Phase 3 unit tests for UIContext and ThemeContext

### DIFF
--- a/agent_docs/web-unit-test-roadmap.md
+++ b/agent_docs/web-unit-test-roadmap.md
@@ -3,7 +3,7 @@
 Prioritized checklist of testable areas in `web/src/`, with effort estimates and implementation guidance.
 
 **Stack:** Vitest + React Testing Library + happy-dom
-**Current state:** 142 tests passing across 9 files. Phases 1-2 complete. Playwright covers E2E (58 tests).
+**Current state:** 180 tests passing across 11 files. Phases 1-3 complete. Playwright covers E2E (58 tests).
 **Target:** ~460 unit tests across 7 phases
 
 ## Completed: Framework Setup
@@ -42,16 +42,14 @@ Prioritized checklist of testable areas in `web/src/`, with effort estimates and
 
 ---
 
-## Phase 3: Contexts (~35 tests)
+## Phase 3: Contexts — COMPLETE (38 tests)
 
-Small surface area, high value — these are used everywhere.
+| File | Tests | Status |
+|------|-------|--------|
+| `src/contexts/UIContext.tsx` | 15 | **Done** — sidebar toggle + localStorage persistence, alert add/remove/clear with key generation, `useUI()` outside provider throws |
+| `src/contexts/ThemeContext.tsx` | 23 | **Done** — LIGHT/DARK/AUTO switching, localStorage persistence + invalid fallback, `matchMedia` listener lifecycle (register/respond/cleanup/unmount), DOM class toggle (`pf-v6-theme-dark`), default context without provider |
 
-| File | What to Test | Est. Tests |
-|------|-------------|-----------|
-| `src/contexts/UIContext.tsx` | Sidebar toggle + localStorage persistence, alert add/remove/clear, `useUI()` outside provider throws | ~15 |
-| `src/contexts/ThemeContext.tsx` | Dark/light/auto theme switching, localStorage persistence, `matchMedia` listener, DOM class updates | ~20 |
-
-**Effort:** ~1 day. Uses `renderHook` with provider wrapper.
+**Notes:** First use of `renderHook` in the codebase. ThemeContext tests use a `createMockMediaQueryList` helper returning a stable object with `_triggerChange` for simulating system theme changes. Per-test `vi.spyOn(window, 'matchMedia')` overrides the global mock; `restoreMocks: true` handles cleanup. DOM class cleanup in `afterEach` since `vitest.setup.ts` only clears localStorage.
 
 ---
 
@@ -160,15 +158,15 @@ Leave these to Playwright E2E:
 |-------|-------|-------|--------|--------|
 | 1 | Pure utilities | 105 | 1-2 days | **Complete** |
 | 2 | Error handling + cookies | 31 | 1 day | **Complete** |
-| 3 | Contexts | ~35 | 1 day | Pending |
+| 3 | Contexts | 38 | 1 day | **Complete** |
 | 4 | Complex hooks | ~60 | 2-3 days | Pending |
 | 5 | API resources | ~80 | 3-4 days | Pending |
 | 6 | Standard hooks | ~100 | 3-4 days | Pending |
 | 7 | Components | 6/~80 | 3-4 days | **In progress** — LoadingPage (6) done |
 
-**Current: 142 tests passing across 9 files | Target: ~460 tests**
+**Current: 180 tests passing across 11 files | Target: ~460 tests**
 
-Phases 1-3 deliver the most value per test written. Phase 4's `usePaginatedSortableTable` is the single highest-ROI target. Phases 5-7 are incremental and can be spread over sprints.
+Phases 1-3 are complete and deliver the most value per test written. Phase 4's `usePaginatedSortableTable` is the single highest-ROI target. Phases 5-7 are incremental and can be spread over sprints.
 
 ---
 

--- a/web/src/contexts/ThemeContext.test.tsx
+++ b/web/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,297 @@
+import {renderHook, act} from '@testing-library/react';
+import React from 'react';
+import {ThemeProvider, ThemePreference, useTheme} from './ThemeContext';
+
+/**
+ * Creates a stable matchMedia mock object. Returns the same object on every
+ * window.matchMedia() call within a test, which is required because
+ * ThemeContext calls matchMedia at component body scope (re-called on render).
+ */
+function createMockMediaQueryList(prefersDark: boolean) {
+  const listeners: Array<(e: MediaQueryListEvent) => void> = [];
+  const mql = {
+    matches: prefersDark,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(
+      (_event: string, cb: (e: MediaQueryListEvent) => void) => {
+        listeners.push(cb);
+      },
+    ),
+    removeEventListener: vi.fn(
+      (_event: string, cb: (e: MediaQueryListEvent) => void) => {
+        const idx = listeners.indexOf(cb);
+        if (idx >= 0) listeners.splice(idx, 1);
+      },
+    ),
+    dispatchEvent: vi.fn(),
+  };
+
+  function triggerChange(newMatches: boolean) {
+    mql.matches = newMatches;
+    listeners.forEach((cb) => cb({matches: newMatches} as MediaQueryListEvent));
+  }
+
+  return {mql, triggerChange};
+}
+
+function wrapper({children}: {children: React.ReactNode}) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+describe('ThemeContext', () => {
+  let mockMql: ReturnType<typeof createMockMediaQueryList>;
+
+  beforeEach(() => {
+    document.documentElement.classList.remove('pf-v6-theme-dark');
+    mockMql = createMockMediaQueryList(false);
+    vi.spyOn(window, 'matchMedia').mockReturnValue(
+      mockMql.mql as unknown as MediaQueryList,
+    );
+  });
+
+  afterEach(() => {
+    document.documentElement.classList.remove('pf-v6-theme-dark');
+  });
+
+  describe('default state', () => {
+    it('defaults to AUTO preference when localStorage is empty', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.themePreference).toBe(ThemePreference.AUTO);
+    });
+
+    it('defaults isDarkTheme to false when system prefers light', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.isDarkTheme).toBe(false);
+    });
+
+    it('defaults isDarkTheme to true when system prefers dark', () => {
+      mockMql = createMockMediaQueryList(true);
+      vi.spyOn(window, 'matchMedia').mockReturnValue(
+        mockMql.mql as unknown as MediaQueryList,
+      );
+
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.isDarkTheme).toBe(true);
+    });
+  });
+
+  describe('localStorage initialization', () => {
+    it('reads LIGHT from localStorage', () => {
+      localStorage.setItem('theme-preference', 'LIGHT');
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.themePreference).toBe(ThemePreference.LIGHT);
+      expect(result.current.isDarkTheme).toBe(false);
+    });
+
+    it('reads DARK from localStorage', () => {
+      localStorage.setItem('theme-preference', 'DARK');
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.themePreference).toBe(ThemePreference.DARK);
+      expect(result.current.isDarkTheme).toBe(true);
+    });
+
+    it('reads AUTO from localStorage', () => {
+      localStorage.setItem('theme-preference', 'AUTO');
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.themePreference).toBe(ThemePreference.AUTO);
+    });
+
+    it('falls back to AUTO for invalid localStorage value', () => {
+      localStorage.setItem('theme-preference', 'INVALID');
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.themePreference).toBe(ThemePreference.AUTO);
+    });
+  });
+
+  describe('setThemePreference', () => {
+    it('switches from AUTO to LIGHT', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.LIGHT);
+      });
+
+      expect(result.current.themePreference).toBe(ThemePreference.LIGHT);
+      expect(result.current.isDarkTheme).toBe(false);
+    });
+
+    it('switches from AUTO to DARK', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.DARK);
+      });
+
+      expect(result.current.themePreference).toBe(ThemePreference.DARK);
+      expect(result.current.isDarkTheme).toBe(true);
+    });
+
+    it('switches from DARK to LIGHT', () => {
+      localStorage.setItem('theme-preference', 'DARK');
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.isDarkTheme).toBe(true);
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.LIGHT);
+      });
+
+      expect(result.current.isDarkTheme).toBe(false);
+    });
+
+    it('switches from LIGHT to AUTO with system=light', () => {
+      localStorage.setItem('theme-preference', 'LIGHT');
+      const {result} = renderHook(() => useTheme(), {wrapper});
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.AUTO);
+      });
+
+      expect(result.current.themePreference).toBe(ThemePreference.AUTO);
+      expect(result.current.isDarkTheme).toBe(false);
+    });
+
+    it('switches from LIGHT to AUTO with system=dark', () => {
+      mockMql = createMockMediaQueryList(true);
+      vi.spyOn(window, 'matchMedia').mockReturnValue(
+        mockMql.mql as unknown as MediaQueryList,
+      );
+      localStorage.setItem('theme-preference', 'LIGHT');
+      const {result} = renderHook(() => useTheme(), {wrapper});
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.AUTO);
+      });
+
+      expect(result.current.themePreference).toBe(ThemePreference.AUTO);
+      expect(result.current.isDarkTheme).toBe(true);
+    });
+  });
+
+  describe('localStorage persistence', () => {
+    it('persists LIGHT to localStorage', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.LIGHT);
+      });
+
+      expect(localStorage.getItem('theme-preference')).toBe('LIGHT');
+    });
+
+    it('persists DARK to localStorage', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.DARK);
+      });
+
+      expect(localStorage.getItem('theme-preference')).toBe('DARK');
+    });
+
+    it('persists AUTO to localStorage', () => {
+      localStorage.setItem('theme-preference', 'DARK');
+      const {result} = renderHook(() => useTheme(), {wrapper});
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.AUTO);
+      });
+
+      expect(localStorage.getItem('theme-preference')).toBe('AUTO');
+    });
+  });
+
+  describe('DOM class updates', () => {
+    it('adds pf-v6-theme-dark class when dark theme is active', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.DARK);
+      });
+
+      expect(
+        document.documentElement.classList.contains('pf-v6-theme-dark'),
+      ).toBe(true);
+    });
+
+    it('removes pf-v6-theme-dark class when switching to light', () => {
+      localStorage.setItem('theme-preference', 'DARK');
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(
+        document.documentElement.classList.contains('pf-v6-theme-dark'),
+      ).toBe(true);
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.LIGHT);
+      });
+
+      expect(
+        document.documentElement.classList.contains('pf-v6-theme-dark'),
+      ).toBe(false);
+    });
+
+    it('does not have dark class when system=light and theme=AUTO', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.themePreference).toBe(ThemePreference.AUTO);
+      expect(
+        document.documentElement.classList.contains('pf-v6-theme-dark'),
+      ).toBe(false);
+    });
+  });
+
+  describe('matchMedia listener (AUTO mode)', () => {
+    it('registers event listener in AUTO mode', () => {
+      renderHook(() => useTheme(), {wrapper});
+      expect(mockMql.mql.addEventListener).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+
+    it('responds to system theme change from light to dark', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+      expect(result.current.isDarkTheme).toBe(false);
+
+      act(() => {
+        mockMql.triggerChange(true);
+      });
+
+      expect(result.current.isDarkTheme).toBe(true);
+    });
+
+    it('removes event listener when switching away from AUTO', () => {
+      const {result} = renderHook(() => useTheme(), {wrapper});
+
+      act(() => {
+        result.current.setThemePreference(ThemePreference.DARK);
+      });
+
+      expect(mockMql.mql.removeEventListener).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+
+    it('removes event listener on unmount in AUTO mode', () => {
+      const {unmount} = renderHook(() => useTheme(), {wrapper});
+
+      unmount();
+
+      expect(mockMql.mql.removeEventListener).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('useTheme without provider', () => {
+    it('returns default context values without provider', () => {
+      const {result} = renderHook(() => useTheme());
+      expect(result.current.themePreference).toBe(ThemePreference.AUTO);
+      expect(result.current.isDarkTheme).toBe(false);
+      expect(typeof result.current.setThemePreference).toBe('function');
+    });
+  });
+});

--- a/web/src/contexts/ThemeContext.test.tsx
+++ b/web/src/contexts/ThemeContext.test.tsx
@@ -29,6 +29,7 @@ function createMockMediaQueryList(prefersDark: boolean) {
     dispatchEvent: vi.fn(),
   };
 
+  /** Simulates a system theme change by invoking all registered listeners. */
   function triggerChange(newMatches: boolean) {
     mql.matches = newMatches;
     listeners.forEach((cb) => cb({matches: newMatches} as MediaQueryListEvent));
@@ -37,6 +38,7 @@ function createMockMediaQueryList(prefersDark: boolean) {
   return {mql, triggerChange};
 }
 
+/** Wrapper component that provides ThemeContext for renderHook tests. */
 function wrapper({children}: {children: React.ReactNode}) {
   return <ThemeProvider>{children}</ThemeProvider>;
 }

--- a/web/src/contexts/ThemeContext.test.tsx
+++ b/web/src/contexts/ThemeContext.test.tsx
@@ -47,6 +47,7 @@ describe('ThemeContext', () => {
   let mockMql: ReturnType<typeof createMockMediaQueryList>;
 
   beforeEach(() => {
+    localStorage.clear();
     document.documentElement.classList.remove('pf-v6-theme-dark');
     mockMql = createMockMediaQueryList(false);
     vi.spyOn(window, 'matchMedia').mockReturnValue(
@@ -55,6 +56,7 @@ describe('ThemeContext', () => {
   });
 
   afterEach(() => {
+    localStorage.clear();
     document.documentElement.classList.remove('pf-v6-theme-dark');
   });
 

--- a/web/src/contexts/UIContext.test.tsx
+++ b/web/src/contexts/UIContext.test.tsx
@@ -1,0 +1,233 @@
+import {renderHook, act} from '@testing-library/react';
+import React from 'react';
+import {UIProvider, useUI, AlertVariant} from './UIContext';
+
+function wrapper({children}: {children: React.ReactNode}) {
+  return <UIProvider>{children}</UIProvider>;
+}
+
+describe('UIContext', () => {
+  describe('sidebar state', () => {
+    it('defaults to open when localStorage is empty', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+      expect(result.current.isSidebarOpen).toBe(true);
+    });
+
+    it('reads initial state from localStorage (open)', () => {
+      localStorage.setItem('quay-sidebar-open', 'true');
+      const {result} = renderHook(() => useUI(), {wrapper});
+      expect(result.current.isSidebarOpen).toBe(true);
+    });
+
+    it('reads initial state from localStorage (closed)', () => {
+      localStorage.setItem('quay-sidebar-open', 'false');
+      const {result} = renderHook(() => useUI(), {wrapper});
+      expect(result.current.isSidebarOpen).toBe(false);
+    });
+
+    it('toggleSidebar flips state from open to closed', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+      expect(result.current.isSidebarOpen).toBe(true);
+
+      act(() => {
+        result.current.toggleSidebar();
+      });
+      expect(result.current.isSidebarOpen).toBe(false);
+    });
+
+    it('toggleSidebar flips state from closed to open', () => {
+      localStorage.setItem('quay-sidebar-open', 'false');
+      const {result} = renderHook(() => useUI(), {wrapper});
+      expect(result.current.isSidebarOpen).toBe(false);
+
+      act(() => {
+        result.current.toggleSidebar();
+      });
+      expect(result.current.isSidebarOpen).toBe(true);
+    });
+
+    it('persists sidebar state to localStorage on toggle', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+
+      act(() => {
+        result.current.toggleSidebar();
+      });
+      expect(localStorage.getItem('quay-sidebar-open')).toBe('false');
+
+      act(() => {
+        result.current.toggleSidebar();
+      });
+      expect(localStorage.getItem('quay-sidebar-open')).toBe('true');
+    });
+
+    it('double toggle returns to original state', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+      expect(result.current.isSidebarOpen).toBe(true);
+
+      act(() => {
+        result.current.toggleSidebar();
+        result.current.toggleSidebar();
+      });
+      expect(result.current.isSidebarOpen).toBe(true);
+    });
+  });
+
+  describe('alert management', () => {
+    it('starts with empty alerts', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+      expect(result.current.alerts).toEqual([]);
+    });
+
+    it('addAlert appends a success alert with explicit key', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+
+      act(() => {
+        result.current.addAlert({
+          variant: AlertVariant.Success,
+          title: 'Created repo',
+          key: 'alert-1',
+        });
+      });
+
+      expect(result.current.alerts).toHaveLength(1);
+      expect(result.current.alerts[0]).toMatchObject({
+        variant: AlertVariant.Success,
+        title: 'Created repo',
+        key: 'alert-1',
+      });
+    });
+
+    it('addAlert appends a failure alert with message', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+
+      act(() => {
+        result.current.addAlert({
+          variant: AlertVariant.Failure,
+          title: 'Failed to delete',
+          key: 'err-1',
+          message: 'Permission denied',
+        });
+      });
+
+      expect(result.current.alerts).toHaveLength(1);
+      expect(result.current.alerts[0]).toMatchObject({
+        variant: AlertVariant.Failure,
+        title: 'Failed to delete',
+        message: 'Permission denied',
+      });
+    });
+
+    it('addAlert generates a key when none is provided', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+
+      act(() => {
+        result.current.addAlert({
+          variant: AlertVariant.Success,
+          title: 'No key provided',
+        });
+      });
+
+      expect(result.current.alerts).toHaveLength(1);
+      expect(result.current.alerts[0].key).toBeDefined();
+      expect(result.current.alerts[0].key).not.toBe('');
+    });
+
+    it('addAlert accumulates multiple alerts in order', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+
+      act(() => {
+        result.current.addAlert({
+          variant: AlertVariant.Success,
+          title: 'First',
+          key: 'a1',
+        });
+        result.current.addAlert({
+          variant: AlertVariant.Failure,
+          title: 'Second',
+          key: 'a2',
+        });
+        result.current.addAlert({
+          variant: AlertVariant.Success,
+          title: 'Third',
+          key: 'a3',
+        });
+      });
+
+      expect(result.current.alerts).toHaveLength(3);
+      expect(result.current.alerts.map((a) => a.title)).toEqual([
+        'First',
+        'Second',
+        'Third',
+      ]);
+    });
+
+    it('removeAlert removes by key and ignores nonexistent keys', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+
+      act(() => {
+        result.current.addAlert({
+          variant: AlertVariant.Success,
+          title: 'Keep',
+          key: 'keep',
+        });
+        result.current.addAlert({
+          variant: AlertVariant.Failure,
+          title: 'Remove',
+          key: 'remove',
+        });
+      });
+
+      act(() => {
+        result.current.removeAlert('remove');
+      });
+      expect(result.current.alerts).toHaveLength(1);
+      expect(result.current.alerts[0].key).toBe('keep');
+
+      act(() => {
+        result.current.removeAlert('nonexistent');
+      });
+      expect(result.current.alerts).toHaveLength(1);
+    });
+
+    it('clearAllAlerts empties array and is a no-op on empty', () => {
+      const {result} = renderHook(() => useUI(), {wrapper});
+
+      act(() => {
+        result.current.addAlert({
+          variant: AlertVariant.Success,
+          title: 'One',
+          key: 'k1',
+        });
+        result.current.addAlert({
+          variant: AlertVariant.Failure,
+          title: 'Two',
+          key: 'k2',
+        });
+      });
+      expect(result.current.alerts).toHaveLength(2);
+
+      act(() => {
+        result.current.clearAllAlerts();
+      });
+      expect(result.current.alerts).toEqual([]);
+
+      act(() => {
+        result.current.clearAllAlerts();
+      });
+      expect(result.current.alerts).toEqual([]);
+    });
+  });
+
+  describe('useUI outside provider', () => {
+    it('throws when used outside UIProvider', () => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useUI());
+      }).toThrow('useUI must be used within a UIProvider');
+
+      spy.mockRestore();
+    });
+  });
+});

--- a/web/src/contexts/UIContext.test.tsx
+++ b/web/src/contexts/UIContext.test.tsx
@@ -2,6 +2,7 @@ import {renderHook, act} from '@testing-library/react';
 import React from 'react';
 import {UIProvider, useUI, AlertVariant} from './UIContext';
 
+/** Wrapper component that provides UIContext for renderHook tests. */
 function wrapper({children}: {children: React.ReactNode}) {
   return <UIProvider>{children}</UIProvider>;
 }


### PR DESCRIPTION
## Summary
- Add 38 unit tests for Phase 3 of the web unit test roadmap, covering both React context providers (`UIContext` and `ThemeContext`)
- First use of `renderHook` in the codebase, establishing the pattern for future hook/context tests
- Update roadmap to reflect Phase 3 completion (180 tests across 11 files)

## Root Cause / Rationale
Phase 3 of the web-unit-test-roadmap targets context providers — small surface area, high value since UIContext is consumed by 40+ components and ThemeContext controls app-wide theme switching. Both had zero test coverage.

## Changes
- **`web/src/contexts/UIContext.test.tsx`** (15 tests):
  - Sidebar toggle with localStorage persistence (read/write/default)
  - Alert management: add (with explicit & auto-generated keys), remove (by key + nonexistent key no-op), clear all (populated + empty)
  - Error path: `useUI()` outside `UIProvider` throws specific error
- **`web/src/contexts/ThemeContext.test.tsx`** (23 tests):
  - Default state with system light/dark preference via `matchMedia`
  - localStorage initialization (LIGHT/DARK/AUTO/invalid fallback)
  - Theme switching (AUTO→LIGHT, AUTO→DARK, DARK→LIGHT, LIGHT→AUTO with system light/dark)
  - localStorage persistence for all preference values
  - DOM class updates (`pf-v6-theme-dark` add/remove)
  - matchMedia listener lifecycle: register in AUTO, respond to system change, cleanup on preference change, cleanup on unmount
  - Default context without provider (does not throw)
- **`agent_docs/web-unit-test-roadmap.md`**: Mark Phase 3 complete, update test counts

## Test Plan
- [x] Unit tests added/updated
- [x] `npx vitest run` — 180 tests passing across 11 files (142 existing + 38 new)
- [x] `npx vitest run src/contexts/` — 38 tests passing (2 files)
- [x] Pre-commit hooks pass (ESLint, gitleaks, trailing whitespace, EOF)
- [ ] No backport needed

## JIRA
N/A — unticketed test infrastructure work (NO-ISSUE)

## Backport
- [x] No backport needed