### PR TITLE
NO-ISSUE: test(web): add Phase 4 unit tests for complex hooks

### DIFF
--- a/agent_docs/web-unit-test-roadmap.md
+++ b/agent_docs/web-unit-test-roadmap.md
@@ -3,7 +3,7 @@
 Prioritized checklist of testable areas in `web/src/`, with effort estimates and implementation guidance.
 
 **Stack:** Vitest + React Testing Library + happy-dom
-**Current state:** 180 tests passing across 11 files. Phases 1-3 complete. Playwright covers E2E (58 tests).
+**Current state:** 239 tests passing across 14 files. Phases 1-4 complete. Playwright covers E2E (58 tests).
 **Target:** ~460 unit tests across 7 phases
 
 ## Completed: Framework Setup
@@ -53,17 +53,15 @@ Prioritized checklist of testable areas in `web/src/`, with effort estimates and
 
 ---
 
-## Phase 4: Complex Hooks (~60 tests)
+## Phase 4: Complex Hooks — COMPLETE (59 tests)
 
-These hooks have significant logic beyond "call API, return data." Highest ROI in the hooks layer.
+| File | Tests | Status |
+|------|-------|--------|
+| `src/hooks/usePaginatedSortableTable.ts` | 31 | **Done** — default state, initial config, string/hex/UUID/number sorting, sort interactions, filtering, pipeline, pagination, paginationProps |
+| `src/hooks/UseUsernameValidation.ts` | 12 | **Done** — state machine transitions (editing/confirming/confirmed/existing), dual API check, sequential validations. axios mocked via `vi.mock`. |
+| `src/hooks/UseQuotaManagement.ts` | 16 | **Done** — useFetchOrganizationQuota (null data, first quota, enabled logic), all 6 mutation hooks (success callbacks, error callbacks with addDisplayError). Resource functions mocked via `vi.mock`. |
 
-| File | Complexity | Est. Tests | Why |
-|------|-----------|-----------|-----|
-| `src/hooks/usePaginatedSortableTable.ts` | High (168 LOC) | ~30 | Pagination + sorting + filtering pipeline. Tests hex/UUID sort, locale-aware string sort, page boundary math. Pure state — no mocking needed. |
-| `src/hooks/UseUsernameValidation.ts` | High (60 LOC) | ~15 | State machine: editing -> confirming -> confirmed/existing/error. Dual async API check. Mock axios. |
-| `src/hooks/UseQuotaManagement.ts` | Medium (242 LOC) | ~15 | 6 hooks for quota CRUD. Standard React Query pattern but worth testing error callbacks. |
-
-**Effort:** ~2-3 days. `usePaginatedSortableTable` is the single highest-ROI test target in the codebase.
+**Notes:** `usePaginatedSortableTable` tests are pure state (no mocking). `UseUsernameValidation` and `UseQuotaManagement` use `QueryClientProvider` wrapper with `createTestQueryClient()` from `test-utils.tsx`. `waitFor` used for all async state transitions. The `onError` path in `UseUsernameValidation` is defensive/unreachable (internal try/catch absorbs all errors).
 
 ---
 
@@ -159,14 +157,14 @@ Leave these to Playwright E2E:
 | 1 | Pure utilities | 105 | 1-2 days | **Complete** |
 | 2 | Error handling + cookies | 31 | 1 day | **Complete** |
 | 3 | Contexts | 38 | 1 day | **Complete** |
-| 4 | Complex hooks | ~60 | 2-3 days | Pending |
+| 4 | Complex hooks | 59 | 2-3 days | **Complete** |
 | 5 | API resources | ~80 | 3-4 days | Pending |
 | 6 | Standard hooks | ~100 | 3-4 days | Pending |
 | 7 | Components | 6/~80 | 3-4 days | **In progress** — LoadingPage (6) done |
 
-**Current: 180 tests passing across 11 files | Target: ~460 tests**
+**Current: 239 tests passing across 14 files | Target: ~460 tests**
 
-Phases 1-3 are complete and deliver the most value per test written. Phase 4's `usePaginatedSortableTable` is the single highest-ROI target. Phases 5-7 are incremental and can be spread over sprints.
+Phases 1-4 are complete and deliver the most value per test written. Phases 5-7 are incremental and can be spread over sprints.
 
 ---
 

--- a/agent_docs/web-unit-test-roadmap.md
+++ b/agent_docs/web-unit-test-roadmap.md
@@ -4,7 +4,7 @@ Prioritized checklist of testable areas in `web/src/`, with effort estimates and
 
 **Stack:** Vitest + React Testing Library + happy-dom
 **Current state:** 239 tests passing across 14 files. Phases 1-4 complete. Playwright covers E2E (58 tests).
-**Target:** ~460 unit tests across 7 phases
+**Target:** ~620 unit tests across 7 phases
 
 ## Completed: Framework Setup
 
@@ -65,49 +65,78 @@ Prioritized checklist of testable areas in `web/src/`, with effort estimates and
 
 ---
 
-## Phase 5: API Resource Layer (~80 tests)
+## Phase 5: API Resource Layer (~110 tests)
 
-29 resource files. Most follow the same pattern: thin axios wrapper with optional data transformation. Create a shared mock factory and template tests.
+29 untested resource files (~346 exported functions). Most follow the same pattern: thin axios wrapper with optional data transformation. Create a shared mock factory and template tests.
 
 **High priority (test first):**
 
 | File | Est. Tests | Notes |
 |------|-----------|-------|
-| `src/resources/RepositoryResource.ts` | ~15 | Pagination logic in `fetchAllRepos`, state classification in `isNonNormalState` |
-| `src/resources/TagResource.ts` | ~15 | Many operations, complex types |
-| `src/resources/OrganizationResource.ts` | ~15 | `OrgDeleteError` class, bulk operations |
-| `src/resources/UserResource.ts` | ~10 | Auth-related transforms |
+| `src/resources/RepositoryResource.ts` | ~18 | Pagination recursion in `fetchAllRepos`, batching logic, `fetchAllReposAsSuperUser` truncation, `isNonNormalState` |
+| `src/resources/TagResource.ts` | ~20 | Many operations, sparse manifest handling, complex types |
+| `src/resources/OrganizationResource.ts` | ~18 | `OrgDeleteError` class, bulk operations, Promise.allSettled error aggregation |
+| `src/resources/UserResource.ts` | ~12 | Auth-related transforms, entity type enumeration |
 
 **Medium priority (batch with template):**
-Remaining ~25 resources: `DefaultPermissionResource`, `MembersResource`, `NotificationResource`, `TeamResources`, `BuildResource`, `MirroringResource`, etc. Most need just 1-2 tests per endpoint.
 
-**Effort:** ~3-4 days. Create `createMockAxios()` utility once, reuse everywhere.
+| File | Est. Tests | Notes |
+|------|-----------|-------|
+| `src/resources/QuotaResource.ts` | ~8 | Endpoint routing by viewMode, abort/cancel handling, 404/403 fallback |
+| `src/resources/AuthResource.ts` | ~4 | Auth state management |
+| `src/resources/RobotsResource.ts` | ~4 | Robot account CRUD |
+| `src/resources/BuildResource.ts` | ~4 | Build trigger/log operations |
+| `src/resources/MirroringResource.ts` | ~4 | Mirror config CRUD |
+| `src/resources/DefaultPermissionResource.ts` | ~3 | Permission CRUD |
+| `src/resources/MembersResource.ts` | ~3 | Member management |
+| `src/resources/NotificationResource.ts` | ~3 | Notification CRUD |
+| `src/resources/TeamResources.ts` | ~3 | Team management |
+
+**Low priority (1-2 tests per endpoint):**
+Remaining ~16 resources: `BillingResource`, `CapabilitiesResource`, `ChangeLogResource`, `GlobalMessagesResource`, `OAuthApplicationResource`, `ProxyCacheResource`, `RegistrySizeResource`, `ServiceKeysResource`, `TeamSyncResource`, `RepositoryAutoPruneResource`, `NamespaceAutoPruneResource`, `ImmutabilityPolicyResource`, `OrgMirrorResource`, `LabelsResource`, `QuayConfig`, `ExternalLoginResource`.
+
+**Effort:** ~4-5 days. Create `createMockAxios()` utility once, reuse everywhere.
 
 ---
 
-## Phase 6: Standard Query/Mutation Hooks (~100 tests)
+## Phase 6: Standard Query/Mutation Hooks (~140 tests)
 
-60+ hooks follow the same React Query pattern. After Phase 4 establishes the testing pattern, these can be templated.
+79 untested hooks (~170 exported functions). 58 are React Query hooks, 21 are custom state/effect hooks. After Phase 4 establishes the testing pattern, these can be templated.
 
 **Pattern:**
 ```text
 hook calls useQuery/useMutation -> mock the resource function -> verify data shape + error handling
 ```
 
-**Group by feature area:**
-- Tags: `UseTags.ts` (7 hooks) — ~20 tests
-- Organizations: `UseOrganizationActions.ts`, `UseOrganizationSettings.ts` — ~15 tests
-- Builds: `UseBuildLogs.ts`, `UseBuilds.ts`, `UseBuildTriggers.ts` — ~15 tests
-- Permissions: `UseRepositoryPermissions.ts`, `UseSuperuserPermissions.ts` — ~10 tests
-- Remaining ~40 hooks: ~40 tests (1 per hook minimum)
+**High priority (complex logic beyond standard React Query):**
 
-**Effort:** ~3-4 days. Highly parallelizable once pattern is established.
+| File | Functions | Est. Tests | Notes |
+|------|-----------|-----------|-------|
+| `UseTags.ts` | 8 | ~20 | 404 vs error handling in `useTagPullStatistics`, multiple query/mutation hooks |
+| `UseRepositoryPermissions.ts` | 6 | ~12 | Transitive permission chains, conditional fallback logic |
+| `UseOrganizationActions.ts` | 3 | ~8 | Mutation chains with callbacks |
+| `UseBuildLogs.ts` | 2 | ~6 | Streaming/incremental fetch pattern |
+| `UseConvertAccount.ts` | — | ~5 | Multi-step state machine |
+| `UsePasswordRecovery.ts` | — | ~5 | Multi-step validation chain |
+
+**Medium priority (standard React Query, group by feature area):**
+- Builds: `UseBuilds.ts`, `UseBuildTriggers.ts` — ~10 tests
+- Permissions: `UseSuperuserPermissions.ts` — ~6 tests
+- Organizations: `UseOrganizationSettings.ts` — ~6 tests
+- Members/Teams: `UseMembers.ts`, `UseTeams.ts` — ~8 tests
+- Notifications: `UseNotifications.ts`, `UseAppNotifications.ts` — ~6 tests
+- Robot accounts: `useRobotAccounts.ts`, `useRobotFederation.ts` — ~6 tests
+- Auth/Login: `UseExternalLoginAuth.ts`, `UseExternalLoginManagement.ts`, `UseExternalLogins.ts` — ~8 tests
+- Config/State: `UseQuayConfig.ts`, `UseQuayState.ts` — ~4 tests
+- Remaining: `UseApplicationTokens`, `UseAuthorizedApplications`, `UseLabels`, `UseEntities`, `UseSecurityDetails`, `UseProxyCache`, `UseMirroringConfig`, `UseAxios`, etc. — ~30 tests (1-2 per hook)
+
+**Effort:** ~4-5 days. Highly parallelizable once pattern is established. Template one hook per complexity tier (simple=1 test, moderate=2, complex=3-5) then batch.
 
 ---
 
-## Phase 7: Components with Logic (~80 tests)
+## Phase 7: Components with Logic (~140 tests)
 
-Focus on components with branching/validation logic. Skip pure layout components.
+101 component files total. Focus on components with branching/validation logic (70+ testable). Skip pure layout/presentation components (~30).
 
 **Seed test completed:**
 
@@ -115,7 +144,20 @@ Focus on components with branching/validation logic. Skip pure layout components
 |-----------|-------|--------|
 | `src/components/LoadingPage.tsx` | 6 | **Done** — Default render, custom title/message, JSX title, primary/secondary actions. Validates PatternFly + happy-dom + RTL chain. |
 
-**High priority:**
+**Critical priority (>250 lines, 5+ hooks, security/core features):**
+
+| Component | Lines | Est. Tests | What to Test |
+|-----------|-------|-----------|-------------|
+| `src/components/modals/RobotTokensModal.tsx` | 505 | ~8 | Token display/generation/revocation, copy-to-clipboard, lifecycle |
+| `src/components/modals/robotAccountWizard/*` (5 files) | 238-370 | ~20 | Multi-step wizard: permission selection, team view, review+submit |
+| `src/components/header/HeaderToolbar.tsx` | 369 | ~8 | Navigation state, user menu, search interactions |
+| `src/components/modals/ChangeAccountTypeModal.tsx` | 368 | ~6 | Account conversion with validation |
+| `src/components/modals/CreateRepoModalTemplate.tsx` | 351 | ~8 | Repository creation form validation and submission |
+| `src/components/modals/CredentialsModal.tsx` | 320 | ~6 | Token display + copy functionality |
+| `src/components/modals/CreateRobotAccountModal.tsx` | 290 | ~6 | Robot account creation with permissions |
+| `src/components/modals/ChangePasswordModal.tsx` | 210 | ~5 | Password validation + change form |
+
+**High priority (significant logic):**
 
 | Component | Est. Tests | What to Test |
 |-----------|-----------|-------------|
@@ -123,16 +165,18 @@ Focus on components with branching/validation logic. Skip pure layout components
 | `src/components/ImmutabilityPolicyForm.tsx` | ~10 | Pattern validation regex, edit/view toggle, error states |
 | `src/components/EntitySearch.tsx` | ~15 | Search input, dropdown filtering, entity selection, team/robot distinction |
 | `src/components/ActivityHeatmap.tsx` | ~10 | Calendar generation (90-day window), week alignment, color scaling |
+| `src/components/TypeAheadSelect.tsx` | ~6 | Search dropdown filtering + selection |
+| `src/components/LabelsEditable.tsx` | ~8 | Label CRUD with inline edit mode |
 | `src/components/errors/ErrorBoundary.tsx` | ~5 | Error capture + fallback render |
 
 **Medium priority:**
 - `FormTextInput.tsx`, `FormCheckbox.tsx`, `FormDateTimePicker.tsx` — ~10 tests each
-- Error display components (`RequestError`, `PageLoadError`, etc.) — ~15 tests total
+- Error display components (`RequestError`, `PageLoadError`, `SiteUnavailableError`, `ErrorModal`, `FormError`, `404`) — ~15 tests total
 
 **Skip (pure presentation, covered by Playwright):**
-- Breadcrumb, Footer, Header, Labels, Sidebar, Table cells, Modals
+- Breadcrumb, Footer (base), Labels (read-only), Sidebar, Table cells (ImageSize, ManifestListSize, RepoCount, Menu), layout-only modals without form logic
 
-**Effort:** ~3-4 days.
+**Effort:** ~5-6 days. Template one modal and one form component first, then batch.
 
 ---
 
@@ -158,13 +202,13 @@ Leave these to Playwright E2E:
 | 2 | Error handling + cookies | 31 | 1 day | **Complete** |
 | 3 | Contexts | 38 | 1 day | **Complete** |
 | 4 | Complex hooks | 59 | 2-3 days | **Complete** |
-| 5 | API resources | ~80 | 3-4 days | Pending |
-| 6 | Standard hooks | ~100 | 3-4 days | Pending |
-| 7 | Components | 6/~80 | 3-4 days | **In progress** — LoadingPage (6) done |
+| 5 | API resources (29 files) | ~110 | 4-5 days | Pending |
+| 6 | Standard hooks (79 files) | ~140 | 4-5 days | Pending |
+| 7 | Components (100 files) | ~140 | 5-6 days | **In progress** — LoadingPage (6) done |
 
-**Current: 239 tests passing across 14 files | Target: ~460 tests**
+**Current: 239 tests passing across 14 files | Target: ~620 tests**
 
-Phases 1-4 are complete and deliver the most value per test written. Phases 5-7 are incremental and can be spread over sprints.
+Phases 1-4 are complete and deliver the most value per test written. Phases 5-7 are incremental and can be spread over sprints. Remaining effort: ~13-16 days.
 
 ---
 
@@ -182,7 +226,11 @@ Phases 1-4 are complete and deliver the most value per test written. Phases 5-7 
 
 Coverage is collected via V8 (`@vitest/coverage-v8`). No enforcement thresholds initially.
 
+**Baseline after Phase 4 (239 tests):** `src/libs/` 84%, `src/contexts/` 100%, `src/hooks/` 4%, `src/resources/` 6%, `src/components/` <1%, overall ~4%.
+
 **Ratchet-up plan:**
-1. After Phase 3 (~175 tests): measure baseline, set thresholds 5% below current
-2. Increase thresholds by 5% each quarter
-3. Target: 80% on `src/libs/`, 60% on `src/hooks/`, 40% overall
+1. After Phase 4 (done): baseline measured. `src/libs/` and `src/contexts/` already meet targets.
+2. After Phase 5: `src/resources/` should reach ~55-60%
+3. After Phase 6: `src/hooks/` should reach ~45-50%
+4. After Phase 7: `src/components/` should reach ~40-45%, overall ~50-55%
+5. Target: 80% on `src/libs/`, 60% on `src/hooks/`, 40% overall

--- a/web/src/hooks/UseQuotaManagement.test.tsx
+++ b/web/src/hooks/UseQuotaManagement.test.tsx
@@ -44,7 +44,7 @@ const mockQuota = {
 
 /** QueryClientProvider wrapper for hooks that use React Query. */
 function wrapper({children}: {children: React.ReactNode}) {
-  const queryClient = createTestQueryClient();
+  const [queryClient] = React.useState(() => createTestQueryClient());
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );

--- a/web/src/hooks/UseQuotaManagement.test.tsx
+++ b/web/src/hooks/UseQuotaManagement.test.tsx
@@ -1,0 +1,375 @@
+import {renderHook, act, waitFor} from '@testing-library/react';
+import React from 'react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {createTestQueryClient} from 'src/test-utils';
+import {
+  useFetchOrganizationQuota,
+  useCreateOrganizationQuota,
+  useUpdateOrganizationQuota,
+  useDeleteOrganizationQuota,
+  useCreateQuotaLimit,
+  useUpdateQuotaLimit,
+  useDeleteQuotaLimit,
+} from './UseQuotaManagement';
+import {
+  fetchOrganizationQuota,
+  createOrganizationQuota,
+  updateOrganizationQuota,
+  deleteOrganizationQuota,
+  createQuotaLimit,
+  updateQuotaLimit,
+  deleteQuotaLimit,
+} from 'src/resources/QuotaResource';
+import {addDisplayError} from 'src/resources/ErrorHandling';
+
+vi.mock('src/resources/QuotaResource', () => ({
+  fetchOrganizationQuota: vi.fn(),
+  createOrganizationQuota: vi.fn(),
+  updateOrganizationQuota: vi.fn(),
+  deleteOrganizationQuota: vi.fn(),
+  createQuotaLimit: vi.fn(),
+  updateQuotaLimit: vi.fn(),
+  deleteQuotaLimit: vi.fn(),
+}));
+
+vi.mock('src/resources/ErrorHandling', () => ({
+  addDisplayError: vi.fn((msg: string, err: Error) => `${msg}: ${err.message}`),
+}));
+
+const mockQuota = {
+  id: 'quota-1',
+  limit_bytes: 1073741824,
+  limits: [{id: 'limit-1', type: 'Warning' as const, limit_percent: 80}],
+};
+
+/** QueryClientProvider wrapper for hooks that use React Query. */
+function wrapper({children}: {children: React.ReactNode}) {
+  const queryClient = createTestQueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('UseQuotaManagement', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('useFetchOrganizationQuota', () => {
+    it('returns null when no quota data exists', async () => {
+      vi.mocked(fetchOrganizationQuota).mockResolvedValueOnce([]);
+      const {result} = renderHook(() => useFetchOrganizationQuota('testOrg'), {
+        wrapper,
+      });
+      await waitFor(() => {
+        expect(result.current.isSuccessLoadingQuotas).toBe(true);
+      });
+      expect(result.current.organizationQuota).toBeNull();
+    });
+
+    it('returns first quota from array', async () => {
+      vi.mocked(fetchOrganizationQuota).mockResolvedValueOnce([mockQuota]);
+      const {result} = renderHook(() => useFetchOrganizationQuota('testOrg'), {
+        wrapper,
+      });
+      await waitFor(() => {
+        expect(result.current.organizationQuota).toEqual(mockQuota);
+      });
+    });
+
+    it('does not fetch when orgName is empty and no viewMode', () => {
+      renderHook(() => useFetchOrganizationQuota(''), {wrapper});
+      expect(fetchOrganizationQuota).not.toHaveBeenCalled();
+    });
+
+    it('is enabled when viewMode is "self" even with empty orgName', async () => {
+      vi.mocked(fetchOrganizationQuota).mockResolvedValueOnce([mockQuota]);
+      const {result} = renderHook(() => useFetchOrganizationQuota('', 'self'), {
+        wrapper,
+      });
+      await waitFor(() => {
+        expect(fetchOrganizationQuota).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(result.current.organizationQuota).toEqual(mockQuota);
+      });
+    });
+  });
+
+  describe('useCreateOrganizationQuota', () => {
+    it('calls resource function and fires onSuccess', async () => {
+      vi.mocked(createOrganizationQuota).mockResolvedValueOnce(undefined);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useCreateOrganizationQuota('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.createQuotaMutation({limit_bytes: 1024});
+      });
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalled();
+      });
+      expect(createOrganizationQuota).toHaveBeenCalledWith(
+        'testOrg',
+        {limit_bytes: 1024},
+        undefined,
+      );
+    });
+
+    it('fires onError with addDisplayError on failure', async () => {
+      const error = new Error('Network error');
+      vi.mocked(createOrganizationQuota).mockRejectedValueOnce(error);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useCreateOrganizationQuota('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.createQuotaMutation({limit_bytes: 1024});
+      });
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
+      expect(addDisplayError).toHaveBeenCalledWith(
+        'quota creation error',
+        error,
+      );
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useUpdateOrganizationQuota', () => {
+    it('calls resource function and fires onSuccess', async () => {
+      vi.mocked(updateOrganizationQuota).mockResolvedValueOnce(undefined);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useUpdateOrganizationQuota('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.updateQuotaMutation({
+          quotaId: 'q1',
+          params: {limit_bytes: 2048},
+        });
+      });
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalled();
+      });
+      expect(updateOrganizationQuota).toHaveBeenCalledWith(
+        'testOrg',
+        'q1',
+        {limit_bytes: 2048},
+        undefined,
+      );
+    });
+
+    it('fires onError with addDisplayError on failure', async () => {
+      const error = new Error('Update failed');
+      vi.mocked(updateOrganizationQuota).mockRejectedValueOnce(error);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useUpdateOrganizationQuota('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.updateQuotaMutation({
+          quotaId: 'q1',
+          params: {limit_bytes: 2048},
+        });
+      });
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
+      expect(addDisplayError).toHaveBeenCalledWith('quota update error', error);
+    });
+  });
+
+  describe('useDeleteOrganizationQuota', () => {
+    it('calls resource function and fires onSuccess', async () => {
+      vi.mocked(deleteOrganizationQuota).mockResolvedValueOnce(undefined);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useDeleteOrganizationQuota('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.deleteQuotaMutation('q1');
+      });
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalled();
+      });
+      expect(deleteOrganizationQuota).toHaveBeenCalledWith(
+        'testOrg',
+        'q1',
+        undefined,
+      );
+    });
+
+    it('fires onError with addDisplayError on failure', async () => {
+      const error = new Error('Delete failed');
+      vi.mocked(deleteOrganizationQuota).mockRejectedValueOnce(error);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useDeleteOrganizationQuota('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.deleteQuotaMutation('q1');
+      });
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
+      expect(addDisplayError).toHaveBeenCalledWith(
+        'quota deletion error',
+        error,
+      );
+    });
+  });
+
+  describe('useCreateQuotaLimit', () => {
+    it('calls resource function and fires onSuccess', async () => {
+      vi.mocked(createQuotaLimit).mockResolvedValueOnce(undefined);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useCreateQuotaLimit('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.createLimitMutation({
+          quotaId: 'q1',
+          params: {type: 'Warning', threshold_percent: 80},
+        });
+      });
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalled();
+      });
+      expect(createQuotaLimit).toHaveBeenCalledWith('testOrg', 'q1', {
+        type: 'Warning',
+        threshold_percent: 80,
+      });
+    });
+
+    it('fires onError with addDisplayError on failure', async () => {
+      const error = new Error('Limit creation failed');
+      vi.mocked(createQuotaLimit).mockRejectedValueOnce(error);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useCreateQuotaLimit('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.createLimitMutation({
+          quotaId: 'q1',
+          params: {type: 'Warning', threshold_percent: 80},
+        });
+      });
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
+      expect(addDisplayError).toHaveBeenCalledWith(
+        'quota limit creation error',
+        error,
+      );
+    });
+  });
+
+  describe('useUpdateQuotaLimit', () => {
+    it('calls resource function and fires onSuccess', async () => {
+      vi.mocked(updateQuotaLimit).mockResolvedValueOnce(undefined);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useUpdateQuotaLimit('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.updateLimitMutation({
+          quotaId: 'q1',
+          limitId: 'l1',
+          params: {type: 'Reject', threshold_percent: 90},
+        });
+      });
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalled();
+      });
+      expect(updateQuotaLimit).toHaveBeenCalledWith('testOrg', 'q1', 'l1', {
+        type: 'Reject',
+        threshold_percent: 90,
+      });
+    });
+
+    it('fires onError with addDisplayError on failure', async () => {
+      const error = new Error('Limit update failed');
+      vi.mocked(updateQuotaLimit).mockRejectedValueOnce(error);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useUpdateQuotaLimit('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.updateLimitMutation({
+          quotaId: 'q1',
+          limitId: 'l1',
+          params: {type: 'Reject', threshold_percent: 90},
+        });
+      });
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
+      expect(addDisplayError).toHaveBeenCalledWith(
+        'quota limit update error',
+        error,
+      );
+    });
+  });
+
+  describe('useDeleteQuotaLimit', () => {
+    it('calls resource function and fires onSuccess', async () => {
+      vi.mocked(deleteQuotaLimit).mockResolvedValueOnce(undefined);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useDeleteQuotaLimit('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.deleteLimitMutation({quotaId: 'q1', limitId: 'l1'});
+      });
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalled();
+      });
+      expect(deleteQuotaLimit).toHaveBeenCalledWith('testOrg', 'q1', 'l1');
+    });
+
+    it('fires onError with addDisplayError on failure', async () => {
+      const error = new Error('Limit delete failed');
+      vi.mocked(deleteQuotaLimit).mockRejectedValueOnce(error);
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const {result} = renderHook(
+        () => useDeleteQuotaLimit('testOrg', {onSuccess, onError}),
+        {wrapper},
+      );
+      act(() => {
+        result.current.deleteLimitMutation({quotaId: 'q1', limitId: 'l1'});
+      });
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+      });
+      expect(addDisplayError).toHaveBeenCalledWith(
+        'quota limit deletion error',
+        error,
+      );
+    });
+  });
+});

--- a/web/src/hooks/UseUsernameValidation.test.tsx
+++ b/web/src/hooks/UseUsernameValidation.test.tsx
@@ -1,0 +1,217 @@
+import {renderHook, act, waitFor} from '@testing-library/react';
+import React from 'react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {createTestQueryClient} from 'src/test-utils';
+import {useUsernameValidation} from './UseUsernameValidation';
+import axios from 'src/libs/axios';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+/** QueryClientProvider wrapper for hooks that use React Query mutations. */
+function wrapper({children}: {children: React.ReactNode}) {
+  const queryClient = createTestQueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useUsernameValidation', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('initial state', () => {
+    it('initializes with state "editing" and isValidating false', () => {
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      expect(result.current.state).toBe('editing');
+      expect(result.current.isValidating).toBe(false);
+    });
+  });
+
+  describe('empty username', () => {
+    it('remains in "editing" when empty string is validated', () => {
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('');
+      });
+      expect(result.current.state).toBe('editing');
+    });
+  });
+
+  describe('current username match', () => {
+    it('transitions to "confirmed" without API calls when username matches currentUsername', async () => {
+      const {result} = renderHook(() => useUsernameValidation('existingUser'), {
+        wrapper,
+      });
+      act(() => {
+        result.current.validateUsername('existingUser');
+      });
+      await waitFor(() => {
+        expect(result.current.state).toBe('confirmed');
+      });
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('user exists', () => {
+    it('transitions to "existing" when user API returns 200', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce({data: {username: 'taken'}});
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('taken');
+      });
+      await waitFor(() => {
+        expect(result.current.state).toBe('existing');
+      });
+    });
+
+    it('calls the user API endpoint with correct username', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce({data: {}});
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('testUser');
+      });
+      await waitFor(() => {
+        expect(axios.get).toHaveBeenCalledWith('/api/v1/users/testUser');
+      });
+    });
+  });
+
+  describe('user not found, org exists', () => {
+    it('transitions to "existing" when user 404s but org returns 200', async () => {
+      vi.mocked(axios.get)
+        .mockRejectedValueOnce(new Error('Not found'))
+        .mockResolvedValueOnce({data: {}});
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('orgName');
+      });
+      await waitFor(() => {
+        expect(result.current.state).toBe('existing');
+      });
+    });
+
+    it('calls both user and org API endpoints', async () => {
+      vi.mocked(axios.get)
+        .mockRejectedValueOnce(new Error('Not found'))
+        .mockResolvedValueOnce({data: {}});
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('testOrg');
+      });
+      await waitFor(() => {
+        expect(axios.get).toHaveBeenCalledTimes(2);
+      });
+      expect(axios.get).toHaveBeenNthCalledWith(1, '/api/v1/users/testOrg');
+      expect(axios.get).toHaveBeenNthCalledWith(
+        2,
+        '/api/v1/organization/testOrg',
+      );
+    });
+  });
+
+  describe('neither user nor org exists', () => {
+    it('transitions to "confirmed" when both APIs 404', async () => {
+      vi.mocked(axios.get)
+        .mockRejectedValueOnce(new Error('Not found'))
+        .mockRejectedValueOnce(new Error('Not found'));
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('newUser');
+      });
+      await waitFor(() => {
+        expect(result.current.state).toBe('confirmed');
+      });
+    });
+  });
+
+  describe('confirming state', () => {
+    it('transitions through "confirming" during validation', async () => {
+      let resolveGet: (value: unknown) => void;
+      vi.mocked(axios.get).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveGet = resolve;
+          }),
+      );
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('someUser');
+      });
+      await waitFor(() => {
+        expect(result.current.state).toBe('confirming');
+      });
+      await act(async () => {
+        resolveGet!({data: {}});
+      });
+      await waitFor(() => {
+        expect(result.current.state).toBe('existing');
+      });
+    });
+  });
+
+  describe('isValidating', () => {
+    it('is true while mutation is in progress', async () => {
+      let resolveGet: (value: unknown) => void;
+      vi.mocked(axios.get).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveGet = resolve;
+          }),
+      );
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('someUser');
+      });
+      await waitFor(() => {
+        expect(result.current.isValidating).toBe(true);
+      });
+      await act(async () => {
+        resolveGet!({data: {}});
+      });
+      await waitFor(() => {
+        expect(result.current.isValidating).toBe(false);
+      });
+    });
+  });
+
+  describe('no currentUsername provided', () => {
+    it('makes API calls when currentUsername is undefined', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce({data: {}});
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('anyUser');
+      });
+      await waitFor(() => {
+        expect(result.current.state).toBe('existing');
+      });
+      expect(axios.get).toHaveBeenCalled();
+    });
+  });
+
+  describe('sequential validations', () => {
+    it('handles multiple validations in sequence', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce({data: {}})
+        .mockRejectedValueOnce(new Error('Not found'))
+        .mockRejectedValueOnce(new Error('Not found'));
+      const {result} = renderHook(() => useUsernameValidation(), {wrapper});
+      act(() => {
+        result.current.validateUsername('existingUser');
+      });
+      await waitFor(() => {
+        expect(result.current.state).toBe('existing');
+      });
+      act(() => {
+        result.current.validateUsername('newUser');
+      });
+      await waitFor(() => {
+        expect(result.current.state).toBe('confirmed');
+      });
+    });
+  });
+});

--- a/web/src/hooks/UseUsernameValidation.test.tsx
+++ b/web/src/hooks/UseUsernameValidation.test.tsx
@@ -13,7 +13,7 @@ vi.mock('src/libs/axios', () => ({
 
 /** QueryClientProvider wrapper for hooks that use React Query mutations. */
 function wrapper({children}: {children: React.ReactNode}) {
-  const queryClient = createTestQueryClient();
+  const [queryClient] = React.useState(() => createTestQueryClient());
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );

--- a/web/src/hooks/usePaginatedSortableTable.test.ts
+++ b/web/src/hooks/usePaginatedSortableTable.test.ts
@@ -1,0 +1,458 @@
+import {renderHook, act} from '@testing-library/react';
+import {usePaginatedSortableTable} from './usePaginatedSortableTable';
+
+interface TestItem {
+  name: string;
+  count: number;
+  hexId: string;
+}
+
+const sampleItems: TestItem[] = [
+  {name: 'banana', count: 5, hexId: 'bb22aa11'},
+  {name: 'apple', count: 10, hexId: 'ff00cc33'},
+  {name: 'cherry', count: 1, hexId: '00aabb11'},
+  {name: 'date', count: 20, hexId: 'aa11bb22'},
+];
+
+const columns: Record<number, (item: TestItem) => string | number> = {
+  0: (item) => item.name,
+  1: (item) => item.count,
+  2: (item) => item.hexId,
+};
+
+/**
+ * Triggers a sort via the getSortableSort onSort handler, simulating
+ * a PatternFly table header click.
+ */
+function triggerSort(
+  result: {current: ReturnType<typeof usePaginatedSortableTable>},
+  columnIndex: number,
+  direction: 'asc' | 'desc',
+) {
+  const sortProps = result.current.getSortableSort(columnIndex);
+  sortProps.onSort(null as unknown as React.MouseEvent, columnIndex, direction);
+}
+
+describe('usePaginatedSortableTable', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('default state', () => {
+    it('initializes with page 1 and perPage 20', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      expect(result.current.page).toBe(1);
+      expect(result.current.perPage).toBe(20);
+    });
+
+    it('has no active sort when no initialSort provided', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      const sortProps = result.current.getSortableSort(0);
+      expect(sortProps.sortBy.index).toBeNull();
+      expect(sortProps.sortBy.direction).toBeNull();
+    });
+
+    it('returns all data when it fits in one page', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      expect(result.current.paginatedData).toHaveLength(4);
+      expect(result.current.totalCount).toBe(4);
+    });
+
+    it('returns empty arrays for empty data', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable([], {columns}),
+      );
+      expect(result.current.paginatedData).toEqual([]);
+      expect(result.current.filteredData).toEqual([]);
+      expect(result.current.sortedData).toEqual([]);
+      expect(result.current.totalCount).toBe(0);
+    });
+  });
+
+  describe('initial configuration', () => {
+    it('respects initialSort config', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {
+          columns,
+          initialSort: {columnIndex: 0, direction: 'asc'},
+        }),
+      );
+      // Sorted by name ascending: apple, banana, cherry, date
+      expect(result.current.paginatedData[0].name).toBe('apple');
+      expect(result.current.paginatedData[3].name).toBe('date');
+    });
+
+    it('respects custom initialPerPage', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {
+          columns,
+          initialPerPage: 2,
+        }),
+      );
+      expect(result.current.perPage).toBe(2);
+      expect(result.current.paginatedData).toHaveLength(2);
+    });
+  });
+
+  describe('string sorting', () => {
+    it('sorts strings ascending via localeCompare', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'asc');
+      });
+      const names = result.current.paginatedData.map((i) => i.name);
+      expect(names).toEqual(['apple', 'banana', 'cherry', 'date']);
+    });
+
+    it('sorts strings descending', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'desc');
+      });
+      const names = result.current.paginatedData.map((i) => i.name);
+      expect(names).toEqual(['date', 'cherry', 'banana', 'apple']);
+    });
+
+    it('sorts numeric strings correctly with numeric option', () => {
+      const items = [
+        {name: 'item10', count: 0, hexId: 'aa'},
+        {name: 'item2', count: 0, hexId: 'bb'},
+        {name: 'item1', count: 0, hexId: 'cc'},
+      ];
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(items, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'asc');
+      });
+      const names = result.current.paginatedData.map((i) => i.name);
+      expect(names).toEqual(['item1', 'item2', 'item10']);
+    });
+
+    it('sorts case-insensitively', () => {
+      const items = [
+        {name: 'Banana', count: 0, hexId: 'aa'},
+        {name: 'apple', count: 0, hexId: 'bb'},
+        {name: 'Cherry', count: 0, hexId: 'cc'},
+      ];
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(items, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'asc');
+      });
+      const names = result.current.paginatedData.map((i) => i.name);
+      expect(names).toEqual(['apple', 'Banana', 'Cherry']);
+    });
+  });
+
+  describe('hex string sorting', () => {
+    it('detects hex strings and sorts by parsed first 8 chars', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 2, 'asc');
+      });
+      const ids = result.current.paginatedData.map((i) => i.hexId);
+      // 00aabb11 < aa11bb22 < bb22aa11 < ff00cc33
+      expect(ids).toEqual(['00aabb11', 'aa11bb22', 'bb22aa11', 'ff00cc33']);
+    });
+
+    it('sorts hex strings descending', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 2, 'desc');
+      });
+      const ids = result.current.paginatedData.map((i) => i.hexId);
+      expect(ids).toEqual(['ff00cc33', 'bb22aa11', 'aa11bb22', '00aabb11']);
+    });
+
+    it('sorts mixed-case hex strings', () => {
+      const items = [
+        {name: 'a', count: 0, hexId: 'FF00AA00'},
+        {name: 'b', count: 0, hexId: 'aa00ff00'},
+        {name: 'c', count: 0, hexId: '00ff00aa'},
+      ];
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(items, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 2, 'asc');
+      });
+      const ids = result.current.paginatedData.map((i) => i.hexId);
+      expect(ids).toEqual(['00ff00aa', 'aa00ff00', 'FF00AA00']);
+    });
+  });
+
+  describe('UUID sorting', () => {
+    it('detects UUIDs and sorts by first 8 hex chars with hyphens stripped', () => {
+      const items = [
+        {
+          name: 'c',
+          count: 0,
+          hexId: 'ff000000-1111-2222-3333-444444444444',
+        },
+        {
+          name: 'a',
+          count: 0,
+          hexId: '00aabb00-1111-2222-3333-444444444444',
+        },
+        {
+          name: 'b',
+          count: 0,
+          hexId: 'aa110000-1111-2222-3333-444444444444',
+        },
+      ];
+      const uuidColumns: Record<number, (item: TestItem) => string | number> = {
+        0: (item) => item.hexId,
+      };
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(items, {columns: uuidColumns}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'asc');
+      });
+      const ids = result.current.paginatedData.map((i) => i.hexId);
+      expect(ids).toEqual([
+        '00aabb00-1111-2222-3333-444444444444',
+        'aa110000-1111-2222-3333-444444444444',
+        'ff000000-1111-2222-3333-444444444444',
+      ]);
+    });
+  });
+
+  describe('number sorting', () => {
+    it('sorts numbers ascending', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 1, 'asc');
+      });
+      const counts = result.current.paginatedData.map((i) => i.count);
+      expect(counts).toEqual([1, 5, 10, 20]);
+    });
+
+    it('sorts numbers descending', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 1, 'desc');
+      });
+      const counts = result.current.paginatedData.map((i) => i.count);
+      expect(counts).toEqual([20, 10, 5, 1]);
+    });
+  });
+
+  describe('sort interactions', () => {
+    it('resets page to 1 when sort changes', () => {
+      const manyItems = Array.from({length: 25}, (_, i) => ({
+        name: `item${i}`,
+        count: i,
+        hexId: `0000000${i}`,
+      }));
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(manyItems, {columns, initialPerPage: 10}),
+      );
+      act(() => {
+        result.current.setPage(2);
+      });
+      expect(result.current.page).toBe(2);
+      act(() => {
+        triggerSort(result, 0, 'asc');
+      });
+      expect(result.current.page).toBe(1);
+    });
+
+    it('updates activeSortIndex and direction after onSort', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      act(() => {
+        triggerSort(result, 1, 'desc');
+      });
+      const sortProps = result.current.getSortableSort(1);
+      expect(sortProps.sortBy.index).toBe(1);
+      expect(sortProps.sortBy.direction).toBe('desc');
+    });
+
+    it('handles missing column extractor gracefully', () => {
+      const sparseColumns: Record<number, (item: TestItem) => string | number> =
+        {
+          0: (item) => item.name,
+        };
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns: sparseColumns}),
+      );
+      // Sort on column 5 which has no extractor
+      act(() => {
+        triggerSort(result, 5, 'asc');
+      });
+      // Should not crash, data returned in original order
+      expect(result.current.paginatedData).toHaveLength(4);
+    });
+  });
+
+  describe('getSortableSort', () => {
+    it('returns object with sortBy, onSort, and columnIndex', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      const sortProps = result.current.getSortableSort(2);
+      expect(sortProps).toHaveProperty('sortBy');
+      expect(sortProps).toHaveProperty('onSort');
+      expect(sortProps).toHaveProperty('columnIndex');
+      expect(sortProps.columnIndex).toBe(2);
+    });
+
+    it('sortBy reflects current sort state', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {
+          columns,
+          initialSort: {columnIndex: 0, direction: 'asc'},
+        }),
+      );
+      const sortProps = result.current.getSortableSort(0);
+      expect(sortProps.sortBy.index).toBe(0);
+      expect(sortProps.sortBy.direction).toBe('asc');
+    });
+  });
+
+  describe('filtering', () => {
+    it('applies filter function to reduce data', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {
+          columns,
+          filter: (item) => item.count > 5,
+        }),
+      );
+      expect(result.current.filteredData).toHaveLength(2);
+      expect(result.current.paginatedData).toHaveLength(2);
+    });
+
+    it('updates totalCount based on filtered data', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {
+          columns,
+          filter: (item) => item.name.startsWith('a'),
+        }),
+      );
+      expect(result.current.totalCount).toBe(1);
+    });
+
+    it('returns all data when no filter provided', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      expect(result.current.filteredData).toHaveLength(4);
+    });
+  });
+
+  describe('filter + sort + paginate pipeline', () => {
+    it('filters first, then sorts, then paginates', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {
+          columns,
+          filter: (item) => item.count >= 5,
+          initialSort: {columnIndex: 1, direction: 'desc'},
+          initialPerPage: 2,
+        }),
+      );
+      // Filter: banana(5), apple(10), date(20) — count >= 5
+      // Sort desc by count: date(20), apple(10), banana(5)
+      // Page 1, perPage 2: [date, apple]
+      expect(result.current.filteredData).toHaveLength(3);
+      expect(result.current.paginatedData).toHaveLength(2);
+      expect(result.current.paginatedData[0].name).toBe('date');
+      expect(result.current.paginatedData[1].name).toBe('apple');
+    });
+  });
+
+  describe('pagination', () => {
+    const manyItems = Array.from({length: 25}, (_, i) => ({
+      name: `item${String(i).padStart(2, '0')}`,
+      count: i,
+      hexId: 'aabbccdd',
+    }));
+
+    it('returns correct slice for page 1', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(manyItems, {columns, initialPerPage: 10}),
+      );
+      expect(result.current.paginatedData).toHaveLength(10);
+      expect(result.current.paginatedData[0].name).toBe('item00');
+    });
+
+    it('returns correct slice for page 2', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(manyItems, {columns, initialPerPage: 10}),
+      );
+      act(() => {
+        result.current.setPage(2);
+      });
+      expect(result.current.paginatedData).toHaveLength(10);
+      expect(result.current.paginatedData[0].name).toBe('item10');
+    });
+
+    it('handles partial last page', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(manyItems, {columns, initialPerPage: 10}),
+      );
+      act(() => {
+        result.current.setPage(3);
+      });
+      expect(result.current.paginatedData).toHaveLength(5);
+      expect(result.current.paginatedData[0].name).toBe('item20');
+    });
+
+    it('setPage updates current page', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      act(() => {
+        result.current.setPage(2);
+      });
+      expect(result.current.page).toBe(2);
+    });
+
+    it('setPerPage updates items per page', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(manyItems, {columns, initialPerPage: 10}),
+      );
+      act(() => {
+        result.current.setPerPage(5);
+      });
+      expect(result.current.perPage).toBe(5);
+      expect(result.current.paginatedData).toHaveLength(5);
+    });
+  });
+
+  describe('paginationProps', () => {
+    it('returns correct shape', () => {
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(sampleItems, {columns}),
+      );
+      const props = result.current.paginationProps;
+      expect(props.total).toBe(4);
+      expect(props.itemsList).toHaveLength(4);
+      expect(props.perPage).toBe(20);
+      expect(props.page).toBe(1);
+      expect(typeof props.setPage).toBe('function');
+      expect(typeof props.setPerPage).toBe('function');
+    });
+  });
+});

--- a/web/src/hooks/usePaginatedSortableTable.test.ts
+++ b/web/src/hooks/usePaginatedSortableTable.test.ts
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {renderHook, act} from '@testing-library/react';
 import {usePaginatedSortableTable} from './usePaginatedSortableTable';
 


### PR DESCRIPTION
## Summary
- Add 59 unit tests across 3 test files for Phase 4 (Complex Hooks) of the web unit test roadmap
- `usePaginatedSortableTable` (31 tests): pagination, sorting (string/hex/UUID/number), filtering, pipeline interactions — pure state, no mocking
- `UseUsernameValidation` (12 tests): state machine transitions (editing/confirming/confirmed/existing), dual async API check with axios mock
- `UseQuotaManagement` (16 tests): fetch quota query (enabled logic, null handling), all 6 mutation hooks (success/error callbacks)
- Update `agent_docs/web-unit-test-roadmap.md` to mark Phase 4 complete (239 tests across 14 files)

## Test plan
- [x] All 239 tests pass (`npx vitest run`) — 180 existing + 59 new
- [x] ESLint passes on all new test files
- [x] Pre-commit hooks pass (formatting, secrets detection)
- [x] No modifications to source hooks, `test-utils.tsx`, or `vitest.setup.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)