### PR TITLE
NO-ISSUE: fix(deps): bump setuptools to 82.0.1 for pyroscope-io build

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -262,21 +262,21 @@ hatchling==1.29.0 \
     #   scikit-build-core
     #   soupsieve
     #   urllib3
-maturin==1.12.6 \
-    --hash=sha256:06fc8d089f98623ce924c669b70911dfed30f9a29956c362945f727f9abc546b \
-    --hash=sha256:2cb41139295eed6411d3cdafc7430738094c2721f34b7eeb44f33cac516115dc \
-    --hash=sha256:351f3af1488a7cbdcff3b6d8482c17164273ac981378a13a4a9937a49aec7d71 \
-    --hash=sha256:3f32e0a3720b81423c9d35c14e728cb1f954678124749776dc72d533ea1115e8 \
-    --hash=sha256:6892b4176992fcc143f9d1c1c874a816e9a041248eef46433db87b0f0aff4278 \
-    --hash=sha256:6dbddfe4dc7ddee60bbac854870bd7cfec660acb54d015d24597d59a1c828f61 \
-    --hash=sha256:75133e56274d43b9227fd49dca9a86e32f1fd56a7b55544910c4ce978c2bb5aa \
-    --hash=sha256:8fdb0f63e77ee3df0f027a120e9af78dbc31edf0eb0f263d55783c250c33b728 \
-    --hash=sha256:977290159d252db946054a0555263c59b3d0c7957135c69e690f4b1558ee9983 \
-    --hash=sha256:bae91976cdc8148038e13c881e1e844e5c63e58e026e8b9945aa2d19b3b4ae89 \
-    --hash=sha256:c0c742beeeef7fb93b6a81bd53e75507887e396fd1003c45117658d063812dad \
-    --hash=sha256:d37be3a811a7f2ee28a0fa0964187efa50e90f21da0c6135c27787fa0b6a89db \
-    --hash=sha256:e90dc12bc6a38e9495692a36c9e231c4d7e0c9bfde60719468ab7d8673db3c45 \
-    --hash=sha256:fa84b7493a2e80759cacc2e668fa5b444d55b9994e90707c42904f55d6322c1e
+maturin==1.13.1 \
+    --hash=sha256:001741c6cff56aa8ea59a0d78ae990c0550d0e3e82b00b683eedb4158a8ef7e6 \
+    --hash=sha256:01c845825c917c07c1d0b2c9032c59c16a7d383d1e649a46481d3e5693c2750f \
+    --hash=sha256:2839024dcd65776abb4759e5bca29941971e095574162a4d335191da4be9ff24 \
+    --hash=sha256:3da18cccf2f683c0977bff9146a0908d6ffce836d600665736ac01679f588cb9 \
+    --hash=sha256:416e4e01cb88b798e606ee43929df897e42c1647b722ef68283816cca99a8742 \
+    --hash=sha256:6b1e5916a253243e8f5f9e847b62bbc98420eec48c9ce2e2e8724c6da89d359b \
+    --hash=sha256:72888e87819ce546d0d2df900e4b385e4ef299077d92ee37b48923a5602dae94 \
+    --hash=sha256:98b5fcf1a186c217830a8295ecc2989c6b1cf50945417adfc15252107b9475b7 \
+    --hash=sha256:9a87ff3b8e4d1c6eac33ebfe8e261e8236516d98d45c0323550621819b5a1a2f \
+    --hash=sha256:a2017d2281203d0c6570240e7d746564d766d756105823b7de68bda6ae722711 \
+    --hash=sha256:c1490584f3c70af45466ee99065b49e6657ebdccac6b10571bb44681309c9396 \
+    --hash=sha256:c6a720b252c99de072922dbe4432ab19662b6f80045b0355fec23bdfccb450da \
+    --hash=sha256:dc91031e0619c1e28730279ef9ee5f106c9b9ec806b013f888676b242f892eb7 \
+    --hash=sha256:f69093ed4a0e6464e52a7fc26d714f859ce15630ec8070743398c6bf41f38a9e
     # via
     #   cryptography
     #   python-bidi
@@ -408,8 +408,13 @@ setuptools-scm==10.0.5 \
     #   pluggy
     #   python-dateutil
     #   setuptools-rust
-    #   urllib3
     #   zipp
+setuptools-scm==9.2.2 \
+    --hash=sha256:1c674ab4665686a0887d7e24c03ab25f24201c213e82ea689d2f3e169ef7ef57 \
+    --hash=sha256:30e8f84d2ab1ba7cb0e653429b179395d0c33775d54807fc5f1dd6671801aef7
+    # via
+    #   hatch-vcs
+    #   urllib3
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
@@ -485,9 +490,7 @@ setuptools==78.1.1 \
     #   pyasn1
     #   pyasn1_modules
     #   pyhanko-certvalidator
-    #   pyroscope-io
     #   pyrsistent
-    #   python-dateutil
     #   python-redis-lock
     #   pyyaml
     #   regex
@@ -504,3 +507,10 @@ setuptools==78.1.1 \
     #   wrapt
     #   xhtml2pdf
     #   zipp
+setuptools==82.0.1 \
+    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
+    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+    # via
+    #   pyroscope-io
+    #   python-dateutil
+    #   setuptools-scm


### PR DESCRIPTION
## Summary
- Bumps `setuptools` from `78.1.1` to `82.0.1` in `requirements.txt` and regenerates `requirements-build.txt`
- `pyroscope-io==1.0.4` requires `setuptools>=82,<83` as a build-system dependency, causing Konflux hermetic builds to fail when only `78.1.1` is prefetched by Cachi2
- Verified with a local `podman build --target build-python` using the downstream Containerfile — all packages install successfully

## Test plan
- [x] Local container build of `build-python` stage passes with `setuptools==82.0.1`
- [x] `pyroscope-io==1.0.4` builds and installs successfully
- [x] No other packages constrain setuptools below 82 (`setuptools-rust` needs `>=62.4`, `setuptools-scm` needs `>=61`)
- [ ] Konflux build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)