### PR TITLE
PROJQUAY-11331: fix(config-tool): remove malformed struct tag space on DistributedStorageArgs.Signature

### DIFF
--- a/config-tool/pkg/lib/shared/structs.go
+++ b/config-tool/pkg/lib/shared/structs.go
@@ -28,7 +28,7 @@ type DistributedStorageArgs struct {
 	SecretKey   string `default:"" validate:"" json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
 	BucketName  string `default:"" validate:"" json:"bucket_name,omitempty" yaml:"bucket_name,omitempty"`
 
-	Signature string `default:"s3v2" validate: "" json:"signature_version,omitempty" yaml:"signature_version,omitempty"`
+	Signature string `default:"s3v2" validate:"" json:"signature_version,omitempty" yaml:"signature_version,omitempty"`
 	// Args for S3Storage
 	S3Bucket    string `default:"" validate:"" json:"s3_bucket,omitempty" yaml:"s3_bucket,omitempty"`
 	S3AccessKey string `default:"" validate:"" json:"s3_access_key,omitempty" yaml:"s3_access_key,omitempty"`

--- a/config-tool/pkg/lib/shared/structs_test.go
+++ b/config-tool/pkg/lib/shared/structs_test.go
@@ -1,0 +1,116 @@
+package shared
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestDistributedStorageArgsSignatureStructTags verifies that the Signature
+// field's struct tags are well-formed and parsed correctly by Go's reflect
+// package. A malformed validate tag (e.g. `validate: ""` with a space) causes
+// the Go tag parser to stop, silently dropping the json and yaml tags.
+func TestDistributedStorageArgsSignatureStructTags(t *testing.T) {
+	f, ok := reflect.TypeOf(DistributedStorageArgs{}).FieldByName("Signature")
+	if !ok {
+		t.Fatal("DistributedStorageArgs.Signature field not found")
+	}
+
+	tests := []struct {
+		tagKey string
+		want   string
+	}{
+		{"json", "signature_version,omitempty"},
+		{"yaml", "signature_version,omitempty"},
+		{"default", "s3v2"},
+		{"validate", ""},
+	}
+
+	for _, tt := range tests {
+		got := f.Tag.Get(tt.tagKey)
+		if got != tt.want {
+			t.Errorf("DistributedStorageArgs.Signature tag %q = %q, want %q (struct tag may be malformed)", tt.tagKey, got, tt.want)
+		}
+	}
+}
+
+// TestDistributedStorageArgsSignatureJSONKey verifies that JSON marshalling
+// uses "signature_version" (not the Go field name "Signature").
+func TestDistributedStorageArgsSignatureJSONKey(t *testing.T) {
+	args := DistributedStorageArgs{
+		Signature: "s3v4",
+	}
+
+	data, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	if _, ok := m["Signature"]; ok {
+		t.Error("JSON output contains Go field name \"Signature\" instead of \"signature_version\" — struct tag is malformed")
+	}
+	if val, ok := m["signature_version"]; !ok {
+		t.Error("JSON output missing \"signature_version\" key — struct tag is malformed")
+	} else if val != "s3v4" {
+		t.Errorf("signature_version = %v, want \"s3v4\"", val)
+	}
+}
+
+// TestDistributedStorageArgsSignatureYAMLKey verifies that YAML marshalling
+// uses "signature_version" (not the Go field name "Signature").
+func TestDistributedStorageArgsSignatureYAMLKey(t *testing.T) {
+	args := DistributedStorageArgs{
+		Signature: "s3v4",
+	}
+
+	data, err := yaml.Marshal(args)
+	if err != nil {
+		t.Fatalf("yaml.Marshal failed: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("yaml.Unmarshal failed: %v", err)
+	}
+
+	if _, ok := m["Signature"]; ok {
+		t.Error("YAML output contains Go field name \"Signature\" instead of \"signature_version\" — struct tag is malformed")
+	}
+	if val, ok := m["signature_version"]; !ok {
+		t.Error("YAML output missing \"signature_version\" key — struct tag is malformed")
+	} else if val != "s3v4" {
+		t.Errorf("signature_version = %v, want \"s3v4\"", val)
+	}
+}
+
+// TestDistributedStorageArgsSignatureOmitempty verifies that the Signature
+// field is omitted from JSON when empty (omitempty tag is working).
+func TestDistributedStorageArgsSignatureOmitempty(t *testing.T) {
+	args := DistributedStorageArgs{
+		Signature: "",
+	}
+
+	data, err := json.Marshal(args)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	if _, ok := m["signature_version"]; ok {
+		t.Error("JSON output contains \"signature_version\" for empty value — omitempty not working")
+	}
+	if _, ok := m["Signature"]; ok {
+		t.Error("JSON output contains Go field name \"Signature\" for empty value — struct tag is malformed and omitempty not working")
+	}
+}


### PR DESCRIPTION
## Summary
- Fix malformed Go struct tag on DistributedStorageArgs.Signature that breaks storage config serialization
- Add struct tag regression tests to prevent reoccurrence

## Root Cause / Rationale
The Signature field in DistributedStorageArgs (config-tool/pkg/lib/shared/structs.go:31) had a space between validate: and "" in its struct tag. This breaks Go struct tag parser, causing all subsequent tags (json, yaml) to be silently ignored. The field then serializes as Signature (Go field name) instead of signature_version, and omitempty is lost. When the operator generates config YAML, Python RadosGWStorage.__init__() receives an unexpected Signature keyword argument and crashes.

## Changes
- config-tool/pkg/lib/shared/structs.go: Remove the space in the validate tag (one-character fix)
- config-tool/pkg/lib/shared/structs_test.go: Add 4 tests verifying struct tag parsing, JSON/YAML key names, and omitempty behavior

## Test Plan
- [x] Unit tests added/updated

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11331

## Backport
- [x] Backport required: redhat-3.15, redhat-3.16, redhat-3.17
- redhat-3.18 is synced with master (no cherry-pick needed)

After merge, run:
/cherrypick redhat-3.15
/cherrypick redhat-3.16
/cherrypick redhat-3.17