### PR TITLE
NO-ISSUE: chore(deps): Regenerate requirements-build.txt for redhat-3.15

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -472,7 +472,6 @@ setuptools==78.1.1 \
     #   pyasn1_modules
     #   pyhanko-certvalidator
     #   pyrsistent
-    #   python-dateutil
     #   pyyaml
     #   reportlab
     #   resumablesha256


### PR DESCRIPTION
## Summary
- Regenerated `requirements-build.txt` using `pybuild-deps compile` with Python 3.12
- Removed duplicate `setuptools==82.0.1` entry (known pybuild-deps bug that produces two conflicting setuptools versions)

## Test plan
- [ ] Verify downstream build succeeds with updated build dependencies