### PR TITLE
[redhat-3.9] PROJQUAY-11350: fix(config-tool): remove malformed struct tag space on DistributedStorageArgs.Signature

### DIFF
--- a/config-tool/pkg/lib/shared/structs.go
+++ b/config-tool/pkg/lib/shared/structs.go
@@ -27,6 +27,8 @@ type DistributedStorageArgs struct {
 	AccessKey   string `default:"" validate:"" json:"access_key,omitempty" yaml:"access_key,omitempty"`
 	SecretKey   string `default:"" validate:"" json:"secret_key,omitempty" yaml:"secret_key,omitempty"`
 	BucketName  string `default:"" validate:"" json:"bucket_name,omitempty" yaml:"bucket_name,omitempty"`
+
+	Signature string `default:"s3v2" validate:"" json:"signature_version,omitempty" yaml:"signature_version,omitempty"`
 	// Args for S3Storage
 	S3Bucket    string `default:"" validate:"" json:"s3_bucket,omitempty" yaml:"s3_bucket,omitempty"`
 	S3AccessKey string `default:"" validate:"" json:"s3_access_key,omitempty" yaml:"s3_access_key,omitempty"`


### PR DESCRIPTION
The Signature field for DistributedStorageArgs was missing on this branch. Add it with the correct struct tag (no malformed space in the validate tag) to match the fix applied on newer branches.

Made-with: Cursor