### PR TITLE
NO-ISSUE: test(playwright): bug discovery tests for repos, robot accounts, logs

### DIFF
--- a/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
@@ -10,18 +10,15 @@ test.describe(
   'Bug Discovery: Robot Account Permissions',
   {tag: ['@bug-discovery', '@organization']},
   () => {
-    test('robot account kebab menu should not throw on select', {
-      tag: ['@robot-accounts'],
-    }, async ({authenticatedPage, api}) => {
+    test('robot account kebab menu should not throw on select', async ({
+      authenticatedPage,
+      api,
+    }) => {
       // Bug: RobotAccountKebab.tsx:17-20
       // The onSelect handler calls document.getElementById() to find the
       // kebab toggle element and calls .focus() on it WITHOUT a null check.
       // If the element is not found (e.g., DOM not ready, element removed),
-      // this throws a TypeError: Cannot read properties of null (reading 'focus')
-      //
-      // Additionally, the Dropdown component already has shouldFocusToggleOnSelect
-      // which handles focus internally, making the manual focus call redundant
-      // and potentially problematic.
+      // this throws a TypeError: Cannot read properties of null
       //
       // Expected behavior: kebab menu closes and returns focus cleanly
       // Actual behavior: potential null dereference crash
@@ -34,9 +31,9 @@ test.describe(
         `/organization/${org.name}?tab=Robotaccounts`,
       );
 
-      // Wait for robot account to appear
+      // Wait for robot account to appear — use fullName for unambiguous match
       const robotRow = authenticatedPage.locator('tr', {
-        hasText: robot.shortname,
+        hasText: robot.fullName,
       });
       await expect(robotRow).toBeVisible();
 
@@ -55,9 +52,11 @@ test.describe(
 
       // Click "Set repository permissions" — this triggers onSelect which calls
       // document.getElementById().focus() without null check
-      await authenticatedPage.getByTestId(
-        `${org.name}+${robot.shortname}-set-repo-perms-btn`,
-      ).click();
+      await authenticatedPage
+        .getByTestId(
+          `${org.name}+${robot.shortname}-set-repo-perms-btn`,
+        )
+        .click();
 
       // The page should not crash — verify we're still on the same page
       await expect(
@@ -65,14 +64,15 @@ test.describe(
       ).toBeVisible();
     });
 
-    test('permissions kebab should not throw when deleting permission', {
-      tag: ['@repository'],
-    }, async ({authenticatedPage, api}) => {
+    test('permissions kebab should not throw when deleting permission', async ({
+      authenticatedPage,
+      api,
+    }) => {
       // Bug: PermissionsKebab.tsx:27-28
       // Same pattern as RobotAccountKebab: document.getElementById().focus()
       // without null check in onSelect handler.
       //
-      // Expected behavior: kebab closes cleanly after selecting "Delete Permission"
+      // Expected behavior: kebab closes cleanly after selecting action
       // Actual behavior: potential null dereference crash
 
       const org = await api.organization('permkebab');
@@ -93,9 +93,9 @@ test.describe(
         `/repository/${org.name}/${repo.name}?tab=settings`,
       );
 
-      // Find the permission row for the robot
+      // Find the permission row for the robot — use fullName for unambiguous match
       const robotRow = authenticatedPage.locator('tr', {
-        hasText: robot.shortname,
+        hasText: robot.fullName,
       });
       await expect(robotRow).toBeVisible();
 
@@ -112,7 +112,6 @@ test.describe(
         .click();
 
       // The page should not crash and the permission should be removed
-      // Wait for the row to disappear (successful deletion)
       await expect(robotRow).not.toBeVisible({timeout: 10000});
     });
   },
@@ -122,31 +121,21 @@ test.describe(
   'Bug Discovery: Robot Account Repo Permissions Modal',
   {tag: ['@bug-discovery', '@organization']},
   () => {
-    test('changing repo permissions should reflect immediately in the UI', {
-      tag: ['@robot-accounts'],
-    }, async ({authenticatedPage, api}) => {
+    test('changing repo permissions should reflect immediately in the UI', async ({
+      authenticatedPage,
+      api,
+    }) => {
       // Bug: AddToRepository.tsx:149-151
       // When updating robot account repository permissions outside the wizard,
       // the code performs a direct state mutation:
       //   const tempItem = updatedRepoPerms;   // alias, NOT copy
       //   delete tempItem[repoName];           // mutates state directly
-      //   setUpdatedRepoPerms(tempItem);        // same reference → React may skip re-render
+      //   setUpdatedRepoPerms(tempItem);       // same reference, React may skip
       //
-      // React's useState setter uses Object.is to compare old and new state.
-      // Since tempItem IS updatedRepoPerms (same object), React may bail out
-      // of re-rendering, causing the permission change to not appear in the UI.
+      // Additional bug at line 53: props.repos.sort() mutates parent state.
+      // Additional bug at line 216: updateRobotAccountsList() called in render.
       //
-      // The bug is partially masked by updateRobotAccountsList() which uses
-      // setTimeout to trigger parent state updates, causing a delayed re-render.
-      //
-      // Additional bug at line 53: props.repos.sort() mutates the parent's
-      // state during render, violating React's immutability rules.
-      //
-      // Additional bug at line 216: updateRobotAccountsList() is called in
-      // the render body (not in useEffect), creating multiple setTimeout
-      // callbacks on every render.
-      //
-      // Expected behavior: permission changes reflect immediately in the dropdown
+      // Expected behavior: permission changes reflect immediately in dropdown
       // Actual behavior: may require extra render cycles or show stale values
 
       const org = await api.organization('robotperms');
@@ -163,9 +152,11 @@ test.describe(
         `${org.name}+${robot.shortname}-toggle-kebab`,
       );
       await kebab.click();
-      await authenticatedPage.getByTestId(
-        `${org.name}+${robot.shortname}-set-repo-perms-btn`,
-      ).click();
+      await authenticatedPage
+        .getByTestId(
+          `${org.name}+${robot.shortname}-set-repo-perms-btn`,
+        )
+        .click();
 
       // Wait for the "Add to repository" modal/panel to appear
       await expect(

--- a/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
@@ -119,10 +119,12 @@ test.describe(
   'Bug Discovery: Robot Account Repo Permissions Modal',
   {tag: ['@bug-discovery', '@organization']},
   () => {
-    test.fixme('changing repo permissions should reflect immediately in the UI', async ({
+    test('changing repo permissions should reflect immediately in the UI', async ({
       authenticatedPage,
       api,
     }) => {
+      // BUG CONFIRMED: test.fixme() — state mutation prevents immediate UI update
+      test.fixme();
       // Bug: AddToRepository.tsx:149-151
       // When updating robot account repository permissions outside the wizard,
       // the code performs a direct state mutation:

--- a/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
@@ -119,7 +119,7 @@ test.describe(
   'Bug Discovery: Robot Account Repo Permissions Modal',
   {tag: ['@bug-discovery', '@organization']},
   () => {
-    test('changing repo permissions should reflect immediately in the UI', async ({
+    test.fixme('changing repo permissions should reflect immediately in the UI', async ({
       authenticatedPage,
       api,
     }) => {

--- a/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
@@ -1,0 +1,203 @@
+import {test, expect} from '../../fixtures';
+
+/**
+ * Bug Discovery Tests: Robot Account Permission Management
+ *
+ * These tests reproduce potential UI bugs found via static analysis
+ * of the robot account wizard and kebab menu components.
+ */
+test.describe(
+  'Bug Discovery: Robot Account Permissions',
+  {tag: ['@bug-discovery', '@organization']},
+  () => {
+    test('robot account kebab menu should not throw on select', {
+      tag: ['@robot-accounts'],
+    }, async ({authenticatedPage, api}) => {
+      // Bug: RobotAccountKebab.tsx:17-20
+      // The onSelect handler calls document.getElementById() to find the
+      // kebab toggle element and calls .focus() on it WITHOUT a null check.
+      // If the element is not found (e.g., DOM not ready, element removed),
+      // this throws a TypeError: Cannot read properties of null (reading 'focus')
+      //
+      // Additionally, the Dropdown component already has shouldFocusToggleOnSelect
+      // which handles focus internally, making the manual focus call redundant
+      // and potentially problematic.
+      //
+      // Expected behavior: kebab menu closes and returns focus cleanly
+      // Actual behavior: potential null dereference crash
+
+      const org = await api.organization('robotkebab');
+      const robot = await api.robot(org.name, 'testbot');
+
+      // Navigate to the organization's robot accounts page
+      await authenticatedPage.goto(
+        `/organization/${org.name}?tab=Robotaccounts`,
+      );
+
+      // Wait for robot account to appear
+      const robotRow = authenticatedPage.locator('tr', {
+        hasText: robot.shortname,
+      });
+      await expect(robotRow).toBeVisible();
+
+      // Open the kebab menu for this robot account
+      const kebab = authenticatedPage.getByTestId(
+        `${org.name}+${robot.shortname}-toggle-kebab`,
+      );
+      await kebab.click();
+
+      // Verify dropdown items are visible
+      await expect(
+        authenticatedPage.getByTestId(
+          `${org.name}+${robot.shortname}-set-repo-perms-btn`,
+        ),
+      ).toBeVisible();
+
+      // Click "Set repository permissions" — this triggers onSelect which calls
+      // document.getElementById().focus() without null check
+      await authenticatedPage.getByTestId(
+        `${org.name}+${robot.shortname}-set-repo-perms-btn`,
+      ).click();
+
+      // The page should not crash — verify we're still on the same page
+      await expect(
+        authenticatedPage.getByText('Add to repository'),
+      ).toBeVisible();
+    });
+
+    test('permissions kebab should not throw when deleting permission', {
+      tag: ['@repository'],
+    }, async ({authenticatedPage, api}) => {
+      // Bug: PermissionsKebab.tsx:27-28
+      // Same pattern as RobotAccountKebab: document.getElementById().focus()
+      // without null check in onSelect handler.
+      //
+      // Expected behavior: kebab closes cleanly after selecting "Delete Permission"
+      // Actual behavior: potential null dereference crash
+
+      const org = await api.organization('permkebab');
+      const repo = await api.repository(org.name, 'permrepo');
+      const robot = await api.robot(org.name, 'permbot');
+
+      // Add a permission to the repo
+      await api.repositoryPermission(
+        org.name,
+        repo.name,
+        'user',
+        robot.fullName,
+        'read',
+      );
+
+      // Navigate to repository settings
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}?tab=settings`,
+      );
+
+      // Find the permission row for the robot
+      const robotRow = authenticatedPage.locator('tr', {
+        hasText: robot.shortname,
+      });
+      await expect(robotRow).toBeVisible();
+
+      // Open the kebab menu for this permission
+      const kebab = authenticatedPage.getByTestId(
+        `${robot.fullName}-toggle-kebab`,
+      );
+      await kebab.click();
+
+      // Click "Delete Permission" — triggers onSelect with
+      // document.getElementById().focus() without null check
+      await authenticatedPage
+        .getByRole('menuitem', {name: 'Delete Permission'})
+        .click();
+
+      // The page should not crash and the permission should be removed
+      // Wait for the row to disappear (successful deletion)
+      await expect(robotRow).not.toBeVisible({timeout: 10000});
+    });
+  },
+);
+
+test.describe(
+  'Bug Discovery: Robot Account Repo Permissions Modal',
+  {tag: ['@bug-discovery', '@organization']},
+  () => {
+    test('changing repo permissions should reflect immediately in the UI', {
+      tag: ['@robot-accounts'],
+    }, async ({authenticatedPage, api}) => {
+      // Bug: AddToRepository.tsx:149-151
+      // When updating robot account repository permissions outside the wizard,
+      // the code performs a direct state mutation:
+      //   const tempItem = updatedRepoPerms;   // alias, NOT copy
+      //   delete tempItem[repoName];           // mutates state directly
+      //   setUpdatedRepoPerms(tempItem);        // same reference → React may skip re-render
+      //
+      // React's useState setter uses Object.is to compare old and new state.
+      // Since tempItem IS updatedRepoPerms (same object), React may bail out
+      // of re-rendering, causing the permission change to not appear in the UI.
+      //
+      // The bug is partially masked by updateRobotAccountsList() which uses
+      // setTimeout to trigger parent state updates, causing a delayed re-render.
+      //
+      // Additional bug at line 53: props.repos.sort() mutates the parent's
+      // state during render, violating React's immutability rules.
+      //
+      // Additional bug at line 216: updateRobotAccountsList() is called in
+      // the render body (not in useEffect), creating multiple setTimeout
+      // callbacks on every render.
+      //
+      // Expected behavior: permission changes reflect immediately in the dropdown
+      // Actual behavior: may require extra render cycles or show stale values
+
+      const org = await api.organization('robotperms');
+      const repo = await api.repository(org.name, 'permrepo');
+      const robot = await api.robot(org.name, 'permbot');
+
+      // Navigate to robot accounts page
+      await authenticatedPage.goto(
+        `/organization/${org.name}?tab=Robotaccounts`,
+      );
+
+      // Open the kebab menu for the robot and click "Set repository permissions"
+      const kebab = authenticatedPage.getByTestId(
+        `${org.name}+${robot.shortname}-toggle-kebab`,
+      );
+      await kebab.click();
+      await authenticatedPage.getByTestId(
+        `${org.name}+${robot.shortname}-set-repo-perms-btn`,
+      ).click();
+
+      // Wait for the "Add to repository" modal/panel to appear
+      await expect(
+        authenticatedPage.getByText('Add to repository'),
+      ).toBeVisible();
+
+      // Verify the repository appears in the list
+      const repoCheckbox = authenticatedPage.getByTestId(
+        `checkbox-row-${repo.name}`,
+      );
+      await expect(repoCheckbox).toBeVisible();
+
+      // Select the repository
+      await repoCheckbox.locator('input[type="checkbox"]').check();
+
+      // Open the bulk permissions kebab and set permission to "Write"
+      await authenticatedPage
+        .locator('#toggle-bulk-perms-kebab')
+        .click();
+      await authenticatedPage
+        .getByRole('menuitem', {name: 'Write'})
+        .click();
+
+      // The permission dropdown for this repo should now show "Write"
+      // Due to the state mutation bug, this might not update immediately
+      const permDropdown = authenticatedPage
+        .locator('tr', {hasText: repo.name})
+        .locator('[class*="dropdown"]')
+        .first();
+
+      // Verify the permission value updated
+      await expect(permDropdown).toContainText('Write', {timeout: 5000});
+    });
+  },
+);

--- a/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts-bug-discovery.spec.ts
@@ -53,9 +53,7 @@ test.describe(
       // Click "Set repository permissions" — this triggers onSelect which calls
       // document.getElementById().focus() without null check
       await authenticatedPage
-        .getByTestId(
-          `${org.name}+${robot.shortname}-set-repo-perms-btn`,
-        )
+        .getByTestId(`${org.name}+${robot.shortname}-set-repo-perms-btn`)
         .click();
 
       // The page should not crash — verify we're still on the same page
@@ -153,9 +151,7 @@ test.describe(
       );
       await kebab.click();
       await authenticatedPage
-        .getByTestId(
-          `${org.name}+${robot.shortname}-set-repo-perms-btn`,
-        )
+        .getByTestId(`${org.name}+${robot.shortname}-set-repo-perms-btn`)
         .click();
 
       // Wait for the "Add to repository" modal/panel to appear
@@ -173,12 +169,8 @@ test.describe(
       await repoCheckbox.locator('input[type="checkbox"]').check();
 
       // Open the bulk permissions kebab and set permission to "Write"
-      await authenticatedPage
-        .locator('#toggle-bulk-perms-kebab')
-        .click();
-      await authenticatedPage
-        .getByRole('menuitem', {name: 'Write'})
-        .click();
+      await authenticatedPage.locator('#toggle-bulk-perms-kebab').click();
+      await authenticatedPage.getByRole('menuitem', {name: 'Write'}).click();
 
       // The permission dropdown for this repo should now show "Write"
       // Due to the state mutation bug, this might not update immediately

--- a/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
+++ b/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
@@ -9,11 +9,12 @@ import {test, expect} from '../../fixtures';
  */
 test.describe(
   'Bug Discovery: Repository List',
-  {tag: ['@bug-discovery']},
+  {tag: ['@bug-discovery', '@repository']},
   () => {
-    test('search for non-existent repo should show empty state, not spinner', {
-      tag: ['@repository'],
-    }, async ({authenticatedPage, api}) => {
+    test('search for non-existent repo should show empty state, not spinner', async ({
+      authenticatedPage,
+      api,
+    }) => {
       // Bug: RepositoriesList.tsx:400-406
       // When filteredRepos.length === 0 (search returns no matches),
       // the code unconditionally renders a Spinner instead of an empty state.
@@ -44,21 +45,21 @@ test.describe(
         .getByPlaceholder(/search by name/i)
         .fill('zzz_nonexistent_repo_xyz_12345');
 
-      // 5. Assert correct behavior: table should NOT show a spinner
-      // The Spinner component renders with role="progressbar"
-      const tableBody = authenticatedPage.getByTestId('repository-list-table');
+      // 5. Assert correct behavior: no spinner should be visible on the page.
+      // The bug replaces the table body content with a Spinner, so we check
+      // the whole page rather than scoping to the table (which may not render).
+      // The Spinner component renders with role="progressbar".
       await expect(
-        tableBody.locator('[role="progressbar"]'),
-      ).not.toBeVisible({timeout: 5000});
-
-      // The table should show some indication that no results were found
-      // (e.g., "No matching repositories" or an empty table without spinner)
-      // Currently the bug causes a Spinner to appear instead
+        authenticatedPage.locator(
+          '[data-testid="repository-list-table"] [role="progressbar"]',
+        ),
+      ).toHaveCount(0, {timeout: 5000});
     });
 
-    test('search with special regex characters should not crash', {
-      tag: ['@repository'],
-    }, async ({authenticatedPage, api}) => {
+    test('search with special regex characters should not crash', async ({
+      authenticatedPage,
+      api,
+    }) => {
       // Bug: FilterInput.tsx supports regex mode, and the search filter
       // in RepositoriesList applies the search. Special characters in
       // the search query could cause a RegExp constructor crash if the
@@ -75,7 +76,8 @@ test.describe(
       ).toBeVisible();
 
       // Type special regex characters that would crash RegExp constructor
-      const searchInput = authenticatedPage.getByPlaceholder(/search by name/i);
+      const searchInput =
+        authenticatedPage.getByPlaceholder(/search by name/i);
       await searchInput.fill('[invalid(regex');
 
       // The page should not crash — no unhandled error
@@ -94,20 +96,18 @@ test.describe(
 
 test.describe(
   'Bug Discovery: Repository Details',
-  {tag: ['@bug-discovery']},
+  {tag: ['@bug-discovery', '@repository']},
   () => {
-    test('navigating with invalid tab param should show default tab', {
-      tag: ['@repository'],
-    }, async ({authenticatedPage, api}) => {
+    test('navigating with invalid tab param should show default tab', async ({
+      authenticatedPage,
+      api,
+    }) => {
       // Bug: RepositoryDetails.tsx:142-145
       // setState is called during render to sync tab state with URL params.
       // When an invalid tab param is provided, getTabIndex returns undefined,
       // so the condition is false and the default tab (Information) should show.
-      // This test validates that the fallback works correctly.
       //
       // Expected behavior: Information tab is shown for invalid ?tab= values
-      // Actual behavior: should work, but the setState-during-render pattern
-      // could cause issues in edge cases (extra renders, flash of wrong content)
 
       const repo = await api.repository(undefined, 'tabbug');
 
@@ -122,16 +122,16 @@ test.describe(
       ).toHaveAttribute('aria-selected', 'true');
     });
 
-    test('tab state should stay in sync with URL across navigation', {
-      tag: ['@repository'],
-    }, async ({authenticatedPage, api}) => {
+    test('tab state should stay in sync with URL across navigation', async ({
+      authenticatedPage,
+      api,
+    }) => {
       // Bug: RepositoryDetails.tsx:142-145
       // The tab state is synced via setState during render, which in React 18
       // causes an extra synchronous re-render. This test validates that rapid
       // tab navigation via URL params stays consistent.
       //
       // Expected behavior: each tab param shows the correct tab content
-      // Actual behavior: extra re-renders could cause flicker or stale state
 
       const repo = await api.repository(undefined, 'tabsyncbug');
 
@@ -168,9 +168,10 @@ test.describe(
       ).toHaveAttribute('aria-selected', 'true');
     });
 
-    test('settings tab should not be accessible via URL for non-admin users', {
-      tag: ['@repository'],
-    }, async ({authenticatedPage, readonlyPage, api}) => {
+    test('settings tab should not be accessible via URL for non-admin users', async ({
+      readonlyPage,
+      api,
+    }) => {
       // Bug: RepositoryDetails.tsx:142-145 + 349
       // The tab param is applied via setState during render WITHOUT checking
       // if the target tab is hidden. The Settings tab has isHidden={!can_admin},
@@ -192,7 +193,6 @@ test.describe(
       );
 
       // The Settings tab should NOT be selected since readonly user is not admin
-      // Instead, the default Information tab should be shown
       const settingsTab = readonlyPage.getByRole('tab', {name: 'Settings'});
 
       // Settings tab header should not be visible for non-admin

--- a/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
+++ b/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
@@ -1,0 +1,207 @@
+import {test, expect} from '../../fixtures';
+
+/**
+ * Bug Discovery Tests: Repository List & Repository Details
+ *
+ * These tests reproduce potential UI bugs found via static analysis
+ * of the React frontend source code. Failing tests confirm the bug;
+ * passing tests indicate a false positive.
+ */
+test.describe(
+  'Bug Discovery: Repository List',
+  {tag: ['@bug-discovery']},
+  () => {
+    test('search for non-existent repo should show empty state, not spinner', {
+      tag: ['@repository'],
+    }, async ({authenticatedPage, api}) => {
+      // Bug: RepositoriesList.tsx:400-406
+      // When filteredRepos.length === 0 (search returns no matches),
+      // the code unconditionally renders a Spinner instead of an empty state.
+      // The condition does not distinguish between "data loading" and
+      // "search returned no results", so users see an infinite spinner
+      // when searching for a repo that doesn't exist.
+      //
+      // Expected behavior: show "No matching repositories" or similar message
+      // Actual behavior: shows an infinite loading spinner
+
+      // 1. Create a repo so the list is non-empty (prevents the early-return empty state)
+      const repo = await api.repository(undefined, 'searchbug');
+
+      // 2. Navigate to the global repositories list
+      await authenticatedPage.goto('/repository');
+
+      // 3. Wait for repos to load
+      await expect(
+        authenticatedPage.getByTestId('repository-list-table'),
+      ).toBeVisible();
+      // Verify our repo is visible to confirm data has loaded
+      await expect(
+        authenticatedPage.getByTestId('repository-list-table'),
+      ).toContainText(repo.name);
+
+      // 4. Search for a string that will match no repos
+      await authenticatedPage
+        .getByPlaceholder(/search by name/i)
+        .fill('zzz_nonexistent_repo_xyz_12345');
+
+      // 5. Assert correct behavior: table should NOT show a spinner
+      // The Spinner component renders with role="progressbar"
+      const tableBody = authenticatedPage.getByTestId('repository-list-table');
+      await expect(
+        tableBody.locator('[role="progressbar"]'),
+      ).not.toBeVisible({timeout: 5000});
+
+      // The table should show some indication that no results were found
+      // (e.g., "No matching repositories" or an empty table without spinner)
+      // Currently the bug causes a Spinner to appear instead
+    });
+
+    test('search with special regex characters should not crash', {
+      tag: ['@repository'],
+    }, async ({authenticatedPage, api}) => {
+      // Bug: FilterInput.tsx supports regex mode, and the search filter
+      // in RepositoriesList applies the search. Special characters in
+      // the search query could cause a RegExp constructor crash if the
+      // regex mode is enabled and the input is not escaped.
+      //
+      // Expected behavior: search gracefully handles special characters
+      // Actual behavior: potential unhandled RegExp syntax error
+
+      const repo = await api.repository(undefined, 'regexbug');
+
+      await authenticatedPage.goto('/repository');
+      await expect(
+        authenticatedPage.getByTestId('repository-list-table'),
+      ).toBeVisible();
+
+      // Type special regex characters that would crash RegExp constructor
+      const searchInput = authenticatedPage.getByPlaceholder(/search by name/i);
+      await searchInput.fill('[invalid(regex');
+
+      // The page should not crash — no unhandled error
+      await expect(
+        authenticatedPage.getByTestId('repository-list-table'),
+      ).toBeVisible();
+
+      // Clear search and verify repos are visible again
+      await searchInput.fill('');
+      await expect(
+        authenticatedPage.getByTestId('repository-list-table'),
+      ).toContainText(repo.name);
+    });
+  },
+);
+
+test.describe(
+  'Bug Discovery: Repository Details',
+  {tag: ['@bug-discovery']},
+  () => {
+    test('navigating with invalid tab param should show default tab', {
+      tag: ['@repository'],
+    }, async ({authenticatedPage, api}) => {
+      // Bug: RepositoryDetails.tsx:142-145
+      // setState is called during render to sync tab state with URL params.
+      // When an invalid tab param is provided, getTabIndex returns undefined,
+      // so the condition is false and the default tab (Information) should show.
+      // This test validates that the fallback works correctly.
+      //
+      // Expected behavior: Information tab is shown for invalid ?tab= values
+      // Actual behavior: should work, but the setState-during-render pattern
+      // could cause issues in edge cases (extra renders, flash of wrong content)
+
+      const repo = await api.repository(undefined, 'tabbug');
+
+      // Navigate with an invalid tab parameter
+      await authenticatedPage.goto(
+        `/repository/${repo.fullName}?tab=nonexistent`,
+      );
+
+      // The Information tab should be active (default fallback)
+      await expect(
+        authenticatedPage.getByRole('tab', {name: 'Information'}),
+      ).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('tab state should stay in sync with URL across navigation', {
+      tag: ['@repository'],
+    }, async ({authenticatedPage, api}) => {
+      // Bug: RepositoryDetails.tsx:142-145
+      // The tab state is synced via setState during render, which in React 18
+      // causes an extra synchronous re-render. This test validates that rapid
+      // tab navigation via URL params stays consistent.
+      //
+      // Expected behavior: each tab param shows the correct tab content
+      // Actual behavior: extra re-renders could cause flicker or stale state
+
+      const repo = await api.repository(undefined, 'tabsyncbug');
+
+      // Navigate to Tags tab via URL
+      await authenticatedPage.goto(
+        `/repository/${repo.fullName}?tab=tags`,
+      );
+      await expect(
+        authenticatedPage.getByRole('tab', {name: 'Tags'}),
+      ).toHaveAttribute('aria-selected', 'true');
+
+      // Navigate to Tag history tab via URL
+      await authenticatedPage.goto(
+        `/repository/${repo.fullName}?tab=history`,
+      );
+      await expect(
+        authenticatedPage.getByRole('tab', {name: 'Tag history'}),
+      ).toHaveAttribute('aria-selected', 'true');
+
+      // Navigate to Settings tab via URL (as owner/admin)
+      await authenticatedPage.goto(
+        `/repository/${repo.fullName}?tab=settings`,
+      );
+      await expect(
+        authenticatedPage.getByRole('tab', {name: 'Settings'}),
+      ).toHaveAttribute('aria-selected', 'true');
+
+      // Navigate back to Information tab
+      await authenticatedPage.goto(
+        `/repository/${repo.fullName}?tab=information`,
+      );
+      await expect(
+        authenticatedPage.getByRole('tab', {name: 'Information'}),
+      ).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('settings tab should not be accessible via URL for non-admin users', {
+      tag: ['@repository'],
+    }, async ({authenticatedPage, readonlyPage, api}) => {
+      // Bug: RepositoryDetails.tsx:142-145 + 349
+      // The tab param is applied via setState during render WITHOUT checking
+      // if the target tab is hidden. The Settings tab has isHidden={!can_admin},
+      // but setActiveTabKey('settings') is called regardless of permissions.
+      // This means a non-admin user navigating to ?tab=settings would have
+      // the Settings tab content mounted (via mountOnEnter) even though the
+      // tab header is hidden.
+      //
+      // Expected behavior: non-admin user sees the default tab (Information)
+      // Actual behavior: Settings content may render without visible tab header
+
+      // Create a public repo owned by testuser
+      const org = await api.organization('tabaccess');
+      const repo = await api.repository(org.name, 'pubrepo', 'public');
+
+      // Navigate as readonly user to the repo with ?tab=settings
+      await readonlyPage.goto(
+        `/repository/${repo.fullName}?tab=settings`,
+      );
+
+      // The Settings tab should NOT be selected since readonly user is not admin
+      // Instead, the default Information tab should be shown
+      const settingsTab = readonlyPage.getByRole('tab', {name: 'Settings'});
+
+      // Settings tab header should not be visible for non-admin
+      await expect(settingsTab).not.toBeVisible();
+
+      // Information tab should be the active/selected tab
+      await expect(
+        readonlyPage.getByRole('tab', {name: 'Information'}),
+      ).toHaveAttribute('aria-selected', 'true');
+    });
+  },
+);

--- a/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
+++ b/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
@@ -11,10 +11,12 @@ test.describe(
   'Bug Discovery: Repository List',
   {tag: ['@bug-discovery', '@repository']},
   () => {
-    test.fixme('search for non-existent repo should show empty state, not spinner', async ({
+    test('search for non-existent repo should show empty state, not spinner', async ({
       authenticatedPage,
       api,
     }) => {
+      // BUG CONFIRMED: test.fixme() — spinner shown instead of empty state
+      test.fixme();
       // Bug: RepositoriesList.tsx:400-406
       // When filteredRepos.length === 0 (search returns no matches),
       // the code unconditionally renders a Spinner instead of an empty state.
@@ -165,10 +167,12 @@ test.describe(
       ).toHaveAttribute('aria-selected', 'true');
     });
 
-    test.fixme('settings tab should not be accessible via URL for non-admin users', async ({
+    test('settings tab should not be accessible via URL for non-admin users', async ({
       readonlyPage,
       api,
     }) => {
+      // BUG CONFIRMED: test.fixme() — Settings tab visible to non-admin via URL
+      test.fixme();
       // Bug: RepositoryDetails.tsx:142-145 + 349
       // The tab param is applied via setState during render WITHOUT checking
       // if the target tab is hidden. The Settings tab has isHidden={!can_admin},

--- a/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
+++ b/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
@@ -76,8 +76,7 @@ test.describe(
       ).toBeVisible();
 
       // Type special regex characters that would crash RegExp constructor
-      const searchInput =
-        authenticatedPage.getByPlaceholder(/search by name/i);
+      const searchInput = authenticatedPage.getByPlaceholder(/search by name/i);
       await searchInput.fill('[invalid(regex');
 
       // The page should not crash — no unhandled error
@@ -136,33 +135,25 @@ test.describe(
       const repo = await api.repository(undefined, 'tabsyncbug');
 
       // Navigate to Tags tab via URL
-      await authenticatedPage.goto(
-        `/repository/${repo.fullName}?tab=tags`,
-      );
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
       await expect(
         authenticatedPage.getByRole('tab', {name: 'Tags'}),
       ).toHaveAttribute('aria-selected', 'true');
 
       // Navigate to Tag history tab via URL
-      await authenticatedPage.goto(
-        `/repository/${repo.fullName}?tab=history`,
-      );
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=history`);
       await expect(
         authenticatedPage.getByRole('tab', {name: 'Tag history'}),
       ).toHaveAttribute('aria-selected', 'true');
 
       // Navigate to Settings tab via URL (as owner/admin)
-      await authenticatedPage.goto(
-        `/repository/${repo.fullName}?tab=settings`,
-      );
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=settings`);
       await expect(
         authenticatedPage.getByRole('tab', {name: 'Settings'}),
       ).toHaveAttribute('aria-selected', 'true');
 
       // Navigate back to Information tab
-      await authenticatedPage.goto(
-        `/repository/${repo.fullName}?tab=information`,
-      );
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=information`);
       await expect(
         authenticatedPage.getByRole('tab', {name: 'Information'}),
       ).toHaveAttribute('aria-selected', 'true');
@@ -188,9 +179,7 @@ test.describe(
       const repo = await api.repository(org.name, 'pubrepo', 'public');
 
       // Navigate as readonly user to the repo with ?tab=settings
-      await readonlyPage.goto(
-        `/repository/${repo.fullName}?tab=settings`,
-      );
+      await readonlyPage.goto(`/repository/${repo.fullName}?tab=settings`);
 
       // The Settings tab should NOT be selected since readonly user is not admin
       const settingsTab = readonlyPage.getByRole('tab', {name: 'Settings'});

--- a/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
+++ b/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
@@ -70,6 +70,9 @@ test.describe(
 
       const repo = await api.repository(undefined, 'regexbug');
 
+      const pageErrors: Error[] = [];
+      authenticatedPage.on('pageerror', (err) => pageErrors.push(err));
+
       await authenticatedPage.goto('/repository');
       await expect(
         authenticatedPage.getByTestId('repository-list-table'),
@@ -83,6 +86,7 @@ test.describe(
       await expect(
         authenticatedPage.getByTestId('repository-list-table'),
       ).toBeVisible();
+      expect(pageErrors).toHaveLength(0);
 
       // Clear search and verify repos are visible again
       await searchInput.fill('');
@@ -182,6 +186,11 @@ test.describe(
 
       // Navigate as readonly user to the repo with ?tab=settings
       await readonlyPage.goto(`/repository/${repo.fullName}?tab=settings`);
+
+      // Verify page loaded successfully before checking tab state
+      await expect(
+        readonlyPage.getByRole('tab', {name: 'Information'}),
+      ).toBeVisible();
 
       // The Settings tab should NOT be selected since readonly user is not admin
       const settingsTab = readonlyPage.getByRole('tab', {name: 'Settings'});

--- a/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
+++ b/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
@@ -153,7 +153,9 @@ test.describe(
       ).toHaveAttribute('aria-selected', 'true');
 
       // Navigate back to Information tab
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=information`);
+      await authenticatedPage.goto(
+        `/repository/${repo.fullName}?tab=information`,
+      );
       await expect(
         authenticatedPage.getByRole('tab', {name: 'Information'}),
       ).toHaveAttribute('aria-selected', 'true');

--- a/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
+++ b/web/playwright/e2e/repository/repository-bug-discovery.spec.ts
@@ -11,7 +11,7 @@ test.describe(
   'Bug Discovery: Repository List',
   {tag: ['@bug-discovery', '@repository']},
   () => {
-    test('search for non-existent repo should show empty state, not spinner', async ({
+    test.fixme('search for non-existent repo should show empty state, not spinner', async ({
       authenticatedPage,
       api,
     }) => {
@@ -165,7 +165,7 @@ test.describe(
       ).toHaveAttribute('aria-selected', 'true');
     });
 
-    test('settings tab should not be accessible via URL for non-admin users', async ({
+    test.fixme('settings tab should not be accessible via URL for non-admin users', async ({
       readonlyPage,
       api,
     }) => {

--- a/web/playwright/e2e/ui/usage-logs-bug-discovery.spec.ts
+++ b/web/playwright/e2e/ui/usage-logs-bug-discovery.spec.ts
@@ -10,18 +10,16 @@ test.describe(
   'Bug Discovery: Usage Logs',
   {tag: ['@bug-discovery', '@logs']},
   () => {
-    test('chart toggle should not break date picker state', {
-      tag: ['@repository'],
-    }, async ({authenticatedPage, api}) => {
+    test('chart toggle should not break date picker state', async ({
+      authenticatedPage,
+      api,
+    }) => {
       // Bug: UsageLogs.tsx:38-41
       // The minDate and maxDate variables are recreated on every render using
       // new Date(). When the user toggles chart visibility, the component
       // re-renders and new Date objects are created. This means the date
       // validators reference fresh dates each render, which could cause
       // inconsistent validation near midnight.
-      //
-      // Additional concern: the useEffect at line 52-63 that invalidates
-      // queries on date change is missing queryClient from its dependency array.
       //
       // Expected behavior: toggling chart does not affect date picker values
       // Actual behavior: dates should remain stable across re-renders
@@ -40,9 +38,9 @@ test.describe(
       await expect(chartToggle).toBeVisible();
 
       // Capture the initial date values from the date pickers
-      // PatternFly DatePicker renders an input with the date value
+      // PatternFly DatePicker uses placeholder "YYYY-MM-DD" (uppercase)
       const datePickers = authenticatedPage.locator(
-        'input[placeholder*="yyyy"]',
+        'input[placeholder*="YYYY" i]',
       );
 
       // There should be two date pickers (start and end)
@@ -70,20 +68,17 @@ test.describe(
       await expect(datePickers.nth(1)).toHaveValue(endDate);
     });
 
-    test('usage logs should load without errors for repository view', {
-      tag: ['@repository'],
-    }, async ({authenticatedPage, api}) => {
+    test('usage logs should load without errors for repository view', async ({
+      authenticatedPage,
+      api,
+    }) => {
       // Bug: UsageLogsGraph.tsx:194-197
       // Chart bars use array index as key: key={index}
-      // If log kinds appear in different order across re-renders (e.g., due
-      // to Object.keys() ordering changing when new log types appear), React
+      // If log kinds appear in different order across re-renders, React
       // will associate the wrong style/data with the wrong bar component.
       //
       // This test validates that the usage logs page loads without errors
       // and renders the chart toggle and date pickers correctly.
-      //
-      // Expected behavior: usage logs render with chart and table
-      // Actual behavior: should work, but chart bars may animate incorrectly
 
       const repo = await api.repository(undefined, 'logsgraph');
 
@@ -100,7 +95,7 @@ test.describe(
 
       // Verify date pickers are present
       const datePickers = authenticatedPage.locator(
-        'input[placeholder*="yyyy"]',
+        'input[placeholder*="YYYY" i]',
       );
       await expect(datePickers.nth(0)).toBeVisible();
       await expect(datePickers.nth(1)).toBeVisible();
@@ -112,7 +107,9 @@ test.describe(
       await expect(chartToggle).toContainText('Hide Chart');
 
       // Page should remain functional (no React error boundary)
-      await expect(authenticatedPage.getByText('Unable to')).not.toBeVisible();
+      await expect(
+        authenticatedPage.getByText('Unable to'),
+      ).not.toBeVisible();
     });
   },
 );

--- a/web/playwright/e2e/ui/usage-logs-bug-discovery.spec.ts
+++ b/web/playwright/e2e/ui/usage-logs-bug-discovery.spec.ts
@@ -1,0 +1,118 @@
+import {test, expect} from '../../fixtures';
+
+/**
+ * Bug Discovery Tests: Usage Logs
+ *
+ * These tests reproduce potential UI bugs found via static analysis
+ * of the UsageLogs component and related chart/date handling.
+ */
+test.describe(
+  'Bug Discovery: Usage Logs',
+  {tag: ['@bug-discovery', '@logs']},
+  () => {
+    test('chart toggle should not break date picker state', {
+      tag: ['@repository'],
+    }, async ({authenticatedPage, api}) => {
+      // Bug: UsageLogs.tsx:38-41
+      // The minDate and maxDate variables are recreated on every render using
+      // new Date(). When the user toggles chart visibility, the component
+      // re-renders and new Date objects are created. This means the date
+      // validators reference fresh dates each render, which could cause
+      // inconsistent validation near midnight.
+      //
+      // Additional concern: the useEffect at line 52-63 that invalidates
+      // queries on date change is missing queryClient from its dependency array.
+      //
+      // Expected behavior: toggling chart does not affect date picker values
+      // Actual behavior: dates should remain stable across re-renders
+
+      const org = await api.organization('logsbug');
+
+      // Navigate to org page and go to Logs tab
+      await authenticatedPage.goto(
+        `/organization/${org.name}?tab=Logs`,
+      );
+
+      // Wait for usage logs section to load
+      const chartToggle = authenticatedPage.getByTestId(
+        'usage-logs-chart-toggle',
+      );
+      await expect(chartToggle).toBeVisible();
+
+      // Capture the initial date values from the date pickers
+      // PatternFly DatePicker renders an input with the date value
+      const datePickers = authenticatedPage.locator(
+        'input[placeholder*="yyyy"]',
+      );
+
+      // There should be two date pickers (start and end)
+      const datePickerCount = await datePickers.count();
+      expect(datePickerCount).toBeGreaterThanOrEqual(2);
+
+      // Get initial date values (these should be auto-populated)
+      const startDate = await datePickers.nth(0).inputValue();
+      const endDate = await datePickers.nth(1).inputValue();
+
+      // Both dates should be populated (not empty)
+      expect(startDate).toBeTruthy();
+      expect(endDate).toBeTruthy();
+
+      // Toggle chart off
+      await chartToggle.click();
+      await expect(chartToggle).toContainText('Show Chart');
+
+      // Toggle chart back on
+      await chartToggle.click();
+      await expect(chartToggle).toContainText('Hide Chart');
+
+      // Dates should remain the same after re-render
+      await expect(datePickers.nth(0)).toHaveValue(startDate);
+      await expect(datePickers.nth(1)).toHaveValue(endDate);
+    });
+
+    test('usage logs should load without errors for repository view', {
+      tag: ['@repository'],
+    }, async ({authenticatedPage, api}) => {
+      // Bug: UsageLogsGraph.tsx:194-197
+      // Chart bars use array index as key: key={index}
+      // If log kinds appear in different order across re-renders (e.g., due
+      // to Object.keys() ordering changing when new log types appear), React
+      // will associate the wrong style/data with the wrong bar component.
+      //
+      // This test validates that the usage logs page loads without errors
+      // and renders the chart toggle and date pickers correctly.
+      //
+      // Expected behavior: usage logs render with chart and table
+      // Actual behavior: should work, but chart bars may animate incorrectly
+
+      const repo = await api.repository(undefined, 'logsgraph');
+
+      // Navigate to repository details, Logs tab
+      await authenticatedPage.goto(
+        `/repository/${repo.fullName}?tab=logs`,
+      );
+
+      // Verify the usage logs section renders
+      const chartToggle = authenticatedPage.getByTestId(
+        'usage-logs-chart-toggle',
+      );
+      await expect(chartToggle).toBeVisible();
+
+      // Verify date pickers are present
+      const datePickers = authenticatedPage.locator(
+        'input[placeholder*="yyyy"]',
+      );
+      await expect(datePickers.nth(0)).toBeVisible();
+      await expect(datePickers.nth(1)).toBeVisible();
+
+      // Toggle chart visibility to exercise re-render path
+      await chartToggle.click();
+      await expect(chartToggle).toContainText('Show Chart');
+      await chartToggle.click();
+      await expect(chartToggle).toContainText('Hide Chart');
+
+      // Page should remain functional (no React error boundary)
+      await expect(authenticatedPage.getByText('Unable to')).not.toBeVisible();
+    });
+  },
+);

--- a/web/playwright/e2e/ui/usage-logs-bug-discovery.spec.ts
+++ b/web/playwright/e2e/ui/usage-logs-bug-discovery.spec.ts
@@ -27,9 +27,7 @@ test.describe(
       const org = await api.organization('logsbug');
 
       // Navigate to org page and go to Logs tab
-      await authenticatedPage.goto(
-        `/organization/${org.name}?tab=Logs`,
-      );
+      await authenticatedPage.goto(`/organization/${org.name}?tab=Logs`);
 
       // Wait for usage logs section to load
       const chartToggle = authenticatedPage.getByTestId(
@@ -83,9 +81,7 @@ test.describe(
       const repo = await api.repository(undefined, 'logsgraph');
 
       // Navigate to repository details, Logs tab
-      await authenticatedPage.goto(
-        `/repository/${repo.fullName}?tab=logs`,
-      );
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=logs`);
 
       // Verify the usage logs section renders
       const chartToggle = authenticatedPage.getByTestId(
@@ -107,9 +103,7 @@ test.describe(
       await expect(chartToggle).toContainText('Hide Chart');
 
       // Page should remain functional (no React error boundary)
-      await expect(
-        authenticatedPage.getByText('Unable to'),
-      ).not.toBeVisible();
+      await expect(authenticatedPage.getByText('Unable to')).not.toBeVisible();
     });
   },
 );


### PR DESCRIPTION
## Summary
Automated bug discovery session. Tests reproduce potential UI bugs found via static analysis of the React frontend.

- **P1 — Likely Bugs (4):** Spinner shown for empty search results, direct state mutation in robot permissions, props mutation during render, side effects in render body
- **P2 — Edge Case Bugs (5):** Hidden tabs accessible via URL, null dereference in kebab menus, array index used as React key in sortable lists
- **9 tests across 3 files** covering repository list, repository details, robot account permissions, and usage logs

### Key findings
| Bug | File | Severity | Description |
|-----|------|----------|-------------|
| Spinner on empty search | RepositoriesList.tsx:400 | P1 | `filteredRepos.length === 0` shows Spinner instead of empty state |
| State mutation | AddToRepository.tsx:149 | P1 | Direct mutation of `updatedRepoPerms` state object |
| Props mutation | AddToRepository.tsx:53 | P1 | `props.repos.sort()` mutates parent state during render |
| Side effect in render | AddToRepository.tsx:216 | P1 | `updateRobotAccountsList()` called outside useEffect |
| Hidden tab via URL | RepositoryDetails.tsx:142 | P2 | `?tab=settings` bypasses `isHidden` for non-admin users |
| Null dereference | RobotAccountKebab.tsx:17 | P2 | `getElementById().focus()` without null check |
| Index as key | TagsTable.tsx:637 | P2 | `key={localIndex}` for sortable tag rows |

## Test plan
- [ ] CI Playwright tests pass (`@bug-discovery` tag)
- [ ] Review each test to confirm the bug is real, not a false positive
- [ ] File JIRA tickets for confirmed P1 bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)