### PR TITLE
NO-ISSUE: chore(scripts): stateful polling in poll-pr.sh with delta output and adaptive backoff

### DIFF
--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -136,7 +136,7 @@ fetch_review_threads() {
           comments(first:3){nodes{databaseId author{login __typename} body path line originalLine}}
         }
       }}}}'  \
-    -f owner="$owner" -f repo="$rname" -F pr="$PR_NUMBER" 2>/dev/null) || { echo '{}'; return; }
+    -f owner="$owner" -f repo="$rname" -F pr="$PR_NUMBER" 2>/dev/null) || return 1
   local has_next
   has_next=$(echo "$result" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null)
   if [ "$has_next" = "true" ]; then
@@ -202,8 +202,8 @@ do_poll() {
     --jq '[.[] | select(.user.login == "coderabbitai[bot]")]' \
     2>/dev/null | jq -s 'flatten | last // {}' || echo '{}')
 
-  local threads_json
-  threads_json=$(fetch_review_threads)
+  local threads_json threads_ok=true
+  threads_json=$(fetch_review_threads) || { threads_ok=false; threads_json='{}'; echo "  WARN: GraphQL review-thread fetch failed; treating as indeterminate." >&2; }
   cr_inline_count=$(echo "$threads_json" | jq \
     '[.data.repository.pullRequest.reviewThreads.nodes[]? |
       select(.isResolved==false and .isOutdated==false) |
@@ -233,16 +233,21 @@ do_poll() {
     2>/dev/null | jq -rs 'flatten | last | .body // ""' || echo '')
 
   # Human PR comments (non-bot, non-our-own-account)
-  local human_comments_json self_login
+  # Note: gh api does not support --arg for jq variables; filter in a separate jq call
+  local human_comments_json self_login _comments_raw
   self_login=$(gh api user --jq '.login' 2>/dev/null || echo '')
-  human_comments_json=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq --arg self "$self_login" '[.[] | select(
-      (.user.login | endswith("[bot]") | not) and
-      .user.login != "openshift-ci-robot" and
-      ($self == "" or .user.login != $self) and
-      (.body | startswith("## Ready for Review") | not)
-    ) | {id: .id, login: .user.login, created_at: .created_at, body: .body}]' \
-    2>/dev/null | jq -s 'flatten | sort_by(.id)' || echo '[]')
+  if _comments_raw=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" 2>/dev/null); then
+    human_comments_json=$(printf '%s' "$_comments_raw" | jq -s --arg self "$self_login" \
+      'flatten | [.[] | select(
+        (.user.login | endswith("[bot]") | not) and
+        .user.login != "openshift-ci-robot" and
+        ($self == "" or .user.login != $self) and
+        (.body | startswith("## Ready for Review") | not)
+      ) | {id: .id, login: .user.login, created_at: .created_at, body: .body}] | sort_by(.id)' \
+      2>/dev/null) || human_comments_json='[]'
+  else
+    human_comments_json='[]'
+  fi
   local human_comment_count human_comment_last_id
   human_comment_count=$(echo "$human_comments_json" | jq 'length')
   human_comment_last_id=$(echo "$human_comments_json" | jq '.[-1].id // 0')
@@ -312,7 +317,7 @@ do_poll() {
     delta_lines+=("  CodeRabbit: +${cr_delta} new unresolved thread(s) (total: ${cr_inline_count})")
   elif [ "$cr_delta" -lt 0 ]; then
     has_changes=true
-    delta_lines+=("  CodeRabbit: ${cr_delta} thread(s) resolved (total: ${cr_inline_count})")
+    delta_lines+=("  CodeRabbit: $(( -cr_delta )) thread(s) resolved (total: ${cr_inline_count})")
   fi
 
   # Human inline comment count change
@@ -324,7 +329,7 @@ do_poll() {
     delta_lines+=("  Human: +${human_inline_delta} new unresolved thread(s) (total: ${human_inline_count})")
   elif [ "$human_inline_delta" -lt 0 ]; then
     has_changes=true
-    delta_lines+=("  Human: ${human_inline_delta} thread(s) resolved (total: ${human_inline_count})")
+    delta_lines+=("  Human: $(( -human_inline_delta )) thread(s) resolved (total: ${human_inline_count})")
   fi
 
   # Human review changes
@@ -586,6 +591,10 @@ do_poll() {
     else
       echo ""
     fi
+    exit_code=2
+
+  elif ! $threads_ok; then
+    echo "  WAITING: review-thread fetch failed — will retry next poll"
     exit_code=2
 
   elif [ "$hr_count" -eq 0 ] || [ "$hr_approved" -eq 0 ]; then

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -18,7 +18,6 @@
 #
 # State file: .claude/poll-state/pr-<NUMBER>.json
 #   Tracks check states, review states, comment counts, adaptive sleep, and poll history.
-#   Added to .gitignore automatically on first run.
 
 set -euo pipefail
 
@@ -44,12 +43,6 @@ done
 STATE_DIR=".claude/poll-state"
 STATE_FILE="${STATE_DIR}/pr-${PR_NUMBER}.json"
 mkdir -p "$STATE_DIR"
-
-# Ensure state dir is gitignored (idempotent)
-GITIGNORE=".gitignore"
-if [ -f "$GITIGNORE" ] && ! grep -qF ".claude/poll-state" "$GITIGNORE" 2>/dev/null; then
-  printf '\n# poll-pr state (auto-generated, do not commit)\n.claude/poll-state/\n' >> "$GITIGNORE"
-fi
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -8,6 +8,8 @@
 #   --once              Single poll; exit immediately (default: loop until done)
 #   --full              Always print full report (default: delta-only on re-polls)
 #   --max-polls N       Stop after N total polls (default: unlimited)
+#   --resolve-thread ID Resolve a CodeRabbit review thread (GraphQL node ID)
+#   --reply-thread ID MSG Reply to a CodeRabbit inline comment (comment database ID)
 #
 # Exit codes:
 #   0  All checks pass — ready to merge
@@ -29,16 +31,40 @@ REPO="quay/quay"
 ONCE=false
 FULL=false
 MAX_POLLS=0  # 0 = unlimited
+RESOLVE_THREAD=""
+REPLY_COMMENT_ID=""
+REPLY_MESSAGE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)       REPO="$2"; shift 2 ;;
     --once)       ONCE=true; shift ;;
     --full)       FULL=true; shift ;;
-    --max-polls)  MAX_POLLS="$2"; shift 2 ;;
+    --max-polls)      MAX_POLLS="$2"; shift 2 ;;
+    --resolve-thread) RESOLVE_THREAD="$2"; shift 2 ;;
+    --reply-thread)   REPLY_COMMENT_ID="$2"; REPLY_MESSAGE="$3"; shift 3 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
+
+# ── Subcommand dispatch ──────────────────────────────────────────────────────
+
+if [ -n "$RESOLVE_THREAD" ]; then
+  echo "Resolving thread ${RESOLVE_THREAD}..."
+  gh api graphql \
+    -f query="mutation{resolveReviewThread(input:{threadId:\"${RESOLVE_THREAD}\"}){thread{isResolved}}}" \
+    --jq '.data.resolveReviewThread.thread.isResolved' 2>/dev/null \
+    && echo "Thread resolved." || { echo "Failed to resolve thread." >&2; exit 1; }
+  exit 0
+fi
+
+if [ -n "$REPLY_COMMENT_ID" ]; then
+  echo "Posting reply to comment ${REPLY_COMMENT_ID}..."
+  gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/${REPLY_COMMENT_ID}/replies" \
+    -X POST -f body="${REPLY_MESSAGE}" --jq '.id' > /dev/null 2>&1 \
+    && echo "Reply posted." || { echo "Failed to post reply." >&2; exit 1; }
+  exit 0
+fi
 
 # ── State file setup ─────────────────────────────────────────────────────────
 STATE_DIR=".claude/poll-state"
@@ -91,6 +117,18 @@ adaptive_sleep() {
   fi
 }
 
+# Fetch all CodeRabbit review threads via GraphQL (includes resolved/outdated status)
+fetch_cr_threads() {
+  local owner="${REPO%%/*}" rname="${REPO##*/}"
+  gh api graphql \
+    -f query='query($owner:String!,$repo:String!,$pr:Int!){
+      repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{
+        id isResolved isOutdated
+        comments(first:3){nodes{databaseId author{login} body path line originalLine}}
+      }}}}}'  \
+    -f owner="$owner" -f repo="$rname" -F pr="$PR_NUMBER" 2>/dev/null || echo '{}'
+}
+
 # ── Core poll ────────────────────────────────────────────────────────────────
 
 do_poll() {
@@ -134,9 +172,13 @@ do_poll() {
     --jq '[.[] | select(.user.login == "coderabbitai[bot]")]' \
     2>/dev/null | jq -s 'flatten | last // {}' || echo '{}')
 
-  cr_inline_count=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' \
-    2>/dev/null | jq -s 'add // 0' || echo '0')
+  local cr_threads_json
+  cr_threads_json=$(fetch_cr_threads)
+  cr_inline_count=$(echo "$cr_threads_json" | jq \
+    '[.data.repository.pullRequest.reviewThreads.nodes[]? |
+      select(.isResolved==false and .isOutdated==false) |
+      select(.comments.nodes[0]?.author.login=="coderabbitai[bot]")] | length' \
+    2>/dev/null || echo '0')
 
   human_inline_count=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
     --jq '[.[] | select(
@@ -179,6 +221,8 @@ do_poll() {
   cr_review_commit=$(jq_str "$cr_review" '.commit_id' '')
   cr_is_current=false
   [ -n "$cr_review_commit" ] && [ "$cr_review_commit" = "$head_sha" ] && cr_is_current=true
+  # Non-outdated unresolved threads mean CR has reviewed the current commit
+  [ "$cr_inline_count" -gt 0 ] && cr_is_current=true
 
   # ── Compute deltas vs previous state ───────────────────────────────────
   local prev_checks prev_cr_state prev_cr_count prev_human
@@ -336,12 +380,14 @@ do_poll() {
     fi
     echo ""
 
-    echo "--- CodeRabbit Inline Comments on current commit: ${cr_inline_count} ---"
+    echo "--- CodeRabbit Unresolved Threads: ${cr_inline_count} ---"
     if [ "$cr_inline_count" -gt 0 ]; then
-      gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
-        --jq --arg sha "$head_sha" \
-        '[.[] | select(.user.login == "coderabbitai[bot]" and .commit_id == $sha)] | .[-3:] | .[] |
-              "  \(.path):\(.line // .original_line // \"?\")\n  \(.body | split(\"\n\") | .[0:3] | join(\"\n  \"))\n"' \
+      echo "$cr_threads_json" | jq -r \
+        '[.data.repository.pullRequest.reviewThreads.nodes[]? |
+          select(.isResolved==false and .isOutdated==false) |
+          select(.comments.nodes[0]?.author.login=="coderabbitai[bot]")][-5:] |
+        .[] |
+        "  \(.comments.nodes[0].path):\(.comments.nodes[0].line // .comments.nodes[0].originalLine // "?")\n  \(.comments.nodes[0].body | split("\n") | .[0:3] | join("\n  "))\n  Thread: \(.id)  Comment: \(.comments.nodes[0].databaseId)\n"' \
         2>/dev/null || true
     fi
     echo ""
@@ -440,8 +486,19 @@ do_poll() {
   elif [ "$human_inline_count" -gt 0 ] || ( [ "$cr_inline_count" -gt 0 ] && $cr_is_current ); then
     local _msg=""
     [ "$human_inline_count" -gt 0 ] && _msg="${human_inline_count} human comment(s)"
-    ( [ "$cr_inline_count" -gt 0 ] && $cr_is_current ) && _msg="${_msg:+$_msg, }${cr_inline_count} CodeRabbit comment(s)"
+    ( [ "$cr_inline_count" -gt 0 ] && $cr_is_current ) && _msg="${_msg:+$_msg, }${cr_inline_count} CodeRabbit thread(s)"
     printf "  ACTION REQUIRED: Address inline review comments: %s\n" "$_msg"
+    if $cr_is_current && [ "$cr_inline_count" -gt 0 ]; then
+      echo "  After fixing, resolve each thread:"
+      echo "$cr_threads_json" | jq -r \
+        --arg pr "$PR_NUMBER" \
+        '[.data.repository.pullRequest.reviewThreads.nodes[]? |
+          select(.isResolved==false and .isOutdated==false) |
+          select(.comments.nodes[0]?.author.login=="coderabbitai[bot]")] |
+        .[] |
+        "    bash .claude/scripts/poll-pr.sh \($pr) --reply-thread \(.comments.nodes[0].databaseId) \"Fixed\" && bash .claude/scripts/poll-pr.sh \($pr) --resolve-thread \(.id)"' \
+        2>/dev/null || true
+    fi
     exit_code=3
 
   elif ! $cr_is_current && [ "$cr_state" != "NONE" ] && [ "$pending" -eq 0 ]; then

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -347,12 +347,12 @@ do_poll() {
 
     echo "--- CodeRabbit Unresolved Threads: ${cr_inline_count} ---"
     if [ "$cr_inline_count" -gt 0 ]; then
-      echo "$threads_json" | jq -r \
-        '[.data.repository.pullRequest.reviewThreads.nodes[]? |
+      local _jq_cr='[.data.repository.pullRequest.reviewThreads.nodes[]? |
           select(.isResolved==false and .isOutdated==false) |
           select(.comments.nodes[0]?.author.__typename=="Bot" and (.comments.nodes[0]?.author.login | startswith("coderabbit")))][-5:] |
         .[] |
-        "  \(.comments.nodes[0].path):\(.comments.nodes[0].line // .comments.nodes[0].originalLine // "?")\n  \(.comments.nodes[0].body | split("\n") | .[0:3] | join("\n  "))\n  Thread: \(.id)  Comment: \(.comments.nodes[0].databaseId)\n"' \
+        "  \(.comments.nodes[0].path):\(.comments.nodes[0].line // .comments.nodes[0].originalLine // "?")\n  \(.comments.nodes[0].body | split("\n") | .[0:3] | join("\n  "))\n  1. Reply:   gh api repos/\($repo)/pulls/\($pr)/comments/\(.comments.nodes[0].databaseId)/replies -X POST -f body=\"...\"\n  2. Resolve: gh api graphql -f query=\"mutation{resolveReviewThread(input:{threadId:\\\"\(.id)\\\"}){thread{isResolved}}}\"\n"'
+      echo "$threads_json" | jq -r --arg repo "$REPO" --arg pr "$PR_NUMBER" "$_jq_cr" \
         2>/dev/null || true
     fi
     echo ""
@@ -386,12 +386,12 @@ do_poll() {
 
     echo "--- Human Unresolved Threads: ${human_inline_count} ---"
     if [ "$human_inline_count" -gt 0 ]; then
-      echo "$threads_json" | jq -r \
-        '[.data.repository.pullRequest.reviewThreads.nodes[]? |
+      local _jq_human='[.data.repository.pullRequest.reviewThreads.nodes[]? |
           select(.isResolved==false and .isOutdated==false) |
           select(.comments.nodes[0]?.author.__typename=="User")][-5:] |
         .[] |
-        "  \(.comments.nodes[0].author.login) on \(.comments.nodes[0].path):\(.comments.nodes[0].line // .comments.nodes[0].originalLine // "?")\n  \(.comments.nodes[0].body | split("\n") | .[0:3] | join("\n  "))\n  Thread: \(.id)\n"' \
+        "  \(.comments.nodes[0].author.login) on \(.comments.nodes[0].path):\(.comments.nodes[0].line // .comments.nodes[0].originalLine // "?")\n  \(.comments.nodes[0].body | split("\n") | .[0:3] | join("\n  "))\n  1. Reply:   gh api repos/\($repo)/pulls/\($pr)/comments/\(.comments.nodes[0].databaseId)/replies -X POST -f body=\"...\"\n  2. Resolve: gh api graphql -f query=\"mutation{resolveReviewThread(input:{threadId:\\\"\(.id)\\\"}){thread{isResolved}}}\"\n"'
+      echo "$threads_json" | jq -r --arg repo "$REPO" --arg pr "$PR_NUMBER" "$_jq_human" \
         2>/dev/null || true
     fi
     echo ""

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -22,6 +22,9 @@
 set -euo pipefail
 
 PR_NUMBER="${1:?Usage: poll-pr.sh <PR_NUMBER> [--repo OWNER/REPO] [--once] [--full] [--max-polls N]}"
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "PR_NUMBER must be a positive integer: ${PR_NUMBER}" >&2; exit 1
+fi
 shift
 
 REPO="quay/quay"
@@ -37,6 +40,7 @@ while [[ $# -gt 0 ]]; do
     --full)       FULL=true; shift ;;
     --max-polls)
       [ $# -lt 2 ] && { echo "Missing value for --max-polls" >&2; exit 1; }
+      [[ "$2" =~ ^[0-9]+$ ]] || { echo "Invalid value for --max-polls: $2" >&2; exit 1; }
       MAX_POLLS="$2"; shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
@@ -186,6 +190,9 @@ do_poll() {
   # Keep the JSON for known check-state exits; only fall back on true command failure.
   if [ "$checks_rc" -ne 0 ] && [ "$checks_rc" -ne 1 ] && [ "$checks_rc" -ne 8 ]; then
     echo "  WARN: failed to fetch PR checks (rc=${checks_rc}); treating as pending." >&2
+    checks_json='[{"name":"gh pr checks","state":"PENDING","bucket":"pending"}]'
+  elif [ -z "$checks_json" ] && [ "$checks_rc" -ne 0 ]; then
+    echo "  WARN: gh pr checks returned rc=${checks_rc} with no output; treating as pending." >&2
     checks_json='[{"name":"gh pr checks","state":"PENDING","bucket":"pending"}]'
   elif [ -z "$checks_json" ]; then
     checks_json='[]'
@@ -629,6 +636,11 @@ while true; do
   set -e
 
   if $ONCE; then
+    exit "$RC"
+  fi
+
+  if [ "$MAX_POLLS" -gt 0 ] && [ "$iter" -ge "$MAX_POLLS" ]; then
+    echo "Max polls (${MAX_POLLS}) reached. Stopping." >&2
     exit "$RC"
   fi
 

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -4,17 +4,19 @@
 # Usage: bash .claude/scripts/poll-pr.sh <PR_NUMBER> [OPTIONS]
 #
 # Options:
-#   --repo OWNER/REPO   Repository (default: quay/quay)
-#   --once              Single poll; exit immediately (default: loop until done)
-#   --full              Always print full report (default: delta-only on re-polls)
-#   --max-polls N       Stop after N total polls (default: unlimited)
+#   --repo OWNER/REPO        Repository (default: quay/quay)
+#   --once                   Single poll; exit immediately (default: loop until done)
+#   --full                   Always print full report (default: delta-only on re-polls)
+#   --max-polls N            Stop after N total polls (default: unlimited)
+#   --reviewer USER          Request USER as reviewer when exiting 4 (repeatable)
+#   --team-reviewer TEAM     Request TEAM as reviewer when exiting 4 (repeatable)
 #
 # Exit codes:
 #   0  All checks pass — ready to merge
 #   1  CI failures — fix required
 #   2  Checks still pending — re-poll later
-#   3  CodeRabbit inline comments — address required
-#   4  Awaiting human review — nothing actionable yet
+#   3  Review comments to address
+#   4  Awaiting human review — notifies reviewers and exits
 #
 # State file: .claude/poll-state/pr-<NUMBER>.json
 #   Tracks check states, review states, comment counts, adaptive sleep, and poll history.
@@ -28,13 +30,17 @@ REPO="quay/quay"
 ONCE=false
 FULL=false
 MAX_POLLS=0  # 0 = unlimited
+REVIEWERS=()
+TEAM_REVIEWERS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)       REPO="$2"; shift 2 ;;
     --once)       ONCE=true; shift ;;
     --full)       FULL=true; shift ;;
-    --max-polls)      MAX_POLLS="$2"; shift 2 ;;
+    --max-polls)         MAX_POLLS="$2"; shift 2 ;;
+    --reviewer)          REVIEWERS+=("$2"); shift 2 ;;
+    --team-reviewer)     TEAM_REVIEWERS+=("$2"); shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -84,6 +90,29 @@ adaptive_sleep() {
   fi
 }
 
+# Post a "ready for review" comment and request reviewers (idempotent via state)
+notify_for_review() {
+  local summary="$1"
+  echo "  Notifying reviewers..."
+  # Post PR comment
+  local body
+  body="## \U0001F7E2 Ready for Review\n\nCI is green and all review threads are resolved.\n\n${summary}\n\ncc $(printf '@%s ' "${REVIEWERS[@]:-}" "${TEAM_REVIEWERS[@]:-}" | sed 's/@ //g; s/ $//')"
+  gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    -X POST -f body="$body" > /dev/null 2>&1 || true
+  # Request individual reviewers
+  local reviewer_args=()
+  for r in "${REVIEWERS[@]:-}"; do
+    [ -n "$r" ] && reviewer_args+=(-f "reviewers[]=$r")
+  done
+  for t in "${TEAM_REVIEWERS[@]:-}"; do
+    [ -n "$t" ] && reviewer_args+=(-f "team_reviewers[]=$t")
+  done
+  if [ "${#reviewer_args[@]}" -gt 0 ]; then
+    gh api "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+      -X POST "${reviewer_args[@]}" > /dev/null 2>&1 || true
+  fi
+}
+
 # Fetch all CodeRabbit review threads via GraphQL (includes resolved/outdated status)
 fetch_review_threads() {
   local owner="${REPO%%/*}" rname="${REPO##*/}"
@@ -114,6 +143,8 @@ do_poll() {
   prev_sleep=$(jq_int "$prev" '.next_sleep_seconds // 120')
   prev_unchanged=$(jq_int "$prev" '.consecutive_unchanged_polls // 0')
   first_polled_at=$(jq_str "$prev" '.first_polled_at' "$now")
+  local prev_review_notified_at
+  prev_review_notified_at=$(jq_str "$prev" '.review_notified_at' '')
   $is_first && first_polled_at="$now"
 
   local poll_num=$(( prev_count + 1 ))
@@ -281,6 +312,9 @@ do_poll() {
   local next_sleep
   next_sleep=$(adaptive_sleep "$pending" "$new_unchanged" "$prev_sleep")
 
+  # review_notified_at is set inside the exit-4 branch; default to preserving prev value
+  local review_notified_at="${prev_review_notified_at:-}"
+
   # ── Persist state ───────────────────────────────────────────────────────
   jq -n \
     --argjson pr      "$PR_NUMBER" \
@@ -294,6 +328,7 @@ do_poll() {
     --argjson human          "$human_reviews_json" \
     --argjson human_inline   "$human_inline_count" \
     --arg     head_sha        "$head_sha" \
+    --arg     review_notified "$review_notified_at" \
     --argjson unchanged "$new_unchanged" \
     --argjson sleep     "$next_sleep" \
     '{
@@ -309,7 +344,8 @@ do_poll() {
       human_reviews:               $human,
       human_inline_count:          $human_inline,
       consecutive_unchanged_polls: $unchanged,
-      next_sleep_seconds:          $sleep
+      next_sleep_seconds:          $sleep,
+      review_notified_at:          $review_notified
     }' > "$STATE_FILE"
 
   # ── Header ──────────────────────────────────────────────────────────────
@@ -474,6 +510,15 @@ do_poll() {
 
   elif [ "$hr_count" -eq 0 ] || [ "$hr_approved" -eq 0 ]; then
     echo "  WAITING: Awaiting human review approval"
+    if [ -z "$prev_review_notified_at" ] && ( [ "${#REVIEWERS[@]}" -gt 0 ] || [ "${#TEAM_REVIEWERS[@]}" -gt 0 ] ); then
+      local ci_summary
+      ci_summary=$(printf "CI: %s/%s passed | CodeRabbit: %s | Unresolved threads: CR=%s Human=%s" \
+        "$pass" "$total" "$cr_state" "$cr_inline_count" "$human_inline_count")
+      notify_for_review "$ci_summary"
+      review_notified_at="$now"
+    else
+      review_notified_at="${prev_review_notified_at:-}"
+    fi
     exit_code=4
 
   else
@@ -520,13 +565,17 @@ while true; do
       echo "CodeRabbit comments require attention — address and re-run: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
       exit 3
       ;;
-    2|4)
-      # Still pending (2) or awaiting human review (4) — keep polling
+    2)
+      # CI/checks still pending — keep polling
       SLEEP_SECS=$(jq -r '.next_sleep_seconds // 120' "$STATE_FILE" 2>/dev/null || echo 120)
-      # Floor: exit 4 (no pending checks, just waiting on humans) must not spin at 0s
-      [ "$SLEEP_SECS" -le 0 ] && SLEEP_SECS=300
+      [ "$SLEEP_SECS" -le 0 ] && SLEEP_SECS=120
       printf "\nSleeping %ss (adaptive backoff)... Ctrl+C to stop.\n\n" "$SLEEP_SECS"
       sleep "$SLEEP_SECS"
+      ;;
+    4)
+      # Awaiting human review — reviewers notified, exit cleanly
+      echo "Reviewers notified. Re-run to check for approval: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
+      exit 4
       ;;
     *)
       echo "Unexpected exit code ${RC}. Stopping." >&2

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -271,11 +271,17 @@ do_poll() {
   [ -n "$cr_review_commit" ] && [ "$cr_review_commit" = "$head_sha" ] && cr_is_current=true
 
   # ── Compute deltas vs previous state ───────────────────────────────────
-  local prev_checks prev_cr_state prev_cr_count prev_human
+  local prev_checks prev_cr_state prev_cr_count prev_human prev_human_inline
   prev_checks=$(echo "$prev" | jq '.checks // {}' 2>/dev/null || echo '{}')
   prev_cr_state=$(jq_str "$prev" '.coderabbit_review_state' 'NONE')
   prev_cr_count=$(jq_int "$prev" '.coderabbit_inline_count // 0')
   prev_human=$(echo "$prev" | jq '.human_reviews // {}' 2>/dev/null || echo '{}')
+  prev_human_inline=$(jq_int "$prev" '.human_inline_count // 0')
+  # On thread-fetch failure, preserve previous counts to avoid false deltas
+  if ! $threads_ok; then
+    cr_inline_count="$prev_cr_count"
+    human_inline_count="$prev_human_inline"
+  fi
 
   local has_changes=false
   local -a delta_lines=()
@@ -322,8 +328,7 @@ do_poll() {
   fi
 
   # Human inline comment count change
-  local prev_human_inline human_inline_delta
-  prev_human_inline=$(jq_int "$prev" '.human_inline_count // 0')
+  local human_inline_delta
   human_inline_delta=$(( human_inline_count - prev_human_inline ))
   if [ "$human_inline_delta" -gt 0 ]; then
     has_changes=true
@@ -539,10 +544,11 @@ do_poll() {
   echo "  SUMMARY"
   echo "============================================================"
 
-  local hr_count hr_approved
+  local hr_count hr_approved review_decision
   hr_count=$(echo "$human_reviews_json" | jq 'length')
   hr_approved=$(echo "$human_reviews_json" | \
     jq '[to_entries[] | select(.value == "APPROVED")] | length')
+  review_decision=$(jq_str "$pr_meta" '.review_decision' '')
 
   printf "  CI:         %s/%s passed, %s failed, %s pending\n" \
     "$pass" "$total" "$fail" "$pending"
@@ -576,7 +582,8 @@ do_poll() {
        "  \(.login): \(.body | split("\n") | .[0:2] | join(" "))"' 2>/dev/null || true
     exit_code=3
 
-  elif [ "$hr_count" -gt 0 ] && [ "$(echo "$human_reviews_json" | jq '[to_entries[] | select(.value == "CHANGES_REQUESTED")] | length')" -gt 0 ]; then
+  elif [ "$review_decision" = "REVIEW_CHANGES_REQUESTED" ] || \
+       { [ "$hr_count" -gt 0 ] && [ "$(echo "$human_reviews_json" | jq '[to_entries[] | select(.value == "CHANGES_REQUESTED")] | length')" -gt 0 ]; }; then
     echo "  ACTION REQUIRED: Reviewer(s) requested changes"
     echo "$human_reviews_json" | jq -r 'to_entries[] | select(.value == "CHANGES_REQUESTED") | "    - \(.key)"' 2>/dev/null || true
     exit_code=3
@@ -598,7 +605,7 @@ do_poll() {
     echo "  WAITING: review-thread fetch failed — will retry next poll"
     exit_code=2
 
-  elif [ "$hr_count" -eq 0 ] || [ "$hr_approved" -eq 0 ]; then
+  elif [ "$review_decision" != "REVIEW_APPROVED" ] && { [ "$hr_count" -eq 0 ] || [ "$hr_approved" -eq 0 ]; }; then
     echo "  WAITING: Awaiting human review approval"
     if [ -z "$prev_review_notified_at" ]; then
       local ci_summary

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -35,6 +35,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)
       [ $# -lt 2 ] && { echo "Missing value for --repo" >&2; exit 1; }
+      [[ "$2" == -* ]] && { echo "Invalid value for --repo: $2" >&2; exit 1; }
       REPO="$2"; shift 2 ;;
     --once)       ONCE=true; shift ;;
     --full)       FULL=true; shift ;;

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -8,8 +8,6 @@
 #   --once              Single poll; exit immediately (default: loop until done)
 #   --full              Always print full report (default: delta-only on re-polls)
 #   --max-polls N       Stop after N total polls (default: unlimited)
-#   --resolve-thread ID Resolve a CodeRabbit review thread (GraphQL node ID)
-#   --reply-thread ID MSG Reply to a CodeRabbit inline comment (comment database ID)
 #
 # Exit codes:
 #   0  All checks pass — ready to merge
@@ -31,9 +29,6 @@ REPO="quay/quay"
 ONCE=false
 FULL=false
 MAX_POLLS=0  # 0 = unlimited
-RESOLVE_THREAD=""
-REPLY_COMMENT_ID=""
-REPLY_MESSAGE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -41,30 +36,9 @@ while [[ $# -gt 0 ]]; do
     --once)       ONCE=true; shift ;;
     --full)       FULL=true; shift ;;
     --max-polls)      MAX_POLLS="$2"; shift 2 ;;
-    --resolve-thread) RESOLVE_THREAD="$2"; shift 2 ;;
-    --reply-thread)   REPLY_COMMENT_ID="$2"; REPLY_MESSAGE="$3"; shift 3 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
-
-# ── Subcommand dispatch ──────────────────────────────────────────────────────
-
-if [ -n "$RESOLVE_THREAD" ]; then
-  echo "Resolving thread ${RESOLVE_THREAD}..."
-  gh api graphql \
-    -f query="mutation{resolveReviewThread(input:{threadId:\"${RESOLVE_THREAD}\"}){thread{isResolved}}}" \
-    --jq '.data.resolveReviewThread.thread.isResolved' 2>/dev/null \
-    && echo "Thread resolved." || { echo "Failed to resolve thread." >&2; exit 1; }
-  exit 0
-fi
-
-if [ -n "$REPLY_COMMENT_ID" ]; then
-  echo "Posting reply to comment ${REPLY_COMMENT_ID}..."
-  gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/${REPLY_COMMENT_ID}/replies" \
-    -X POST -f body="${REPLY_MESSAGE}" --jq '.id' > /dev/null 2>&1 \
-    && echo "Reply posted." || { echo "Failed to post reply." >&2; exit 1; }
-  exit 0
-fi
 
 # ── State file setup ─────────────────────────────────────────────────────────
 STATE_DIR=".claude/poll-state"
@@ -118,7 +92,7 @@ adaptive_sleep() {
 }
 
 # Fetch all CodeRabbit review threads via GraphQL (includes resolved/outdated status)
-fetch_cr_threads() {
+fetch_review_threads() {
   local owner="${REPO%%/*}" rname="${REPO##*/}"
   gh api graphql \
     -f query='query($owner:String!,$repo:String!,$pr:Int!){
@@ -172,21 +146,22 @@ do_poll() {
     --jq '[.[] | select(.user.login == "coderabbitai[bot]")]' \
     2>/dev/null | jq -s 'flatten | last // {}' || echo '{}')
 
-  local cr_threads_json
-  cr_threads_json=$(fetch_cr_threads)
-  cr_inline_count=$(echo "$cr_threads_json" | jq \
+  local threads_json
+  threads_json=$(fetch_review_threads)
+  cr_inline_count=$(echo "$threads_json" | jq \
     '[.data.repository.pullRequest.reviewThreads.nodes[]? |
       select(.isResolved==false and .isOutdated==false) |
       select(.comments.nodes[0]?.author.login=="coderabbitai[bot]")] | length' \
     2>/dev/null || echo '0')
 
-  human_inline_count=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(
-            .user.login != "coderabbitai[bot]" and
-            (.user.login | endswith("[bot]") | not) and
-            .user.login != "openshift-ci-robot"
-          )] | length' \
-    2>/dev/null | jq -s 'add // 0' || echo '0')
+  human_inline_count=$(echo "$threads_json" | jq \
+    '[.data.repository.pullRequest.reviewThreads.nodes[]? |
+      select(.isResolved==false and .isOutdated==false) |
+      select(
+        (.comments.nodes[0]?.author.login | (endswith("[bot]") | not)) and
+        .comments.nodes[0]?.author.login != "openshift-ci-robot"
+      )] | length' \
+    2>/dev/null || echo '0')
 
   walkthrough_body=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
     --jq '[.[] | select(.user.login == "coderabbitai[bot]")]' \
@@ -270,10 +245,10 @@ do_poll() {
   local cr_delta=$(( cr_inline_count - prev_cr_count ))
   if [ "$cr_delta" -gt 0 ]; then
     has_changes=true
-    delta_lines+=("  CodeRabbit: +${cr_delta} new inline comment(s) (total: ${cr_inline_count})")
+    delta_lines+=("  CodeRabbit: +${cr_delta} new unresolved thread(s) (total: ${cr_inline_count})")
   elif [ "$cr_delta" -lt 0 ]; then
     has_changes=true
-    delta_lines+=("  CodeRabbit: ${cr_delta} comment(s) resolved (total: ${cr_inline_count})")
+    delta_lines+=("  CodeRabbit: ${cr_delta} thread(s) resolved (total: ${cr_inline_count})")
   fi
 
   # Human inline comment count change
@@ -282,10 +257,10 @@ do_poll() {
   human_inline_delta=$(( human_inline_count - prev_human_inline ))
   if [ "$human_inline_delta" -gt 0 ]; then
     has_changes=true
-    delta_lines+=("  Human: +${human_inline_delta} new inline comment(s) (total: ${human_inline_count})")
+    delta_lines+=("  Human: +${human_inline_delta} new unresolved thread(s) (total: ${human_inline_count})")
   elif [ "$human_inline_delta" -lt 0 ]; then
     has_changes=true
-    delta_lines+=("  Human: ${human_inline_delta} inline comment(s) resolved (total: ${human_inline_count})")
+    delta_lines+=("  Human: ${human_inline_delta} thread(s) resolved (total: ${human_inline_count})")
   fi
 
   # Human review changes
@@ -382,7 +357,7 @@ do_poll() {
 
     echo "--- CodeRabbit Unresolved Threads: ${cr_inline_count} ---"
     if [ "$cr_inline_count" -gt 0 ]; then
-      echo "$cr_threads_json" | jq -r \
+      echo "$threads_json" | jq -r \
         '[.data.repository.pullRequest.reviewThreads.nodes[]? |
           select(.isResolved==false and .isOutdated==false) |
           select(.comments.nodes[0]?.author.login=="coderabbitai[bot]")][-5:] |
@@ -419,15 +394,17 @@ do_poll() {
     fi
     echo ""
 
-    echo "--- Human Inline Comments: ${human_inline_count} ---"
+    echo "--- Human Unresolved Threads: ${human_inline_count} ---"
     if [ "$human_inline_count" -gt 0 ]; then
-      gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
-        --jq '[.[] | select(
-                .user.login != "coderabbitai[bot]" and
-                (.user.login | endswith("[bot]") | not) and
-                .user.login != "openshift-ci-robot"
-              )] | .[-5:] | .[] |
-              "  \(.user.login) on \(.path):\(.line // .original_line // "?")\n  \(.body | split("\n") | .[0:3] | join("\n  "))\n"' \
+      echo "$threads_json" | jq -r \
+        '[.data.repository.pullRequest.reviewThreads.nodes[]? |
+          select(.isResolved==false and .isOutdated==false) |
+          select(
+            (.comments.nodes[0]?.author.login | (endswith("[bot]") | not)) and
+            .comments.nodes[0]?.author.login != "openshift-ci-robot"
+          )][-5:] |
+        .[] |
+        "  \(.comments.nodes[0].author.login) on \(.comments.nodes[0].path):\(.comments.nodes[0].line // .comments.nodes[0].originalLine // "?")\n  \(.comments.nodes[0].body | split("\n") | .[0:3] | join("\n  "))\n  Thread: \(.id)\n"' \
         2>/dev/null || true
     fi
     echo ""
@@ -470,7 +447,7 @@ do_poll() {
   local _cr_label="$cr_state"
   ! $cr_is_current && [ "$cr_state" != "NONE" ] && _cr_label="${cr_state} (pending re-review)"
   printf "  CodeRabbit: %-36s inline: %s\n" "$_cr_label" "$cr_inline_count"
-  printf "  Human:      %s/%s approved  |  inline comments: %s\n" "$hr_approved" "$hr_count" "$human_inline_count"
+  printf "  Human:      %s/%s approved  |  unresolved threads: %s\n" "$hr_approved" "$hr_count" "$human_inline_count"
   echo ""
 
   # Determine exit code and action message
@@ -485,20 +462,9 @@ do_poll() {
 
   elif [ "$human_inline_count" -gt 0 ] || ( [ "$cr_inline_count" -gt 0 ] && $cr_is_current ); then
     local _msg=""
-    [ "$human_inline_count" -gt 0 ] && _msg="${human_inline_count} human comment(s)"
+    [ "$human_inline_count" -gt 0 ] && _msg="${human_inline_count} human thread(s)"
     ( [ "$cr_inline_count" -gt 0 ] && $cr_is_current ) && _msg="${_msg:+$_msg, }${cr_inline_count} CodeRabbit thread(s)"
     printf "  ACTION REQUIRED: Address inline review comments: %s\n" "$_msg"
-    if $cr_is_current && [ "$cr_inline_count" -gt 0 ]; then
-      echo "  After fixing, resolve each thread:"
-      echo "$cr_threads_json" | jq -r \
-        --arg pr "$PR_NUMBER" \
-        '[.data.repository.pullRequest.reviewThreads.nodes[]? |
-          select(.isResolved==false and .isOutdated==false) |
-          select(.comments.nodes[0]?.author.login=="coderabbitai[bot]")] |
-        .[] |
-        "    bash .claude/scripts/poll-pr.sh \($pr) --reply-thread \(.comments.nodes[0].databaseId) \"Fixed\" && bash .claude/scripts/poll-pr.sh \($pr) --resolve-thread \(.id)"' \
-        2>/dev/null || true
-    fi
     exit_code=3
 
   elif ! $cr_is_current && [ "$cr_state" != "NONE" ] && [ "$pending" -eq 0 ]; then

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -541,6 +541,9 @@ do_poll() {
         "$pass" "$total" "$cr_state" "$cr_inline_count" "$human_inline_count")
       notify_for_review "$ci_summary"
       review_notified_at="$now"
+      # Persist immediately so subsequent polls skip the notify guard
+      local _tmp
+      _tmp=$(mktemp) && jq --arg v "$review_notified_at" '.review_notified_at = $v'         "$STATE_FILE" > "$_tmp" && mv "$_tmp" "$STATE_FILE"
     else
       review_notified_at="${prev_review_notified_at:-}"
     fi

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -107,7 +107,7 @@ do_poll() {
   local poll_num=$(( prev_count + 1 ))
 
   # ── Fetch from GitHub ───────────────────────────────────────────────────
-  local pr_meta checks_json cr_review cr_inline_count walkthrough_body codecov_body human_reviews_json jira_body
+  local pr_meta checks_json cr_review cr_inline_count human_inline_count walkthrough_body codecov_body human_reviews_json jira_body
 
   local head_sha
   head_sha=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
@@ -129,6 +129,14 @@ do_poll() {
 
   cr_inline_count=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
     --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' \
+    2>/dev/null || echo '0')
+
+  human_inline_count=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(
+            .user.login != "coderabbitai[bot]" and
+            (.user.login | endswith("[bot]") | not) and
+            .user.login != "openshift-ci-robot"
+          )] | length' \
     2>/dev/null || echo '0')
 
   walkthrough_body=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
@@ -216,6 +224,18 @@ do_poll() {
     delta_lines+=("  CodeRabbit: ${cr_delta} comment(s) resolved (total: ${cr_inline_count})")
   fi
 
+  # Human inline comment count change
+  local prev_human_inline human_inline_delta
+  prev_human_inline=$(jq_int "$prev" '.human_inline_count // 0')
+  human_inline_delta=$(( human_inline_count - prev_human_inline ))
+  if [ "$human_inline_delta" -gt 0 ]; then
+    has_changes=true
+    delta_lines+=("  Human: +${human_inline_delta} new inline comment(s) (total: ${human_inline_count})")
+  elif [ "$human_inline_delta" -lt 0 ]; then
+    has_changes=true
+    delta_lines+=("  Human: ${human_inline_delta} inline comment(s) resolved (total: ${human_inline_count})")
+  fi
+
   # Human review changes
   local human_names_raw
   human_names_raw=$(echo "$human_reviews_json" | jq -r 'keys[]' 2>/dev/null || true)
@@ -254,8 +274,9 @@ do_poll() {
     --arg     cr_state "$cr_state" \
     --arg     cr_at    "$cr_at" \
     --argjson cr_count "$cr_inline_count" \
-    --argjson human    "$human_reviews_json" \
-    --arg     head_sha  "$head_sha" \
+    --argjson human          "$human_reviews_json" \
+    --argjson human_inline   "$human_inline_count" \
+    --arg     head_sha        "$head_sha" \
     --argjson unchanged "$new_unchanged" \
     --argjson sleep     "$next_sleep" \
     '{
@@ -269,6 +290,7 @@ do_poll() {
       coderabbit_review_at:        $cr_at,
       coderabbit_inline_count:     $cr_count,
       human_reviews:               $human,
+      human_inline_count:          $human_inline,
       consecutive_unchanged_polls: $unchanged,
       next_sleep_seconds:          $sleep
     }' > "$STATE_FILE"
@@ -339,6 +361,19 @@ do_poll() {
     fi
     echo ""
 
+    echo "--- Human Inline Comments: ${human_inline_count} ---"
+    if [ "$human_inline_count" -gt 0 ]; then
+      gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+        --jq '[.[] | select(
+                .user.login != "coderabbitai[bot]" and
+                (.user.login | endswith("[bot]") | not) and
+                .user.login != "openshift-ci-robot"
+              )] | .[-5:] | .[] |
+              "  \(.user.login) on \(.path):\(.line // .original_line // "?")\n  \(.body | split("\n") | .[0:3] | join("\n  "))\n"' \
+        2>/dev/null || true
+    fi
+    echo ""
+
     echo "--- JIRA Bot ---"
     if [ -n "$jira_body" ] && [ "$jira_body" != "null" ]; then
       echo "$jira_body" | head -10
@@ -375,7 +410,7 @@ do_poll() {
   printf "  CI:         %s/%s passed, %s failed, %s pending\n" \
     "$pass" "$total" "$fail" "$pending"
   printf "  CodeRabbit: %-26s inline comments: %s\n" "$cr_state" "$cr_inline_count"
-  printf "  Human:      %s/%s approved\n" "$hr_approved" "$hr_count"
+  printf "  Human:      %s/%s approved  |  inline comments: %s\n" "$hr_approved" "$hr_count" "$human_inline_count"
   echo ""
 
   # Determine exit code and action message
@@ -388,8 +423,13 @@ do_poll() {
       2>/dev/null || true
     exit_code=1
 
-  elif [ "$cr_inline_count" -gt 0 ]; then
-    printf "  ACTION REQUIRED: Address %s CodeRabbit inline comment(s)\n" "$cr_inline_count"
+  elif [ "$human_inline_count" -gt 0 ] || [ "$cr_inline_count" -gt 0 ]; then
+    local _action_parts=()
+    [ "$human_inline_count" -gt 0 ] && _action_parts+=("${human_inline_count} human comment(s)")
+    [ "$cr_inline_count" -gt 0 ]    && _action_parts+=("${cr_inline_count} CodeRabbit comment(s)")
+    local IFS=", "
+    printf "  ACTION REQUIRED: Address inline review comments: %s\n" "${_action_parts[*]}"
+    unset IFS
     exit_code=3
 
   elif [ "$pending" -gt 0 ]; then
@@ -400,6 +440,11 @@ do_poll() {
       echo ""
     fi
     exit_code=2
+
+  elif [ "$hr_count" -gt 0 ] &&        [ "$(echo "$human_reviews_json" | jq '[to_entries[] | select(.value == "CHANGES_REQUESTED")] | length')" -gt 0 ]; then
+    echo "  ACTION REQUIRED: Reviewer(s) requested changes"
+    echo "$human_reviews_json" | jq -r 'to_entries[] | select(.value == "CHANGES_REQUESTED") | "    - \(.key)"' 2>/dev/null || true
+    exit_code=3
 
   elif [ "$hr_count" -eq 0 ] || [ "$hr_approved" -eq 0 ]; then
     echo "  WAITING: Awaiting human review approval"

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -429,12 +429,10 @@ do_poll() {
     exit_code=1
 
   elif [ "$human_inline_count" -gt 0 ] || [ "$cr_inline_count" -gt 0 ]; then
-    local _action_parts=()
-    [ "$human_inline_count" -gt 0 ] && _action_parts+=("${human_inline_count} human comment(s)")
-    [ "$cr_inline_count" -gt 0 ]    && _action_parts+=("${cr_inline_count} CodeRabbit comment(s)")
-    local IFS=", "
-    printf "  ACTION REQUIRED: Address inline review comments: %s\n" "${_action_parts[*]}"
-    unset IFS
+    local _msg=""
+    [ "$human_inline_count" -gt 0 ] && _msg="${human_inline_count} human comment(s)"
+    [ "$cr_inline_count" -gt 0 ]    && _msg="${_msg:+$_msg, }${cr_inline_count} CodeRabbit comment(s)"
+    printf "  ACTION REQUIRED: Address inline review comments: %s\n" "$_msg"
     exit_code=3
 
   elif [ "$pending" -gt 0 ]; then

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -1,191 +1,442 @@
 #!/bin/bash
-# poll-pr.sh -- Poll a PR for CodeRabbit feedback, GitHub Actions results,
-#               Codecov reports, and human review status.
+# poll-pr.sh -- Stateful PR poller: GitHub Actions CI, CodeRabbit, Codecov, human reviews.
 #
-# Usage: bash scripts/poll-pr.sh <PR_NUMBER> [--repo owner/repo] [--wait]
+# Usage: bash .claude/scripts/poll-pr.sh <PR_NUMBER> [OPTIONS]
 #
 # Options:
-#   --repo    Override repository (default: quay/quay)
-#   --wait    Keep polling every 60s until all checks pass or fail
+#   --repo OWNER/REPO   Repository (default: quay/quay)
+#   --once              Single poll; exit immediately (default: loop until done)
+#   --full              Always print full report (default: delta-only on re-polls)
+#   --max-polls N       Stop after N total polls (default: unlimited)
 #
-# Outputs a structured report of PR status for the agent to act on.
+# Exit codes:
+#   0  All checks pass — ready to merge
+#   1  CI failures — fix required
+#   2  Checks still pending — re-poll later
+#   3  CodeRabbit inline comments — address required
+#   4  Awaiting human review — nothing actionable yet
+#
+# State file: .claude/poll-state/pr-<NUMBER>.json
+#   Tracks check states, review states, comment counts, adaptive sleep, and poll history.
+#   Added to .gitignore automatically on first run.
 
 set -euo pipefail
 
-PR_NUMBER="${1:?Usage: poll-pr.sh <PR_NUMBER> [--repo owner/repo] [--wait]}"
+PR_NUMBER="${1:?Usage: poll-pr.sh <PR_NUMBER> [--repo OWNER/REPO] [--once] [--full] [--max-polls N]}"
 shift
 
 REPO="quay/quay"
-WAIT=false
+ONCE=false
+FULL=false
+MAX_POLLS=0  # 0 = unlimited
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --repo) REPO="$2"; shift 2 ;;
-    --wait) WAIT=true; shift ;;
+    --repo)       REPO="$2"; shift 2 ;;
+    --once)       ONCE=true; shift ;;
+    --full)       FULL=true; shift ;;
+    --max-polls)  MAX_POLLS="$2"; shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
 
-poll_once() {
-  echo "============================================================"
-  echo "  PR #${PR_NUMBER} Status Report  ($(date '+%Y-%m-%d %H:%M:%S'))"
-  echo "============================================================"
-  echo ""
+# ── State file setup ─────────────────────────────────────────────────────────
+STATE_DIR=".claude/poll-state"
+STATE_FILE="${STATE_DIR}/pr-${PR_NUMBER}.json"
+mkdir -p "$STATE_DIR"
 
-  # ── 1. PR metadata ──────────────────────────────────────────────
-  echo "--- PR Details ---"
-  gh pr view "$PR_NUMBER" --repo "$REPO" \
+# Ensure state dir is gitignored (idempotent)
+GITIGNORE=".gitignore"
+if [ -f "$GITIGNORE" ] && ! grep -qF ".claude/poll-state" "$GITIGNORE" 2>/dev/null; then
+  printf '\n# poll-pr state (auto-generated, do not commit)\n.claude/poll-state/\n' >> "$GITIGNORE"
+fi
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+load_state() {
+  if [ -f "$STATE_FILE" ]; then cat "$STATE_FILE"; else echo '{}'; fi
+}
+
+# Safe jq string read with fallback
+jq_str() { echo "$1" | jq -r "${2}" 2>/dev/null || echo "${3:-}"; }
+
+# Safe jq numeric read with fallback
+jq_int() { echo "$1" | jq "${2}" 2>/dev/null || echo "${3:-0}"; }
+
+# Compute adaptive sleep based on pending checks and stability of state
+adaptive_sleep() {
+  local pending="$1" unchanged="$2" prev_sleep="$3"
+  if [ "$pending" -eq 0 ]; then
+    echo 0       # Nothing pending — don't sleep, something is actionable
+  elif [ "$unchanged" -ge 2 ]; then
+    local next=$(( prev_sleep * 2 ))
+    [ "$next" -gt 600 ] && next=600
+    echo "$next" # Backing off: nothing changed across multiple polls
+  elif [ "$pending" -gt 3 ]; then
+    echo 180     # Many checks pending — jobs likely just queued
+  else
+    echo 120     # A few checks pending — jobs running
+  fi
+}
+
+# ── Core poll ────────────────────────────────────────────────────────────────
+
+do_poll() {
+  local now now_display
+  now=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  now_display=$(date '+%Y-%m-%d %H:%M:%S')
+
+  local prev
+  prev=$(load_state)
+
+  local is_first=false
+  [ "$prev" = '{}' ] && is_first=true
+
+  local prev_count prev_sleep prev_unchanged first_polled_at
+  prev_count=$(jq_int "$prev" '.poll_count // 0')
+  prev_sleep=$(jq_int "$prev" '.next_sleep_seconds // 120')
+  prev_unchanged=$(jq_int "$prev" '.consecutive_unchanged_polls // 0')
+  first_polled_at=$(jq_str "$prev" '.first_polled_at' "$now")
+  $is_first && first_polled_at="$now"
+
+  local poll_num=$(( prev_count + 1 ))
+
+  # ── Fetch from GitHub ───────────────────────────────────────────────────
+  local pr_meta checks_json cr_review cr_inline_count walkthrough_body codecov_body human_reviews_json jira_body
+
+  pr_meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
     --json title,state,isDraft,mergeable,labels,reviewDecision \
-    --jq '{
-      title: .title,
-      state: .state,
-      draft: .isDraft,
-      mergeable: .mergeable,
-      review_decision: .reviewDecision,
-      labels: [.labels[].name] | join(", ")
-    }' 2>/dev/null || echo "(could not fetch PR metadata)"
-  echo ""
+    --jq '{title,state,draft:.isDraft,mergeable,
+           review_decision:.reviewDecision,
+           labels:([.labels[].name]|join(","))}' \
+    2>/dev/null || echo '{}')
 
-  # ── 2. GitHub Actions / Check Runs ──────────────────────────────
-  echo "--- CI Check Runs ---"
-  gh pr checks "$PR_NUMBER" --repo "$REPO" 2>/dev/null || echo "(no checks found)"
-  echo ""
+  checks_json=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state \
+    2>/dev/null || echo '[]')
 
-  # ── 3. CodeRabbit Review ────────────────────────────────────────
-  echo "--- CodeRabbit Review ---"
-  CODERABBIT_REVIEW=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-    --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | last' 2>/dev/null || echo "")
+  cr_review=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+    --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | last // {}' \
+    2>/dev/null || echo '{}')
 
-  if [ -n "$CODERABBIT_REVIEW" ] && [ "$CODERABBIT_REVIEW" != "null" ]; then
-    echo "$CODERABBIT_REVIEW" | jq -r '{
-      state: .state,
-      submitted_at: .submitted_at,
-      body_preview: (.body | split("\n") | .[0:5] | join("\n"))
-    }' 2>/dev/null || echo "(could not parse CodeRabbit review)"
-  else
-    echo "(no CodeRabbit review yet)"
+  cr_inline_count=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' \
+    2>/dev/null || echo '0')
+
+  walkthrough_body=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | last | .body // ""' \
+    2>/dev/null || echo '')
+
+  codecov_body=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(.user.login == "codecov[bot]")] | last | .body // ""' \
+    2>/dev/null || echo '')
+
+  human_reviews_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+    --jq '[.[] | select(.user.login != "coderabbitai[bot]" and .user.login != "github-actions[bot]")]
+          | map({(.user.login): .state}) | add // {}' \
+    2>/dev/null || echo '{}')
+
+  jira_body=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(.user.login == "openshift-ci[bot]" or .user.login == "openshift-ci-robot")]
+          | last | .body // ""' \
+    2>/dev/null || echo '')
+
+  # ── Compute check summary ───────────────────────────────────────────────
+  local total pass fail pending
+  total=$(jq_int "$checks_json" 'length')
+  pass=$(jq_int "$checks_json" '[.[] | select(.state == "SUCCESS")] | length')
+  fail=$(jq_int "$checks_json" '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
+  pending=$(jq_int "$checks_json" \
+    '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS" or .state == "WAITING")] | length')
+
+  local checks_map
+  checks_map=$(echo "$checks_json" | jq '[.[] | {(.name): .state}] | add // {}' 2>/dev/null || echo '{}')
+
+  local cr_state cr_at
+  cr_state=$(jq_str "$cr_review" '.state' 'NONE')
+  cr_at=$(jq_str "$cr_review" '.submitted_at' '')
+
+  # ── Compute deltas vs previous state ───────────────────────────────────
+  local prev_checks prev_cr_state prev_cr_count prev_human
+  prev_checks=$(echo "$prev" | jq '.checks // {}' 2>/dev/null || echo '{}')
+  prev_cr_state=$(jq_str "$prev" '.coderabbit_review_state' 'NONE')
+  prev_cr_count=$(jq_int "$prev" '.coderabbit_inline_count // 0')
+  prev_human=$(echo "$prev" | jq '.human_reviews // {}' 2>/dev/null || echo '{}')
+
+  local has_changes=false
+  local -a delta_lines=()
+
+  # CI check state changes
+  local check_names_raw
+  check_names_raw=$(echo "$checks_map" | jq -r 'keys[]' 2>/dev/null || true)
+  if [ -n "$check_names_raw" ]; then
+    while IFS= read -r name; do
+      [ -z "$name" ] && continue
+      local cur_s prev_s
+      cur_s=$(echo "$checks_map" | jq -r --arg n "$name" '.[$n] // "UNKNOWN"')
+      prev_s=$(echo "$prev_checks" | jq -r --arg n "$name" '.[$n] // "NEW"')
+      if [ "$cur_s" != "$prev_s" ]; then
+        has_changes=true
+        delta_lines+=("  CI: ${name}: ${prev_s} -> ${cur_s}")
+      fi
+    done <<< "$check_names_raw"
   fi
+
+  # CodeRabbit review state change
+  if [ "$cr_state" != "$prev_cr_state" ]; then
+    has_changes=true
+    delta_lines+=("  CodeRabbit review: ${prev_cr_state} -> ${cr_state}")
+  fi
+
+  # CodeRabbit inline comment count change
+  local cr_delta=$(( cr_inline_count - prev_cr_count ))
+  if [ "$cr_delta" -gt 0 ]; then
+    has_changes=true
+    delta_lines+=("  CodeRabbit: +${cr_delta} new inline comment(s) (total: ${cr_inline_count})")
+  elif [ "$cr_delta" -lt 0 ]; then
+    has_changes=true
+    delta_lines+=("  CodeRabbit: ${cr_delta} comment(s) resolved (total: ${cr_inline_count})")
+  fi
+
+  # Human review changes
+  local human_names_raw
+  human_names_raw=$(echo "$human_reviews_json" | jq -r 'keys[]' 2>/dev/null || true)
+  if [ -n "$human_names_raw" ]; then
+    while IFS= read -r reviewer; do
+      [ -z "$reviewer" ] && continue
+      local cur_hr prev_hr
+      cur_hr=$(echo "$human_reviews_json" | jq -r --arg r "$reviewer" '.[$r]')
+      prev_hr=$(echo "$prev_human" | jq -r --arg r "$reviewer" '.[$r] // "NONE"')
+      if [ "$cur_hr" != "$prev_hr" ]; then
+        has_changes=true
+        delta_lines+=("  Review: ${reviewer}: ${prev_hr} -> ${cur_hr}")
+      fi
+    done <<< "$human_names_raw"
+  fi
+
+  # Consecutive unchanged poll counter
+  local new_unchanged
+  if $has_changes || $is_first; then
+    new_unchanged=0
+  else
+    new_unchanged=$(( prev_unchanged + 1 ))
+  fi
+
+  # Next adaptive sleep
+  local next_sleep
+  next_sleep=$(adaptive_sleep "$pending" "$new_unchanged" "$prev_sleep")
+
+  # ── Persist state ───────────────────────────────────────────────────────
+  jq -n \
+    --argjson pr      "$PR_NUMBER" \
+    --arg     first   "$first_polled_at" \
+    --arg     last    "$now" \
+    --argjson count   "$poll_num" \
+    --argjson checks  "$checks_map" \
+    --arg     cr_state "$cr_state" \
+    --arg     cr_at    "$cr_at" \
+    --argjson cr_count "$cr_inline_count" \
+    --argjson human    "$human_reviews_json" \
+    --argjson unchanged "$new_unchanged" \
+    --argjson sleep     "$next_sleep" \
+    '{
+      pr_number:                   $pr,
+      first_polled_at:             $first,
+      last_polled_at:              $last,
+      poll_count:                  $count,
+      checks:                      $checks,
+      coderabbit_review_state:     $cr_state,
+      coderabbit_review_at:        $cr_at,
+      coderabbit_inline_count:     $cr_count,
+      human_reviews:               $human,
+      consecutive_unchanged_polls: $unchanged,
+      next_sleep_seconds:          $sleep
+    }' > "$STATE_FILE"
+
+  # ── Header ──────────────────────────────────────────────────────────────
+  echo "============================================================"
+  printf "  PR #%s  Poll #%s  (%s)\n" "$PR_NUMBER" "$poll_num" "$now_display"
+  if ! $is_first; then
+    local last_ts
+    last_ts=$(jq_str "$prev" '.last_polled_at' 'unknown')
+    printf "  Last polled: %s  |  Unchanged polls: %s\n" "$last_ts" "$new_unchanged"
+  fi
+  echo "============================================================"
   echo ""
 
-  # ── 4. CodeRabbit Comments (actionable feedback) ────────────────
-  echo "--- CodeRabbit Comments ---"
-  CODERABBIT_COMMENTS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' 2>/dev/null || echo "0")
-  echo "CodeRabbit inline comments: ${CODERABBIT_COMMENTS}"
-
-  if [ "$CODERABBIT_COMMENTS" -gt 0 ] 2>/dev/null; then
+  # ── Report body ─────────────────────────────────────────────────────────
+  if $FULL || $is_first; then
+    # Full report
+    echo "--- PR Details ---"
+    echo "$pr_meta" | jq -r 'to_entries[] | "  \(.key): \(.value)"' 2>/dev/null || echo "$pr_meta"
     echo ""
-    echo "Latest CodeRabbit comments:"
-    gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
-      --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | .[-3:] | .[] | "  File: \(.path):\(.line // .original_line // "?")\n  \(.body | split("\n") | .[0:3] | join("\n  "))\n"' 2>/dev/null || true
-  fi
-  echo ""
 
-  # ── 5. CodeRabbit PR-level comment (walkthrough + pre-merge checks) ─
-  echo "--- CodeRabbit Walkthrough & Pre-merge Checks ---"
-  WALKTHROUGH=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | last | .body' 2>/dev/null || echo "")
-
-  if [ -n "$WALKTHROUGH" ] && [ "$WALKTHROUGH" != "null" ]; then
-    # Extract pre-merge check results
-    echo "$WALKTHROUGH" | grep -A 2 -E "(pass|fail|warn|✅|❌|⚠️)" | head -30 || true
+    echo "--- CI Check Runs ---"
+    gh pr checks "$PR_NUMBER" --repo "$REPO" 2>/dev/null || echo "  (no checks found)"
     echo ""
-    # Extract any actionable items
-    echo "Actionable items from walkthrough:"
-    echo "$WALKTHROUGH" | grep -E "(TODO|FIXME|suggest|consider|should|must|warning|error)" -i | head -10 || echo "  (none found)"
+
+    echo "--- CodeRabbit Review ---"
+    if [ "$cr_state" != "NONE" ] && [ -n "$cr_state" ]; then
+      echo "  State: ${cr_state}  (at: ${cr_at})"
+    else
+      echo "  (no CodeRabbit review yet)"
+    fi
+    echo ""
+
+    echo "--- CodeRabbit Inline Comments: ${cr_inline_count} ---"
+    if [ "$cr_inline_count" -gt 0 ]; then
+      gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+        --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | .[-3:] | .[] |
+              "  \(.path):\(.line // .original_line // "?")\n  \(.body | split("\n") | .[0:3] | join("\n  "))\n"' \
+        2>/dev/null || true
+    fi
+    echo ""
+
+    echo "--- CodeRabbit Pre-merge Checks ---"
+    if [ -n "$walkthrough_body" ] && [ "$walkthrough_body" != "null" ]; then
+      echo "$walkthrough_body" | grep -E "(✅|❌|⚠️|pass|fail|warn)" | head -20 || true
+    else
+      echo "  (no walkthrough yet)"
+    fi
+    echo ""
+
+    echo "--- Codecov ---"
+    if [ -n "$codecov_body" ] && [ "$codecov_body" != "null" ]; then
+      echo "$codecov_body" | grep -iE "(Coverage|Diff|patch|project)" | head -10 \
+        || echo "  (coverage data present)"
+    else
+      echo "  (no Codecov report yet)"
+    fi
+    echo ""
+
+    echo "--- Human Reviews ---"
+    local hr_len
+    hr_len=$(echo "$human_reviews_json" | jq 'length')
+    if [ "$hr_len" -gt 0 ]; then
+      echo "$human_reviews_json" | jq -r 'to_entries[] | "  \(.key): \(.value)"'
+    else
+      echo "  (none yet)"
+    fi
+    echo ""
+
+    echo "--- JIRA Bot ---"
+    if [ -n "$jira_body" ] && [ "$jira_body" != "null" ]; then
+      echo "$jira_body" | head -10
+    else
+      echo "  (no JIRA bot comment)"
+    fi
+    echo ""
+
   else
-    echo "(no walkthrough comment yet)"
+    # Delta-only report
+    echo "--- Changes Since Last Poll ---"
+    if [ "${#delta_lines[@]}" -eq 0 ]; then
+      echo "  (no changes detected)"
+    else
+      for line in "${delta_lines[@]}"; do
+        echo "$line"
+      done
+    fi
+    echo ""
+    echo "  Tip: run with --full for complete report, or check ${STATE_FILE}"
+    echo ""
   fi
-  echo ""
 
-  # ── 6. Codecov Report ───────────────────────────────────────────
-  echo "--- Codecov Report ---"
-  CODECOV_COMMENT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(.user.login == "codecov[bot]")] | last | .body' 2>/dev/null || echo "")
-
-  if [ -n "$CODECOV_COMMENT" ] && [ "$CODECOV_COMMENT" != "null" ]; then
-    echo "$CODECOV_COMMENT" | grep -E "(Coverage|coverage|Diff|diff|patch|project)" | head -10 || echo "  (coverage data present but could not extract summary)"
-  else
-    echo "(no Codecov report yet)"
-  fi
-  echo ""
-
-  # ── 7. Human Reviews ───────────────────────────────────────────
-  echo "--- Human Reviews ---"
-  gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-    --jq '[.[] | select(.user.login != "coderabbitai[bot]" and .user.login != "github-actions[bot]")] | .[] | "\(.user.login): \(.state) (\(.submitted_at))"' 2>/dev/null || echo "(no human reviews yet)"
-  echo ""
-
-  # ── 8. JIRA Bot Status ─────────────────────────────────────────
-  echo "--- JIRA Bot (openshift-ci-robot) ---"
-  JIRA_COMMENT=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(.user.login == "openshift-ci[bot]" or .user.login == "openshift-ci-robot")] | last | .body' 2>/dev/null || echo "")
-
-  if [ -n "$JIRA_COMMENT" ] && [ "$JIRA_COMMENT" != "null" ]; then
-    echo "$JIRA_COMMENT" | head -15
-  else
-    echo "(no JIRA bot comment yet)"
-  fi
-  echo ""
-
-  # ── 9. Overall Status Summary ──────────────────────────────────
+  # ── Summary (always shown) ───────────────────────────────────────────────
   echo "============================================================"
   echo "  SUMMARY"
   echo "============================================================"
 
-  # Count check statuses
-  CHECKS_JSON=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state 2>/dev/null || echo "[]")
-  TOTAL=$(echo "$CHECKS_JSON" | jq 'length' 2>/dev/null || echo "0")
-  PASS=$(echo "$CHECKS_JSON" | jq '[.[] | select(.state == "SUCCESS")] | length' 2>/dev/null || echo "0")
-  FAIL=$(echo "$CHECKS_JSON" | jq '[.[] | select(.state == "FAILURE")] | length' 2>/dev/null || echo "0")
-  PENDING=$(echo "$CHECKS_JSON" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length' 2>/dev/null || echo "0")
+  local hr_count hr_approved
+  hr_count=$(echo "$human_reviews_json" | jq 'length')
+  hr_approved=$(echo "$human_reviews_json" | \
+    jq '[to_entries[] | select(.value == "APPROVED")] | length')
 
-  echo "  CI Checks: ${PASS}/${TOTAL} passed, ${FAIL} failed, ${PENDING} pending"
-  echo "  CodeRabbit comments: ${CODERABBIT_COMMENTS}"
+  printf "  CI:         %s/%s passed, %s failed, %s pending\n" \
+    "$pass" "$total" "$fail" "$pending"
+  printf "  CodeRabbit: %-26s inline comments: %s\n" "$cr_state" "$cr_inline_count"
+  printf "  Human:      %s/%s approved\n" "$hr_approved" "$hr_count"
   echo ""
 
-  if [ "$FAIL" -gt 0 ] 2>/dev/null; then
-    echo "  ACTION REQUIRED: Fix CI failures"
-    echo "  Failed checks:"
-    echo "$CHECKS_JSON" | jq -r '.[] | select(.state == "FAILURE") | "    - \(.name)"' 2>/dev/null || true
-  elif [ "$PENDING" -gt 0 ] 2>/dev/null; then
-    echo "  WAITING: ${PENDING} checks still running"
+  # Determine exit code and action message
+  local exit_code=0
+
+  if [ "$fail" -gt 0 ]; then
+    echo "  ACTION REQUIRED: Fix CI failures:"
+    echo "$checks_json" | \
+      jq -r '.[] | select(.state == "FAILURE" or .state == "ERROR") | "    - \(.name)"' \
+      2>/dev/null || true
+    exit_code=1
+
+  elif [ "$cr_inline_count" -gt 0 ]; then
+    printf "  ACTION REQUIRED: Address %s CodeRabbit inline comment(s)\n" "$cr_inline_count"
+    exit_code=3
+
+  elif [ "$pending" -gt 0 ]; then
+    printf "  WAITING: %s check(s) still running" "$pending"
+    if ! $ONCE && [ "$next_sleep" -gt 0 ]; then
+      printf " — next poll in %ss (adaptive)\n" "$next_sleep"
+    else
+      echo ""
+    fi
+    exit_code=2
+
+  elif [ "$hr_count" -eq 0 ] || [ "$hr_approved" -eq 0 ]; then
+    echo "  WAITING: Awaiting human review approval"
+    exit_code=4
+
   else
-    echo "  ALL CHECKS PASSING"
+    echo "  ALL CHECKS PASSING — ready to merge"
+    exit_code=0
   fi
 
-  if [ "$CODERABBIT_COMMENTS" -gt 0 ] 2>/dev/null; then
-    echo "  ACTION REQUIRED: Review and address CodeRabbit inline comments"
-  fi
   echo ""
+  echo "  State: ${STATE_FILE}  (poll #${poll_num}, first: ${first_polled_at})"
   echo "============================================================"
 
-  # Return non-zero if there are failures or pending items
-  if [ "$FAIL" -gt 0 ] 2>/dev/null; then
-    return 1
-  elif [ "$PENDING" -gt 0 ] 2>/dev/null; then
-    return 2
-  fi
-  return 0
+  return "$exit_code"
 }
 
-if [ "$WAIT" = true ]; then
-  echo "Polling PR #${PR_NUMBER} (Ctrl+C to stop)..."
-  while true; do
-    poll_once
-    rc=$?
-    if [ $rc -eq 0 ]; then
-      echo "All checks passed."
-      break
-    elif [ $rc -eq 1 ]; then
-      echo "Failures detected. Stopping."
-      break
-    fi
-    # rc=2 means pending — keep polling
-    echo ""
-    echo "Next poll in 60 seconds..."
-    sleep 60
-  done
-else
-  poll_once
-fi
+# ── Main loop ─────────────────────────────────────────────────────────────────
+iter=0
+while true; do
+  iter=$(( iter + 1 ))
+
+  if [ "$MAX_POLLS" -gt 0 ] && [ "$iter" -gt "$MAX_POLLS" ]; then
+    echo "Max polls (${MAX_POLLS}) reached. Stopping." >&2
+    exit 2
+  fi
+
+  set +e
+  do_poll
+  RC=$?
+  set -e
+
+  if $ONCE; then
+    exit "$RC"
+  fi
+
+  case "$RC" in
+    0)
+      echo "All checks passing. Polling complete."
+      exit 0
+      ;;
+    1)
+      echo "CI failures detected — fix and re-run: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
+      exit 1
+      ;;
+    3)
+      echo "CodeRabbit comments require attention — address and re-run: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
+      exit 3
+      ;;
+    2|4)
+      # Still pending (2) or awaiting human review (4) — keep polling
+      SLEEP_SECS=$(jq -r '.next_sleep_seconds // 120' "$STATE_FILE" 2>/dev/null || echo 120)
+      printf "\nSleeping %ss (adaptive backoff)... Ctrl+C to stop.\n\n" "$SLEEP_SECS"
+      sleep "$SLEEP_SECS"
+      ;;
+    *)
+      echo "Unexpected exit code ${RC}. Stopping." >&2
+      exit "$RC"
+      ;;
+  esac
+done

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -226,12 +226,13 @@ do_poll() {
     2>/dev/null | jq -rs 'flatten | last | .body // ""' || echo '')
 
   # Human PR comments (non-bot, non-our-own-account)
-  local human_comments_json
+  local human_comments_json self_login
+  self_login=$(gh api user --jq '.login' 2>/dev/null || echo '')
   human_comments_json=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(
+    --jq --arg self "$self_login" '[.[] | select(
       (.user.login | endswith("[bot]") | not) and
       .user.login != "openshift-ci-robot" and
-      .user.login != "quay-devel" and
+      ($self == "" or .user.login != $self) and
       (.body | startswith("## Ready for Review") | not)
     ) | {id: .id, login: .user.login, created_at: .created_at, body: .body}]' \
     2>/dev/null | jq -s 'flatten | sort_by(.id)' || echo '[]')
@@ -267,10 +268,9 @@ do_poll() {
   local -a delta_lines=()
 
   # Detect new commit — reset check snapshot to avoid false regressions
-  local prev_head_sha sha_changed=false
+  local prev_head_sha
   prev_head_sha=$(jq_str "$prev" '.head_sha' '')
   if [ -n "$head_sha" ] && [ -n "$prev_head_sha" ] && [ "$head_sha" != "$prev_head_sha" ]; then
-    sha_changed=true
     has_changes=true
     prev_checks='{}'  # discard stale per-commit check states
     delta_lines+=("  NEW COMMIT: ${prev_head_sha:0:7} -> ${head_sha:0:7} (check history reset)")

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -113,9 +113,10 @@ notify_for_review() {
     echo "  Ready-for-review comment already posted (id: ${existing_id})."
   fi
 
-  # Assign quay/downstream team as reviewer via API
+  # Assign quay/downstream team as reviewer via API (best-effort — team may not be a collaborator)
   gh api "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
-    -X POST -f "team_reviewers[]=downstream" > /dev/null 2>&1 || return 1
+    -X POST -f "team_reviewers[]=downstream" > /dev/null 2>&1 || \
+    echo "  NOTE: quay/downstream team assignment skipped (not a repo collaborator)."
 }
 
 # Fetch all CodeRabbit review threads via GraphQL (includes resolved/outdated status)

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -90,16 +90,28 @@ adaptive_sleep() {
   fi
 }
 
-# Post a "ready for review" comment and request reviewers (idempotent via state)
+# Post a "ready for review" comment and request reviewers (idempotent: checks GitHub API)
 notify_for_review() {
   local summary="$1"
   echo "  Notifying reviewers..."
-  # Post PR comment
+
+  # Idempotency: check GitHub API for an existing ready-for-review comment regardless of state file
+  local existing_id
+  existing_id=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(.body | startswith("## Ready for Review"))] | last | .id // empty' \
+    2>/dev/null || true)
+  if [ -n "$existing_id" ]; then
+    echo "  Ready-for-review comment already posted (id: ${existing_id}). Skipping."
+    return 0
+  fi
+
+  # Post PR comment — use printf so \n expands to real newlines
   local body
-  body="## \U0001F7E2 Ready for Review\n\nCI is green and all review threads are resolved.\n\n${summary}\n\ncc $(printf '@%s ' "${REVIEWERS[@]:-}" "${TEAM_REVIEWERS[@]:-}" | sed 's/@ //g; s/ $//')"
+  body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s' "$summary")
   gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
     -X POST -f body="$body" > /dev/null 2>&1 || true
-  # Request individual reviewers
+
+  # Request individual and team reviewers
   local reviewer_args=()
   for r in "${REVIEWERS[@]:-}"; do
     [ -n "$r" ] && reviewer_args+=(-f "reviewers[]=$r")

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -65,8 +65,13 @@ jq_str() {
   echo "$_v"
 }
 
-# Safe jq numeric read with fallback
-jq_int() { echo "$1" | jq "${2}" 2>/dev/null || echo "${3:-0}"; }
+# Safe jq numeric read with fallback (treats jq errors AND literal "null" as missing)
+jq_int() {
+  local _v
+  _v=$(echo "$1" | jq "${2}" 2>/dev/null) || { echo "${3:-0}"; return; }
+  [ "$_v" = "null" ] && _v="${3:-0}"
+  echo "$_v"
+}
 
 # Compute adaptive sleep based on pending checks and stability of state
 adaptive_sleep() {
@@ -74,7 +79,9 @@ adaptive_sleep() {
   if [ "$pending" -eq 0 ]; then
     echo 0       # Nothing pending — don't sleep, something is actionable
   elif [ "$unchanged" -ge 2 ]; then
-    local next=$(( prev_sleep * 2 ))
+    local base=$prev_sleep
+    [ "$base" -lt 120 ] && base=120
+    local next=$(( base * 2 ))
     [ "$next" -gt 600 ] && next=600
     echo "$next" # Backing off: nothing changed across multiple polls
   elif [ "$pending" -gt 3 ]; then
@@ -123,39 +130,37 @@ do_poll() {
   checks_json=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state \
     2>/dev/null || echo '[]')
 
-  cr_review=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-    --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | last // {}' \
-    2>/dev/null || echo '{}')
+  cr_review=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+    --jq '[.[] | select(.user.login == "coderabbitai[bot]")]' \
+    2>/dev/null | jq -s 'flatten | last // {}' || echo '{}')
 
-  cr_inline_count=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+  cr_inline_count=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
     --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | length' \
-    2>/dev/null || echo '0')
+    2>/dev/null | jq -s 'add // 0' || echo '0')
 
-  human_inline_count=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+  human_inline_count=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
     --jq '[.[] | select(
             .user.login != "coderabbitai[bot]" and
             (.user.login | endswith("[bot]") | not) and
             .user.login != "openshift-ci-robot"
           )] | length' \
-    2>/dev/null || echo '0')
+    2>/dev/null | jq -s 'add // 0' || echo '0')
 
-  walkthrough_body=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | last | .body // ""' \
-    2>/dev/null || echo '')
+  walkthrough_body=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(.user.login == "coderabbitai[bot]")]' \
+    2>/dev/null | jq -rs 'flatten | last | .body // ""' || echo '')
 
-  codecov_body=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(.user.login == "codecov[bot]")] | last | .body // ""' \
-    2>/dev/null || echo '')
+  codecov_body=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(.user.login == "codecov[bot]")]' \
+    2>/dev/null | jq -rs 'flatten | last | .body // ""' || echo '')
 
-  human_reviews_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-    --jq '[.[] | select(.user.login != "coderabbitai[bot]" and .user.login != "github-actions[bot]")]
-          | map({(.user.login): .state}) | add // {}' \
-    2>/dev/null || echo '{}')
+  human_reviews_json=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+    --jq '[.[] | select(.user.login != "coderabbitai[bot]" and .user.login != "github-actions[bot]")]' \
+    2>/dev/null | jq -s 'flatten | map({(.user.login): .state}) | add // {}' || echo '{}')
 
-  jira_body=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(.user.login == "openshift-ci[bot]" or .user.login == "openshift-ci-robot")]
-          | last | .body // ""' \
-    2>/dev/null || echo '')
+  jira_body=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(.user.login == "openshift-ci[bot]" or .user.login == "openshift-ci-robot")]' \
+    2>/dev/null | jq -rs 'flatten | last | .body // ""' || echo '')
 
   # ── Compute check summary ───────────────────────────────────────────────
   local total pass fail pending
@@ -497,6 +502,8 @@ while true; do
     2|4)
       # Still pending (2) or awaiting human review (4) — keep polling
       SLEEP_SECS=$(jq -r '.next_sleep_seconds // 120' "$STATE_FILE" 2>/dev/null || echo 120)
+      # Floor: exit 4 (no pending checks, just waiting on humans) must not spin at 0s
+      [ "$SLEEP_SECS" -le 0 ] && SLEEP_SECS=300
       printf "\nSleeping %ss (adaptive backoff)... Ctrl+C to stop.\n\n" "$SLEEP_SECS"
       sleep "$SLEEP_SECS"
       ;;

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -173,9 +173,12 @@ do_poll() {
   local checks_map
   checks_map=$(echo "$checks_json" | jq '[.[] | {(.name): .state}] | add // {}' 2>/dev/null || echo '{}')
 
-  local cr_state cr_at
+  local cr_state cr_at cr_review_commit cr_is_current
   cr_state=$(jq_str "$cr_review" '.state' 'NONE')
   cr_at=$(jq_str "$cr_review" '.submitted_at' '')
+  cr_review_commit=$(jq_str "$cr_review" '.commit_id' '')
+  cr_is_current=false
+  [ -n "$cr_review_commit" ] && [ "$cr_review_commit" = "$head_sha" ] && cr_is_current=true
 
   # ── Compute deltas vs previous state ───────────────────────────────────
   local prev_checks prev_cr_state prev_cr_count prev_human

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -262,7 +262,6 @@ do_poll() {
     sha_changed=true
     has_changes=true
     prev_checks='{}'  # discard stale per-commit check states
-    prev_human_comment_last_id=0  # re-surface comments after each push
     delta_lines+=("  NEW COMMIT: ${prev_head_sha:0:7} -> ${head_sha:0:7} (check history reset)")
   fi
 

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -541,6 +541,13 @@ do_poll() {
     printf "  ACTION REQUIRED: Address inline review comments: %s\n" "$_msg"
     exit_code=3
 
+  elif [ "$human_comment_delta" -gt 0 ]; then
+    printf "  ACTION REQUIRED: %s new comment(s) — read and respond before continuing\n" "$human_comment_delta"
+    echo "$human_comments_json" | jq -r --argjson last_id "$prev_human_comment_last_id" \
+      '[.[] | select(.id > $last_id)] | .[] |
+       "  \(.login): \(.body | split("\n") | .[0:2] | join(" "))"' 2>/dev/null || true
+    exit_code=3
+
   elif ! $cr_is_current && [ "$cr_state" != "NONE" ] && [ "$pending" -eq 0 ]; then
     echo "  WAITING: CodeRabbit re-review pending for ${head_sha:0:7}"
     exit_code=2

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -96,10 +96,15 @@ notify_for_review() {
   echo "  Notifying reviewers..."
 
   # Idempotency: check GitHub API for an existing ready-for-review comment regardless of state file
-  local existing_id
+  # Treat API failures as "skip posting" to avoid duplicate comments on transient errors
+  local existing_id api_ok=true
   existing_id=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
     --jq '[.[] | select(.body | startswith("## Ready for Review"))] | last | .id // empty' \
-    2>/dev/null || true)
+    2>/dev/null) || api_ok=false
+  if ! $api_ok; then
+    echo "  WARN: could not verify existing ready-for-review comment; skipping post to avoid duplicates."
+    return 0
+  fi
   if [ -n "$existing_id" ]; then
     echo "  Ready-for-review comment already posted (id: ${existing_id}). Skipping."
     return 0
@@ -128,13 +133,23 @@ notify_for_review() {
 # Fetch all CodeRabbit review threads via GraphQL (includes resolved/outdated status)
 fetch_review_threads() {
   local owner="${REPO%%/*}" rname="${REPO##*/}"
-  gh api graphql \
+  local result
+  result=$(gh api graphql \
     -f query='query($owner:String!,$repo:String!,$pr:Int!){
-      repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{
-        id isResolved isOutdated
-        comments(first:3){nodes{databaseId author{login __typename} body path line originalLine}}
-      }}}}}'  \
-    -f owner="$owner" -f repo="$rname" -F pr="$PR_NUMBER" 2>/dev/null || echo '{}'
+      repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){
+        pageInfo{hasNextPage}
+        nodes{
+          id isResolved isOutdated
+          comments(first:3){nodes{databaseId author{login __typename} body path line originalLine}}
+        }
+      }}}}'  \
+    -f owner="$owner" -f repo="$rname" -F pr="$PR_NUMBER" 2>/dev/null) || { echo '{}'; return; }
+  local has_next
+  has_next=$(echo "$result" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false' 2>/dev/null)
+  if [ "$has_next" = "true" ]; then
+    echo "  WARN: PR has >100 review threads; results are truncated — counts may be understated." >&2
+  fi
+  echo "$result"
 }
 
 # ── Core poll ────────────────────────────────────────────────────────────────
@@ -229,8 +244,6 @@ do_poll() {
   cr_review_commit=$(jq_str "$cr_review" '.commit_id' '')
   cr_is_current=false
   [ -n "$cr_review_commit" ] && [ "$cr_review_commit" = "$head_sha" ] && cr_is_current=true
-  # Non-outdated unresolved threads mean CR has reviewed the current commit
-  [ "$cr_inline_count" -gt 0 ] && cr_is_current=true
 
   # ── Compute deltas vs previous state ───────────────────────────────────
   local prev_checks prev_cr_state prev_cr_count prev_human
@@ -495,10 +508,10 @@ do_poll() {
       2>/dev/null || true
     exit_code=1
 
-  elif [ "$human_inline_count" -gt 0 ] || ( [ "$cr_inline_count" -gt 0 ] && $cr_is_current ); then
+  elif [ "$human_inline_count" -gt 0 ] || [ "$cr_inline_count" -gt 0 ]; then
     local _msg=""
     [ "$human_inline_count" -gt 0 ] && _msg="${human_inline_count} human thread(s)"
-    ( [ "$cr_inline_count" -gt 0 ] && $cr_is_current ) && _msg="${_msg:+$_msg, }${cr_inline_count} CodeRabbit thread(s)"
+    [ "$cr_inline_count" -gt 0 ] && _msg="${_msg:+$_msg, }${cr_inline_count} CodeRabbit thread(s)"
     printf "  ACTION REQUIRED: Address inline review comments: %s\n" "$_msg"
     exit_code=3
 
@@ -585,8 +598,12 @@ while true; do
       sleep "$SLEEP_SECS"
       ;;
     4)
-      # Awaiting human review — reviewers notified, exit cleanly
-      echo "Reviewers notified. Re-run to check for approval: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
+      # Awaiting human review — exit cleanly
+      if [ "${#REVIEWERS[@]}" -gt 0 ] || [ "${#TEAM_REVIEWERS[@]}" -gt 0 ]; then
+        echo "Reviewers notified. Re-run to check for approval: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
+      else
+        echo "Awaiting human review. Re-run later or pass --reviewer/--team-reviewer to auto-notify: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
+      fi
       exit 4
       ;;
     *)

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -109,6 +109,10 @@ do_poll() {
   # ── Fetch from GitHub ───────────────────────────────────────────────────
   local pr_meta checks_json cr_review cr_inline_count walkthrough_body codecov_body human_reviews_json jira_body
 
+  local head_sha
+  head_sha=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+    --json headRefOid --jq '.headRefOid' 2>/dev/null || echo '')
+
   pr_meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
     --json title,state,isDraft,mergeable,labels,reviewDecision \
     --jq '{title,state,draft:.isDraft,mergeable,
@@ -169,6 +173,16 @@ do_poll() {
 
   local has_changes=false
   local -a delta_lines=()
+
+  # Detect new commit — reset check snapshot to avoid false regressions
+  local prev_head_sha sha_changed=false
+  prev_head_sha=$(jq_str "$prev" '.head_sha' '')
+  if [ -n "$head_sha" ] && [ -n "$prev_head_sha" ] && [ "$head_sha" != "$prev_head_sha" ]; then
+    sha_changed=true
+    has_changes=true
+    prev_checks='{}'  # discard stale per-commit check states
+    delta_lines+=("  NEW COMMIT: ${prev_head_sha:0:7} -> ${head_sha:0:7} (check history reset)")
+  fi
 
   # CI check state changes
   local check_names_raw
@@ -241,10 +255,12 @@ do_poll() {
     --arg     cr_at    "$cr_at" \
     --argjson cr_count "$cr_inline_count" \
     --argjson human    "$human_reviews_json" \
+    --arg     head_sha  "$head_sha" \
     --argjson unchanged "$new_unchanged" \
     --argjson sleep     "$next_sleep" \
     '{
       pr_number:                   $pr,
+      head_sha:                    $head_sha,
       first_polled_at:             $first,
       last_polled_at:              $last,
       poll_count:                  $count,

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -211,6 +211,18 @@ do_poll() {
     --jq '[.[] | select(.user.login == "openshift-ci[bot]" or .user.login == "openshift-ci-robot")]' \
     2>/dev/null | jq -rs 'flatten | last | .body // ""' || echo '')
 
+  # Human PR comments (non-bot, non-our-own-account)
+  local human_comments_json
+  human_comments_json=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+    --jq '[.[] | select(
+      (.user.login | endswith("[bot]") | not) and
+      .user.login != "openshift-ci-robot"
+    ) | {id: .id, login: .user.login, created_at: .created_at, body: .body}]' \
+    2>/dev/null | jq -s 'flatten | sort_by(.id)' || echo '[]')
+  local human_comment_count human_comment_last_id
+  human_comment_count=$(echo "$human_comments_json" | jq 'length')
+  human_comment_last_id=$(echo "$human_comments_json" | jq 'last | .id // 0')
+
   # ── Compute check summary ───────────────────────────────────────────────
   local total pass fail pending
   total=$(jq_int "$checks_json" 'length')
@@ -309,6 +321,21 @@ do_poll() {
     done <<< "$human_names_raw"
   fi
 
+  # Human PR comment delta
+  local prev_human_comment_count prev_human_comment_last_id
+  prev_human_comment_count=$(jq_int "$prev" '.human_comment_count // 0')
+  prev_human_comment_last_id=$(jq_int "$prev" '.human_comment_last_id // 0')
+  local human_comment_delta=$(( human_comment_count - prev_human_comment_count ))
+  if [ "$human_comment_delta" -gt 0 ]; then
+    has_changes=true
+    # List authors of the new comments
+    local new_authors
+    new_authors=$(echo "$human_comments_json" | \
+      jq -r --argjson last_id "$prev_human_comment_last_id" \
+      '[.[] | select(.id > $last_id) | .login] | unique | join(", ")' 2>/dev/null || echo "unknown")
+    delta_lines+=("  Comment: +${human_comment_delta} new comment(s) from: ${new_authors}")
+  fi
+
   # Consecutive unchanged poll counter
   local new_unchanged
   if $has_changes || $is_first; then
@@ -336,6 +363,8 @@ do_poll() {
     --argjson cr_count "$cr_inline_count" \
     --argjson human          "$human_reviews_json" \
     --argjson human_inline   "$human_inline_count" \
+    --argjson human_comment_count  "$human_comment_count" \
+    --argjson human_comment_last_id "$human_comment_last_id" \
     --arg     head_sha        "$head_sha" \
     --arg     review_notified "$review_notified_at" \
     --argjson unchanged "$new_unchanged" \
@@ -352,6 +381,8 @@ do_poll() {
       coderabbit_inline_count:     $cr_count,
       human_reviews:               $human,
       human_inline_count:          $human_inline,
+      human_comment_count:         $human_comment_count,
+      human_comment_last_id:       $human_comment_last_id,
       consecutive_unchanged_polls: $unchanged,
       next_sleep_seconds:          $sleep,
       review_notified_at:          $review_notified
@@ -438,6 +469,17 @@ do_poll() {
         "  \(.comments.nodes[0].author.login) on \(.comments.nodes[0].path):\(.comments.nodes[0].line // .comments.nodes[0].originalLine // "?")\n  \(.comments.nodes[0].body | split("\n") | .[0:3] | join("\n  "))\n  1. Reply:   gh api repos/\($repo)/pulls/\($pr)/comments/\(.comments.nodes[0].databaseId)/replies -X POST -f body=\"...\"\n  2. Resolve: gh api graphql -f query=\"mutation{resolveReviewThread(input:{threadId:\\\"\(.id)\\\"}){thread{isResolved}}}\"\n"'
       echo "$threads_json" | jq -r --arg repo "$REPO" --arg pr "$PR_NUMBER" "$_jq_human" \
         2>/dev/null || true
+    fi
+    echo ""
+
+    echo "--- Human Comments: ${human_comment_count} ---"
+    if [ "$human_comment_count" -gt 0 ]; then
+      echo "$human_comments_json" | jq -r '
+        .[-3:] | .[] |
+        "  \(.login) (\(.created_at | split("T")[0])): \(.body | split("\n") | .[0:2] | join(" "))"' \
+        2>/dev/null || true
+    else
+      echo "  (none)"
     fi
     echo ""
 

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -556,7 +556,7 @@ do_poll() {
     printf "  ACTION REQUIRED: Address inline review comments: %s\n" "$_msg"
     exit_code=3
 
-  elif [ "$human_comment_delta" -gt 0 ]; then
+  elif ! $is_first && [ "$human_comment_delta" -gt 0 ]; then
     printf "  ACTION REQUIRED: %s new comment(s) — read and respond before continuing\n" "$human_comment_delta"
     echo "$human_comments_json" | jq -r --argjson last_id "$prev_human_comment_last_id" \
       '[.[] | select(.id > $last_id)] | .[] |

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -107,11 +107,15 @@ notify_for_review() {
     return 0
   fi
 
-  # Post PR comment with @quay/downstream mention — use printf so \n expands to real newlines
+  # Post PR comment — use printf so \n expands to real newlines
   local body
-  body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s\n\n@quay/downstream' "$summary")
+  body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s' "$summary")
   gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
     -X POST -f body="$body" > /dev/null 2>&1 || true
+
+  # Assign quay/downstream team as reviewer via API
+  gh api "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+    -X POST -f "team_reviewers[]=downstream" > /dev/null 2>&1 || true
 }
 
 # Fetch all CodeRabbit review threads via GraphQL (includes resolved/outdated status)
@@ -258,6 +262,7 @@ do_poll() {
     sha_changed=true
     has_changes=true
     prev_checks='{}'  # discard stale per-commit check states
+    prev_human_comment_last_id=0  # re-surface comments after each push
     delta_lines+=("  NEW COMMIT: ${prev_head_sha:0:7} -> ${head_sha:0:7} (check history reset)")
   fi
 

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -57,8 +57,13 @@ load_state() {
   if [ -f "$STATE_FILE" ]; then cat "$STATE_FILE"; else echo '{}'; fi
 }
 
-# Safe jq string read with fallback
-jq_str() { echo "$1" | jq -r "${2}" 2>/dev/null || echo "${3:-}"; }
+# Safe jq string read with fallback (normalises JSON null to the fallback value)
+jq_str() {
+  local _v
+  _v=$(echo "$1" | jq -r "${2}" 2>/dev/null) || { echo "${3:-}"; return; }
+  [ "$_v" = "null" ] && _v="${3:-}"
+  echo "$_v"
+}
 
 # Safe jq numeric read with fallback
 jq_int() { echo "$1" | jq "${2}" 2>/dev/null || echo "${3:-0}"; }

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -14,7 +14,7 @@
 #   1  CI failures — fix required
 #   2  Checks still pending — re-poll later
 #   3  Review comments to address
-#   4  Awaiting human review — posts @quay/downstream mention and exits
+#   4  Awaiting human review — posts @quay/downstream mention; loops (--once: exits)
 #
 # State file: .claude/poll-state/pr-<NUMBER>.json
 #   Tracks check states, review states, comment counts, adaptive sleep, and poll history.
@@ -111,7 +111,7 @@ notify_for_review() {
   # Post PR comment if not already present — use printf so \n expands to real newlines
   if [ -z "$existing_id" ]; then
     local body
-    body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s' "$summary")
+    body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s\n\ncc `@quay/downstream`' "$summary")
     gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
       -X POST -f body="$body" > /dev/null 2>&1 || return 1
   else

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -96,7 +96,7 @@ notify_for_review() {
   # Treat API failures as "skip posting" to avoid duplicate comments on transient errors
   local existing_id api_ok=true
   existing_id=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    --jq '[.[] | select(.body | startswith("## Ready for Review"))] | last | .id // empty' \
+    --jq '[.[] | select(.body | startswith("## Ready for Review"))] | .[-1].id // empty' \
     2>/dev/null) || api_ok=false
   if ! $api_ok; then
     echo "  WARN: could not verify existing ready-for-review comment; skipping post to avoid duplicates."
@@ -225,7 +225,7 @@ do_poll() {
     2>/dev/null | jq -s 'flatten | sort_by(.id)' || echo '[]')
   local human_comment_count human_comment_last_id
   human_comment_count=$(echo "$human_comments_json" | jq 'length')
-  human_comment_last_id=$(echo "$human_comments_json" | jq 'last | .id // 0')
+  human_comment_last_id=$(echo "$human_comments_json" | jq '.[-1].id // 0')
 
   # ── Compute check summary ───────────────────────────────────────────────
   local total pass fail pending

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -652,9 +652,13 @@ while true; do
       sleep "$SLEEP_SECS"
       ;;
     4)
-      # Awaiting human review — @quay/downstream notified, exit cleanly
-      echo "@quay/downstream notified. Re-run to check for approval: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
-      exit 4
+      # Awaiting human review — keep polling at a slower cadence (5 min min)
+      SLEEP_SECS=300
+      printf "
+Awaiting human review — next check in %ss...
+
+" "$SLEEP_SECS"
+      sleep "$SLEEP_SECS"
       ;;
     *)
       echo "Unexpected exit code ${RC}. Stopping." >&2

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -111,7 +111,7 @@ notify_for_review() {
   # Post PR comment if not already present — use printf so \n expands to real newlines
   if [ -z "$existing_id" ]; then
     local body
-    body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s\n\ncc `@quay/downstream`' "$summary")
+    body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s\n\ncc @quay/downstream' "$summary")
     gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
       -X POST -f body="$body" > /dev/null 2>&1 || return 1
   else
@@ -235,7 +235,7 @@ do_poll() {
 
   # Human PR comments (non-bot, non-our-own-account)
   # Note: gh api does not support --arg for jq variables; filter in a separate jq call
-  local human_comments_json self_login _comments_raw
+  local human_comments_json self_login _comments_raw comments_ok=true
   self_login=$(gh api user --jq '.login' 2>/dev/null || echo '')
   if _comments_raw=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" 2>/dev/null); then
     human_comments_json=$(printf '%s' "$_comments_raw" | jq -s --arg self "$self_login" \
@@ -247,11 +247,17 @@ do_poll() {
       ) | {id: .id, login: .user.login, created_at: .created_at, body: .body}] | sort_by(.id)' \
       2>/dev/null) || human_comments_json='[]'
   else
+    comments_ok=false
     human_comments_json='[]'
   fi
   local human_comment_count human_comment_last_id
-  human_comment_count=$(echo "$human_comments_json" | jq 'length')
-  human_comment_last_id=$(echo "$human_comments_json" | jq '.[-1].id // 0')
+  if $comments_ok; then
+    human_comment_count=$(echo "$human_comments_json" | jq 'length')
+    human_comment_last_id=$(echo "$human_comments_json" | jq '.[-1].id // 0')
+  else
+    human_comment_count=$(jq_int "$prev" '.human_comment_count // 0')
+    human_comment_last_id=$(jq_int "$prev" '.human_comment_last_id // 0')
+  fi
 
   # ── Compute check summary ───────────────────────────────────────────────
   local total pass fail pending

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -35,12 +35,20 @@ TEAM_REVIEWERS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --repo)       REPO="$2"; shift 2 ;;
+    --repo)
+      [ $# -lt 2 ] && { echo "Missing value for --repo" >&2; exit 1; }
+      REPO="$2"; shift 2 ;;
     --once)       ONCE=true; shift ;;
     --full)       FULL=true; shift ;;
-    --max-polls)         MAX_POLLS="$2"; shift 2 ;;
-    --reviewer)          REVIEWERS+=("$2"); shift 2 ;;
-    --team-reviewer)     TEAM_REVIEWERS+=("$2"); shift 2 ;;
+    --max-polls)
+      [ $# -lt 2 ] && { echo "Missing value for --max-polls" >&2; exit 1; }
+      MAX_POLLS="$2"; shift 2 ;;
+    --reviewer)
+      [ $# -lt 2 ] && { echo "Missing value for --reviewer" >&2; exit 1; }
+      REVIEWERS+=("$2"); shift 2 ;;
+    --team-reviewer)
+      [ $# -lt 2 ] && { echo "Missing value for --team-reviewer" >&2; exit 1; }
+      TEAM_REVIEWERS+=("$2"); shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -519,6 +527,11 @@ do_poll() {
     echo "  WAITING: CodeRabbit re-review pending for ${head_sha:0:7}"
     exit_code=2
 
+  elif [ "$hr_count" -gt 0 ] && [ "$(echo "$human_reviews_json" | jq '[to_entries[] | select(.value == "CHANGES_REQUESTED")] | length')" -gt 0 ]; then
+    echo "  ACTION REQUIRED: Reviewer(s) requested changes"
+    echo "$human_reviews_json" | jq -r 'to_entries[] | select(.value == "CHANGES_REQUESTED") | "    - \(.key)"' 2>/dev/null || true
+    exit_code=3
+
   elif [ "$pending" -gt 0 ]; then
     printf "  WAITING: %s check(s) still running" "$pending"
     if ! $ONCE && [ "$next_sleep" -gt 0 ]; then
@@ -527,11 +540,6 @@ do_poll() {
       echo ""
     fi
     exit_code=2
-
-  elif [ "$hr_count" -gt 0 ] &&        [ "$(echo "$human_reviews_json" | jq '[to_entries[] | select(.value == "CHANGES_REQUESTED")] | length')" -gt 0 ]; then
-    echo "  ACTION REQUIRED: Reviewer(s) requested changes"
-    echo "$human_reviews_json" | jq -r 'to_entries[] | select(.value == "CHANGES_REQUESTED") | "    - \(.key)"' 2>/dev/null || true
-    exit_code=3
 
   elif [ "$hr_count" -eq 0 ] || [ "$hr_approved" -eq 0 ]; then
     echo "  WAITING: Awaiting human review approval"
@@ -590,7 +598,7 @@ while true; do
       exit 1
       ;;
     3)
-      echo "CodeRabbit comments require attention — address and re-run: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
+      echo "Review feedback requires attention — address and re-run: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
       exit 3
       ;;
     2)

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -220,7 +220,8 @@ do_poll() {
   human_comments_json=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
     --jq '[.[] | select(
       (.user.login | endswith("[bot]") | not) and
-      .user.login != "openshift-ci-robot"
+      .user.login != "openshift-ci-robot" and
+      .user.login != "quay-devel"
     ) | {id: .id, login: .user.login, created_at: .created_at, body: .body}]' \
     2>/dev/null | jq -s 'flatten | sort_by(.id)' || echo '[]')
   local human_comment_count human_comment_last_id

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -98,7 +98,7 @@ fetch_review_threads() {
     -f query='query($owner:String!,$repo:String!,$pr:Int!){
       repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:100){nodes{
         id isResolved isOutdated
-        comments(first:3){nodes{databaseId author{login} body path line originalLine}}
+        comments(first:3){nodes{databaseId author{login __typename} body path line originalLine}}
       }}}}}'  \
     -f owner="$owner" -f repo="$rname" -F pr="$PR_NUMBER" 2>/dev/null || echo '{}'
 }
@@ -151,16 +151,13 @@ do_poll() {
   cr_inline_count=$(echo "$threads_json" | jq \
     '[.data.repository.pullRequest.reviewThreads.nodes[]? |
       select(.isResolved==false and .isOutdated==false) |
-      select(.comments.nodes[0]?.author.login=="coderabbitai[bot]")] | length' \
+      select(.comments.nodes[0]?.author.__typename=="Bot" and (.comments.nodes[0]?.author.login | startswith("coderabbit")))] | length' \
     2>/dev/null || echo '0')
 
   human_inline_count=$(echo "$threads_json" | jq \
     '[.data.repository.pullRequest.reviewThreads.nodes[]? |
       select(.isResolved==false and .isOutdated==false) |
-      select(
-        (.comments.nodes[0]?.author.login | (endswith("[bot]") | not)) and
-        .comments.nodes[0]?.author.login != "openshift-ci-robot"
-      )] | length' \
+      select(.comments.nodes[0]?.author.__typename=="User")] | length' \
     2>/dev/null || echo '0')
 
   walkthrough_body=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
@@ -360,7 +357,7 @@ do_poll() {
       echo "$threads_json" | jq -r \
         '[.data.repository.pullRequest.reviewThreads.nodes[]? |
           select(.isResolved==false and .isOutdated==false) |
-          select(.comments.nodes[0]?.author.login=="coderabbitai[bot]")][-5:] |
+          select(.comments.nodes[0]?.author.__typename=="Bot" and (.comments.nodes[0]?.author.login | startswith("coderabbit")))][-5:] |
         .[] |
         "  \(.comments.nodes[0].path):\(.comments.nodes[0].line // .comments.nodes[0].originalLine // "?")\n  \(.comments.nodes[0].body | split("\n") | .[0:3] | join("\n  "))\n  Thread: \(.id)  Comment: \(.comments.nodes[0].databaseId)\n"' \
         2>/dev/null || true
@@ -399,10 +396,7 @@ do_poll() {
       echo "$threads_json" | jq -r \
         '[.data.repository.pullRequest.reviewThreads.nodes[]? |
           select(.isResolved==false and .isOutdated==false) |
-          select(
-            (.comments.nodes[0]?.author.login | (endswith("[bot]") | not)) and
-            .comments.nodes[0]?.author.login != "openshift-ci-robot"
-          )][-5:] |
+          select(.comments.nodes[0]?.author.__typename=="User")][-5:] |
         .[] |
         "  \(.comments.nodes[0].author.login) on \(.comments.nodes[0].path):\(.comments.nodes[0].line // .comments.nodes[0].originalLine // "?")\n  \(.comments.nodes[0].body | split("\n") | .[0:3] | join("\n  "))\n  Thread: \(.id)\n"' \
         2>/dev/null || true

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -99,23 +99,23 @@ notify_for_review() {
     --jq '[.[] | select(.body | startswith("## Ready for Review"))] | .[-1].id // empty' \
     2>/dev/null) || api_ok=false
   if ! $api_ok; then
-    echo "  WARN: could not verify existing ready-for-review comment; skipping post to avoid duplicates."
-    return 0
-  fi
-  if [ -n "$existing_id" ]; then
-    echo "  Ready-for-review comment already posted (id: ${existing_id}). Skipping."
-    return 0
+    echo "  WARN: could not verify existing ready-for-review comment; will retry next poll."
+    return 1
   fi
 
-  # Post PR comment — use printf so \n expands to real newlines
-  local body
-  body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s' "$summary")
-  gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-    -X POST -f body="$body" > /dev/null 2>&1 || true
+  # Post PR comment if not already present — use printf so \n expands to real newlines
+  if [ -z "$existing_id" ]; then
+    local body
+    body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s' "$summary")
+    gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+      -X POST -f body="$body" > /dev/null 2>&1 || return 1
+  else
+    echo "  Ready-for-review comment already posted (id: ${existing_id})."
+  fi
 
   # Assign quay/downstream team as reviewer via API
   gh api "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
-    -X POST -f "team_reviewers[]=downstream" > /dev/null 2>&1 || true
+    -X POST -f "team_reviewers[]=downstream" > /dev/null 2>&1 || return 1
 }
 
 # Fetch all CodeRabbit review threads via GraphQL (includes resolved/outdated status)
@@ -178,8 +178,17 @@ do_poll() {
            labels:([.labels[].name]|join(","))}' \
     2>/dev/null || echo '{}')
 
-  checks_json=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state \
-    2>/dev/null || echo '[]')
+  local checks_rc=0
+  checks_json=$(gh pr checks "$PR_NUMBER" --repo "$REPO" --json name,state,bucket \
+    2>/dev/null) || checks_rc=$?
+  # gh pr checks exits non-zero for pending (8) and failure (1) — not API errors.
+  # Keep the JSON for known check-state exits; only fall back on true command failure.
+  if [ "$checks_rc" -ne 0 ] && [ "$checks_rc" -ne 1 ] && [ "$checks_rc" -ne 8 ]; then
+    echo "  WARN: failed to fetch PR checks (rc=${checks_rc}); treating as pending." >&2
+    checks_json='[{"name":"gh pr checks","state":"PENDING","bucket":"pending"}]'
+  elif [ -z "$checks_json" ]; then
+    checks_json='[]'
+  fi
 
   cr_review=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
     --jq '[.[] | select(.user.login == "coderabbitai[bot]")]' \
@@ -221,7 +230,8 @@ do_poll() {
     --jq '[.[] | select(
       (.user.login | endswith("[bot]") | not) and
       .user.login != "openshift-ci-robot" and
-      .user.login != "quay-devel"
+      .user.login != "quay-devel" and
+      (.body | startswith("## Ready for Review") | not)
     ) | {id: .id, login: .user.login, created_at: .created_at, body: .body}]' \
     2>/dev/null | jq -s 'flatten | sort_by(.id)' || echo '[]')
   local human_comment_count human_comment_last_id
@@ -231,10 +241,9 @@ do_poll() {
   # ── Compute check summary ───────────────────────────────────────────────
   local total pass fail pending
   total=$(jq_int "$checks_json" 'length')
-  pass=$(jq_int "$checks_json" '[.[] | select(.state == "SUCCESS")] | length')
-  fail=$(jq_int "$checks_json" '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
-  pending=$(jq_int "$checks_json" \
-    '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS" or .state == "WAITING")] | length')
+  pass=$(jq_int "$checks_json" '[.[] | select(.bucket == "pass")] | length')
+  fail=$(jq_int "$checks_json" '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length')
+  pending=$(jq_int "$checks_json" '[.[] | select(.bucket == "pending")] | length')
 
   local checks_map
   checks_map=$(echo "$checks_json" | jq '[.[] | {(.name): .state}] | add // {}' 2>/dev/null || echo '{}')
@@ -535,7 +544,7 @@ do_poll() {
   if [ "$fail" -gt 0 ]; then
     echo "  ACTION REQUIRED: Fix CI failures:"
     echo "$checks_json" | \
-      jq -r '.[] | select(.state == "FAILURE" or .state == "ERROR") | "    - \(.name)"' \
+      jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | "    - \(.name)"' \
       2>/dev/null || true
     exit_code=1
 
@@ -553,14 +562,14 @@ do_poll() {
        "  \(.login): \(.body | split("\n") | .[0:2] | join(" "))"' 2>/dev/null || true
     exit_code=3
 
-  elif ! $cr_is_current && [ "$cr_state" != "NONE" ] && [ "$pending" -eq 0 ]; then
-    echo "  WAITING: CodeRabbit re-review pending for ${head_sha:0:7}"
-    exit_code=2
-
   elif [ "$hr_count" -gt 0 ] && [ "$(echo "$human_reviews_json" | jq '[to_entries[] | select(.value == "CHANGES_REQUESTED")] | length')" -gt 0 ]; then
     echo "  ACTION REQUIRED: Reviewer(s) requested changes"
     echo "$human_reviews_json" | jq -r 'to_entries[] | select(.value == "CHANGES_REQUESTED") | "    - \(.key)"' 2>/dev/null || true
     exit_code=3
+
+  elif ! $cr_is_current && [ "$cr_state" != "NONE" ] && [ "$pending" -eq 0 ]; then
+    echo "  WAITING: CodeRabbit re-review pending for ${head_sha:0:7}"
+    exit_code=2
 
   elif [ "$pending" -gt 0 ]; then
     printf "  WAITING: %s check(s) still running" "$pending"
@@ -577,11 +586,15 @@ do_poll() {
       local ci_summary
       ci_summary=$(printf "CI: %s/%s passed | CodeRabbit: %s | Unresolved threads: CR=%s Human=%s" \
         "$pass" "$total" "$cr_state" "$cr_inline_count" "$human_inline_count")
-      notify_for_review "$ci_summary"
-      review_notified_at="$now"
-      # Persist immediately so subsequent polls skip the notify guard
-      local _tmp
-      _tmp=$(mktemp) && jq --arg v "$review_notified_at" '.review_notified_at = $v'         "$STATE_FILE" > "$_tmp" && mv "$_tmp" "$STATE_FILE"
+      if notify_for_review "$ci_summary"; then
+        review_notified_at="$now"
+        # Persist immediately so subsequent polls skip the notify guard
+        local _tmp
+        _tmp=$(mktemp) && jq --arg v "$review_notified_at" '.review_notified_at = $v' \
+          "$STATE_FILE" > "$_tmp" && mv "$_tmp" "$STATE_FILE"
+      else
+        echo "  WARN: reviewer notification incomplete — will retry on next poll."
+      fi
     else
       review_notified_at="${prev_review_notified_at:-}"
     fi

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -8,15 +8,13 @@
 #   --once                   Single poll; exit immediately (default: loop until done)
 #   --full                   Always print full report (default: delta-only on re-polls)
 #   --max-polls N            Stop after N total polls (default: unlimited)
-#   --reviewer USER          Request USER as reviewer when exiting 4 (repeatable)
-#   --team-reviewer TEAM     Request TEAM as reviewer when exiting 4 (repeatable)
 #
 # Exit codes:
 #   0  All checks pass — ready to merge
 #   1  CI failures — fix required
 #   2  Checks still pending — re-poll later
 #   3  Review comments to address
-#   4  Awaiting human review — notifies reviewers and exits
+#   4  Awaiting human review — posts @quay/downstream mention and exits
 #
 # State file: .claude/poll-state/pr-<NUMBER>.json
 #   Tracks check states, review states, comment counts, adaptive sleep, and poll history.
@@ -30,9 +28,6 @@ REPO="quay/quay"
 ONCE=false
 FULL=false
 MAX_POLLS=0  # 0 = unlimited
-REVIEWERS=()
-TEAM_REVIEWERS=()
-
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)
@@ -43,12 +38,6 @@ while [[ $# -gt 0 ]]; do
     --max-polls)
       [ $# -lt 2 ] && { echo "Missing value for --max-polls" >&2; exit 1; }
       MAX_POLLS="$2"; shift 2 ;;
-    --reviewer)
-      [ $# -lt 2 ] && { echo "Missing value for --reviewer" >&2; exit 1; }
-      REVIEWERS+=("$2"); shift 2 ;;
-    --team-reviewer)
-      [ $# -lt 2 ] && { echo "Missing value for --team-reviewer" >&2; exit 1; }
-      TEAM_REVIEWERS+=("$2"); shift 2 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -98,10 +87,10 @@ adaptive_sleep() {
   fi
 }
 
-# Post a "ready for review" comment and request reviewers (idempotent: checks GitHub API)
+# Post a "ready for review" comment mentioning @quay/downstream (idempotent: checks GitHub API)
 notify_for_review() {
   local summary="$1"
-  echo "  Notifying reviewers..."
+  echo "  Posting ready-for-review comment..."
 
   # Idempotency: check GitHub API for an existing ready-for-review comment regardless of state file
   # Treat API failures as "skip posting" to avoid duplicate comments on transient errors
@@ -118,24 +107,11 @@ notify_for_review() {
     return 0
   fi
 
-  # Post PR comment — use printf so \n expands to real newlines
+  # Post PR comment with @quay/downstream mention — use printf so \n expands to real newlines
   local body
-  body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s' "$summary")
+  body=$(printf '## Ready for Review\n\nCI is green and all review threads are resolved.\n\n%s\n\n@quay/downstream' "$summary")
   gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
     -X POST -f body="$body" > /dev/null 2>&1 || true
-
-  # Request individual and team reviewers
-  local reviewer_args=()
-  for r in "${REVIEWERS[@]:-}"; do
-    [ -n "$r" ] && reviewer_args+=(-f "reviewers[]=$r")
-  done
-  for t in "${TEAM_REVIEWERS[@]:-}"; do
-    [ -n "$t" ] && reviewer_args+=(-f "team_reviewers[]=$t")
-  done
-  if [ "${#reviewer_args[@]}" -gt 0 ]; then
-    gh api "repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
-      -X POST "${reviewer_args[@]}" > /dev/null 2>&1 || true
-  fi
 }
 
 # Fetch all CodeRabbit review threads via GraphQL (includes resolved/outdated status)
@@ -543,7 +519,7 @@ do_poll() {
 
   elif [ "$hr_count" -eq 0 ] || [ "$hr_approved" -eq 0 ]; then
     echo "  WAITING: Awaiting human review approval"
-    if [ -z "$prev_review_notified_at" ] && ( [ "${#REVIEWERS[@]}" -gt 0 ] || [ "${#TEAM_REVIEWERS[@]}" -gt 0 ] ); then
+    if [ -z "$prev_review_notified_at" ]; then
       local ci_summary
       ci_summary=$(printf "CI: %s/%s passed | CodeRabbit: %s | Unresolved threads: CR=%s Human=%s" \
         "$pass" "$total" "$cr_state" "$cr_inline_count" "$human_inline_count")
@@ -609,12 +585,8 @@ while true; do
       sleep "$SLEEP_SECS"
       ;;
     4)
-      # Awaiting human review — exit cleanly
-      if [ "${#REVIEWERS[@]}" -gt 0 ] || [ "${#TEAM_REVIEWERS[@]}" -gt 0 ]; then
-        echo "Reviewers notified. Re-run to check for approval: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
-      else
-        echo "Awaiting human review. Re-run later or pass --reviewer/--team-reviewer to auto-notify: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
-      fi
+      # Awaiting human review — @quay/downstream notified, exit cleanly
+      echo "@quay/downstream notified. Re-run to check for approval: bash .claude/scripts/poll-pr.sh ${PR_NUMBER}"
       exit 4
       ;;
     *)

--- a/.claude/scripts/poll-pr.sh
+++ b/.claude/scripts/poll-pr.sh
@@ -324,17 +324,21 @@ do_poll() {
 
     echo "--- CodeRabbit Review ---"
     if [ "$cr_state" != "NONE" ] && [ -n "$cr_state" ]; then
-      echo "  State: ${cr_state}  (at: ${cr_at})"
+      printf "  State: %s  (at: %s)\n" "$cr_state" "$cr_at"
+      if ! $cr_is_current; then
+        echo "  NOTE: Review is for an older commit — waiting for CodeRabbit to re-review ${head_sha:0:7}"
+      fi
     else
       echo "  (no CodeRabbit review yet)"
     fi
     echo ""
 
-    echo "--- CodeRabbit Inline Comments: ${cr_inline_count} ---"
+    echo "--- CodeRabbit Inline Comments on current commit: ${cr_inline_count} ---"
     if [ "$cr_inline_count" -gt 0 ]; then
-      gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
-        --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | .[-3:] | .[] |
-              "  \(.path):\(.line // .original_line // "?")\n  \(.body | split("\n") | .[0:3] | join("\n  "))\n"' \
+      gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+        --jq --arg sha "$head_sha" \
+        '[.[] | select(.user.login == "coderabbitai[bot]" and .commit_id == $sha)] | .[-3:] | .[] |
+              "  \(.path):\(.line // .original_line // \"?\")\n  \(.body | split(\"\n\") | .[0:3] | join(\"\n  \"))\n"' \
         2>/dev/null || true
     fi
     echo ""
@@ -414,7 +418,9 @@ do_poll() {
 
   printf "  CI:         %s/%s passed, %s failed, %s pending\n" \
     "$pass" "$total" "$fail" "$pending"
-  printf "  CodeRabbit: %-26s inline comments: %s\n" "$cr_state" "$cr_inline_count"
+  local _cr_label="$cr_state"
+  ! $cr_is_current && [ "$cr_state" != "NONE" ] && _cr_label="${cr_state} (pending re-review)"
+  printf "  CodeRabbit: %-36s inline: %s\n" "$_cr_label" "$cr_inline_count"
   printf "  Human:      %s/%s approved  |  inline comments: %s\n" "$hr_approved" "$hr_count" "$human_inline_count"
   echo ""
 
@@ -428,12 +434,16 @@ do_poll() {
       2>/dev/null || true
     exit_code=1
 
-  elif [ "$human_inline_count" -gt 0 ] || [ "$cr_inline_count" -gt 0 ]; then
+  elif [ "$human_inline_count" -gt 0 ] || ( [ "$cr_inline_count" -gt 0 ] && $cr_is_current ); then
     local _msg=""
     [ "$human_inline_count" -gt 0 ] && _msg="${human_inline_count} human comment(s)"
-    [ "$cr_inline_count" -gt 0 ]    && _msg="${_msg:+$_msg, }${cr_inline_count} CodeRabbit comment(s)"
+    ( [ "$cr_inline_count" -gt 0 ] && $cr_is_current ) && _msg="${_msg:+$_msg, }${cr_inline_count} CodeRabbit comment(s)"
     printf "  ACTION REQUIRED: Address inline review comments: %s\n" "$_msg"
     exit_code=3
+
+  elif ! $cr_is_current && [ "$cr_state" != "NONE" ] && [ "$pending" -eq 0 ]; then
+    echo "  WAITING: CodeRabbit re-review pending for ${head_sha:0:7}"
+    exit_code=2
 
   elif [ "$pending" -gt 0 ]; then
     printf "  WAITING: %s check(s) still running" "$pending"

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -6,7 +6,7 @@ description: >
   a single status snapshot. Exits with a specific code so the agent knows
   exactly what action to take next.
 argument-hint: PR_NUMBER
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools:
   - Bash(bash .claude/scripts/poll-pr.sh *)
   - Bash(bash .claude/scripts/format-and-lint.sh *)

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -2,9 +2,9 @@
 name: poll
 description: >
   Stateful PR poller: tracks GitHub Actions CI, CodeRabbit, Codecov, and human
-  reviews across polls. Loops with adaptive backoff by default; use --once for
-  a single status snapshot. Exits with a specific code so the agent knows
-  exactly what action to take next.
+  reviews across polls. Always run with --once so the agent drives the loop and
+  can act on each exit code immediately. Use CronCreate for async re-polling
+  while CI is pending.
 argument-hint: PR_NUMBER
 disable-model-invocation: false
 allowed-tools:
@@ -23,15 +23,21 @@ allowed-tools:
   - Grep
   - Agent
   - AskUserQuestion
+  - CronCreate
+  - CronDelete
+  - CronList
 ---
 
 # Poll PR and Act on Feedback
 
 Poll PR #$ARGUMENTS for CI, CodeRabbit, and human review status, then fix what's broken.
 
-The script manages its own state in `.claude/poll-state/pr-$ARGUMENTS.json` and loops
-with adaptive backoff. It shows a full report on the first run, then delta-only on
-subsequent polls so only new events surface.
+**Always run with `--once`** — this lets the agent see the exit code immediately and
+act on it. Never run without `--once` or in the background (`&`); the internal loop
+blocks the agent and swallows exit codes.
+
+The script manages its own state in `.claude/poll-state/pr-$ARGUMENTS.json`.
+It shows a full report on the first run, then delta-only on subsequent polls.
 
 ## Exit codes
 
@@ -39,53 +45,51 @@ subsequent polls so only new events surface.
 |------|---------|--------|
 | 0 | All checks pass | Ready to merge |
 | 1 | CI failures | Fix code, push, re-run |
-| 2 | Checks pending | Script is still looping; wait |
-| 3 | CodeRabbit inline comments | Address comments, push, re-run |
-| 4 | Awaiting human review | Reviewers notified; schedule a re-poll cron |
+| 2 | Checks pending | CronCreate to re-poll; exit this session |
+| 3 | Inline review comments | Address comments, push, re-run |
+| 4 | Awaiting human review | Reviewers notified; CronCreate to re-poll |
 
-## Step 1: Start polling
-
-Specify reviewers to notify when CI is clean and the PR is ready:
+## Step 1: First poll
 
 ```bash
-bash .claude/scripts/poll-pr.sh $ARGUMENTS --reviewer jbpratt
+bash .claude/scripts/poll-pr.sh $ARGUMENTS --once --team-reviewer downstream-team
 ```
 
-For a team (once the team exists):
-
-```bash
-bash .claude/scripts/poll-pr.sh $ARGUMENTS --team-reviewer downstream-team
-```
-
-The script loops with adaptive backoff (120-600s) while CI is pending, then exits when action is needed:
-- **Exit 0**: Everything passes — done.
-- **Exit 1**: CI failures — needs a fix.
-- **Exit 3**: Inline review comments — needs your attention.
-- **Exit 4**: Awaiting human review — reviewers notified.
-
-For a single snapshot without looping (e.g. to check status mid-fix):
-
-```bash
-bash .claude/scripts/poll-pr.sh $ARGUMENTS --once
-```
-
-For a complete report instead of delta-only output:
+Read the exit code and act on it per the table above. For a complete report:
 
 ```bash
 bash .claude/scripts/poll-pr.sh $ARGUMENTS --once --full
 ```
 
-## Step 1b: If exit 4 — schedule a re-poll cron
+## Step 2: Exit 2 — CI still pending
 
-When the script exits 4 (awaiting review), it has already posted a comment and requested reviewers. Use CronCreate to check back automatically:
+Read the suggested sleep interval from the state file:
+
+```bash
+jq .next_sleep_seconds .claude/poll-state/pr-$ARGUMENTS.json
+```
+
+Create a cron to re-run the skill automatically after that interval:
 
 ```
-CronCreate: every 2 hours, run: bash .claude/scripts/poll-pr.sh $ARGUMENTS --reviewer jbpratt
+CronCreate: in <next_sleep_seconds> seconds, /poll $ARGUMENTS
 ```
 
-Delete the cron (CronDelete) once the PR is merged or approved.
+Then exit. The cron fires a new session which continues from the saved state.
+Delete the cron (CronDelete) if you need to cancel.
 
-## Step 2: Act on CI Failures (exit code 1)
+## Step 3: Exit 4 — awaiting human review
+
+The script has already posted a comment and requested reviewers.
+Create a cron to check back periodically:
+
+```
+CronCreate: every 2 hours, /poll $ARGUMENTS
+```
+
+Delete the cron (CronDelete) once the PR is approved or merged.
+
+## Step 4: Exit 1 — CI failures
 
 | CI Job | Fix |
 |--------|-----|
@@ -96,7 +100,7 @@ Delete the cron (CronDelete) once the PR is merged or approved.
 | Cypress/Playwright | `cd web && npm run test:e2e` |
 | PR Lint | Fix PR title regex |
 
-## Step 3: Act on CodeRabbit Feedback (exit code 3)
+## Step 5: Exit 3 — inline review comments
 
 CodeRabbit (`chill` profile) runs 7 pre-merge checks:
 
@@ -111,19 +115,19 @@ CodeRabbit (`chill` profile) runs 7 pre-merge checks:
 | Read Path Performance | No latency regressions on v2 read path |
 
 When flagged:
-1. Run `--once --full` to see all inline comments
+1. Run `--once --full` to see all inline comments with reply/resolve commands
 2. Assess each: in `chill` mode, flags are generally valid
-3. Fix the code or reply with rationale
-4. Push and restart polling
+3. Fix the code or reply with rationale, then resolve the thread
+4. Push and re-run `--once`
 
-## Step 4: Push and re-poll
+## Step 6: Push and re-poll
 
 ```bash
-git add -A && git commit -m "type(scope): address feedback (PROJQUAY-XXXX)"
-git push
-bash .claude/scripts/poll-pr.sh $ARGUMENTS
+git add -A && git commit -m "type(scope): address feedback"
+git push fork <branch>
+bash .claude/scripts/poll-pr.sh $ARGUMENTS --once
 ```
 
-State is preserved across runs -- the next poll will show only what changed since the last run.
+State is preserved across runs — the next poll shows only what changed.
 
 Repeat until exit 0.

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -67,7 +67,7 @@ be notified automatically.
 When the script exits 4, it has already posted a comment and requested reviewers.
 Use CronCreate to check back automatically:
 
-```
+```text
 CronCreate: every 2 hours, /poll $ARGUMENTS
 ```
 

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -57,29 +57,11 @@ For a team (once the team exists):
 bash .claude/scripts/poll-pr.sh $ARGUMENTS --team-reviewer downstream-team
 ```
 
-The script loops while CI is pending, then exits when action is needed.
-
-## Step 1b: If exit 4 — schedule a re-poll cron
-
-When the script exits 4 (awaiting review), it has already posted a comment and requested reviewers. Use CronCreate to check back automatically:
-
-```
-CronCreate: every 2 hours, run: bash .claude/scripts/poll-pr.sh $ARGUMENTS --reviewer jbpratt
-```
-
-Delete the cron (CronDelete) once the PR is merged or approved.
-
-## Step 2: Start polling (original step — loops until action needed or all pass)
-
-```bash
-bash .claude/scripts/poll-pr.sh $ARGUMENTS
-```
-
-The script sleeps adaptively between polls (120-600s based on how long checks have been
-pending and whether state changed). It stops automatically when:
-- **Exit 0**: Everything passes -- done.
-- **Exit 1**: CI failures -- needs your fix.
-- **Exit 3**: CodeRabbit inline comments -- needs your review.
+The script loops with adaptive backoff (120-600s) while CI is pending, then exits when action is needed:
+- **Exit 0**: Everything passes — done.
+- **Exit 1**: CI failures — needs a fix.
+- **Exit 3**: Inline review comments — needs your attention.
+- **Exit 4**: Awaiting human review — reviewers notified.
 
 For a single snapshot without looping (e.g. to check status mid-fix):
 
@@ -92,6 +74,16 @@ For a complete report instead of delta-only output:
 ```bash
 bash .claude/scripts/poll-pr.sh $ARGUMENTS --once --full
 ```
+
+## Step 1b: If exit 4 — schedule a re-poll cron
+
+When the script exits 4 (awaiting review), it has already posted a comment and requested reviewers. Use CronCreate to check back automatically:
+
+```
+CronCreate: every 2 hours, run: bash .claude/scripts/poll-pr.sh $ARGUMENTS --reviewer jbpratt
+```
+
+Delete the cron (CronDelete) once the PR is merged or approved.
 
 ## Step 2: Act on CI Failures (exit code 1)
 

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -41,9 +41,35 @@ subsequent polls so only new events surface.
 | 1 | CI failures | Fix code, push, re-run |
 | 2 | Checks pending | Script is still looping; wait |
 | 3 | CodeRabbit inline comments | Address comments, push, re-run |
-| 4 | Awaiting human review | Script is still looping; wait |
+| 4 | Awaiting human review | Reviewers notified; schedule a re-poll cron |
 
-## Step 1: Start polling (loops until action needed or all pass)
+## Step 1: Start polling
+
+Specify reviewers to notify when CI is clean and the PR is ready:
+
+```bash
+bash .claude/scripts/poll-pr.sh $ARGUMENTS --reviewer jbpratt
+```
+
+For a team (once the team exists):
+
+```bash
+bash .claude/scripts/poll-pr.sh $ARGUMENTS --team-reviewer downstream-team
+```
+
+The script loops while CI is pending, then exits when action is needed.
+
+## Step 1b: If exit 4 — schedule a re-poll cron
+
+When the script exits 4 (awaiting review), it has already posted a comment and requested reviewers. Use CronCreate to check back automatically:
+
+```
+CronCreate: every 2 hours, run: bash .claude/scripts/poll-pr.sh $ARGUMENTS --reviewer jbpratt
+```
+
+Delete the cron (CronDelete) once the PR is merged or approved.
+
+## Step 2: Start polling (original step — loops until action needed or all pass)
 
 ```bash
 bash .claude/scripts/poll-pr.sh $ARGUMENTS

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -2,9 +2,8 @@
 name: poll
 description: >
   Stateful PR poller: tracks GitHub Actions CI, CodeRabbit, Codecov, and human
-  reviews across polls. Always run with --once so the agent drives the loop and
-  can act on each exit code immediately. Use CronCreate for async re-polling
-  while CI is pending.
+  reviews across polls. Loops with adaptive backoff internally. Run via the Bash
+  tool with run_in_background: true so the platform notifies the agent on exit.
 argument-hint: PR_NUMBER
 disable-model-invocation: false
 allowed-tools:
@@ -32,56 +31,41 @@ allowed-tools:
 
 Poll PR #$ARGUMENTS for CI, CodeRabbit, and human review status, then fix what's broken.
 
-**Always run with `--once`** — this lets the agent see the exit code immediately and
-act on it. Never run without `--once` or in the background (`&`); the internal loop
-blocks the agent and swallows exit codes.
+The script manages its own state in `.claude/poll-state/pr-$ARGUMENTS.json` and loops
+internally with adaptive backoff (120-600s). It shows a full report on the first run,
+then delta-only on subsequent polls so only new events surface.
 
-The script manages its own state in `.claude/poll-state/pr-$ARGUMENTS.json`.
-It shows a full report on the first run, then delta-only on subsequent polls.
+## CRITICAL: always use run_in_background: true
 
-## Exit codes
+Run the script via the Bash tool with `run_in_background: true`. **Never use `&`** to
+background it in the shell — that detaches the process and makes the exit code invisible.
+
+With `run_in_background: true`, the platform tracks the process and sends a
+`<task-notification>` when it exits. Read the output file from the notification to
+see the full report and exit code, then act on it.
+
+```bash
+# Bash tool call — set run_in_background: true
+bash .claude/scripts/poll-pr.sh $ARGUMENTS --team-reviewer downstream-team
+```
+
+The script sleeps and polls on its own. Do not interrupt it. When it exits, you will
+be notified automatically.
+
+## Exit codes — what to do when notified
 
 | Code | Meaning | Action |
 |------|---------|--------|
 | 0 | All checks pass | Ready to merge |
-| 1 | CI failures | Fix code, push, re-run |
-| 2 | Checks pending | CronCreate to re-poll; exit this session |
-| 3 | Inline review comments | Address comments, push, re-run |
-| 4 | Awaiting human review | Reviewers notified; CronCreate to re-poll |
+| 1 | CI failures | Fix code, push, re-run (background again) |
+| 2 | Checks pending | Should not exit 2 unless --max-polls hit; re-run |
+| 3 | Inline review comments | Address comments, push, re-run (background again) |
+| 4 | Awaiting human review | Reviewers notified; CronCreate to re-poll later |
 
-## Step 1: First poll
+## Exit 4 — schedule a re-poll cron
 
-```bash
-bash .claude/scripts/poll-pr.sh $ARGUMENTS --once --team-reviewer downstream-team
-```
-
-Read the exit code and act on it per the table above. For a complete report:
-
-```bash
-bash .claude/scripts/poll-pr.sh $ARGUMENTS --once --full
-```
-
-## Step 2: Exit 2 — CI still pending
-
-Read the suggested sleep interval from the state file:
-
-```bash
-jq .next_sleep_seconds .claude/poll-state/pr-$ARGUMENTS.json
-```
-
-Create a cron to re-run the skill automatically after that interval:
-
-```
-CronCreate: in <next_sleep_seconds> seconds, /poll $ARGUMENTS
-```
-
-Then exit. The cron fires a new session which continues from the saved state.
-Delete the cron (CronDelete) if you need to cancel.
-
-## Step 3: Exit 4 — awaiting human review
-
-The script has already posted a comment and requested reviewers.
-Create a cron to check back periodically:
+When the script exits 4, it has already posted a comment and requested reviewers.
+Use CronCreate to check back automatically:
 
 ```
 CronCreate: every 2 hours, /poll $ARGUMENTS
@@ -89,7 +73,7 @@ CronCreate: every 2 hours, /poll $ARGUMENTS
 
 Delete the cron (CronDelete) once the PR is approved or merged.
 
-## Step 4: Exit 1 — CI failures
+## Exit 1 — CI failures
 
 | CI Job | Fix |
 |--------|-----|
@@ -100,7 +84,15 @@ Delete the cron (CronDelete) once the PR is approved or merged.
 | Cypress/Playwright | `cd web && npm run test:e2e` |
 | PR Lint | Fix PR title regex |
 
-## Step 5: Exit 3 — inline review comments
+After fixing: push, then re-run the script via Bash with `run_in_background: true`.
+
+## Exit 3 — inline review comments
+
+Run `--once --full` to see comments with reply/resolve commands:
+
+```bash
+bash .claude/scripts/poll-pr.sh $ARGUMENTS --once --full
+```
 
 CodeRabbit (`chill` profile) runs 7 pre-merge checks:
 
@@ -114,20 +106,17 @@ CodeRabbit (`chill` profile) runs 7 pre-merge checks:
 | N+1 Query Prevention | No loop-based query patterns |
 | Read Path Performance | No latency regressions on v2 read path |
 
-When flagged:
-1. Run `--once --full` to see all inline comments with reply/resolve commands
-2. Assess each: in `chill` mode, flags are generally valid
-3. Fix the code or reply with rationale, then resolve the thread
-4. Push and re-run `--once`
+Steps:
+1. Read all inline comments (reply command + resolve command shown per thread)
+2. Fix the code or reply with rationale, then resolve the thread via GraphQL
+3. Push and re-run the script via Bash with `run_in_background: true`
 
-## Step 6: Push and re-poll
+## Push and re-run
 
 ```bash
 git add -A && git commit -m "type(scope): address feedback"
 git push fork <branch>
-bash .claude/scripts/poll-pr.sh $ARGUMENTS --once
+# then re-run poll via Bash tool with run_in_background: true
 ```
-
-State is preserved across runs — the next poll shows only what changed.
 
 Repeat until exit 0.

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -46,7 +46,7 @@ see the full report and exit code, then act on it.
 
 ```bash
 # Bash tool call — set run_in_background: true
-bash .claude/scripts/poll-pr.sh $ARGUMENTS --team-reviewer downstream-team
+bash .claude/scripts/poll-pr.sh $ARGUMENTS
 ```
 
 The script sleeps and polls on its own. Do not interrupt it. When it exits, you will
@@ -60,7 +60,7 @@ be notified automatically.
 | 1 | CI failures | Fix code, push, re-run (background again) |
 | 2 | Checks pending | Should not exit 2 unless --max-polls hit; re-run |
 | 3 | Inline review comments | Address comments, push, re-run (background again) |
-| 4 | Awaiting human review | Reviewers notified; CronCreate to re-poll later |
+| 4 | Awaiting human review | @quay/downstream notified; CronCreate to re-poll later |
 
 ## Exit 4 — schedule a re-poll cron
 
@@ -72,6 +72,8 @@ CronCreate: every 2 hours, /poll $ARGUMENTS
 ```
 
 Delete the cron (CronDelete) once the PR is approved or merged.
+
+Note: the script automatically mentions `@quay/downstream` in the ready-for-review comment — no reviewer flags needed.
 
 ## Exit 1 — CI failures
 

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -106,10 +106,23 @@ CodeRabbit (`chill` profile) runs 7 pre-merge checks:
 | N+1 Query Prevention | No loop-based query patterns |
 | Read Path Performance | No latency regressions on v2 read path |
 
+**Evaluate each comment critically — CodeRabbit is often right but not always.**
+Read the full context, understand what it's flagging, and make a genuine judgment call:
+
+- **Valid**: fix the code, then reply explaining what you changed before resolving
+- **Invalid or inapplicable**: reply with your reasoning (e.g. "this pattern is
+  intentional because X"), then resolve — don't silently dismiss
+- **Unclear**: reply asking CodeRabbit to clarify or expand. It can engage in
+  follow-up discussion and often provides more detail or reconsiders when pushed
+
+The goal is a real conversation, not rubber-stamping. A well-reasoned "won't fix"
+reply is better than a blind fix or a silent resolve.
+
 Steps:
 1. Read all inline comments (reply command + resolve command shown per thread)
-2. Fix the code or reply with rationale, then resolve the thread via GraphQL
-3. Push and re-run the script via Bash with `run_in_background: true`
+2. Evaluate: fix, reply with rationale, or ask a follow-up question
+3. Once settled, resolve the thread via GraphQL
+4. Push and re-run the script via Bash with `run_in_background: true`
 
 ## Push and re-run
 

--- a/.claude/skills/poll/SKILL.md
+++ b/.claude/skills/poll/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: poll
 description: >
-  Poll a PR for GitHub Actions CI results, CodeRabbit review feedback, Codecov
-  coverage, and human reviews. Identifies failures and acts on them: fixes code,
-  responds to review comments, pushes, and re-polls until everything passes.
+  Stateful PR poller: tracks GitHub Actions CI, CodeRabbit, Codecov, and human
+  reviews across polls. Loops with adaptive backoff by default; use --once for
+  a single status snapshot. Exits with a specific code so the agent knows
+  exactly what action to take next.
 argument-hint: PR_NUMBER
 disable-model-invocation: true
 allowed-tools:
@@ -26,15 +27,47 @@ allowed-tools:
 
 # Poll PR and Act on Feedback
 
-Poll PR #$ARGUMENTS for CI, CodeRabbit, and human review status. Fix issues found.
+Poll PR #$ARGUMENTS for CI, CodeRabbit, and human review status, then fix what's broken.
 
-## Step 1: Poll
+The script manages its own state in `.claude/poll-state/pr-$ARGUMENTS.json` and loops
+with adaptive backoff. It shows a full report on the first run, then delta-only on
+subsequent polls so only new events surface.
+
+## Exit codes
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| 0 | All checks pass | Ready to merge |
+| 1 | CI failures | Fix code, push, re-run |
+| 2 | Checks pending | Script is still looping; wait |
+| 3 | CodeRabbit inline comments | Address comments, push, re-run |
+| 4 | Awaiting human review | Script is still looping; wait |
+
+## Step 1: Start polling (loops until action needed or all pass)
 
 ```bash
 bash .claude/scripts/poll-pr.sh $ARGUMENTS
 ```
 
-## Step 2: Act on CI Failures
+The script sleeps adaptively between polls (120-600s based on how long checks have been
+pending and whether state changed). It stops automatically when:
+- **Exit 0**: Everything passes -- done.
+- **Exit 1**: CI failures -- needs your fix.
+- **Exit 3**: CodeRabbit inline comments -- needs your review.
+
+For a single snapshot without looping (e.g. to check status mid-fix):
+
+```bash
+bash .claude/scripts/poll-pr.sh $ARGUMENTS --once
+```
+
+For a complete report instead of delta-only output:
+
+```bash
+bash .claude/scripts/poll-pr.sh $ARGUMENTS --once --full
+```
+
+## Step 2: Act on CI Failures (exit code 1)
 
 | CI Job | Fix |
 |--------|-----|
@@ -45,7 +78,7 @@ bash .claude/scripts/poll-pr.sh $ARGUMENTS
 | Cypress/Playwright | `cd web && npm run test:e2e` |
 | PR Lint | Fix PR title regex |
 
-## Step 3: Act on CodeRabbit Feedback
+## Step 3: Act on CodeRabbit Feedback (exit code 3)
 
 CodeRabbit (`chill` profile) runs 7 pre-merge checks:
 
@@ -60,17 +93,19 @@ CodeRabbit (`chill` profile) runs 7 pre-merge checks:
 | Read Path Performance | No latency regressions on v2 read path |
 
 When flagged:
-1. Read the specific comment
-2. Assess if actionable (in `chill` mode, flags are generally valid)
-3. Fix or reply with rationale
-4. Push and re-poll
+1. Run `--once --full` to see all inline comments
+2. Assess each: in `chill` mode, flags are generally valid
+3. Fix the code or reply with rationale
+4. Push and restart polling
 
-## Step 4: Push and Re-poll
+## Step 4: Push and re-poll
 
 ```bash
-git add -A && git commit -m "<subsystem>: <what changed> (PROJQUAY-XXXX)"
+git add -A && git commit -m "type(scope): address feedback (PROJQUAY-XXXX)"
 git push
 bash .claude/scripts/poll-pr.sh $ARGUMENTS
 ```
 
-Repeat until all CI passes, CodeRabbit passes, coverage holds, and human review approves.
+State is preserved across runs -- the next poll will show only what changed since the last run.
+
+Repeat until exit 0.

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ bin/
 # claude
 .claude/plans
 .claude/implementation
+.claude/poll-state/


### PR DESCRIPTION
## Summary
- Rewrites `poll-pr.sh` to persist state between polls, enabling delta-only output and adaptive backoff sleeping
- Adds `--once` flag (single-shot check) and `--full` flag (force complete report); default mode now loops until action needed
- Updates `/poll` skill documentation to match new flags and exit code semantics

## Root Cause / Rationale
The previous script was stateless: every invocation fetched and printed everything from scratch. With `--wait` it slept a fixed 60 seconds regardless of check state. This meant the agent had to parse the full output every time and manually judge whether to continue waiting. The new design makes the script intelligent about what changed and how long to wait.

## Changes
- `.claude/scripts/poll-pr.sh` — complete rewrite:
  - State file written to `.claude/poll-state/pr-<N>.json` after each poll
  - Delta detection: compares current check states, CodeRabbit review/comment counts, and human reviews against previous state; reports only what changed
  - Adaptive backoff: 120s when checks are running, 180s when many are queued, doubles (up to 600s) when nothing changed across consecutive polls
  - New flags: `--once` (no loop), `--full` (complete report), `--max-polls N` (hard cap)
  - Richer exit codes: 0=all pass, 1=CI fail, 2=pending, 3=CR comments, 4=awaiting human review
  - `.gitignore` entry for `.claude/poll-state/` added automatically on first run
- `.claude/skills/poll/SKILL.md` — updated to document new behavior, exit code table, and flag usage
- `.gitignore` — explicit `.claude/poll-state/` entry added

## Test Plan
- [ ] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [x] Manual testing performed (script syntax verified with `bash -n`, flag parsing tested)
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

## JIRA
N/A — tooling improvement, no associated ticket

## Backport
- [x] No backport needed