### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/auth/basic.py
+++ b/auth/basic.py
@@ -36,7 +36,7 @@ def validate_basic_auth(auth_header):
     assert isinstance(auth_header, str)
     credentials, err = _parse_basic_auth_header(auth_header)
     if err is not None:
-        logger.debug("Got invalid basic auth header: %s", auth_header)
+        logger.debug("Got invalid basic auth header")
         return ValidateResult(AuthKind.basic, missing=True)
 
     auth_username, auth_password_or_token = credentials
@@ -55,7 +55,7 @@ def _parse_basic_auth_header(auth):
     try:
         credentials = [part.decode("utf-8") for part in b64decode(normalized[1]).split(b":", 1)]
     except (TypeError, UnicodeDecodeError, ValueError):
-        logger.exception("Exception when parsing basic auth header: %s", auth)
+        logger.exception("Exception when parsing basic auth header")
         return None, "Could not parse basic auth header"
 
     if len(credentials) != 2:

--- a/auth/signedgrant.py
+++ b/auth/signedgrant.py
@@ -36,12 +36,12 @@ def validate_signed_grant(auth_header):
     # Try to parse the token from the header.
     normalized = [part.strip() for part in auth_header.split(" ") if part]
     if normalized[0].lower() != "token" or len(normalized) != 2:
-        logger.debug("Not a token: %s", auth_header)
+        logger.debug("Not a token")
         return ValidateResult(AuthKind.signed_grant, missing=True)
 
     # Check that it starts with the expected prefix.
     if not normalized[1].startswith(SIGNATURE_PREFIX):
-        logger.debug("Not a signed grant token: %s", auth_header)
+        logger.debug("Not a signed grant token")
         return ValidateResult(AuthKind.signed_grant, missing=True)
 
     # Decrypt the grant.
@@ -51,10 +51,10 @@ def validate_signed_grant(auth_header):
     try:
         token_data = ser.loads(encrypted, max_age=app.config["SIGNED_GRANT_EXPIRATION_SEC"])
     except BadSignature:
-        logger.warning("Signed grant could not be validated: %s", encrypted)
+        logger.warning("Signed grant could not be validated")
         return ValidateResult(
             AuthKind.signed_grant, error_message="Signed grant could not be validated"
         )
 
-    logger.debug("Successfully validated signed grant with data: %s", token_data)
+    logger.debug("Successfully validated signed grant")
     return ValidateResult(AuthKind.signed_grant, signed_data=token_data)


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `auth/basic.py:L37`

Invalid Basic Authorization headers are logged verbatim, including the full `Authorization` value. Because Basic auth is base64-encoded credentials, this can leak usernames/passwords (or tokens) to log sinks and monitoring systems.

## Solution

Never log raw authorization headers. Replace with constant messages or redact values (e.g., log only scheme and token length/hash). For exception paths, remove `%s` interpolation of the header.

## Changes

- `auth/basic.py` (modified)
- `auth/signedgrant.py` (modified)