### PR TITLE
NO-ISSUE: test(web): add Phase 5 unit tests for API resource layer

### DIFF
--- a/agent_docs/web-unit-test-roadmap.md
+++ b/agent_docs/web-unit-test-roadmap.md
@@ -3,7 +3,7 @@
 Prioritized checklist of testable areas in `web/src/`, with effort estimates and implementation guidance.
 
 **Stack:** Vitest + React Testing Library + happy-dom
-**Current state:** 239 tests passing across 14 files. Phases 1-4 complete. Playwright covers E2E (58 tests).
+**Current state:** 530 tests passing across 41 files. Phases 1-5 complete. Playwright covers E2E (58 tests).
 **Target:** ~620 unit tests across 7 phases
 
 ## Completed: Framework Setup
@@ -65,37 +65,53 @@ Prioritized checklist of testable areas in `web/src/`, with effort estimates and
 
 ---
 
-## Phase 5: API Resource Layer (~110 tests)
+## Phase 5: API Resource Layer — COMPLETE (291 tests)
 
-29 untested resource files (~346 exported functions). Most follow the same pattern: thin axios wrapper with optional data transformation. Create a shared mock factory and template tests.
+27 resource files tested. All use `vi.mock('src/libs/axios')` module-level mocking with a shared `mockResponse()` helper per file.
 
-**High priority (test first):**
+**High priority (4 files, 120 tests):**
 
-| File | Est. Tests | Notes |
-|------|-----------|-------|
-| `src/resources/RepositoryResource.ts` | ~18 | Pagination recursion in `fetchAllRepos`, batching logic, `fetchAllReposAsSuperUser` truncation, `isNonNormalState` |
-| `src/resources/TagResource.ts` | ~20 | Many operations, sparse manifest handling, complex types |
-| `src/resources/OrganizationResource.ts` | ~18 | `OrgDeleteError` class, bulk operations, Promise.allSettled error aggregation |
-| `src/resources/UserResource.ts` | ~12 | Auth-related transforms, entity type enumeration |
+| File | Tests | Status |
+|------|-------|--------|
+| `src/resources/RepositoryResource.ts` | 38 | **Done** — `isNonNormalState`, pagination recursion, batching, superuser truncation, CRUD, bulk operations with `BulkOperationError`, permission type mapping, transitive permissions with 404 handling |
+| `src/resources/TagResource.ts` | 34 | **Done** — `getTags` with URL params, label CRUD, bulk delete with force mode, manifest retrieval, tag operations, pull statistics error paths |
+| `src/resources/OrganizationResource.ts` | 20 | **Done** — org CRUD, `OrgDeleteError`, superuser paths, bulk delete with `Promise.allSettled`, `updateOrgSettings` null key stripping |
+| `src/resources/UserResource.ts` | 28 | **Done** — `getEntityKind` enumeration, entity search with robot prefix stripping/filtering, user CRUD, `UserDeleteError`/`ApplicationTokenError` detail extraction, app token CRUD |
 
-**Medium priority (batch with template):**
+**Medium priority (9 files, 114 tests):**
 
-| File | Est. Tests | Notes |
-|------|-----------|-------|
-| `src/resources/QuotaResource.ts` | ~8 | Endpoint routing by viewMode, abort/cancel handling, 404/403 fallback |
-| `src/resources/AuthResource.ts` | ~4 | Auth state management |
-| `src/resources/RobotsResource.ts` | ~4 | Robot account CRUD |
-| `src/resources/BuildResource.ts` | ~4 | Build trigger/log operations |
-| `src/resources/MirroringResource.ts` | ~4 | Mirror config CRUD |
-| `src/resources/DefaultPermissionResource.ts` | ~3 | Permission CRUD |
-| `src/resources/MembersResource.ts` | ~3 | Member management |
-| `src/resources/NotificationResource.ts` | ~3 | Notification CRUD |
-| `src/resources/TeamResources.ts` | ~3 | Team management |
+| File | Tests | Status |
+|------|-------|--------|
+| `src/resources/QuotaResource.ts` | 21 | **Done** — viewMode-based URL routing (self/org/superuser), 404/403 fallback, `bytesToHumanReadable`/`humanReadableToBytes` conversions |
+| `src/resources/AuthResource.ts` | 10 | **Done** — `GlobalAuthState` management, login/logout, CSRF token |
+| `src/resources/RobotsResource.ts` | 14 | **Done** — Robot CRUD with org prefix stripping, federation config, bulk operations |
+| `src/resources/BuildResource.ts` | 17 | **Done** — Build CRUD, trigger management, `startBuild` ref type routing, `fetchBuildLogs` with archived redirect, parallel superuser log fetch |
+| `src/resources/MirroringResource.ts` | 11 | **Done** — Mirror config CRUD, `timestampToISO`/`timestampFromISO`, status labels |
+| `src/resources/DefaultPermissionResource.ts` | 10 | **Done** — Permission CRUD, `addRepoPermissionToTeam` with console.error (no throw), bulk delete |
+| `src/resources/MembersResource.ts` | 9 | **Done** — Member/collaborator CRUD, parallel fetch |
+| `src/resources/NotificationResource.ts` | 12 | **Done** — Notification CRUD with eventConfig transform, `isNotificationDisabled` (>=3 failures) |
+| `src/resources/TeamResources.ts` | 10 | **Done** — Team CRUD, `updateTeamRepoPerm` with role='none' delete path |
 
-**Low priority (1-2 tests per endpoint):**
-Remaining ~16 resources: `BillingResource`, `CapabilitiesResource`, `ChangeLogResource`, `GlobalMessagesResource`, `OAuthApplicationResource`, `ProxyCacheResource`, `RegistrySizeResource`, `ServiceKeysResource`, `TeamSyncResource`, `RepositoryAutoPruneResource`, `NamespaceAutoPruneResource`, `ImmutabilityPolicyResource`, `OrgMirrorResource`, `LabelsResource`, `QuayConfig`, `ExternalLoginResource`.
+**Low priority (14 files, 57 tests):**
 
-**Effort:** ~4-5 days. Create `createMockAxios()` utility once, reuse everywhere.
+| File | Tests | Status |
+|------|-------|--------|
+| `src/resources/BillingResource.ts` | 8 | **Done** |
+| `src/resources/OrgMirrorResource.ts` | 10 | **Done** |
+| `src/resources/ImmutabilityPolicyResource.ts` | 6 | **Done** |
+| `src/resources/OAuthApplicationResource.ts` | 5 | **Done** |
+| `src/resources/TeamSyncResource.ts` | 5 | **Done** |
+| `src/resources/ServiceKeysResource.ts` | 4 | **Done** |
+| `src/resources/NamespaceAutoPruneResource.ts` | 4 | **Done** |
+| `src/resources/RepositoryAutoPruneResource.ts` | 3 | **Done** |
+| `src/resources/ProxyCacheResource.ts` | 2 | **Done** |
+| `src/resources/RegistrySizeResource.ts` | 2 | **Done** |
+| `src/resources/GlobalMessagesResource.ts` | 4 | **Done** |
+| `src/resources/CapabilitiesResource.ts` | 1 | **Done** |
+| `src/resources/ChangeLogResource.ts` | 1 | **Done** |
+| `src/resources/QuayConfig.ts` | 1 | **Done** |
+
+**Notes:** `LabelsResource.ts` and `ExternalLoginResource.ts` do not exist in the resources directory. No shared `createMockAxios()` utility was needed — the per-file `vi.mock` + `mockResponse()` pattern is simple and self-contained.
 
 ---
 
@@ -202,13 +218,13 @@ Leave these to Playwright E2E:
 | 2 | Error handling + cookies | 31 | 1 day | **Complete** |
 | 3 | Contexts | 38 | 1 day | **Complete** |
 | 4 | Complex hooks | 59 | 2-3 days | **Complete** |
-| 5 | API resources (29 files) | ~110 | 4-5 days | Pending |
+| 5 | API resources (27 files) | 291 | 4-5 days | **Complete** |
 | 6 | Standard hooks (79 files) | ~140 | 4-5 days | Pending |
 | 7 | Components (100 files) | ~140 | 5-6 days | **In progress** — LoadingPage (6) done |
 
-**Current: 239 tests passing across 14 files | Target: ~620 tests**
+**Current: 530 tests passing across 41 files | Target: ~620 tests**
 
-Phases 1-4 are complete and deliver the most value per test written. Phases 5-7 are incremental and can be spread over sprints. Remaining effort: ~13-16 days.
+Phases 1-5 are complete. Phases 6-7 are incremental and can be spread over sprints. Remaining effort: ~9-11 days.
 
 ---
 
@@ -216,8 +232,8 @@ Phases 1-4 are complete and deliver the most value per test written. Phases 5-7 
 
 1. [x] **`createTestQueryClient()`** — Fresh QueryClient per render, in `src/test-utils.tsx`
 2. [x] **`customRender()`** — Wraps in RecoilRoot + UIProvider + QueryClientProvider, in `src/test-utils.tsx`
-3. [ ] **`createMockAxios()`** — Factory for axios-mock-adapter setup (Phase 5)
-4. [ ] **Mock data factories** — e.g., `createMockOrg()`, `createMockRepo()`, `createMockTag()` (Phase 5)
+3. [x] **Axios mocking pattern** — `vi.mock('src/libs/axios')` + per-file `mockResponse()` helper (Phase 5). No shared factory needed — pattern is simple and self-contained.
+4. [ ] **Mock data factories** — e.g., `createMockOrg()`, `createMockRepo()`, `createMockTag()` (Phase 6-7, if needed)
 5. [ ] **`renderWithRoute()`** — MemoryRouter wrapper for components using `useNavigate`/`useParams` (Phase 7, if needed)
 
 ---
@@ -226,11 +242,11 @@ Phases 1-4 are complete and deliver the most value per test written. Phases 5-7 
 
 Coverage is collected via V8 (`@vitest/coverage-v8`). No enforcement thresholds initially.
 
-**Baseline after Phase 4 (239 tests):** `src/libs/` 84%, `src/contexts/` 100%, `src/hooks/` 4%, `src/resources/` 6%, `src/components/` <1%, overall ~4%.
+**Baseline after Phase 5 (530 tests):** `src/libs/` 84%, `src/contexts/` 100%, `src/hooks/` 4%, `src/resources/` ~55-60%, `src/components/` <1%, overall ~8%.
 
 **Ratchet-up plan:**
 1. After Phase 4 (done): baseline measured. `src/libs/` and `src/contexts/` already meet targets.
-2. After Phase 5: `src/resources/` should reach ~55-60%
+2. After Phase 5 (done): `src/resources/` ~55-60%
 3. After Phase 6: `src/hooks/` should reach ~45-50%
 4. After Phase 7: `src/components/` should reach ~40-45%, overall ~50-55%
 5. Target: 80% on `src/libs/`, 60% on `src/hooks/`, 40% overall

--- a/agent_docs/web-unit-test-roadmap.md
+++ b/agent_docs/web-unit-test-roadmap.md
@@ -4,7 +4,7 @@ Prioritized checklist of testable areas in `web/src/`, with effort estimates and
 
 **Stack:** Vitest + React Testing Library + happy-dom
 **Current state:** 530 tests passing across 41 files. Phases 1-5 complete. Playwright covers E2E (58 tests).
-**Target:** ~620 unit tests across 7 phases
+**Target:** ~810 unit tests across 7 phases
 
 ## Completed: Framework Setup
 
@@ -75,34 +75,34 @@ Prioritized checklist of testable areas in `web/src/`, with effort estimates and
 |------|-------|--------|
 | `src/resources/RepositoryResource.ts` | 38 | **Done** — `isNonNormalState`, pagination recursion, batching, superuser truncation, CRUD, bulk operations with `BulkOperationError`, permission type mapping, transitive permissions with 404 handling |
 | `src/resources/TagResource.ts` | 34 | **Done** — `getTags` with URL params, label CRUD, bulk delete with force mode, manifest retrieval, tag operations, pull statistics error paths |
-| `src/resources/OrganizationResource.ts` | 20 | **Done** — org CRUD, `OrgDeleteError`, superuser paths, bulk delete with `Promise.allSettled`, `updateOrgSettings` null key stripping |
-| `src/resources/UserResource.ts` | 28 | **Done** — `getEntityKind` enumeration, entity search with robot prefix stripping/filtering, user CRUD, `UserDeleteError`/`ApplicationTokenError` detail extraction, app token CRUD |
+| `src/resources/OrganizationResource.ts` | 16 | **Done** — org CRUD, `OrgDeleteError`, superuser paths, bulk delete with `Promise.allSettled`, `updateOrgSettings` null key stripping |
+| `src/resources/UserResource.ts` | 32 | **Done** — `getEntityKind` enumeration, entity search with robot prefix stripping/filtering, user CRUD, `UserDeleteError`/`ApplicationTokenError` detail extraction, app token CRUD |
 
-**Medium priority (9 files, 114 tests):**
+**Medium priority (9 files, 117 tests):**
 
 | File | Tests | Status |
 |------|-------|--------|
-| `src/resources/QuotaResource.ts` | 21 | **Done** — viewMode-based URL routing (self/org/superuser), 404/403 fallback, `bytesToHumanReadable`/`humanReadableToBytes` conversions |
+| `src/resources/QuotaResource.ts` | 26 | **Done** — viewMode-based URL routing (self/org/superuser), 404/403 fallback, `bytesToHumanReadable`/`humanReadableToBytes` conversions |
 | `src/resources/AuthResource.ts` | 10 | **Done** — `GlobalAuthState` management, login/logout, CSRF token |
 | `src/resources/RobotsResource.ts` | 14 | **Done** — Robot CRUD with org prefix stripping, federation config, bulk operations |
-| `src/resources/BuildResource.ts` | 17 | **Done** — Build CRUD, trigger management, `startBuild` ref type routing, `fetchBuildLogs` with archived redirect, parallel superuser log fetch |
-| `src/resources/MirroringResource.ts` | 11 | **Done** — Mirror config CRUD, `timestampToISO`/`timestampFromISO`, status labels |
-| `src/resources/DefaultPermissionResource.ts` | 10 | **Done** — Permission CRUD, `addRepoPermissionToTeam` with console.error (no throw), bulk delete |
-| `src/resources/MembersResource.ts` | 9 | **Done** — Member/collaborator CRUD, parallel fetch |
+| `src/resources/BuildResource.ts` | 16 | **Done** — Build CRUD, trigger management, `startBuild` ref type routing, `fetchBuildLogs` with archived redirect, parallel superuser log fetch |
+| `src/resources/MirroringResource.ts` | 10 | **Done** — Mirror config CRUD, `timestampToISO`/`timestampFromISO`, status labels |
+| `src/resources/DefaultPermissionResource.ts` | 9 | **Done** — Permission CRUD, `addRepoPermissionToTeam` with console.error (no throw), bulk delete |
+| `src/resources/MembersResource.ts` | 7 | **Done** — Member/collaborator CRUD, parallel fetch |
 | `src/resources/NotificationResource.ts` | 12 | **Done** — Notification CRUD with eventConfig transform, `isNotificationDisabled` (>=3 failures) |
-| `src/resources/TeamResources.ts` | 10 | **Done** — Team CRUD, `updateTeamRepoPerm` with role='none' delete path |
+| `src/resources/TeamResources.ts` | 13 | **Done** — Team CRUD, `updateTeamRepoPerm` with role='none' delete path |
 
 **Low priority (14 files, 57 tests):**
 
 | File | Tests | Status |
 |------|-------|--------|
-| `src/resources/BillingResource.ts` | 8 | **Done** |
-| `src/resources/OrgMirrorResource.ts` | 10 | **Done** |
+| `src/resources/BillingResource.ts` | 9 | **Done** |
+| `src/resources/OrgMirrorResource.ts` | 9 | **Done** |
 | `src/resources/ImmutabilityPolicyResource.ts` | 6 | **Done** |
 | `src/resources/OAuthApplicationResource.ts` | 5 | **Done** |
 | `src/resources/TeamSyncResource.ts` | 5 | **Done** |
 | `src/resources/ServiceKeysResource.ts` | 4 | **Done** |
-| `src/resources/NamespaceAutoPruneResource.ts` | 4 | **Done** |
+| `src/resources/NamespaceAutoPruneResource.ts` | 5 | **Done** |
 | `src/resources/RepositoryAutoPruneResource.ts` | 3 | **Done** |
 | `src/resources/ProxyCacheResource.ts` | 2 | **Done** |
 | `src/resources/RegistrySizeResource.ts` | 2 | **Done** |
@@ -222,7 +222,7 @@ Leave these to Playwright E2E:
 | 6 | Standard hooks (79 files) | ~140 | 4-5 days | Pending |
 | 7 | Components (100 files) | ~140 | 5-6 days | **In progress** — LoadingPage (6) done |
 
-**Current: 530 tests passing across 41 files | Target: ~620 tests**
+**Current: 530 tests passing across 41 files | Target: ~810 tests**
 
 Phases 1-5 are complete. Phases 6-7 are incremental and can be spread over sprints. Remaining effort: ~9-11 days.
 

--- a/web/src/resources/AuthResource.test.ts
+++ b/web/src/resources/AuthResource.test.ts
@@ -1,0 +1,159 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  loginUser,
+  logoutUser,
+  getCsrfToken,
+  getUser,
+  getOrganization,
+  getExternalLoginAuthUrl,
+  detachExternalLogin,
+  verifyUser,
+  GlobalAuthState,
+} from './AuthResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('AuthResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    GlobalAuthState.isLoggedIn = false;
+    GlobalAuthState.csrfToken = null;
+    GlobalAuthState.bearerToken = null;
+  });
+
+  describe('loginUser', () => {
+    it('sets GlobalAuthState on successful login', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({success: true}),
+      );
+
+      const result = await loginUser('alice', 'password');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/signin', {
+        username: 'alice',
+        password: 'password',
+      });
+      expect(result.success).toBe(true);
+      expect(GlobalAuthState.isLoggedIn).toBe(true);
+    });
+
+    it('does not set isLoggedIn on failed login', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({success: false}),
+      );
+
+      await loginUser('alice', 'wrong');
+      expect(GlobalAuthState.isLoggedIn).toBe(false);
+    });
+  });
+
+  describe('logoutUser', () => {
+    it('clears GlobalAuthState on logout', async () => {
+      GlobalAuthState.isLoggedIn = true;
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await logoutUser();
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/signout');
+      expect(GlobalAuthState.isLoggedIn).toBe(false);
+    });
+  });
+
+  describe('getCsrfToken', () => {
+    it('stores CSRF token in GlobalAuthState', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({csrf_token: 'tok123'}),
+      );
+
+      const result = await getCsrfToken();
+      expect(axios.get).toHaveBeenCalledWith('/csrf_token');
+      expect(GlobalAuthState.csrfToken).toBe('tok123');
+      expect(result.csrf_token).toBe('tok123');
+    });
+  });
+
+  describe('getUser', () => {
+    it('fetches user by username', async () => {
+      const resp = mockResponse({username: 'alice'});
+      vi.mocked(axios.get).mockResolvedValueOnce(resp);
+
+      const result = await getUser('alice');
+      expect(axios.get).toHaveBeenCalledWith('api/v1/users/alice');
+      expect(result).toBe(resp);
+    });
+  });
+
+  describe('getOrganization', () => {
+    it('fetches organization by name', async () => {
+      const resp = mockResponse({name: 'myorg'});
+      vi.mocked(axios.get).mockResolvedValueOnce(resp);
+
+      const result = await getOrganization('myorg');
+      expect(axios.get).toHaveBeenCalledWith('api/v1/organization/myorg');
+      expect(result).toBe(resp);
+    });
+  });
+
+  describe('getExternalLoginAuthUrl', () => {
+    it('returns auth URL for a service', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({auth_url: 'https://auth.example.com'}),
+      );
+
+      const result = await getExternalLoginAuthUrl('github');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/externallogin/github', {
+        kind: 'login',
+      });
+      expect(result.auth_url).toBe('https://auth.example.com');
+    });
+
+    it('passes custom action', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await getExternalLoginAuthUrl('google', 'attach');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/externallogin/google', {
+        kind: 'attach',
+      });
+    });
+  });
+
+  describe('detachExternalLogin', () => {
+    it('detaches external login provider', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await detachExternalLogin('github');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/detachexternal/github');
+    });
+  });
+
+  describe('verifyUser', () => {
+    it('verifies user password', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({success: true}),
+      );
+
+      const result = await verifyUser('mypassword');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/signin/verify', {
+        password: 'mypassword',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/web/src/resources/BillingResource.test.ts
+++ b/web/src/resources/BillingResource.test.ts
@@ -1,0 +1,128 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchSubscription,
+  setSubscription,
+  fetchPlans,
+  fetchPrivateAllowed,
+  fetchCard,
+  setMarketplaceOrgAttachment,
+  setMarketplaceOrgRemoval,
+} from './BillingResource';
+import {ResourceError} from './ErrorHandling';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('BillingResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchSubscription', () => {
+    it('uses user endpoint when no org provided', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({plan: 'free'}));
+
+      await fetchSubscription();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/user/plan');
+    });
+
+    it('uses org endpoint when org provided', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({plan: 'team'}));
+
+      await fetchSubscription('myorg');
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/organization/myorg/plan');
+    });
+  });
+
+  describe('setSubscription', () => {
+    it('sets subscription with plan only', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await setSubscription('pro');
+      expect(axios.put).toHaveBeenCalledWith('/api/v1/user/plan', {
+        plan: 'pro',
+      });
+    });
+
+    it('includes token when provided', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await setSubscription('pro', 'myorg', 'stripe_tok');
+      expect(vi.mocked(axios.put).mock.calls[0][1]).toEqual({
+        plan: 'pro',
+        token: 'stripe_tok',
+      });
+    });
+  });
+
+  describe('fetchPlans', () => {
+    it('fetches available plans', async () => {
+      const plans = [{title: 'Free', price: 0}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({plans}));
+
+      const result = await fetchPlans();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/plans/');
+      expect(result).toEqual(plans);
+    });
+  });
+
+  describe('fetchPrivateAllowed', () => {
+    it('uses user endpoint when no org', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({privateAllowed: true, privateCount: 5}),
+      );
+
+      const result = await fetchPrivateAllowed();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/user/private');
+      expect(result.privateAllowed).toBe(true);
+    });
+  });
+
+  describe('fetchCard', () => {
+    it('fetches card info', async () => {
+      const card = {last4: '1234', type: 'visa'};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({card}));
+
+      const result = await fetchCard();
+      expect(result).toEqual(card);
+    });
+  });
+
+  describe('setMarketplaceOrgAttachment', () => {
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.post).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(
+        setMarketplaceOrgAttachment('myorg', [{id: '1'}]),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('setMarketplaceOrgRemoval', () => {
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.post).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(
+        setMarketplaceOrgRemoval('myorg', [{id: '1'}]),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+});

--- a/web/src/resources/BuildResource.test.ts
+++ b/web/src/resources/BuildResource.test.ts
@@ -1,0 +1,228 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchBuilds,
+  fetchBuild,
+  fetchBuildTriggers,
+  toggleBuildTrigger,
+  deleteBuildTrigger,
+  startBuild,
+  startDockerfileBuild,
+  cancelBuild,
+  fetchBuildLogs,
+  fileDrop,
+  fetchBuildLogsSuperuser,
+} from './BuildResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('BuildResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchBuilds', () => {
+    it('fetches builds with default limit', async () => {
+      const builds = [{id: 'b1', phase: 'complete'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({builds}));
+
+      const result = await fetchBuilds('org', 'repo');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/build/',
+        {params: {limit: 10}},
+      );
+      expect(result).toEqual(builds);
+    });
+
+    it('includes since param when buildsSinceInSeconds is provided', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({builds: []}));
+
+      await fetchBuilds('org', 'repo', 3600);
+      expect(vi.mocked(axios.get).mock.calls[0][1]).toEqual({
+        params: {limit: 10, since: 3600},
+      });
+    });
+  });
+
+  describe('fetchBuild', () => {
+    it('fetches a single build', async () => {
+      const build = {id: 'b1', phase: 'building'};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(build));
+
+      const result = await fetchBuild('org', 'repo', 'b1');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/build/b1',
+      );
+      expect(result).toEqual(build);
+    });
+  });
+
+  describe('fetchBuildTriggers', () => {
+    it('fetches triggers with abort signal', async () => {
+      const controller = new AbortController();
+      const triggers = [{id: 't1', service: 'github'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({triggers}));
+
+      const result = await fetchBuildTriggers('org', 'repo', controller.signal);
+      expect(result).toEqual(triggers);
+    });
+  });
+
+  describe('startBuild', () => {
+    it('sends commit_sha when ref is a string', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({id: 'b1'}));
+
+      await startBuild('org', 'repo', 'trigger1', 'abc123');
+      expect(vi.mocked(axios.post).mock.calls[0][1]).toEqual({
+        commit_sha: 'abc123',
+      });
+    });
+
+    it('sends refs when ref is an object', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({id: 'b1'}));
+
+      const ref = {kind: 'branch', name: 'main'};
+      await startBuild('org', 'repo', 'trigger1', ref);
+      expect(vi.mocked(axios.post).mock.calls[0][1]).toEqual({refs: ref});
+    });
+  });
+
+  describe('startDockerfileBuild', () => {
+    it('starts a build with file_id', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({id: 'b1'}));
+
+      await startDockerfileBuild('org', 'repo', 'file-123');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/build/',
+        {file_id: 'file-123'},
+      );
+    });
+
+    it('includes pull_robot when provided', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({id: 'b1'}));
+
+      await startDockerfileBuild('org', 'repo', 'file-123', 'org+bot');
+      expect(vi.mocked(axios.post).mock.calls[0][1]).toEqual({
+        file_id: 'file-123',
+        pull_robot: 'org+bot',
+      });
+    });
+  });
+
+  describe('cancelBuild', () => {
+    it('cancels a build', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await cancelBuild('org', 'repo', 'b1');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/build/b1',
+      );
+    });
+  });
+
+  describe('fetchBuildLogs', () => {
+    it('returns logs directly when no logs_url', async () => {
+      const logs = {logs: [{message: 'building'}], start: 0, total: 1};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(logs));
+
+      const result = await fetchBuildLogs('org', 'repo', 'b1');
+      expect(result).toEqual(logs);
+    });
+
+    it('fetches archived logs when logs_url is present', async () => {
+      const archivedLogs = {logs: [{message: 'archived'}], start: 0, total: 1};
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(
+          mockResponse({logs_url: 'https://archive.example.com/logs'}),
+        )
+        .mockResolvedValueOnce(mockResponse(archivedLogs));
+
+      const result = await fetchBuildLogs('org', 'repo', 'b1');
+      expect(vi.mocked(axios.get).mock.calls[1][0]).toBe(
+        'https://archive.example.com/logs',
+      );
+      expect(result).toEqual(archivedLogs);
+    });
+  });
+
+  describe('fileDrop', () => {
+    it('creates a filedrop', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({file_id: 'f1', url: 'https://upload.example.com'}),
+      );
+
+      const result = await fileDrop();
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/filedrop/', {
+        mimeType: 'application/octet-stream',
+      });
+      expect(result.file_id).toBe('f1');
+    });
+  });
+
+  describe('fetchBuildLogsSuperuser', () => {
+    it('fetches build info and logs in parallel and merges them', async () => {
+      const buildData = {id: 'b1', uuid: 'uuid1', status: 'complete'};
+      const logsData = {logs: [{message: 'step 1'}, {message: 'step 2'}]};
+
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(mockResponse(buildData))
+        .mockResolvedValueOnce(mockResponse(logsData));
+
+      const result = await fetchBuildLogsSuperuser('uuid1');
+      expect(result.id).toBe('b1');
+      expect(result.logs).toEqual(logsData.logs);
+    });
+
+    it('returns empty logs array when logs data has no logs', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(mockResponse({id: 'b1'}))
+        .mockResolvedValueOnce(mockResponse({}));
+
+      const result = await fetchBuildLogsSuperuser('uuid1');
+      expect(result.logs).toEqual([]);
+    });
+  });
+
+  describe('toggleBuildTrigger', () => {
+    it('toggles trigger enabled state', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({triggers: []}));
+
+      await toggleBuildTrigger('org', 'repo', 't1', true);
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/trigger/t1',
+        {enabled: true},
+      );
+    });
+  });
+
+  describe('deleteBuildTrigger', () => {
+    it('deletes a build trigger', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(
+        mockResponse({triggers: []}),
+      );
+
+      await deleteBuildTrigger('org', 'repo', 't1');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/trigger/t1',
+      );
+    });
+  });
+});

--- a/web/src/resources/CapabilitiesResource.test.ts
+++ b/web/src/resources/CapabilitiesResource.test.ts
@@ -1,0 +1,47 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {fetchRegistryCapabilities} from './CapabilitiesResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('CapabilitiesResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchRegistryCapabilities', () => {
+    it('fetches registry capabilities', async () => {
+      const caps = {
+        sparse_manifests: {
+          supported: true,
+          required_architectures: ['amd64'],
+          optional_architectures_allowed: true,
+        },
+        mirror_architectures: ['amd64', 'arm64'],
+      };
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(caps));
+
+      const result = await fetchRegistryCapabilities();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/registry/capabilities');
+      expect(result).toEqual(caps);
+    });
+  });
+});

--- a/web/src/resources/ChangeLogResource.test.ts
+++ b/web/src/resources/ChangeLogResource.test.ts
@@ -1,0 +1,40 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {fetchChangeLog} from './ChangeLogResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('ChangeLogResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchChangeLog', () => {
+    it('fetches the changelog', async () => {
+      const data = {log: '## v1.0.0\n- Initial release'};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(data));
+
+      const result = await fetchChangeLog();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/superuser/changelog/');
+      expect(result).toEqual(data);
+    });
+  });
+});

--- a/web/src/resources/DefaultPermissionResource.test.ts
+++ b/web/src/resources/DefaultPermissionResource.test.ts
@@ -1,0 +1,148 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchDefaultPermissions,
+  updateDefaultPermission,
+  deleteDefaultPermission,
+  createDefaultPermission,
+  addRepoPermissionToTeam,
+  bulkDeleteDefaultPermissions,
+} from './DefaultPermissionResource';
+import {ResourceError} from './ErrorHandling';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('DefaultPermissionResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchDefaultPermissions', () => {
+    it('fetches prototypes for an org', async () => {
+      const prototypes = [{id: '1', role: 'read'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({prototypes}));
+
+      const result = await fetchDefaultPermissions('myorg');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/prototypes',
+      );
+      expect(result).toEqual(prototypes);
+    });
+  });
+
+  describe('updateDefaultPermission', () => {
+    it('updates permission role (lowercased)', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await updateDefaultPermission('myorg', 'perm1', 'Admin');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/prototypes/perm1',
+        {id: 'perm1', role: 'admin'},
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.put).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(
+        updateDefaultPermission('myorg', 'perm1', 'admin'),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('deleteDefaultPermission', () => {
+    it('deletes a default permission', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteDefaultPermission('myorg', {
+        id: 'perm1',
+        createdBy: 'alice',
+      } as any);
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/prototypes/perm1',
+      );
+    });
+  });
+
+  describe('createDefaultPermission', () => {
+    it('creates a default permission', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      const permObj = {
+        activating_user: {name: 'alice'},
+        delegate: {name: 'bob', kind: 'user'},
+        role: 'read',
+      };
+      await createDefaultPermission('myorg', permObj as any);
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/prototypes',
+        permObj,
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.post).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(
+        createDefaultPermission('myorg', {
+          activating_user: {name: 'alice'},
+        } as any),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('addRepoPermissionToTeam', () => {
+    it('adds team permission (does not throw on error)', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await addRepoPermissionToTeam('org', 'repo', 'devs', 'Write');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/permissions/team/devs',
+        {role: 'write'},
+      );
+    });
+
+    it('catches errors without throwing', async () => {
+      vi.mocked(axios.put).mockRejectedValueOnce(new AxiosError('fail'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
+
+      await expect(
+        addRepoPermissionToTeam('org', 'repo', 'devs', 'Write'),
+      ).resolves.toBeUndefined();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('bulkDeleteDefaultPermissions', () => {
+    it('deletes multiple permissions', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      await expect(
+        bulkDeleteDefaultPermissions('myorg', [
+          {id: 'p1', createdBy: 'alice'},
+          {id: 'p2', createdBy: 'bob'},
+        ] as any),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/web/src/resources/DefaultPermissionResource.test.ts
+++ b/web/src/resources/DefaultPermissionResource.test.ts
@@ -143,6 +143,15 @@ describe('DefaultPermissionResource', () => {
           {id: 'p2', createdBy: 'bob'},
         ] as any),
       ).resolves.toBeUndefined();
+      expect(axios.delete).toHaveBeenCalledTimes(2);
+      expect(axios.delete).toHaveBeenNthCalledWith(
+        1,
+        '/api/v1/organization/myorg/prototypes/p1',
+      );
+      expect(axios.delete).toHaveBeenNthCalledWith(
+        2,
+        '/api/v1/organization/myorg/prototypes/p2',
+      );
     });
   });
 });

--- a/web/src/resources/GlobalMessagesResource.test.ts
+++ b/web/src/resources/GlobalMessagesResource.test.ts
@@ -1,0 +1,73 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchGlobalMessages,
+  createGlobalMessage,
+  deleteGlobalMessage,
+} from './GlobalMessagesResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('GlobalMessagesResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchGlobalMessages', () => {
+    it('returns messages array', async () => {
+      const messages = [{uuid: 'm1', content: 'Maintenance window'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({messages}));
+
+      const result = await fetchGlobalMessages();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/messages');
+      expect(result).toEqual(messages);
+    });
+
+    it('returns empty array when messages is missing', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({}));
+
+      const result = await fetchGlobalMessages();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('createGlobalMessage', () => {
+    it('creates a global message', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await createGlobalMessage({
+        message: {content: 'test', media_type: 'text/plain', severity: 'info'},
+      });
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/messages', {
+        message: {content: 'test', media_type: 'text/plain', severity: 'info'},
+      });
+    });
+  });
+
+  describe('deleteGlobalMessage', () => {
+    it('deletes a global message by uuid', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteGlobalMessage('msg-uuid');
+      expect(axios.delete).toHaveBeenCalledWith('/api/v1/message/msg-uuid');
+    });
+  });
+});

--- a/web/src/resources/ImmutabilityPolicyResource.test.ts
+++ b/web/src/resources/ImmutabilityPolicyResource.test.ts
@@ -1,0 +1,119 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchNamespaceImmutabilityPolicies,
+  createNamespaceImmutabilityPolicy,
+  deleteNamespaceImmutabilityPolicy,
+  fetchRepositoryImmutabilityPolicies,
+  createRepositoryImmutabilityPolicy,
+  deleteRepositoryImmutabilityPolicy,
+} from './ImmutabilityPolicyResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('ImmutabilityPolicyResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchNamespaceImmutabilityPolicies', () => {
+    it('fetches namespace policies', async () => {
+      const controller = new AbortController();
+      const policies = [{uuid: 'p1', tagPattern: '*', tagPatternMatches: true}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({policies}));
+
+      const result = await fetchNamespaceImmutabilityPolicies(
+        'myorg',
+        controller.signal,
+      );
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'organization/myorg/immutabilitypolicy',
+      );
+      expect(result).toEqual(policies);
+    });
+  });
+
+  describe('createNamespaceImmutabilityPolicy', () => {
+    it('creates a namespace policy', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({uuid: 'new-p1'}, 201),
+      );
+
+      const result = await createNamespaceImmutabilityPolicy('myorg', {
+        tagPattern: 'release-*',
+        tagPatternMatches: true,
+      });
+      expect(result).toEqual({uuid: 'new-p1'});
+    });
+  });
+
+  describe('deleteNamespaceImmutabilityPolicy', () => {
+    it('deletes a namespace policy', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse({}));
+
+      await deleteNamespaceImmutabilityPolicy('myorg', 'p1');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/immutabilitypolicy/p1',
+      );
+    });
+  });
+
+  describe('fetchRepositoryImmutabilityPolicies', () => {
+    it('fetches repository policies', async () => {
+      const controller = new AbortController();
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({policies: []}));
+
+      await fetchRepositoryImmutabilityPolicies(
+        'org',
+        'repo',
+        controller.signal,
+      );
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'repository/org/repo/immutabilitypolicy',
+      );
+    });
+  });
+
+  describe('createRepositoryImmutabilityPolicy', () => {
+    it('creates a repository policy', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({uuid: 'rp1'}, 201),
+      );
+
+      const result = await createRepositoryImmutabilityPolicy('org', 'repo', {
+        tagPattern: 'v*',
+        tagPatternMatches: true,
+      });
+      expect(result).toEqual({uuid: 'rp1'});
+    });
+  });
+
+  describe('deleteRepositoryImmutabilityPolicy', () => {
+    it('deletes a repository policy', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse({}));
+
+      await deleteRepositoryImmutabilityPolicy('org', 'repo', 'rp1');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/immutabilitypolicy/rp1',
+      );
+    });
+  });
+});

--- a/web/src/resources/MembersResource.test.ts
+++ b/web/src/resources/MembersResource.test.ts
@@ -1,0 +1,124 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchAllMembers,
+  fetchMembersForOrg,
+  fetchCollaboratorsForOrg,
+  fetchTeamMembersForOrg,
+  deleteTeamMemberForOrg,
+  deleteCollaboratorForOrg,
+  addMemberToTeamForOrg,
+} from './MembersResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('MembersResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchMembersForOrg', () => {
+    it('fetches members for an org', async () => {
+      const controller = new AbortController();
+      const members = [{name: 'alice', kind: 'user'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({members}));
+
+      const result = await fetchMembersForOrg('myorg', controller.signal);
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/members',
+        {signal: controller.signal},
+      );
+      expect(result).toEqual(members);
+    });
+  });
+
+  describe('fetchCollaboratorsForOrg', () => {
+    it('fetches collaborators for an org', async () => {
+      const controller = new AbortController();
+      const collaborators = [{name: 'bob', kind: 'user'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({collaborators}));
+
+      const result = await fetchCollaboratorsForOrg('myorg', controller.signal);
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain('collaborators');
+      expect(result).toEqual(collaborators);
+    });
+  });
+
+  describe('fetchAllMembers', () => {
+    it('fetches members for multiple orgs in parallel', async () => {
+      const controller = new AbortController();
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(mockResponse({members: [{name: 'a'}]}))
+        .mockResolvedValueOnce(mockResponse({members: [{name: 'b'}]}));
+
+      const result = await fetchAllMembers(['org1', 'org2'], controller.signal);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('fetchTeamMembersForOrg', () => {
+    it('fetches team members with includePending', async () => {
+      const teamMembers = {members: [{name: 'alice'}]};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(teamMembers));
+
+      const result = await fetchTeamMembersForOrg('myorg', 'devs');
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'includePending=true',
+      );
+      expect(result).toEqual(teamMembers);
+    });
+  });
+
+  describe('deleteTeamMemberForOrg', () => {
+    it('deletes a team member', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteTeamMemberForOrg('myorg', 'devs', 'alice');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/team/devs/members/alice',
+      );
+    });
+  });
+
+  describe('deleteCollaboratorForOrg', () => {
+    it('deletes a collaborator', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteCollaboratorForOrg('myorg', 'bob');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/members/bob',
+      );
+    });
+  });
+
+  describe('addMemberToTeamForOrg', () => {
+    it('adds a member to a team', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({added: true}));
+
+      const result = await addMemberToTeamForOrg('myorg', 'devs', 'alice');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/team/devs/members/alice',
+        {},
+      );
+      expect(result).toEqual({added: true});
+    });
+  });
+});

--- a/web/src/resources/MirroringResource.test.ts
+++ b/web/src/resources/MirroringResource.test.ts
@@ -1,0 +1,147 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  getMirrorConfig,
+  createMirrorConfig,
+  toggleMirroring,
+  syncMirror,
+  cancelSync,
+  timestampToISO,
+  timestampFromISO,
+  statusLabels,
+} from './MirroringResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('MirroringResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('getMirrorConfig', () => {
+    it('fetches mirror configuration', async () => {
+      const config = {is_enabled: true, sync_status: 'SYNC_SUCCESS'};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(config));
+
+      const result = await getMirrorConfig('org', 'repo');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/mirror',
+      );
+      expect(result).toEqual(config);
+    });
+  });
+
+  describe('createMirrorConfig', () => {
+    it('creates mirror configuration', async () => {
+      const config = {
+        is_enabled: true,
+        external_reference: 'docker.io/library/nginx',
+        robot_username: 'org+bot',
+        external_registry_config: {
+          verify_tls: true,
+          unsigned_images: false,
+          proxy: {http_proxy: null, https_proxy: null, no_proxy: null},
+        },
+        sync_start_date: '2024-01-01T00:00:00Z',
+        sync_interval: 86400,
+        root_rule: {rule_kind: 'tag_glob_csv', rule_value: ['*']},
+      };
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(config, 201));
+
+      const result = await createMirrorConfig('org', 'repo', config);
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/mirror',
+        config,
+      );
+      expect(result).toEqual(config);
+    });
+  });
+
+  describe('toggleMirroring', () => {
+    it('enables mirroring', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await toggleMirroring('org', 'repo', true);
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/mirror',
+        {is_enabled: true},
+      );
+    });
+
+    it('disables mirroring', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await toggleMirroring('org', 'repo', false);
+      expect(vi.mocked(axios.put).mock.calls[0][1]).toEqual({
+        is_enabled: false,
+      });
+    });
+  });
+
+  describe('syncMirror', () => {
+    it('triggers sync-now', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await syncMirror('org', 'repo');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/mirror/sync-now',
+      );
+    });
+  });
+
+  describe('cancelSync', () => {
+    it('cancels a sync', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await cancelSync('org', 'repo');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/mirror/sync-cancel',
+      );
+    });
+  });
+
+  describe('timestampToISO', () => {
+    it('converts unix timestamp to ISO string without milliseconds', () => {
+      const result = timestampToISO(1704067200);
+      expect(result).toBe('2024-01-01T00:00:00Z');
+    });
+  });
+
+  describe('timestampFromISO', () => {
+    it('converts ISO string to unix timestamp', () => {
+      const result = timestampFromISO('2024-01-01T00:00:00Z');
+      expect(result).toBe(1704067200);
+    });
+
+    it('is inverse of timestampToISO', () => {
+      const ts = 1704067200;
+      expect(timestampFromISO(timestampToISO(ts))).toBe(ts);
+    });
+  });
+
+  describe('statusLabels', () => {
+    it('maps sync statuses to display labels', () => {
+      expect(statusLabels.NEVER_RUN).toBe('Scheduled');
+      expect(statusLabels.SYNC_FAILED).toBe('Failed');
+      expect(statusLabels.SYNC_SUCCESS).toBe('Success');
+    });
+  });
+});

--- a/web/src/resources/NamespaceAutoPruneResource.test.ts
+++ b/web/src/resources/NamespaceAutoPruneResource.test.ts
@@ -1,0 +1,90 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  AutoPruneMethod,
+  fetchNamespaceAutoPrunePolicies,
+  createNamespaceAutoPrunePolicy,
+  deleteNamespaceAutoPrunePolicy,
+} from './NamespaceAutoPruneResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('NamespaceAutoPruneResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchNamespaceAutoPrunePolicies', () => {
+    it('uses org endpoint for organizations', async () => {
+      const controller = new AbortController();
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({policies: []}));
+
+      await fetchNamespaceAutoPrunePolicies('myorg', false, controller.signal);
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'organization/myorg',
+      );
+    });
+
+    it('uses user endpoint when isUser=true', async () => {
+      const controller = new AbortController();
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({policies: []}));
+
+      await fetchNamespaceAutoPrunePolicies('user', true, controller.signal);
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toBe(
+        '/api/v1/user/autoprunepolicy/',
+      );
+    });
+  });
+
+  describe('createNamespaceAutoPrunePolicy', () => {
+    it('creates a policy for an org', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await createNamespaceAutoPrunePolicy(
+        'myorg',
+        {method: AutoPruneMethod.TAG_NUMBER, value: 5},
+        false,
+      );
+      expect(vi.mocked(axios.post).mock.calls[0][0]).toContain(
+        'organization/myorg',
+      );
+    });
+  });
+
+  describe('deleteNamespaceAutoPrunePolicy', () => {
+    it('deletes a policy', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse({}));
+
+      await deleteNamespaceAutoPrunePolicy('myorg', 'p1', false);
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/autoprunepolicy/p1',
+      );
+    });
+  });
+
+  describe('AutoPruneMethod enum', () => {
+    it('has correct values', () => {
+      expect(AutoPruneMethod.NONE).toBe('none');
+      expect(AutoPruneMethod.TAG_NUMBER).toBe('number_of_tags');
+      expect(AutoPruneMethod.TAG_CREATION_DATE).toBe('creation_date');
+    });
+  });
+});

--- a/web/src/resources/NotificationResource.test.ts
+++ b/web/src/resources/NotificationResource.test.ts
@@ -109,6 +109,15 @@ describe('NotificationResource', () => {
       await expect(
         bulkDeleteNotifications('org', 'repo', ['u1', 'u2']),
       ).resolves.toBeUndefined();
+      expect(axios.delete).toHaveBeenCalledTimes(2);
+      expect(axios.delete).toHaveBeenNthCalledWith(
+        1,
+        '/api/v1/repository/org/repo/notification/u1',
+      );
+      expect(axios.delete).toHaveBeenNthCalledWith(
+        2,
+        '/api/v1/repository/org/repo/notification/u2',
+      );
     });
   });
 
@@ -151,6 +160,15 @@ describe('NotificationResource', () => {
       await expect(
         bulkEnableNotifications('org', 'repo', ['u1', 'u2']),
       ).resolves.toBeUndefined();
+      expect(axios.post).toHaveBeenCalledTimes(2);
+      expect(axios.post).toHaveBeenNthCalledWith(
+        1,
+        '/api/v1/repository/org/repo/notification/u1',
+      );
+      expect(axios.post).toHaveBeenNthCalledWith(
+        2,
+        '/api/v1/repository/org/repo/notification/u2',
+      );
     });
   });
 

--- a/web/src/resources/NotificationResource.test.ts
+++ b/web/src/resources/NotificationResource.test.ts
@@ -1,0 +1,187 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchNotifications,
+  createNotification,
+  deleteNotification,
+  bulkDeleteNotifications,
+  testNotification,
+  enableNotification,
+  bulkEnableNotifications,
+  isNotificationDisabled,
+  isNotificationEnabled,
+  NotificationEventType,
+  NotificationMethodType,
+  RepoNotification,
+} from './NotificationResource';
+import {ResourceError} from './ErrorHandling';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+/** Creates a minimal RepoNotification for testing. */
+function createMockNotification(
+  overrides: Partial<RepoNotification> = {},
+): RepoNotification {
+  return {
+    config: {},
+    event: NotificationEventType.repoPush,
+    event_config: {} as any,
+    method: NotificationMethodType.slack,
+    title: 'test',
+    ...overrides,
+  };
+}
+
+describe('NotificationResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchNotifications', () => {
+    it('fetches notifications for a repo', async () => {
+      const notifications = [{uuid: 'n1', title: 'test'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({notifications}));
+
+      const result = await fetchNotifications('org', 'repo');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/notification/',
+      );
+      expect(result).toEqual(notifications);
+    });
+  });
+
+  describe('createNotification', () => {
+    it('creates notification with eventConfig from event_config', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      const notification = createMockNotification({
+        event_config: {ref_regex: '.*'} as any,
+      });
+      await createNotification('org', 'repo', notification);
+      const sentBody = vi.mocked(axios.post).mock.calls[0][1];
+      expect(sentBody.eventConfig).toEqual({ref_regex: '.*'});
+    });
+  });
+
+  describe('deleteNotification', () => {
+    it('deletes a notification', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteNotification('org', 'repo', 'uuid-1');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/notification/uuid-1',
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.delete).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(deleteNotification('org', 'repo', 'uuid-1')).rejects.toThrow(
+        ResourceError,
+      );
+    });
+  });
+
+  describe('bulkDeleteNotifications', () => {
+    it('deletes multiple notifications', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      await expect(
+        bulkDeleteNotifications('org', 'repo', ['u1', 'u2']),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('testNotification', () => {
+    it('tests a notification', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await testNotification('org', 'repo', 'uuid-1');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/notification/uuid-1/test',
+      );
+    });
+  });
+
+  describe('enableNotification', () => {
+    it('enables a notification', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await enableNotification('org', 'repo', 'uuid-1');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/notification/uuid-1',
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.post).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(enableNotification('org', 'repo', 'uuid-1')).rejects.toThrow(
+        ResourceError,
+      );
+    });
+  });
+
+  describe('bulkEnableNotifications', () => {
+    it('enables multiple notifications', async () => {
+      vi.mocked(axios.post)
+        .mockResolvedValueOnce(mockResponse({}))
+        .mockResolvedValueOnce(mockResponse({}));
+
+      await expect(
+        bulkEnableNotifications('org', 'repo', ['u1', 'u2']),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('isNotificationDisabled', () => {
+    it('returns true when number_of_failures >= 3', () => {
+      expect(
+        isNotificationDisabled(createMockNotification({number_of_failures: 3})),
+      ).toBe(true);
+      expect(
+        isNotificationDisabled(createMockNotification({number_of_failures: 5})),
+      ).toBe(true);
+    });
+
+    it('returns false when number_of_failures < 3', () => {
+      expect(
+        isNotificationDisabled(createMockNotification({number_of_failures: 2})),
+      ).toBe(false);
+      expect(
+        isNotificationDisabled(createMockNotification({number_of_failures: 0})),
+      ).toBe(false);
+    });
+  });
+
+  describe('isNotificationEnabled', () => {
+    it('is inverse of isNotificationDisabled', () => {
+      expect(
+        isNotificationEnabled(createMockNotification({number_of_failures: 3})),
+      ).toBe(false);
+      expect(
+        isNotificationEnabled(createMockNotification({number_of_failures: 0})),
+      ).toBe(true);
+    });
+  });
+});

--- a/web/src/resources/OAuthApplicationResource.test.ts
+++ b/web/src/resources/OAuthApplicationResource.test.ts
@@ -1,0 +1,89 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchOAuthApplications,
+  updateOAuthApplication,
+  createOAuthApplication,
+  resetOAuthApplicationClientSecret,
+} from './OAuthApplicationResource';
+import {ResourceError} from './ErrorHandling';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('OAuthApplicationResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchOAuthApplications', () => {
+    it('fetches applications for an org', async () => {
+      const applications = [{client_id: 'c1', name: 'app1'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({applications}));
+
+      const result = await fetchOAuthApplications('myorg');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/applications',
+      );
+      expect(result).toEqual(applications);
+    });
+  });
+
+  describe('updateOAuthApplication', () => {
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.put).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(
+        updateOAuthApplication('myorg', 'c1', {name: 'new'}),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('createOAuthApplication', () => {
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.post).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(
+        createOAuthApplication('myorg', {name: 'app'} as any),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('resetOAuthApplicationClientSecret', () => {
+    it('resets client secret', async () => {
+      const app = {client_id: 'c1', client_secret: 'new_secret'};
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(app));
+
+      const result = await resetOAuthApplicationClientSecret('myorg', 'c1');
+      expect(vi.mocked(axios.post).mock.calls[0][0]).toContain(
+        'resetclientsecret',
+      );
+      expect(result).toEqual(app);
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.post).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(
+        resetOAuthApplicationClientSecret('myorg', 'c1'),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+});

--- a/web/src/resources/OAuthApplicationResource.test.ts
+++ b/web/src/resources/OAuthApplicationResource.test.ts
@@ -30,6 +30,7 @@ function mockResponse(data: unknown, status = 200): AxiosResponse {
 
 describe('OAuthApplicationResource', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     localStorage.clear();
   });
 

--- a/web/src/resources/OrgMirrorResource.test.ts
+++ b/web/src/resources/OrgMirrorResource.test.ts
@@ -1,0 +1,155 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  getOrgMirrorConfig,
+  createOrgMirrorConfig,
+  deleteOrgMirrorConfig,
+  syncOrgMirrorNow,
+  verifyOrgMirrorConnection,
+  getOrgMirrorRepos,
+  orgMirrorStatusLabels,
+  orgMirrorStatusColors,
+} from './OrgMirrorResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('OrgMirrorResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('getOrgMirrorConfig', () => {
+    it('fetches org mirror config', async () => {
+      const config = {is_enabled: true, sync_status: 'SUCCESS'};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(config));
+
+      const result = await getOrgMirrorConfig('myorg');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/mirror',
+      );
+      expect(result).toEqual(config);
+    });
+  });
+
+  describe('createOrgMirrorConfig', () => {
+    it('creates org mirror config', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await createOrgMirrorConfig('myorg', {
+        external_registry_type: 'quay',
+        external_registry_url: 'https://quay.io',
+        external_namespace: 'upstream',
+        robot_username: 'org+bot',
+        visibility: 'private',
+        sync_interval: 3600,
+        sync_start_date: '2024-01-01T00:00:00Z',
+      });
+      expect(vi.mocked(axios.post).mock.calls[0][0]).toContain(
+        'organization/myorg/mirror',
+      );
+    });
+  });
+
+  describe('deleteOrgMirrorConfig', () => {
+    it('deletes org mirror config', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteOrgMirrorConfig('myorg');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/mirror',
+      );
+    });
+  });
+
+  describe('syncOrgMirrorNow', () => {
+    it('triggers sync', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await syncOrgMirrorNow('myorg');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/mirror/sync-now',
+      );
+    });
+  });
+
+  describe('verifyOrgMirrorConnection', () => {
+    it('verifies connection', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({success: true, message: 'OK'}),
+      );
+
+      const result = await verifyOrgMirrorConnection('myorg');
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('getOrgMirrorRepos', () => {
+    it('fetches repos with default pagination', async () => {
+      const repos = {
+        repositories: [],
+        page: 1,
+        limit: 100,
+        total: 0,
+        has_next: false,
+      };
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(repos));
+
+      const result = await getOrgMirrorRepos('myorg');
+      expect(vi.mocked(axios.get).mock.calls[0][1]).toEqual({
+        params: {page: 1, limit: 100},
+      });
+      expect(result).toEqual(repos);
+    });
+
+    it('includes status filter when provided', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({
+          repositories: [],
+          page: 1,
+          limit: 100,
+          total: 0,
+          has_next: false,
+        }),
+      );
+
+      await getOrgMirrorRepos('myorg', 1, 50, 'FAIL');
+      expect(vi.mocked(axios.get).mock.calls[0][1]).toEqual({
+        params: {page: 1, limit: 50, status: 'FAIL'},
+      });
+    });
+  });
+
+  describe('orgMirrorStatusLabels', () => {
+    it('maps all status values', () => {
+      expect(orgMirrorStatusLabels.SUCCESS).toBe('Success');
+      expect(orgMirrorStatusLabels.FAIL).toBe('Failed');
+      expect(orgMirrorStatusLabels.NEVER_RUN).toBe('Pending');
+    });
+  });
+
+  describe('orgMirrorStatusColors', () => {
+    it('maps status to colors', () => {
+      expect(orgMirrorStatusColors.SUCCESS).toBe('green');
+      expect(orgMirrorStatusColors.FAIL).toBe('red');
+      expect(orgMirrorStatusColors.SYNCING).toBe('blue');
+    });
+  });
+});

--- a/web/src/resources/OrganizationResource.test.ts
+++ b/web/src/resources/OrganizationResource.test.ts
@@ -1,0 +1,232 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchOrg,
+  fetchOrgsAsSuperUser,
+  OrgDeleteError,
+  deleteOrg,
+  bulkDeleteOrganizations,
+  createOrg,
+  updateOrgSettings,
+  renameOrganization,
+  takeOwnership,
+} from './OrganizationResource';
+import {BulkOperationError} from './ErrorHandling';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('OrganizationResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchOrg', () => {
+    it('fetches organization by name with abort signal', async () => {
+      const org = {
+        name: 'myorg',
+        email: 'org@test.com',
+        tag_expiration_s: 1209600,
+      };
+      const controller = new AbortController();
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(org));
+
+      const result = await fetchOrg('myorg', controller.signal);
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/organization/myorg', {
+        signal: controller.signal,
+      });
+      expect(result).toEqual(org);
+    });
+  });
+
+  describe('fetchOrgsAsSuperUser', () => {
+    it('returns organizations array', async () => {
+      const orgs = [{name: 'org1'}, {name: 'org2'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({organizations: orgs}),
+      );
+
+      const result = await fetchOrgsAsSuperUser();
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/superuser/organizations/',
+      );
+      expect(result).toEqual(orgs);
+    });
+  });
+
+  describe('OrgDeleteError', () => {
+    it('is an instance of Error with correct properties', () => {
+      const axiosErr = new AxiosError('fail');
+      const err = new OrgDeleteError('delete failed', 'myorg', axiosErr);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(OrgDeleteError);
+      expect(err.org).toBe('myorg');
+      expect(err.error).toBe(axiosErr);
+      expect(err.message).toBe('delete failed');
+    });
+  });
+
+  describe('deleteOrg', () => {
+    it('deletes org via standard API', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteOrg('myorg');
+      expect(axios.delete).toHaveBeenCalledWith('/api/v1/organization/myorg');
+    });
+
+    it('uses superuser API when isSuperUser is true', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteOrg('myorg', true);
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/superuser/organizations/myorg',
+      );
+    });
+
+    it('throws OrgDeleteError on failure', async () => {
+      vi.mocked(axios.delete).mockRejectedValueOnce(new AxiosError('fail'));
+
+      try {
+        await deleteOrg('myorg');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(OrgDeleteError);
+        expect((err as OrgDeleteError).org).toBe('myorg');
+      }
+    });
+  });
+
+  describe('bulkDeleteOrganizations', () => {
+    it('deletes all organizations successfully', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      const result = await bulkDeleteOrganizations(['org1', 'org2']);
+      expect(result).toHaveLength(2);
+      expect(result[0].status).toBe('fulfilled');
+    });
+
+    it('throws BulkOperationError when some deletions fail', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockRejectedValueOnce(new AxiosError('fail'));
+
+      try {
+        await bulkDeleteOrganizations(['org1', 'org2']);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(BulkOperationError);
+        expect(
+          (err as BulkOperationError<OrgDeleteError>).getErrors().size,
+        ).toBe(1);
+      }
+    });
+
+    it('uses superuser API for bulk delete when isSuperUser is true', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      await bulkDeleteOrganizations(['org1', 'org2'], true);
+      expect(vi.mocked(axios.delete).mock.calls[0][0]).toContain('superuser');
+      expect(vi.mocked(axios.delete).mock.calls[1][0]).toContain('superuser');
+    });
+  });
+
+  describe('createOrg', () => {
+    it('creates org with name only', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await createOrg('neworg');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/organization/', {
+        name: 'neworg',
+      });
+    });
+
+    it('creates org with name and email', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await createOrg('neworg', 'org@test.com');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/organization/', {
+        name: 'neworg',
+        email: 'org@test.com',
+      });
+    });
+  });
+
+  describe('updateOrgSettings', () => {
+    it('uses organization endpoint for org settings', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await updateOrgSettings('myorg', {tag_expiration_s: 86400});
+      expect(axios.put).toHaveBeenCalledWith('/api/v1/organization/myorg', {
+        tag_expiration_s: 86400,
+      });
+    });
+
+    it('uses user endpoint when isUser is true', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await updateOrgSettings('myuser', {
+        isUser: true,
+        tag_expiration_s: 86400,
+      });
+      expect(vi.mocked(axios.put).mock.calls[0][0]).toBe('/api/v1/user/');
+    });
+
+    it('strips null and undefined keys from params', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await updateOrgSettings('myorg', {
+        tag_expiration_s: 86400,
+        email: null as unknown as string,
+        invoice_email_address: undefined as unknown as string,
+      });
+      const sentBody = vi.mocked(axios.put).mock.calls[0][1];
+      expect(sentBody).not.toHaveProperty('email');
+      expect(sentBody).not.toHaveProperty('invoice_email_address');
+      expect(sentBody).toHaveProperty('tag_expiration_s', 86400);
+    });
+  });
+
+  describe('renameOrganization', () => {
+    it('renames org via superuser endpoint', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await renameOrganization('oldorg', 'neworg');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/superuser/organizations/oldorg',
+        {name: 'neworg'},
+      );
+    });
+  });
+
+  describe('takeOwnership', () => {
+    it('takes ownership of a namespace', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await takeOwnership('myns');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/superuser/takeownership/myns',
+      );
+    });
+  });
+});

--- a/web/src/resources/OrganizationResource.test.ts
+++ b/web/src/resources/OrganizationResource.test.ts
@@ -146,8 +146,12 @@ describe('OrganizationResource', () => {
         .mockResolvedValueOnce(mockResponse(null, 204));
 
       await bulkDeleteOrganizations(['org1', 'org2'], true);
-      expect(vi.mocked(axios.delete).mock.calls[0][0]).toContain('superuser');
-      expect(vi.mocked(axios.delete).mock.calls[1][0]).toContain('superuser');
+      expect(axios.delete).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/superuser/organizations/org1'),
+      );
+      expect(axios.delete).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/superuser/organizations/org2'),
+      );
     });
   });
 

--- a/web/src/resources/ProxyCacheResource.test.ts
+++ b/web/src/resources/ProxyCacheResource.test.ts
@@ -1,0 +1,63 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchProxyCacheConfig,
+  createProxyCacheConfig,
+} from './ProxyCacheResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('ProxyCacheResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchProxyCacheConfig', () => {
+    it('fetches proxy cache config for an org', async () => {
+      const config = {upstream_registry: 'docker.io'};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(config));
+
+      const result = await fetchProxyCacheConfig('myorg');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/proxycache',
+        {signal: undefined},
+      );
+      expect(result).toEqual(config);
+    });
+  });
+
+  describe('createProxyCacheConfig', () => {
+    it('normalizes null values for empty credentials', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await createProxyCacheConfig({
+        org_name: 'myorg',
+        upstream_registry: 'docker.io',
+        upstream_registry_username: '',
+        upstream_registry_password: '',
+      } as any);
+
+      const sentBody = vi.mocked(axios.post).mock.calls[0][1];
+      expect(sentBody.upstream_registry_username).toBeNull();
+      expect(sentBody.upstream_registry_password).toBeNull();
+    });
+  });
+});

--- a/web/src/resources/QuayConfig.test.ts
+++ b/web/src/resources/QuayConfig.test.ts
@@ -1,0 +1,40 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {fetchQuayConfig} from './QuayConfig';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('QuayConfig', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchQuayConfig', () => {
+    it('fetches quay configuration', async () => {
+      const config = {features: {BUILD_SUPPORT: true}};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(config));
+
+      const result = await fetchQuayConfig();
+      expect(axios.get).toHaveBeenCalledWith('/config');
+      expect(result).toEqual(config);
+    });
+  });
+});

--- a/web/src/resources/QuotaResource.test.ts
+++ b/web/src/resources/QuotaResource.test.ts
@@ -1,0 +1,228 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchOrganizationQuota,
+  createOrganizationQuota,
+  updateOrganizationQuota,
+  deleteOrganizationQuota,
+  createQuotaLimit,
+  updateQuotaLimit,
+  deleteQuotaLimit,
+  bytesToHumanReadable,
+  humanReadableToBytes,
+} from './QuotaResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('QuotaResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchOrganizationQuota', () => {
+    it('uses organization endpoint by default', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse([]));
+
+      await fetchOrganizationQuota('myorg');
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toBe(
+        '/api/v1/organization/myorg/quota',
+      );
+    });
+
+    it('uses self endpoint for viewMode=self', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse([]));
+
+      await fetchOrganizationQuota('myuser', undefined, 'self');
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toBe('/api/v1/user/quota');
+    });
+
+    it('uses superuser endpoint for viewMode=superuser', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse([]));
+
+      await fetchOrganizationQuota('someuser', undefined, 'superuser');
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toBe(
+        '/api/v1/superuser/users/someuser/quota',
+      );
+    });
+
+    it('returns empty array on 404', async () => {
+      const err = new AxiosError('Not Found');
+      (err as any).response = {status: 404};
+      vi.mocked(axios.get).mockRejectedValueOnce(err);
+
+      const result = await fetchOrganizationQuota('myorg');
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array on 403', async () => {
+      const err = new AxiosError('Forbidden');
+      (err as any).response = {status: 403};
+      vi.mocked(axios.get).mockRejectedValueOnce(err);
+
+      const result = await fetchOrganizationQuota('myorg');
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array on CanceledError', async () => {
+      const err = new Error('canceled');
+      err.name = 'CanceledError';
+      vi.mocked(axios.get).mockRejectedValueOnce(err);
+
+      const result = await fetchOrganizationQuota('myorg');
+      expect(result).toEqual([]);
+    });
+
+    it('re-throws other errors', async () => {
+      vi.mocked(axios.get).mockRejectedValueOnce(new Error('network fail'));
+
+      await expect(fetchOrganizationQuota('myorg')).rejects.toThrow(
+        'network fail',
+      );
+    });
+  });
+
+  describe('createOrganizationQuota', () => {
+    it('uses organization endpoint by default', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await createOrganizationQuota('myorg', {limit_bytes: 1000});
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/quota',
+        {limit_bytes: 1000},
+      );
+    });
+
+    it('uses superuser endpoint for viewMode=superuser', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await createOrganizationQuota('user1', {limit_bytes: 1000}, 'superuser');
+      expect(vi.mocked(axios.post).mock.calls[0][0]).toContain('superuser');
+    });
+  });
+
+  describe('updateOrganizationQuota', () => {
+    it('updates quota with correct endpoint', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await updateOrganizationQuota('myorg', 'q1', {limit_bytes: 2000});
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/quota/q1',
+        {limit_bytes: 2000},
+      );
+    });
+  });
+
+  describe('deleteOrganizationQuota', () => {
+    it('deletes quota with correct endpoint', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteOrganizationQuota('myorg', 'q1');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/quota/q1',
+      );
+    });
+  });
+
+  describe('createQuotaLimit', () => {
+    it('creates a quota limit', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await createQuotaLimit('myorg', 'q1', {
+        type: 'Warning',
+        threshold_percent: 80,
+      });
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/quota/q1/limit',
+        {type: 'Warning', threshold_percent: 80},
+      );
+    });
+  });
+
+  describe('updateQuotaLimit', () => {
+    it('updates a quota limit', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await updateQuotaLimit('myorg', 'q1', 'l1', {
+        type: 'Reject',
+        threshold_percent: 90,
+      });
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/quota/q1/limit/l1',
+        {type: 'Reject', threshold_percent: 90},
+      );
+    });
+  });
+
+  describe('deleteQuotaLimit', () => {
+    it('deletes a quota limit', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteQuotaLimit('myorg', 'q1', 'l1');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/quota/q1/limit/l1',
+      );
+    });
+  });
+
+  describe('bytesToHumanReadable', () => {
+    it('returns bytes for small values', () => {
+      expect(bytesToHumanReadable(500)).toEqual({value: 500, unit: 'B'});
+    });
+
+    it('converts to KiB', () => {
+      expect(bytesToHumanReadable(1024)).toEqual({value: 1, unit: 'KiB'});
+    });
+
+    it('converts to MiB', () => {
+      expect(bytesToHumanReadable(1024 * 1024)).toEqual({
+        value: 1,
+        unit: 'MiB',
+      });
+    });
+
+    it('converts to GiB', () => {
+      expect(bytesToHumanReadable(1024 ** 3)).toEqual({value: 1, unit: 'GiB'});
+    });
+
+    it('converts to TiB', () => {
+      expect(bytesToHumanReadable(1024 ** 4)).toEqual({value: 1, unit: 'TiB'});
+    });
+
+    it('rounds to 2 decimal places', () => {
+      const result = bytesToHumanReadable(1536);
+      expect(result).toEqual({value: 1.5, unit: 'KiB'});
+    });
+  });
+
+  describe('humanReadableToBytes', () => {
+    it('converts KiB to bytes', () => {
+      expect(humanReadableToBytes(1, 'KiB')).toBe(1024);
+    });
+
+    it('converts GiB to bytes', () => {
+      expect(humanReadableToBytes(2, 'GiB')).toBe(2 * 1024 ** 3);
+    });
+
+    it('returns value for unknown unit (multiplier=1)', () => {
+      expect(humanReadableToBytes(100, 'unknown')).toBe(100);
+    });
+  });
+});

--- a/web/src/resources/RegistrySizeResource.test.ts
+++ b/web/src/resources/RegistrySizeResource.test.ts
@@ -1,0 +1,59 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchRegistrySize,
+  queueRegistrySizeCalculation,
+} from './RegistrySizeResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('RegistrySizeResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchRegistrySize', () => {
+    it('fetches registry size data', async () => {
+      const data = {
+        size_bytes: 1024,
+        last_ran: 1700000000,
+        queued: false,
+        running: false,
+      };
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(data));
+
+      const result = await fetchRegistrySize();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/superuser/registrysize/');
+      expect(result).toEqual(data);
+    });
+  });
+
+  describe('queueRegistrySizeCalculation', () => {
+    it('queues size calculation', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await queueRegistrySizeCalculation();
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/superuser/registrysize/',
+      );
+    });
+  });
+});

--- a/web/src/resources/RepositoryAutoPruneResource.test.ts
+++ b/web/src/resources/RepositoryAutoPruneResource.test.ts
@@ -1,0 +1,78 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchRepositoryAutoPrunePolicies,
+  createRepositoryAutoPrunePolicy,
+  deleteRepositoryAutoPrunePolicy,
+} from './RepositoryAutoPruneResource';
+import {AutoPruneMethod} from './NamespaceAutoPruneResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('RepositoryAutoPruneResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchRepositoryAutoPrunePolicies', () => {
+    it('fetches policies for a repository', async () => {
+      const controller = new AbortController();
+      const policies = [{uuid: 'p1', method: 'number_of_tags', value: 10}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({policies}));
+
+      const result = await fetchRepositoryAutoPrunePolicies(
+        'org',
+        'repo',
+        controller.signal,
+      );
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'autoprunepolicy',
+      );
+      expect(result).toEqual(policies);
+    });
+  });
+
+  describe('createRepositoryAutoPrunePolicy', () => {
+    it('creates a policy', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await createRepositoryAutoPrunePolicy('org', 'repo', {
+        method: AutoPruneMethod.TAG_NUMBER,
+        value: 10,
+      });
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/autoprunepolicy/',
+        {method: 'number_of_tags', value: 10},
+      );
+    });
+  });
+
+  describe('deleteRepositoryAutoPrunePolicy', () => {
+    it('deletes a policy', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse({}));
+
+      await deleteRepositoryAutoPrunePolicy('org', 'repo', 'p1');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/autoprunepolicy/p1',
+      );
+    });
+  });
+});

--- a/web/src/resources/RepositoryResource.test.ts
+++ b/web/src/resources/RepositoryResource.test.ts
@@ -1,0 +1,623 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  isNonNormalState,
+  fetchAllRepos,
+  fetchRepositoriesForNamespace,
+  fetchRepositories,
+  fetchAllReposAsSuperUser,
+  fetchRepositoryDetails,
+  createNewRepository,
+  setRepositoryVisibility,
+  setRepositoryState,
+  bulkDeleteRepositories,
+  fetchUserRepoPermissions,
+  fetchAllTeamPermissionsForRepository,
+  setRepoPermissions,
+  bulkSetRepoPermissions,
+  bulkDeleteRepoPermissions,
+  deleteRepoPermissions,
+  deleteRepository,
+  RepoDeleteError,
+  fetchEntityTransitivePermission,
+  RepositoryState,
+  RepoRole,
+  IRepository,
+  RepoMember,
+} from './RepositoryResource';
+import {BulkOperationError, ResourceError} from './ErrorHandling';
+import {EntityKind} from './UserResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+/** Creates a minimal IRepository for testing. */
+function createMockRepo(
+  namespace: string,
+  name: string,
+  overrides: Partial<IRepository> = {},
+): IRepository {
+  return {namespace, name, ...overrides};
+}
+
+describe('RepositoryResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('isNonNormalState', () => {
+    it('returns false for null', () => {
+      expect(isNonNormalState(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isNonNormalState(undefined)).toBe(false);
+    });
+
+    it('returns false for NORMAL', () => {
+      expect(isNonNormalState('NORMAL')).toBe(false);
+    });
+
+    it('returns true for READ_ONLY', () => {
+      expect(isNonNormalState('READ_ONLY')).toBe(true);
+    });
+
+    it('returns true for MIRROR', () => {
+      expect(isNonNormalState('MIRROR')).toBe(true);
+    });
+
+    it('returns true for MARKED_FOR_DELETION', () => {
+      expect(isNonNormalState('MARKED_FOR_DELETION')).toBe(true);
+    });
+  });
+
+  describe('fetchRepositoriesForNamespace', () => {
+    it('fetches repos for a single namespace', async () => {
+      const repos = [createMockRepo('org1', 'repo1')];
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({repositories: repos, next_page: null}),
+      );
+
+      const result = await fetchRepositoriesForNamespace('org1');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository?last_modified=true&namespace=org1&public=true',
+        {signal: undefined},
+      );
+      expect(result).toEqual(repos);
+    });
+
+    it('recursively paginates when next_page is present', async () => {
+      const page1Repos = [createMockRepo('org1', 'repo1')];
+      const page2Repos = [createMockRepo('org1', 'repo2')];
+
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(
+          mockResponse({repositories: page1Repos, next_page: 'token123'}),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({repositories: page2Repos, next_page: null}),
+        );
+
+      const result = await fetchRepositoriesForNamespace('org1');
+      expect(result).toEqual([...page1Repos, ...page2Repos]);
+      expect(axios.get).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(axios.get).mock.calls[1][0]).toContain(
+        'next_page=token123',
+      );
+    });
+
+    it('calls onPartialResult for each page', async () => {
+      const page1Repos = [createMockRepo('org1', 'repo1')];
+      const page2Repos = [createMockRepo('org1', 'repo2')];
+      const onPartialResult = vi.fn();
+
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(
+          mockResponse({repositories: page1Repos, next_page: 'tok'}),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({repositories: page2Repos, next_page: null}),
+        );
+
+      await fetchRepositoriesForNamespace('org1', {onPartialResult});
+      expect(onPartialResult).toHaveBeenCalledTimes(2);
+      expect(onPartialResult).toHaveBeenCalledWith(page1Repos);
+      expect(onPartialResult).toHaveBeenCalledWith(page2Repos);
+    });
+
+    it('passes abort signal to axios', async () => {
+      const controller = new AbortController();
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({repositories: [], next_page: null}),
+      );
+
+      await fetchRepositoriesForNamespace('org1', {
+        signal: controller.signal,
+      });
+      expect(vi.mocked(axios.get).mock.calls[0][1]).toEqual({
+        signal: controller.signal,
+      });
+    });
+  });
+
+  describe('fetchAllRepos', () => {
+    it('returns empty array for empty namespaces', async () => {
+      const result = await fetchAllRepos([]);
+      expect(result).toEqual([]);
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array for null namespaces', async () => {
+      const result = await fetchAllRepos(null as unknown as string[]);
+      expect(result).toEqual([]);
+    });
+
+    it('returns nested arrays by default (not flattened)', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(
+          mockResponse({
+            repositories: [createMockRepo('ns1', 'r1')],
+            next_page: null,
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            repositories: [createMockRepo('ns2', 'r2')],
+            next_page: null,
+          }),
+        );
+
+      const result = await fetchAllRepos(['ns1', 'ns2']);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual([createMockRepo('ns1', 'r1')]);
+      expect(result[1]).toEqual([createMockRepo('ns2', 'r2')]);
+    });
+
+    it('flattens results when flatten=true', async () => {
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(
+          mockResponse({
+            repositories: [createMockRepo('ns1', 'r1')],
+            next_page: null,
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            repositories: [createMockRepo('ns2', 'r2')],
+            next_page: null,
+          }),
+        );
+
+      const result = await fetchAllRepos(['ns1', 'ns2'], {flatten: true});
+      expect(result).toEqual([
+        createMockRepo('ns1', 'r1'),
+        createMockRepo('ns2', 'r2'),
+      ]);
+    });
+  });
+
+  describe('fetchRepositories', () => {
+    it('fetches repositories with public=true', async () => {
+      const repos = [createMockRepo('org1', 'repo1')];
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({repositories: repos}),
+      );
+
+      const result = await fetchRepositories();
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository?last_modified=true&public=true',
+      );
+      expect(result).toEqual(repos);
+    });
+  });
+
+  describe('fetchAllReposAsSuperUser', () => {
+    it('returns repos with truncated=false for single page', async () => {
+      const repos = [createMockRepo('ns', 'r1')];
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({repositories: repos, next_page: null}),
+      );
+
+      const result = await fetchAllReposAsSuperUser();
+      expect(result).toEqual({repos, truncated: false});
+    });
+
+    it('paginates and concatenates results', async () => {
+      const page1 = [createMockRepo('ns', 'r1')];
+      const page2 = [createMockRepo('ns', 'r2')];
+
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(
+          mockResponse({repositories: page1, next_page: 'tok'}),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({repositories: page2, next_page: null}),
+        );
+
+      const result = await fetchAllReposAsSuperUser();
+      expect(result).toEqual({
+        repos: [...page1, ...page2],
+        truncated: false,
+      });
+    });
+
+    it('calls onPartialResult callback for each page', async () => {
+      const repos = [createMockRepo('ns', 'r1')];
+      const onPartialResult = vi.fn();
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({repositories: repos, next_page: null}),
+      );
+
+      await fetchAllReposAsSuperUser({onPartialResult});
+      expect(onPartialResult).toHaveBeenCalledWith(repos);
+    });
+  });
+
+  describe('fetchRepositoryDetails', () => {
+    it('fetches repo details with stats', async () => {
+      const details = {
+        name: 'myrepo',
+        namespace: 'myorg',
+        can_admin: true,
+        can_write: true,
+        description: 'test',
+        is_public: true,
+        is_starred: false,
+        is_free_account: false,
+        is_organization: true,
+        kind: 'image',
+        state: 'NORMAL',
+        status_token: null,
+        tag_expiration_s: 1209600,
+        trust_enabled: false,
+      };
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(details));
+
+      const result = await fetchRepositoryDetails('myorg', 'myrepo');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/myorg/myrepo?includeStats=true&includeTags=false',
+      );
+      expect(result).toEqual(details);
+    });
+  });
+
+  describe('createNewRepository', () => {
+    it('creates repository with correct payload', async () => {
+      const created = {namespace: 'org', name: 'repo', kind: 'image'};
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(created, 201));
+
+      const result = await createNewRepository(
+        'org',
+        'repo',
+        'public',
+        'A description',
+        'image',
+      );
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/repository', {
+        namespace: 'org',
+        repository: 'repo',
+        visibility: 'public',
+        description: 'A description',
+        repo_kind: 'image',
+      });
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('setRepositoryVisibility', () => {
+    it('posts visibility change', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({success: true}),
+      );
+
+      await setRepositoryVisibility('org', 'repo', 'private');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/changevisibility',
+        {visibility: 'private'},
+      );
+    });
+  });
+
+  describe('setRepositoryState', () => {
+    it('puts state change', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({success: true}));
+
+      await setRepositoryState('org', 'repo', RepositoryState.READ_ONLY);
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/changestate',
+        {state: 'READ_ONLY'},
+      );
+    });
+  });
+
+  describe('deleteRepository', () => {
+    it('deletes repository successfully', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await expect(deleteRepository('org', 'repo')).resolves.toBeUndefined();
+      expect(axios.delete).toHaveBeenCalledWith('/api/v1/repository/org/repo');
+    });
+
+    it('throws RepoDeleteError on failure', async () => {
+      vi.mocked(axios.delete).mockRejectedValueOnce(
+        new AxiosError('Not Found'),
+      );
+
+      try {
+        await deleteRepository('org', 'repo');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(RepoDeleteError);
+        expect((err as RepoDeleteError).repo).toBe('org/repo');
+      }
+    });
+  });
+
+  describe('bulkDeleteRepositories', () => {
+    it('deletes all repositories successfully', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      await expect(
+        bulkDeleteRepositories([
+          createMockRepo('org', 'r1'),
+          createMockRepo('org', 'r2'),
+        ]),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws BulkOperationError when some deletions fail', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockRejectedValueOnce(new AxiosError('fail'));
+
+      try {
+        await bulkDeleteRepositories([
+          createMockRepo('org', 'r1'),
+          createMockRepo('org', 'r2'),
+        ]);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(BulkOperationError);
+        expect(
+          (err as BulkOperationError<RepoDeleteError>).getErrors().size,
+        ).toBe(1);
+      }
+    });
+  });
+
+  describe('fetchUserRepoPermissions', () => {
+    it('returns permissions map', async () => {
+      const perms = {
+        user1: {role: 'admin', name: 'user1', avatar: {}, is_robot: false},
+      };
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({permissions: perms}),
+      );
+
+      const result = await fetchUserRepoPermissions('org', 'repo');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/permissions/user/',
+      );
+      expect(result).toEqual(perms);
+    });
+  });
+
+  describe('fetchAllTeamPermissionsForRepository', () => {
+    it('returns team permissions map', async () => {
+      const perms = {
+        team1: {role: 'read', name: 'team1', avatar: {}},
+      };
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({permissions: perms}),
+      );
+
+      const result = await fetchAllTeamPermissionsForRepository('org', 'repo');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/permissions/team/',
+      );
+      expect(result).toEqual(perms);
+    });
+  });
+
+  describe('setRepoPermissions', () => {
+    it('maps robot entity type to user in the API path', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      const role: RepoMember = {
+        org: 'org',
+        repo: 'repo',
+        name: 'org+bot',
+        type: EntityKind.robot,
+        role: RepoRole.read,
+      };
+      await setRepoPermissions(role, RepoRole.write);
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/permissions/user/org+bot',
+        {role: 'write'},
+      );
+    });
+
+    it('uses team type directly in the API path', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      const role: RepoMember = {
+        org: 'org',
+        repo: 'repo',
+        name: 'devs',
+        type: EntityKind.team,
+        role: RepoRole.read,
+      };
+      await setRepoPermissions(role, RepoRole.admin);
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/permissions/team/devs',
+        {role: 'admin'},
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.put).mockRejectedValueOnce(new AxiosError('fail'));
+
+      const role: RepoMember = {
+        org: 'org',
+        repo: 'repo',
+        name: 'user1',
+        type: EntityKind.user,
+        role: RepoRole.read,
+      };
+      await expect(setRepoPermissions(role, RepoRole.write)).rejects.toThrow(
+        ResourceError,
+      );
+    });
+  });
+
+  describe('deleteRepoPermissions', () => {
+    it('maps robot type to user in delete path', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      const role: RepoMember = {
+        org: 'org',
+        repo: 'repo',
+        name: 'org+bot',
+        type: EntityKind.robot,
+        role: RepoRole.read,
+      };
+      await deleteRepoPermissions(role);
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/permissions/user/org+bot',
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.delete).mockRejectedValueOnce(new AxiosError('fail'));
+
+      const role: RepoMember = {
+        org: 'org',
+        repo: 'repo',
+        name: 'user1',
+        type: EntityKind.user,
+        role: RepoRole.read,
+      };
+      await expect(deleteRepoPermissions(role)).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('bulkSetRepoPermissions', () => {
+    it('sets permissions for multiple roles', async () => {
+      vi.mocked(axios.put)
+        .mockResolvedValueOnce(mockResponse({}))
+        .mockResolvedValueOnce(mockResponse({}));
+
+      const roles: RepoMember[] = [
+        {
+          org: 'org',
+          repo: 'repo',
+          name: 'u1',
+          type: EntityKind.user,
+          role: RepoRole.read,
+        },
+        {
+          org: 'org',
+          repo: 'repo',
+          name: 'u2',
+          type: EntityKind.user,
+          role: RepoRole.read,
+        },
+      ];
+      await expect(
+        bulkSetRepoPermissions(roles, RepoRole.write),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('bulkDeleteRepoPermissions', () => {
+    it('deletes permissions for multiple roles', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      const roles: RepoMember[] = [
+        {
+          org: 'org',
+          repo: 'repo',
+          name: 'u1',
+          type: EntityKind.user,
+          role: RepoRole.read,
+        },
+        {
+          org: 'org',
+          repo: 'repo',
+          name: 'u2',
+          type: EntityKind.user,
+          role: RepoRole.read,
+        },
+      ];
+      await expect(bulkDeleteRepoPermissions(roles)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('fetchEntityTransitivePermission', () => {
+    it('returns permissions array on success', async () => {
+      const permissions = [{role: 'admin'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({permissions}));
+
+      const result = await fetchEntityTransitivePermission(
+        'org',
+        'repo',
+        'user1',
+      );
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/permissions/user/user1/transitive',
+      );
+      expect(result).toEqual(permissions);
+    });
+
+    it('returns empty array on 404', async () => {
+      const err = new AxiosError('Not Found', '404', undefined, undefined, {
+        status: 404,
+        data: {},
+        statusText: 'Not Found',
+        headers: {},
+        config: {} as InternalAxiosRequestConfig,
+      });
+      vi.mocked(axios.get).mockRejectedValueOnce(err);
+
+      const result = await fetchEntityTransitivePermission(
+        'org',
+        'repo',
+        'user1',
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('RepoDeleteError', () => {
+    it('stores repo name and error', () => {
+      const axiosErr = new AxiosError('fail');
+      const err = new RepoDeleteError('delete failed', 'org/repo', axiosErr);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(RepoDeleteError);
+      expect(err.repo).toBe('org/repo');
+      expect(err.error).toBe(axiosErr);
+      expect(err.message).toBe('delete failed');
+    });
+  });
+});

--- a/web/src/resources/RobotsResource.test.ts
+++ b/web/src/resources/RobotsResource.test.ts
@@ -1,0 +1,235 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchAllRobots,
+  fetchRobotsForNamespace,
+  createNewRobotForNamespace,
+  deleteRobotAccount,
+  bulkDeleteRobotAccounts,
+  RobotDeleteError,
+  fetchRobotPermissionsForNamespace,
+  fetchRobotAccountToken,
+  regenerateRobotToken,
+  fetchRobotFederationConfig,
+  createRobotFederationConfig,
+  IRobot,
+} from './RobotsResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('RobotsResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchRobotsForNamespace', () => {
+    it('fetches robots for an organization', async () => {
+      const controller = new AbortController();
+      const robots = [{name: 'org+bot1'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({robots}));
+
+      const result = await fetchRobotsForNamespace(
+        'org',
+        false,
+        controller.signal,
+      );
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'organization/org',
+      );
+      expect(result).toEqual(robots);
+    });
+
+    it('uses user path when isUser=true', async () => {
+      const controller = new AbortController();
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({robots: []}));
+
+      await fetchRobotsForNamespace('user1', true, controller.signal);
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain('/user/robots');
+    });
+  });
+
+  describe('fetchAllRobots', () => {
+    it('fetches robots for multiple orgs in parallel', async () => {
+      const controller = new AbortController();
+      vi.mocked(axios.get)
+        .mockResolvedValueOnce(mockResponse({robots: [{name: 'org1+bot'}]}))
+        .mockResolvedValueOnce(mockResponse({robots: [{name: 'org2+bot'}]}));
+
+      const result = await fetchAllRobots(['org1', 'org2'], controller.signal);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('createNewRobotForNamespace', () => {
+    it('creates a robot for an organization', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(
+        mockResponse({name: 'org+newbot'}, 201),
+      );
+
+      const result = await createNewRobotForNamespace('org', 'newbot', 'A bot');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/org/robots/newbot',
+        {description: 'A bot'},
+      );
+      expect(result).toEqual({name: 'org+newbot'});
+    });
+
+    it('uses user path when isUser=true', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}, 201));
+
+      await createNewRobotForNamespace('user1', 'mybot', 'desc', true);
+      expect(vi.mocked(axios.put).mock.calls[0][0]).toContain(
+        '/user/robots/mybot',
+      );
+    });
+  });
+
+  describe('deleteRobotAccount', () => {
+    it('deletes robot account stripping org prefix', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteRobotAccount('org', 'org+bot1');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/org/robots/bot1',
+      );
+    });
+
+    it('throws RobotDeleteError on failure', async () => {
+      vi.mocked(axios.delete).mockRejectedValueOnce(new AxiosError('fail'));
+
+      try {
+        await deleteRobotAccount('org', 'org+bot1');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(RobotDeleteError);
+        expect((err as RobotDeleteError).robotName).toBe('org+bot1');
+      }
+    });
+  });
+
+  describe('bulkDeleteRobotAccounts', () => {
+    it('deletes multiple robot accounts', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      const robots: IRobot[] = [
+        {name: 'org+bot1', created: '', last_accessed: '', description: ''},
+        {name: 'org+bot2', created: '', last_accessed: '', description: ''},
+      ];
+      const result = await bulkDeleteRobotAccounts('org', robots);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('fetchRobotPermissionsForNamespace', () => {
+    it('fetches permissions stripping org prefix from robot name', async () => {
+      const controller = new AbortController();
+      const permissions = [{repoName: 'repo1', role: 'read'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({permissions}));
+
+      const result = await fetchRobotPermissionsForNamespace(
+        'org',
+        'org+bot1',
+        false,
+        controller.signal,
+      );
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        '/robots/bot1/permissions',
+      );
+      expect(result).toEqual(permissions);
+    });
+  });
+
+  describe('fetchRobotAccountToken', () => {
+    it('fetches robot token', async () => {
+      const controller = new AbortController();
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({token: 'secret'}),
+      );
+
+      const result = await fetchRobotAccountToken(
+        'org',
+        'org+bot1',
+        false,
+        controller.signal,
+      );
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain('/robots/bot1');
+      expect(result).toEqual({token: 'secret'});
+    });
+  });
+
+  describe('regenerateRobotToken', () => {
+    it('regenerates token via POST', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({token: 'newtoken'}),
+      );
+
+      const result = await regenerateRobotToken('org', 'org+bot1');
+      expect(vi.mocked(axios.post).mock.calls[0][0]).toContain(
+        '/robots/bot1/regenerate',
+      );
+      expect(result).toEqual({token: 'newtoken'});
+    });
+  });
+
+  describe('fetchRobotFederationConfig', () => {
+    it('fetches federation config', async () => {
+      const controller = new AbortController();
+      const config = [{issuer: 'https://example.com', subject: 'sub1'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(config));
+
+      const result = await fetchRobotFederationConfig(
+        'org',
+        'org+bot1',
+        controller.signal,
+      );
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        '/robots/bot1/federation',
+      );
+      expect(result).toEqual(config);
+    });
+  });
+
+  describe('createRobotFederationConfig', () => {
+    it('creates federation config', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      const config = [{issuer: 'https://example.com', subject: 'sub1'}];
+      await createRobotFederationConfig('org', 'org+bot1', config);
+      expect(vi.mocked(axios.post).mock.calls[0][0]).toContain(
+        '/robots/bot1/federation',
+      );
+      expect(vi.mocked(axios.post).mock.calls[0][1]).toEqual(config);
+    });
+  });
+
+  describe('RobotDeleteError', () => {
+    it('stores robotName and error', () => {
+      const axiosErr = new AxiosError('fail');
+      const err = new RobotDeleteError('delete failed', 'org+bot', axiosErr);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(RobotDeleteError);
+      expect(err.robotName).toBe('org+bot');
+      expect(err.error).toBe(axiosErr);
+    });
+  });
+});

--- a/web/src/resources/ServiceKeysResource.test.ts
+++ b/web/src/resources/ServiceKeysResource.test.ts
@@ -1,0 +1,84 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchServiceKeys,
+  createServiceKey,
+  deleteServiceKey,
+  approveServiceKey,
+} from './ServiceKeysResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('ServiceKeysResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchServiceKeys', () => {
+    it('fetches service keys', async () => {
+      const keys = [{kid: 'k1', service: 'quay'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({keys}));
+
+      const result = await fetchServiceKeys();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/superuser/keys');
+      expect(result).toEqual(keys);
+    });
+  });
+
+  describe('createServiceKey', () => {
+    it('creates a service key', async () => {
+      const key = {kid: 'k1', service: 'quay'};
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(key));
+
+      const result = await createServiceKey({
+        service: 'quay',
+        expiration: null,
+      });
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/superuser/keys', {
+        service: 'quay',
+        expiration: null,
+      });
+      expect(result).toEqual(key);
+    });
+  });
+
+  describe('deleteServiceKey', () => {
+    it('deletes a service key', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteServiceKey('k1');
+      expect(axios.delete).toHaveBeenCalledWith('/api/v1/superuser/keys/k1');
+    });
+  });
+
+  describe('approveServiceKey', () => {
+    it('approves a service key', async () => {
+      const key = {kid: 'k1', service: 'quay'};
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(key));
+
+      const result = await approveServiceKey('k1');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/superuser/approvedkeys/k1',
+      );
+      expect(result).toEqual(key);
+    });
+  });
+});

--- a/web/src/resources/TagResource.test.ts
+++ b/web/src/resources/TagResource.test.ts
@@ -46,12 +46,23 @@ function mockResponse(data: unknown, status = 200): AxiosResponse {
 }
 
 describe('TagResource', () => {
+  const originalLocation = window.location;
+
   beforeEach(() => {
     localStorage.clear();
     // Reset window.location.search for getTags tests
     Object.defineProperty(window, 'location', {
       value: {search: '', protocol: 'https:', host: 'localhost'},
       writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
     });
   });
 

--- a/web/src/resources/TagResource.test.ts
+++ b/web/src/resources/TagResource.test.ts
@@ -1,0 +1,494 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  getTags,
+  getLabels,
+  createLabel,
+  deleteLabel,
+  bulkCreateLabels,
+  bulkDeleteLabels,
+  bulkDeleteTags,
+  deleteTag,
+  expireTag,
+  TagDeleteError,
+  getManifestByDigest,
+  getSecurityDetails,
+  createTag,
+  setExpiration,
+  bulkSetExpiration,
+  setTagImmutability,
+  bulkSetTagImmutability,
+  restoreTag,
+  permanentlyDeleteTag,
+  getTagPullStatistics,
+  Label,
+} from './TagResource';
+import {BulkOperationError, ResourceError} from './ErrorHandling';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('TagResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Reset window.location.search for getTags tests
+    Object.defineProperty(window, 'location', {
+      value: {search: '', protocol: 'https:', host: 'localhost'},
+      writable: true,
+    });
+  });
+
+  describe('getTags', () => {
+    it('fetches tags with default parameters', async () => {
+      const tagsResponse = {page: 1, has_additional: false, tags: []};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(tagsResponse));
+
+      const result = await getTags('org', 'repo', 1);
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/tag/?limit=100&page=1&onlyActiveTags=true',
+      );
+      expect(result).toEqual(tagsResponse);
+    });
+
+    it('appends specificTag when provided', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({page: 1, has_additional: false, tags: []}),
+      );
+
+      await getTags('org', 'repo', 1, 50, 'v1.0');
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'specificTag=v1.0',
+      );
+    });
+
+    it('omits onlyActiveTags when set to false', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({page: 1, has_additional: false, tags: []}),
+      );
+
+      await getTags('org', 'repo', 1, 100, null, false);
+      expect(vi.mocked(axios.get).mock.calls[0][0]).not.toContain(
+        'onlyActiveTags',
+      );
+    });
+
+    it('appends filter_tag_name from URL search params', async () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          search: '?filter_tag_name=latest',
+          protocol: 'https:',
+          host: 'localhost',
+        },
+        writable: true,
+      });
+      vi.mocked(axios.get).mockResolvedValueOnce(
+        mockResponse({page: 1, has_additional: false, tags: []}),
+      );
+
+      await getTags('org', 'repo', 1);
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'filter_tag_name=latest',
+      );
+    });
+  });
+
+  describe('getLabels', () => {
+    it('fetches labels for a manifest digest', async () => {
+      const labels = [{key: 'env', value: 'prod'}];
+      const controller = new AbortController();
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({labels}));
+
+      const result = await getLabels(
+        'org',
+        'repo',
+        'sha256:abc',
+        controller.signal,
+      );
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/manifest/sha256:abc/labels',
+        {signal: controller.signal},
+      );
+      expect(result).toEqual(labels);
+    });
+  });
+
+  describe('createLabel', () => {
+    it('creates a label on a manifest', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}, 201));
+
+      const label: Label = {
+        key: 'env',
+        value: 'prod',
+        media_type: 'text/plain',
+      };
+      await expect(
+        createLabel('org', 'repo', 'sha256:abc', label),
+      ).resolves.toBeUndefined();
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/manifest/sha256:abc/labels',
+        {key: 'env', value: 'prod', media_type: 'text/plain'},
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.post).mockRejectedValueOnce(new AxiosError('fail'));
+
+      const label: Label = {key: 'env', value: 'prod'};
+      await expect(
+        createLabel('org', 'repo', 'sha256:abc', label),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('deleteLabel', () => {
+    it('deletes a label by id', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      const label: Label = {id: 'label-1', key: 'env', value: 'prod'};
+      await expect(
+        deleteLabel('org', 'repo', 'sha256:abc', label),
+      ).resolves.toBeUndefined();
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/manifest/sha256:abc/labels/label-1',
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.delete).mockRejectedValueOnce(new AxiosError('fail'));
+
+      const label: Label = {id: 'label-1', key: 'env', value: 'prod'};
+      await expect(
+        deleteLabel('org', 'repo', 'sha256:abc', label),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('bulkCreateLabels', () => {
+    it('creates multiple labels via Promise.allSettled', async () => {
+      vi.mocked(axios.post)
+        .mockResolvedValueOnce(mockResponse({}, 201))
+        .mockResolvedValueOnce(mockResponse({}, 201));
+
+      const labels: Label[] = [
+        {key: 'a', value: '1'},
+        {key: 'b', value: '2'},
+      ];
+      await expect(
+        bulkCreateLabels('org', 'repo', 'sha256:abc', labels),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('bulkDeleteLabels', () => {
+    it('deletes multiple labels via Promise.allSettled', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      const labels: Label[] = [
+        {id: '1', key: 'a', value: '1'},
+        {id: '2', key: 'b', value: '2'},
+      ];
+      await expect(
+        bulkDeleteLabels('org', 'repo', 'sha256:abc', labels),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('deleteTag', () => {
+    it('deletes a tag successfully', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await expect(deleteTag('org', 'repo', 'latest')).resolves.toBeUndefined();
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/tag/latest',
+      );
+    });
+
+    it('throws TagDeleteError on failure', async () => {
+      vi.mocked(axios.delete).mockRejectedValueOnce(new AxiosError('fail'));
+
+      try {
+        await deleteTag('org', 'repo', 'latest');
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(TagDeleteError);
+        expect((err as TagDeleteError).tag).toBe('org/repo:latest');
+      }
+    });
+  });
+
+  describe('expireTag', () => {
+    it('expires a tag with correct payload', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await expireTag('org', 'repo', 'v1');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/tag/v1/expire',
+        {include_submanifests: true, is_alive: true},
+      );
+    });
+
+    it('throws TagDeleteError on failure', async () => {
+      vi.mocked(axios.post).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(expireTag('org', 'repo', 'v1')).rejects.toThrow(
+        TagDeleteError,
+      );
+    });
+  });
+
+  describe('bulkDeleteTags', () => {
+    it('deletes all tags successfully', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      await expect(
+        bulkDeleteTags('org', 'repo', ['t1', 't2']),
+      ).resolves.toBeUndefined();
+    });
+
+    it('uses expireTag when force=true', async () => {
+      vi.mocked(axios.post)
+        .mockResolvedValueOnce(mockResponse({}))
+        .mockResolvedValueOnce(mockResponse({}));
+
+      await bulkDeleteTags('org', 'repo', ['t1', 't2'], true);
+      expect(axios.post).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(axios.post).mock.calls[0][0]).toContain('/expire');
+    });
+
+    it('throws BulkOperationError when some deletions fail', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockRejectedValueOnce(new AxiosError('fail'));
+
+      try {
+        await bulkDeleteTags('org', 'repo', ['t1', 't2']);
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(BulkOperationError);
+        expect(
+          (err as BulkOperationError<TagDeleteError>).getErrors().size,
+        ).toBe(1);
+      }
+    });
+  });
+
+  describe('getManifestByDigest', () => {
+    it('fetches manifest without modelcard by default', async () => {
+      const manifest = {
+        digest: 'sha256:abc',
+        is_manifest_list: false,
+        manifest_data: '{}',
+      };
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(manifest));
+
+      const result = await getManifestByDigest('org', 'repo', 'sha256:abc');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/manifest/sha256:abc',
+      );
+      expect(result).toEqual(manifest);
+    });
+
+    it('appends include_modelcard query param when true', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({}));
+
+      await getManifestByDigest('org', 'repo', 'sha256:abc', true);
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'include_modelcard=true',
+      );
+    });
+  });
+
+  describe('getSecurityDetails', () => {
+    it('fetches security details with vulnerabilities', async () => {
+      const security = {status: 'scanned', data: {Layer: {}}};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(security));
+
+      const result = await getSecurityDetails('org', 'repo', 'sha256:abc');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/manifest/sha256:abc/security?vulnerabilities=true',
+      );
+      expect(result).toEqual(security);
+    });
+  });
+
+  describe('createTag', () => {
+    it('creates a tag pointing to a manifest digest', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await createTag('org', 'repo', 'v2', 'sha256:def');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/tag/v2',
+        {manifest_digest: 'sha256:def'},
+      );
+    });
+  });
+
+  describe('setExpiration', () => {
+    it('sets expiration on a tag', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await setExpiration('org', 'repo', 'v1', 1700000000);
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/tag/v1',
+        {expiration: 1700000000},
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.put).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(
+        setExpiration('org', 'repo', 'v1', 1700000000),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('bulkSetExpiration', () => {
+    it('sets expiration for multiple tags', async () => {
+      vi.mocked(axios.put)
+        .mockResolvedValueOnce(mockResponse({}))
+        .mockResolvedValueOnce(mockResponse({}));
+
+      await expect(
+        bulkSetExpiration('org', 'repo', ['t1', 't2'], 1700000000),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('setTagImmutability', () => {
+    it('sets immutability on a tag', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await setTagImmutability('org', 'repo', 'v1', true);
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/tag/v1',
+        {immutable: true},
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.put).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(
+        setTagImmutability('org', 'repo', 'v1', true),
+      ).rejects.toThrow(ResourceError);
+    });
+  });
+
+  describe('bulkSetTagImmutability', () => {
+    it('sets immutability for multiple tags', async () => {
+      vi.mocked(axios.put)
+        .mockResolvedValueOnce(mockResponse({}))
+        .mockResolvedValueOnce(mockResponse({}));
+
+      await expect(
+        bulkSetTagImmutability('org', 'repo', ['t1', 't2'], true),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('restoreTag', () => {
+    it('restores a tag to a specific digest', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await restoreTag('org', 'repo', 'v1', 'sha256:abc');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/tag/v1/restore',
+        {manifest_digest: 'sha256:abc'},
+      );
+    });
+  });
+
+  describe('permanentlyDeleteTag', () => {
+    it('permanently deletes a tag with correct payload', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await permanentlyDeleteTag('org', 'repo', 'v1', 'sha256:abc');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo/tag/v1/expire',
+        {
+          manifest_digest: 'sha256:abc',
+          include_submanifests: true,
+          is_alive: false,
+        },
+      );
+    });
+  });
+
+  describe('getTagPullStatistics', () => {
+    it('returns pull statistics on success', async () => {
+      const stats = {
+        tag_name: 'latest',
+        tag_pull_count: 42,
+        last_tag_pull_date: '2024-01-01',
+        current_manifest_digest: 'sha256:abc',
+        manifest_pull_count: 100,
+        last_manifest_pull_date: '2024-01-02',
+      };
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(stats));
+
+      const result = await getTagPullStatistics('org', 'repo', 'latest');
+      expect(result).toEqual(stats);
+    });
+
+    it('throws ResourceError with specific message on 404', async () => {
+      const err = new AxiosError('Not Found');
+      (err as any).response = {status: 404};
+      vi.mocked(axios.get).mockRejectedValueOnce(err);
+
+      try {
+        await getTagPullStatistics('org', 'repo', 'latest');
+        expect.unreachable('should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ResourceError);
+        expect((e as ResourceError).message).toContain('not available');
+      }
+    });
+
+    it('throws ResourceError with generic message on other errors', async () => {
+      const err = new AxiosError('Server Error');
+      (err as any).response = {status: 500};
+      vi.mocked(axios.get).mockRejectedValueOnce(err);
+
+      try {
+        await getTagPullStatistics('org', 'repo', 'latest');
+        expect.unreachable('should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ResourceError);
+        expect((e as ResourceError).message).toContain('Unable to fetch');
+      }
+    });
+  });
+
+  describe('TagDeleteError', () => {
+    it('stores tag name and error', () => {
+      const axiosErr = new AxiosError('fail');
+      const err = new TagDeleteError('delete failed', 'org/repo:v1', axiosErr);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(TagDeleteError);
+      expect(err.tag).toBe('org/repo:v1');
+      expect(err.error).toBe(axiosErr);
+    });
+  });
+});

--- a/web/src/resources/TagResource.test.ts
+++ b/web/src/resources/TagResource.test.ts
@@ -108,6 +108,7 @@ describe('TagResource', () => {
           host: 'localhost',
         },
         writable: true,
+        configurable: true,
       });
       vi.mocked(axios.get).mockResolvedValueOnce(
         mockResponse({page: 1, has_additional: false, tags: []}),

--- a/web/src/resources/TeamResources.test.ts
+++ b/web/src/resources/TeamResources.test.ts
@@ -1,0 +1,199 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  createNewTeamForNamespace,
+  updateTeamForRobot,
+  updateTeamDetailsForNamespace,
+  updateTeamRepoPerm,
+  fetchTeamsForNamespace,
+  fetchTeamRepoPermsForOrg,
+  deleteTeamForOrg,
+  bulkDeleteTeams,
+  TeamDeleteError,
+} from './TeamResources';
+import {ResourceError} from './ErrorHandling';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('TeamResources', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('createNewTeamForNamespace', () => {
+    it('creates a team with default member role', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await createNewTeamForNamespace('org', 'devs');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/org/team/devs',
+        {name: 'devs', role: 'member'},
+      );
+    });
+
+    it('includes description when provided', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await createNewTeamForNamespace('org', 'devs', 'Development team');
+      expect(vi.mocked(axios.put).mock.calls[0][1]).toEqual({
+        name: 'devs',
+        role: 'member',
+        description: 'Development team',
+      });
+    });
+  });
+
+  describe('updateTeamForRobot', () => {
+    it('adds robot to team with org-prefixed name', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(
+        mockResponse({name: 'org+bot'}),
+      );
+
+      const result = await updateTeamForRobot('org', 'devs', 'bot');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/org/team/devs/members/org+bot',
+        {},
+      );
+      expect(result).toBe('org+bot');
+    });
+  });
+
+  describe('updateTeamDetailsForNamespace', () => {
+    it('updates team role', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({name: 'devs'}));
+
+      await updateTeamDetailsForNamespace('org', 'devs', 'admin');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/org/team/devs',
+        {name: 'devs', role: 'admin'},
+      );
+    });
+
+    it('includes description when provided', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({name: 'devs'}));
+
+      await updateTeamDetailsForNamespace(
+        'org',
+        'devs',
+        'member',
+        'Updated desc',
+      );
+      expect(vi.mocked(axios.put).mock.calls[0][1]).toHaveProperty(
+        'description',
+        'Updated desc',
+      );
+    });
+  });
+
+  describe('updateTeamRepoPerm', () => {
+    it('updates repo permissions with PUT for non-none roles', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await updateTeamRepoPerm('org', 'devs', [
+        {repoName: 'repo1', role: 'read'},
+      ] as any);
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo1/permissions/team/devs',
+        {role: 'read'},
+      );
+    });
+
+    it('uses DELETE for role=none', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await updateTeamRepoPerm('org', 'devs', [
+        {repoName: 'repo1', role: 'none'},
+      ] as any);
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/repository/org/repo1/permissions/team/devs',
+      );
+    });
+  });
+
+  describe('fetchTeamsForNamespace', () => {
+    it('fetches teams for an org', async () => {
+      const teams = {devs: {name: 'devs', role: 'member'}};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({teams}));
+
+      const result = await fetchTeamsForNamespace('org');
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/organization/org', {
+        signal: undefined,
+      });
+      expect(result).toEqual(teams);
+    });
+  });
+
+  describe('fetchTeamRepoPermsForOrg', () => {
+    it('fetches team repo permissions', async () => {
+      const permissions = [{repoName: 'repo1', role: 'read'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({permissions}));
+
+      const result = await fetchTeamRepoPermsForOrg('org', 'devs');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/organization/org/team/devs/permissions',
+        {signal: undefined},
+      );
+      expect(result).toEqual(permissions);
+    });
+  });
+
+  describe('deleteTeamForOrg', () => {
+    it('deletes a team', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteTeamForOrg('org', 'devs');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/org/team/devs',
+      );
+    });
+
+    it('throws ResourceError on failure', async () => {
+      vi.mocked(axios.delete).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(deleteTeamForOrg('org', 'devs')).rejects.toThrow(
+        ResourceError,
+      );
+    });
+  });
+
+  describe('bulkDeleteTeams', () => {
+    it('deletes multiple teams', async () => {
+      vi.mocked(axios.delete)
+        .mockResolvedValueOnce(mockResponse(null, 204))
+        .mockResolvedValueOnce(mockResponse(null, 204));
+
+      await expect(
+        bulkDeleteTeams('org', [{name: 'devs'}, {name: 'ops'}] as any),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('TeamDeleteError', () => {
+    it('stores team and error properties', () => {
+      const axiosErr = new AxiosError('fail');
+      const err = new TeamDeleteError('delete failed', 'devs', axiosErr);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(TeamDeleteError);
+      expect(err.team).toBe('devs');
+      expect(err.error).toBe(axiosErr);
+    });
+  });
+});

--- a/web/src/resources/TeamSyncResource.test.ts
+++ b/web/src/resources/TeamSyncResource.test.ts
@@ -1,0 +1,75 @@
+import {AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {enableTeamSyncForOrg, removeTeamSyncForOrg} from './TeamSyncResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('TeamSyncResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('enableTeamSyncForOrg', () => {
+    it('sends group_name for oidc service', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await enableTeamSyncForOrg('myorg', 'devs', 'my-group', 'oidc');
+      expect(vi.mocked(axios.post).mock.calls[0][1]).toEqual({
+        group_name: 'my-group',
+      });
+    });
+
+    it('sends group_dn for ldap service', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await enableTeamSyncForOrg('myorg', 'devs', 'cn=devs,dc=example', 'ldap');
+      expect(vi.mocked(axios.post).mock.calls[0][1]).toEqual({
+        group_dn: 'cn=devs,dc=example',
+      });
+    });
+
+    it('sends group_id for keystone service', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await enableTeamSyncForOrg('myorg', 'devs', 'grp-123', 'keystone');
+      expect(vi.mocked(axios.post).mock.calls[0][1]).toEqual({
+        group_id: 'grp-123',
+      });
+    });
+
+    it('throws for unsupported service', async () => {
+      await expect(
+        enableTeamSyncForOrg('myorg', 'devs', 'grp', 'saml' as any),
+      ).rejects.toThrow('Unsupported team sync service');
+    });
+  });
+
+  describe('removeTeamSyncForOrg', () => {
+    it('removes team sync', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse({}));
+
+      await removeTeamSyncForOrg('myorg', 'devs');
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/team/devs/syncing',
+      );
+    });
+  });
+});

--- a/web/src/resources/UserResource.test.ts
+++ b/web/src/resources/UserResource.test.ts
@@ -1,0 +1,392 @@
+import {AxiosError, AxiosResponse, InternalAxiosRequestConfig} from 'axios';
+import axios from 'src/libs/axios';
+import {
+  fetchUser,
+  fetchUsersAsSuperUser,
+  getEntityKind,
+  fetchEntities,
+  createUser,
+  createSuperuserUser,
+  updateSuperuserUser,
+  deleteSuperuserUser,
+  updateUser,
+  createClientKey,
+  convert,
+  deleteUser,
+  UserDeleteError,
+  ApplicationTokenError,
+  fetchApplicationTokens,
+  createApplicationToken,
+  fetchApplicationToken,
+  revokeApplicationToken,
+  sendRecoveryEmail,
+  EntityKind,
+  Entity,
+} from './UserResource';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+/** Creates a mock Axios response with the given data and status. */
+function mockResponse(data: unknown, status = 200): AxiosResponse {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+    headers: {},
+    config: {} as InternalAxiosRequestConfig,
+  };
+}
+
+describe('UserResource', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('fetchUser', () => {
+    it('fetches the current user', async () => {
+      const user = {username: 'testuser', anonymous: false};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(user));
+
+      const result = await fetchUser();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/user/');
+      expect(result).toEqual(user);
+    });
+  });
+
+  describe('fetchUsersAsSuperUser', () => {
+    it('returns users array', async () => {
+      const users = [{username: 'u1'}, {username: 'u2'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({users}));
+
+      const result = await fetchUsersAsSuperUser();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/superuser/users/');
+      expect(result).toEqual(users);
+    });
+  });
+
+  describe('getEntityKind', () => {
+    it('returns team for team entities', () => {
+      const entity: Entity = {name: 'devs', kind: EntityKind.team};
+      expect(getEntityKind(entity)).toBe(EntityKind.team);
+    });
+
+    it('returns robot for user entities with is_robot=true', () => {
+      const entity: Entity = {
+        name: 'org+bot',
+        kind: EntityKind.user,
+        is_robot: true,
+      };
+      expect(getEntityKind(entity)).toBe(EntityKind.robot);
+    });
+
+    it('returns user for user entities without is_robot', () => {
+      const entity: Entity = {name: 'alice', kind: EntityKind.user};
+      expect(getEntityKind(entity)).toBe(EntityKind.user);
+    });
+
+    it('returns undefined for unknown entity kind', () => {
+      const entity: Entity = {
+        name: 'unknown',
+        kind: 'other' as EntityKind,
+      };
+      expect(getEntityKind(entity)).toBeUndefined();
+    });
+  });
+
+  describe('fetchEntities', () => {
+    it('fetches entities for a namespace', async () => {
+      const results = [{name: 'user1', kind: 'user'}];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({results}));
+
+      const result = await fetchEntities('user', 'myorg');
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/v1/entities/user?namespace=myorg',
+      );
+      expect(result).toEqual(results);
+    });
+
+    it('includes teams in search when includeTeams=true', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({results: []}));
+
+      await fetchEntities('alice', 'myorg', true);
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        'includeTeams=true',
+      );
+    });
+
+    it('strips prefix before + for robot account searches', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({results: []}));
+
+      await fetchEntities('org+mybot', 'myorg');
+      expect(vi.mocked(axios.get).mock.calls[0][0]).toContain(
+        '/api/v1/entities/mybot',
+      );
+    });
+
+    it('filters out robots when includeRobots=false', async () => {
+      const results = [
+        {name: 'alice', kind: EntityKind.user, is_robot: false},
+        {name: 'org+bot', kind: EntityKind.user, is_robot: true},
+        {name: 'devs', kind: EntityKind.team},
+      ];
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({results}));
+
+      const result = await fetchEntities('a', 'myorg', false, false);
+      expect(result).toHaveLength(2);
+      expect(
+        result.every((e) => !e.is_robot || e.kind !== EntityKind.user),
+      ).toBe(true);
+    });
+
+    it('returns empty array when results is missing', async () => {
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({}));
+
+      const result = await fetchEntities('x', 'myorg');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('createUser', () => {
+    it('creates a user account', async () => {
+      const response = {awaiting_verification: true};
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(response));
+
+      const result = await createUser('alice', 'pass123', 'alice@test.com');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/user/', {
+        username: 'alice',
+        password: 'pass123',
+        email: 'alice@test.com',
+      });
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('createSuperuserUser', () => {
+    it('creates a user as superuser', async () => {
+      const response = {
+        username: 'bob',
+        email: 'bob@test.com',
+        password: 'gen',
+        enabled: true,
+      };
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(response));
+
+      const result = await createSuperuserUser({
+        username: 'bob',
+        email: 'bob@test.com',
+      });
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/superuser/users/', {
+        username: 'bob',
+        email: 'bob@test.com',
+      });
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('updateSuperuserUser', () => {
+    it('updates a user as superuser', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await updateSuperuserUser('bob', {enabled: false});
+      expect(axios.put).toHaveBeenCalledWith('/api/v1/superuser/users/bob', {
+        enabled: false,
+      });
+    });
+  });
+
+  describe('deleteSuperuserUser', () => {
+    it('deletes a user as superuser', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteSuperuserUser('bob');
+      expect(axios.delete).toHaveBeenCalledWith('/api/v1/superuser/users/bob');
+    });
+  });
+
+  describe('updateUser', () => {
+    it('updates current user settings', async () => {
+      const user = {username: 'alice', email: 'new@test.com'};
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse(user));
+
+      const result = await updateUser({email: 'new@test.com'});
+      expect(axios.put).toHaveBeenCalledWith('api/v1/user/', {
+        email: 'new@test.com',
+      });
+      expect(result).toEqual(user);
+    });
+  });
+
+  describe('createClientKey', () => {
+    it('returns the generated key', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({key: 'abc123'}),
+      );
+
+      const result = await createClientKey('mypassword');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/user/clientkey', {
+        password: 'mypassword',
+      });
+      expect(result).toBe('abc123');
+    });
+  });
+
+  describe('convert', () => {
+    it('converts user account', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await convert({adminUser: 'admin', adminPassword: 'pass'});
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/user/convert', {
+        adminUser: 'admin',
+        adminPassword: 'pass',
+      });
+    });
+  });
+
+  describe('deleteUser', () => {
+    it('deletes the current user account', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await expect(deleteUser()).resolves.toBeUndefined();
+      expect(axios.delete).toHaveBeenCalledWith('/api/v1/user/');
+    });
+
+    it('throws UserDeleteError on failure', async () => {
+      const axiosErr = new AxiosError('Server Error');
+      (axiosErr as any).response = {data: {detail: 'Cannot delete'}};
+      vi.mocked(axios.delete).mockRejectedValueOnce(axiosErr);
+
+      try {
+        await deleteUser();
+        expect.unreachable('should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(UserDeleteError);
+        expect((err as UserDeleteError).message).toContain('Cannot delete');
+      }
+    });
+  });
+
+  describe('UserDeleteError', () => {
+    it('extracts detail from API response', () => {
+      const axiosErr = new AxiosError('Request failed');
+      (axiosErr as any).response = {data: {detail: 'user has repos'}};
+      const err = new UserDeleteError('Delete failed', 'alice', axiosErr);
+      expect(err.message).toContain('user has repos');
+      expect(err.username).toBe('alice');
+    });
+
+    it('falls back to error.message when no detail', () => {
+      const axiosErr = new AxiosError('Network Error');
+      const err = new UserDeleteError('Delete failed', 'alice', axiosErr);
+      expect(err.message).toContain('Network Error');
+    });
+  });
+
+  describe('ApplicationTokenError', () => {
+    it('stores tokenId and extracts API detail', () => {
+      const axiosErr = new AxiosError('fail');
+      (axiosErr as any).response = {data: {detail: 'token expired'}};
+      const err = new ApplicationTokenError('Token error', 'tok-123', axiosErr);
+      expect(err.tokenId).toBe('tok-123');
+      expect(err.message).toContain('token expired');
+    });
+  });
+
+  describe('fetchApplicationTokens', () => {
+    it('returns tokens response', async () => {
+      const response = {
+        tokens: [{uuid: '1', title: 'test'}],
+        only_expiring: false,
+      };
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(response));
+
+      const result = await fetchApplicationTokens();
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/user/apptoken');
+      expect(result).toEqual(response);
+    });
+
+    it('throws ApplicationTokenError on failure', async () => {
+      vi.mocked(axios.get).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(fetchApplicationTokens()).rejects.toThrow(
+        ApplicationTokenError,
+      );
+    });
+  });
+
+  describe('createApplicationToken', () => {
+    it('creates token with title', async () => {
+      const response = {token: {uuid: '1', title: 'My Token'}};
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(response));
+
+      const result = await createApplicationToken('My Token');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/user/apptoken', {
+        title: 'My Token',
+      });
+      expect(result).toEqual(response);
+    });
+
+    it('throws ApplicationTokenError on failure', async () => {
+      vi.mocked(axios.post).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(createApplicationToken('test')).rejects.toThrow(
+        ApplicationTokenError,
+      );
+    });
+  });
+
+  describe('fetchApplicationToken', () => {
+    it('returns a specific token', async () => {
+      const token = {uuid: 'tok-1', title: 'test', token_code: 'secret'};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse({token}));
+
+      const result = await fetchApplicationToken('tok-1');
+      expect(axios.get).toHaveBeenCalledWith('/api/v1/user/apptoken/tok-1');
+      expect(result).toEqual(token);
+    });
+
+    it('throws ApplicationTokenError on failure', async () => {
+      vi.mocked(axios.get).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(fetchApplicationToken('tok-1')).rejects.toThrow(
+        ApplicationTokenError,
+      );
+    });
+  });
+
+  describe('revokeApplicationToken', () => {
+    it('deletes a token by uuid', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await revokeApplicationToken('tok-1');
+      expect(axios.delete).toHaveBeenCalledWith('/api/v1/user/apptoken/tok-1');
+    });
+
+    it('throws ApplicationTokenError on failure', async () => {
+      vi.mocked(axios.delete).mockRejectedValueOnce(new AxiosError('fail'));
+
+      await expect(revokeApplicationToken('tok-1')).rejects.toThrow(
+        ApplicationTokenError,
+      );
+    });
+  });
+
+  describe('sendRecoveryEmail', () => {
+    it('sends recovery email for a user', async () => {
+      const response = {email: 'alice@test.com'};
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse(response));
+
+      const result = await sendRecoveryEmail('alice');
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/v1/superusers/users/alice/sendrecovery',
+      );
+      expect(result).toEqual(response);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add **291 unit tests** across **27 resource files** covering the entire API resource layer (Phase 5 of `agent_docs/web-unit-test-roadmap.md`)
- All tests use `vi.mock('src/libs/axios')` module-level mocking with per-file `mockResponse()` helpers
- Total test count: **530 tests** passing across **41 files** (up from 239/14 after Phase 4)

### Breakdown

| Priority | Files | Tests | Key coverage |
|----------|-------|-------|-------------|
| High | 4 | 120 | RepositoryResource (pagination recursion, bulk ops), TagResource (URL params, force delete), OrganizationResource (OrgDeleteError, bulk delete), UserResource (entity enumeration, app tokens) |
| Medium | 9 | 114 | QuotaResource (viewMode routing, 404/403 fallback), AuthResource, RobotsResource (federation), BuildResource (log fetching), MirroringResource, DefaultPermissionResource, MembersResource, NotificationResource, TeamResources |
| Low | 14 | 57 | BillingResource, OrgMirrorResource, ImmutabilityPolicyResource, OAuthApplicationResource, TeamSyncResource, ServiceKeysResource, AutoPrune resources, ProxyCacheResource, RegistrySizeResource, GlobalMessagesResource, CapabilitiesResource, ChangeLogResource, QuayConfig |

### Notes
- `LabelsResource.ts` and `ExternalLoginResource.ts` listed in the roadmap do not exist — skipped
- Updated `agent_docs/web-unit-test-roadmap.md` to mark Phase 5 complete with actual test counts

## Test plan
- [x] `npx vitest run` — 530 tests passing across 41 files
- [x] `pre-commit run --files <all 27 new test files>` — all hooks pass (ESLint, secrets, trailing whitespace)
- [ ] CI: web-unit-tests workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)