### PR TITLE
NO-ISSUE: chore(skills): enable model invocation for all skills

### DIFF
--- a/.claude/skills/backport/SKILL.md
+++ b/.claude/skills/backport/SKILL.md
@@ -4,7 +4,6 @@ description: >
   Trigger the openshift-cherrypick-robot to backport a merged PR to a release
   branch. Checks Target Version from JIRA if no branch is specified.
 argument-hint: PR_NUMBER [BRANCH]
-disable-model-invocation: true
 allowed-tools:
   - Bash(bash .claude/scripts/jira-ops.sh *)
   - Bash(gh pr *)

--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -4,7 +4,6 @@ description: >
   Quick CI status check for a pull request. Shows pass/fail/pending status
   for all GitHub Actions jobs, Prow, and Konflux checks.
 argument-hint: PR_NUMBER
-disable-model-invocation: true
 allowed-tools:
   - Bash(bash .claude/scripts/check-ci.sh *)
   - Bash(gh *)

--- a/.claude/skills/code/SKILL.md
+++ b/.claude/skills/code/SKILL.md
@@ -4,7 +4,6 @@ description: >
   Implement changes following Quay conventions. Reads the relevant AGENTS.md
   and agent_docs/ for the area being worked on, then guides implementation,
   quality checks (pre-commit, tests), and commit with proper message format.
-disable-model-invocation: true
 allowed-tools:
   - Bash(bash .claude/scripts/format-and-lint.sh *)
   - Bash(git *)

--- a/.claude/skills/jira/SKILL.md
+++ b/.claude/skills/jira/SKILL.md
@@ -5,7 +5,6 @@ description: >
   view, assign, transition, check-version, and set-version operations.
   Uses redhat.atlassian.net REST API.
 argument-hint: PROJQUAY-XXXX|QUAYIO-XXXX [action]
-disable-model-invocation: true
 allowed-tools:
   - Bash(bash .claude/scripts/jira-ops.sh *)
   - Read

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -4,7 +4,6 @@ description: >
   Create a pull request with the correct PROJQUAY/QUAYIO/NO-ISSUE title format,
   filled-in description template, and JIRA reference. Validates the PR title
   against the CI-enforced regex before creating.
-disable-model-invocation: true
 allowed-tools:
   - Bash(bash .claude/scripts/validate-pr-title.sh *)
   - Bash(git *)

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -5,7 +5,6 @@ description: >
   checks if backporting is needed, and loads the relevant agent_docs/ for the
   ticket's area. Use at the start of any PROJQUAY or QUAYIO ticketed work.
 argument-hint: PROJQUAY-XXXX
-disable-model-invocation: true
 allowed-tools:
   - Bash(bash .claude/scripts/session-setup.sh)
   - Bash(bash .claude/scripts/jira-ops.sh *)


### PR DESCRIPTION
## Summary

- Remove `disable-model-invocation: true` from all 7 Claude Code skill definitions (`backport`, `ci`, `code`, `jira`, `poll`, `pr`, `start`)
- Skills will now actively invoke the model to execute their step-by-step instructions rather than displaying them passively

## Test plan

- [ ] Invoke `/start`, `/code`, `/pr`, `/poll`, `/ci`, `/jira`, `/backport` in a Claude Code session — each should now execute its workflow rather than just printing instructions