### PR TITLE
NO-ISSUE: feat(playwright): add remote-playwright skill for cluster browser automation

### DIFF
--- a/.claude/scripts/remote-playwright.sh
+++ b/.claude/scripts/remote-playwright.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy a Playwright browser server pod to an OpenShift/K8s cluster.
+# Resolves @playwright/cli's dependency version automatically so the
+# server always matches the client.
+#
+# Usage: remote-playwright.sh [up|down|status] [KUBECONFIG_PATH] [NAMESPACE]
+
+ACTION="${1:-up}"
+KUBECONFIG_PATH="${2:-/tmp/k}"
+NAMESPACE="${3:-playwright}"
+
+export KUBECONFIG="$KUBECONFIG_PATH"
+
+PF_DIR=/tmp/pw-remote
+PF_PID_FILE="$PF_DIR/port-forward.pid"
+MANAGED_BY_LABEL="app.kubernetes.io/managed-by=remote-playwright"
+
+stop_port_forward() {
+  if [[ -f "$PF_PID_FILE" ]]; then
+    local pid
+    pid="$(cat "$PF_PID_FILE" 2>/dev/null || true)"
+    if [[ -n "${pid:-}" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+    fi
+    rm -f "$PF_PID_FILE"
+  fi
+}
+
+pf_is_active() {
+  [[ -f "$PF_PID_FILE" ]] && kill -0 "$(cat "$PF_PID_FILE" 2>/dev/null)" 2>/dev/null
+}
+
+status() {
+  echo "=== Remote Playwright Status ==="
+  echo "Kubeconfig: $KUBECONFIG_PATH"
+  echo "Namespace:  $NAMESPACE"
+  oc get pods -n "$NAMESPACE" -l app=playwright-server 2>/dev/null || echo "No pods found"
+  echo ""
+  if pf_is_active; then
+    echo "Port-forward: active (pid $(cat "$PF_PID_FILE"))"
+  else
+    echo "Port-forward: inactive"
+  fi
+}
+
+down() {
+  echo "Tearing down remote playwright..."
+  stop_port_forward
+  oc delete deployment/playwright-server service/playwright-server \
+    -n "$NAMESPACE" --ignore-not-found 2>/dev/null || true
+  if oc get namespace "$NAMESPACE" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}' 2>/dev/null \
+      | grep -qx 'remote-playwright'; then
+    oc delete namespace "$NAMESPACE" --ignore-not-found 2>/dev/null || true
+  fi
+  echo "Done."
+}
+
+connect() {
+  mkdir -p "$PF_DIR"
+
+  if ! pf_is_active; then
+    echo "Setting up port-forward..."
+    stop_port_forward
+    oc port-forward -n "$NAMESPACE" svc/playwright-server 3000:3000 > /tmp/pf-playwright.log 2>&1 &
+    echo $! > "$PF_PID_FILE"
+    sleep 3
+    if ! pf_is_active; then
+      echo "ERROR: Port-forward failed" >&2
+      cat /tmp/pf-playwright.log
+      rm -f "$PF_PID_FILE"
+      exit 1
+    fi
+  fi
+  echo "Port-forward active (pid $(cat "$PF_PID_FILE"))"
+
+  cat > "$PF_DIR/cli.config.json" << 'CLIEOF'
+{
+  "browser": {
+    "remoteEndpoint": "ws://localhost:3000/",
+    "isolated": true
+  }
+}
+CLIEOF
+
+  echo "Connecting @playwright/cli..."
+  npx @playwright/cli attach --config "$PF_DIR/cli.config.json" 2>&1
+
+  echo ""
+  echo "=== Ready ==="
+  echo "Commands:"
+  echo "  npx @playwright/cli goto <url>"
+  echo "  npx @playwright/cli snapshot"
+  echo "  npx @playwright/cli screenshot"
+  echo "  npx @playwright/cli click <ref>"
+  echo "  npx @playwright/cli fill <ref> <text>"
+  echo "  npx @playwright/cli video-start / video-stop"
+}
+
+pick_docker_tag() {
+  local prefix="$1"
+  curl -sL "https://mcr.microsoft.com/v2/playwright/tags/list" 2>/dev/null \
+    | python3 -c "
+import sys, json
+tags = json.load(sys.stdin).get('tags', [])
+candidates = [t for t in tags if t.startswith('${prefix}') and t.endswith('-noble') and 'alpha' not in t and 'beta' not in t]
+def version_key(tag):
+    base = tag.split('-', 1)[0].lstrip('v')
+    return tuple(int(part) for part in base.split('.'))
+if candidates:
+    print(max(candidates, key=version_key))
+" 2>/dev/null || true
+}
+
+up() {
+  echo "Resolving @playwright/cli dependency version..."
+  PW_VERSION=$(npm info @playwright/cli@latest dependencies.playwright 2>/dev/null)
+  if [[ -z "$PW_VERSION" ]]; then
+    echo "ERROR: Could not resolve playwright version from @playwright/cli" >&2
+    exit 1
+  fi
+  echo "Playwright version: $PW_VERSION"
+
+  PW_MAJOR_MINOR=$(echo "$PW_VERSION" | grep -oP '^\d+\.\d+')
+  DOCKER_TAG=$(pick_docker_tag "v${PW_MAJOR_MINOR}.")
+
+  # Fallback: try prior minor version if no stable image for this series
+  if [[ -z "$DOCKER_TAG" ]]; then
+    PREV_MINOR=$((${PW_MAJOR_MINOR##*.} - 1))
+    PW_MAJOR="${PW_MAJOR_MINOR%%.*}"
+    DOCKER_TAG=$(pick_docker_tag "v${PW_MAJOR}.${PREV_MINOR}.")
+  fi
+
+  if [[ -z "$DOCKER_TAG" ]]; then
+    echo "ERROR: Could not find a suitable Playwright Docker image" >&2
+    exit 1
+  fi
+  echo "Docker image:  mcr.microsoft.com/playwright:$DOCKER_TAG"
+
+  echo "Checking cluster..."
+  oc whoami --show-server
+
+  # Check if already running with matching image
+  if oc get pods -n "$NAMESPACE" -l app=playwright-server --field-selector=status.phase=Running 2>/dev/null | grep -q Running; then
+    RUNNING_IMAGE=$(oc get deployment/playwright-server -n "$NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+    if [[ "$RUNNING_IMAGE" == "mcr.microsoft.com/playwright:$DOCKER_TAG" ]]; then
+      echo "Playwright server already running in $NAMESPACE (image matches)"
+      stop_port_forward
+      sleep 1
+      connect
+      return 0
+    fi
+    echo "Running server image ($RUNNING_IMAGE) differs from resolved (mcr.microsoft.com/playwright:$DOCKER_TAG) — redeploying..."
+  fi
+
+  echo "Deploying playwright server..."
+  oc apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $NAMESPACE
+  labels:
+    app.kubernetes.io/managed-by: remote-playwright
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: playwright-server
+  namespace: $NAMESPACE
+  labels:
+    app: playwright-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: playwright-server
+  template:
+    metadata:
+      labels:
+        app: playwright-server
+    spec:
+      containers:
+        - name: playwright
+          image: mcr.microsoft.com/playwright:$DOCKER_TAG
+          command:
+            - /bin/sh
+            - -c
+            - |
+              npx playwright@$PW_VERSION install chromium &&
+              xvfb-run npx playwright@$PW_VERSION run-server --host 0.0.0.0 --port 3000 --mode extension
+          env:
+            - name: HOME
+              value: /tmp
+            - name: npm_config_cache
+              value: /tmp/.npm
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+            limits:
+              cpu: "2"
+              memory: 4Gi
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: playwright-server
+  namespace: $NAMESPACE
+spec:
+  selector:
+    app: playwright-server
+  ports:
+    - port: 3000
+      targetPort: 3000
+      protocol: TCP
+EOF
+
+  echo "Waiting for rollout..."
+  oc rollout status deployment/playwright-server -n "$NAMESPACE" --timeout=300s
+
+  local ready=false
+  for _i in $(seq 1 30); do
+    if oc logs -n "$NAMESPACE" deployment/playwright-server --tail=5 2>/dev/null | grep -q "Listening on"; then
+      echo "Server is listening."
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+
+  if [[ "$ready" != "true" ]]; then
+    echo "ERROR: Server failed to start within 60s" >&2
+    oc logs -n "$NAMESPACE" deployment/playwright-server --tail=30 2>/dev/null || true
+    exit 1
+  fi
+
+  connect
+}
+
+case "$ACTION" in
+  up)     up ;;
+  down)   down ;;
+  status) status ;;
+  *)      echo "Usage: $0 [up|down|status] [KUBECONFIG] [NAMESPACE]"; exit 1 ;;
+esac

--- a/.claude/skills/remote-playwright/SKILL.md
+++ b/.claude/skills/remote-playwright/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: remote-playwright
+description: >
+  Deploy and connect to a remote Playwright browser on an OpenShift cluster.
+  Sets up a Playwright run-server pod, port-forwarding, and @playwright/cli
+  for interactive browser automation (goto, click, snapshot, screenshot,
+  video recording). Use when you need a remote browser for E2E interaction
+  or visual verification on a cluster.
+argument-hint: "[KUBECONFIG_PATH] [NAMESPACE]"
+allowed-tools:
+  - Bash(bash .claude/scripts/remote-playwright.sh *)
+  - Bash(npx @playwright/cli*)
+  - Read
+---
+
+# Remote Playwright Browser
+
+Deploy and connect to a Playwright browser running on an OpenShift cluster.
+
+## Arguments
+
+Parse `$ARGUMENTS` into at most two values before invoking Bash:
+- **Arg 1**: KUBECONFIG path (default: `/tmp/k`)
+- **Arg 2**: Namespace (default: `playwright`)
+
+Set variables from `$ARGUMENTS`:
+```
+KUBECONFIG_PATH = first arg or /tmp/k
+NAMESPACE = second arg or playwright
+```
+
+## Step 1: Deploy and Connect
+
+```bash
+bash .claude/scripts/remote-playwright.sh up "$KUBECONFIG_PATH" "$NAMESPACE"
+```
+
+The script handles everything: version resolution, deployment, port-forwarding, and CLI connection. Wait for the `=== Ready ===` output.
+
+## Step 2: Verify
+
+```bash
+npx @playwright/cli goto https://example.com
+npx @playwright/cli snapshot
+npx @playwright/cli screenshot
+```
+
+## Step 3: Report
+
+Summarize connection status and remind user of available commands:
+- `npx @playwright/cli goto <url>` -- navigate
+- `npx @playwright/cli snapshot` -- accessibility tree
+- `npx @playwright/cli screenshot` -- save PNG
+- `npx @playwright/cli click <ref>` -- click element by ref from snapshot
+- `npx @playwright/cli fill <ref> <text>` -- fill input
+- `npx @playwright/cli video-start` / `video-stop` -- record session
+- `npx @playwright/cli tab-list` / `tab-new` / `tab-select` -- manage tabs
+- `npx @playwright/cli cookie-list` / `state-save` / `state-load` -- session state
+
+## Teardown
+
+```bash
+bash .claude/scripts/remote-playwright.sh down "$KUBECONFIG_PATH" "$NAMESPACE"
+```
+
+## Troubleshooting
+
+| Error | Fix |
+|-------|-----|
+| `428 Precondition Required` | Version mismatch -- re-run `up` to auto-resolve |
+| `unable to connect to a browser that does not have any contexts` | Config missing `isolated: true` -- re-run `up` |
+| Port 3000 in use | Re-run `up` -- it kills stale forwards automatically |


### PR DESCRIPTION
## Summary

- Adds a `/remote-playwright` Claude skill and backing script (`.claude/scripts/remote-playwright.sh`) that deploys a Playwright browser server pod on an OpenShift cluster and connects `@playwright/cli` locally for interactive browser automation
- The script dynamically resolves `@playwright/cli`'s Playwright dependency version at runtime — no hardcoded versions to maintain
- Supports `up` (deploy + connect), `down` (teardown), and `status` commands

## How it works

1. **Version resolution**: Queries `npm info @playwright/cli@latest` to get the Playwright version the CLI expects, then finds a matching Docker base image from `mcr.microsoft.com/playwright`
2. **Deployment**: Generates and applies K8s manifests inline — Namespace, Deployment (with `xvfb-run` + `run-server --mode extension`), and Service
3. **Connection**: Sets up `oc port-forward` (K8s >= 1.31 supports WebSocket natively), writes a CLI config with `isolated: true`, and runs `@playwright/cli attach`
4. **Usage**: Once connected, all `@playwright/cli` commands work against the remote browser — `goto`, `snapshot`, `screenshot`, `click`, `fill`, `video-start/stop`, tab management, cookie/storage management

### Key discoveries from this session

- Standard Playwright CLI commands (`open`, `codegen`, `screenshot`) have **no remote browser support** — they always launch locally
- `@playwright/cli` (separate package, v0.1.x) has `attach --endpoint` for remote connections, but it's designed for `run-server --mode extension`, not default mode
- Extension mode launches a browser with no contexts — `isolated: true` in the CLI config is required so the CLI creates its own context instead of failing on `browser.contexts()[0]`
- The base Docker image provides system dependencies but not matching browser binaries when using a different Playwright version — the deployment installs the correct Chromium at startup via `npx playwright@VERSION install chromium`
- OpenShift's restricted SCC assigns a random UID — `HOME=/tmp` and `npm_config_cache=/tmp/.npm` env vars work around the `EACCES /.npm` error

## Files

| File | Description |
|------|-------------|
| `.claude/scripts/remote-playwright.sh` | Setup script — version resolution, deployment, port-forward, CLI connect |
| `.claude/skills/remote-playwright/SKILL.md` | Skill definition — calls the script, documents available commands |

## Test plan

- [x] Tested full `up` flow from clean state on OCP 4.21 (K8s v1.34.6) cluster
- [x] Verified `goto https://example.com` navigates successfully
- [x] Verified `snapshot` returns accessibility tree
- [x] Verified `screenshot` saves PNG locally (viewable)
- [x] Verified `click` interacts with page elements by ref
- [x] Verified `video-start` / `video-stop` records a 1.9MB webm across multiple sites
- [x] Verified `down` cleanly tears down namespace and port-forward
- [x] Verified idempotent `up` reconnects when pod already running

🤖 Generated with [Claude Code](https://claude.com/claude-code)