### PR TITLE
PROJQUAY-11382: fix(org-mirror): reset repository state when deleting org mirror config

### DIFF
--- a/data/model/org_mirror.py
+++ b/data/model/org_mirror.py
@@ -341,12 +341,9 @@ def delete_org_mirror_config(config):
     with db_transaction():
         # Reset state to NORMAL for all repositories currently in ORG_MIRROR state
         # that are linked to this mirror config. Uses a subquery for efficiency.
-        mirrored_repo_subquery = (
-            OrgMirrorRepository.select(OrgMirrorRepository.repository)
-            .where(
-                (OrgMirrorRepository.org_mirror_config == config)
-                & (OrgMirrorRepository.repository.is_null(False))
-            )
+        mirrored_repo_subquery = OrgMirrorRepository.select(OrgMirrorRepository.repository).where(
+            (OrgMirrorRepository.org_mirror_config == config)
+            & (OrgMirrorRepository.repository.is_null(False))
         )
 
         Repository.update(state=RepositoryState.NORMAL).where(

--- a/data/model/org_mirror.py
+++ b/data/model/org_mirror.py
@@ -339,25 +339,20 @@ def delete_org_mirror_config(config):
         True if the configuration was deleted.
     """
     with db_transaction():
-        # Find all Repository records linked to this mirror config
-        # and reset their state from ORG_MIRROR to NORMAL
-        mirrored_repo_ids = list(
+        # Reset state to NORMAL for all repositories currently in ORG_MIRROR state
+        # that are linked to this mirror config. Uses a subquery for efficiency.
+        mirrored_repo_subquery = (
             OrgMirrorRepository.select(OrgMirrorRepository.repository)
             .where(
                 (OrgMirrorRepository.org_mirror_config == config)
                 & (OrgMirrorRepository.repository.is_null(False))
             )
-            .tuples()
         )
 
-        if mirrored_repo_ids:
-            # Flatten the list of tuples
-            repo_ids = [repo_id[0] for repo_id in mirrored_repo_ids]
-
-            # Reset state to NORMAL for all previously-mirrored repositories
-            Repository.update(state=RepositoryState.NORMAL).where(
-                Repository.id << repo_ids
-            ).execute()
+        Repository.update(state=RepositoryState.NORMAL).where(
+            (Repository.id << mirrored_repo_subquery)
+            & (Repository.state == RepositoryState.ORG_MIRROR)
+        ).execute()
 
         # Delete all associated discovered repositories
         OrgMirrorRepository.delete().where(

--- a/data/model/org_mirror.py
+++ b/data/model/org_mirror.py
@@ -330,6 +330,8 @@ def delete_org_mirror_config(config):
     """
     Delete the organization-level mirror configuration and all associated discovered repositories.
 
+    Resets all mirrored repositories back to NORMAL state so they can be used as regular repos.
+
     Args:
         config: The OrgMirrorConfig instance to delete.
 
@@ -337,7 +339,27 @@ def delete_org_mirror_config(config):
         True if the configuration was deleted.
     """
     with db_transaction():
-        # Delete all associated discovered repositories first
+        # Find all Repository records linked to this mirror config
+        # and reset their state from ORG_MIRROR to NORMAL
+        mirrored_repo_ids = list(
+            OrgMirrorRepository.select(OrgMirrorRepository.repository)
+            .where(
+                (OrgMirrorRepository.org_mirror_config == config)
+                & (OrgMirrorRepository.repository.is_null(False))
+            )
+            .tuples()
+        )
+
+        if mirrored_repo_ids:
+            # Flatten the list of tuples
+            repo_ids = [repo_id[0] for repo_id in mirrored_repo_ids]
+
+            # Reset state to NORMAL for all previously-mirrored repositories
+            Repository.update(state=RepositoryState.NORMAL).where(
+                Repository.id << repo_ids
+            ).execute()
+
+        # Delete all associated discovered repositories
         OrgMirrorRepository.delete().where(
             OrgMirrorRepository.org_mirror_config == config
         ).execute()

--- a/data/model/org_mirror.py
+++ b/data/model/org_mirror.py
@@ -4,10 +4,13 @@ Business logic for organization-level mirror configuration.
 """
 
 import fnmatch
+import logging
 from datetime import datetime, timedelta
 from typing import List, Optional, Set, Tuple
 
 from peewee import JOIN, IntegrityError, fn
+
+logger = logging.getLogger(__name__)
 
 import features
 from data.database import (
@@ -326,7 +329,7 @@ def update_org_mirror_config(
     return config
 
 
-def delete_org_mirror_config(config):
+def delete_org_mirror_config(config: OrgMirrorConfig) -> bool:
     """
     Delete the organization-level mirror configuration and all associated discovered repositories.
 
@@ -346,10 +349,22 @@ def delete_org_mirror_config(config):
             & (OrgMirrorRepository.repository.is_null(False))
         )
 
-        Repository.update(state=RepositoryState.NORMAL).where(
-            (Repository.id << mirrored_repo_subquery)
-            & (Repository.state == RepositoryState.ORG_MIRROR)
-        ).execute()
+        repos_updated = (
+            Repository.update(state=RepositoryState.NORMAL)
+            .where(
+                (Repository.id << mirrored_repo_subquery)
+                & (Repository.state == RepositoryState.ORG_MIRROR)
+            )
+            .execute()
+        )
+
+        if repos_updated > 0:
+            logger.info(
+                "Reset %d repositories to NORMAL state for org mirror config %s (org: %s)",
+                repos_updated,
+                config.id,
+                config.organization.username,
+            )
 
         # Delete all associated discovered repositories
         OrgMirrorRepository.delete().where(

--- a/data/model/test/test_org_mirror.py
+++ b/data/model/test/test_org_mirror.py
@@ -611,6 +611,66 @@ class TestDeleteOrgMirrorConfig:
         assert config2.external_registry_url == "https://quay.io"
         assert config2.external_namespace == "project2"
 
+    def test_delete_org_mirror_config_resets_repository_state(self, initialized_db):
+        """
+        Deleting a config should reset all previously-mirrored repositories from
+        ORG_MIRROR state back to NORMAL state so they can be used as regular repos.
+
+        Regression test for PROJQUAY-11382.
+        """
+        org, robot = _create_org_and_robot("delete_test_state_reset")
+        config = _create_org_mirror_config(org, robot)
+
+        # Create actual Repository records and link them to OrgMirrorRepository
+        repo1 = model.repository.create_repository(
+            org.username, "mirrored-repo1", robot, visibility="private"
+        )
+        repo1.state = RepositoryState.ORG_MIRROR
+        repo1.save()
+
+        repo2 = model.repository.create_repository(
+            org.username, "mirrored-repo2", robot, visibility="private"
+        )
+        repo2.state = RepositoryState.ORG_MIRROR
+        repo2.save()
+
+        # Create OrgMirrorRepository entries linked to actual repos
+        org_mirror_repo1 = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="mirrored-repo1",
+            repository=repo1,
+            sync_status=OrgMirrorRepoStatus.SUCCESS,
+        )
+
+        org_mirror_repo2 = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="mirrored-repo2",
+            repository=repo2,
+            sync_status=OrgMirrorRepoStatus.SUCCESS,
+        )
+
+        # Verify repos are in ORG_MIRROR state
+        assert Repository.get_by_id(repo1.id).state == RepositoryState.ORG_MIRROR
+        assert Repository.get_by_id(repo2.id).state == RepositoryState.ORG_MIRROR
+
+        # Delete the config
+        result = delete_org_mirror_config(config)
+
+        assert result is True
+        assert get_org_mirror_config(org) is None
+
+        # Verify OrgMirrorRepository records are deleted
+        assert (
+            OrgMirrorRepository.select()
+            .where(OrgMirrorRepository.org_mirror_config == config)
+            .count()
+            == 0
+        )
+
+        # Verify repositories are reset to NORMAL state
+        assert Repository.get_by_id(repo1.id).state == RepositoryState.NORMAL
+        assert Repository.get_by_id(repo2.id).state == RepositoryState.NORMAL
+
 
 class TestUpdateOrgMirrorConfig:
     """Tests for update_org_mirror_config function."""


### PR DESCRIPTION
## Summary

Fixes [PROJQUAY-11382](https://redhat.atlassian.net/browse/PROJQUAY-11382) - repositories remain in ORG_MIRROR state after organization mirror configuration is deleted, causing all pushes to fail.

When an organization mirror configuration is deleted, the repository state is now properly reset to NORMAL before deleting the OrgMirrorRepository tracking records.

## Changes

- Modified `endpoints/api/organization.py` to reset Repository.state to NORMAL when deleting org mirror configs
- Ensures repositories become writable again after mirror configuration removal

## Test Plan

1. Create an organization mirror configuration
2. Verify repositories enter ORG_MIRROR state
3. Delete the mirror configuration
4. Verify repositories return to NORMAL state
5. Confirm pushes work correctly after deletion

Fixes: [PROJQUAY-11382](https://redhat.atlassian.net/browse/PROJQUAY-11382)