### PR TITLE
QUAYIO-798: config: Change default repository visibility on quay.io to public

### DIFF
--- a/config.py
+++ b/config.py
@@ -852,8 +852,8 @@ class DefaultConfig(ImmutableConfig):
     FEATURE_MANIFEST_SIZE_BACKFILL = True
     FEATURE_MANIFEST_SUBJECT_BACKFILL = True
 
-    # Repos created by push default to private visibility
-    CREATE_PRIVATE_REPO_ON_PUSH = True
+    # Repos created by push default to public visibility
+    CREATE_PRIVATE_REPO_ON_PUSH = False
 
     # Create organization on push if it does not exist
     CREATE_NAMESPACE_ON_PUSH = False

--- a/endpoints/v2/test/test_v2auth.py
+++ b/endpoints/v2/test/test_v2auth.py
@@ -412,3 +412,29 @@ def test_generate_registry_jwt(
         assert (
             model.repository.get_repository("devtable", "visibility").visibility.name == visibility
         )
+
+
+def test_push_creates_public_repo_by_default(app, client):
+    """When CREATE_PRIVATE_REPO_ON_PUSH is not set, repos default to public."""
+    original_app.config.pop("CREATE_PRIVATE_REPO_ON_PUSH", None)
+
+    params = {
+        "service": original_app.config["SERVER_HOSTNAME"],
+        "scope": "repository:devtable/defaultvisibility:pull,push,*",
+    }
+    headers = {"Authorization": gen_basic_auth("devtable", "password")}
+
+    resp = conduct_call(
+        client,
+        "v2.generate_registry_jwt",
+        url_for,
+        "GET",
+        params,
+        {},
+        200,
+        headers=headers,
+    )
+
+    repo = model.repository.get_repository("devtable", "defaultvisibility")
+    assert repo is not None
+    assert repo.visibility.name == "public"

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -379,7 +379,7 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
                         logger.debug("Creating repository: %s/%s", namespace, reponame)
                         visibility = (
                             "private"
-                            if app.config.get("CREATE_PRIVATE_REPO_ON_PUSH", True)
+                            if app.config.get("CREATE_PRIVATE_REPO_ON_PUSH", False)
                             else "public"
                         )
                         found = model.repository.get_or_create_repository(

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1477,8 +1477,8 @@ CONFIG_SCHEMA = {
         },
         "CREATE_PRIVATE_REPO_ON_PUSH": {
             "type": "boolean",
-            "description": "Whether new repositories created by push are set to private visibility. Defaults to True.",
-            "x-example": True,
+            "description": "Whether new repositories created by push are set to private visibility. Defaults to False.",
+            "x-example": False,
         },
         "CREATE_NAMESPACE_ON_PUSH": {
             "type": "boolean",


### PR DESCRIPTION
Problem: Free-tier quay.io users can bypass the 2 private repo limit by pushing images via CLI to non-existent repo paths. Quay auto-creates these as private repos, effectively giving unlimited private repos with no incentive to upgrade.

Fix: Changed the default value of CREATE_PRIVATE_REPO_ON_PUSH from True to False so auto-created repos are public by default.