### PR TITLE
PROJQUAY-11027: fix(mirror): preserve future syncs when canceling org mirror

### DIFF
--- a/data/model/org_mirror.py
+++ b/data/model/org_mirror.py
@@ -1139,10 +1139,8 @@ def release_org_mirror_config(
     Release an org mirror config after discovery and update its status.
 
     Calculates next sync_start_date based on sync_interval.
-    Decrements retries on failure, resets on success.
-
-    If discovery is cancelled, the job will not be attempted until manual
-    sync-now is triggered by the user.
+    Decrements retries on failure, resets on success or cancel.
+    Cancel is transitioned to SUCCESS after scheduling the next sync.
 
     Args:
         org_mirror_config: The OrgMirrorConfig to release
@@ -1159,9 +1157,11 @@ def release_org_mirror_config(
     if sync_status == OrgMirrorStatus.FAIL:
         retries = max(0, retries - 1)
 
-    # On success or exhausted retries, schedule next sync
-    if sync_status == OrgMirrorStatus.SUCCESS or (
-        sync_status == OrgMirrorStatus.FAIL and retries < 1
+    # On success, cancel, or exhausted retries, schedule next sync
+    if (
+        sync_status == OrgMirrorStatus.SUCCESS
+        or sync_status == OrgMirrorStatus.CANCEL
+        or (sync_status == OrgMirrorStatus.FAIL and retries < 1)
     ):
         now = datetime.utcnow()
         if org_mirror_config.sync_start_date:
@@ -1177,10 +1177,10 @@ def release_org_mirror_config(
     else:
         next_start_date = org_mirror_config.sync_start_date
 
-    # If cancelled, stop syncing until user triggers sync-now again
+    # After cancel is processed, transition to SUCCESS so the next scheduled
+    # sync proceeds with normal discovery instead of re-entering cancel (PROJQUAY-11027).
     if sync_status == OrgMirrorStatus.CANCEL:
-        next_start_date = None
-        retries = 0
+        sync_status = OrgMirrorStatus.SUCCESS
 
     query = OrgMirrorConfig.update(
         sync_transaction_id=uuid_generator(),
@@ -1363,6 +1363,9 @@ def update_sync_status_to_cancel(org_mirror_config: OrgMirrorConfig) -> Optional
     (ignores transaction ID) since we need to interrupt an active worker.
     This allows cancellation from any status except when already CANCEL.
 
+    Only the current sync is cancelled; sync_start_date is preserved so
+    future scheduled syncs continue normally.
+
     Note: This only updates the config status. The worker will propagate
     CANCEL to associated OrgMirrorRepository entries when it picks up
     the config.
@@ -1380,11 +1383,11 @@ def update_sync_status_to_cancel(org_mirror_config: OrgMirrorConfig) -> Optional
     # Force cancel the config (ignore transaction_id for interrupt).
     # sync_expiration_date is set to now to signal "needs processing" — the worker
     # clears it after propagating CANCEL to repos, preventing re-pickup.
+    # sync_start_date is preserved so that future syncs remain scheduled (PROJQUAY-11027).
     now = datetime.utcnow()
     config_query = OrgMirrorConfig.update(
         sync_transaction_id=uuid_generator(),
         sync_status=OrgMirrorStatus.CANCEL,
-        sync_start_date=None,
         sync_expiration_date=now,
         sync_retries_remaining=0,
     ).where(OrgMirrorConfig.id == org_mirror_config.id)

--- a/data/model/test/test_org_mirror.py
+++ b/data/model/test/test_org_mirror.py
@@ -1736,12 +1736,14 @@ class TestUpdateSyncStatusToCancel:
 
     def test_cancel_when_syncing(self, initialized_db):
         """
-        Should cancel when status is SYNCING.
+        Should cancel when status is SYNCING and preserve sync_start_date.
         """
         from data.model.org_mirror import update_sync_status_to_cancel
 
         org, robot = _create_org_and_robot("cancel_test1")
         config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        original_sync_start_date = config.sync_start_date
 
         # Set to SYNCING
         config.sync_status = OrgMirrorStatus.SYNCING
@@ -1753,7 +1755,7 @@ class TestUpdateSyncStatusToCancel:
         assert result is not None
         assert result.sync_status == OrgMirrorStatus.CANCEL
         assert result.sync_expiration_date is not None
-        assert result.sync_start_date is None
+        assert result.sync_start_date == original_sync_start_date
         assert result.sync_retries_remaining == 0
 
     def test_cancel_when_sync_now(self, initialized_db):
@@ -1906,12 +1908,154 @@ class TestUpdateSyncStatusToCancel:
         assert claimed is not None
         release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
 
-        # After release, config must NOT be eligible again
+        # After release, config must NOT be eligible again immediately
         config = OrgMirrorConfig.get_by_id(config.id)
         eligible_ids = [c.id for c in get_eligible_org_mirror_configs()]
         assert config.id not in eligible_ids
-        assert config.sync_status == OrgMirrorStatus.CANCEL
+        # Cancel transitions to SUCCESS after processing (PROJQUAY-11027)
+        assert config.sync_status == OrgMirrorStatus.SUCCESS
         assert config.sync_expiration_date is None
+
+    def test_cancel_preserves_sync_start_date(self, initialized_db):
+        """
+        Regression test for PROJQUAY-11027: cancelling a sync must preserve
+        sync_start_date so that future scheduled syncs continue.
+        """
+        from data.model.org_mirror import update_sync_status_to_cancel
+
+        org, robot = _create_org_and_robot("cancel_preserve_date")
+        future_date = datetime.utcnow() + timedelta(hours=2)
+        config = _create_org_mirror_config(org, robot, is_enabled=True, sync_start_date=future_date)
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        result = update_sync_status_to_cancel(config)
+
+        assert result is not None
+        assert result.sync_status == OrgMirrorStatus.CANCEL
+        assert result.sync_start_date is not None
+        assert result.sync_start_date == future_date
+
+    def test_cancel_release_schedules_next_sync(self, initialized_db):
+        """
+        Regression test for PROJQUAY-11027: after cancel is processed by the
+        worker, release_org_mirror_config must schedule the next sync instead
+        of clearing sync_start_date.
+        """
+        from data.model.org_mirror import (
+            MAX_SYNC_RETRIES,
+            claim_org_mirror_config,
+            release_org_mirror_config,
+            update_sync_status_to_cancel,
+        )
+
+        org, robot = _create_org_and_robot("cancel_release_schedule")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        update_sync_status_to_cancel(config)
+
+        config = OrgMirrorConfig.get_by_id(config.id)
+        claimed = claim_org_mirror_config(config)
+        assert claimed is not None
+
+        released = release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
+
+        assert released is not None
+        assert released.sync_status == OrgMirrorStatus.SUCCESS
+        assert released.sync_start_date is not None
+        assert released.sync_start_date > datetime.utcnow()
+        assert released.sync_retries_remaining == MAX_SYNC_RETRIES
+        assert released.sync_expiration_date is None
+
+    def test_cancel_full_flow_preserves_future_syncs(self, initialized_db):
+        """
+        Regression test for PROJQUAY-11027: end-to-end cancel flow.
+        After cancel → release, config must have a future sync_start_date
+        and must become eligible again once that date arrives.
+        """
+        from data.model.org_mirror import (
+            claim_org_mirror_config,
+            get_eligible_org_mirror_configs,
+            release_org_mirror_config,
+            update_sync_status_to_cancel,
+        )
+
+        org, robot = _create_org_and_robot("cancel_full_flow")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        # User cancels
+        update_sync_status_to_cancel(config)
+
+        # Worker processes cancel
+        config = OrgMirrorConfig.get_by_id(config.id)
+        claimed = claim_org_mirror_config(config)
+        released = release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
+
+        # Status transitions to SUCCESS so next pickup runs normal discovery
+        assert released.sync_status == OrgMirrorStatus.SUCCESS
+
+        # Not eligible immediately (sync_start_date is in the future)
+        eligible_ids = [c.id for c in get_eligible_org_mirror_configs()]
+        assert released.id not in eligible_ids
+
+        # Simulate time passing: set sync_start_date to the past
+        OrgMirrorConfig.update(sync_start_date=datetime.utcnow() - timedelta(seconds=1)).where(
+            OrgMirrorConfig.id == released.id
+        ).execute()
+
+        # Now the config should be eligible for syncing again
+        eligible_ids = [c.id for c in get_eligible_org_mirror_configs()]
+        assert released.id in eligible_ids
+
+    def test_cancel_does_not_create_recancel_loop(self, initialized_db):
+        """
+        Regression test for PROJQUAY-11027: after cancel is processed, the
+        config must NOT re-enter the cancel path on the next worker pickup.
+        The status must be SUCCESS so the worker runs normal discovery.
+        """
+        from data.model.org_mirror import (
+            claim_org_mirror_config,
+            get_eligible_org_mirror_configs,
+            release_org_mirror_config,
+            update_sync_status_to_cancel,
+        )
+
+        org, robot = _create_org_and_robot("cancel_no_loop")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        # Cancel and process
+        update_sync_status_to_cancel(config)
+        config = OrgMirrorConfig.get_by_id(config.id)
+        claimed = claim_org_mirror_config(config)
+        release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
+
+        # Simulate time passing so config becomes eligible
+        OrgMirrorConfig.update(sync_start_date=datetime.utcnow() - timedelta(seconds=1)).where(
+            OrgMirrorConfig.id == config.id
+        ).execute()
+
+        # Config is eligible
+        eligible = list(get_eligible_org_mirror_configs())
+        matched = [c for c in eligible if c.id == config.id]
+        assert len(matched) == 1
+
+        # Worker picks it up — status must be SUCCESS, NOT CANCEL
+        picked_up = matched[0]
+        assert picked_up.sync_status == OrgMirrorStatus.SUCCESS
 
 
 class TestPropagateStatusToRepos:

--- a/endpoints/api/test/test_org_mirror.py
+++ b/endpoints/api/test/test_org_mirror.py
@@ -4,7 +4,7 @@ Unit tests for organization-level mirror API endpoints.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -1354,6 +1354,43 @@ class TestSyncCancel:
             conduct_api_call(cl, org_mirror.OrgMirrorSyncCancel, "POST", params, None, 400)
 
         # Clean up
+        _cleanup_org_mirror_config("buynlarge")
+
+    def test_sync_cancel_preserves_sync_start_date(self, app):
+        """
+        Regression test for PROJQUAY-11027: calling the sync-cancel endpoint
+        must NOT clear sync_start_date. Future scheduled syncs must be preserved.
+        """
+        from data.database import OrgMirrorStatus
+
+        _cleanup_org_mirror_config("buynlarge")
+
+        future_date = datetime.utcnow() + timedelta(hours=2)
+        org = model.organization.get_organization("buynlarge")
+        robot = model.user.lookup_robot("buynlarge+coolrobot")
+        config = OrgMirrorConfig.create(
+            organization=org,
+            internal_robot=robot,
+            external_registry_type=SourceRegistryType.HARBOR,
+            external_registry_url="https://harbor.example.com",
+            external_namespace="project",
+            visibility=Visibility.get(name="private"),
+            sync_interval=3600,
+            sync_start_date=future_date,
+            is_enabled=True,
+            sync_status=OrgMirrorStatus.SYNCING,
+            skopeo_timeout=300,
+        )
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"orgname": "buynlarge"}
+            conduct_api_call(cl, org_mirror.OrgMirrorSyncCancel, "POST", params, None, 204)
+
+        config = model.org_mirror.get_org_mirror_config(org)
+        assert config.sync_status == OrgMirrorStatus.CANCEL
+        assert config.sync_start_date is not None
+        assert abs((config.sync_start_date - future_date).total_seconds()) < 2
+
         _cleanup_org_mirror_config("buynlarge")
 
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.tsx
@@ -48,8 +48,8 @@ export const OrgMirroringStatus: React.FC<OrgMirroringStatusProps> = ({
       >
         <ModalHeader title="Cancel sync" />
         <ModalBody>
-          Are you sure you want to cancel the current sync operation? All
-          in-progress and scheduled syncs will be stopped.
+          Are you sure you want to cancel the current sync operation? Future
+          scheduled syncs will continue as normal.
         </ModalBody>
         <ModalFooter>
           <Button

--- a/workers/repomirrorworker/test/test_org_mirror_worker.py
+++ b/workers/repomirrorworker/test/test_org_mirror_worker.py
@@ -1233,9 +1233,9 @@ class TestPerformOrgMirrorDiscoveryEdgeCases:
         assert len(cancel_calls) == 1
         assert "cancelled" in cancel_calls[0][1]["metadata"]["message"].lower()
 
-        # Verify config released with CANCEL status
+        # After cancel processing, status transitions to SUCCESS (PROJQUAY-11027)
         refreshed = OrgMirrorConfig.get_by_id(config.id)
-        assert refreshed.sync_status == OrgMirrorStatus.CANCEL
+        assert refreshed.sync_status == OrgMirrorStatus.SUCCESS
 
     @disable_existing_org_mirrors
     @patch("workers.repomirrorworker.get_registry_adapter")


### PR DESCRIPTION
## Summary

- **Fix**: Cancel Sync was clearing `sync_start_date` in two places (`update_sync_status_to_cancel()` and `release_org_mirror_config()`), permanently disabling all future scheduled syncs instead of only stopping the current one
- **Change**: Preserve `sync_start_date` on cancel, schedule the next sync after cancel processing (same as SUCCESS), and transition CANCEL → SUCCESS to prevent an infinite cancel-loop
- **Frontend**: Updated cancel confirmation text to reflect the new behavior ("Future scheduled syncs will continue as normal")

## Changes

| File | Change |
|------|--------|
| `data/model/org_mirror.py` | Remove `sync_start_date=None` from cancel update; add CANCEL to next-sync scheduling; transition CANCEL→SUCCESS after processing |
| `data/model/test/test_org_mirror.py` | Update 2 assertions + add 4 regression tests (date preservation, scheduling, full flow, cancel-loop prevention) |
| `endpoints/api/test/test_org_mirror.py` | Add API-level regression test verifying `sync_start_date` preserved after cancel endpoint |
| `workers/repomirrorworker/test/test_org_mirror_worker.py` | Update assertion: status is SUCCESS after cancel processing |
| `OrgMirroringStatus.tsx` | Update cancel confirmation modal text |

## Test plan

- [x] `test_cancel_preserves_sync_start_date` — verifies sync_start_date not cleared
- [x] `test_cancel_release_schedules_next_sync` — verifies next sync scheduled with SUCCESS status
- [x] `test_cancel_full_flow_preserves_future_syncs` — end-to-end cancel → eligible cycle
- [x] `test_cancel_does_not_create_recancel_loop` — verifies no infinite cancel loop
- [x] `test_sync_cancel_preserves_sync_start_date` (API) — verifies API contract preserves date
- [x] All 298 tests pass across model, API, and worker test suites
- [ ] Run `make unit-test` in CI for full suite validation
- [ ] Verify cancel confirmation modal text in browser

Fixes [PROJQUAY-11027](https://redhat.atlassian.net/browse/PROJQUAY-11027)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
