### PR TITLE
PROJQUAY-7340: fix(repomirror): use temporary authfile to avoid exposing creds in process list

### DIFF
--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -24,6 +24,7 @@ jobs:
           with-clair: true
           with-keycloak: true
           with-jaeger: true
+          with-repomirror: true
           extra-config: |
             FEATURE_MAILING: true
             FEATURE_SECURITY_SCANNER: true

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ testpaths = ./
 python_files = **/test/test*.py
 log_cli = 0
 log_cli_level = INFO
+markers =
+    integration: marks tests that require network access or external binaries (deselect with -m "not integration")
 
 [testenv]
 deps =

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -20,6 +20,24 @@ _SANITIZE_PATTERNS = [
 
 SKOPEO_TIMEOUT_SECONDS = 300
 
+_FILESYSTEM_TRANSPORTS = frozenset({"oci-archive", "oci", "dir", "docker-archive"})
+
+
+def _registry_netloc(image: str) -> Optional[str]:
+    """Return the registry hostname for an image URI, or None for filesystem transports.
+
+    Filesystem transports (oci-archive, dir, docker-archive, oci) have no registry
+    host; returning None prevents empty-string keys in the authfile.
+    """
+    transport = image.partition(":")[0].lower()
+    if transport in _FILESYSTEM_TRANSPORTS:
+        return None
+    if transport == "docker-daemon":
+        remainder = image.split(":", 1)[1].lstrip("/")
+        parts = remainder.split("/")
+        return parts[0] if len(parts) > 1 else None
+    return urllib.parse.urlparse(image).netloc or None
+
 
 def sanitize_skopeo_output(output: Optional[str]) -> Optional[str]:
     if not output:
@@ -49,8 +67,9 @@ def wrap_anonymous(user: Optional[str] = None, passwd: Optional[str] = None) -> 
 def create_authfile_content(content: list) -> dict:
     """Build a Docker-style auth.json dict from a list of AuthContent entries.
 
-    Entries with a None or empty username are excluded so the authfile only
-    contains registries that actually require authentication.
+    Entries with a None/empty username or a None/empty location are excluded so
+    the authfile only contains registries that actually require authentication
+    and have a resolvable registry hostname.
     """
     return dict(
         auths=dict(
@@ -63,7 +82,10 @@ def create_authfile_content(content: list) -> dict:
                         ).decode("utf8")
                     },
                 ),
-                filter(lambda y: y.username not in ("", None), content),
+                filter(
+                    lambda y: y.username not in ("", None) and y.location not in ("", None),
+                    content,
+                ),
             )
         )
     )
@@ -107,8 +129,8 @@ class SkopeoMirror(object):
         )
         content = create_authfile_content(
             [
-                AuthContent(urllib.parse.urlparse(src_image).netloc, src_username, src_password),
-                AuthContent(urllib.parse.urlparse(dest_image).netloc, dest_username, dest_password),
+                AuthContent(_registry_netloc(src_image), src_username, src_password),
+                AuthContent(_registry_netloc(dest_image), dest_username, dest_password),
             ]
         )
 
@@ -142,7 +164,7 @@ class SkopeoMirror(object):
         args = args + ["list-tags", "--tls-verify=%s" % verify_tls]
         content = create_authfile_content(
             [
-                AuthContent(urllib.parse.urlparse(repository).netloc, username, password),
+                AuthContent(_registry_netloc(repository), username, password),
             ]
         )
 
@@ -177,7 +199,7 @@ class SkopeoMirror(object):
             args = args + ["--debug"]
         args = args + ["inspect", "--raw", "--tls-verify=%s" % verify_tls]
         content = create_authfile_content(
-            [AuthContent(urllib.parse.urlparse(image).netloc, username, password)]
+            [AuthContent(_registry_netloc(image), username, password)]
         )
         with NamedTemporaryFile() as authfile:
             authfile.write(json.dumps(content).encode("utf8"))
@@ -206,7 +228,7 @@ class SkopeoMirror(object):
             args = args + ["--debug"]
         args = args + ["inspect", "--tls-verify=%s" % verify_tls]
         content = create_authfile_content(
-            [AuthContent(urllib.parse.urlparse(image).netloc, username, password)]
+            [AuthContent(_registry_netloc(image), username, password)]
         )
         with NamedTemporaryFile() as authfile:
             authfile.write(json.dumps(content).encode("utf8"))
@@ -248,12 +270,12 @@ class SkopeoMirror(object):
         content = create_authfile_content(
             [
                 AuthContent(
-                    urllib.parse.urlparse(src_image_with_digest).netloc,
+                    _registry_netloc(src_image_with_digest),
                     src_username,
                     src_password,
                 ),
                 AuthContent(
-                    urllib.parse.urlparse(dest_image_with_digest).netloc,
+                    _registry_netloc(dest_image_with_digest),
                     dest_username,
                     dest_password,
                 ),

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -88,6 +88,7 @@ class SkopeoMirror(object):
         verbose_logs=False,
         unsigned_images=False,
     ):
+        """Copy src_image to dest_image via skopeo, using a temporary authfile for credentials."""
         args = ["/usr/bin/skopeo"]
         if verbose_logs:
             args = args + ["--debug"]

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -6,9 +6,10 @@ import re
 import subprocess
 import urllib.parse
 from collections import namedtuple
+from contextlib import contextmanager
 from shlex import quote
 from tempfile import NamedTemporaryFile, SpooledTemporaryFile
-from typing import Optional
+from typing import Iterator, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -71,24 +72,26 @@ def create_authfile_content(content: list) -> dict:
     the authfile only contains registries that actually require authentication
     and have a resolvable registry hostname.
     """
-    return dict(
-        auths=dict(
-            map(
-                lambda x: (
-                    x.location,
-                    {
-                        "auth": base64.b64encode(
-                            wrap_anonymous(x.username, x.password).encode("utf8")
-                        ).decode("utf8")
-                    },
-                ),
-                filter(
-                    lambda y: y.username not in ("", None) and y.location not in ("", None),
-                    content,
-                ),
-            )
-        )
-    )
+    return {
+        "auths": {
+            e.location: {
+                "auth": base64.b64encode(
+                    wrap_anonymous(e.username, e.password).encode("utf8")
+                ).decode("utf8")
+            }
+            for e in content
+            if e.username not in ("", None) and e.location not in ("", None)
+        }
+    }
+
+
+@contextmanager
+def _authfile(entries: list) -> Iterator[str]:
+    """Write a Docker auth.json for *entries* to a temp file and yield its path."""
+    with NamedTemporaryFile() as tmp:
+        tmp.write(json.dumps(create_authfile_content(entries)).encode("utf8"))
+        tmp.flush()
+        yield tmp.name
 
 
 class SkopeoMirror(object):
@@ -127,17 +130,13 @@ class SkopeoMirror(object):
         logger.debug(
             "Creating mirroring job: upstream image %s, local repository %s", src_image, dest_image
         )
-        content = create_authfile_content(
+        with _authfile(
             [
                 AuthContent(_registry_netloc(src_image), src_username, src_password),
                 AuthContent(_registry_netloc(dest_image), dest_username, dest_password),
             ]
-        )
-
-        with NamedTemporaryFile() as authfile:
-            authfile.write(json.dumps(content).encode("utf8"))
-            authfile.flush()
-            args.extend(["--authfile", authfile.name])
+        ) as authfile_path:
+            args.extend(["--authfile", authfile_path])
             args = args + [quote(src_image), quote(dest_image)]
             return self.run_skopeo(args, proxy, timeout)
 
@@ -162,17 +161,11 @@ class SkopeoMirror(object):
         if verbose_logs:
             args = args + ["--debug"]
         args = args + ["list-tags", "--tls-verify=%s" % verify_tls]
-        content = create_authfile_content(
-            [
-                AuthContent(_registry_netloc(repository), username, password),
-            ]
-        )
-
         all_tags = []
-        with NamedTemporaryFile() as authfile:
-            authfile.write(json.dumps(content).encode("utf8"))
-            authfile.flush()
-            args.extend(["--authfile", authfile.name])
+        with _authfile(
+            [AuthContent(_registry_netloc(repository), username, password)]
+        ) as authfile_path:
+            args.extend(["--authfile", authfile_path])
             args = args + [repository]
             result = self.run_skopeo(args, proxy, timeout)
             if result.success:
@@ -198,13 +191,8 @@ class SkopeoMirror(object):
         if verbose_logs:
             args = args + ["--debug"]
         args = args + ["inspect", "--raw", "--tls-verify=%s" % verify_tls]
-        content = create_authfile_content(
-            [AuthContent(_registry_netloc(image), username, password)]
-        )
-        with NamedTemporaryFile() as authfile:
-            authfile.write(json.dumps(content).encode("utf8"))
-            authfile.flush()
-            args.extend(["--authfile", authfile.name])
+        with _authfile([AuthContent(_registry_netloc(image), username, password)]) as authfile_path:
+            args.extend(["--authfile", authfile_path])
             args = args + [image]
             return self.run_skopeo(args, proxy or {}, timeout)
 
@@ -227,13 +215,8 @@ class SkopeoMirror(object):
         if verbose_logs:
             args = args + ["--debug"]
         args = args + ["inspect", "--tls-verify=%s" % verify_tls]
-        content = create_authfile_content(
-            [AuthContent(_registry_netloc(image), username, password)]
-        )
-        with NamedTemporaryFile() as authfile:
-            authfile.write(json.dumps(content).encode("utf8"))
-            authfile.flush()
-            args.extend(["--authfile", authfile.name])
+        with _authfile([AuthContent(_registry_netloc(image), username, password)]) as authfile_path:
+            args.extend(["--authfile", authfile_path])
             args = args + [image]
             return self.run_skopeo(args, proxy or {}, timeout)
 
@@ -267,7 +250,7 @@ class SkopeoMirror(object):
             "--src-tls-verify=%s" % src_tls_verify,
             "--dest-tls-verify=%s" % dest_tls_verify,
         ]
-        content = create_authfile_content(
+        with _authfile(
             [
                 AuthContent(
                     _registry_netloc(src_image_with_digest),
@@ -280,26 +263,10 @@ class SkopeoMirror(object):
                     dest_password,
                 ),
             ]
-        )
-        with NamedTemporaryFile() as authfile:
-            authfile.write(json.dumps(content).encode("utf8"))
-            authfile.flush()
-            args.extend(["--authfile", authfile.name])
+        ) as authfile_path:
+            args.extend(["--authfile", authfile_path])
             args = args + [quote(src_image_with_digest), quote(dest_image_with_digest)]
             return self.run_skopeo(args, proxy or {}, timeout)
-
-    def external_registry_credentials(
-        self, arg: str, username: Optional[str], password: Optional[str]
-    ) -> list[str]:
-        credentials = []
-        if username is not None and username != "":
-            if password is not None and password != "":
-                creds = "%s:%s" % (username, password)
-            else:
-                creds = "%s" % username
-            credentials = [arg, creds]
-
-        return credentials
 
     def setup_env(self, proxy):
         env = os.environ.copy()

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -37,7 +37,7 @@ SkopeoResults = namedtuple("SkopeoResults", "success tags stdout stderr")
 AuthContent = namedtuple("AuthContent", ["location", "username", "password"])
 
 
-def wrap_anonymous(user: str = "", passwd: str = "") -> str:
+def wrap_anonymous(user: Optional[str] = None, passwd: Optional[str] = None) -> str:
     if user in ("", None):
         return ""
     if passwd in ("", None):
@@ -138,13 +138,13 @@ class SkopeoMirror(object):
                 AuthContent(urllib.parse.urlparse(repository).netloc, username, password),
             ]
         )
-        args = args + [repository]
 
         all_tags = []
         with NamedTemporaryFile() as authfile:
             authfile.write(json.dumps(content).encode("utf8"))
             authfile.flush()
             args.extend(["--authfile", authfile.name])
+            args = args + [repository]
             result = self.run_skopeo(args, proxy, timeout)
             if result.success:
                 all_tags = json.loads(result.stdout)["Tags"]
@@ -169,9 +169,15 @@ class SkopeoMirror(object):
         if verbose_logs:
             args = args + ["--debug"]
         args = args + ["inspect", "--raw", "--tls-verify=%s" % verify_tls]
-        args = args + self.external_registry_credentials("--creds", username, password)
-        args = args + [image]
-        return self.run_skopeo(args, proxy or {}, timeout)
+        content = create_authfile_content(
+            [AuthContent(urllib.parse.urlparse(image).netloc, username, password)]
+        )
+        with NamedTemporaryFile() as authfile:
+            authfile.write(json.dumps(content).encode("utf8"))
+            authfile.flush()
+            args.extend(["--authfile", authfile.name])
+            args = args + [image]
+            return self.run_skopeo(args, proxy or {}, timeout)
 
     def inspect(
         self,
@@ -192,9 +198,15 @@ class SkopeoMirror(object):
         if verbose_logs:
             args = args + ["--debug"]
         args = args + ["inspect", "--tls-verify=%s" % verify_tls]
-        args = args + self.external_registry_credentials("--creds", username, password)
-        args = args + [image]
-        return self.run_skopeo(args, proxy or {}, timeout)
+        content = create_authfile_content(
+            [AuthContent(urllib.parse.urlparse(image).netloc, username, password)]
+        )
+        with NamedTemporaryFile() as authfile:
+            authfile.write(json.dumps(content).encode("utf8"))
+            authfile.flush()
+            args.extend(["--authfile", authfile.name])
+            args = args + [image]
+            return self.run_skopeo(args, proxy or {}, timeout)
 
     def copy_by_digest(
         self,
@@ -226,12 +238,26 @@ class SkopeoMirror(object):
             "--src-tls-verify=%s" % src_tls_verify,
             "--dest-tls-verify=%s" % dest_tls_verify,
         ]
-        args = args + self.external_registry_credentials(
-            "--dest-creds", dest_username, dest_password
+        content = create_authfile_content(
+            [
+                AuthContent(
+                    urllib.parse.urlparse(src_image_with_digest).netloc,
+                    src_username,
+                    src_password,
+                ),
+                AuthContent(
+                    urllib.parse.urlparse(dest_image_with_digest).netloc,
+                    dest_username,
+                    dest_password,
+                ),
+            ]
         )
-        args = args + self.external_registry_credentials("--src-creds", src_username, src_password)
-        args = args + [quote(src_image_with_digest), quote(dest_image_with_digest)]
-        return self.run_skopeo(args, proxy or {}, timeout)
+        with NamedTemporaryFile() as authfile:
+            authfile.write(json.dumps(content).encode("utf8"))
+            authfile.flush()
+            args.extend(["--authfile", authfile.name])
+            args = args + [quote(src_image_with_digest), quote(dest_image_with_digest)]
+            return self.run_skopeo(args, proxy or {}, timeout)
 
     def external_registry_credentials(
         self, arg: str, username: Optional[str], password: Optional[str]

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -38,6 +38,7 @@ AuthContent = namedtuple("AuthContent", ["location", "username", "password"])
 
 
 def wrap_anonymous(user: Optional[str] = None, passwd: Optional[str] = None) -> str:
+    """Return 'user:passwd' for use in a Docker auth entry, or '' if either value is absent."""
     if user in ("", None):
         return ""
     if passwd in ("", None):
@@ -46,6 +47,11 @@ def wrap_anonymous(user: Optional[str] = None, passwd: Optional[str] = None) -> 
 
 
 def create_authfile_content(content: list) -> dict:
+    """Build a Docker-style auth.json dict from a list of AuthContent entries.
+
+    Entries with a None or empty username are excluded so the authfile only
+    contains registries that actually require authentication.
+    """
     return dict(
         auths=dict(
             map(

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -1,11 +1,13 @@
+import base64
 import json
 import logging
 import os
 import re
 import subprocess
+import urllib.parse
 from collections import namedtuple
-from pipes import quote
-from tempfile import SpooledTemporaryFile
+from shlex import quote
+from tempfile import NamedTemporaryFile, SpooledTemporaryFile
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -15,6 +17,8 @@ _SANITIZE_PATTERNS = [
     (re.compile(r"(--(src-creds|dest-creds|creds)[=\s]+)\S+", re.IGNORECASE), r"\1[REDACTED]"),
     (re.compile(r'("auth"\s*:\s*")[^"]+(")', re.IGNORECASE), r"\1[REDACTED]\2"),
 ]
+
+SKOPEO_TIMEOUT_SECONDS = 300
 
 
 def sanitize_skopeo_output(output: Optional[str]) -> Optional[str]:
@@ -30,6 +34,33 @@ def sanitize_skopeo_output(output: Optional[str]) -> Optional[str]:
 # stdout: stdout from skopeo subprocess
 # stderr: stderr from skopeo subprocess
 SkopeoResults = namedtuple("SkopeoResults", "success tags stdout stderr")
+AuthContent = namedtuple("AuthContent", ["location", "username", "password"])
+
+
+def wrap_anonymous(user: str = "", passwd: str = "") -> str:
+    if user in ("", None):
+        return ""
+    if passwd in ("", None):
+        return ""
+    return f"{user}:{passwd}"
+
+
+def create_authfile_content(content: list) -> dict:
+    return dict(
+        auths=dict(
+            map(
+                lambda x: (
+                    x.location,
+                    {
+                        "auth": base64.b64encode(
+                            wrap_anonymous(x.username, x.password).encode("utf8")
+                        ).decode("utf8")
+                    },
+                ),
+                filter(lambda y: y.username not in ("", None), content),
+            )
+        )
+    )
 
 
 class SkopeoMirror(object):
@@ -51,7 +82,6 @@ class SkopeoMirror(object):
         verbose_logs=False,
         unsigned_images=False,
     ):
-
         args = ["/usr/bin/skopeo"]
         if verbose_logs:
             args = args + ["--debug"]
@@ -65,16 +95,22 @@ class SkopeoMirror(object):
             "--src-tls-verify=%s" % src_tls_verify,
             "--dest-tls-verify=%s" % dest_tls_verify,
         ]
-        args = args + self.external_registry_credentials(
-            "--dest-creds", dest_username, dest_password
-        )
-        args = args + self.external_registry_credentials("--src-creds", src_username, src_password)
-        args = args + [quote(src_image), quote(dest_image)]
         logger.debug(
             "Creating mirroring job: upstream image %s, local repository %s", src_image, dest_image
         )
+        content = create_authfile_content(
+            [
+                AuthContent(urllib.parse.urlparse(src_image).netloc, src_username, src_password),
+                AuthContent(urllib.parse.urlparse(dest_image).netloc, dest_username, dest_password),
+            ]
+        )
 
-        return self.run_skopeo(args, proxy, timeout)
+        with NamedTemporaryFile() as authfile:
+            authfile.write(json.dumps(content).encode("utf8"))
+            authfile.flush()
+            args.extend(["--authfile", authfile.name])
+            args = args + [quote(src_image), quote(dest_image)]
+            return self.run_skopeo(args, proxy, timeout)
 
     def tags(
         self,
@@ -97,13 +133,21 @@ class SkopeoMirror(object):
         if verbose_logs:
             args = args + ["--debug"]
         args = args + ["list-tags", "--tls-verify=%s" % verify_tls]
-        args = args + self.external_registry_credentials("--creds", username, password)
+        content = create_authfile_content(
+            [
+                AuthContent(urllib.parse.urlparse(repository).netloc, username, password),
+            ]
+        )
         args = args + [repository]
 
         all_tags = []
-        result = self.run_skopeo(args, proxy, timeout)
-        if result.success:
-            all_tags = json.loads(result.stdout)["Tags"]
+        with NamedTemporaryFile() as authfile:
+            authfile.write(json.dumps(content).encode("utf8"))
+            authfile.flush()
+            args.extend(["--authfile", authfile.name])
+            result = self.run_skopeo(args, proxy, timeout)
+            if result.success:
+                all_tags = json.loads(result.stdout)["Tags"]
 
         return SkopeoResults(result.success, all_tags, result.stdout, result.stderr)
 

--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -1,0 +1,68 @@
+import base64
+import os
+
+import pytest
+
+from util.repomirror.skopeomirror import (
+    SKOPEO_TIMEOUT_SECONDS,
+    AuthContent,
+    SkopeoMirror,
+    create_authfile_content,
+)
+
+
+def test_create_authfile_content():
+    content = create_authfile_content(
+        [
+            AuthContent("quay.io", "user1", "user1"),
+            AuthContent("registry.redhat.io", "user2", "user2"),
+            AuthContent("docker.io", "anonymous", ""),
+        ]
+    )
+    assert content.get("auths").get("quay.io").get("auth") == base64.b64encode(
+        "user1:user1".encode("utf8")
+    ).decode("utf8")
+    assert content.get("auths").get("registry.redhat.io").get("auth") == base64.b64encode(
+        "user2:user2".encode("utf8")
+    ).decode("utf8")
+    assert content.get("auths").get("docker.io").get("auth") == ""
+
+
+def test_skopeo_command_copy():
+    result = SkopeoMirror().copy(
+        "docker://quay.io/quay/busybox:latest",
+        "oci-archive://dev/null",
+        proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
+        timeout=SKOPEO_TIMEOUT_SECONDS,
+    )
+    assert result.success == True
+    assert "Copying blob sha256:" in result.stdout
+    assert result.stderr == ""
+
+
+def test_skopeo_command_authenticated():
+    # since there's no fixed user to test authenticated skip for now
+    assert True == True
+    return
+    result = SkopeoMirror().copy(
+        f"docker://{os.environ.get('src_image')}",
+        "oci-archive://dev/null",
+        src_username=os.environ.get("user-to-authenticated"),
+        src_password=os.environ.get("pass-to-authenticated"),
+        proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
+        timeout=SKOPEO_TIMEOUT_SECONDS,
+    )
+    assert result.success == True
+    assert "Copying blob sha256:" in result.stdout
+    assert result.stderr == ""
+
+
+def test_skopeo_command_tags():
+    result = SkopeoMirror().tags(
+        "docker://quay.io/quay/busybox",
+        proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
+        timeout=SKOPEO_TIMEOUT_SECONDS,
+    )
+    assert result.success == True
+    assert len(result.tags) > 0
+    assert result.stderr == ""

--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -7,6 +7,7 @@ from util.repomirror.skopeomirror import (
     SKOPEO_TIMEOUT_SECONDS,
     AuthContent,
     SkopeoMirror,
+    _registry_netloc,
     create_authfile_content,
 )
 
@@ -39,8 +40,7 @@ def test_create_authfile_content_filters_none_username():
             AuthContent("quay.io", "user", "pass"),
         ]
     )
-    assert "registry.example.com" not in content.get("auths", {})
-    assert "quay.io" in content.get("auths", {})
+    assert set(content.get("auths", {}).keys()) == {"quay.io"}
 
 
 def test_create_authfile_content_empty_when_no_credentials():
@@ -48,6 +48,23 @@ def test_create_authfile_content_empty_when_no_credentials():
         [AuthContent("quay.io", None, None), AuthContent("docker.io", "", "")]
     )
     assert content == {"auths": {}}
+
+
+def test_registry_netloc_docker_transport():
+    assert _registry_netloc("docker://quay.io/repo:tag") == "quay.io"
+    assert _registry_netloc("docker://registry.example.com/repo:tag") == "registry.example.com"
+
+
+def test_registry_netloc_filesystem_transports_return_none():
+    assert _registry_netloc("oci-archive:/tmp/x.tar") is None
+    assert _registry_netloc("oci:/tmp/x") is None
+    assert _registry_netloc("dir:/tmp/x") is None
+    assert _registry_netloc("docker-archive:/tmp/x.tar") is None
+
+
+def test_registry_netloc_docker_daemon():
+    assert _registry_netloc("docker-daemon:registry.example.com/image:tag") == "registry.example.com"
+    assert _registry_netloc("docker-daemon:image") is None
 
 
 @pytest.mark.integration

--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -63,7 +63,9 @@ def test_registry_netloc_filesystem_transports_return_none():
 
 
 def test_registry_netloc_docker_daemon():
-    assert _registry_netloc("docker-daemon:registry.example.com/image:tag") == "registry.example.com"
+    assert (
+        _registry_netloc("docker-daemon:registry.example.com/image:tag") == "registry.example.com"
+    )
     assert _registry_netloc("docker-daemon:image") is None
 
 

--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -25,9 +25,30 @@ def test_create_authfile_content():
     assert content.get("auths").get("registry.redhat.io").get("auth") == base64.b64encode(
         "user2:user2".encode("utf8")
     ).decode("utf8")
+    # "anonymous" with no password: username passes the None/empty filter but
+    # wrap_anonymous returns "" for missing password → empty auth value.
     assert content.get("auths").get("docker.io").get("auth") == ""
 
 
+def test_create_authfile_content_filters_none_username():
+    content = create_authfile_content(
+        [
+            AuthContent("registry.example.com", None, None),
+            AuthContent("quay.io", "user", "pass"),
+        ]
+    )
+    assert "registry.example.com" not in content.get("auths", {})
+    assert "quay.io" in content.get("auths", {})
+
+
+def test_create_authfile_content_empty_when_no_credentials():
+    content = create_authfile_content(
+        [AuthContent("quay.io", None, None), AuthContent("docker.io", "", "")]
+    )
+    assert content == {"auths": {}}
+
+
+@pytest.mark.integration
 def test_skopeo_command_copy():
     result = SkopeoMirror().copy(
         "docker://quay.io/quay/busybox:latest",
@@ -35,15 +56,13 @@ def test_skopeo_command_copy():
         proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
         timeout=SKOPEO_TIMEOUT_SECONDS,
     )
-    assert result.success == True
+    assert result.success
     assert "Copying blob sha256:" in result.stdout
     assert result.stderr == ""
 
 
+@pytest.mark.skip(reason="no fixed credentials available for authenticated testing")
 def test_skopeo_command_authenticated():
-    # since there's no fixed user to test authenticated skip for now
-    assert True == True
-    return
     result = SkopeoMirror().copy(
         f"docker://{os.environ.get('src_image')}",
         "oci-archive://dev/null",
@@ -52,17 +71,18 @@ def test_skopeo_command_authenticated():
         proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
         timeout=SKOPEO_TIMEOUT_SECONDS,
     )
-    assert result.success == True
+    assert result.success
     assert "Copying blob sha256:" in result.stdout
     assert result.stderr == ""
 
 
+@pytest.mark.integration
 def test_skopeo_command_tags():
     result = SkopeoMirror().tags(
         "docker://quay.io/quay/busybox",
         proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
         timeout=SKOPEO_TIMEOUT_SECONDS,
     )
-    assert result.success == True
+    assert result.success
     assert len(result.tags) > 0
     assert result.stderr == ""

--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -12,22 +12,24 @@ from util.repomirror.skopeomirror import (
 
 
 def test_create_authfile_content():
+    registries = ["quay.io", "registry.redhat.io", "docker.io"]
     content = create_authfile_content(
         [
-            AuthContent("quay.io", "user1", "user1"),
-            AuthContent("registry.redhat.io", "user2", "user2"),
-            AuthContent("docker.io", "anonymous", ""),
+            AuthContent(registries[0], "user1", "user1"),
+            AuthContent(registries[1], "user2", "user2"),
+            # "anonymous" with no password: username passes the None/empty filter but
+            # wrap_anonymous returns "" for missing password → empty auth value.
+            AuthContent(registries[2], "anonymous", ""),
         ]
     )
-    assert content.get("auths").get("quay.io").get("auth") == base64.b64encode(
-        "user1:user1".encode("utf8")
-    ).decode("utf8")
-    assert content.get("auths").get("registry.redhat.io").get("auth") == base64.b64encode(
-        "user2:user2".encode("utf8")
-    ).decode("utf8")
-    # "anonymous" with no password: username passes the None/empty filter but
-    # wrap_anonymous returns "" for missing password → empty auth value.
-    assert content.get("auths").get("docker.io").get("auth") == ""
+    auths = content["auths"]
+    assert auths[registries[0]]["auth"] == base64.b64encode("user1:user1".encode("utf8")).decode(
+        "utf8"
+    )
+    assert auths[registries[1]]["auth"] == base64.b64encode("user2:user2".encode("utf8")).decode(
+        "utf8"
+    )
+    assert auths[registries[2]]["auth"] == ""
 
 
 def test_create_authfile_content_filters_none_username():

--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -52,7 +52,7 @@ def test_create_authfile_content_empty_when_no_credentials():
 def test_skopeo_command_copy():
     result = SkopeoMirror().copy(
         "docker://quay.io/quay/busybox:latest",
-        "oci-archive://dev/null",
+        "oci-archive:/dev/null",
         proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},
         timeout=SKOPEO_TIMEOUT_SECONDS,
     )
@@ -65,7 +65,7 @@ def test_skopeo_command_copy():
 def test_skopeo_command_authenticated():
     result = SkopeoMirror().copy(
         f"docker://{os.environ.get('src_image')}",
-        "oci-archive://dev/null",
+        "oci-archive:/dev/null",
         src_username=os.environ.get("user-to-authenticated"),
         src_password=os.environ.get("pass-to-authenticated"),
         proxy={"http_proxy": "", "https_proxy": "", "no_proxy": ""},

--- a/web/playwright/e2e/repository/mirroring.spec.ts
+++ b/web/playwright/e2e/repository/mirroring.spec.ts
@@ -606,7 +606,8 @@ test.describe(
           {
             timeout: 120_000,
             intervals: [5_000, 10_000, 15_000],
-            message: 'Mirror sync did not complete successfully within 2 minutes',
+            message:
+              'Mirror sync did not complete successfully within 2 minutes',
           },
         )
         .toBe('SUCCESS');

--- a/web/playwright/e2e/repository/mirroring.spec.ts
+++ b/web/playwright/e2e/repository/mirroring.spec.ts
@@ -596,25 +596,6 @@ test.describe(
 
       await api.raw.triggerMirrorSync(org.name, repo.name);
 
-      // Skip gracefully if the mirror worker is not running in this environment.
-      // The worker transitions SYNC_NOW -> SYNCING within a few seconds when present.
-      let workerRunning = false;
-      for (let i = 0; i < 6; i++) {
-        await new Promise((r) => setTimeout(r, 5_000));
-        const cfg = await api.raw.getMirrorConfig(org.name, repo.name);
-        if (
-          cfg?.sync_status !== 'SYNC_NOW' &&
-          cfg?.sync_status !== 'NEVER_RUN'
-        ) {
-          workerRunning = true;
-          break;
-        }
-      }
-      test.skip(
-        !workerRunning,
-        'Mirror worker not running in this environment — skipping real-sync validation',
-      );
-
       // Poll until the mirror worker finishes. Throw on FAIL so the test
       // surfaces a clear message rather than timing out.
       await expect

--- a/web/playwright/e2e/repository/mirroring.spec.ts
+++ b/web/playwright/e2e/repository/mirroring.spec.ts
@@ -566,5 +566,51 @@ test.describe(
         authenticatedPage.getByTestId('architecture-filter-helper'),
       ).toContainText('s390x');
     });
+
+    test('completes a real sync using authfile credentials', async ({api}) => {
+      // Validates the authfile credential path end-to-end: if skopeomirror.py
+      // writes a malformed authfile or passes credentials on the CLI instead,
+      // the sync will fail or produce an error status here.
+      const org = await api.organization('syncauthfileorg');
+      const repo = await api.repository(org.name, 'syncauthfilerepo');
+      const robot = await api.robot(org.name, 'syncauthfilebot');
+      await api.setMirrorState(org.name, repo.name);
+
+      // Mirror a small, stable public image so the sync completes quickly.
+      const now = new Date();
+      await api.raw.createMirrorConfig(org.name, repo.name, {
+        external_reference: 'quay.io/quay/busybox',
+        sync_interval: 86400,
+        sync_start_date: now.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        root_rule: {rule_kind: 'tag_glob_csv', rule_value: ['latest']},
+        robot_username: robot.fullName,
+        skopeo_timeout_interval: 300,
+        is_enabled: true,
+        verify_tls: true,
+      });
+
+      await api.raw.triggerMirrorSync(org.name, repo.name);
+
+      // Poll until the mirror worker finishes (SUCCESS or FAILED).
+      const finalStatus = await expect
+        .poll(
+          async () => {
+            const cfg = await api.raw.getMirrorConfig(org.name, repo.name);
+            return cfg?.sync_status ?? 'UNKNOWN';
+          },
+          {
+            timeout: 120_000,
+            intervals: [5_000, 10_000, 15_000],
+            message: 'Mirror sync did not finish within 2 minutes',
+          },
+        )
+        .toMatch(/^(SUCCESS|FAILED)$/);
+
+      expect(finalStatus).toBe('SUCCESS');
+
+      // Confirm the synced tag landed in the repository.
+      const tags = await api.raw.getTags(org.name, repo.name);
+      expect(tags.tags.some((t) => t.name === 'latest')).toBe(true);
+    });
   },
 );

--- a/web/playwright/e2e/repository/mirroring.spec.ts
+++ b/web/playwright/e2e/repository/mirroring.spec.ts
@@ -577,11 +577,14 @@ test.describe(
       await api.setMirrorState(org.name, repo.name);
 
       // Mirror a small, stable public image so the sync completes quickly.
-      const now = new Date();
+      // Push sync_start_date into the future so the scheduler won't fire
+      // independently; triggerMirrorSync() is the only driver.
+      const syncStartDate = new Date();
+      syncStartDate.setMinutes(syncStartDate.getMinutes() + 5);
       await api.raw.createMirrorConfig(org.name, repo.name, {
         external_reference: 'quay.io/quay/busybox',
         sync_interval: 86400,
-        sync_start_date: now.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        sync_start_date: syncStartDate.toISOString().replace(/\.\d{3}Z$/, 'Z'),
         root_rule: {rule_kind: 'tag_glob_csv', rule_value: ['latest']},
         robot_username: robot.fullName,
         skopeo_timeout_interval: 300,

--- a/web/playwright/e2e/repository/mirroring.spec.ts
+++ b/web/playwright/e2e/repository/mirroring.spec.ts
@@ -568,6 +568,8 @@ test.describe(
     });
 
     test('completes a real sync using authfile credentials', async ({api}) => {
+      // This test waits up to 2 minutes for a real skopeo sync to complete.
+      test.setTimeout(180_000);
       // Validates the authfile credential path end-to-end: if skopeomirror.py
       // writes a malformed authfile or passes credentials on the CLI instead,
       // the sync will fail or produce an error status here.

--- a/web/playwright/e2e/repository/mirroring.spec.ts
+++ b/web/playwright/e2e/repository/mirroring.spec.ts
@@ -596,6 +596,25 @@ test.describe(
 
       await api.raw.triggerMirrorSync(org.name, repo.name);
 
+      // Skip gracefully if the mirror worker is not running in this environment.
+      // The worker transitions SYNC_NOW -> SYNCING within a few seconds when present.
+      let workerRunning = false;
+      for (let i = 0; i < 6; i++) {
+        await new Promise((r) => setTimeout(r, 5_000));
+        const cfg = await api.raw.getMirrorConfig(org.name, repo.name);
+        if (
+          cfg?.sync_status !== 'SYNC_NOW' &&
+          cfg?.sync_status !== 'NEVER_RUN'
+        ) {
+          workerRunning = true;
+          break;
+        }
+      }
+      test.skip(
+        !workerRunning,
+        'Mirror worker not running in this environment — skipping real-sync validation',
+      );
+
       // Poll until the mirror worker finishes. Throw on FAIL so the test
       // surfaces a clear message rather than timing out.
       await expect

--- a/web/playwright/e2e/repository/mirroring.spec.ts
+++ b/web/playwright/e2e/repository/mirroring.spec.ts
@@ -591,22 +591,25 @@ test.describe(
 
       await api.raw.triggerMirrorSync(org.name, repo.name);
 
-      // Poll until the mirror worker finishes (SUCCESS or FAILED).
-      const finalStatus = await expect
+      // Poll until the mirror worker finishes. Throw on FAIL so the test
+      // surfaces a clear message rather than timing out.
+      await expect
         .poll(
           async () => {
             const cfg = await api.raw.getMirrorConfig(org.name, repo.name);
-            return cfg?.sync_status ?? 'UNKNOWN';
+            const status = cfg?.sync_status ?? 'UNKNOWN';
+            if (status === 'FAIL') {
+              throw new Error(`Mirror sync failed with status: ${status}`);
+            }
+            return status;
           },
           {
             timeout: 120_000,
             intervals: [5_000, 10_000, 15_000],
-            message: 'Mirror sync did not finish within 2 minutes',
+            message: 'Mirror sync did not complete successfully within 2 minutes',
           },
         )
-        .toMatch(/^(SUCCESS|FAILED)$/);
-
-      expect(finalStatus).toBe('SUCCESS');
+        .toBe('SUCCESS');
 
       // Confirm the synced tag landed in the repository.
       const tags = await api.raw.getTags(org.name, repo.name);

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -123,11 +123,23 @@ def test_successful_mirror(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
         except Exception as e:
+            print(f"Exception {e} {args}")
             skopeo_calls.append(skopeo_call)
             raise e
 
@@ -182,7 +194,18 @@ def test_mirror_unsigned_images(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -241,7 +264,18 @@ def test_successful_disabled_sync_now(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -299,7 +333,18 @@ def test_successful_mirror_verbose_logs(run_skopeo_mock, initialized_db, app, mo
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -422,7 +467,18 @@ def test_rollback(
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             if args[1] == "copy" and args[8].endswith(":updated"):
@@ -515,7 +571,18 @@ def test_mirror_config_server_hostname(run_skopeo_mock, initialized_db, app, mon
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -582,7 +649,18 @@ def test_quote_params(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -646,7 +724,18 @@ def test_quote_params_password(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -675,7 +764,18 @@ def test_inspect_error_mirror(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            # since we change from credentials to authfile we need to check the diff
+            auth_diff = set(skopeo_call["args"]).difference(set(args))
+            assert any(
+                [
+                    auth_diff == set(),
+                    "--creds" in auth_diff,
+                    "--dest-creds" in auth_diff,
+                    "--src-creds" in auth_diff,
+                ]
+            )
+            # we want an --authfile in the args instead
+            assert "--authfile" in args
             assert proxy == {}
 
             return skopeo_call["results"]

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -1,5 +1,5 @@
-import logging
 import json
+import logging
 from functools import wraps
 from io import BytesIO
 from unittest.mock import patch

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -33,7 +33,7 @@ from workers.repomirrorworker.repomirrorworker import RepoMirrorWorker
 
 
 def _assert_skopeo_args(actual_args, expected_args):
-    """Assert skopeo args match, ignoring the --authfile path (a tempfile changes each call)."""
+    """Assert skopeo args match expected, ignoring the transient --authfile <tmppath> pair."""
 
     def strip_authfile(args):
         a = list(args)

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -1,7 +1,10 @@
+import logging
 import json
 from functools import wraps
 from io import BytesIO
 from unittest.mock import patch
+
+logger = logging.getLogger(__name__)
 
 import mock
 import pytest
@@ -27,6 +30,20 @@ from workers.repomirrorworker import (
     push_sparse_manifest_list,
 )
 from workers.repomirrorworker.repomirrorworker import RepoMirrorWorker
+
+
+def _assert_skopeo_args(actual_args, expected_args):
+    """Assert skopeo args match, ignoring the --authfile path (a tempfile changes each call)."""
+
+    def strip_authfile(args):
+        a = list(args)
+        if "--authfile" in a:
+            i = a.index("--authfile")
+            del a[i : i + 2]
+        return a
+
+    assert strip_authfile(actual_args) == strip_authfile(expected_args)
+    assert "--authfile" in actual_args
 
 
 def disable_existing_mirrors(func):
@@ -123,23 +140,12 @@ def test_successful_mirror(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            # since we change from credentials to authfile we need to check the diff
-            auth_diff = set(skopeo_call["args"]).difference(set(args))
-            assert any(
-                [
-                    auth_diff == set(),
-                    "--creds" in auth_diff,
-                    "--dest-creds" in auth_diff,
-                    "--src-creds" in auth_diff,
-                ]
-            )
-            # we want an --authfile in the args instead
-            assert "--authfile" in args
+            _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
             return skopeo_call["results"]
         except Exception as e:
-            print(f"Exception {e} {args}")
+            logger.debug("skopeo_test exception: %s args=%s", e, args)
             skopeo_calls.append(skopeo_call)
             raise e
 
@@ -194,18 +200,7 @@ def test_mirror_unsigned_images(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            # since we change from credentials to authfile we need to check the diff
-            auth_diff = set(skopeo_call["args"]).difference(set(args))
-            assert any(
-                [
-                    auth_diff == set(),
-                    "--creds" in auth_diff,
-                    "--dest-creds" in auth_diff,
-                    "--src-creds" in auth_diff,
-                ]
-            )
-            # we want an --authfile in the args instead
-            assert "--authfile" in args
+            _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -264,18 +259,7 @@ def test_successful_disabled_sync_now(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            # since we change from credentials to authfile we need to check the diff
-            auth_diff = set(skopeo_call["args"]).difference(set(args))
-            assert any(
-                [
-                    auth_diff == set(),
-                    "--creds" in auth_diff,
-                    "--dest-creds" in auth_diff,
-                    "--src-creds" in auth_diff,
-                ]
-            )
-            # we want an --authfile in the args instead
-            assert "--authfile" in args
+            _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -333,18 +317,7 @@ def test_successful_mirror_verbose_logs(run_skopeo_mock, initialized_db, app, mo
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            # since we change from credentials to authfile we need to check the diff
-            auth_diff = set(skopeo_call["args"]).difference(set(args))
-            assert any(
-                [
-                    auth_diff == set(),
-                    "--creds" in auth_diff,
-                    "--dest-creds" in auth_diff,
-                    "--src-creds" in auth_diff,
-                ]
-            )
-            # we want an --authfile in the args instead
-            assert "--authfile" in args
+            _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -467,18 +440,7 @@ def test_rollback(
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            # since we change from credentials to authfile we need to check the diff
-            auth_diff = set(skopeo_call["args"]).difference(set(args))
-            assert any(
-                [
-                    auth_diff == set(),
-                    "--creds" in auth_diff,
-                    "--dest-creds" in auth_diff,
-                    "--src-creds" in auth_diff,
-                ]
-            )
-            # we want an --authfile in the args instead
-            assert "--authfile" in args
+            _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
             if args[1] == "copy" and args[8].endswith(":updated"):
@@ -571,18 +533,7 @@ def test_mirror_config_server_hostname(run_skopeo_mock, initialized_db, app, mon
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            # since we change from credentials to authfile we need to check the diff
-            auth_diff = set(skopeo_call["args"]).difference(set(args))
-            assert any(
-                [
-                    auth_diff == set(),
-                    "--creds" in auth_diff,
-                    "--dest-creds" in auth_diff,
-                    "--src-creds" in auth_diff,
-                ]
-            )
-            # we want an --authfile in the args instead
-            assert "--authfile" in args
+            _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -649,18 +600,7 @@ def test_quote_params(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            # since we change from credentials to authfile we need to check the diff
-            auth_diff = set(skopeo_call["args"]).difference(set(args))
-            assert any(
-                [
-                    auth_diff == set(),
-                    "--creds" in auth_diff,
-                    "--dest-creds" in auth_diff,
-                    "--src-creds" in auth_diff,
-                ]
-            )
-            # we want an --authfile in the args instead
-            assert "--authfile" in args
+            _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -724,18 +664,7 @@ def test_quote_params_password(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            # since we change from credentials to authfile we need to check the diff
-            auth_diff = set(skopeo_call["args"]).difference(set(args))
-            assert any(
-                [
-                    auth_diff == set(),
-                    "--creds" in auth_diff,
-                    "--dest-creds" in auth_diff,
-                    "--src-creds" in auth_diff,
-                ]
-            )
-            # we want an --authfile in the args instead
-            assert "--authfile" in args
+            _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
             return skopeo_call["results"]
@@ -764,18 +693,7 @@ def test_inspect_error_mirror(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            # since we change from credentials to authfile we need to check the diff
-            auth_diff = set(skopeo_call["args"]).difference(set(args))
-            assert any(
-                [
-                    auth_diff == set(),
-                    "--creds" in auth_diff,
-                    "--dest-creds" in auth_diff,
-                    "--src-creds" in auth_diff,
-                ]
-            )
-            # we want an --authfile in the args instead
-            assert "--authfile" in args
+            _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
             return skopeo_call["results"]

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -33,16 +33,17 @@ from workers.repomirrorworker.repomirrorworker import RepoMirrorWorker
 
 
 def _assert_skopeo_args(actual_args, expected_args):
-    """Assert skopeo args match expected, ignoring the transient --authfile <tmppath> pair."""
+    """Assert skopeo args match, stripping transient --authfile and legacy inline --*-creds pairs."""
 
-    def strip_authfile(args):
+    def strip_cred_flags(args):
         a = list(args)
-        if "--authfile" in a:
-            i = a.index("--authfile")
-            del a[i : i + 2]
+        for flag in ("--authfile", "--src-creds", "--dest-creds", "--creds"):
+            while flag in a:
+                i = a.index(flag)
+                del a[i : i + 2]
         return a
 
-    assert strip_authfile(actual_args) == strip_authfile(expected_args)
+    assert strip_cred_flags(actual_args) == strip_cred_flags(expected_args)
     assert "--authfile" in actual_args
 
 

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -45,6 +45,8 @@ def _assert_skopeo_args(actual_args, expected_args):
 
     assert strip_cred_flags(actual_args) == strip_cred_flags(expected_args)
     assert "--authfile" in actual_args
+    for legacy in ("--src-creds", "--dest-creds", "--creds"):
+        assert legacy not in actual_args
 
 
 def disable_existing_mirrors(func):

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -898,7 +898,7 @@ def test_mirror_with_architecture_filter(run_skopeo_mock, push_manifest_mock, in
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            _assert_skopeo_args(args, skopeo_call["args"])
             return skopeo_call["results"]
         except Exception as e:
             skopeo_calls.append(skopeo_call)
@@ -967,7 +967,7 @@ def test_mirror_without_architecture_filter_uses_all(run_skopeo_mock, initialize
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            _assert_skopeo_args(args, skopeo_call["args"])
             return skopeo_call["results"]
         except Exception as e:
             skopeo_calls.append(skopeo_call)
@@ -1056,7 +1056,7 @@ def test_mirror_single_arch_image_with_matching_filter(run_skopeo_mock, initiali
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            _assert_skopeo_args(args, skopeo_call["args"])
             return skopeo_call["results"]
         except Exception as e:
             skopeo_calls.append(skopeo_call)
@@ -1119,7 +1119,7 @@ def test_mirror_single_arch_image_with_nonmatching_filter(run_skopeo_mock, initi
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            _assert_skopeo_args(args, skopeo_call["args"])
             return skopeo_call["results"]
         except Exception as e:
             skopeo_calls.append(skopeo_call)
@@ -1263,7 +1263,7 @@ def test_mirror_mixed_tags_with_architecture_filter(
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            _assert_skopeo_args(args, skopeo_call["args"])
             return skopeo_call["results"]
         except Exception as e:
             skopeo_calls.append(skopeo_call)
@@ -1325,7 +1325,7 @@ def test_mirror_no_matching_architectures(run_skopeo_mock, initialized_db, app):
     def skopeo_test(args, proxy, timeout=300):
         try:
             skopeo_call = skopeo_calls.pop(0)
-            assert args == skopeo_call["args"]
+            _assert_skopeo_args(args, skopeo_call["args"])
             return skopeo_call["results"]
         except Exception as e:
             skopeo_calls.append(skopeo_call)
@@ -2108,7 +2108,7 @@ def test_perform_mirror_empty_tags(run_skopeo_mock, initialized_db, app):
 
     def skopeo_test(args, _proxy, timeout=300):
         skopeo_call = skopeo_calls.pop(0)
-        assert args == skopeo_call["args"]
+        _assert_skopeo_args(args, skopeo_call["args"])
         return skopeo_call["results"]
 
     run_skopeo_mock.side_effect = skopeo_test
@@ -2162,7 +2162,7 @@ def test_perform_mirror_cancel_during_sync(mock_check_status, run_skopeo_mock, i
 
     def skopeo_test(args, _proxy, timeout=300):
         skopeo_call = skopeo_calls.pop(0)
-        assert args == skopeo_call["args"]
+        _assert_skopeo_args(args, skopeo_call["args"])
         return skopeo_call["results"]
 
     run_skopeo_mock.side_effect = skopeo_test


### PR DESCRIPTION
## Summary

Rebase and cleanup of #3681 (authored by @michaelalang).

- Replace skopeo `--dest-creds`/`--src-creds`/`--creds` CLI flags with a temporary `auth.json` file passed via `--authfile`, so credentials are never visible in `ps`/process listings
- Update `test_repomirrorworker.py` tests to assert `--authfile` is present instead of `--creds` flags
- Add new `util/test/test_skopeomirror.py` unit tests for `create_authfile_content` and `AuthContent`

**Fixes applied during rebase:**
- Resolved conflict with master's `sanitize_skopeo_output` / `_SANITIZE_PATTERNS` additions; kept both
- `SKOPEO_TIMEOUT_SECONDS = 300` constant added (imported by new tests)
- `from pipes import quote` → `from shlex import quote` (`pipes` module removed in Python 3.13)
- `create_authfile_content` mutable default argument removed
- `filter` now excludes `None` usernames in addition to empty strings, preventing spurious authfile entries for unauthenticated calls

Closes #3681

## Test plan
- [ ] `TEST=true PYTHONPATH="." pytest util/test/test_skopeomirror.py::test_create_authfile_content` — passes locally
- [ ] CI unit tests
- [ ] CI pre-commit / types checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)