### PR TITLE
QUAYIO-1726: fix(otel): prevent BatchSpanProcessor crash under gevent monkey-patching

### DIFF
--- a/util/metrics/otel.py
+++ b/util/metrics/otel.py
@@ -1,3 +1,5 @@
+import logging
+import threading
 from functools import wraps
 
 from opentelemetry import trace
@@ -9,8 +11,30 @@ from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 
 import features
 
+logger = logging.getLogger(__name__)
+
+
+def _patch_gevent_thread_cleanup():
+    """
+    Under gevent monkey-patching, BatchSpanProcessor's daemon thread becomes
+    a greenlet.  When it terminates, threading._delete() raises KeyError
+    because the greenlet ID was never registered in threading._active.
+    Patch Thread._delete to suppress that KeyError.
+    """
+    original = threading.Thread._delete
+
+    def _safe_delete(self):
+        try:
+            original(self)
+        except KeyError:
+            logger.debug("Suppressed KeyError in Thread._delete (likely gevent greenlet)")
+
+    threading.Thread._delete = _safe_delete
+
 
 def init_exporter(app_config):
+
+    _patch_gevent_thread_cleanup()
 
     otel_config = app_config.get("OTEL_CONFIG", {})
 

--- a/util/metrics/otel.py
+++ b/util/metrics/otel.py
@@ -20,7 +20,21 @@ def _patch_gevent_thread_cleanup():
     a greenlet.  When it terminates, threading._delete() raises KeyError
     because the greenlet ID was never registered in threading._active.
     Patch Thread._delete to suppress that KeyError.
+
+    Guarded: only applies when gevent has monkey-patched threading.
+    Idempotent: a marker attribute prevents re-wrapping on repeated calls.
     """
+    if getattr(threading.Thread._delete, "_quay_gevent_patched", False):
+        return
+
+    try:
+        from gevent import monkey
+    except ImportError:
+        return
+
+    if not monkey.is_module_patched("threading"):
+        return
+
     original = threading.Thread._delete
 
     def _safe_delete(self):
@@ -29,6 +43,7 @@ def _patch_gevent_thread_cleanup():
         except KeyError:
             logger.debug("Suppressed KeyError in Thread._delete (likely gevent greenlet)")
 
+    _safe_delete._quay_gevent_patched = True
     threading.Thread._delete = _safe_delete
 
 

--- a/util/metrics/test/test_otel.py
+++ b/util/metrics/test/test_otel.py
@@ -1,0 +1,122 @@
+"""
+Tests for util/metrics/otel.py.
+
+Validates that _patch_gevent_thread_cleanup() prevents the KeyError crash
+when a greenlet-backed thread terminates under gevent monkey-patching,
+and that init_exporter() still sets up the OTel pipeline correctly.
+"""
+
+import threading
+from unittest.mock import patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from util.metrics.otel import _patch_gevent_thread_cleanup, init_exporter
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracer_provider():
+    """Reset the global OTel TracerProvider before each test."""
+    trace._TRACER_PROVIDER = None
+    trace._TRACER_PROVIDER_SET_ONCE._done = False
+    yield
+    trace._TRACER_PROVIDER = None
+    trace._TRACER_PROVIDER_SET_ONCE._done = False
+
+
+class TestPatchGeventThreadCleanup:
+    def test_thread_delete_suppresses_key_error(self):
+        _patch_gevent_thread_cleanup()
+
+        t = threading.Thread(target=lambda: None)
+        t.start()
+        t.join()
+
+        # Simulate the gevent bug: calling _delete() when the thread ID
+        # is not in threading._active should not raise.
+        threading._active.pop(t.ident, None)
+        t._delete()  # would raise KeyError without the patch
+
+    def test_thread_delete_still_works_normally(self):
+        _patch_gevent_thread_cleanup()
+
+        t = threading.Thread(target=lambda: None)
+        t.start()
+        t.join()
+
+        # Normal _delete() on a thread that IS in _active should work fine.
+        if t.ident in threading._active:
+            t._delete()
+        assert t.ident not in threading._active
+
+    def test_patch_is_idempotent(self):
+        _patch_gevent_thread_cleanup()
+        _patch_gevent_thread_cleanup()
+
+        t = threading.Thread(target=lambda: None)
+        t.start()
+        t.join()
+        threading._active.pop(t.ident, None)
+        t._delete()  # should still not raise
+
+
+class TestInitExporter:
+    def test_sets_tracer_provider(self):
+        config = {"OTEL_CONFIG": {"service_name": "test-quay"}}
+        init_exporter(config)
+
+        provider = trace.get_tracer_provider()
+        assert isinstance(provider, TracerProvider)
+
+    def test_configures_dynatrace_exporter(self):
+        config = {
+            "OTEL_CONFIG": {
+                "service_name": "test-quay",
+                "dt_api_url": "https://dt.example.com/api/v2/otlp",
+                "dt_api_token": "fake-token",
+            }
+        }
+        with patch("util.metrics.otel.OTLPSpanExporter") as mock_cls:
+            mock_cls.return_value = InMemorySpanExporter()
+            init_exporter(config)
+
+        mock_cls.assert_called_once_with(
+            endpoint="https://dt.example.com/api/v2/otlp/v1/traces",
+            headers={"Authorization": "Api-Token fake-token"},
+        )
+
+    def test_uses_batch_span_processor(self):
+        config = {"OTEL_CONFIG": {"service_name": "test-quay"}}
+        with patch("util.metrics.otel.OTLPSpanExporter", return_value=InMemorySpanExporter()):
+            init_exporter(config)
+
+        provider = trace.get_tracer_provider()
+        processors = provider._active_span_processor._span_processors
+        assert any(isinstance(p, BatchSpanProcessor) for p in processors)
+
+
+class TestSpanExportPipeline:
+    """Verify spans flow through the pipeline end-to-end."""
+
+    def test_span_exported_successfully(self):
+        in_memory = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(BatchSpanProcessor(in_memory))
+        trace.set_tracer_provider(provider)
+
+        _patch_gevent_thread_cleanup()
+
+        tracer = trace.get_tracer("test-tracer")
+        with tracer.start_as_current_span("test-span") as span:
+            span.set_attribute("test.key", "test-value")
+
+        provider.force_flush()
+
+        exported = in_memory.get_finished_spans()
+        assert len(exported) == 1
+        assert exported[0].name == "test-span"
+        assert exported[0].attributes["test.key"] == "test-value"

--- a/util/metrics/test/test_otel.py
+++ b/util/metrics/test/test_otel.py
@@ -7,7 +7,7 @@ and that init_exporter() still sets up the OTel pipeline correctly.
 """
 
 import threading
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from opentelemetry import trace
@@ -19,49 +19,95 @@ from util.metrics.otel import _patch_gevent_thread_cleanup, init_exporter
 
 
 @pytest.fixture(autouse=True)
-def _reset_tracer_provider():
-    """Reset the global OTel TracerProvider before each test."""
+def _reset_globals():
+    """Reset OTel TracerProvider and threading.Thread._delete between tests."""
+    original_delete = threading.Thread._delete
     trace._TRACER_PROVIDER = None
     trace._TRACER_PROVIDER_SET_ONCE._done = False
     yield
+    threading.Thread._delete = original_delete
     trace._TRACER_PROVIDER = None
     trace._TRACER_PROVIDER_SET_ONCE._done = False
 
 
 class TestPatchGeventThreadCleanup:
-    def test_thread_delete_suppresses_key_error(self):
-        _patch_gevent_thread_cleanup()
+    def _enable_patch(self):
+        """Mock gevent.monkey.is_module_patched to return True so the guard passes."""
+        mock_monkey = MagicMock()
+        mock_monkey.is_module_patched.return_value = True
+        return patch.dict("sys.modules", {"gevent": MagicMock(monkey=mock_monkey)})
+
+    def test_suppresses_key_error(self):
+        """When original _delete raises KeyError, the wrapper suppresses it."""
+        original = threading.Thread._delete
+
+        def _raise_key_error(self):
+            raise KeyError(threading.get_ident())
+
+        threading.Thread._delete = _raise_key_error
+
+        with self._enable_patch():
+            _patch_gevent_thread_cleanup()
 
         t = threading.Thread(target=lambda: None)
-        t.start()
-        t.join()
+        t._delete()  # should not raise
 
-        # Simulate the gevent bug: calling _delete() when the thread ID
-        # is not in threading._active should not raise.
-        threading._active.pop(t.ident, None)
-        t._delete()  # would raise KeyError without the patch
+    def test_propagates_other_exceptions(self):
+        """Non-KeyError exceptions are not suppressed."""
+        original = threading.Thread._delete
 
-    def test_thread_delete_still_works_normally(self):
-        _patch_gevent_thread_cleanup()
+        def _raise_runtime(self):
+            raise RuntimeError("unexpected")
+
+        threading.Thread._delete = _raise_runtime
+
+        with self._enable_patch():
+            _patch_gevent_thread_cleanup()
 
         t = threading.Thread(target=lambda: None)
-        t.start()
-        t.join()
-
-        # Normal _delete() on a thread that IS in _active should work fine.
-        if t.ident in threading._active:
+        with pytest.raises(RuntimeError, match="unexpected"):
             t._delete()
-        assert t.ident not in threading._active
 
-    def test_patch_is_idempotent(self):
-        _patch_gevent_thread_cleanup()
-        _patch_gevent_thread_cleanup()
+    def test_calls_through_when_no_error(self):
+        """When the original _delete succeeds, the wrapper calls it normally."""
+        calls = []
+
+        def _tracking_delete(self):
+            calls.append(self)
+
+        threading.Thread._delete = _tracking_delete
+
+        with self._enable_patch():
+            _patch_gevent_thread_cleanup()
 
         t = threading.Thread(target=lambda: None)
-        t.start()
-        t.join()
-        threading._active.pop(t.ident, None)
-        t._delete()  # should still not raise
+        t._delete()
+        assert calls == [t]
+
+    def test_idempotent(self):
+        """Calling _patch_gevent_thread_cleanup multiple times doesn't re-wrap."""
+        with self._enable_patch():
+            _patch_gevent_thread_cleanup()
+            first_delete = threading.Thread._delete
+
+            _patch_gevent_thread_cleanup()
+            assert threading.Thread._delete is first_delete
+
+    def test_skips_when_gevent_not_installed(self):
+        """When gevent is not importable, _delete is not patched."""
+        original = threading.Thread._delete
+        with patch.dict("sys.modules", {"gevent": None}):
+            _patch_gevent_thread_cleanup()
+        assert threading.Thread._delete is original
+
+    def test_skips_when_threading_not_patched(self):
+        """When gevent hasn't monkey-patched threading, _delete is not patched."""
+        original = threading.Thread._delete
+        mock_monkey = MagicMock()
+        mock_monkey.is_module_patched.return_value = False
+        with patch.dict("sys.modules", {"gevent": MagicMock(monkey=mock_monkey)}):
+            _patch_gevent_thread_cleanup()
+        assert threading.Thread._delete is original
 
 
 class TestInitExporter:
@@ -107,8 +153,6 @@ class TestSpanExportPipeline:
         provider = TracerProvider()
         provider.add_span_processor(BatchSpanProcessor(in_memory))
         trace.set_tracer_provider(provider)
-
-        _patch_gevent_thread_cleanup()
 
         tracer = trace.get_tracer("test-tracer")
         with tracer.start_as_current_span("test-span") as span:


### PR DESCRIPTION
Patch threading.Thread._delete to suppress the KeyError raised when a gevent greenlet-backed daemon thread terminates without being registered in threading._active.

Made-with: Cursor

### Testing

```
Local integration test:

Added FEATURE_OTEL_TRACING: true to local-dev/stack/config.yaml
Ran make local-dev-up, restarted quay container
Sent 10 requests to http://localhost:8080/v2/ to exercise the OTel pipeline
Waited for BatchSpanProcessor background thread export cycle
Verified docker logs quay-quay shows no KeyError from threading._delete
Verified container stays running (no crash-loop)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents intermittent thread-cleanup errors during OpenTelemetry exporter initialization, improving span-processing stability.
* **Tests**
  * Added comprehensive tests for OpenTelemetry utilities: exporter configuration (Dynatrace endpoint and Api-Token header), span processing pipeline, and thread-cleanup edge cases including end-to-end span export verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->