### PR TITLE
PROJQUAY-11359: feat(claude): add cluster-provision skill for ephemeral OpenShift clusters

### DIFF
--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -11,7 +11,7 @@ KUBECONFIG_OUT="${2:-/tmp/k}"
 OCP_VERSION="${3:-4.18}"
 
 GANGWAY_BASE="https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com"
-JOB_NAME="periodic-ci-quay-quay-master-claim-cluster-for-dev"
+JOB_NAME="periodic-ci-quay-quay-master-claim-claim-cluster"
 STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cluster-provision-${UID}"
 STATE_FILE="${STATE_DIR}/state.json"
 
@@ -19,9 +19,9 @@ POLL_INTERVAL_INITIAL=15
 POLL_INTERVAL_MAX=30
 POLL_TIMEOUT=2400  # 40 minutes
 
-GCS_BUCKETS=("test-platform-results" "origin-ci-test")
 GCSWEB_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
-ARTIFACT_SUBPATH="artifacts/claim-cluster-for-dev/export-kubeconfig/kubeconfig"
+ARTIFACT_SUBPATH="artifacts/claim-cluster/export-kubeconfig/artifacts/kubeconfig.enc"
+ENCRYPTION_KEY="${CLUSTER_PROVISION_KEY:-}"
 
 CURL_CONNECT_TIMEOUT=10
 CURL_MAX_TIME=30
@@ -55,7 +55,14 @@ check_prereqs() {
         echo "For a permanent token, join the appropriate Rover group."
         exit 1
     fi
-    for cmd in curl jq; do
+    if [[ -z "${ENCRYPTION_KEY}" ]]; then
+        echo "CLUSTER_PROVISION_KEY is not set."
+        echo ""
+        echo "This is the passphrase used to decrypt the cluster kubeconfig."
+        echo "Contact the Quay CI team for access."
+        exit 1
+    fi
+    for cmd in curl jq openssl; do
         command -v "$cmd" >/dev/null 2>&1 || die "'$cmd' is required but not found on PATH"
     done
 }
@@ -139,27 +146,38 @@ update_state_field() {
     fi
 }
 
-try_download_kubeconfig() {
-    local gcs_path="$1"
-    local bucket url http_code tmpfile
+gcs_from_url() {
+    local job_url="$1"
+    echo "$job_url" | sed -n 's|.*/view/gs/||p'
+}
 
-    for bucket in "${GCS_BUCKETS[@]}"; do
-        url="${GCSWEB_BASE}/${bucket}/${gcs_path}/${ARTIFACT_SUBPATH}"
-        tmpfile=$(mktemp)
-        if ! http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
-            --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time 60 \
-            "$url"); then
-            rm -f "$tmpfile"
-            continue
-        fi
-        if [[ "$http_code" == "200" ]] && [[ -s "$tmpfile" ]]; then
-            mkdir -p "$(dirname "$KUBECONFIG_OUT")"
-            mv "$tmpfile" "$KUBECONFIG_OUT"
-            chmod 600 "$KUBECONFIG_OUT"
-            return 0
-        fi
+try_download_kubeconfig() {
+    local gcs_root="$1"
+    local url http_code tmpfile
+    url="${GCSWEB_BASE}/${gcs_root}/${ARTIFACT_SUBPATH}"
+    tmpfile=$(mktemp)
+    if ! http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+        --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time 60 \
+        "$url"); then
         rm -f "$tmpfile"
-    done
+        return 1
+    fi
+    if [[ "$http_code" == "200" ]] && [[ -s "$tmpfile" ]]; then
+        mkdir -p "$(dirname "$KUBECONFIG_OUT")"
+        if openssl enc -d -aes-256-cbc -pbkdf2 \
+            -pass pass:"${ENCRYPTION_KEY}" \
+            -in "$tmpfile" \
+            -out "${KUBECONFIG_OUT}"; then
+            chmod 600 "$KUBECONFIG_OUT"
+            rm -f "$tmpfile"
+            return 0
+        else
+            echo "WARNING: Failed to decrypt kubeconfig. Wrong CLUSTER_PROVISION_KEY?" >&2
+            rm -f "$tmpfile"
+            return 1
+        fi
+    fi
+    rm -f "$tmpfile"
     return 1
 }
 
@@ -218,8 +236,10 @@ validate_cluster() {
 
 poll_and_download() {
     local exec_id="$1"
-    local start_epoch interval status gcs_path elapsed response
+    local job_url="$2"
+    local gcs_root start_epoch interval status elapsed response
 
+    gcs_root=$(gcs_from_url "$job_url")
     start_epoch=$(epoch_now)
     interval=$POLL_INTERVAL_INITIAL
 
@@ -228,47 +248,35 @@ poll_and_download() {
     while true; do
         elapsed=$(( $(epoch_now) - start_epoch ))
         if (( elapsed > POLL_TIMEOUT )); then
-            local job_url
-            job_url=$(jq -r '.job_url // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
             die "Timed out after ${POLL_TIMEOUT}s waiting for cluster. Check job: ${job_url}"
         fi
 
         response=$(gangway_get "/v1/executions/${exec_id}")
         status=$(echo "$response" | jq -r '.job_status // empty')
-        gcs_path=$(echo "$response" | jq -r '.gcs_path // empty')
 
         update_state_field "status" "$status"
-        if [[ -n "$gcs_path" ]]; then
-            update_state_field "gcs_path" "$gcs_path"
-        fi
 
         case "$status" in
             FAILURE|ERROR|ABORTED)
-                local job_url
-                job_url=$(echo "$response" | jq -r '.job_url // "unknown"')
                 die "Job ended with status ${status}. Check: ${job_url}"
                 ;;
         esac
 
-        if [[ -n "$gcs_path" ]]; then
-            if try_download_kubeconfig "$gcs_path"; then
-                update_state_field "status" "READY"
-                info "Kubeconfig downloaded to ${KUBECONFIG_OUT}"
-                validate_cluster
-                echo ""
-                echo "=== Cluster Ready ==="
-                echo "Kubeconfig: ${KUBECONFIG_OUT}"
-                echo "Usage:      export KUBECONFIG=${KUBECONFIG_OUT}"
-                echo "            oc whoami"
-                local job_url
-                job_url=$(jq -r '.job_url // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
-                echo "Job URL:    ${job_url}"
-                echo "Note:       Cluster auto-expires in ~4 hours"
-                return 0
-            fi
+        if [[ -n "$gcs_root" ]] && try_download_kubeconfig "$gcs_root"; then
+            update_state_field "status" "READY"
+            info "Kubeconfig downloaded to ${KUBECONFIG_OUT}"
+            validate_cluster
+            echo ""
+            echo "=== Cluster Ready ==="
+            echo "Kubeconfig: ${KUBECONFIG_OUT}"
+            echo "Usage:      export KUBECONFIG=${KUBECONFIG_OUT}"
+            echo "            oc whoami"
+            echo "Job URL:    ${job_url}"
+            echo "Note:       Cluster auto-expires in ~4 hours"
+            return 0
         fi
 
-        info "Status: ${status} | GCS path: ${gcs_path:-not yet available} | Elapsed: ${elapsed}s | Next check in ${interval}s"
+        info "Status: ${status} | Elapsed: ${elapsed}s | Next check in ${interval}s"
         sleep "$interval"
         if (( interval < POLL_INTERVAL_MAX )); then
             interval=$POLL_INTERVAL_MAX
@@ -281,14 +289,15 @@ up() {
 
     if [[ -f "$STATE_FILE" ]]; then
         [[ -L "$STATE_FILE" ]] && die "Refusing to read symlinked state file: $STATE_FILE"
-        local existing_id existing_status
+        local existing_id existing_status existing_job_url
         existing_id=$(jq -r '.execution_id // empty' "$STATE_FILE")
         existing_status=$(jq -r '.status // empty' "$STATE_FILE")
 
         if [[ -n "$existing_id" && "$existing_status" != "FAILURE" && "$existing_status" != "ERROR" && "$existing_status" != "ABORTED" ]]; then
             info "Found existing execution ${existing_id} (status: ${existing_status}). Resuming..."
+            existing_job_url=$(jq -r '.job_url // empty' "$STATE_FILE")
             update_state_field "kubeconfig_path" "$KUBECONFIG_OUT"
-            poll_and_download "$existing_id"
+            poll_and_download "$existing_id" "$existing_job_url"
             return $?
         fi
     fi
@@ -318,7 +327,7 @@ up() {
 
     save_state "$exec_id" "$gcs_path" "$job_url" "$KUBECONFIG_OUT" "$(iso_now)" "$job_status"
 
-    poll_and_download "$exec_id"
+    poll_and_download "$exec_id" "$job_url"
 }
 
 down() {

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -12,7 +12,7 @@ OCP_VERSION="${3:-4.18}"
 
 GANGWAY_BASE="https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com"
 JOB_NAME="periodic-ci-quay-quay-master-claim-cluster-for-dev"
-STATE_DIR="/tmp/cluster-provision"
+STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cluster-provision-${UID}"
 STATE_FILE="${STATE_DIR}/state.json"
 
 POLL_INTERVAL_INITIAL=15
@@ -64,13 +64,17 @@ gangway_post() {
     local endpoint="$1" payload="$2"
     local http_code body tmpfile
     tmpfile=$(mktemp)
-    http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+    if ! http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
         --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time "$CURL_MAX_TIME" \
         -X POST \
         -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
         -H "Content-Type: application/json" \
         -d "$payload" \
-        "${GANGWAY_BASE}${endpoint}")
+        "${GANGWAY_BASE}${endpoint}"); then
+        body=$(cat "$tmpfile" 2>/dev/null || true)
+        rm -f "$tmpfile"
+        die "Gangway API POST ${endpoint} transport error: ${body}"
+    fi
     body=$(cat "$tmpfile")
     rm -f "$tmpfile"
 
@@ -87,10 +91,14 @@ gangway_get() {
     local endpoint="$1"
     local http_code body tmpfile
     tmpfile=$(mktemp)
-    http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+    if ! http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
         --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time "$CURL_MAX_TIME" \
         -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
-        "${GANGWAY_BASE}${endpoint}")
+        "${GANGWAY_BASE}${endpoint}"); then
+        body=$(cat "$tmpfile" 2>/dev/null || true)
+        rm -f "$tmpfile"
+        die "Gangway API GET ${endpoint} transport error: ${body}"
+    fi
     body=$(cat "$tmpfile")
     rm -f "$tmpfile"
 
@@ -104,7 +112,8 @@ gangway_get() {
 }
 
 save_state() {
-    mkdir -p "$STATE_DIR"
+    mkdir -p -m 700 "$STATE_DIR"
+    [[ -L "$STATE_FILE" ]] && die "Refusing to write through symlinked state file: $STATE_FILE"
     cat > "$STATE_FILE" <<STATEEOF
 {
   "execution_id": "$1",
@@ -120,6 +129,7 @@ STATEEOF
 update_state_field() {
     local field="$1" value="$2"
     if [[ -f "$STATE_FILE" ]]; then
+        [[ -L "$STATE_FILE" ]] && die "Refusing to write through symlinked state file: $STATE_FILE"
         local tmp
         tmp=$(jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$STATE_FILE")
         echo "$tmp" > "$STATE_FILE"
@@ -133,9 +143,12 @@ try_download_kubeconfig() {
     for bucket in "${GCS_BUCKETS[@]}"; do
         url="${GCSWEB_BASE}/${bucket}/${gcs_path}/${ARTIFACT_SUBPATH}"
         tmpfile=$(mktemp)
-        http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+        if ! http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
             --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time 60 \
-            "$url")
+            "$url"); then
+            rm -f "$tmpfile"
+            continue
+        fi
         if [[ "$http_code" == "200" ]] && [[ -s "$tmpfile" ]]; then
             mv "$tmpfile" "$KUBECONFIG_OUT"
             chmod 600 "$KUBECONFIG_OUT"
@@ -224,12 +237,14 @@ up() {
     check_prereqs
 
     if [[ -f "$STATE_FILE" ]]; then
+        [[ -L "$STATE_FILE" ]] && die "Refusing to read symlinked state file: $STATE_FILE"
         local existing_id existing_status
         existing_id=$(jq -r '.execution_id // empty' "$STATE_FILE")
         existing_status=$(jq -r '.status // empty' "$STATE_FILE")
 
         if [[ -n "$existing_id" && "$existing_status" != "FAILURE" && "$existing_status" != "ERROR" && "$existing_status" != "ABORTED" ]]; then
             info "Found existing execution ${existing_id} (status: ${existing_status}). Resuming..."
+            update_state_field "kubeconfig_path" "$KUBECONFIG_OUT"
             poll_and_download "$existing_id"
             return $?
         fi
@@ -265,6 +280,7 @@ up() {
 
 down() {
     if [[ -f "$STATE_FILE" ]]; then
+        [[ -L "$STATE_FILE" ]] && die "Refusing to read symlinked state file: $STATE_FILE"
         local kubeconfig_path
         kubeconfig_path=$(jq -r '.kubeconfig_path // empty' "$STATE_FILE")
         info "Cleaning up state..."
@@ -287,6 +303,8 @@ status() {
         echo "No active cluster provision."
         return 0
     fi
+
+    [[ -L "$STATE_FILE" ]] && die "Refusing to read symlinked state file: $STATE_FILE"
 
     local state exec_id started_at cur_status kubeconfig_path job_url gcs_path
     state=$(cat "$STATE_FILE")

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -112,7 +112,9 @@ gangway_get() {
 }
 
 save_state() {
-    mkdir -p -m 700 "$STATE_DIR"
+    mkdir -p "$STATE_DIR"
+    chmod 700 "$STATE_DIR"
+    [[ -L "$STATE_DIR" ]] && die "Refusing to write through symlinked state dir: $STATE_DIR"
     [[ -L "$STATE_FILE" ]] && die "Refusing to write through symlinked state file: $STATE_FILE"
     jq -n \
         --arg eid "$1" \
@@ -128,10 +130,12 @@ save_state() {
 update_state_field() {
     local field="$1" value="$2"
     if [[ -f "$STATE_FILE" ]]; then
+        [[ -L "$STATE_DIR" ]] && die "Refusing to write through symlinked state dir: $STATE_DIR"
         [[ -L "$STATE_FILE" ]] && die "Refusing to write through symlinked state file: $STATE_FILE"
-        local tmp
-        tmp=$(jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$STATE_FILE")
-        echo "$tmp" > "$STATE_FILE"
+        local tmpfile
+        tmpfile=$(mktemp "${STATE_DIR}/.state.XXXXXX")
+        jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$STATE_FILE" > "$tmpfile"
+        mv "$tmpfile" "$STATE_FILE"
     fi
 }
 
@@ -149,6 +153,7 @@ try_download_kubeconfig() {
             continue
         fi
         if [[ "$http_code" == "200" ]] && [[ -s "$tmpfile" ]]; then
+            mkdir -p "$(dirname "$KUBECONFIG_OUT")"
             mv "$tmpfile" "$KUBECONFIG_OUT"
             chmod 600 "$KUBECONFIG_OUT"
             return 0

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -203,16 +203,16 @@ ensure_oc() {
 
 validate_cluster() {
     ensure_oc
-    if command -v oc >/dev/null 2>&1; then
-        local server
-        server=$(oc --kubeconfig="$KUBECONFIG_OUT" whoami --show-server 2>/dev/null || true)
-        if [[ -n "$server" ]]; then
-            info "Cluster validated — server: ${server}"
-        else
-            echo "WARNING: Could not validate cluster connectivity. The kubeconfig was downloaded but 'oc whoami --show-server' failed."
-        fi
+    if ! command -v oc >/dev/null 2>&1; then
+        echo "WARNING: could not install 'oc' — skipping cluster validation."
+        return
+    fi
+    local server
+    server=$(oc --kubeconfig="$KUBECONFIG_OUT" whoami --show-server 2>/dev/null || true)
+    if [[ -n "$server" ]]; then
+        info "Cluster validated — server: ${server}"
     else
-        echo "WARNING: 'oc' not found on PATH. Skipping cluster validation. Install 'oc' to verify connectivity."
+        echo "WARNING: Could not validate cluster connectivity. The kubeconfig was downloaded but 'oc whoami --show-server' failed."
     fi
 }
 
@@ -396,19 +396,19 @@ status() {
         fi
     fi
 
-    if [[ -f "$kubeconfig_path" ]] && command -v oc >/dev/null 2>&1; then
-        echo ""
-        info "Testing cluster connectivity..."
-        local server
-        server=$(oc --kubeconfig="$kubeconfig_path" whoami --show-server 2>/dev/null || true)
-        if [[ -n "$server" ]]; then
-            echo "Cluster:       ${server} (reachable)"
-        else
-            echo "Cluster:       NOT reachable"
+    if [[ -f "$kubeconfig_path" ]]; then
+        ensure_oc
+        if command -v oc >/dev/null 2>&1; then
+            echo ""
+            info "Testing cluster connectivity..."
+            local server
+            server=$(oc --kubeconfig="$kubeconfig_path" whoami --show-server 2>/dev/null || true)
+            if [[ -n "$server" ]]; then
+                echo "Cluster:       ${server} (reachable)"
+            else
+                echo "Cluster:       NOT reachable"
+            fi
         fi
-    elif [[ -f "$kubeconfig_path" ]]; then
-        echo ""
-        echo "Kubeconfig exists but 'oc' is not on PATH — cannot test connectivity."
     fi
 }
 

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -163,7 +163,46 @@ try_download_kubeconfig() {
     return 1
 }
 
+ensure_oc() {
+    if command -v oc >/dev/null 2>&1; then
+        return 0
+    fi
+    info "oc not found — installing..."
+    local arch tmpdir tarball
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64)  arch="amd64" ;;
+        aarch64) arch="arm64" ;;
+        *)       echo "WARNING: unsupported arch $arch — skipping oc install"; return 1 ;;
+    esac
+    tmpdir=$(mktemp -d)
+    tarball="${tmpdir}/oc.tar.gz"
+    if curl -sL --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time 120 \
+        -o "$tarball" \
+        "https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/ocp/stable/openshift-client-linux.tar.gz"; then
+        tar -xzf "$tarball" -C "$tmpdir" oc 2>/dev/null
+        if [[ -x "${tmpdir}/oc" ]]; then
+            mv "${tmpdir}/oc" /usr/local/bin/oc 2>/dev/null || mv "${tmpdir}/oc" "${HOME}/.local/bin/oc" 2>/dev/null || {
+                export PATH="${tmpdir}:${PATH}"
+                info "oc installed to ${tmpdir}/oc (added to PATH)"
+                return 0
+            }
+            info "oc installed to $(command -v oc)"
+        else
+            echo "WARNING: failed to extract oc from tarball"
+            rm -rf "$tmpdir"
+            return 1
+        fi
+    else
+        echo "WARNING: failed to download oc binary"
+        rm -rf "$tmpdir"
+        return 1
+    fi
+    rm -f "$tarball"
+}
+
 validate_cluster() {
+    ensure_oc
     if command -v oc >/dev/null 2>&1; then
         local server
         server=$(oc --kubeconfig="$KUBECONFIG_OUT" whoami --show-server 2>/dev/null || true)

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -279,6 +279,7 @@ up() {
 }
 
 down() {
+    command -v jq >/dev/null 2>&1 || die "'jq' is required but not found on PATH"
     if [[ -f "$STATE_FILE" ]]; then
         [[ -L "$STATE_FILE" ]] && die "Refusing to read symlinked state file: $STATE_FILE"
         local kubeconfig_path
@@ -299,6 +300,7 @@ down() {
 }
 
 status() {
+    command -v jq >/dev/null 2>&1 || die "'jq' is required but not found on PATH"
     if [[ ! -f "$STATE_FILE" ]]; then
         echo "No active cluster provision."
         return 0

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -16,7 +16,7 @@ STATE_DIR="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/cluster-provision-${UID}"
 STATE_FILE="${STATE_DIR}/state.json"
 
 POLL_INTERVAL_INITIAL=15
-POLL_INTERVAL_MAX=30
+POLL_INTERVAL_MAX=60
 POLL_TIMEOUT=2400  # 40 minutes
 
 GCSWEB_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
@@ -96,26 +96,35 @@ gangway_post() {
 
 gangway_get() {
     local endpoint="$1"
-    local http_code body tmpfile
-    tmpfile=$(mktemp)
-    if ! http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
-        --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time "$CURL_MAX_TIME" \
-        -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
-        "${GANGWAY_BASE}${endpoint}"); then
-        body=$(cat "$tmpfile" 2>/dev/null || true)
+    local http_code body tmpfile attempt
+    for attempt in 1 2 3; do
+        tmpfile=$(mktemp)
+        if ! http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+            --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time "$CURL_MAX_TIME" \
+            -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
+            "${GANGWAY_BASE}${endpoint}"); then
+            body=$(cat "$tmpfile" 2>/dev/null || true)
+            rm -f "$tmpfile"
+            die "Gangway API GET ${endpoint} transport error: ${body}"
+        fi
+        body=$(cat "$tmpfile")
         rm -f "$tmpfile"
-        die "Gangway API GET ${endpoint} transport error: ${body}"
-    fi
-    body=$(cat "$tmpfile")
-    rm -f "$tmpfile"
 
-    if [[ "$http_code" == "401" ]]; then
-        die "Authentication failed (HTTP 401). Your GANGWAY_TOKEN may be expired. Re-run: oc login ... && export GANGWAY_TOKEN=\$(oc whoami -t)"
-    fi
-    if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
-        die "Gangway API GET ${endpoint} failed (HTTP ${http_code}): ${body}"
-    fi
-    echo "$body"
+        if [[ "$http_code" == "429" ]]; then
+            info "Gangway rate-limited (429) — backing off 90s (attempt ${attempt}/3)..."
+            sleep 90
+            continue
+        fi
+        if [[ "$http_code" == "401" ]]; then
+            die "Authentication failed (HTTP 401). Your GANGWAY_TOKEN may be expired. Re-run: oc login ... && export GANGWAY_TOKEN=\$(oc whoami -t)"
+        fi
+        if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+            die "Gangway API GET ${endpoint} failed (HTTP ${http_code}): ${body}"
+        fi
+        echo "$body"
+        return 0
+    done
+    die "Gangway API GET ${endpoint} failed after 3 attempts (rate limited)"
 }
 
 save_state() {
@@ -153,16 +162,19 @@ gcs_from_url() {
 
 try_download_kubeconfig() {
     local gcs_root="$1"
-    local url http_code tmpfile
+    local url response_meta http_code content_type tmpfile
     url="${GCSWEB_BASE}/${gcs_root}/${ARTIFACT_SUBPATH}"
     tmpfile=$(mktemp)
-    if ! http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+    if ! response_meta=$(curl -s -w "%{http_code}|%{content_type}" -o "$tmpfile" \
         --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time 60 \
         "$url"); then
         rm -f "$tmpfile"
         return 1
     fi
-    if [[ "$http_code" == "200" ]] && [[ -s "$tmpfile" ]]; then
+    http_code="${response_meta%%|*}"
+    content_type="${response_meta#*|}"
+    # gcsweb returns 200+HTML for missing files; only proceed for binary content
+    if [[ "$http_code" == "200" ]] && [[ "$content_type" != *"text/html"* ]] && [[ -s "$tmpfile" ]]; then
         mkdir -p "$(dirname "$KUBECONFIG_OUT")"
         if openssl enc -d -aes-256-cbc -pbkdf2 \
             -pass pass:"${ENCRYPTION_KEY}" \
@@ -237,7 +249,7 @@ validate_cluster() {
 poll_and_download() {
     local exec_id="$1"
     local job_url="$2"
-    local gcs_root start_epoch interval status elapsed response
+    local gcs_root start_epoch interval status elapsed response live_url
 
     gcs_root=$(gcs_from_url "$job_url")
     start_epoch=$(epoch_now)
@@ -253,6 +265,17 @@ poll_and_download() {
 
         response=$(gangway_get "/v1/executions/${exec_id}")
         status=$(echo "$response" | jq -r '.job_status // empty')
+
+        # Gangway may not return job_url at trigger time; pick it up from poll responses
+        if [[ -z "$gcs_root" ]]; then
+            live_url=$(echo "$response" | jq -r '.job_url // empty')
+            if [[ -n "$live_url" ]]; then
+                job_url="$live_url"
+                gcs_root=$(gcs_from_url "$job_url")
+                update_state_field "job_url" "$job_url"
+                info "Job URL: ${job_url}"
+            fi
+        fi
 
         update_state_field "status" "$status"
 

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Provision an ephemeral OpenShift cluster via the OpenShift CI Gangway API.
+# Claims a cluster from a Hive ClusterPool, downloads kubeconfig, validates.
+#
+# Usage: cluster-provision.sh [up|down|status] [KUBECONFIG_PATH] [OCP_VERSION]
+
+ACTION="${1:-status}"
+KUBECONFIG_OUT="${2:-/tmp/k}"
+OCP_VERSION="${3:-4.18}"
+
+GANGWAY_BASE="https://gangway-ci.apps.ci.l2s4.p1.openshiftapps.com"
+JOB_NAME="periodic-ci-quay-quay-master-claim-cluster-for-dev"
+STATE_DIR="/tmp/cluster-provision"
+STATE_FILE="${STATE_DIR}/state.json"
+
+POLL_INTERVAL_INITIAL=15
+POLL_INTERVAL_MAX=30
+POLL_TIMEOUT=2400  # 40 minutes
+
+GCS_BUCKETS=("test-platform-results" "origin-ci-test")
+GCSWEB_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
+ARTIFACT_SUBPATH="artifacts/claim-cluster-for-dev/export-kubeconfig/kubeconfig"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+epoch_now() { date +%s; }
+iso_now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+epoch_from_iso() {
+    local ts="$1"
+    if date -d "$ts" +%s 2>/dev/null; then
+        return
+    fi
+    date -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null || echo "0"
+}
+
+check_prereqs() {
+    if [[ -z "${GANGWAY_TOKEN:-}" ]]; then
+        echo "GANGWAY_TOKEN is not set."
+        echo ""
+        echo "To obtain a token:"
+        echo "  1. Log in to the OpenShift CI cluster:"
+        echo "     oc login https://api.ci.l2s4.p1.openshiftapps.com:6443 --web"
+        echo "  2. Get your token:"
+        echo "     oc whoami -t"
+        echo "  3. Export it:"
+        echo "     export GANGWAY_TOKEN=\$(oc whoami -t)"
+        echo ""
+        echo "For a permanent token, join the appropriate Rover group."
+        exit 1
+    fi
+    for cmd in curl jq; do
+        command -v "$cmd" >/dev/null 2>&1 || die "'$cmd' is required but not found on PATH"
+    done
+}
+
+gangway_post() {
+    local endpoint="$1" payload="$2"
+    local http_code body tmpfile
+    tmpfile=$(mktemp)
+    http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+        -X POST \
+        -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "$payload" \
+        "${GANGWAY_BASE}${endpoint}")
+    body=$(cat "$tmpfile")
+    rm -f "$tmpfile"
+
+    if [[ "$http_code" == "401" ]]; then
+        die "Authentication failed (HTTP 401). Your GANGWAY_TOKEN may be expired. Re-run: oc login ... && export GANGWAY_TOKEN=\$(oc whoami -t)"
+    fi
+    if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+        die "Gangway API POST ${endpoint} failed (HTTP ${http_code}): ${body}"
+    fi
+    echo "$body"
+}
+
+gangway_get() {
+    local endpoint="$1"
+    local http_code body tmpfile
+    tmpfile=$(mktemp)
+    http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+        -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
+        "${GANGWAY_BASE}${endpoint}")
+    body=$(cat "$tmpfile")
+    rm -f "$tmpfile"
+
+    if [[ "$http_code" == "401" ]]; then
+        die "Authentication failed (HTTP 401). Your GANGWAY_TOKEN may be expired. Re-run: oc login ... && export GANGWAY_TOKEN=\$(oc whoami -t)"
+    fi
+    if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+        die "Gangway API GET ${endpoint} failed (HTTP ${http_code}): ${body}"
+    fi
+    echo "$body"
+}
+
+save_state() {
+    mkdir -p "$STATE_DIR"
+    cat > "$STATE_FILE" <<STATEEOF
+{
+  "execution_id": "$1",
+  "gcs_path": "$2",
+  "job_url": "$3",
+  "kubeconfig_path": "$4",
+  "started_at": "$5",
+  "status": "$6"
+}
+STATEEOF
+}
+
+update_state_field() {
+    local field="$1" value="$2"
+    if [[ -f "$STATE_FILE" ]]; then
+        local tmp
+        tmp=$(jq --arg f "$field" --arg v "$value" '.[$f] = $v' "$STATE_FILE")
+        echo "$tmp" > "$STATE_FILE"
+    fi
+}
+
+try_download_kubeconfig() {
+    local gcs_path="$1"
+    local bucket url http_code tmpfile
+
+    for bucket in "${GCS_BUCKETS[@]}"; do
+        url="${GCSWEB_BASE}/${bucket}/${gcs_path}/${ARTIFACT_SUBPATH}"
+        tmpfile=$(mktemp)
+        http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" "$url")
+        if [[ "$http_code" == "200" ]] && [[ -s "$tmpfile" ]]; then
+            mv "$tmpfile" "$KUBECONFIG_OUT"
+            chmod 600 "$KUBECONFIG_OUT"
+            return 0
+        fi
+        rm -f "$tmpfile"
+    done
+    return 1
+}
+
+validate_cluster() {
+    if command -v oc >/dev/null 2>&1; then
+        local server
+        server=$(oc --kubeconfig="$KUBECONFIG_OUT" whoami --show-server 2>/dev/null || true)
+        if [[ -n "$server" ]]; then
+            info "Cluster validated — server: ${server}"
+        else
+            echo "WARNING: Could not validate cluster connectivity. The kubeconfig was downloaded but 'oc whoami --show-server' failed."
+        fi
+    else
+        echo "WARNING: 'oc' not found on PATH. Skipping cluster validation. Install 'oc' to verify connectivity."
+    fi
+}
+
+poll_and_download() {
+    local exec_id="$1"
+    local start_epoch interval status gcs_path elapsed response
+
+    start_epoch=$(epoch_now)
+    interval=$POLL_INTERVAL_INITIAL
+
+    info "Polling for cluster readiness (timeout: ${POLL_TIMEOUT}s)..."
+
+    while true; do
+        elapsed=$(( $(epoch_now) - start_epoch ))
+        if (( elapsed > POLL_TIMEOUT )); then
+            local job_url
+            job_url=$(jq -r '.job_url // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
+            die "Timed out after ${POLL_TIMEOUT}s waiting for cluster. Check job: ${job_url}"
+        fi
+
+        response=$(gangway_get "/v1/executions/${exec_id}")
+        status=$(echo "$response" | jq -r '.job_status // empty')
+        gcs_path=$(echo "$response" | jq -r '.gcs_path // empty')
+
+        update_state_field "status" "$status"
+        if [[ -n "$gcs_path" ]]; then
+            update_state_field "gcs_path" "$gcs_path"
+        fi
+
+        case "$status" in
+            FAILURE|ERROR|ABORTED)
+                local job_url
+                job_url=$(echo "$response" | jq -r '.job_url // "unknown"')
+                die "Job ended with status ${status}. Check: ${job_url}"
+                ;;
+        esac
+
+        if [[ -n "$gcs_path" ]]; then
+            if try_download_kubeconfig "$gcs_path"; then
+                update_state_field "status" "READY"
+                info "Kubeconfig downloaded to ${KUBECONFIG_OUT}"
+                validate_cluster
+                echo ""
+                echo "=== Cluster Ready ==="
+                echo "Kubeconfig: ${KUBECONFIG_OUT}"
+                echo "Usage:      export KUBECONFIG=${KUBECONFIG_OUT}"
+                echo "            oc whoami"
+                local job_url
+                job_url=$(jq -r '.job_url // "unknown"' "$STATE_FILE" 2>/dev/null || echo "unknown")
+                echo "Job URL:    ${job_url}"
+                echo "Note:       Cluster auto-expires in ~4 hours"
+                return 0
+            fi
+        fi
+
+        info "Status: ${status} | GCS path: ${gcs_path:-not yet available} | Elapsed: ${elapsed}s | Next check in ${interval}s"
+        sleep "$interval"
+        if (( interval < POLL_INTERVAL_MAX )); then
+            interval=$POLL_INTERVAL_MAX
+        fi
+    done
+}
+
+up() {
+    check_prereqs
+
+    if [[ -f "$STATE_FILE" ]]; then
+        local existing_id existing_status
+        existing_id=$(jq -r '.execution_id // empty' "$STATE_FILE")
+        existing_status=$(jq -r '.status // empty' "$STATE_FILE")
+
+        if [[ -n "$existing_id" && "$existing_status" != "FAILURE" && "$existing_status" != "ERROR" && "$existing_status" != "ABORTED" ]]; then
+            info "Found existing execution ${existing_id} (status: ${existing_status}). Resuming..."
+            poll_and_download "$existing_id"
+            return $?
+        fi
+    fi
+
+    info "Triggering cluster claim via Gangway..."
+    local payload response exec_id gcs_path job_url job_status
+    payload=$(jq -n '{
+        job_name: $job,
+        job_execution_type: "1",
+        pod_spec_options: { envs: {} }
+    }' --arg job "$JOB_NAME")
+
+    response=$(gangway_post "/v1/executions" "$payload")
+
+    exec_id=$(echo "$response" | jq -r '.id // empty')
+    gcs_path=$(echo "$response" | jq -r '.gcs_path // empty')
+    job_url=$(echo "$response" | jq -r '.job_url // empty')
+    job_status=$(echo "$response" | jq -r '.job_status // empty')
+
+    if [[ -z "$exec_id" ]]; then
+        die "Failed to get execution ID from Gangway response: ${response}"
+    fi
+
+    info "Execution triggered: ${exec_id}"
+    info "Job URL: ${job_url}"
+    info "Initial status: ${job_status}"
+
+    save_state "$exec_id" "$gcs_path" "$job_url" "$KUBECONFIG_OUT" "$(iso_now)" "$job_status"
+
+    poll_and_download "$exec_id"
+}
+
+down() {
+    if [[ -f "$STATE_FILE" ]]; then
+        local kubeconfig_path
+        kubeconfig_path=$(jq -r '.kubeconfig_path // empty' "$STATE_FILE")
+        info "Cleaning up state..."
+        rm -f "$STATE_FILE"
+        if [[ -n "$kubeconfig_path" && -f "$kubeconfig_path" ]]; then
+            rm -f "$kubeconfig_path"
+            info "Removed kubeconfig: ${kubeconfig_path}"
+        fi
+        rmdir "$STATE_DIR" 2>/dev/null || true
+        info "Cleanup complete."
+    else
+        info "No active cluster provision found."
+    fi
+    echo ""
+    echo "Note: Clusters auto-expire after ~4 hours via Hive. No explicit API teardown is needed."
+}
+
+status() {
+    if [[ ! -f "$STATE_FILE" ]]; then
+        echo "No active cluster provision."
+        return 0
+    fi
+
+    local state exec_id started_at cur_status kubeconfig_path job_url gcs_path
+    state=$(cat "$STATE_FILE")
+    exec_id=$(echo "$state" | jq -r '.execution_id // "unknown"')
+    started_at=$(echo "$state" | jq -r '.started_at // "unknown"')
+    cur_status=$(echo "$state" | jq -r '.status // "unknown"')
+    kubeconfig_path=$(echo "$state" | jq -r '.kubeconfig_path // "unknown"')
+    job_url=$(echo "$state" | jq -r '.job_url // "unknown"')
+    gcs_path=$(echo "$state" | jq -r '.gcs_path // "unknown"')
+
+    echo "=== Cluster Provision Status ==="
+    echo "Execution ID:  ${exec_id}"
+    echo "Started:       ${started_at}"
+    echo "Cached Status: ${cur_status}"
+    echo "Job URL:       ${job_url}"
+    echo "GCS Path:      ${gcs_path}"
+    echo "Kubeconfig:    ${kubeconfig_path}"
+
+    if [[ "$started_at" != "unknown" ]]; then
+        local start_epoch now_epoch elapsed remaining_s remaining_m
+        start_epoch=$(epoch_from_iso "$started_at")
+        now_epoch=$(epoch_now)
+        elapsed=$(( now_epoch - start_epoch ))
+        remaining_s=$(( 14400 - elapsed ))
+        if (( remaining_s > 0 )); then
+            remaining_m=$(( remaining_s / 60 ))
+            echo "Est. remaining: ~${remaining_m} minutes"
+        else
+            echo "Est. remaining: EXPIRED (started >4h ago)"
+        fi
+    fi
+
+    if [[ -n "${GANGWAY_TOKEN:-}" && "$exec_id" != "unknown" ]]; then
+        echo ""
+        info "Fetching live status from Gangway..."
+        local live_response live_status
+        live_response=$(gangway_get "/v1/executions/${exec_id}" 2>/dev/null || true)
+        if [[ -n "$live_response" ]]; then
+            live_status=$(echo "$live_response" | jq -r '.job_status // empty')
+            if [[ -n "$live_status" ]]; then
+                echo "Live Status:   ${live_status}"
+                update_state_field "status" "$live_status"
+            fi
+        fi
+    fi
+
+    if [[ -f "$kubeconfig_path" ]] && command -v oc >/dev/null 2>&1; then
+        echo ""
+        info "Testing cluster connectivity..."
+        local server
+        server=$(oc --kubeconfig="$kubeconfig_path" whoami --show-server 2>/dev/null || true)
+        if [[ -n "$server" ]]; then
+            echo "Cluster:       ${server} (reachable)"
+        else
+            echo "Cluster:       NOT reachable"
+        fi
+    elif [[ -f "$kubeconfig_path" ]]; then
+        echo ""
+        echo "Kubeconfig exists but 'oc' is not on PATH — cannot test connectivity."
+    fi
+}
+
+case "$ACTION" in
+    up)     up ;;
+    down)   down ;;
+    status) status ;;
+    *)      echo "Usage: $0 [up|down|status] [KUBECONFIG_PATH] [OCP_VERSION]"; exit 1 ;;
+esac

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -23,6 +23,9 @@ GCS_BUCKETS=("test-platform-results" "origin-ci-test")
 GCSWEB_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
 ARTIFACT_SUBPATH="artifacts/claim-cluster-for-dev/export-kubeconfig/kubeconfig"
 
+CURL_CONNECT_TIMEOUT=10
+CURL_MAX_TIME=30
+
 die() { echo "ERROR: $*" >&2; exit 1; }
 info() { echo "==> $*"; }
 
@@ -62,6 +65,7 @@ gangway_post() {
     local http_code body tmpfile
     tmpfile=$(mktemp)
     http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+        --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time "$CURL_MAX_TIME" \
         -X POST \
         -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
         -H "Content-Type: application/json" \
@@ -84,6 +88,7 @@ gangway_get() {
     local http_code body tmpfile
     tmpfile=$(mktemp)
     http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+        --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time "$CURL_MAX_TIME" \
         -H "Authorization: Bearer ${GANGWAY_TOKEN}" \
         "${GANGWAY_BASE}${endpoint}")
     body=$(cat "$tmpfile")
@@ -128,7 +133,9 @@ try_download_kubeconfig() {
     for bucket in "${GCS_BUCKETS[@]}"; do
         url="${GCSWEB_BASE}/${bucket}/${gcs_path}/${ARTIFACT_SUBPATH}"
         tmpfile=$(mktemp)
-        http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" "$url")
+        http_code=$(curl -s -w "%{http_code}" -o "$tmpfile" \
+            --connect-timeout "$CURL_CONNECT_TIMEOUT" --max-time 60 \
+            "$url")
         if [[ "$http_code" == "200" ]] && [[ -s "$tmpfile" ]]; then
             mv "$tmpfile" "$KUBECONFIG_OUT"
             chmod 600 "$KUBECONFIG_OUT"
@@ -233,8 +240,8 @@ up() {
     payload=$(jq -n '{
         job_name: $job,
         job_execution_type: "1",
-        pod_spec_options: { envs: {} }
-    }' --arg job "$JOB_NAME")
+        pod_spec_options: { envs: { OCP_VERSION: $ocp } }
+    }' --arg job "$JOB_NAME" --arg ocp "$OCP_VERSION")
 
     response=$(gangway_post "/v1/executions" "$payload")
 

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -21,7 +21,7 @@ POLL_TIMEOUT=2400  # 40 minutes
 
 GCSWEB_BASE="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
 ARTIFACT_SUBPATH="artifacts/claim-cluster/export-kubeconfig/artifacts/kubeconfig.enc"
-ENCRYPTION_KEY="${CLUSTER_PROVISION_KEY:-}"
+ENCRYPTION_KEY="${KUBECONFIG_ENCRYPTION_KEY:-}"
 
 CURL_CONNECT_TIMEOUT=10
 CURL_MAX_TIME=30
@@ -56,7 +56,7 @@ check_prereqs() {
         exit 1
     fi
     if [[ -z "${ENCRYPTION_KEY}" ]]; then
-        echo "CLUSTER_PROVISION_KEY is not set."
+        echo "KUBECONFIG_ENCRYPTION_KEY is not set."
         echo ""
         echo "This is the passphrase used to decrypt the cluster kubeconfig."
         echo "Contact the Quay CI team for access."
@@ -172,7 +172,7 @@ try_download_kubeconfig() {
             rm -f "$tmpfile"
             return 0
         else
-            echo "WARNING: Failed to decrypt kubeconfig. Wrong CLUSTER_PROVISION_KEY?" >&2
+            echo "WARNING: Failed to decrypt kubeconfig. Wrong KUBECONFIG_ENCRYPTION_KEY?" >&2
             rm -f "$tmpfile"
             return 1
         fi

--- a/.claude/scripts/cluster-provision.sh
+++ b/.claude/scripts/cluster-provision.sh
@@ -114,16 +114,15 @@ gangway_get() {
 save_state() {
     mkdir -p -m 700 "$STATE_DIR"
     [[ -L "$STATE_FILE" ]] && die "Refusing to write through symlinked state file: $STATE_FILE"
-    cat > "$STATE_FILE" <<STATEEOF
-{
-  "execution_id": "$1",
-  "gcs_path": "$2",
-  "job_url": "$3",
-  "kubeconfig_path": "$4",
-  "started_at": "$5",
-  "status": "$6"
-}
-STATEEOF
+    jq -n \
+        --arg eid "$1" \
+        --arg gcs "$2" \
+        --arg url "$3" \
+        --arg kfg "$4" \
+        --arg sta "$5" \
+        --arg sts "$6" \
+        '{execution_id: $eid, gcs_path: $gcs, job_url: $url, kubeconfig_path: $kfg, started_at: $sta, status: $sts}' \
+        > "$STATE_FILE"
 }
 
 update_state_field() {

--- a/.claude/skills/cluster-provision/SKILL.md
+++ b/.claude/skills/cluster-provision/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: cluster-provision
+description: >
+  Provision an ephemeral OpenShift cluster via the OpenShift CI Gangway API.
+  Claims a cluster from a Hive ClusterPool, downloads kubeconfig, and validates
+  connectivity. Clusters auto-expire after ~4 hours. Use when you need a real
+  OpenShift cluster for blackbox testing or integration work.
+argument-hint: "[KUBECONFIG_PATH] [OCP_VERSION]"
+allowed-tools:
+  - Bash(bash .claude/scripts/cluster-provision.sh *)
+  - Bash(oc --kubeconfig=*)
+  - Read
+---
+
+# Cluster Provision
+
+Provision an ephemeral OpenShift cluster from a Hive ClusterPool via the OpenShift CI Gangway REST API.
+
+## Arguments
+
+Parse `$ARGUMENTS` into at most two values before invoking Bash:
+- **Arg 1**: KUBECONFIG path (default: `/tmp/k`)
+- **Arg 2**: OCP version (default: `4.18`)
+
+Set variables from `$ARGUMENTS`:
+```
+KUBECONFIG_PATH = first arg or /tmp/k
+OCP_VERSION = second arg or 4.18
+```
+
+## Step 1: Provision the cluster
+
+```bash
+bash .claude/scripts/cluster-provision.sh up "$KUBECONFIG_PATH" "$OCP_VERSION"
+```
+
+The script handles everything: triggering the Gangway API, polling for readiness, downloading the kubeconfig, and validating connectivity. Wait for the `=== Cluster Ready ===` output.
+
+## Step 2: Verify
+
+```bash
+oc --kubeconfig="$KUBECONFIG_PATH" whoami
+oc --kubeconfig="$KUBECONFIG_PATH" get nodes
+```
+
+## Step 3: Report
+
+Summarize connection status and remind user:
+- The cluster is ready
+- Kubeconfig path
+- Cluster server URL
+- Cluster auto-expires in ~4 hours
+- Prow job URL for reference
+
+## Status
+
+```bash
+bash .claude/scripts/cluster-provision.sh status
+```
+
+Shows execution ID, elapsed time, estimated remaining time, and tests cluster connectivity.
+
+## Teardown
+
+```bash
+bash .claude/scripts/cluster-provision.sh down
+```
+
+Removes local state and kubeconfig. Clusters auto-expire after ~4 hours via Hive — no explicit API teardown needed.
+
+## Troubleshooting
+
+| Error | Fix |
+|-------|-----|
+| `GANGWAY_TOKEN is not set` | Run: `oc login https://api.ci.l2s4.p1.openshiftapps.com:6443 --web && export GANGWAY_TOKEN=$(oc whoami -t)` |
+| `HTTP 401` | Token expired — re-authenticate with `oc login` |
+| `HTTP 404` on trigger | ProwJob `periodic-ci-quay-quay-master-claim-cluster-for-dev` not configured in `openshift/release` |
+| Timeout after 40 min | Pool exhausted or job stuck — check the Prow job URL |
+| Kubeconfig download fails | GCS artifact path mismatch — download manually from the Prow job artifacts tab |
+| `oc whoami` fails | Cluster not fully ready or VPN required — wait and retry |

--- a/.claude/skills/cluster-provision/SKILL.md
+++ b/.claude/skills/cluster-provision/SKILL.md
@@ -2,8 +2,9 @@
 name: cluster-provision
 description: >
   Provision an ephemeral OpenShift cluster via the OpenShift CI Gangway API.
-  Claims a cluster from a Hive ClusterPool, downloads kubeconfig, and validates
-  connectivity. Clusters auto-expire after ~4 hours. Use when you need a real
+  Claims a cluster from a Hive ClusterPool, downloads and decrypts kubeconfig,
+  and validates connectivity. Requires GANGWAY_TOKEN and CLUSTER_PROVISION_KEY
+  env vars. Clusters auto-expire after ~4 hours. Use when you need a real
   OpenShift cluster for blackbox testing or integration work.
 argument-hint: "[KUBECONFIG_PATH] [OCP_VERSION]"
 allowed-tools:
@@ -74,7 +75,8 @@ Removes local state and kubeconfig. Clusters auto-expire after ~4 hours via Hive
 |-------|-----|
 | `GANGWAY_TOKEN is not set` | Run: `oc login https://api.ci.l2s4.p1.openshiftapps.com:6443 --web && export GANGWAY_TOKEN=$(oc whoami -t)` |
 | `HTTP 401` | Token expired — re-authenticate with `oc login` |
-| `HTTP 404` on trigger | ProwJob `periodic-ci-quay-quay-master-claim-cluster-for-dev` not configured in `openshift/release` |
+| `CLUSTER_PROVISION_KEY is not set` | Contact the Quay CI team for the decryption passphrase |
+| `HTTP 404` on trigger | ProwJob `periodic-ci-quay-quay-master-claim-claim-cluster` not configured in `openshift/release` |
 | Timeout after 40 min | Pool exhausted or job stuck — check the Prow job URL |
 | Kubeconfig download fails | GCS artifact path mismatch — download manually from the Prow job artifacts tab |
 | `oc whoami` fails | Cluster not fully ready or VPN required — wait and retry |

--- a/.claude/skills/cluster-provision/SKILL.md
+++ b/.claude/skills/cluster-provision/SKILL.md
@@ -23,7 +23,7 @@ Parse `$ARGUMENTS` into at most two values before invoking Bash:
 - **Arg 2**: OCP version (default: `4.18`)
 
 Set variables from `$ARGUMENTS`:
-```
+```text
 KUBECONFIG_PATH = first arg or /tmp/k
 OCP_VERSION = second arg or 4.18
 ```

--- a/.claude/skills/cluster-provision/SKILL.md
+++ b/.claude/skills/cluster-provision/SKILL.md
@@ -3,7 +3,7 @@ name: cluster-provision
 description: >
   Provision an ephemeral OpenShift cluster via the OpenShift CI Gangway API.
   Claims a cluster from a Hive ClusterPool, downloads and decrypts kubeconfig,
-  and validates connectivity. Requires GANGWAY_TOKEN and CLUSTER_PROVISION_KEY
+  and validates connectivity. Requires GANGWAY_TOKEN and KUBECONFIG_ENCRYPTION_KEY
   env vars. Clusters auto-expire after ~4 hours. Use when you need a real
   OpenShift cluster for blackbox testing or integration work.
 argument-hint: "[KUBECONFIG_PATH] [OCP_VERSION]"
@@ -75,7 +75,7 @@ Removes local state and kubeconfig. Clusters auto-expire after ~4 hours via Hive
 |-------|-----|
 | `GANGWAY_TOKEN is not set` | Run: `oc login https://api.ci.l2s4.p1.openshiftapps.com:6443 --web && export GANGWAY_TOKEN=$(oc whoami -t)` |
 | `HTTP 401` | Token expired — re-authenticate with `oc login` |
-| `CLUSTER_PROVISION_KEY is not set` | Contact the Quay CI team for the decryption passphrase |
+| `KUBECONFIG_ENCRYPTION_KEY is not set` | Contact the Quay CI team for the decryption passphrase |
 | `HTTP 404` on trigger | ProwJob `periodic-ci-quay-quay-master-claim-claim-cluster` not configured in `openshift/release` |
 | Timeout after 40 min | Pool exhausted or job stuck — check the Prow job URL |
 | Kubeconfig download fails | GCS artifact path mismatch — download manually from the Prow job artifacts tab |


### PR DESCRIPTION
## Summary
- Adds `cluster-provision` Claude Code skill that provisions ephemeral OpenShift clusters via the OpenShift CI Gangway REST API
- New script `.claude/scripts/cluster-provision.sh` handles the full lifecycle: trigger ProwJob, poll for readiness, download kubeconfig from GCS artifacts, validate connectivity
- New skill definition `.claude/skills/cluster-provision/SKILL.md` follows the same pattern as `remote-playwright`
- Clusters are claimed from Hive ClusterPools and auto-expire after ~4 hours

## Details
The skill supports three actions:
- **`up`** — triggers a ProwJob via Gangway, polls until the cluster is ready (40 min timeout), downloads kubeconfig, validates with `oc whoami --show-server`
- **`down`** — cleans up local state and kubeconfig (clusters auto-expire via Hive)
- **`status`** — shows cached and live execution status, estimates remaining time, tests connectivity

Key design choices:
- Idempotent `up`: resumes polling if an existing execution is still in progress
- Tries multiple GCS bucket paths for kubeconfig download (artifact URL pattern needs validation with a real run)
- macOS/Linux date compatibility for epoch conversion
- Requires `GANGWAY_TOKEN` env var (obtained via `oc login` to app.ci)

## Prerequisites (not part of this PR)
1. ProwJob `periodic-ci-quay-quay-master-claim-cluster-for-dev` must be configured in `openshift/release`
2. `GANGWAY_TOKEN` env var must be set in the session

## Test plan
- [x] `bash .claude/scripts/cluster-provision.sh status` — reports "No active cluster provision" cleanly
- [x] `GANGWAY_TOKEN="" bash .claude/scripts/cluster-provision.sh up` — prints helpful setup instructions
- [x] `bash .claude/scripts/cluster-provision.sh down` — handles no-active-cluster gracefully
- [x] Invalid action prints usage
- [x] `bash -n` syntax validation passes
- [ ] End-to-end test with real Gangway token (requires ProwJob to be configured first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)