### PR TITLE
PROJQUAY-11027: fix(mirror): preserve future syncs when canceling org mirror

### DIFF
--- a/data/model/org_mirror.py
+++ b/data/model/org_mirror.py
@@ -1139,10 +1139,8 @@ def release_org_mirror_config(
     Release an org mirror config after discovery and update its status.
 
     Calculates next sync_start_date based on sync_interval.
-    Decrements retries on failure, resets on success.
-
-    If discovery is cancelled, the job will not be attempted until manual
-    sync-now is triggered by the user.
+    Decrements retries on failure, resets on success or cancel.
+    Cancel is transitioned to SUCCESS after scheduling the next sync.
 
     Args:
         org_mirror_config: The OrgMirrorConfig to release
@@ -1159,9 +1157,11 @@ def release_org_mirror_config(
     if sync_status == OrgMirrorStatus.FAIL:
         retries = max(0, retries - 1)
 
-    # On success or exhausted retries, schedule next sync
-    if sync_status == OrgMirrorStatus.SUCCESS or (
-        sync_status == OrgMirrorStatus.FAIL and retries < 1
+    # On success, cancel, or exhausted retries, schedule next sync
+    if (
+        sync_status == OrgMirrorStatus.SUCCESS
+        or sync_status == OrgMirrorStatus.CANCEL
+        or (sync_status == OrgMirrorStatus.FAIL and retries < 1)
     ):
         now = datetime.utcnow()
         if org_mirror_config.sync_start_date:
@@ -1177,10 +1177,9 @@ def release_org_mirror_config(
     else:
         next_start_date = org_mirror_config.sync_start_date
 
-    # If cancelled, stop syncing until user triggers sync-now again
+    # Transition cancel to SUCCESS so the next pickup runs normal discovery (PROJQUAY-11027).
     if sync_status == OrgMirrorStatus.CANCEL:
-        next_start_date = None
-        retries = 0
+        sync_status = OrgMirrorStatus.SUCCESS
 
     query = OrgMirrorConfig.update(
         sync_transaction_id=uuid_generator(),
@@ -1227,9 +1226,9 @@ def expire_org_mirror_config(org_mirror_config: OrgMirrorConfig) -> Optional[Org
 
 def schedule_org_mirror_repos_for_sync(config: OrgMirrorConfig) -> int:
     """
-    Schedule all NEVER_RUN repos under a config for immediate sync.
+    Schedule repos under a config for immediate sync.
 
-    Called after discovery to trigger the repo-level sync phase.
+    Transitions NEVER_RUN and CANCEL repos to SYNC_NOW (PROJQUAY-11027).
 
     Args:
         config: The OrgMirrorConfig whose repos should be scheduled
@@ -1240,12 +1239,14 @@ def schedule_org_mirror_repos_for_sync(config: OrgMirrorConfig) -> int:
     now = datetime.utcnow()
 
     query = OrgMirrorRepository.update(
+        sync_status=OrgMirrorRepoStatus.SYNC_NOW,
         sync_start_date=now,
         sync_retries_remaining=MAX_SYNC_RETRIES,
     ).where(
         OrgMirrorRepository.org_mirror_config == config,
-        OrgMirrorRepository.sync_status == OrgMirrorRepoStatus.NEVER_RUN,
-        OrgMirrorRepository.sync_start_date >> None,  # Only if not already scheduled
+        OrgMirrorRepository.sync_status
+        << [OrgMirrorRepoStatus.NEVER_RUN, OrgMirrorRepoStatus.CANCEL],
+        OrgMirrorRepository.sync_start_date >> None,
     )
 
     return query.execute()
@@ -1363,6 +1364,9 @@ def update_sync_status_to_cancel(org_mirror_config: OrgMirrorConfig) -> Optional
     (ignores transaction ID) since we need to interrupt an active worker.
     This allows cancellation from any status except when already CANCEL.
 
+    Only the current sync is cancelled; sync_start_date is preserved so
+    future scheduled syncs continue normally.
+
     Note: This only updates the config status. The worker will propagate
     CANCEL to associated OrgMirrorRepository entries when it picks up
     the config.
@@ -1373,18 +1377,15 @@ def update_sync_status_to_cancel(org_mirror_config: OrgMirrorConfig) -> Optional
     Returns:
         Updated OrgMirrorConfig if successfully cancelled, None if already CANCEL
     """
-    # Only skip if already cancelled (idempotent)
     if org_mirror_config.sync_status == OrgMirrorStatus.CANCEL:
         return None
 
-    # Force cancel the config (ignore transaction_id for interrupt).
-    # sync_expiration_date is set to now to signal "needs processing" — the worker
-    # clears it after propagating CANCEL to repos, preventing re-pickup.
+    # Force cancel (ignore transaction_id for interrupt).
+    # sync_expiration_date signals "needs processing"; worker clears it after propagating.
     now = datetime.utcnow()
     config_query = OrgMirrorConfig.update(
         sync_transaction_id=uuid_generator(),
         sync_status=OrgMirrorStatus.CANCEL,
-        sync_start_date=None,
         sync_expiration_date=now,
         sync_retries_remaining=0,
     ).where(OrgMirrorConfig.id == org_mirror_config.id)

--- a/data/model/test/test_org_mirror.py
+++ b/data/model/test/test_org_mirror.py
@@ -1736,12 +1736,14 @@ class TestUpdateSyncStatusToCancel:
 
     def test_cancel_when_syncing(self, initialized_db):
         """
-        Should cancel when status is SYNCING.
+        Should cancel when status is SYNCING and preserve sync_start_date.
         """
         from data.model.org_mirror import update_sync_status_to_cancel
 
         org, robot = _create_org_and_robot("cancel_test1")
         config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        original_sync_start_date = config.sync_start_date
 
         # Set to SYNCING
         config.sync_status = OrgMirrorStatus.SYNCING
@@ -1753,7 +1755,7 @@ class TestUpdateSyncStatusToCancel:
         assert result is not None
         assert result.sync_status == OrgMirrorStatus.CANCEL
         assert result.sync_expiration_date is not None
-        assert result.sync_start_date is None
+        assert result.sync_start_date == original_sync_start_date
         assert result.sync_retries_remaining == 0
 
     def test_cancel_when_sync_now(self, initialized_db):
@@ -1906,12 +1908,382 @@ class TestUpdateSyncStatusToCancel:
         assert claimed is not None
         release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
 
-        # After release, config must NOT be eligible again
+        # After release, config must NOT be eligible again immediately
         config = OrgMirrorConfig.get_by_id(config.id)
         eligible_ids = [c.id for c in get_eligible_org_mirror_configs()]
         assert config.id not in eligible_ids
-        assert config.sync_status == OrgMirrorStatus.CANCEL
+        # Cancel transitions to SUCCESS after processing (PROJQUAY-11027)
+        assert config.sync_status == OrgMirrorStatus.SUCCESS
         assert config.sync_expiration_date is None
+
+    def test_cancel_preserves_sync_start_date(self, initialized_db):
+        """
+        Regression test for PROJQUAY-11027: cancelling a sync must preserve
+        sync_start_date so that future scheduled syncs continue.
+        """
+        from data.model.org_mirror import update_sync_status_to_cancel
+
+        org, robot = _create_org_and_robot("cancel_preserve_date")
+        future_date = datetime.utcnow() + timedelta(hours=2)
+        config = _create_org_mirror_config(org, robot, is_enabled=True, sync_start_date=future_date)
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        result = update_sync_status_to_cancel(config)
+
+        assert result is not None
+        assert result.sync_status == OrgMirrorStatus.CANCEL
+        assert result.sync_start_date is not None
+        assert result.sync_start_date == future_date
+
+    def test_cancel_release_schedules_next_sync(self, initialized_db):
+        """
+        Regression test for PROJQUAY-11027: after cancel is processed by the
+        worker, release_org_mirror_config must schedule the next sync instead
+        of clearing sync_start_date.
+        """
+        from data.model.org_mirror import (
+            MAX_SYNC_RETRIES,
+            claim_org_mirror_config,
+            release_org_mirror_config,
+            update_sync_status_to_cancel,
+        )
+
+        org, robot = _create_org_and_robot("cancel_release_schedule")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        update_sync_status_to_cancel(config)
+
+        config = OrgMirrorConfig.get_by_id(config.id)
+        claimed = claim_org_mirror_config(config)
+        assert claimed is not None
+
+        released = release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
+
+        assert released is not None
+        assert released.sync_status == OrgMirrorStatus.SUCCESS
+        assert released.sync_start_date is not None
+        assert released.sync_start_date > datetime.utcnow()
+        assert released.sync_retries_remaining == MAX_SYNC_RETRIES
+        assert released.sync_expiration_date is None
+
+    def test_cancel_release_with_no_sync_start_date(self, initialized_db):
+        """
+        Cover the else branch in release_org_mirror_config when sync_start_date
+        is None at cancel time — next sync should still be scheduled using
+        sync_interval from now.
+        """
+        from data.model.org_mirror import (
+            MAX_SYNC_RETRIES,
+            claim_org_mirror_config,
+            release_org_mirror_config,
+            update_sync_status_to_cancel,
+        )
+
+        org, robot = _create_org_and_robot("cancel_release_no_start")
+        config = _create_org_mirror_config(org, robot, is_enabled=True, sync_start_date=None)
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        update_sync_status_to_cancel(config)
+
+        config = OrgMirrorConfig.get_by_id(config.id)
+        claimed = claim_org_mirror_config(config)
+        assert claimed is not None
+
+        before = datetime.utcnow()
+        released = release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
+
+        assert released is not None
+        assert released.sync_status == OrgMirrorStatus.SUCCESS
+        assert released.sync_start_date is not None
+        assert released.sync_start_date > before
+        assert released.sync_retries_remaining == MAX_SYNC_RETRIES
+
+    def test_cancel_full_flow_preserves_future_syncs(self, initialized_db):
+        """
+        Regression test for PROJQUAY-11027: end-to-end cancel flow.
+        After cancel → release, config must have a future sync_start_date
+        and must become eligible again once that date arrives.
+        """
+        from data.model.org_mirror import (
+            claim_org_mirror_config,
+            get_eligible_org_mirror_configs,
+            release_org_mirror_config,
+            update_sync_status_to_cancel,
+        )
+
+        org, robot = _create_org_and_robot("cancel_full_flow")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        # User cancels
+        update_sync_status_to_cancel(config)
+
+        # Worker processes cancel
+        config = OrgMirrorConfig.get_by_id(config.id)
+        claimed = claim_org_mirror_config(config)
+        assert claimed is not None
+        released = release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
+
+        # Status transitions to SUCCESS so next pickup runs normal discovery
+        assert released.sync_status == OrgMirrorStatus.SUCCESS
+
+        # Not eligible immediately (sync_start_date is in the future)
+        eligible_ids = [c.id for c in get_eligible_org_mirror_configs()]
+        assert released.id not in eligible_ids
+
+        # Simulate time passing: set sync_start_date to the past
+        OrgMirrorConfig.update(sync_start_date=datetime.utcnow() - timedelta(seconds=1)).where(
+            OrgMirrorConfig.id == released.id
+        ).execute()
+
+        # Now the config should be eligible for syncing again
+        eligible_ids = [c.id for c in get_eligible_org_mirror_configs()]
+        assert released.id in eligible_ids
+
+    def test_cancel_does_not_create_recancel_loop(self, initialized_db):
+        """
+        Regression test for PROJQUAY-11027: after cancel is processed, the
+        config must NOT re-enter the cancel path on the next worker pickup.
+        The status must be SUCCESS so the worker runs normal discovery.
+        """
+        from data.model.org_mirror import (
+            claim_org_mirror_config,
+            get_eligible_org_mirror_configs,
+            release_org_mirror_config,
+            update_sync_status_to_cancel,
+        )
+
+        org, robot = _create_org_and_robot("cancel_no_loop")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        # Cancel and process
+        update_sync_status_to_cancel(config)
+        config = OrgMirrorConfig.get_by_id(config.id)
+        claimed = claim_org_mirror_config(config)
+        assert claimed is not None
+        release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
+
+        # Simulate time passing so config becomes eligible
+        OrgMirrorConfig.update(sync_start_date=datetime.utcnow() - timedelta(seconds=1)).where(
+            OrgMirrorConfig.id == config.id
+        ).execute()
+
+        # Config is eligible
+        eligible = list(get_eligible_org_mirror_configs())
+        matched = [c for c in eligible if c.id == config.id]
+        assert len(matched) == 1
+
+        # Worker picks it up — status must be SUCCESS, NOT CANCEL
+        picked_up = matched[0]
+        assert picked_up.sync_status == OrgMirrorStatus.SUCCESS
+
+    def test_cancel_repos_transition_to_sync_now_on_next_cycle(self, initialized_db):
+        """
+        Regression test for PROJQUAY-11027: after cancel is processed,
+        schedule_org_mirror_repos_for_sync must transition CANCEL repos
+        to SYNC_NOW so they rejoin the sync cycle. SKIP repos are untouched.
+        """
+        from data.model.org_mirror import (
+            MAX_SYNC_RETRIES,
+            claim_org_mirror_config,
+            propagate_status_to_repos,
+            release_org_mirror_config,
+            schedule_org_mirror_repos_for_sync,
+            update_sync_status_to_cancel,
+        )
+
+        org, robot = _create_org_and_robot("cancel_repo_sync_now")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        repo1 = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="repo-a",
+            sync_status=OrgMirrorRepoStatus.SYNCING,
+            sync_start_date=datetime.utcnow(),
+            sync_retries_remaining=MAX_SYNC_RETRIES,
+        )
+        repo2 = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="repo-b",
+            sync_status=OrgMirrorRepoStatus.SUCCESS,
+            sync_start_date=datetime.utcnow(),
+            sync_retries_remaining=MAX_SYNC_RETRIES,
+        )
+        repo_skip = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="repo-skip",
+            sync_status=OrgMirrorRepoStatus.SKIP,
+        )
+
+        config.sync_status = OrgMirrorStatus.SYNCING
+        config.sync_expiration_date = datetime.utcnow() + timedelta(hours=1)
+        config.save()
+
+        # Cancel and propagate to repos
+        update_sync_status_to_cancel(config)
+        config = OrgMirrorConfig.get_by_id(config.id)
+        propagate_status_to_repos(config, OrgMirrorRepoStatus.CANCEL)
+
+        # Repos are CANCEL with retries=0, sync_start_date=None
+        repo1 = OrgMirrorRepository.get_by_id(repo1.id)
+        repo2 = OrgMirrorRepository.get_by_id(repo2.id)
+        assert repo1.sync_status == OrgMirrorRepoStatus.CANCEL
+        assert repo1.sync_retries_remaining == 0
+        assert repo1.sync_start_date is None
+
+        # Worker releases config (cancel → success)
+        claimed = claim_org_mirror_config(config)
+        assert claimed is not None
+        release_org_mirror_config(claimed, OrgMirrorStatus.CANCEL)
+
+        # Repos stay CANCEL after release — no bulk reset
+        repo1 = OrgMirrorRepository.get_by_id(repo1.id)
+        repo2 = OrgMirrorRepository.get_by_id(repo2.id)
+        assert repo1.sync_status == OrgMirrorRepoStatus.CANCEL
+        assert repo2.sync_status == OrgMirrorRepoStatus.CANCEL
+
+        # Next discovery cycle: schedule picks up CANCEL repos → SYNC_NOW
+        config = OrgMirrorConfig.get_by_id(config.id)
+        scheduled = schedule_org_mirror_repos_for_sync(config)
+        assert scheduled == 2
+
+        repo1 = OrgMirrorRepository.get_by_id(repo1.id)
+        repo2 = OrgMirrorRepository.get_by_id(repo2.id)
+        repo_skip = OrgMirrorRepository.get_by_id(repo_skip.id)
+        assert repo1.sync_status == OrgMirrorRepoStatus.SYNC_NOW
+        assert repo1.sync_retries_remaining == MAX_SYNC_RETRIES
+        assert repo1.sync_start_date is not None
+        assert repo2.sync_status == OrgMirrorRepoStatus.SYNC_NOW
+        assert repo2.sync_retries_remaining == MAX_SYNC_RETRIES
+        assert repo_skip.sync_status == OrgMirrorRepoStatus.SKIP
+
+
+class TestScheduleOrgMirrorReposForSync:
+    """Tests for schedule_org_mirror_repos_for_sync function."""
+
+    def test_schedules_never_run_repos(self, initialized_db):
+        """NEVER_RUN repos with no sync_start_date are transitioned to SYNC_NOW."""
+        from data.model.org_mirror import schedule_org_mirror_repos_for_sync
+
+        org, robot = _create_org_and_robot("schedule_never_run")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        repo = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="never-run-repo",
+            sync_status=OrgMirrorRepoStatus.NEVER_RUN,
+            sync_start_date=None,
+            sync_retries_remaining=0,
+        )
+
+        scheduled = schedule_org_mirror_repos_for_sync(config)
+
+        assert scheduled == 1
+        repo = OrgMirrorRepository.get_by_id(repo.id)
+        assert repo.sync_status == OrgMirrorRepoStatus.SYNC_NOW
+        assert repo.sync_start_date is not None
+        assert repo.sync_retries_remaining == MAX_SYNC_RETRIES
+
+    def test_skips_repos_with_existing_sync_start_date(self, initialized_db):
+        """Repos that already have a sync_start_date set are NOT rescheduled."""
+        from data.model.org_mirror import schedule_org_mirror_repos_for_sync
+
+        org, robot = _create_org_and_robot("schedule_skip_dated")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        # CANCEL repo with a sync_start_date already set — must not be picked up
+        repo = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="cancel-dated-repo",
+            sync_status=OrgMirrorRepoStatus.CANCEL,
+            sync_start_date=datetime.utcnow() + timedelta(hours=1),
+            sync_retries_remaining=MAX_SYNC_RETRIES,
+        )
+
+        scheduled = schedule_org_mirror_repos_for_sync(config)
+
+        assert scheduled == 0
+        repo = OrgMirrorRepository.get_by_id(repo.id)
+        assert repo.sync_status == OrgMirrorRepoStatus.CANCEL  # unchanged
+
+    def test_returns_zero_when_no_eligible_repos(self, initialized_db):
+        """Returns 0 when no repos need scheduling (all SKIP/SUCCESS)."""
+        from data.model.org_mirror import schedule_org_mirror_repos_for_sync
+
+        org, robot = _create_org_and_robot("schedule_no_eligible")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="skip-repo",
+            sync_status=OrgMirrorRepoStatus.SKIP,
+        )
+        OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="success-repo",
+            sync_status=OrgMirrorRepoStatus.SUCCESS,
+            sync_start_date=datetime.utcnow(),
+        )
+
+        scheduled = schedule_org_mirror_repos_for_sync(config)
+
+        assert scheduled == 0
+
+    def test_schedules_both_cancel_and_never_run(self, initialized_db):
+        """Both CANCEL and NEVER_RUN repos (with no sync_start_date) are scheduled together."""
+        from data.model.org_mirror import schedule_org_mirror_repos_for_sync
+
+        org, robot = _create_org_and_robot("schedule_mixed")
+        config = _create_org_mirror_config(org, robot, is_enabled=True)
+
+        cancel_repo = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="cancel-repo",
+            sync_status=OrgMirrorRepoStatus.CANCEL,
+            sync_start_date=None,
+            sync_retries_remaining=0,
+        )
+        never_run_repo = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="never-run-repo",
+            sync_status=OrgMirrorRepoStatus.NEVER_RUN,
+            sync_start_date=None,
+            sync_retries_remaining=0,
+        )
+        skip_repo = OrgMirrorRepository.create(
+            org_mirror_config=config,
+            repository_name="skip-repo",
+            sync_status=OrgMirrorRepoStatus.SKIP,
+        )
+
+        scheduled = schedule_org_mirror_repos_for_sync(config)
+
+        assert scheduled == 2
+        cancel_repo = OrgMirrorRepository.get_by_id(cancel_repo.id)
+        never_run_repo = OrgMirrorRepository.get_by_id(never_run_repo.id)
+        skip_repo = OrgMirrorRepository.get_by_id(skip_repo.id)
+        assert cancel_repo.sync_status == OrgMirrorRepoStatus.SYNC_NOW
+        assert cancel_repo.sync_retries_remaining == MAX_SYNC_RETRIES
+        assert never_run_repo.sync_status == OrgMirrorRepoStatus.SYNC_NOW
+        assert never_run_repo.sync_retries_remaining == MAX_SYNC_RETRIES
+        assert skip_repo.sync_status == OrgMirrorRepoStatus.SKIP  # unchanged
 
 
 class TestPropagateStatusToRepos:

--- a/endpoints/api/test/test_org_mirror.py
+++ b/endpoints/api/test/test_org_mirror.py
@@ -4,7 +4,7 @@ Unit tests for organization-level mirror API endpoints.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -1354,6 +1354,44 @@ class TestSyncCancel:
             conduct_api_call(cl, org_mirror.OrgMirrorSyncCancel, "POST", params, None, 400)
 
         # Clean up
+        _cleanup_org_mirror_config("buynlarge")
+
+    def test_sync_cancel_preserves_sync_start_date(self, app):
+        """
+        Regression test for PROJQUAY-11027: calling the sync-cancel endpoint
+        must NOT clear sync_start_date. Future scheduled syncs must be preserved.
+        """
+        from data.database import OrgMirrorStatus
+
+        _cleanup_org_mirror_config("buynlarge")
+
+        future_date = datetime.utcnow() + timedelta(hours=2)
+        org = model.organization.get_organization("buynlarge")
+        robot = model.user.lookup_robot("buynlarge+coolrobot")
+        config = OrgMirrorConfig.create(
+            organization=org,
+            internal_robot=robot,
+            external_registry_type=SourceRegistryType.HARBOR,
+            external_registry_url="https://harbor.example.com",
+            external_namespace="project",
+            visibility=Visibility.get(name="private"),
+            sync_interval=3600,
+            sync_start_date=future_date,
+            is_enabled=True,
+            sync_status=OrgMirrorStatus.SYNCING,
+            skopeo_timeout=300,
+        )
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"orgname": "buynlarge"}
+            conduct_api_call(cl, org_mirror.OrgMirrorSyncCancel, "POST", params, None, 204)
+
+        refreshed = model.org_mirror.get_org_mirror_config(org)
+        assert refreshed.sync_status == OrgMirrorStatus.CANCEL
+        assert refreshed.sync_start_date is not None
+        # Small tolerance to absorb DB datetime precision / round-trip drift.
+        assert abs((refreshed.sync_start_date - future_date).total_seconds()) < 2
+
         _cleanup_org_mirror_config("buynlarge")
 
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.tsx
@@ -48,8 +48,8 @@ export const OrgMirroringStatus: React.FC<OrgMirroringStatusProps> = ({
       >
         <ModalHeader title="Cancel sync" />
         <ModalBody>
-          Are you sure you want to cancel the current sync operation? All
-          in-progress and scheduled syncs will be stopped.
+          Are you sure you want to cancel the current sync operation? Future
+          scheduled syncs will continue as normal.
         </ModalBody>
         <ModalFooter>
           <Button

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -1160,7 +1160,7 @@ def perform_org_mirror_discovery(org_mirror_config: OrgMirrorConfig):
             org_name,
         )
     else:
-        # Normal scheduled sync: only schedule NEVER_RUN repos
+        # Normal scheduled sync: schedule NEVER_RUN and CANCEL repos
         scheduled_count = schedule_org_mirror_repos_for_sync(claimed_config)
         logger.info(
             "Scheduled %d repositories for sync for org mirror %s",

--- a/workers/repomirrorworker/test/test_org_mirror_worker.py
+++ b/workers/repomirrorworker/test/test_org_mirror_worker.py
@@ -1233,9 +1233,11 @@ class TestPerformOrgMirrorDiscoveryEdgeCases:
         assert len(cancel_calls) == 1
         assert "cancelled" in cancel_calls[0][1]["metadata"]["message"].lower()
 
-        # Verify config released with CANCEL status
+        # After cancel processing, status transitions to SUCCESS (PROJQUAY-11027)
         refreshed = OrgMirrorConfig.get_by_id(config.id)
-        assert refreshed.sync_status == OrgMirrorStatus.CANCEL
+        assert refreshed.sync_status == OrgMirrorStatus.SUCCESS
+        assert refreshed.sync_start_date is not None
+        assert refreshed.sync_start_date > datetime.utcnow()
 
     @disable_existing_org_mirrors
     @patch("workers.repomirrorworker.get_registry_adapter")


### PR DESCRIPTION
## Summary
- Cancel no longer kills future syncs: `update_sync_status_to_cancel` preserves `sync_start_date` instead of clearing it, and `release_org_mirror_config` transitions CANCEL to SUCCESS with a scheduled next sync
- Repo-level CANCEL recovery: `schedule_org_mirror_repos_for_sync` now picks up both NEVER_RUN and CANCEL repos, transitioning them to SYNC_NOW with restored retries on the next discovery cycle
- UI copy fix: Cancel confirmation dialog updated to indicate future scheduled syncs will continue

## Root Cause
When a user cancelled an active org mirror sync, `update_sync_status_to_cancel` set `sync_start_date=None` and `retries=0`. After the worker processed the cancel, the config stayed in CANCEL state with no scheduled date, permanently stopping all future syncs until the user manually triggered sync-now.

## Test plan
- [x] Unit tests for `update_sync_status_to_cancel` preserving `sync_start_date`
- [x] Unit test for `release_org_mirror_config` scheduling next sync after cancel
- [x] End-to-end test: cancel, release, time passes, config becomes eligible again
- [x] Regression test: no re-cancel loop (status is SUCCESS not CANCEL on next pickup)
- [x] Repo-level test: CANCEL repos transition to SYNC_NOW on next discovery, SKIP untouched
- [x] API test: sync-cancel endpoint preserves `sync_start_date`
- [x] Worker test: updated assertion for cancel to SUCCESS transition