### PR TITLE
PROJQUAY-11403: fix(ui): fix manifest track line on unrelated pages

### DIFF
--- a/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
@@ -571,11 +571,8 @@ export default function TagsTable(props: TableProps) {
 
   // Calculate manifest tracks for visual grouping of tags sharing the same digest
   const {tracks, getTrackEntry, getLineClass, trackCount} = useManifestTracks(
-    props.allTags,
+    props.tags,
   );
-
-  // Page offset converts local row index to global index for track lookup
-  const pageOffset = (props.page - 1) * props.perPage;
 
   // Select all tags sharing a given manifest digest
   const selectTagsByManifest = (manifestDigest: string) => {
@@ -638,7 +635,7 @@ export default function TagsTable(props: TableProps) {
             org={props.org}
             repo={props.repo}
             tag={tag}
-            rowIndex={pageOffset + localIndex}
+            rowIndex={localIndex}
             selectedTags={props.selectedTags}
             isTagExpanded={isTagExpanded}
             setTagExpanded={setTagExpanded}


### PR DESCRIPTION
## Summary
- Fix manifest track visualization (vertical colored lines) appearing on pages where no visible tags share a manifest digest
- Compute tracks from only the current page's visible tags (`props.tags`) instead of all tags (`props.allTags`)
- Use local row indices instead of global offsets since tracks are now per-page

## Root Cause
In `TagsTable.tsx`, `useManifestTracks` received all tags across all pages. When two tags sharing a digest were far apart (e.g., global index 5 and index 3000), `entryByIndex` was populated for every index between them, rendering a continuous "middle" line on every intermediate page — even though neither matching tag was visible.

## Pre-Merge Testing passed:

### Image tags with different digest:
<img width="2369" height="1268" alt="image" src="https://github.com/user-attachments/assets/ea3976cb-cebe-41e1-9fee-def1daaa61a6" />

### Image tags with the same digest:
<img width="2369" height="1268" alt="image" src="https://github.com/user-attachments/assets/ff6d4d6f-0e7c-433c-8f3e-4a6869803973" />

### clicking a dot still selects all tags sharing that manifest across all pages
<img width="2369" height="1268" alt="image" src="https://github.com/user-attachments/assets/61265ac5-917f-4f68-9511-17adf3abd9c1" />




## Test plan
- [x] Existing `useManifestTracks` unit tests pass (17/17)
- [x] Navigate to a repository with many tags (3000+) and verify no spurious vertical lines on pages where all visible tags have unique digests
- [x] Verify track lines/dots appear correctly on pages where 2+ visible tags share a digest
- [x] Verify clicking a dot still selects all tags sharing that manifest across all pages

JIRA: https://redhat.atlassian.net/browse/PROJQUAY-11403

🤖 Generated with [Claude Code](https://claude.com/claude-code)