### PR TITLE
NO-ISSUE: ci(playwright): add API endpoint coverage analysis from Jaeger traces

### DIFF
--- a/.github/scripts/analyze-api-coverage.py
+++ b/.github/scripts/analyze-api-coverage.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""
+Analyze API endpoint coverage from Jaeger/OTEL traces collected during E2E tests.
+
+Compares observed (method, route) pairs from trace spans against the full catalog
+of registered Flask routes, producing a coverage report in GitHub Step Summary
+and a JSON artifact for trend tracking.
+
+Environment variables:
+    TRACES_FILE     - Path to Jaeger traces JSON (default: jaeger-traces/traces.json)
+    COVERAGE_FILE   - Path to write JSON report (default: jaeger-traces/api-coverage.json)
+    QUAY_API_URL    - Quay base URL for discovery endpoint (default: http://localhost:8080)
+    GITHUB_STEP_SUMMARY - GitHub Actions step summary file (set automatically in CI)
+"""
+
+import json
+import os
+import re
+import urllib.request
+from collections import defaultdict
+from datetime import datetime, timezone
+
+TRACES_FILE = os.environ.get("TRACES_FILE", "jaeger-traces/traces.json")
+COVERAGE_FILE = os.environ.get("COVERAGE_FILE", "jaeger-traces/api-coverage.json")
+QUAY_API_URL = os.environ.get("QUAY_API_URL", "http://localhost:8080")
+COMMIT_SHA = os.environ.get("COMMIT_SHA", "unknown")
+
+# V2 registry routes — small, stable set defined in endpoints/v2/.
+# After normalization these become the canonical forms we compare against.
+V2_ROUTES = [
+    ("GET", "/v2/"),
+    ("GET", "/v2/auth"),
+    ("POST", "/v2/auth"),
+    ("HEAD", "/v2/<repository>/blobs/<digest>"),
+    ("GET", "/v2/<repository>/blobs/<digest>"),
+    ("DELETE", "/v2/<repository>/blobs/<digest>"),
+    ("POST", "/v2/<repository>/blobs/uploads/"),
+    ("GET", "/v2/<repository>/blobs/uploads/<upload_uuid>"),
+    ("PATCH", "/v2/<repository>/blobs/uploads/<upload_uuid>"),
+    ("PUT", "/v2/<repository>/blobs/uploads/<upload_uuid>"),
+    ("DELETE", "/v2/<repository>/blobs/uploads/<upload_uuid>"),
+    ("GET", "/v2/<repository>/manifests/<manifest_ref>"),
+    ("PUT", "/v2/<repository>/manifests/<manifest_ref>"),
+    ("DELETE", "/v2/<repository>/manifests/<manifest_ref>"),
+    ("GET", "/v2/_catalog"),
+    ("GET", "/v2/<repository>/tags/list"),
+    ("GET", "/v2/<repository>/referrers/<manifest_ref>"),
+]
+
+
+def normalize_route(route: str) -> str:
+    """Normalize Flask/Swagger route patterns to a canonical form.
+
+    Handles three formats:
+      Flask with converters:  /<repopath:repository>/blobs/<regex("..."):digest>
+      Swagger:                /api/v1/repository/{repository}
+      Plain Flask:            /<repository>/blobs/<digest>
+
+    All normalize to:         /<repository>/blobs/<digest>
+    """
+    # Strip Flask type converters first (before touching braces, since regex
+    # patterns can contain {n,m} quantifiers that would be misinterpreted)
+    route = re.sub(r"<[^>]*:(\w+)>", r"<\1>", route)
+    # Swagger {param} -> <param>
+    route = route.replace("{", "<").replace("}", ">")
+    return route
+
+
+def parse_traces(traces_file: str) -> tuple[set, dict]:
+    """Extract observed (method, route) pairs and status codes from Jaeger traces.
+
+    Returns:
+        covered: set of (method, normalized_route) tuples
+        status_matrix: dict of (method, normalized_route) -> set of status codes
+    """
+    with open(traces_file) as f:
+        data = json.load(f)
+
+    traces = data.get("data", [])
+    if not traces:
+        return set(), {}
+
+    covered = set()
+    status_matrix = defaultdict(set)
+
+    for trace in traces:
+        for span in trace.get("spans", []):
+            tags = {t["key"]: t["value"] for t in span.get("tags", [])}
+
+            route = tags.get("http.route")
+            method = tags.get("http.method")
+            if not route or not method:
+                continue
+
+            if method == "OPTIONS":
+                continue
+
+            normalized = normalize_route(route)
+            key = (method, normalized)
+            covered.add(key)
+
+            status = tags.get("http.status_code")
+            if status is not None:
+                status_matrix[key].add(int(status))
+
+    return covered, status_matrix
+
+
+def fetch_api_v1_catalog(quay_url: str) -> set:
+    """Fetch API v1 routes from the Quay discovery endpoint."""
+    url = f"{quay_url}/api/v1/discovery?internal=true"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            discovery = json.loads(resp.read())
+    except Exception as e:
+        print(f"::warning::Could not fetch discovery endpoint: {e}")
+        return set()
+
+    catalog = set()
+    for path, path_data in discovery.get("paths", {}).items():
+        normalized = normalize_route(path)
+        for method in ("get", "post", "put", "delete", "patch", "head"):
+            if method in path_data:
+                catalog.add((method.upper(), normalized))
+
+    return catalog
+
+
+def build_v2_catalog() -> set:
+    """Return the hardcoded V2 registry route catalog."""
+    return {(method, route) for method, route in V2_ROUTES}
+
+
+def categorize_route(route: str) -> str:
+    if route.startswith("/api/v1/"):
+        return "api_v1"
+    if route.startswith("/v2/"):
+        return "v2_registry"
+    return "other"
+
+
+def build_report(catalog: set, covered: set, status_matrix: dict) -> dict:
+    """Build the coverage report structure."""
+    categories = defaultdict(lambda: {"covered": 0, "total": 0})
+
+    for method, route in sorted(catalog):
+        cat = categorize_route(route)
+        categories[cat]["total"] += 1
+        if (method, route) in covered:
+            categories[cat]["covered"] += 1
+
+    for cat_data in categories.values():
+        total = cat_data["total"]
+        cat_data["pct"] = round(cat_data["covered"] / total * 100, 1) if total else 0
+
+    uncovered = sorted(catalog - covered)
+    covered_in_catalog = sorted(catalog & covered)
+
+    total_routes = len(catalog)
+    total_covered = len(covered_in_catalog)
+    total_pct = round(total_covered / total_routes * 100, 1) if total_routes else 0
+
+    # Routes observed in traces but not in catalog (unexpected)
+    extra = sorted(covered - catalog)
+    extra_filtered = [(m, r) for m, r in extra if categorize_route(r) != "other"]
+
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "commit_sha": COMMIT_SHA,
+        "summary": {
+            "api_v1": dict(categories["api_v1"]),
+            "v2_registry": dict(categories["v2_registry"]),
+            "total": {
+                "covered": total_covered,
+                "total": total_routes,
+                "pct": total_pct,
+            },
+        },
+        "covered": [
+            {
+                "method": m,
+                "route": r,
+                "category": categorize_route(r),
+                "status_codes": sorted(status_matrix.get((m, r), [])),
+            }
+            for m, r in covered_in_catalog
+        ],
+        "uncovered": [
+            {"method": m, "route": r, "category": categorize_route(r)} for m, r in uncovered
+        ],
+        "extra": [{"method": m, "route": r} for m, r in extra_filtered],
+    }
+
+
+def write_step_summary(report: dict, status_matrix: dict) -> str:
+    """Generate GitHub Step Summary markdown."""
+    lines = []
+    lines.append("## API Endpoint Coverage")
+    lines.append("")
+
+    s = report["summary"]
+    lines.append("| Category | Covered | Total | Coverage |")
+    lines.append("|----------|---------|-------|----------|")
+
+    for label, key in [("API v1", "api_v1"), ("V2 Registry", "v2_registry")]:
+        cat = s.get(key, {})
+        if cat.get("total", 0) > 0:
+            lines.append(f"| {label} | {cat['covered']} | {cat['total']} | {cat['pct']}% |")
+
+    t = s["total"]
+    lines.append(f"| **Total** | **{t['covered']}** | **{t['total']}** | **{t['pct']}%** |")
+
+    uncovered = report["uncovered"]
+    if uncovered:
+        lines.append("")
+        lines.append(f"### Uncovered Routes ({len(uncovered)})")
+        lines.append("")
+        lines.append("| Method | Route | Category |")
+        lines.append("|--------|-------|----------|")
+        for entry in uncovered:
+            lines.append(f"| {entry['method']} | `{entry['route']}` | {entry['category']} |")
+
+    covered = report["covered"]
+    routes_with_multiple_statuses = [e for e in covered if len(e["status_codes"]) > 1]
+    if routes_with_multiple_statuses:
+        lines.append("")
+        lines.append(
+            f"### Status Code Matrix ({len(routes_with_multiple_statuses)} routes with multiple status codes)"
+        )
+        lines.append("")
+        lines.append("| Method | Route | Status Codes |")
+        lines.append("|--------|-------|-------------|")
+        for entry in routes_with_multiple_statuses:
+            codes = ", ".join(str(c) for c in entry["status_codes"])
+            lines.append(f"| {entry['method']} | `{entry['route']}` | {codes} |")
+
+    extra = report.get("extra", [])
+    if extra:
+        lines.append("")
+        lines.append(f"### Routes in Traces but Not in Catalog ({len(extra)})")
+        lines.append("")
+        lines.append("| Method | Route |")
+        lines.append("|--------|-------|")
+        for entry in extra:
+            lines.append(f"| {entry['method']} | `{entry['route']}` |")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    if not os.path.isfile(TRACES_FILE) or os.path.getsize(TRACES_FILE) == 0:
+        print("::warning::Traces file not found or empty — skipping API coverage analysis")
+        return
+
+    try:
+        with open(TRACES_FILE) as f:
+            probe = json.load(f)
+        if "data" not in probe:
+            print("::warning::Traces file missing 'data' key — skipping API coverage analysis")
+            return
+    except (json.JSONDecodeError, KeyError):
+        print("::warning::Traces file is not valid JSON — skipping API coverage analysis")
+        return
+
+    trace_count = len(probe.get("data", []))
+    print(f"Parsing {trace_count} traces from {TRACES_FILE}")
+
+    covered, status_matrix = parse_traces(TRACES_FILE)
+    print(f"Found {len(covered)} unique (method, route) pairs (excluding OPTIONS)")
+
+    api_v1_catalog = fetch_api_v1_catalog(QUAY_API_URL)
+    v2_catalog = build_v2_catalog()
+    catalog = api_v1_catalog | v2_catalog
+
+    if not catalog:
+        print("::warning::Could not build route catalog — skipping coverage calculation")
+        # Still write what we observed
+        catalog = set()
+
+    print(
+        f"Route catalog: {len(api_v1_catalog)} API v1 + {len(v2_catalog)} V2 = {len(catalog)} total"
+    )
+
+    report = build_report(catalog, covered, status_matrix)
+
+    os.makedirs(os.path.dirname(COVERAGE_FILE) or ".", exist_ok=True)
+    with open(COVERAGE_FILE, "w") as f:
+        json.dump(report, f, indent=2)
+    print(f"Coverage report written to {COVERAGE_FILE}")
+
+    summary_md = write_step_summary(report, status_matrix)
+
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            f.write(summary_md)
+        print("Step summary appended to GITHUB_STEP_SUMMARY")
+    else:
+        print(summary_md)
+
+    s = report["summary"]["total"]
+    print(f"\nAPI Coverage: {s['pct']}% ({s['covered']}/{s['total']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/analyze-api-coverage.py
+++ b/.github/scripts/analyze-api-coverage.py
@@ -24,6 +24,7 @@ TRACES_FILE = os.environ.get("TRACES_FILE", "jaeger-traces/traces.json")
 COVERAGE_FILE = os.environ.get("COVERAGE_FILE", "jaeger-traces/api-coverage.json")
 QUAY_API_URL = os.environ.get("QUAY_API_URL", "http://localhost:8080")
 COMMIT_SHA = os.environ.get("COMMIT_SHA", "unknown")
+TRACE_LIMIT = int(os.environ.get("TRACE_LIMIT", "50000"))
 
 # V2 registry routes — small, stable set defined in endpoints/v2/.
 # After normalization these become the canonical forms we compare against.
@@ -139,7 +140,7 @@ def categorize_route(route: str) -> str:
     return "other"
 
 
-def build_report(catalog: set, covered: set, status_matrix: dict) -> dict:
+def build_report(catalog: set, covered: set, status_matrix: dict, trace_count: int = 0) -> dict:
     """Build the coverage report structure."""
     categories = defaultdict(lambda: {"covered": 0, "total": 0})
 
@@ -168,6 +169,8 @@ def build_report(catalog: set, covered: set, status_matrix: dict) -> dict:
         "schema_version": 1,
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "commit_sha": COMMIT_SHA,
+        "trace_count": trace_count,
+        "trace_limit_hit": trace_count >= TRACE_LIMIT,
         "summary": {
             "api_v1": dict(categories["api_v1"]),
             "v2_registry": dict(categories["v2_registry"]),
@@ -210,6 +213,13 @@ def write_step_summary(report: dict, status_matrix: dict) -> str:
 
     t = s["total"]
     lines.append(f"| **Total** | **{t['covered']}** | **{t['total']}** | **{t['pct']}%** |")
+
+    if report.get("trace_limit_hit"):
+        lines.append("")
+        lines.append(
+            f"> **Note:** Trace export hit the {TRACE_LIMIT} trace limit. "
+            "Coverage may be under-counted."
+        )
 
     uncovered = report["uncovered"]
     if uncovered:
@@ -267,6 +277,12 @@ def main():
     trace_count = len(probe.get("data", []))
     print(f"Parsing {trace_count} traces from {TRACES_FILE}")
 
+    if trace_count >= TRACE_LIMIT:
+        print(
+            f"::warning::Trace count ({trace_count}) hit the export limit ({TRACE_LIMIT}). "
+            "Coverage may be under-counted — some routes from later tests may be missing."
+        )
+
     covered, status_matrix = parse_traces(TRACES_FILE)
     print(f"Found {len(covered)} unique (method, route) pairs (excluding OPTIONS)")
 
@@ -283,7 +299,7 @@ def main():
         f"Route catalog: {len(api_v1_catalog)} API v1 + {len(v2_catalog)} V2 = {len(catalog)} total"
     )
 
-    report = build_report(catalog, covered, status_matrix)
+    report = build_report(catalog, covered, status_matrix, trace_count)
 
     os.makedirs(os.path.dirname(COVERAGE_FILE) or ".", exist_ok=True)
     with open(COVERAGE_FILE, "w") as f:

--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -153,7 +153,7 @@ jobs:
         if: always()
         run: |
           mkdir -p jaeger-traces
-          curl -sf "http://localhost:16686/api/traces?service=quay&limit=10000&lookback=2h" \
+          curl -sf "http://localhost:16686/api/traces?service=quay&limit=50000&lookback=2h" \
             -o jaeger-traces/traces.json \
             || echo "::warning::Could not export Jaeger traces"
 

--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -153,7 +153,7 @@ jobs:
         if: always()
         run: |
           mkdir -p jaeger-traces
-          curl -sf "http://localhost:16686/api/traces?service=quay&limit=1000" \
+          curl -sf "http://localhost:16686/api/traces?service=quay&limit=10000&lookback=2h" \
             -o jaeger-traces/traces.json \
             || echo "::warning::Could not export Jaeger traces"
 
@@ -164,6 +164,16 @@ jobs:
         env:
           TRACES_FILE: jaeger-traces/traces.json
           METRICS_FILE: jaeger-traces/trace-metrics.json
+          COMMIT_SHA: ${{ github.sha }}
+
+      - name: Analyze API endpoint coverage
+        if: always()
+        continue-on-error: true
+        run: python3 .github/scripts/analyze-api-coverage.py
+        env:
+          TRACES_FILE: jaeger-traces/traces.json
+          COVERAGE_FILE: jaeger-traces/api-coverage.json
+          QUAY_API_URL: http://localhost:8080
           COMMIT_SHA: ${{ github.sha }}
 
       - name: Upload Jaeger traces

--- a/agent_docs/e2e-coverage.md
+++ b/agent_docs/e2e-coverage.md
@@ -1,0 +1,202 @@
+# E2E Coverage Measurement for Playwright Tests
+
+## Context
+
+We want to measure which parts of Quay are actually exercised by our 70+ Playwright E2E tests. This is different from traditional code coverage — we're not measuring lines hit, but answering: **which API endpoints and UI paths do our E2E tests actually cover?**
+
+The key insight from research: **Jaeger/OTEL tracing is already running with 100% sample rate during CI E2E tests** (`local-dev/jaeger/jaeger-config.yaml` sets `sample_rate: 1.0`). Every API request from every Playwright test is already captured as a trace span with `http.method`, `http.route`, and `http.status_code`. The data already exists — we just need to analyze it.
+
+**Coverport** (Konflux) is Go-specific (uses `go build -cover` + GOCOVERDIR) — not applicable to our Python/React stack.
+
+---
+
+## Phase 1: API Endpoint Coverage from Jaeger Traces
+
+**Status:** Implemented
+**Effort:** ~1 day
+**Value:** Very high
+**Dependencies:** None — data already exists
+**PR scope:** Single PR
+
+### What it delivers
+
+A report showing which Flask API routes were exercised during E2E tests vs. the full set of registered routes. Answers: "Which API endpoints have zero E2E test coverage?"
+
+### How it works
+
+1. After E2E tests complete, traces are already exported to `jaeger-traces/traces.json` (line 157 of `web-playwright-ci.yaml`)
+2. A new Python script extracts unique `(http.method, http.route)` tuples from the Jaeger spans
+3. The script fetches the complete route list from Quay's `/api/v1/discovery?internal=true` endpoint (which calls `app.url_map.iter_rules()` via `endpoints/api/discovery.py`)
+4. For V2 registry routes, the script enumerates the known routes from `endpoints/v2/` (blob, manifest, catalog, tag, referrers, v2auth)
+5. The script produces: coverage percentage, covered routes, uncovered routes, and a status-code matrix
+
+### Files to create/modify
+
+**New: `.github/scripts/analyze-api-coverage.py`**
+- Reads `jaeger-traces/traces.json` (Jaeger API format: `.data[].spans[].tags[]`)
+- Extracts `(http.method, http.route, http.status_code)` from span tags set by `opentelemetry-instrumentation-flask` (FlaskInstrumentor in `app.py:381`)
+- Fetches complete route catalog from `http://localhost:8080/api/v1/discovery?internal=true`
+- V2 routes are hardcoded (stable set: `/v2/`, blob, manifest, catalog, tag, referrers, v2auth patterns)
+- Outputs JSON report + GitHub Step Summary markdown table
+- No external dependencies — uses only stdlib `json`, `urllib`
+
+**Modify: `.github/workflows/web-playwright-ci.yaml`**
+- Add step after "Analyze Jaeger traces" (around line 163):
+  ```yaml
+  - name: Analyze API endpoint coverage
+    if: always()
+    continue-on-error: true
+    run: python3 .github/scripts/analyze-api-coverage.py
+    env:
+      TRACES_FILE: jaeger-traces/traces.json
+      QUAY_API_URL: http://localhost:8080
+  ```
+- Include `api-coverage.json` in the existing `jaeger-traces/` artifact upload
+
+### Output format (GitHub Step Summary)
+
+```markdown
+## API Endpoint Coverage
+
+| Metric | Value |
+|--------|-------|
+| Total API routes | 142 |
+| Exercised by E2E tests | 87 |
+| Coverage | 61.3% |
+
+### Uncovered Routes
+| Method | Route | Tag |
+|--------|-------|-----|
+| POST | /api/v1/repository/{repository}/build/ | build |
+| DELETE | /api/v1/organization/{orgname}/logs | logs |
+
+### Status Code Matrix (Top 20)
+| Method | Route | Status Codes Seen |
+|--------|-------|-------------------|
+| GET | /api/v1/repository/{repository} | 200, 404 |
+| POST | /api/v1/repository | 201, 400 |
+```
+
+### Risks & mitigations
+
+- **Jaeger trace limit:** Current curl uses `limit=1000`. With 70+ test files making many API calls, this may truncate. **Fix:** Increase to `limit=5000` or query multiple pages.
+- **Span attribute names:** OTEL Flask instrumentation sets `http.route` (the Flask URL rule pattern, not the concrete URL). If `http.route` is missing on some spans, fall back to parsing `http.target` or `operationName`. Need to verify actual attribute names from a real trace export.
+- **Two-phase execution:** DB auth and OIDC auth phases both write traces. Since Jaeger aggregates all traces, the single export captures both phases automatically.
+- **V2 registry routes:** These run in a separate gunicorn process (`gunicorn-registry`) with a different service name. Verify the Jaeger export includes spans from both services, or make a second query for the registry service.
+
+### Verification
+
+1. Run E2E tests locally with Jaeger (`make local-dev-up` with jaeger config merged)
+2. Export traces: `curl -sf "http://localhost:16686/api/traces?service=quay&limit=5000" -o traces.json`
+3. Inspect a span to confirm `http.route` and `http.method` tags are present
+4. Run the analysis script against the exported traces
+5. Verify the uncovered routes list makes sense (e.g., build endpoints should be uncovered since no build tests exist)
+
+---
+
+## Phase 2: Frontend V8 Coverage via Monocart Reporter
+
+**Status:** Not started
+**Effort:** ~2-3 days
+**Value:** Medium
+**Dependencies:** `monocart-coverage-reports` npm package
+**PR scope:** Single PR
+
+### What it delivers
+
+Line/branch/function coverage of the React/TypeScript frontend code as exercised by E2E tests, uploaded to Codecov with `e2e-frontend` flag.
+
+### Why this approach
+
+Shows which UI components and code paths are never rendered during E2E tests. The V8 approach requires no build changes — Playwright collects coverage natively from Chromium. No Istanbul build instrumentation needed.
+
+### How it works
+
+Monocart Coverage Reports is a Playwright-compatible reporter that automatically calls `page.coverage.startJSCoverage()` / `stopJSCoverage()` per test, converts V8 coverage to Istanbul format using source maps, and generates LCOV output.
+
+### Files to create/modify
+
+**Modify: `web/package.json`**
+- Add devDependency: `monocart-coverage-reports`
+
+**Modify: `web/playwright.config.ts`**
+- Add monocart reporter alongside existing reporters:
+  ```ts
+  ['monocart-coverage-reports', {
+    name: 'E2E Coverage',
+    outputDir: 'coverage/e2e',
+    sourceFilter: (sourcePath) => sourcePath.includes('/src/'),
+    reports: ['lcovonly', 'v8'],
+  }]
+  ```
+
+**Modify: `.github/workflows/web-playwright-ci.yaml`**
+- Challenge: CI uses `--reporter=blob` for each phase, overriding the config reporters. Need to either:
+  - Add monocart alongside blob: `--reporter=blob,monocart-coverage-reports`
+  - Or use env var to conditionally include monocart in the config
+- Add Codecov upload step after merge:
+  ```yaml
+  - name: Upload frontend E2E coverage
+    uses: codecov/codecov-action@v4
+    with:
+      flags: e2e-frontend
+      files: web/coverage/e2e/lcov.info
+  ```
+
+**Modify: `.github/codecov.yml`**
+- Add e2e-frontend flag configuration
+
+### Risks & mitigations
+
+- **Blob reporter + monocart:** When CI uses `--reporter=blob`, this overrides the config file's `reporter` array. Need to verify compatibility or find a workaround.
+- **Two-phase merge:** Coverage from DB auth and OIDC phases needs merging. Monocart can write to the same output dir, but need to verify it appends rather than overwrites.
+- **Source map resolution:** Production build generates source maps (`webpack.prod.js`). Monocart should resolve TypeScript source paths, but need to verify with the actual webpack config.
+- **CI time impact:** V8 coverage collection adds minimal overhead per test. Monocart processing at the end adds ~10-30 seconds.
+
+---
+
+## Phase 3: Nice-to-Haves
+
+### 3A. API Coverage Diff on PRs
+
+**Effort:** ~half day | **Depends on:** Phase 1
+
+Store `api-coverage.json` as a baseline artifact on the default branch. On PR runs, diff against baseline and post a PR comment showing routes that gained/lost coverage. Makes coverage regression visible in code review.
+
+### 3B. Response Code Coverage Matrix Enhancement
+
+**Effort:** ~half day | **Depends on:** Phase 1
+
+Extend Phase 1 to track `(method, route, status_code)` triples. Shows that `DELETE /api/v1/repository/{path}` was tested with `204` but never with `404` or `403`. More actionable than line-level coverage for API testing.
+
+### 3C. Backend Line-Level Coverage via coverage.py
+
+**Status:** NOT recommended
+
+Operationally complex: must patch gunicorn/gevent, flush coverage data from long-running workers, extract `.coverage` files from container. The signal-to-noise ratio is low — unit tests already target 70% line coverage. **Skip unless there's a specific need.**
+
+---
+
+## What we're NOT doing (and why)
+
+- **Backend line-level coverage:** High complexity (gunicorn/gevent/container extraction), low marginal value over unit test coverage
+- **Istanbul build instrumentation:** Unnecessary since V8 coverage works without it on Chromium
+- **Production/runtime coverage:** Out of scope — this is about CI E2E tests
+- **Coverport:** Go-only tool, not applicable
+
+---
+
+## Key files reference
+
+| File | Role |
+|------|------|
+| `.github/workflows/web-playwright-ci.yaml` | CI workflow (add coverage steps) |
+| `.github/scripts/analyze-jaeger-traces.sh` | Existing trace analysis (pattern reference) |
+| `.github/scripts/analyze-api-coverage.py` | New script (Phase 1) |
+| `.github/codecov.yml` | Codecov config |
+| `web/playwright.config.ts` | Playwright config (Phase 2) |
+| `web/package.json` | Dependencies (Phase 2) |
+| `endpoints/api/discovery.py` | Route enumeration via `app.url_map.iter_rules()` |
+| `local-dev/jaeger/jaeger-config.yaml` | Jaeger config (sample_rate: 1.0) |
+| `app.py:380-389` | OTEL Flask instrumentation setup |
+| `util/metrics/otel.py` | OTEL exporter initialization |

--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -448,6 +448,7 @@ class OrgRobotFederation(ApiResource):
     }
 
     @require_scope(scopes.ORG_ADMIN)
+    @nickname("getOrgRobotFederation")
     def get(self, orgname, robot_shortname):
         permission = AdministerOrganizationPermission(orgname)
         # Global readonly superusers can always view, regular superusers need FULL_ACCESS
@@ -463,6 +464,7 @@ class OrgRobotFederation(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @nickname("createOrgRobotFederation")
     @validate_json_request("CreateRobotFederation", optional=False)
     def post(self, orgname, robot_shortname):
         permission = AdministerOrganizationPermission(orgname)
@@ -482,6 +484,7 @@ class OrgRobotFederation(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @nickname("deleteOrgRobotFederation")
     def delete(self, orgname, robot_shortname):
         permission = AdministerOrganizationPermission(orgname)
         if permission.can() or allow_if_superuser_with_full_access():


### PR DESCRIPTION
## Summary

- Add a new Python script (`.github/scripts/analyze-api-coverage.py`) that extracts API endpoint coverage from the Jaeger traces already collected during Playwright E2E tests
- Compares observed `(method, route)` pairs against the full route catalog (API v1 via discovery endpoint + hardcoded V2 registry routes)
- Produces a coverage report in **GitHub Step Summary** showing covered/uncovered routes and a status code matrix
- Writes a JSON artifact (`api-coverage.json`) alongside existing trace data for trend tracking
- Increases Jaeger trace export limit from 1,000 to 10,000 to avoid truncation

### How it works

The OTEL Flask instrumentation (`FlaskInstrumentor`) already sets `http.method`, `http.route`, and `http.status_code` on every span at 100% sample rate in CI. This script simply analyzes that existing data — no new instrumentation or dependencies required.

### Example output (GitHub Step Summary)

| Category | Covered | Total | Coverage |
|----------|---------|-------|----------|
| API v1   | 64      | ~142  | ~45%     |
| V2 Registry | 8    | 17    | 47%      |
| **Total** | **72** | **~159** | **~45%** |

## Test plan

- [ ] Verify the new "Analyze API endpoint coverage" step runs successfully in CI
- [ ] Check the GitHub Step Summary for the coverage report
- [ ] Verify `api-coverage.json` appears in the `jaeger-traces` artifact
- [ ] Confirm the script handles edge cases gracefully (empty traces, unreachable discovery endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)