### PR TITLE
QUAYIO-1725: fix(setup.py): remove whitelist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if os.path.isfile(requirementPath):
             if (
                 line
                 and not line.startswith("#")
-                and not line.startswith("git")
+                and not line.startswith("git+")
                 and "@" not in line
                 and line.split("==")[0] not in ("setuptools", "wheel")
             ):

--- a/setup.py
+++ b/setup.py
@@ -1,66 +1,21 @@
 import os
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
-# File used to export Quay modules to be used in other projects.
-# Current modules exported to support reuse of database models.
-# Modules and dependencies are exported via whitelist - only the
-# required modules are exported for efficiency.
-
-# The only Quay dependencies that will be exported with package
-packages = [
-    "alembic",
-    "Authlib",
-    "bitmath",
-    "boto3",
-    "bcrypt",
-    "botocore",
-    "cachetools",
-    "cryptography",
-    "Deprecated",
-    "elasticsearch",
-    "Flask",
-    "hashids",
-    "jsonschema",
-    "keystoneauth1",
-    "peewee",
-    "pymemcache",
-    "PyYAML",
-    "redis",
-    "rehash",
-    "six",
-    "SQLAlchemy",
-    "stripe",
-    "tldextract",
-    "toposort",
-    "tzlocal",
-    "beautifulsoup4",
-    "bintrees",
-    "gevent",
-    "greenlet",
-    "gunicorn",
-    "Jinja2",
-    "maxminddb",
-    "mixpanel",
-    "netaddr",
-    "psutil",
-    "PyJWT",
-    "pyOpenSSL",
-    "sentry-sdk",
-    "requests",
-    "Werkzeug",
-    "xhtml2pdf",
-]
-
-# Pull dependency versions from requirements.txt
-# Exclude dependencies built directly from source, none are required
 quay_root = os.path.dirname(os.path.realpath(__file__))
 requirementPath = quay_root + "/requirements.txt"
 install_requires = []
 if os.path.isfile(requirementPath):
     with open(requirementPath) as f:
         for line in f.read().splitlines():
-            if not line.startswith("git") and line.split("==")[0] in packages:
+            line = line.strip()
+            if (
+                line
+                and not line.startswith("#")
+                and not line.startswith("git")
+                and "@" not in line
+                and line.split("==")[0] not in ("setuptools", "wheel")
+            ):
                 install_requires.append(line)
 
 setup(
@@ -70,30 +25,22 @@ setup(
     author="Quay Team",
     author_email="",
     url="https://github.com/quay/quay",
-    packages=[
-        "features",
-        "auth",
-        "data",
-        "data.cache",
-        "data.logs_model",
-        "data.logs_model.logs_producer",
-        "data.model",
-        "data.model.oci",
-        "data.registry_model",
-        "data.secscan_model",
-        "util",
-        "util.metrics",
-        "util.migrate",
-        "util.secscan",
-        "util.secscan.v4",
-        "util.security",
-        "image",
-        "image.docker",
-        "image.oci",
-        "image.docker.schema2",
-        "image.shared",
-        "digest",
-        "oauth",
-    ],
+    packages=find_packages(
+        exclude=[
+            "test",
+            "test.*",
+            "*.test",
+            "*.test.*",
+            "*.tests",
+            "*.tests.*",
+            "web",
+            "web.*",
+            "conf",
+            "conf.*",
+            "static",
+            "static.*",
+            "initdb",
+        ],
+    ),
     install_requires=install_requires,
 )


### PR DESCRIPTION
`setup.py` has relied on a manual whitelist for other packages that import Quay as a Git dependency:
- https://github.com/quay/quay-service-tool/blob/main/backend/pyproject.toml#L6
- https://github.com/quay/quay-db-jobs/blob/master/pyproject.toml#L7

This manual whitelist requires people to update it for the two consumers of Quay as a library (service-tool & db-jobs) so the whitelist has been removed meaning that these two should no longer break when Quay adds a new dependency.