### PR TITLE
PROJQUAY-11415: feat(workflow): add ambient retrospective workflow

### DIFF
--- a/.ambient/workflows/retrospective/ambient.json
+++ b/.ambient/workflows/retrospective/ambient.json
@@ -1,0 +1,31 @@
+{
+  "name": "Ambient Retrospective",
+  "description": "Self-improving workflow that reviews daily sessions, identifies patterns and stuck points, and proposes improvements to agent_docs, skills, and workflow context.",
+  "systemPrompt": "You are a workflow improvement analyst. Your job is to review Ambient sessions from the past day, identify where agents got stuck or succeeded, extract learnings, and propose concrete improvements to the workflow system. You have access to ACP session APIs to introspect session history. You are methodical, evidence-based, and concise. You produce actionable proposals, not vague suggestions. Every recommendation must cite the specific session and message that motivated it.",
+  "startupPrompt": "**Ambient Retrospective Engine**\n\nThis workflow reviews recent sessions and produces improvement proposals.\n\nAvailable commands:\n- `/retrospect` -- Run the full COLLECT -> ANALYZE -> PROPOSE -> OUTPUT cycle\n\nTo begin: `/retrospect`",
+  "rubric": {
+    "activationPrompt": "After producing the retrospective digest, evaluate the quality of the analysis.",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "coverage": {
+          "type": "number",
+          "description": "Session coverage: how many relevant sessions were analyzed vs skipped (1-5)"
+        },
+        "insight_quality": {
+          "type": "number",
+          "description": "Quality of insights: specific, evidence-backed, actionable vs vague/generic (1-5)"
+        },
+        "proposal_quality": {
+          "type": "number",
+          "description": "Quality of improvement proposals: concrete diffs vs hand-wavy suggestions (1-5)"
+        },
+        "digest_clarity": {
+          "type": "number",
+          "description": "Digest readability: well-structured, scannable, right level of detail (1-5)"
+        }
+      },
+      "required": ["coverage", "insight_quality", "proposal_quality", "digest_clarity"]
+    }
+  }
+}

--- a/.ambient/workflows/retrospective/rubric.md
+++ b/.ambient/workflows/retrospective/rubric.md
@@ -1,0 +1,27 @@
+**Session Coverage** (1-5)
+Score 1: Looked at 0-1 sessions. Skipped most of the day's work.
+Score 2: Sampled a few sessions but missed significant ones.
+Score 3: Reviewed most sessions. May have missed idle/short ones.
+Score 4: Reviewed all completed sessions. Noted running ones for next cycle.
+Score 5: Comprehensive coverage. Every session cataloged with phase, outcome, and relevance assessed.
+
+**Insight Quality** (1-5)
+Score 1: Generic observations ("agents sometimes get stuck"). No evidence cited.
+Score 2: Some specific observations but no session/message citations.
+Score 3: Specific findings with session references. Patterns identified across sessions.
+Score 4: Evidence-backed insights with exact message quotes. Root causes identified, not just symptoms.
+Score 5: Deep pattern analysis across sessions. Connects stuck points to specific gaps in docs/skills. Quantifies impact (time lost, retries needed).
+
+**Proposal Quality** (1-5)
+Score 1: Vague suggestions ("improve documentation"). No concrete changes.
+Score 2: General direction ("add a section about X to agent_docs"). No diff or content.
+Score 3: Specific proposals with target file and section. Content outlined but not written.
+Score 4: Ready-to-apply proposals with exact file paths, content, and rationale. Could be turned into a PR.
+Score 5: Proposals include priority ranking, effort estimate, and expected impact. Grouped by theme. Conflicts with existing content identified and resolved.
+
+**Digest Clarity** (1-5)
+Score 1: Wall of text. No structure. Hard to scan.
+Score 2: Some structure but too verbose or too sparse.
+Score 3: Clear sections (findings, proposals, metrics). Scannable.
+Score 4: Well-structured with executive summary, detailed findings, and prioritized action items.
+Score 5: Perfect digest: 30-second executive summary, detailed evidence section, prioritized proposals with effort/impact, metrics dashboard. Suitable for async review.

--- a/.ambient/workflows/retrospective/scripts/extract-session-messages.py
+++ b/.ambient/workflows/retrospective/scripts/extract-session-messages.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Extract messages from an Ambient session via the backend export endpoint.
+
+Handles two AG-UI event patterns:
+  1. Streaming deltas (active sessions): TEXT_MESSAGE_START/CONTENT/END
+  2. MESSAGES_SNAPSHOT (completed sessions): full conversation array
+
+Usage:
+  python3 extract-session-messages.py <project> <session-name> [max-messages]
+
+Requires BOT_TOKEN at /run/secrets/ambient/bot-token
+"""
+
+import json
+import sys
+import urllib.request
+
+
+def extract_messages(events, max_messages=50):
+    msg_roles = {}
+    msg_deltas = {}
+    messages = []
+    last_snapshot = None
+
+    for event in events:
+        etype = event.get("type", "")
+        mid = event.get("messageId", "")
+
+        if etype == "TEXT_MESSAGE_START" and mid:
+            msg_roles[mid] = event.get("role", "assistant")
+            msg_deltas[mid] = []
+        elif etype == "TEXT_MESSAGE_CONTENT" and mid:
+            if "delta" in event:
+                msg_deltas.setdefault(mid, []).append(event["delta"])
+        elif etype == "TEXT_MESSAGE_END" and mid:
+            if mid in msg_deltas:
+                full_text = "".join(msg_deltas.pop(mid))
+                if full_text.strip():
+                    messages.append(
+                        {
+                            "role": msg_roles.pop(mid, "assistant"),
+                            "text": full_text[:500],
+                        }
+                    )
+        elif etype == "MESSAGES_SNAPSHOT":
+            last_snapshot = event
+
+    if not messages and last_snapshot:
+        for msg in last_snapshot.get("messages", []):
+            role = msg.get("role", "")
+            content = msg.get("content", "")
+            if role in ("user", "assistant") and isinstance(content, str) and content.strip():
+                messages.append({"role": role, "text": content[:500]})
+
+    return messages[-max_messages:]
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: extract-session-messages.py <project> <session-name> [max]")
+        sys.exit(1)
+
+    project = sys.argv[1]
+    session_name = sys.argv[2]
+    max_msgs = int(sys.argv[3]) if len(sys.argv) > 3 else 50
+
+    try:
+        bot_token = open("/run/secrets/ambient/bot-token").read().strip()
+    except FileNotFoundError:
+        print(json.dumps({"error": "bot-token not found"}))
+        sys.exit(1)
+
+    base = "http://backend-service.ambient-code.svc.cluster.local:8080/api"
+    url = f"{base}/projects/{project}/agentic-sessions/{session_name}/export"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {bot_token}"})
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read())
+    except Exception as e:
+        print(json.dumps({"error": str(e), "messages": []}))
+        sys.exit(1)
+
+    events = data.get("aguiEvents", [])
+    messages = extract_messages(events, max_msgs)
+
+    print(
+        json.dumps(
+            {
+                "session": session_name,
+                "total_events": len(events),
+                "messages": messages,
+                "message_count": len(messages),
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.ambient/workflows/retrospective/skills/retrospect/SKILL.md
+++ b/.ambient/workflows/retrospective/skills/retrospect/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: retrospect
+description: >
+  Run the full retrospective cycle: collect session data, analyze patterns,
+  identify stuck points and successes, and propose concrete improvements
+  to agent_docs, skills, and workflow context.
+allowed-tools:
+  - Bash(git log *)
+  - Bash(git diff *)
+  - Bash(python3 *)
+  - Bash(date *)
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Agent
+  - mcp__acp__acp_list_sessions
+  - mcp__acp__acp_get_session
+  - mcp__acp__acp_get_session_status
+  - mcp__rubric__evaluate_rubric
+---
+
+# Retrospective Engine
+
+Run the COLLECT -> ANALYZE -> PROPOSE -> OUTPUT cycle for continuous workflow improvement.
+
+## Phase 1: COLLECT
+
+### Step 1: Enumerate Sessions
+
+List all sessions from the last 24 hours, including completed ones:
+
+```
+mcp__acp__acp_list_sessions(include_completed=true, limit=100)
+```
+
+Record each session's name, displayName, phase, and createdAt.
+
+### Step 2: Retrieve Session Details and Messages
+
+For each session, get the full spec (including `initialPrompt`) and conditions:
+
+```
+mcp__acp__acp_get_session(session_name="<name>")
+```
+
+Then get messages. Try `acp_get_session_status` first. If messages come back
+empty, fall back to the extract script:
+
+```bash
+python3 .ambient/workflows/retrospective/scripts/extract-session-messages.py <PROJECT> <SESSION_NAME> 30
+```
+
+The script handles both AG-UI streaming deltas (active sessions) and
+MESSAGES_SNAPSHOT fallback (completed sessions). It outputs JSON with a
+`messages` array.
+
+For each session extract:
+- What it was trying to accomplish (initialPrompt + displayName)
+- Whether it succeeded or got stuck
+- Key messages showing conversation flow
+- Error messages, retries, or user corrections
+- Which skills/commands were invoked
+- Duration (startTime to lastActivityTime)
+
+Skip sessions that are still actively Running.
+
+### Step 3: Check Git Activity
+
+```bash
+git log --since="24 hours ago" --oneline --all
+```
+
+Cross-reference commits with session autoBranches.
+
+### Step 4: Review Existing Workflow State
+
+Read the current workflow files to understand what guidance already exists:
+
+- `AGENTS.md` and `CLAUDE.md`
+- `agent_docs/` documentation
+- `.claude/skills/` definitions
+
+## Phase 2: ANALYZE
+
+### Step 5: Classify Session Outcomes
+
+| Category | Signal |
+|----------|--------|
+| **Smooth** | Completed with minimal back-and-forth, no corrections |
+| **Recovered** | Hit obstacle but self-corrected or user corrected once |
+| **Stuck** | Multiple retries, user frustration, or abandoned |
+| **Failed** | Session in Failed phase or explicit failure |
+
+### Step 6: Root Cause Analysis (Stuck/Failed)
+
+- **Missing documentation** — agent didn't know how
+- **Missing skill** — manual steps that should be automated
+- **Wrong approach** — suboptimal path taken
+- **Tool limitation** — needed unavailable capability
+- **External blocker** — CI, API, auth issues
+- **Platform bug** — Ambient platform issue
+
+### Step 7: Identify Successes and Patterns
+
+- Sessions that went well — patterns worth codifying
+- Cross-session recurring themes
+- Convention violations appearing repeatedly
+
+## Phase 3: PROPOSE
+
+### Step 8: Generate Improvement Proposals
+
+For each finding, generate a concrete proposal:
+
+- **Documentation gaps**: target file path, section, actual content, evidence
+- **Skill improvements**: target SKILL.md, change, rationale, evidence
+- **New skills**: name, description, what it automates, outline
+- **Workflow changes**: target file, change, impact
+
+### Step 9: Prioritize
+
+- **P1**: High frequency + high impact + low effort
+- **P2**: High frequency OR high impact
+- **P3**: Low frequency + low impact
+
+## Phase 4: OUTPUT
+
+### Step 10: Write Daily Digest
+
+Write to `/workspace/artifacts/retrospective-<DATE>.md`:
+
+```markdown
+# Ambient Retrospective — <DATE>
+
+## Executive Summary
+<!-- 3-5 bullets -->
+
+## Session Inventory
+| Session | Status | Duration | Outcome | Notes |
+|---------|--------|----------|---------|-------|
+
+## Findings
+### Stuck Points
+### Successes
+### Patterns
+
+## Improvement Proposals
+### P1 — Do First
+### P2 — Do Soon
+### P3 — Backlog
+
+## Metrics
+- Sessions reviewed: N
+- Stuck points identified: N
+- Proposals generated: N
+```
+
+### Step 11: Evaluate
+
+Run rubric evaluation against `.ambient/workflows/retrospective/rubric.md`.


### PR DESCRIPTION
## Summary
- Add a self-improving retrospective workflow that can be launched as a scheduled Ambient session
- Reviews daily session history via ACP APIs and the backend export endpoint
- Identifies where agents got stuck, extracts learnings, and proposes concrete improvements to agent_docs, skills, and workflow context
- Includes AG-UI event extraction script that handles both streaming deltas (active sessions) and MESSAGES_SNAPSHOT (completed sessions)

## Root Cause / Rationale
There is no feedback loop for the Ambient workflow system — agents make the same mistakes across sessions because learnings aren't captured systematically. This workflow creates a continuous improvement cycle by analyzing session transcripts, identifying patterns (stuck points, successes, convention violations), and generating prioritized proposals for documentation, skill, and workflow improvements.

## Changes
- `.ambient/workflows/retrospective/ambient.json` — Workflow config with system prompt and rubric schema (4 dimensions: coverage, insight quality, proposal quality, digest clarity)
- `.ambient/workflows/retrospective/rubric.md` — Detailed scoring rubric for retrospective quality
- `.ambient/workflows/retrospective/skills/retrospect/SKILL.md` — `/retrospect` skill implementing the COLLECT → ANALYZE → PROPOSE → OUTPUT cycle
- `.ambient/workflows/retrospective/scripts/extract-session-messages.py` — Python script to extract messages from AG-UI events via the backend export endpoint, handling both streaming delta reassembly and MESSAGES_SNAPSHOT fallback

## Test Plan
- [x] Manual testing performed — ran full retrospective cycle against 26 live sessions, produced digest with 4 stuck points, 3 successes, and 6 prioritized improvement proposals
- [x] AG-UI extraction script validated against live active session (5 messages from 3,796 events) and stopped session (8 messages via MESSAGES_SNAPSHOT)
- [ ] No backport needed

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11415

## Backport
- [x] No backport needed