### PR TITLE
NO-ISSUE: fix(api): add missing UserRobotFederation endpoints to fix Angular UI crash

### DIFF
--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -435,22 +435,113 @@ class RegenerateOrgRobot(ApiResource):
         raise Unauthorized()
 
 
+def _parse_federation_config(request):
+    fed_config = list()
+    seen = set()
+    for item in request.json:
+        if not item:
+            raise request_error(message="Missing one or more required fields (issuer, subject)")
+        issuer = item.get("issuer")
+        subject = item.get("subject")
+        if not issuer or not subject:
+            raise request_error(message="Missing one or more required fields (issuer, subject)")
+        if not (issuer.startswith("http://") or issuer.startswith("https://")):
+            raise request_error(message="Issuer must be a URL (http:// or https://)")
+        entry = {"issuer": issuer, "subject": subject}
+
+        if f"{issuer}:{subject}" in seen:
+            raise request_error(message="Duplicate federation config entry")
+
+        seen.add(f"{issuer}:{subject}")
+        fed_config.append(entry)
+
+    return list(fed_config)
+
+
+@resource("/v1/user/robots/<robot_shortname>/federation")
+@path_param(
+    "robot_shortname", "The short name for the robot, without any user or organization prefix"
+)
+class UserRobotFederation(ApiResource):
+    """
+    Resource for managing federation configuration of a user's robot account.
+    """
+
+    schemas = {
+        "CreateRobotFederation": CREATE_ROBOT_FEDERATION_SCHEMA,
+    }
+
+    @require_user_admin()
+    @nickname("getUserRobotFederation")
+    def get(self, robot_shortname):
+        """
+        Returns the federation configuration for the user's robot.
+        """
+        parent = get_authenticated_user()
+        robot_username = format_robot_username(parent.username, robot_shortname)
+        robot = lookup_robot(robot_username)
+        return get_robot_federation_config(robot)
+
+    @require_user_admin(disallow_for_restricted_users=True)
+    @nickname("createUserRobotFederation")
+    @validate_json_request("CreateRobotFederation", optional=False)
+    def post(self, robot_shortname):
+        """
+        Create or update federation configuration for the user's robot.
+        """
+        parent = get_authenticated_user()
+        fed_config = _parse_federation_config(request)
+
+        robot_username = format_robot_username(parent.username, robot_shortname)
+        robot = lookup_robot(robot_username)
+        create_robot_federation_config(robot, fed_config)
+        log_action(
+            "create_robot_federation",
+            parent.username,
+            {"config": fed_config, "robot": robot_shortname},
+        )
+        return fed_config
+
+    @require_user_admin(disallow_for_restricted_users=True)
+    @nickname("deleteUserRobotFederation")
+    def delete(self, robot_shortname):
+        """
+        Delete federation configuration for the user's robot.
+        """
+        parent = get_authenticated_user()
+        robot_username = format_robot_username(parent.username, robot_shortname)
+        robot = lookup_robot(robot_username)
+        delete_robot_federation_config(robot)
+        log_action(
+            "delete_robot_federation",
+            parent.username,
+            {"robot": robot_shortname},
+        )
+        return "", 204
+
+
 @resource("/v1/organization/<orgname>/robots/<robot_shortname>/federation")
 @path_param("orgname", "The name of the organization")
 @path_param(
     "robot_shortname", "The short name for the robot, without any user or organization prefix"
 )
-@related_user_resource(UserRobot)
+@related_user_resource(UserRobotFederation)
 class OrgRobotFederation(ApiResource):
+    """
+    Resource for managing federation configuration of an organization's robot account.
+    """
 
     schemas = {
         "CreateRobotFederation": CREATE_ROBOT_FEDERATION_SCHEMA,
     }
 
     @require_scope(scopes.ORG_ADMIN)
+    @nickname("getOrgRobotFederation")
     def get(self, orgname, robot_shortname):
+        """
+        Returns the federation configuration for the organization's robot.
+        """
         permission = AdministerOrganizationPermission(orgname)
-        # Global readonly superusers can always view, regular superusers need FULL_ACCESS
         if (
             permission.can()
             or allow_if_global_readonly_superuser()
@@ -463,11 +554,15 @@ class OrgRobotFederation(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @nickname("createOrgRobotFederation")
     @validate_json_request("CreateRobotFederation", optional=False)
     def post(self, orgname, robot_shortname):
+        """
+        Create or update federation configuration for the organization's robot.
+        """
         permission = AdministerOrganizationPermission(orgname)
         if permission.can() or allow_if_superuser_with_full_access():
-            fed_config = self._parse_federation_config(request)
+            fed_config = _parse_federation_config(request)
 
             robot_username = format_robot_username(orgname, robot_shortname)
             robot = lookup_robot(robot_username)
@@ -482,7 +577,11 @@ class OrgRobotFederation(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
+    @nickname("deleteOrgRobotFederation")
     def delete(self, orgname, robot_shortname):
+        """
+        Delete federation configuration for the organization's robot.
+        """
         permission = AdministerOrganizationPermission(orgname)
         if permission.can() or allow_if_superuser_with_full_access():
             robot_username = format_robot_username(orgname, robot_shortname)
@@ -495,25 +594,3 @@ class OrgRobotFederation(ApiResource):
             )
             return "", 204
         raise Unauthorized()
-
-    def _parse_federation_config(self, request):
-        fed_config = list()
-        seen = set()
-        for item in request.json:
-            if not item:
-                raise request_error(message="Missing one or more required fields (issuer, subject)")
-            issuer = item.get("issuer")
-            subject = item.get("subject")
-            if not issuer or not subject:
-                raise request_error(message="Missing one or more required fields (issuer, subject)")
-            if not (issuer.startswith("http://") or issuer.startswith("https://")):
-                raise request_error(message="Issuer must be a URL (http:// or https://)")
-            entry = {"issuer": issuer, "subject": subject}
-
-            if f"{issuer}:{subject}" in seen:
-                raise request_error(message="Duplicate federation config entry")
-
-            seen.add(f"{issuer}:{subject}")
-            fed_config.append(entry)
-
-        return list(fed_config)

--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -436,6 +436,12 @@ class RegenerateOrgRobot(ApiResource):
 
 
 def _parse_federation_config(request):
+    """
+    Parse and validate federation configuration from the request body.
+
+    Expects a JSON array of objects with 'issuer' (a URL) and 'subject' fields.
+    Raises request_error on missing fields, invalid issuer URLs, or duplicates.
+    """
     fed_config = list()
     seen = set()
     for item in request.json:
@@ -449,10 +455,10 @@ def _parse_federation_config(request):
             raise request_error(message="Issuer must be a URL (http:// or https://)")
         entry = {"issuer": issuer, "subject": subject}
 
-        if f"{issuer}:{subject}" in seen:
+        if (issuer, subject) in seen:
             raise request_error(message="Duplicate federation config entry")
 
-        seen.add(f"{issuer}:{subject}")
+        seen.add((issuer, subject))
         fed_config.append(entry)
 
     return list(fed_config)

--- a/endpoints/api/test/test_robot.py
+++ b/endpoints/api/test/test_robot.py
@@ -269,6 +269,84 @@ def test_user_robot_federation_create(app):
         assert len(resp.json) == 0
 
 
+def test_user_robot_federation_multiple_configs(app):
+    with client_with_identity("devtable", app) as cl:
+        fed_config = [
+            {"issuer": "https://issuer1", "subject": "subject1"},
+            {"issuer": "https://issuer2", "subject": "subject2"},
+        ]
+        conduct_api_call(
+            cl,
+            UserRobotFederation,
+            "POST",
+            {"robot_shortname": "dtrobot"},
+            fed_config,
+            expected_code=200,
+        )
+
+        resp = conduct_api_call(
+            cl,
+            UserRobotFederation,
+            "GET",
+            {"robot_shortname": "dtrobot"},
+            expected_code=200,
+        )
+
+        assert len(resp.json) == 2
+
+
+def test_user_robot_federation_invalid_issuer(app):
+    with client_with_identity("devtable", app) as cl:
+        conduct_api_call(
+            cl,
+            UserRobotFederation,
+            "POST",
+            {"robot_shortname": "dtrobot"},
+            [{"issuer": "not-a-url", "subject": "subject1"}],
+            expected_code=400,
+        )
+
+
+def test_user_robot_federation_empty_config(app):
+    with client_with_identity("devtable", app) as cl:
+        conduct_api_call(
+            cl,
+            UserRobotFederation,
+            "POST",
+            {"robot_shortname": "dtrobot"},
+            [{}],
+            expected_code=400,
+        )
+
+
+def test_org_robot_federation_unauthorized_reader(app):
+    with client_with_identity("reader", app) as cl:
+        conduct_api_call(
+            cl,
+            OrgRobotFederation,
+            "GET",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            expected_code=403,
+        )
+
+        conduct_api_call(
+            cl,
+            OrgRobotFederation,
+            "POST",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            [{"issuer": "https://issuer1", "subject": "subject1"}],
+            expected_code=403,
+        )
+
+        conduct_api_call(
+            cl,
+            OrgRobotFederation,
+            "DELETE",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            expected_code=403,
+        )
+
+
 @pytest.mark.parametrize(
     "fed_config, raises_error, error_message",
     [

--- a/endpoints/api/test/test_robot.py
+++ b/endpoints/api/test/test_robot.py
@@ -11,7 +11,9 @@ from endpoints.api.robot import (
     OrgRobotFederation,
     OrgRobotList,
     UserRobot,
+    UserRobotFederation,
     UserRobotList,
+    _parse_federation_config,
 )
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
@@ -225,6 +227,48 @@ def test_robot_federation_create(app):
         assert len(resp.json) == 0
 
 
+def test_user_robot_federation_create(app):
+    with client_with_identity("devtable", app) as cl:
+        conduct_api_call(
+            cl,
+            UserRobotFederation,
+            "POST",
+            {"robot_shortname": "dtrobot"},
+            [{"issuer": "https://issuer1", "subject": "subject1"}],
+            expected_code=200,
+        )
+
+        resp = conduct_api_call(
+            cl,
+            UserRobotFederation,
+            "GET",
+            {"robot_shortname": "dtrobot"},
+            expected_code=200,
+        )
+
+        assert len(resp.json) == 1
+        assert resp.json[0].get("issuer") == "https://issuer1"
+        assert resp.json[0].get("subject") == "subject1"
+
+        conduct_api_call(
+            cl,
+            UserRobotFederation,
+            "DELETE",
+            {"robot_shortname": "dtrobot"},
+            expected_code=204,
+        )
+
+        resp = conduct_api_call(
+            cl,
+            UserRobotFederation,
+            "GET",
+            {"robot_shortname": "dtrobot"},
+            expected_code=200,
+        )
+
+        assert len(resp.json) == 0
+
+
 @pytest.mark.parametrize(
     "fed_config, raises_error, error_message",
     [
@@ -262,7 +306,7 @@ def test_parse_federation_config(app, fed_config, raises_error, error_message):
     with app.app_context():
         if raises_error:
             with pytest.raises(Exception) as ex:
-                parsed = OrgRobotFederation()._parse_federation_config(request)
+                parsed = _parse_federation_config(request)
             assert error_message in str(ex.value)
         else:
-            parsed = OrgRobotFederation()._parse_federation_config(request)
+            parsed = _parse_federation_config(request)

--- a/endpoints/api/test/test_security.py
+++ b/endpoints/api/test/test_security.py
@@ -6932,6 +6932,12 @@ SECURITY_TESTS: List[
         "testuser",
         401,
     ),
+    (UserRobotFederation, "GET", {"robot_shortname": "robotname"}, None, None, 401),
+    (UserRobotFederation, "GET", {"robot_shortname": "robotname"}, None, "devtable", 400),
+    (UserRobotFederation, "POST", {"robot_shortname": "robotname"}, None, None, 401),
+    (UserRobotFederation, "POST", {"robot_shortname": "robotname"}, None, "devtable", 400),
+    (UserRobotFederation, "DELETE", {"robot_shortname": "robotname"}, None, None, 401),
+    (UserRobotFederation, "DELETE", {"robot_shortname": "robotname"}, None, "devtable", 400),
     (
         RepositoryTagPullStatistics,
         "GET",


### PR DESCRIPTION
fix(api): add missing UserRobotFederation endpoints to fix Angular UI crash

OrgRobotFederation declared @related_user_resource(UserRobot) but no
UserRobotFederation class existed. After #5830 added @nickname decorators,
these operations appeared in the Swagger spec for the first time. The
Angular frontend's getMatchingUserOperationName() then crashed trying to
find matching HTTP methods on UserRobot (which lacks a POST method).

- Add UserRobotFederation class at /v1/user/robots/<shortname>/federation
- Point OrgRobotFederation's @related_user_resource to UserRobotFederation
- Extract _parse_federation_config to module-level shared function
- Add tests for user-level robot federation endpoints