### PR TITLE
NO-ISSUE: fix(api): remove @nickname from OrgRobotFederation to fix Angular UI error

### DIFF
--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -448,7 +448,6 @@ class OrgRobotFederation(ApiResource):
     }
 
     @require_scope(scopes.ORG_ADMIN)
-    @nickname("getOrgRobotFederation")
     def get(self, orgname, robot_shortname):
         permission = AdministerOrganizationPermission(orgname)
         # Global readonly superusers can always view, regular superusers need FULL_ACCESS
@@ -464,7 +463,6 @@ class OrgRobotFederation(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
-    @nickname("createOrgRobotFederation")
     @validate_json_request("CreateRobotFederation", optional=False)
     def post(self, orgname, robot_shortname):
         permission = AdministerOrganizationPermission(orgname)
@@ -484,7 +482,6 @@ class OrgRobotFederation(ApiResource):
         raise Unauthorized()
 
     @require_scope(scopes.ORG_ADMIN)
-    @nickname("deleteOrgRobotFederation")
     def delete(self, orgname, robot_shortname):
         permission = AdministerOrganizationPermission(orgname)
         if permission.can() or allow_if_superuser_with_full_access():


### PR DESCRIPTION

The @nickname decorators added in 65de0968a made OrgRobotFederation visible to /api/v1/discovery, but since there is no corresponding UserRobotFederation class, the Angular API service throws "Could not find user operation matching org operation: createOrgRobotFederation" on every page load. Remove the nicknames until a UserRobotFederation resource is added.