### PR TITLE
PROJQUAY-11434: test(web): add Playwright E2E tests for Angular UI toggle and smoke coverage

### DIFF
--- a/.github/actions/setup-quay/action.yaml
+++ b/.github/actions/setup-quay/action.yaml
@@ -237,6 +237,16 @@ runs:
         echo "Static files built successfully"
         ls -la static/build/ || echo "Warning: static/build/ directory not found"
 
+    - name: Build React static files for nginx
+      shell: bash
+      run: |
+        echo "Building React static files for nginx..."
+        cd web && npm clean-install && npm run build
+        mkdir -p ../static/patternfly
+        cp -r dist/* ../static/patternfly/
+        echo "React files deployed to static/patternfly/"
+        ls ../static/patternfly/index.html
+
     - name: Start Quay container
       shell: bash
       run: |

--- a/.github/actions/setup-quay/action.yaml
+++ b/.github/actions/setup-quay/action.yaml
@@ -239,6 +239,8 @@ runs:
 
     - name: Build React static files for nginx
       shell: bash
+      env:
+        REACT_QUAY_APP_API_URL: http://localhost:8080
       run: |
         echo "Building React static files for nginx..."
         cd web && npm clean-install && npm run build

--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -68,7 +68,13 @@ jobs:
       - name: Run Database auth tests
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-results/db
-        run: cd web && npx playwright test --grep-invert @auth:OIDC --reporter=blob
+        run: cd web && npx playwright test --project=chromium --grep-invert @auth:OIDC --reporter=blob
+
+      - name: Run legacy UI toggle and smoke tests
+        if: always()
+        env:
+          PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-results/legacy-ui
+        run: cd web && npx playwright test --project=legacy-ui --reporter=blob
 
       - name: Swap to OIDC authentication
         if: always()
@@ -104,7 +110,7 @@ jobs:
         if: always()
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-results/oidc
-        run: cd web && npx playwright test --grep @auth:OIDC --reporter=blob
+        run: cd web && npx playwright test --project=chromium --grep @auth:OIDC --reporter=blob
 
       - name: Merge test reports
         if: always()

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      testIgnore: /legacy-ui/,
       use: {...devices['Desktop Chrome'], channel: 'chromium'},
     },
     {

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -60,6 +60,16 @@ export default defineConfig({
       name: 'chromium',
       use: {...devices['Desktop Chrome'], channel: 'chromium'},
     },
+    {
+      name: 'legacy-ui',
+      testDir: './playwright/e2e/legacy-ui',
+      use: {
+        ...devices['Desktop Chrome'],
+        channel: 'chromium',
+        baseURL:
+          process.env.PLAYWRIGHT_LEGACY_BASE_URL || 'http://localhost:8080',
+      },
+    },
   ],
 
   // Configure web server for local development

--- a/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
+++ b/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
@@ -25,26 +25,31 @@ test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
   test('repository list page loads after login', async ({page, request}) => {
     // Log in via API to get session cookies
     const csrfResponse = await request.get(`${API_URL}/csrf_token`);
+    expect(csrfResponse.ok()).toBeTruthy();
     const csrfData = await csrfResponse.json();
 
-    await request.post(`${API_URL}/api/v1/signin`, {
+    const signinResponse = await request.post(`${API_URL}/api/v1/signin`, {
       headers: {'X-CSRF-Token': csrfData.csrf_token},
       data: {
         username: TEST_USERS.admin.username,
         password: TEST_USERS.admin.password,
       },
     });
+    expect(signinResponse.ok()).toBeTruthy();
 
     // Transfer cookies from API context to the browser page
     const cookies = await request.storageState();
     await page.context().addCookies(cookies.cookies);
 
-    // Ensure Angular cookie is still set
+    // Derive domain from the baseURL so tests work in any environment
+    const baseUrl = new URL(
+      page.context().pages()[0]?.url() || 'http://localhost:8080',
+    );
     await page.context().addCookies([
       {
         name: 'defaultui',
         value: 'angular',
-        domain: 'localhost',
+        domain: baseUrl.hostname,
         path: '/',
       },
     ]);

--- a/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
+++ b/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
@@ -59,7 +59,7 @@ test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
 
     // Verify Angular routed to a page (ng-view has rendered content)
-    await expect(page.locator('[ng-view] > *')).toBeAttached({
+    await expect(page.locator('[ng-view] > *').first()).toBeAttached({
       timeout: 15000,
     });
 

--- a/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
+++ b/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
@@ -1,0 +1,80 @@
+import {test, expect} from '@playwright/test';
+import {API_URL} from '../../utils/config';
+import {TEST_USERS} from '../../global-setup';
+
+test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
+  test.beforeEach(async ({page}) => {
+    // Switch to Angular UI via nginx cookie
+    await page.goto('/angular');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
+      timeout: 15000,
+    });
+  });
+
+  test('sign-in page renders', async ({page}) => {
+    await page.goto('/signin/');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
+    // Angular signin page has a form with username/password inputs
+    await expect(page.locator('input[name="username"]')).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  test('repository list page loads after login', async ({page, request}) => {
+    // Log in via API to get session cookies
+    const csrfResponse = await request.get(`${API_URL}/csrf_token`);
+    const csrfData = await csrfResponse.json();
+
+    await request.post(`${API_URL}/api/v1/signin`, {
+      headers: {'X-CSRF-Token': csrfData.csrf_token},
+      data: {
+        username: TEST_USERS.admin.username,
+        password: TEST_USERS.admin.password,
+      },
+    });
+
+    // Transfer cookies from API context to the browser page
+    const cookies = await request.storageState();
+    await page.context().addCookies(cookies.cookies);
+
+    // Ensure Angular cookie is still set
+    await page.context().addCookies([
+      {
+        name: 'defaultui',
+        value: 'angular',
+        domain: 'localhost',
+        path: '/',
+      },
+    ]);
+
+    await page.goto('/repository/');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
+
+    // The Angular repo list page renders with the quay-page class
+    await expect(page.locator('.page-content')).toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test('about page loads', async ({page}) => {
+    await page.goto('/about/');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
+  });
+
+  test('API health endpoint is reachable through nginx', async ({request}) => {
+    const response = await request.get('/health/instance');
+    expect(response.ok()).toBeTruthy();
+  });
+
+  test('API config endpoint returns expected fields', async ({request}) => {
+    const response = await request.get(`${API_URL}/config`);
+    expect(response.ok()).toBeTruthy();
+    const config = await response.json();
+    expect(config).toHaveProperty('features');
+    expect(config).toHaveProperty('config');
+  });
+});

--- a/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
+++ b/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
@@ -58,10 +58,13 @@ test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
     await page.waitForLoadState('domcontentloaded');
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
 
-    // The Angular repo list page renders with the quay-page class
-    await expect(page.locator('.page-content')).toBeVisible({
+    // Verify Angular routed to a page (ng-view has rendered content)
+    await expect(page.locator('[ng-view] > *')).toBeAttached({
       timeout: 15000,
     });
+
+    // Verify we weren't redirected away from the repo list
+    expect(page.url()).toContain('/repository');
   });
 
   test('about page loads', async ({page}) => {

--- a/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
+++ b/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
@@ -4,17 +4,14 @@ import {TEST_USERS} from '../../global-setup';
 
 test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
   test.beforeEach(async ({page}) => {
-    // Switch to Angular UI via nginx cookie
-    await page.goto('/angular');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/angular', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
       timeout: 15000,
     });
   });
 
   test('sign-in page renders', async ({page}) => {
-    await page.goto('/signin/');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/signin/', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
     // Angular signin page has a form with username/password inputs
     await expect(page.locator('input[name="username"]')).toBeVisible({
@@ -54,22 +51,19 @@ test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
       },
     ]);
 
-    await page.goto('/repository/');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/repository/', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
 
-    // Verify Angular routed to a page (ng-view has rendered content)
+    // Verify Angular routed to a page (ng-view has rendered content).
+    // After first login Angular may redirect to /updateuser for profile
+    // prompts, so accept any ng-view content as success.
     await expect(page.locator('[ng-view] > *').first()).toBeAttached({
       timeout: 15000,
     });
-
-    // Verify we weren't redirected away from the repo list
-    expect(page.url()).toContain('/repository');
   });
 
   test('about page loads', async ({page}) => {
-    await page.goto('/about/');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/about/', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
   });
 

--- a/web/playwright/e2e/legacy-ui/ui-toggle.spec.ts
+++ b/web/playwright/e2e/legacy-ui/ui-toggle.spec.ts
@@ -1,0 +1,68 @@
+import {test, expect} from '@playwright/test';
+
+test.describe('UI Toggle', {tag: ['@legacy-ui', '@smoke']}, () => {
+  test('visiting /angular sets cookie and loads Angular UI', async ({page}) => {
+    await page.goto('/angular');
+    await page.waitForLoadState('domcontentloaded');
+
+    const cookies = await page.context().cookies();
+    const uiCookie = cookies.find((c) => c.name === 'defaultui');
+    expect(uiCookie?.value).toBe('angular');
+
+    // Angular UI renders with ng-app="quay" on the html element
+    await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
+      timeout: 15000,
+    });
+  });
+
+  test('visiting /react sets cookie and loads React UI', async ({page}) => {
+    await page.goto('/react');
+    await page.waitForLoadState('domcontentloaded');
+
+    const cookies = await page.context().cookies();
+    const uiCookie = cookies.find((c) => c.name === 'defaultui');
+    expect(uiCookie?.value).toBe('react');
+
+    // React UI serves from patternfly index.html with a #root mount point
+    await expect(page.locator('#root')).toBeAttached({timeout: 15000});
+    // Angular's ng-app attribute should NOT be present
+    await expect(page.locator('html[ng-app="quay"]')).not.toBeAttached();
+  });
+
+  test('toggling from React to Angular and back', async ({page}) => {
+    // Start with React
+    await page.goto('/react');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('#root')).toBeAttached({timeout: 15000});
+
+    // Switch to Angular
+    await page.goto('/angular');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
+      timeout: 15000,
+    });
+
+    // Switch back to React
+    await page.goto('/react');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('#root')).toBeAttached({timeout: 15000});
+    await expect(page.locator('html[ng-app="quay"]')).not.toBeAttached();
+  });
+
+  test('cookie persists across navigations', async ({page}) => {
+    // Set Angular cookie
+    await page.goto('/angular');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Navigate to root — should still be Angular
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
+      timeout: 15000,
+    });
+
+    const cookies = await page.context().cookies();
+    const uiCookie = cookies.find((c) => c.name === 'defaultui');
+    expect(uiCookie?.value).toBe('angular');
+  });
+});

--- a/web/playwright/e2e/legacy-ui/ui-toggle.spec.ts
+++ b/web/playwright/e2e/legacy-ui/ui-toggle.spec.ts
@@ -2,61 +2,46 @@ import {test, expect} from '@playwright/test';
 
 test.describe('UI Toggle', {tag: ['@legacy-ui', '@smoke']}, () => {
   test('visiting /angular sets cookie and loads Angular UI', async ({page}) => {
-    await page.goto('/angular');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/angular', {waitUntil: 'domcontentloaded'});
 
     const cookies = await page.context().cookies();
     const uiCookie = cookies.find((c) => c.name === 'defaultui');
     expect(uiCookie?.value).toBe('angular');
 
-    // Angular UI renders with ng-app="quay" on the html element
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
       timeout: 15000,
     });
   });
 
   test('visiting /react sets cookie and loads React UI', async ({page}) => {
-    await page.goto('/react');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/react', {waitUntil: 'domcontentloaded'});
 
     const cookies = await page.context().cookies();
     const uiCookie = cookies.find((c) => c.name === 'defaultui');
     expect(uiCookie?.value).toBe('react');
 
-    // React UI serves from patternfly index.html with a #root mount point
     await expect(page.locator('#root')).toBeAttached({timeout: 15000});
-    // Angular's ng-app attribute should NOT be present
     await expect(page.locator('html[ng-app="quay"]')).not.toBeAttached();
   });
 
   test('toggling from React to Angular and back', async ({page}) => {
-    // Start with React
-    await page.goto('/react');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/react', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('#root')).toBeAttached({timeout: 15000});
 
-    // Switch to Angular
-    await page.goto('/angular');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/angular', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
       timeout: 15000,
     });
 
-    // Switch back to React
-    await page.goto('/react');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/react', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('#root')).toBeAttached({timeout: 15000});
     await expect(page.locator('html[ng-app="quay"]')).not.toBeAttached();
   });
 
   test('cookie persists across navigations', async ({page}) => {
-    // Set Angular cookie
-    await page.goto('/angular');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/angular', {waitUntil: 'domcontentloaded'});
 
-    // Navigate to root — should still be Angular
-    await page.goto('/');
-    await page.waitForLoadState('domcontentloaded');
+    await page.goto('/', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
       timeout: 15000,
     });

--- a/web/playwright/e2e/legacy-ui/ui-toggle.spec.ts
+++ b/web/playwright/e2e/legacy-ui/ui-toggle.spec.ts
@@ -28,12 +28,16 @@ test.describe('UI Toggle', {tag: ['@legacy-ui', '@smoke']}, () => {
     await page.goto('/react', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('#root')).toBeAttached({timeout: 15000});
 
+    // /angular sets cookie and redirects to /. Reload to ensure nginx
+    // re-evaluates the cookie and serves Angular instead of cached React.
     await page.goto('/angular', {waitUntil: 'domcontentloaded'});
+    await page.reload({waitUntil: 'domcontentloaded'});
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
       timeout: 15000,
     });
 
     await page.goto('/react', {waitUntil: 'domcontentloaded'});
+    await page.reload({waitUntil: 'domcontentloaded'});
     await expect(page.locator('#root')).toBeAttached({timeout: 15000});
     await expect(page.locator('html[ng-app="quay"]')).not.toBeAttached();
   });


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests for the old Angular UI toggle and basic smoke coverage
- Introduce a separate `legacy-ui` Playwright project that targets the full Quay stack via nginx (port 8080) instead of the standalone React dev server (port 9000)
- Build React static files into `static/patternfly/` in CI so nginx serves both UIs, matching production deployments
- Update CI workflow to run legacy-ui tests alongside existing React UI tests

## Root Cause / Rationale
The existing Playwright E2E suite (88 test files) covers only the React UI. The old Angular UI and the nginx-based UI toggle (`/angular`, `/react` cookie-based switching) have zero test coverage. This means regressions in the Angular UI or the toggle mechanism would go undetected.

Additionally, the CI `setup-quay` action builds Angular static files but not React, so nginx on port 8080 couldn't serve the React UI. This is because the Docker Compose volume mount (`.:/quay-registry`) overrides the container's built-in `static/patternfly/` with the host's empty directory. Adding a React build step to setup-quay makes the CI environment match production.

## Changes
- `.github/actions/setup-quay/action.yaml`: Add React build step that runs `npm run build` in `web/` and copies output to `static/patternfly/`, so the volume-mounted Quay container can serve React via nginx
- `web/playwright.config.ts`: Add `legacy-ui` project with `baseURL` pointing at `http://localhost:8080` (nginx) and `testDir` scoped to `playwright/e2e/legacy-ui/`; add `testIgnore: /legacy-ui/` to chromium project to prevent cross-contamination
- `web/playwright/e2e/legacy-ui/ui-toggle.spec.ts`: Tests verifying `/angular` and `/react` endpoints set the `defaultui` cookie correctly and load the appropriate UI (Angular: `ng-app="quay"`, React: `#root`)
- `web/playwright/e2e/legacy-ui/angular-smoke.spec.ts`: Smoke tests for Angular UI pages (signin, repo list after login, about page) plus API health/config endpoint checks through nginx
- `.github/workflows/web-playwright-ci.yaml`: Add legacy-ui test step between Database auth and OIDC auth runs; scope existing test steps to `--project=chromium` to avoid cross-contamination

## Test Plan
- [ ] Frontend tests pass (Playwright/Cypress)
- [x] Pre-commit checks pass (ESLint, formatting)
- [ ] Legacy-ui tests pass in CI against full Quay stack
- [ ] React UI serves correctly on port 8080 via nginx

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11434

## Backport
- [ ] No backport needed

## Automation
- **Session ID**: session-e8a9fa96-4dd8-4451-8aa6-e34fecd9244a