### PR TITLE
PROJQUAY-11433: fix(gc): batch repository state updates on namespace deletion

### DIFF
--- a/data/model/gc.py
+++ b/data/model/gc.py
@@ -81,8 +81,11 @@ def purge_repository(repo, force=False):
     assert repo.state == RepositoryState.MARKED_FOR_DELETION or force
 
     # Update the repo state to ensure nothing else is written to it.
-    repo.state = RepositoryState.MARKED_FOR_DELETION
-    repo.save()
+    # Skip the individual save when the state is already set (e.g. after a bulk
+    # UPDATE from delete_user()) to avoid N per-repo round-trips.
+    if repo.state != RepositoryState.MARKED_FOR_DELETION:
+        repo.state = RepositoryState.MARKED_FOR_DELETION
+        repo.save()
 
     # GC to remove the images and storage.
     _purge_repository_contents(repo)

--- a/data/model/test/test_user.py
+++ b/data/model/test/test_user.py
@@ -7,7 +7,14 @@ from mock import patch
 from auth.scopes import READ_REPO
 from auth.test.mock_oidc_server import MOCK_PUBLIC_KEY, generate_mock_oidc_token
 from data import model
-from data.database import DeletedNamespace, EmailConfirmation, FederatedLogin, User
+from data.database import (
+    DeletedNamespace,
+    EmailConfirmation,
+    FederatedLogin,
+    Repository,
+    RepositoryState,
+    User,
+)
 from data.fields import Credential
 from data.model.notification import create_notification
 from data.model.oauth import (
@@ -30,6 +37,7 @@ from data.model.user import (
     create_user_noverify,
     delete_namespace_via_marker,
     delete_robot,
+    delete_user,
     get_active_namespaces,
     get_active_users,
     get_estimated_robot_count,
@@ -272,6 +280,49 @@ def test_delete_namespace_via_marker(initialized_db):
 
     with pytest.raises(DeletedNamespace.DoesNotExist):
         DeletedNamespace.get(id=marker_id)
+
+
+def test_delete_namespace_bulk_state_update(initialized_db):
+    """Repos must be bulk-marked MARKED_FOR_DELETION before purge_repository is called."""
+    user = create_user_noverify("foobar", "foo@example.com", email_required=False)
+    repo_ids = set()
+    for name in ("repo1", "repo2", "repo3", "repo4", "repo5"):
+        repo_ids.add(create_repository("foobar", name, user).id)
+
+    seen_states = []
+
+    real_purge = model.gc.purge_repository
+
+    def recording_purge(repo, force=False):
+        seen_states.append((repo.id, repo.state))
+        return real_purge(repo, force=force)
+
+    with patch("data.model.user.gc.purge_repository", side_effect=recording_purge):
+        result = delete_user(user, [])
+
+    assert result is True
+    assert len(seen_states) == 5
+    for repo_id, state in seen_states:
+        assert (
+            state == RepositoryState.MARKED_FOR_DELETION
+        ), f"repo {repo_id} was not pre-marked; purge_repository saw state {state}"
+
+
+def test_delete_namespace_with_mixed_repo_states(initialized_db):
+    """delete_user succeeds when some repos are already MARKED_FOR_DELETION."""
+    user = create_user_noverify("foobar", "foo@example.com", email_required=False)
+    repo_normal = create_repository("foobar", "normal", user)
+    repo_already = create_repository("foobar", "already_marked", user)
+
+    Repository.update(state=RepositoryState.MARKED_FOR_DELETION).where(
+        Repository.id == repo_already.id
+    ).execute()
+
+    result = delete_user(user, [])
+    assert result is True
+
+    with pytest.raises(User.DoesNotExist):
+        User.get(id=user.id)
 
 
 def test_delete_robot(initialized_db):

--- a/data/model/user.py
+++ b/data/model/user.py
@@ -1439,6 +1439,13 @@ def delete_user(user, queues):
         queue.delete_namespaced_items(user.username)
 
     # Delete any repositories under the user's namespace.
+    # Bulk-mark all repos for deletion in one UPDATE to avoid N individual
+    # per-repo saves inside purge_repository() that held long-duration locks.
+    Repository.update(state=RepositoryState.MARKED_FOR_DELETION).where(
+        Repository.namespace_user == user,
+        Repository.state != RepositoryState.MARKED_FOR_DELETION,
+    ).execute()
+
     while True:
         is_progressing = False
         repositories = list(Repository.select().where(Repository.namespace_user == user))


### PR DESCRIPTION
## Summary
- Replace N individual `repo.save()` calls during namespace deletion with a single bulk `UPDATE repository SET state=MARKED_FOR_DELETION WHERE namespace_user=<user>` before the purge loop
- Guard `purge_repository()` from re-issuing a redundant per-repo save when the state is already set

## Root Cause / Rationale
Jaeger traces showed `UPDATE "repository" SET "namespace_user_..."` queries taking 14.7 s and 5.7 s during org/user deletion. The root cause was `delete_user()` calling `gc.purge_repository()` per repo, each of which issued an individual `repo.save()` inside a transaction with cascading deletes across 20+ tables — creating N long-held locks for namespaces with many repositories.

## Changes
- `data/model/user.py`: bulk-update all namespace repos to `MARKED_FOR_DELETION` in one `Repository.update(...).execute()` call before the `purge_repository` loop
- `data/model/gc.py`: skip the individual `repo.save()` inside `purge_repository()` when the state is already `MARKED_FOR_DELETION` (eliminates the redundant round-trip for the namespace deletion path; no behaviour change for the GC worker path)
- `data/model/test/test_user.py`: two new tests — one verifying repos are pre-marked before `purge_repository` is called, one verifying deletion works correctly when some repos are already in `MARKED_FOR_DELETION` state

No migration needed — no schema changes.

## Test Plan
- [x] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [ ] Manual testing performed
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11433

## Backport
- [ ] Backport required: <!-- branch name -->
- [x] No backport needed

## Automation
- **Session ID**: session-a0f1c781-a4ee-4831-a2fd-e4203e49f110