### PR TITLE
NO-ISSUE: chore(ci): run playwright e2e tests on all pull requests

### DIFF
--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -3,10 +3,6 @@ on:
   pull_request:
     branches:
       - "*"
-    paths:
-      - "web/**"
-      - ".github/workflows/web-playwright-ci.yaml"
-      - ".github/actions/setup-quay/**"
 
 jobs:
   playwright:


### PR DESCRIPTION
## Summary
- Remove `paths` filter from the Playwright E2E Tests workflow so the job runs on every pull request, not only when `web/` files change.

## Root Cause / Rationale
The Playwright e2e CI job was previously gated by path filters (`web/**`, `.github/workflows/web-playwright-ci.yaml`, `.github/actions/setup-quay/**`). This meant backend-only PRs never ran e2e tests, risking regressions that only surface through end-to-end interactions (API contract changes, config behavior, auth flows, etc.).

## Changes
- `.github/workflows/web-playwright-ci.yaml`: removed the `paths:` block from the `pull_request` trigger so the workflow fires on all PRs regardless of which files changed.

## Test Plan
- [ ] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [ ] Manual testing performed
- [x] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

## JIRA
N/A — NO-ISSUE chore

## Backport
- [ ] Backport required
- [x] No backport needed

## Automation
- **Session ID**: session-847a66b7-4493-456a-b244-6c06f136ca9a