### PR TITLE
PROJQUAY-10575: fix(mirror): fix cancel mirror log showing garbled text

### DIFF
--- a/web/src/hooks/UseLogDescriptions.tsx
+++ b/web/src/hooks/UseLogDescriptions.tsx
@@ -330,16 +330,28 @@ export function useLogDescriptions() {
       return `Mirror started for ${metadata.message}`;
     },
     repo_mirror_sync_success: function (metadata: Metadata) {
-      return `Mirror finished successfully for ${metadata.message} ${metadata.tags}`;
+      let msg = `Mirror finished successfully for ${metadata.message}`;
+      if (metadata.tags) msg += ` ${metadata.tags}`;
+      return msg;
     },
     repo_mirror_sync_failed: function (metadata: Metadata) {
-      return `Mirror finished unsuccessfully for ${metadata.message} ${metadata.tags} ${metadata.stdout} ${metadata.stderr}`;
+      let msg = `Mirror finished unsuccessfully for ${metadata.message}`;
+      if (metadata.tags) msg += ` ${metadata.tags}`;
+      if (metadata.stdout) msg += ` ${metadata.stdout}`;
+      if (metadata.stderr) msg += ` ${metadata.stderr}`;
+      return msg;
     },
     repo_mirror_sync_tag_success: function (metadata: Metadata) {
-      return `Mirror of ${metadata.tag} successful to repository ${metadata.namespace}/${metadata.repo} ${metadata.message} ${metadata.stdout} ${metadata.stderr}`;
+      let msg = `Mirror of ${metadata.tag} successful to repository ${metadata.namespace}/${metadata.repo} ${metadata.message}`;
+      if (metadata.stdout) msg += ` ${metadata.stdout}`;
+      if (metadata.stderr) msg += ` ${metadata.stderr}`;
+      return msg;
     },
     repo_mirror_sync_tag_failed: function (metadata: Metadata) {
-      return `Mirror of ${metadata.tag} failure to repository ${metadata.namespace}/${metadata.repo} ${metadata.message} ${metadata.stdout} ${metadata.stderr}`;
+      let msg = `Mirror of ${metadata.tag} failure to repository ${metadata.namespace}/${metadata.repo} ${metadata.message}`;
+      if (metadata.stdout) msg += ` ${metadata.stdout}`;
+      if (metadata.stderr) msg += ` ${metadata.stderr}`;
+      return msg;
     },
     repo_mirror_config_changed: function (metadata: Metadata) {
       switch (metadata.changed) {

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -404,15 +404,14 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
                 rollback(mirror, now_ms)
             else:
                 rollback(mirror, now_ms, failed_tags)
-        if overall_status == RepoMirrorStatus.CANCEL:
+        elif overall_status == RepoMirrorStatus.CANCEL:
             log_message = "'%s' with tag pattern '%s'"
             emit_log(
                 mirror,
                 "repo_mirror_sync_failed",
                 "Cancelled",
                 log_message % (mirror.external_reference, ",".join(mirror.root_rule.rule_value)),
-                stdout="Not applicable",
-                stderr="Not applicable",
+                tags=", ".join(tags),
             )
         else:
             emit_log(


### PR DESCRIPTION
## Summary
- Backend: Fix if/if/else to if/elif/else in perform_mirror() finally block to prevent a spurious success log after FAIL. Pass actual tags instead of hardcoded Not applicable for stdout/stderr.
- Frontend: Add null-guards to mirror log description renderers so null/undefined metadata fields are omitted instead of rendered as literal strings.

## Test plan
- Cancel a running mirror sync and verify the usage log shows clean text
- Verify successful and failed mirror syncs still log correctly
- Confirm no regression in tag-level success/failure log entries

Fixes: [PROJQUAY-10575](https://redhat.atlassian.net/browse/PROJQUAY-10575)