### PR TITLE
PROJQUAY-10658: fix(oauth): prevent Host Header Injection in redirect URLs

### DIFF
--- a/endpoints/oauth/login.py
+++ b/endpoints/oauth/login.py
@@ -3,7 +3,7 @@ import os
 import re
 import time
 from collections import namedtuple
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 
 import recaptcha2
 from flask import Blueprint, abort, redirect, request, session, url_for
@@ -169,17 +169,10 @@ def _render_ologin_error(service_name, error_message=None, register_redirect=Fal
 
         params = urlencode(params_dict)
 
-        # Use the Referer header to determine the correct origin to redirect to
-        referer = request.headers.get("Referer")
-
-        if referer:
-            # Parse the origin from the referer
-            parsed = urlparse(referer)
-            origin = f"{parsed.scheme}://{parsed.netloc}"
-            return redirect(f"{origin}/oauth-error?{params}")
-        else:
-            # Fallback to relative redirect
-            return redirect(f"/oauth-error?{params}")
+        # Use the configured app URL to construct the redirect, never trust
+        # client-supplied headers (Host, Referer) for redirect targets.
+        app_url = get_app_url()
+        return redirect(f"{app_url}/oauth-error?{params}")
 
     # Angular UI: render error in template
     resp = index("", error_info=error_info)

--- a/endpoints/oauth/test/test_oauth_error.py
+++ b/endpoints/oauth/test/test_oauth_error.py
@@ -26,11 +26,12 @@ class TestRenderOAuthErrorAuthenticated:
     @patch("endpoints.oauth.login.request")
     @patch("endpoints.oauth.login.get_authenticated_user")
     @patch("endpoints.oauth.login.redirect")
+    @patch("endpoints.oauth.login.get_app_url")
     @patch("features.USER_CREATION", True)
     @patch("features.DIRECT_LOGIN", True)
     @patch("features.INVITE_ONLY_USER_CREATION", False)
     def test_react_ui_authenticated_user_adds_params(
-        self, mock_redirect, mock_get_user, mock_request, app
+        self, mock_get_app_url, mock_redirect, mock_get_user, mock_request, app
     ):
         """Test that authenticated user params are added to redirect URL."""
         # Setup authenticated user
@@ -40,7 +41,7 @@ class TestRenderOAuthErrorAuthenticated:
 
         # Setup React UI
         mock_request.cookies.get.return_value = "react"
-        mock_request.headers.get.return_value = "http://localhost:9000/"
+        mock_get_app_url.return_value = "https://quay.example.com"
         mock_redirect.return_value = Mock()
 
         # Execute
@@ -54,11 +55,12 @@ class TestRenderOAuthErrorAuthenticated:
     @patch("endpoints.oauth.login.request")
     @patch("endpoints.oauth.login.get_authenticated_user")
     @patch("endpoints.oauth.login.redirect")
+    @patch("endpoints.oauth.login.get_app_url")
     @patch("features.USER_CREATION", True)
     @patch("features.DIRECT_LOGIN", True)
     @patch("features.INVITE_ONLY_USER_CREATION", False)
     def test_react_ui_unauthenticated_user_no_params(
-        self, mock_redirect, mock_get_user, mock_request, app
+        self, mock_get_app_url, mock_redirect, mock_get_user, mock_request, app
     ):
         """Test that unauthenticated user doesn't add authenticated params."""
         # Setup unauthenticated (None)
@@ -66,7 +68,7 @@ class TestRenderOAuthErrorAuthenticated:
 
         # Setup React UI
         mock_request.cookies.get.return_value = "react"
-        mock_request.headers.get.return_value = "http://localhost:9000/"
+        mock_get_app_url.return_value = "https://quay.example.com"
         mock_redirect.return_value = Mock()
 
         # Execute
@@ -80,32 +82,52 @@ class TestRenderOAuthErrorAuthenticated:
     @patch("endpoints.oauth.login.request")
     @patch("endpoints.oauth.login.get_authenticated_user")
     @patch("endpoints.oauth.login.redirect")
-    def test_react_ui_no_referer_uses_relative_redirect(
-        self, mock_redirect, mock_get_user, mock_request, app
+    @patch("endpoints.oauth.login.get_app_url")
+    def test_react_ui_uses_configured_app_url(
+        self, mock_get_app_url, mock_redirect, mock_get_user, mock_request, app
     ):
-        """Test fallback to relative redirect when Referer header is missing."""
+        """Test that redirect uses configured app URL, not Referer header."""
         mock_get_user.return_value = None
         mock_request.cookies.get.return_value = "react"
-        mock_request.headers.get.return_value = None  # No Referer header
+        mock_get_app_url.return_value = "https://quay.example.com"
         mock_redirect.return_value = Mock()
 
         _render_ologin_error("GitHub", "Error", False)
 
-        # Verify relative redirect (no origin prefix)
         call_args = mock_redirect.call_args[0][0]
-        assert call_args.startswith("/oauth-error?")
-        assert "http" not in call_args  # No absolute URL
+        assert call_args.startswith("https://quay.example.com/oauth-error?")
 
     @patch("endpoints.oauth.login.request")
     @patch("endpoints.oauth.login.get_authenticated_user")
     @patch("endpoints.oauth.login.redirect")
+    @patch("endpoints.oauth.login.get_app_url")
+    def test_react_ui_ignores_malicious_referer(
+        self, mock_get_app_url, mock_redirect, mock_get_user, mock_request, app
+    ):
+        """Test that a malicious Referer header does not affect the redirect URL."""
+        mock_get_user.return_value = None
+        mock_request.cookies.get.return_value = "react"
+        mock_request.headers.get.return_value = "https://evil.attacker.com/phishing"
+        mock_get_app_url.return_value = "https://quay.example.com"
+        mock_redirect.return_value = Mock()
+
+        _render_ologin_error("GitHub", "Error", False)
+
+        call_args = mock_redirect.call_args[0][0]
+        assert "evil.attacker.com" not in call_args
+        assert call_args.startswith("https://quay.example.com/oauth-error?")
+
+    @patch("endpoints.oauth.login.request")
+    @patch("endpoints.oauth.login.get_authenticated_user")
+    @patch("endpoints.oauth.login.redirect")
+    @patch("endpoints.oauth.login.get_app_url")
     def test_react_ui_register_redirect_param(
-        self, mock_redirect, mock_get_user, mock_request, app
+        self, mock_get_app_url, mock_redirect, mock_get_user, mock_request, app
     ):
         """Test register_redirect parameter is added when True."""
         mock_get_user.return_value = None
         mock_request.cookies.get.return_value = "react"
-        mock_request.headers.get.return_value = "http://localhost:9000/"
+        mock_get_app_url.return_value = "https://quay.example.com"
         mock_redirect.return_value = Mock()
 
         _render_ologin_error("GitHub", "Error", register_redirect=True)


### PR DESCRIPTION
## Summary

- **Fixes [PROJQUAY-10658](https://redhat.atlassian.net/browse/PROJQUAY-10658)**: Replaces unvalidated `Referer` header usage with the server-configured app URL (`get_app_url()`) when constructing OAuth error redirect URLs
- Removes the open redirect vulnerability where attackers could manipulate the `Referer` header to redirect users to arbitrary domains for phishing/credential theft
- Cleans up unused `urlparse` import

## Details

The `_render_ologin_error` function in `endpoints/oauth/login.py` previously extracted the origin from the `Referer` request header to construct absolute redirect URLs for the React UI OAuth error page. An attacker could craft a request with a malicious Referer (e.g., `https://evil.attacker.com/`) causing the server to issue a `302 Location: https://evil.attacker.com/oauth-error?...` response.

The fix uses `get_app_url()` which derives the URL from the server's `PREFERRED_URL_SCHEME` and `SERVER_HOSTNAME` configuration — the same trusted pattern used by all other redirect paths in the codebase (e.g., `_perform_login`, `cli_token_func`, `attach_func`).

## Test plan

- [x] Updated existing tests to use `get_app_url()` mock instead of Referer header mock
- [x] Added new `test_react_ui_ignores_malicious_referer` test verifying attacker-controlled Referer is not used
- [x] Added `test_react_ui_uses_configured_app_url` test verifying configured URL is used
- [x] Verified syntax correctness of both modified files
- [ ] Run full test suite: `pytest endpoints/oauth/test/test_oauth_error.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)