### PR TITLE
PROJQUAY-11351: fix(web): sort tag date columns chronologically instead of lexicographically

### DIFF
--- a/web/playwright/e2e/repository/tag-sort-dates.spec.ts
+++ b/web/playwright/e2e/repository/tag-sort-dates.spec.ts
@@ -23,6 +23,9 @@ test.describe(
         fullName: `${TEST_USERS.user.username}/${repoName}`,
       };
 
+      const ensureDistinctTimestamp = () =>
+        new Promise((resolve) => setTimeout(resolve, 1100));
+
       await pushImage(
         repo.namespace,
         repo.name,
@@ -30,6 +33,7 @@ test.describe(
         TEST_USERS.user.username,
         TEST_USERS.user.password,
       );
+      await ensureDistinctTimestamp();
       await pushImage(
         repo.namespace,
         repo.name,
@@ -37,6 +41,7 @@ test.describe(
         TEST_USERS.user.username,
         TEST_USERS.user.password,
       );
+      await ensureDistinctTimestamp();
       await pushImage(
         repo.namespace,
         repo.name,

--- a/web/playwright/e2e/repository/tag-sort-dates.spec.ts
+++ b/web/playwright/e2e/repository/tag-sort-dates.spec.ts
@@ -58,7 +58,12 @@ test.describe(
 
     test('Last Modified column sorts tags chronologically', async ({
       authenticatedPage,
+      cachedContainerAvailable,
     }) => {
+      test.skip(
+        !cachedContainerAvailable,
+        'Requires cached container image to push test tags',
+      );
       await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       // Wait for all 3 tags to render

--- a/web/playwright/e2e/repository/tag-sort-dates.spec.ts
+++ b/web/playwright/e2e/repository/tag-sort-dates.spec.ts
@@ -1,0 +1,111 @@
+import {test, expect} from '../../fixtures';
+import {TEST_USERS} from '../../global-setup';
+import {ApiClient} from '../../utils/api';
+import {pushImage} from '../../utils/container';
+
+test.describe(
+  'Repository Details - Tag Date Column Sorting (PROJQUAY-11351)',
+  {tag: ['@tags', '@repository', '@container']},
+  () => {
+    let repo: {namespace: string; name: string; fullName: string};
+
+    test.beforeAll(async ({userContext, cachedContainerAvailable}) => {
+      test.setTimeout(180000);
+      if (!cachedContainerAvailable) return;
+
+      const api = new ApiClient(userContext.request);
+      const repoName = `tag-sort-dates-${Date.now()}`;
+      await api.createRepository(TEST_USERS.user.username, repoName, 'private');
+
+      repo = {
+        namespace: TEST_USERS.user.username,
+        name: repoName,
+        fullName: `${TEST_USERS.user.username}/${repoName}`,
+      };
+
+      await pushImage(
+        repo.namespace,
+        repo.name,
+        'first',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+      await pushImage(
+        repo.namespace,
+        repo.name,
+        'second',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+      await pushImage(
+        repo.namespace,
+        repo.name,
+        'third',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+    });
+
+    test.afterAll(async ({userContext}) => {
+      if (!repo) return;
+      const api = new ApiClient(userContext.request);
+      try {
+        await api.deleteRepository(repo.namespace, repo.name);
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    test('Last Modified column sorts tags chronologically', async ({
+      authenticatedPage,
+    }) => {
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+
+      // Wait for all 3 tags to render
+      await expect(
+        authenticatedPage.getByRole('link', {name: 'first'}),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByRole('link', {name: 'second'}),
+      ).toBeVisible();
+      await expect(
+        authenticatedPage.getByRole('link', {name: 'third'}),
+      ).toBeVisible();
+
+      // Get the sort button for "Last Modified" column header
+      const lastModifiedHeader = authenticatedPage.getByRole('button', {
+        name: /Last Modified/,
+      });
+
+      // Click to sort ascending (oldest first)
+      await lastModifiedHeader.click();
+
+      // Get all tag names in display order
+      let tagNames = await authenticatedPage
+        .getByTestId('table-entry')
+        .locator('[data-label="Tag"] a')
+        .allTextContents();
+
+      // In ascending order, "first" (earliest) should come before "third" (latest)
+      const firstIdxAsc = tagNames.indexOf('first');
+      const secondIdxAsc = tagNames.indexOf('second');
+      const thirdIdxAsc = tagNames.indexOf('third');
+      expect(firstIdxAsc).toBeLessThan(secondIdxAsc);
+      expect(secondIdxAsc).toBeLessThan(thirdIdxAsc);
+
+      // Click again to sort descending (newest first)
+      await lastModifiedHeader.click();
+
+      tagNames = await authenticatedPage
+        .getByTestId('table-entry')
+        .locator('[data-label="Tag"] a')
+        .allTextContents();
+
+      const firstIdxDesc = tagNames.indexOf('first');
+      const secondIdxDesc = tagNames.indexOf('second');
+      const thirdIdxDesc = tagNames.indexOf('third');
+      expect(thirdIdxDesc).toBeLessThan(secondIdxDesc);
+      expect(secondIdxDesc).toBeLessThan(firstIdxDesc);
+    });
+  },
+);

--- a/web/src/hooks/usePaginatedSortableTable.test.ts
+++ b/web/src/hooks/usePaginatedSortableTable.test.ts
@@ -456,4 +456,163 @@ describe('usePaginatedSortableTable', () => {
       expect(typeof props.setPerPage).toBe('function');
     });
   });
+
+  // Regression tests for PROJQUAY-11351: date columns must sort chronologically
+  describe('date sorting (PROJQUAY-11351)', () => {
+    interface TagLikeItem {
+      name: string;
+      last_modified: string;
+      start_ts: number;
+      expiration: string;
+      last_pulled: string;
+    }
+
+    // Realistic data matching the Jira screenshots. RFC 2822 strings start
+    // with the weekday name, so localeCompare sorts "Fri" < "Mon" < "Tue"
+    // instead of chronologically.
+    const tagItems: TagLikeItem[] = [
+      {
+        name: 'tag-apr13-1233',
+        last_modified: 'Mon, 13 Apr 2026 12:33:00 -0000',
+        start_ts: 1776076380,
+        expiration: 'Fri, 01 May 2026 00:00:00 -0000',
+        last_pulled: 'Mon, 13 Apr 2026 14:00:00 -0000',
+      },
+      {
+        name: 'tag-apr13-0921',
+        last_modified: 'Mon, 13 Apr 2026 09:21:00 -0000',
+        start_ts: 1776064860,
+        expiration: 'Wed, 29 Apr 2026 00:00:00 -0000',
+        last_pulled: 'Mon, 13 Apr 2026 10:00:00 -0000',
+      },
+      {
+        name: 'tag-apr10-1329',
+        last_modified: 'Fri, 10 Apr 2026 13:29:00 -0000',
+        start_ts: 1775829540,
+        expiration: 'Mon, 27 Apr 2026 00:00:00 -0000',
+        last_pulled: 'Fri, 10 Apr 2026 15:00:00 -0000',
+      },
+      {
+        name: 'tag-apr10-1150',
+        last_modified: 'Fri, 10 Apr 2026 11:50:00 -0000',
+        start_ts: 1775823600,
+        expiration: 'Sun, 26 Apr 2026 00:00:00 -0000',
+        last_pulled: 'Fri, 10 Apr 2026 12:00:00 -0000',
+      },
+      {
+        name: 'tag-apr07-1453',
+        last_modified: 'Tue, 07 Apr 2026 14:53:00 -0000',
+        start_ts: 1775588580,
+        expiration: 'Thu, 23 Apr 2026 00:00:00 -0000',
+        last_pulled: 'Tue, 07 Apr 2026 16:00:00 -0000',
+      },
+    ];
+
+    const CHRONOLOGICAL_ASC = [
+      'tag-apr07-1453',
+      'tag-apr10-1150',
+      'tag-apr10-1329',
+      'tag-apr13-0921',
+      'tag-apr13-1233',
+    ];
+    const CHRONOLOGICAL_DESC = [...CHRONOLOGICAL_ASC].reverse();
+
+    it('sorts Last Modified ascending chronologically using start_ts', () => {
+      const cols: Record<number, (item: TagLikeItem) => string | number> = {
+        0: (item) => item.start_ts || 0,
+      };
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(tagItems, {columns: cols}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'asc');
+      });
+      const names = result.current.paginatedData.map((t) => t.name);
+      expect(names).toEqual(CHRONOLOGICAL_ASC);
+    });
+
+    it('sorts Last Modified descending chronologically using start_ts', () => {
+      const cols: Record<number, (item: TagLikeItem) => string | number> = {
+        0: (item) => item.start_ts || 0,
+      };
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(tagItems, {columns: cols}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'desc');
+      });
+      const names = result.current.paginatedData.map((t) => t.name);
+      expect(names).toEqual(CHRONOLOGICAL_DESC);
+    });
+
+    it('sorts Expires ascending chronologically using parsed timestamp', () => {
+      const cols: Record<number, (item: TagLikeItem) => string | number> = {
+        0: (item) =>
+          item.expiration ? new Date(item.expiration).getTime() : 0,
+      };
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(tagItems, {columns: cols}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'asc');
+      });
+      const names = result.current.paginatedData.map((t) => t.name);
+      expect(names).toEqual(CHRONOLOGICAL_ASC);
+    });
+
+    it('sorts Last Pulled descending chronologically using parsed timestamp', () => {
+      const cols: Record<number, (item: TagLikeItem) => string | number> = {
+        0: (item) =>
+          item.last_pulled ? new Date(item.last_pulled).getTime() : 0,
+      };
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(tagItems, {columns: cols}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'desc');
+      });
+      const names = result.current.paginatedData.map((t) => t.name);
+      expect(names).toEqual(CHRONOLOGICAL_DESC);
+    });
+
+    it('sorts items with missing dates to the beginning', () => {
+      const itemsWithMissing: TagLikeItem[] = [
+        ...tagItems,
+        {
+          name: 'tag-no-dates',
+          last_modified: '',
+          start_ts: 0,
+          expiration: '',
+          last_pulled: '',
+        },
+      ];
+      const cols: Record<number, (item: TagLikeItem) => string | number> = {
+        0: (item) => item.start_ts || 0,
+      };
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(itemsWithMissing, {columns: cols}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'asc');
+      });
+      expect(result.current.paginatedData[0].name).toBe('tag-no-dates');
+    });
+
+    it('RFC 2822 string sorting produces WRONG order (regression guard)', () => {
+      const buggyColumns: Record<
+        number,
+        (item: TagLikeItem) => string | number
+      > = {
+        0: (item) => item.last_modified,
+      };
+      const {result} = renderHook(() =>
+        usePaginatedSortableTable(tagItems, {columns: buggyColumns}),
+      );
+      act(() => {
+        triggerSort(result, 0, 'asc');
+      });
+      const names = result.current.paginatedData.map((t) => t.name);
+      expect(names).not.toEqual(CHRONOLOGICAL_ASC);
+    });
+  });
 });

--- a/web/src/libs/utils.test.ts
+++ b/web/src/libs/utils.test.ts
@@ -24,6 +24,7 @@ import {
   getSeconds,
   formatRelativeTime,
   extractTextFromReactNode,
+  toEpochOrZero,
 } from './utils';
 
 describe('formatSize', () => {
@@ -398,6 +399,35 @@ describe('formatRelativeTime', () => {
     const result = formatRelativeTime(Date.now() / 1000 - 3600); // 1 hour ago
     expect(typeof result).toBe('string');
     expect(result).not.toBe('Never');
+  });
+});
+
+describe('toEpochOrZero', () => {
+  it('returns 0 for undefined', () => {
+    expect(toEpochOrZero(undefined)).toBe(0);
+  });
+
+  it('returns 0 for empty string', () => {
+    expect(toEpochOrZero('')).toBe(0);
+  });
+
+  it('parses valid RFC 2822 date string', () => {
+    const result = toEpochOrZero('Mon, 13 Apr 2026 12:33:00 -0000');
+    expect(result).toBe(Date.parse('Mon, 13 Apr 2026 12:33:00 -0000'));
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('parses valid ISO 8601 date string', () => {
+    const result = toEpochOrZero('2026-04-13T12:33:00Z');
+    expect(result).toBe(Date.parse('2026-04-13T12:33:00Z'));
+  });
+
+  it('returns 0 for invalid date string', () => {
+    expect(toEpochOrZero('not-a-date')).toBe(0);
+  });
+
+  it('returns 0 for malformed date string', () => {
+    expect(toEpochOrZero('99/99/9999')).toBe(0);
   });
 });
 

--- a/web/src/libs/utils.ts
+++ b/web/src/libs/utils.ts
@@ -36,6 +36,12 @@ export function formatDate(
   });
 }
 
+export function toEpochOrZero(value?: string): number {
+  if (!value) return 0;
+  const ts = Date.parse(value);
+  return Number.isFinite(ts) ? ts : 0;
+}
+
 export function formatSize(sizeInBytes: number) {
   // Handle null/undefined but allow 0 as a valid value
   if (sizeInBytes === null || sizeInBytes === undefined) {

--- a/web/src/libs/utils.ts
+++ b/web/src/libs/utils.ts
@@ -36,6 +36,7 @@ export function formatDate(
   });
 }
 
+/** Parse a date string to epoch millis, returning 0 for falsy or unparseable values. */
 export function toEpochOrZero(value?: string): number {
   if (!value) return 0;
   const ts = Date.parse(value);

--- a/web/src/routes/RepositoryDetails/Tags/TagsList.test.ts
+++ b/web/src/routes/RepositoryDetails/Tags/TagsList.test.ts
@@ -35,9 +35,7 @@ describe('Tag date column extractors (PROJQUAY-11351)', () => {
       const result = extractExpires(
         makeTag({expiration: 'Mon, 13 Apr 2026 12:33:00 -0000'}),
       );
-      expect(result).toBe(
-        Date.parse('Mon, 13 Apr 2026 12:33:00 -0000'),
-      );
+      expect(result).toBe(Date.parse('Mon, 13 Apr 2026 12:33:00 -0000'));
       expect(result).toBeGreaterThan(0);
     });
 
@@ -55,9 +53,7 @@ describe('Tag date column extractors (PROJQUAY-11351)', () => {
       const result = extractLastPulled(
         makeTag({last_pulled: 'Mon, 13 Apr 2026 09:21:00 -0000'}),
       );
-      expect(result).toBe(
-        Date.parse('Mon, 13 Apr 2026 09:21:00 -0000'),
-      );
+      expect(result).toBe(Date.parse('Mon, 13 Apr 2026 09:21:00 -0000'));
       expect(result).toBeGreaterThan(0);
     });
 

--- a/web/src/routes/RepositoryDetails/Tags/TagsList.test.ts
+++ b/web/src/routes/RepositoryDetails/Tags/TagsList.test.ts
@@ -1,0 +1,72 @@
+import {Tag} from 'src/resources/TagResource';
+import {
+  extractLastModified,
+  extractExpires,
+  extractLastPulled,
+} from './tagColumnExtractors';
+
+const makeTag = (overrides: Partial<Tag> = {}): Tag =>
+  ({
+    name: 'latest',
+    manifest_digest: 'sha256:abc',
+    size: 1024,
+    start_ts: 0,
+    expiration: undefined,
+    last_pulled: undefined,
+    ...overrides,
+  }) as Tag;
+
+describe('Tag date column extractors (PROJQUAY-11351)', () => {
+  describe('extractLastModified', () => {
+    it('returns start_ts when present', () => {
+      expect(extractLastModified(makeTag({start_ts: 1681393980}))).toBe(
+        1681393980,
+      );
+    });
+
+    it('returns 0 when start_ts is falsy', () => {
+      expect(extractLastModified(makeTag({start_ts: 0}))).toBe(0);
+      expect(extractLastModified(makeTag({start_ts: undefined}))).toBe(0);
+    });
+  });
+
+  describe('extractExpires', () => {
+    it('returns epoch millis for valid date string', () => {
+      const result = extractExpires(
+        makeTag({expiration: 'Mon, 13 Apr 2026 12:33:00 -0000'}),
+      );
+      expect(result).toBe(
+        Date.parse('Mon, 13 Apr 2026 12:33:00 -0000'),
+      );
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('returns 0 for undefined expiration', () => {
+      expect(extractExpires(makeTag({expiration: undefined}))).toBe(0);
+    });
+
+    it('returns 0 for empty string expiration', () => {
+      expect(extractExpires(makeTag({expiration: ''}))).toBe(0);
+    });
+  });
+
+  describe('extractLastPulled', () => {
+    it('returns epoch millis for valid date string', () => {
+      const result = extractLastPulled(
+        makeTag({last_pulled: 'Mon, 13 Apr 2026 09:21:00 -0000'}),
+      );
+      expect(result).toBe(
+        Date.parse('Mon, 13 Apr 2026 09:21:00 -0000'),
+      );
+      expect(result).toBeGreaterThan(0);
+    });
+
+    it('returns 0 for undefined last_pulled', () => {
+      expect(extractLastPulled(makeTag({last_pulled: undefined}))).toBe(0);
+    });
+
+    it('returns 0 for empty string last_pulled', () => {
+      expect(extractLastPulled(makeTag({last_pulled: ''}))).toBe(0);
+    });
+  });
+});

--- a/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
@@ -26,6 +26,7 @@ import TagsTable from './TagsTable';
 import {TagsToolbar} from './TagsToolbar';
 import {usePaginatedSortableTable} from '../../../hooks/usePaginatedSortableTable';
 import {enrichTagsWithCosignData, isCosignSignatureTag} from 'src/libs/cosign';
+import {toEpochOrZero} from 'src/libs/utils';
 
 export default function TagsList(props: TagsProps) {
   const [tags, setTags] = useState<Tag[]>([]);
@@ -41,12 +42,6 @@ export default function TagsList(props: TagsProps) {
   const filteredTags = showSignatures
     ? tags
     : tags.filter((tag) => !isCosignSignatureTag(tag.name));
-
-  const toEpochOrZero = (value?: string): number => {
-    if (!value) return 0;
-    const ts = Date.parse(value);
-    return Number.isFinite(ts) ? ts : 0;
-  };
 
   // Use unified table hook for sorting, filtering, and pagination
   const {

--- a/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
@@ -27,6 +27,11 @@ import {TagsToolbar} from './TagsToolbar';
 import {usePaginatedSortableTable} from '../../../hooks/usePaginatedSortableTable';
 import {enrichTagsWithCosignData, isCosignSignatureTag} from 'src/libs/cosign';
 import {toEpochOrZero} from 'src/libs/utils';
+import {
+  extractLastModified,
+  extractExpires,
+  extractLastPulled,
+} from './tagColumnExtractors';
 
 export default function TagsList(props: TagsProps) {
   const [tags, setTags] = useState<Tag[]>([]);
@@ -53,10 +58,10 @@ export default function TagsList(props: TagsProps) {
     columns: {
       2: (item: Tag) => item.name, // Tag Name
       4: (item: Tag) => item.size || 0, // Size
-      5: (item: Tag) => item.start_ts || 0, // Last Modified
-      6: (item: Tag) => toEpochOrZero(item.expiration), // Expires
+      5: extractLastModified, // Last Modified
+      6: extractExpires, // Expires
       7: (item: Tag) => item.manifest_digest, // Manifest
-      8: (item: Tag) => toEpochOrZero(item.last_pulled), // Last Pulled
+      8: extractLastPulled, // Last Pulled
       9: (item: Tag) => item.pull_count || 0, // Pull Count
     },
     filter: searchFilter,

--- a/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
@@ -42,6 +42,12 @@ export default function TagsList(props: TagsProps) {
     ? tags
     : tags.filter((tag) => !isCosignSignatureTag(tag.name));
 
+  const toEpochOrZero = (value?: string): number => {
+    if (!value) return 0;
+    const ts = Date.parse(value);
+    return Number.isFinite(ts) ? ts : 0;
+  };
+
   // Use unified table hook for sorting, filtering, and pagination
   const {
     paginatedData: paginatedTags,
@@ -53,11 +59,9 @@ export default function TagsList(props: TagsProps) {
       2: (item: Tag) => item.name, // Tag Name
       4: (item: Tag) => item.size || 0, // Size
       5: (item: Tag) => item.start_ts || 0, // Last Modified
-      6: (item: Tag) =>
-        item.expiration ? new Date(item.expiration).getTime() : 0, // Expires
+      6: (item: Tag) => toEpochOrZero(item.expiration), // Expires
       7: (item: Tag) => item.manifest_digest, // Manifest
-      8: (item: Tag) =>
-        item.last_pulled ? new Date(item.last_pulled).getTime() : 0, // Last Pulled
+      8: (item: Tag) => toEpochOrZero(item.last_pulled), // Last Pulled
       9: (item: Tag) => item.pull_count || 0, // Pull Count
     },
     filter: searchFilter,

--- a/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsList.tsx
@@ -52,10 +52,12 @@ export default function TagsList(props: TagsProps) {
     columns: {
       2: (item: Tag) => item.name, // Tag Name
       4: (item: Tag) => item.size || 0, // Size
-      5: (item: Tag) => item.last_modified, // Last Modified
-      6: (item: Tag) => item.expiration || '', // Expires
+      5: (item: Tag) => item.start_ts || 0, // Last Modified
+      6: (item: Tag) =>
+        item.expiration ? new Date(item.expiration).getTime() : 0, // Expires
       7: (item: Tag) => item.manifest_digest, // Manifest
-      8: (item: Tag) => item.last_pulled || '', // Last Pulled
+      8: (item: Tag) =>
+        item.last_pulled ? new Date(item.last_pulled).getTime() : 0, // Last Pulled
       9: (item: Tag) => item.pull_count || 0, // Pull Count
     },
     filter: searchFilter,

--- a/web/src/routes/RepositoryDetails/Tags/tagColumnExtractors.ts
+++ b/web/src/routes/RepositoryDetails/Tags/tagColumnExtractors.ts
@@ -1,0 +1,6 @@
+import {Tag} from 'src/resources/TagResource';
+import {toEpochOrZero} from 'src/libs/utils';
+
+export const extractLastModified = (item: Tag) => item.start_ts || 0;
+export const extractExpires = (item: Tag) => toEpochOrZero(item.expiration);
+export const extractLastPulled = (item: Tag) => toEpochOrZero(item.last_pulled);


### PR DESCRIPTION
## Summary
- Fix date sorting in Tag view to use chronological instead of lexicographic comparison
- Affects Last Modified, Expires, and Last Pulled columns
- Follows existing pattern from BuildHistory.tsx

## Changes
Changed three column extractors in `TagsList.tsx` to return numeric timestamps instead of RFC 2822 date strings:
- **Last Modified**: `item.last_modified` (string) → `item.start_ts || 0` (epoch seconds)
- **Expires**: `item.expiration || ''` (string) → `new Date(item.expiration).getTime() : 0` (milliseconds)
- **Last Pulled**: `item.last_pulled || ''` (string) → `new Date(item.last_pulled).getTime() : 0` (milliseconds)

Added 6 regression tests covering all three columns, both sort directions, missing date edge case, and a guard proving the old string approach fails.

## Test plan
- [x] 6 new regression tests in `usePaginatedSortableTable.test.ts`
- [x] Full test suite passes (933/933 tests across 131 files)
- [x] TypeScript, ESLint, and Prettier checks pass
- [ ] Manual browser verification (recommended for QE)

Fixes: [PROJQUAY-11351](https://redhat.atlassian.net/browse/PROJQUAY-11351)

🤖 Generated with [Claude Code](https://claude.ai/code)