### PR TITLE
PROJQUAY-11394: fix(oci): display manifest layers for custom OCI artifacts

### DIFF
--- a/endpoints/api/manifest.py
+++ b/endpoints/api/manifest.py
@@ -95,7 +95,9 @@ def _manifest_dict(manifest):
             manifest.layers_compressed_size if not manifest.is_manifest_list else 0
         ),
         "layers": (
-            [_layer_dict(lyr.layer_info, idx) for idx, lyr in enumerate(layers)] if layers else None
+            [_layer_dict(lyr.layer_info, idx) for idx, lyr in enumerate(layers)]
+            if layers is not None
+            else None
         ),
     }
 

--- a/image/oci/manifest.py
+++ b/image/oci/manifest.py
@@ -299,6 +299,19 @@ class OCIManifest(ManifestInterface):
         not support layers.
         """
         if not self.is_image_manifest:
+            for filesystem_layer in self.filesystem_layers:
+                yield ManifestImageLayer(
+                    layer_id=str(filesystem_layer.digest),
+                    compressed_size=filesystem_layer.compressed_size,
+                    is_remote=filesystem_layer.is_remote,
+                    urls=filesystem_layer.urls,
+                    command=None,
+                    blob_digest=str(filesystem_layer.digest),
+                    created_datetime=None,
+                    author=None,
+                    comment=None,
+                    internal_layer=filesystem_layer,
+                )
             return
 
         for image_layer in self._manifest_image_layers(content_retriever):

--- a/image/oci/test/test_oci_manifest.py
+++ b/image/oci/test/test_oci_manifest.py
@@ -336,6 +336,120 @@ def test_validate_helm_oci_manifest():
     manifest = OCIManifest(Bytes.for_string_or_unicode(manifest_bytes))
 
 
+def test_get_layers_for_custom_artifact():
+    HELM_CHART_CONFIG_TYPE = "application/vnd.cncf.helm.config.v1+json"
+    HELM_CHART_LAYER_TYPES = ["application/tar+gzip"]
+    register_artifact_type(HELM_CHART_CONFIG_TYPE, HELM_CHART_LAYER_TYPES)
+
+    helm_manifest_bytes = json.dumps(
+        {
+            "schemaVersion": 2,
+            "config": {
+                "mediaType": "application/vnd.cncf.helm.config.v1+json",
+                "digest": "sha256:65a07b841ece031e6d0ec5eb948eacb17aa6d7294cdeb01d5348e86242951487",
+                "size": 141,
+            },
+            "layers": [
+                {
+                    "mediaType": "application/tar+gzip",
+                    "digest": "sha256:d84c9c29e0899862a0fa0f73da4d9f8c8c38e2da5d3258764aa7ba74bb914718",
+                    "size": 3562,
+                }
+            ],
+        }
+    )
+
+    manifest = OCIManifest(Bytes.for_string_or_unicode(helm_manifest_bytes))
+    assert not manifest.is_image_manifest
+
+    retriever = ContentRetrieverForTesting()
+    layers = list(manifest.get_layers(retriever))
+    assert len(layers) == 1
+
+    layer = layers[0]
+    assert (
+        layer.blob_digest
+        == "sha256:d84c9c29e0899862a0fa0f73da4d9f8c8c38e2da5d3258764aa7ba74bb914718"
+    )
+    assert layer.compressed_size == 3562
+    assert layer.is_remote is False
+    assert layer.command is None
+    assert layer.created_datetime is None
+    assert layer.author is None
+    assert layer.comment is None
+    assert layer.urls is None
+
+
+def test_get_layers_for_multi_layer_artifact():
+    CUSTOM_CONFIG = "application/vnd.example.config.v1+json"
+    CUSTOM_LAYER = "application/vnd.example.data.v1+tar"
+    register_artifact_type(CUSTOM_CONFIG, [CUSTOM_LAYER])
+
+    manifest_bytes = json.dumps(
+        {
+            "schemaVersion": 2,
+            "config": {
+                "mediaType": CUSTOM_CONFIG,
+                "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "size": 100,
+            },
+            "layers": [
+                {
+                    "mediaType": CUSTOM_LAYER,
+                    "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+                    "size": 1000,
+                },
+                {
+                    "mediaType": CUSTOM_LAYER,
+                    "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+                    "size": 2000,
+                },
+            ],
+        }
+    )
+
+    manifest = OCIManifest(Bytes.for_string_or_unicode(manifest_bytes))
+    retriever = ContentRetrieverForTesting()
+    layers = list(manifest.get_layers(retriever))
+
+    assert len(layers) == 2
+    assert (
+        layers[0].blob_digest
+        == "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+    )
+    assert layers[0].compressed_size == 1000
+    assert (
+        layers[1].blob_digest
+        == "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+    )
+    assert layers[1].compressed_size == 2000
+
+
+def test_get_layers_still_works_for_image_manifest():
+    retriever = ContentRetrieverForTesting.for_config(
+        {
+            "config": {},
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "history": [
+                {"created": "2018-04-03T18:37:09.284840891Z", "created_by": "foo"},
+                {"created": "2018-04-12T18:37:09.284840891Z", "created_by": "bar"},
+                {"created": "2018-04-03T18:37:09.284840891Z", "created_by": "baz"},
+            ],
+            "architecture": "amd64",
+            "os": "linux",
+        },
+        "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7",
+        7023,
+    )
+
+    manifest = OCIManifest(Bytes.for_string_or_unicode(SAMPLE_MANIFEST))
+    assert manifest.is_image_manifest
+
+    layers = list(manifest.get_layers(retriever))
+    assert len(layers) == 3
+    assert layers[0].command is not None
+
+
 INVALID_LAYER_SIZE_MANIFEST = json.dumps(
     {
         "schemaVersion": 2,


### PR DESCRIPTION
## Summary

- **Bug**: Quay UI shows empty "Manifest Layers" for custom OCI artifacts (Gemara bundles, Helm charts, etc.) while regular container images display full layer history.
- **Root cause**: `OCIManifest.get_layers()` returned an empty generator for any manifest whose config media type was not `application/vnd.oci.image.config.v1+json`, causing the API to send `layers: null`.
- **Fix**: Added a code path in `get_layers()` for non-image manifests that yields `ManifestImageLayer` entries from filesystem layer descriptors (digest, size), with `None` for image-specific metadata. Both frontends already handle this gracefully by falling back to displaying blob digests.

## Changes

| File | Change |
|------|--------|
| `image/oci/manifest.py` | `get_layers()` now yields layers for non-image OCI manifests instead of returning empty |
| `endpoints/api/manifest.py` | Changed `if layers` (falsy) to `if layers is not None` (identity check) in `_manifest_dict()` |
| `image/oci/test/test_oci_manifest.py` | Added 3 tests: single-layer artifact, multi-layer artifact, image manifest regression |

## Test plan

- [x] `pytest image/oci/test/test_oci_manifest.py` — 12/12 pass (9 existing + 3 new)
- [ ] CI: `endpoints/api/test/test_manifest.py` — API endpoint tests (requires Flask deps)
- [ ] CI: `data/secscan_model/test/test_secscan_v4_model.py` — security scanner compatibility
- [ ] CI: `data/registry_model/test/` — registry model regression tests

## Verification

Security scanner compatibility verified: `_has_container_layers()` correctly identifies custom artifact layers as non-container via `hasattr(internal, "mediatype")` duck-type check, so artifacts continue to be skipped for vulnerability scanning.

Fixes [PROJQUAY-11394](https://redhat.atlassian.net/browse/PROJQUAY-11394)

🤖 Generated with [Claude Code](https://claude.ai/code)