### PR TITLE
PROJQUAY-11314: fix(config): reject single-label hostnames in config validation

### DIFF
--- a/config-tool/pkg/lib/fieldgroups/hostsettings/hostsettings_test.go
+++ b/config-tool/pkg/lib/fieldgroups/hostsettings/hostsettings_test.go
@@ -162,6 +162,26 @@ WHgsCLsLspQZqpi5o9pKqo1WH8b+uaqm5LDQvvrk3kkQLB/M5VMI
 			want:   "invalid",
 			opts:   validOpts,
 		},
+		{
+			config: map[string]interface{}{"PREFERRED_URL_SCHEME": "http", "SERVER_HOSTNAME": "myregistry"},
+			name:   "singleLabelHostname",
+			want:   "invalid",
+		},
+		{
+			config: map[string]interface{}{"PREFERRED_URL_SCHEME": "http", "SERVER_HOSTNAME": "myregistry:8443"},
+			name:   "singleLabelHostnameWithPort",
+			want:   "invalid",
+		},
+		{
+			config: map[string]interface{}{"PREFERRED_URL_SCHEME": "http", "SERVER_HOSTNAME": "localhost"},
+			name:   "localhostAllowed",
+			want:   "valid",
+		},
+		{
+			config: map[string]interface{}{"PREFERRED_URL_SCHEME": "http", "SERVER_HOSTNAME": "localhost:8443"},
+			name:   "localhostWithPortAllowed",
+			want:   "valid",
+		},
 	}
 	for _, tt := range tests {
 

--- a/config-tool/pkg/lib/shared/validators.go
+++ b/config-tool/pkg/lib/shared/validators.go
@@ -239,18 +239,32 @@ func ValidateIsURL(input string, field string, fgName string) (bool, ValidationE
 }
 
 // ValidateIsHostname tests a string to determine if it is a well-structured hostname or not.
+// Hostnames must be fully qualified domain names (contain at least one dot) or "localhost".
 func ValidateIsHostname(input string, field string, fgName string) (bool, ValidationError) {
 
 	// trim whitespace
 	input = strings.Trim(input, " ")
 
-	// check against regex
-	re, _ := regexp.Compile(`^[a-zA-Z-0-9\.]+(:[0-9]+)?$`)
+	// check against regex for valid hostname characters
+	re, _ := regexp.Compile(`^[a-zA-Z0-9\.\-]+(:[0-9]+)?$`)
 	if !re.MatchString(input) {
 		newError := ValidationError{
 			Tags:       []string{field},
 			FieldGroup: fgName,
 			Message:    field + " must be of type Hostname",
+		}
+		return false, newError
+	}
+
+	// extract hostname without port
+	hostPart := strings.Split(input, ":")[0]
+
+	// require FQDN format (at least one dot) or localhost
+	if hostPart != "localhost" && !strings.Contains(hostPart, ".") {
+		newError := ValidationError{
+			Tags:       []string{field},
+			FieldGroup: fgName,
+			Message:    field + " must be a fully qualified domain name (e.g. registry.example.com). Single-label hostnames like '" + hostPart + "' are not supported by OpenShift",
 		}
 		return false, newError
 	}

--- a/config-tool/pkg/lib/shared/validators_test.go
+++ b/config-tool/pkg/lib/shared/validators_test.go
@@ -4,6 +4,45 @@ import (
 	"testing"
 )
 
+func TestValidateIsHostname(t *testing.T) {
+	var tests = []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		// Valid FQDNs
+		{"fqdn", "registry.example.com", true},
+		{"fqdnWithPort", "registry.example.com:8443", true},
+		{"twoParts", "fakehost.com", true},
+		{"twoParts with port", "fakehost.com:443", true},
+		{"subdomains", "my.registry.example.com", true},
+		{"hyphenated", "my-registry.example.com", true},
+		{"hyphenatedWithPort", "my-registry.example.com:5000", true},
+		{"localhost", "localhost", true},
+		{"localhostWithPort", "localhost:8443", true},
+
+		// Invalid: single-label hostnames (no dots, not localhost)
+		{"singleLabel", "myregistry", false},
+		{"singleLabelWithPort", "myregistry:8443", false},
+		{"singleLabelHyphen", "my-registry", false},
+		{"singleLabelHyphenWithPort", "my-registry:8443", false},
+
+		// Invalid: bad characters
+		{"invalidChars", "registry!.com", false},
+		{"spaces", "registry .com", false},
+		{"underscore", "my_registry.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, err := ValidateIsHostname(tt.input, "TEST_FIELD", "TestGroup")
+			if ok != tt.want {
+				t.Errorf("ValidateIsHostname(%q) = %v, want %v. Error: %s", tt.input, ok, tt.want, err.Message)
+			}
+		})
+	}
+}
+
 // TestValidateCertPairWithHostname tests the Validate function
 func TestValidateCertPairWithHostname(t *testing.T) {
 


### PR DESCRIPTION
## Summary

- Tightens `ValidateIsHostname()` in the config-tool to reject single-label hostnames (e.g. `myregistry`, `myregistry:8443`) that lack FQDN format
- Allows `localhost` as a special-case exception for local development
- Fixes an unintended ASCII range bug in the hostname character class regex (`[a-zA-Z-0-9\.]` → `[a-zA-Z0-9\.\-]`)
- Adds comprehensive test coverage for hostname validation including single-label rejection and localhost allowance

## Context

**Jira:** [PROJQUAY-11314](https://redhat.atlassian.net/browse/PROJQUAY-11314)

The quay mirror registry installer accepts hostnames like `myregistry:8443` which pass config validation but are later rejected by OpenShift's `assisted-service` DNS validation regex (which requires FQDN format with at least one dot). This creates a confusing failure mode: the registry installs successfully but is unusable by OpenShift or oc-mirror.

The root cause is the overly permissive regex in `ValidateIsHostname()` which only checks character validity, not FQDN structure. This fix adds an explicit check requiring at least one dot in the hostname (or `localhost`), with a clear error message pointing users to the correct format.

## Changes

| File | Change |
|------|--------|
| `config-tool/pkg/lib/shared/validators.go` | Added FQDN check after regex; fixed character class regex |
| `config-tool/pkg/lib/shared/validators_test.go` | Added 16 test cases for hostname validation |
| `config-tool/pkg/lib/fieldgroups/hostsettings/hostsettings_test.go` | Added 4 integration test cases |

## Test plan

- [x] All 16 new `TestValidateIsHostname` cases pass (valid FQDNs, localhost, single-label rejection, bad characters)
- [x] All 12 `TestValidateHostSettings` cases pass (including 4 new single-label/localhost cases)
- [x] Pre-existing `TestValidateCertPairWithHostname` failure confirmed unrelated (legacy CN vs SAN issue)
- [ ] Manual: install mirror-registry with `--quayHostname myregistry:8443` and verify it now fails with clear error
- [ ] Manual: install with `--quayHostname registry.example.com:8443` and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)