### PR TITLE
PROJQUAY-11403: fix(ui): fix manifest track line on unrelated pages [redhat-3.17]

### DIFF
--- a/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
@@ -571,11 +571,8 @@ export default function TagsTable(props: TableProps) {
 
   // Calculate manifest tracks for visual grouping of tags sharing the same digest
   const {tracks, getTrackEntry, getLineClass, trackCount} = useManifestTracks(
-    props.allTags,
+    props.tags,
   );
-
-  // Page offset converts local row index to global index for track lookup
-  const pageOffset = (props.page - 1) * props.perPage;
 
   // Select all tags sharing a given manifest digest
   const selectTagsByManifest = (manifestDigest: string) => {
@@ -638,7 +635,7 @@ export default function TagsTable(props: TableProps) {
             org={props.org}
             repo={props.repo}
             tag={tag}
-            rowIndex={pageOffset + localIndex}
+            rowIndex={localIndex}
             selectedTags={props.selectedTags}
             isTagExpanded={isTagExpanded}
             setTagExpanded={setTagExpanded}


### PR DESCRIPTION
Cherry-pick of #5827 onto `redhat-3.17`.

## Summary
- Fixes manifest track line appearing on pages that don't contain either of the two tags sharing a digest
- Computes manifest tracks from only the current page's visible tags instead of all tags across all pages

## Original PR
#5827