### PR TITLE
NO-ISSUE: fix(test): stabilize flaky Playwright e2e tests

### DIFF
--- a/web/playwright/e2e/superuser/repo-tag-actions.spec.ts
+++ b/web/playwright/e2e/superuser/repo-tag-actions.spec.ts
@@ -14,7 +14,9 @@ test.describe(
     }) => {
       const org = await api.organization('sucreateorg');
 
-      await superuserPage.goto(`/organization/${org.name}`);
+      await superuserPage.goto(`/organization/${org.name}`, {
+        waitUntil: 'networkidle',
+      });
 
       // Click create repository
       await superuserPage
@@ -29,8 +31,12 @@ test.describe(
       // Select private visibility
       await superuserPage.getByTestId('visibility-private-radio').click();
 
-      // Submit
-      await superuserPage.getByTestId('create-repository-submit-btn').click();
+      // Wait for form to stabilize after radio toggle re-render
+      const submitBtn = superuserPage.getByTestId(
+        'create-repository-submit-btn',
+      );
+      await expect(submitBtn).toBeEnabled();
+      await submitBtn.click();
 
       // Verify success alert appears
       await expect(

--- a/web/playwright/e2e/superuser/repo-tag-actions.spec.ts
+++ b/web/playwright/e2e/superuser/repo-tag-actions.spec.ts
@@ -14,11 +14,12 @@ test.describe(
     }) => {
       const org = await api.organization('sucreateorg');
 
-      await superuserPage.goto(`/organization/${org.name}`, {
-        waitUntil: 'networkidle',
-      });
+      await superuserPage.goto(`/organization/${org.name}`);
 
       // Click create repository
+      await superuserPage
+        .getByRole('button', {name: 'Create Repository'})
+        .waitFor({state: 'visible', timeout: 30000});
       await superuserPage
         .getByRole('button', {name: 'Create Repository'})
         .click();

--- a/web/playwright/e2e/tags/tag-immutability.spec.ts
+++ b/web/playwright/e2e/tags/tag-immutability.spec.ts
@@ -19,7 +19,9 @@ test.describe(
         TEST_USERS.user.password,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
@@ -75,7 +77,9 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
@@ -106,7 +110,9 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
@@ -143,7 +149,9 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
@@ -191,7 +199,9 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {
@@ -273,7 +283,9 @@ test.describe(
         ),
       ]);
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {
@@ -330,7 +342,9 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'already-immutable'}),
@@ -369,7 +383,9 @@ test.describe(
         true,
       );
 
-      await superuserPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await superuserPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         superuserPage.getByRole('link', {name: 'immutable-tag', exact: true}),
@@ -438,14 +454,16 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'immutable-tag',
           exact: true,
         }),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 15000});
       await expect(
         authenticatedPage.getByRole('link', {name: 'mutable-tag', exact: true}),
       ).toBeVisible();
@@ -507,14 +525,16 @@ test.describe(
         expirationTimestamp,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'expiring-tag',
           exact: true,
         }),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 15000});
 
       const tagRow = authenticatedPage.getByRole('row').filter({
         has: authenticatedPage.getByRole('link', {
@@ -564,14 +584,16 @@ test.describe(
         expirationTimestamp,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'expiring-tag',
           exact: true,
         }),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 15000});
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'non-expiring-tag',
@@ -655,14 +677,16 @@ test.describe(
         ),
       ]);
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'expiring-tag-1',
           exact: true,
         }),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 15000});
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'expiring-tag-2',
@@ -716,7 +740,9 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {
@@ -755,7 +781,9 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       const tagRow = authenticatedPage.getByRole('row').filter({
         has: authenticatedPage.getByRole('link', {
@@ -818,7 +846,9 @@ test.describe(
         ),
       ]);
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {
@@ -877,7 +907,9 @@ test.describe(
       ).not.toBeVisible();
 
       // Wait for tags to reload and verify lock icons are gone
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       const updatedRow1 = authenticatedPage.getByRole('row').filter({
         has: authenticatedPage.getByRole('link', {
@@ -914,7 +946,9 @@ test.describe(
         TEST_USERS.user.password,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {
@@ -1004,7 +1038,9 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
@@ -1085,7 +1121,9 @@ test.describe(
         TEST_USERS.user.password,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
+        waitUntil: 'networkidle',
+      });
 
       // Wait for tag to render (UI loads tag as mutable)
       await expect(

--- a/web/playwright/e2e/tags/tag-immutability.spec.ts
+++ b/web/playwright/e2e/tags/tag-immutability.spec.ts
@@ -897,7 +897,7 @@ test.describe(
       ).not.toBeVisible({timeout: 30000});
       await expect(
         updatedRow2.getByTestId('immutable-tag-icon'),
-      ).not.toBeVisible({timeout: 10000});
+      ).not.toBeVisible({timeout: 30000});
     });
 
     // PROJQUAY-10503: Bulk remove immutability disabled when no immutable tags selected

--- a/web/playwright/e2e/tags/tag-immutability.spec.ts
+++ b/web/playwright/e2e/tags/tag-immutability.spec.ts
@@ -19,13 +19,11 @@ test.describe(
         TEST_USERS.user.password,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       const tagRow = authenticatedPage
         .getByRole('row')
@@ -77,13 +75,11 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       const tagRow = authenticatedPage
         .getByRole('row')
@@ -110,13 +106,11 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       const tagRow = authenticatedPage
         .getByRole('row')
@@ -149,13 +143,11 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       const tagRow = authenticatedPage
         .getByRole('row')
@@ -199,16 +191,14 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'immutable-tag',
           exact: true,
         }),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
       await expect(
         authenticatedPage.getByRole('link', {name: 'mutable-tag', exact: true}),
       ).toBeVisible();
@@ -283,16 +273,14 @@ test.describe(
         ),
       ]);
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'immutable-1',
           exact: true,
         }),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'immutable-2',
@@ -342,13 +330,11 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'already-immutable'}),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       const immutableRow = authenticatedPage.getByRole('row').filter({
         has: authenticatedPage.getByRole('link', {name: 'already-immutable'}),
@@ -383,13 +369,11 @@ test.describe(
         true,
       );
 
-      await superuserPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await superuserPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         superuserPage.getByRole('link', {name: 'immutable-tag', exact: true}),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       const tagRow = superuserPage.getByRole('row').filter({
         has: superuserPage.getByRole('link', {
@@ -454,16 +438,14 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'immutable-tag',
           exact: true,
         }),
-      ).toBeVisible({timeout: 15000});
+      ).toBeVisible({timeout: 30000});
       await expect(
         authenticatedPage.getByRole('link', {name: 'mutable-tag', exact: true}),
       ).toBeVisible();
@@ -525,16 +507,14 @@ test.describe(
         expirationTimestamp,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'expiring-tag',
           exact: true,
         }),
-      ).toBeVisible({timeout: 15000});
+      ).toBeVisible({timeout: 30000});
 
       const tagRow = authenticatedPage.getByRole('row').filter({
         has: authenticatedPage.getByRole('link', {
@@ -584,16 +564,14 @@ test.describe(
         expirationTimestamp,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'expiring-tag',
           exact: true,
         }),
-      ).toBeVisible({timeout: 15000});
+      ).toBeVisible({timeout: 30000});
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'non-expiring-tag',
@@ -677,16 +655,14 @@ test.describe(
         ),
       ]);
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'expiring-tag-1',
           exact: true,
         }),
-      ).toBeVisible({timeout: 15000});
+      ).toBeVisible({timeout: 30000});
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'expiring-tag-2',
@@ -740,16 +716,14 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'immutable-tag',
           exact: true,
         }),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       const tagRow = authenticatedPage.getByRole('row').filter({
         has: authenticatedPage.getByRole('link', {
@@ -781,9 +755,7 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       const tagRow = authenticatedPage.getByRole('row').filter({
         has: authenticatedPage.getByRole('link', {
@@ -794,7 +766,7 @@ test.describe(
 
       // Verify "Never" is visible but is NOT rendered as a link
       const neverText = tagRow.getByText('Never');
-      await expect(neverText).toBeVisible();
+      await expect(neverText).toBeVisible({timeout: 30000});
 
       // Should not be inside an <a> tag (not clickable)
       const neverLink = tagRow.locator('a', {hasText: 'Never'});
@@ -846,16 +818,14 @@ test.describe(
         ),
       ]);
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'immutable-1',
           exact: true,
         }),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'immutable-2',
@@ -907,9 +877,7 @@ test.describe(
       ).not.toBeVisible();
 
       // Wait for tags to reload and verify lock icons are gone
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       const updatedRow1 = authenticatedPage.getByRole('row').filter({
         has: authenticatedPage.getByRole('link', {
@@ -926,7 +894,7 @@ test.describe(
 
       await expect(
         updatedRow1.getByTestId('immutable-tag-icon'),
-      ).not.toBeVisible({timeout: 10000});
+      ).not.toBeVisible({timeout: 30000});
       await expect(
         updatedRow2.getByTestId('immutable-tag-icon'),
       ).not.toBeVisible({timeout: 10000});
@@ -946,16 +914,14 @@ test.describe(
         TEST_USERS.user.password,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {
           name: 'mutable-tag',
           exact: true,
         }),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       const tagRow = authenticatedPage.getByRole('row').filter({
         has: authenticatedPage.getByRole('link', {
@@ -1001,7 +967,7 @@ test.describe(
       // Wait for table to load
       await expect(
         authenticatedPage.getByTestId('usage-logs-table'),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       // Filter by "immutable" to find our log entry
       await authenticatedPage.getByPlaceholder('Filter logs').fill('immutable');
@@ -1038,13 +1004,11 @@ test.describe(
         true,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       const tagRow = authenticatedPage
         .getByRole('row')
@@ -1121,14 +1085,12 @@ test.describe(
         TEST_USERS.user.password,
       );
 
-      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`, {
-        waitUntil: 'networkidle',
-      });
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
       // Wait for tag to render (UI loads tag as mutable)
       await expect(
         authenticatedPage.getByRole('link', {name: 'v1.0.0'}),
-      ).toBeVisible();
+      ).toBeVisible({timeout: 30000});
 
       // Make tag immutable via API while UI still shows stale mutable state.
       // This simulates a tag becoming immutable after the page was loaded

--- a/web/playwright/e2e/user/account-settings.spec.ts
+++ b/web/playwright/e2e/user/account-settings.spec.ts
@@ -179,19 +179,38 @@ test.describe('Account Settings', {tag: ['@user']}, () => {
       // Click generate password button
       await authenticatedPage.locator('#cli-password-button').click();
 
-      // Enter correct password
-      await authenticatedPage
-        .locator('#delete-confirmation-input')
-        .fill(password);
-      await authenticatedPage.locator('#submit').click();
-      await authenticatedPage.waitForLoadState('networkidle');
+      // Submit password with retry — the previous wrong-password test
+      // increments invalid_login_attempts and Quay's exponential backoff
+      // can reject the next attempt with HTTP 429.
+      const credentialsHeading = authenticatedPage.getByRole('heading', {
+        name: `Credentials for ${username}`,
+      });
+      const rateLimitError = authenticatedPage.getByText(
+        'Too many login attempts',
+      );
+
+      for (let attempt = 0; attempt < 3; attempt++) {
+        await authenticatedPage
+          .locator('#delete-confirmation-input')
+          .fill(password);
+        await authenticatedPage.locator('#submit').click();
+        await authenticatedPage.waitForLoadState('networkidle');
+
+        if (
+          await credentialsHeading.isVisible({timeout: 2000}).catch(() => false)
+        ) {
+          break;
+        }
+
+        if (
+          await rateLimitError.isVisible({timeout: 1000}).catch(() => false)
+        ) {
+          await authenticatedPage.waitForTimeout(2000 * (attempt + 1));
+        }
+      }
 
       // Credentials modal should appear
-      await expect(
-        authenticatedPage.getByRole('heading', {
-          name: `Credentials for ${username}`,
-        }),
-      ).toBeVisible();
+      await expect(credentialsHeading).toBeVisible();
 
       // Verify all credential format tabs exist
       await expect(

--- a/web/playwright/e2e/user/account-settings.spec.ts
+++ b/web/playwright/e2e/user/account-settings.spec.ts
@@ -197,13 +197,19 @@ test.describe('Account Settings', {tag: ['@user']}, () => {
         await authenticatedPage.waitForLoadState('networkidle');
 
         if (
-          await credentialsHeading.isVisible({timeout: 2000}).catch(() => false)
+          await expect(credentialsHeading)
+            .toBeVisible({timeout: 2000})
+            .then(() => true)
+            .catch(() => false)
         ) {
           break;
         }
 
         if (
-          await rateLimitError.isVisible({timeout: 1000}).catch(() => false)
+          await expect(rateLimitError)
+            .toBeVisible({timeout: 1000})
+            .then(() => true)
+            .catch(() => false)
         ) {
           await authenticatedPage.waitForTimeout(2000 * (attempt + 1));
         }


### PR DESCRIPTION
## Summary
- Fix 3 categories of consistently flaky Playwright E2E tests identified across 4+ CI runs
- **tag-immutability.spec.ts**: 19 tests timing out due to page render delays under CI load
- **account-settings.spec.ts**: 1 test rate-limited by Quay's login backoff
- **repo-tag-actions.spec.ts**: 1 test failing due to DOM element detachment during re-render

## Root Cause / Rationale
Analysis of CI job [25305904016](https://github.com/quay/quay/actions/runs/25305904016) and 4+ prior failed runs revealed:

1. **Tag immutability page render delays**: With 4 parallel workers, the Quay server is under heavy load. `goto()` returns before React finishes rendering, and the default 5s `toBeVisible()` timeout expires before the tags table appears. Initially attempted `waitUntil: 'networkidle'`, but this caused *worse* hangs — React Query keeps network connections alive, preventing `networkidle` from ever resolving. The fix uses element-based waits with 30s timeouts instead, directly verifying the content rendered without depending on network idle timing.

2. **Account settings rate limiting**: The "shows error for wrong password" test increments `invalid_login_attempts` in the DB. The immediately following "generates encrypted password" test hits Quay's exponential backoff rate limiter (HTTP 429: "Too many login attempts").

3. **Superuser repo creation DOM detach**: After clicking the visibility radio toggle, React re-renders the modal, detaching the submit button from the DOM. Playwright retried 58 times over 30s waiting for the element to stabilize.

## Changes
- `tag-immutability.spec.ts`: Removed `waitUntil: 'networkidle'` from all `goto()` calls and added `{timeout: 30000}` to the first `toBeVisible()` assertion after each navigation, giving React ample time to render under CI load without risking `networkidle` hangs.
- `account-settings.spec.ts`: Replaced single password submission with a retry loop (up to 3 attempts) that detects "Too many login attempts" errors and backs off before re-submitting. Uses `expect().toBeVisible()` for proper auto-retrying assertions.
- `repo-tag-actions.spec.ts`: Added a `waitFor({state: 'visible', timeout: 30000})` before clicking, plus explicit `toBeEnabled()` assertion on the submit button, allowing the DOM to stabilize after the radio toggle re-render.

## Test Plan
- [ ] Frontend tests pass (Playwright/Cypress)
- [x] Pre-commit hooks pass (ESLint, trailing whitespace, secrets)
- [x] Changes are test-only — no production code modified

## JIRA
N/A — NO-ISSUE chore

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-525c8ed4-e6e6-4b06-a45f-39ab5f0e775a