### PR TITLE
NO-ISSUE: fix(skills): use ADF format and acli for pilot-update Jira comments

### DIFF
--- a/.claude/skills/pilot-update/SKILL.md
+++ b/.claude/skills/pilot-update/SKILL.md
@@ -16,6 +16,9 @@ allowed-tools:
   - Bash(date *)
   - Bash(bash .claude/scripts/jira-ops.sh *)
   - Bash(curl *)
+  - Bash(acli jira workitem comment create *)
+  - Bash(acli jira workitem comment list *)
+  - Bash(acli jira workitem comment delete *)
   - mcp__mcp-atlassian__jira_get_issue
   - mcp__mcp-atlassian__jira_search
   - mcp__mcp-atlassian__jira_batch_get_changelogs
@@ -234,7 +237,9 @@ After presenting the seeded bullets, use AskUserQuestion to prompt the user:
 
 ## Phase 4: Review and Confirm
 
-Assemble the complete comment using the template:
+Assemble the complete comment using the template below for **terminal
+preview** (Markdown for readability). The actual posted comment will use
+ADF format — see Phase 5.
 
 ```markdown
 ## Quay Agentic SDLC Pilot Update — {start_date} to {end_date}
@@ -281,27 +286,70 @@ outcome to report in the latter. Specifically:
 
 ## Phase 5: Post the Comment
 
-Post the confirmed comment to PROJQUAY-11352.
+> **Critical:** Jira Cloud requires **Atlassian Document Format (ADF)**
+> JSON for rich comment formatting. Markdown and Jira wiki markup both
+> render as raw unformatted text. You **must** convert the comment to ADF
+> before posting.
 
-**Method 1 — Jira MCP (preferred in Ambient sessions):**
-If `mcp__mcp-atlassian__jira_get_issue` is available, the Jira MCP
-integration is active. However, the MCP tools exposed in this skill do
-not include a comment-posting tool. Proceed to Method 2.
+### Converting to ADF
 
-**Method 2 — Jira REST API via curl:**
-Source credentials using the same locations as
-`.claude/scripts/jira-ops.sh`: `JIRA_API_TOKEN` environment variable
-(with email from `~/.config/acli/jira_config.yaml`), or token from
-`~/.config/acli/token.txt` / `~/.acli-token`. Post the comment with:
+Build an ADF JSON document from the confirmed Markdown. The top-level
+structure is:
+
+```json
+{
+  "type": "doc",
+  "version": 1,
+  "content": [ ... ]
+}
+```
+
+Map Markdown elements to ADF nodes:
+
+| Markdown | ADF node |
+|----------|----------|
+| `## Heading` | `{"type":"heading","attrs":{"level":2},"content":[{"type":"text","text":"..."}]}` |
+| `### Heading` | `{"type":"heading","attrs":{"level":3},"content":[{"type":"text","text":"..."}]}` |
+| `- bullet item` | Wrap items in `{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[...]}]}]}` |
+| `**bold text**` | `{"type":"text","text":"...","marks":[{"type":"strong"}]}` |
+| `[link text](url)` | `{"type":"text","text":"...","marks":[{"type":"link","attrs":{"href":"..."}}]}` |
+| Plain text | `{"type":"text","text":"..."}` |
+| Paragraph break | `{"type":"paragraph","content":[...]}` |
+
+Write the ADF JSON to a temp file (e.g., `/tmp/pilot-update-adf.json`).
+
+### Method 1 — acli (preferred)
+
+`acli` is pre-authenticated in Ambient sessions (encrypted token stored
+in `~/.config/acli/jira_config.yaml`). Post the comment with:
 
 ```bash
+acli jira workitem comment create \
+  --key PROJQUAY-11352 \
+  --body-file /tmp/pilot-update-adf.json
+```
+
+Verify success by checking the exit code. If it fails, proceed to
+Method 2.
+
+### Method 2 — Jira REST API via curl (fallback)
+
+This requires `JIRA_API_TOKEN` to be set (not available in all Ambient
+sessions). Source credentials from `.claude/scripts/jira-ops.sh` locations:
+`JIRA_API_TOKEN` env var, or `~/.config/acli/token.txt`, or
+`~/.acli-token`.
+
+The ADF document must be wrapped in a `body` field:
+
+```bash
+adf_content=$(cat /tmp/pilot-update-adf.json)
 resp_file="$(mktemp)"
 http_code="$(
   curl -sS -o "$resp_file" -w "%{http_code}" -X POST \
     -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
     -H "Content-Type: application/json" \
     "https://redhat.atlassian.net/rest/api/3/issue/PROJQUAY-11352/comment" \
-    -d '{"body":{"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":"<final_markdown>"}]}]}}'
+    -d "{\"body\": ${adf_content}}"
 )"
 
 if [[ "$http_code" != 2* ]]; then
@@ -310,8 +358,8 @@ if [[ "$http_code" != 2* ]]; then
 fi
 ```
 
-If the curl call returns a non-2xx status, display the full markdown for
-the user to copy-paste manually and report the error.
+If both methods fail, display the full Markdown for the user to
+copy-paste manually and report the error.
 
 Confirm success with: "Comment posted to PROJQUAY-11352."
 

--- a/.claude/skills/pilot-update/SKILL.md
+++ b/.claude/skills/pilot-update/SKILL.md
@@ -18,7 +18,6 @@ allowed-tools:
   - Bash(curl *)
   - Bash(acli jira workitem comment create *)
   - Bash(acli jira workitem comment list *)
-  - Bash(acli jira workitem comment delete *)
   - mcp__mcp-atlassian__jira_get_issue
   - mcp__mcp-atlassian__jira_search
   - mcp__mcp-atlassian__jira_batch_get_changelogs
@@ -334,10 +333,10 @@ Method 2.
 
 ### Method 2 — Jira REST API via curl (fallback)
 
-This requires `JIRA_API_TOKEN` to be set (not available in all Ambient
+This requires both `JIRA_EMAIL` and `JIRA_API_TOKEN` to be set (not available in all Ambient
 sessions). Source credentials from `.claude/scripts/jira-ops.sh` locations:
-`JIRA_API_TOKEN` env var, or `~/.config/acli/token.txt`, or
-`~/.acli-token`.
+`JIRA_API_TOKEN` env var (or `~/.config/acli/token.txt` / `~/.acli-token`),
+and `JIRA_EMAIL` (defaults to `quay-devel@redhat.com` if not set).
 
 The ADF document must be wrapped in a `body` field:
 
@@ -358,8 +357,8 @@ if [[ "$http_code" != 2* ]]; then
 fi
 ```
 
-If both methods fail, display the full Markdown for the user to
-copy-paste manually and report the error.
+If both methods fail, save the ADF JSON file and instruct the user to
+paste the content into the Jira rich-text editor manually. Report the error.
 
 Confirm success with: "Comment posted to PROJQUAY-11352."
 
@@ -376,8 +375,8 @@ Confirm success with: "Comment posted to PROJQUAY-11352."
 - **Jira batch changelog limit**: if >20 keys, batch in groups of 20.
 - **User provides empty input for a subjective section**: use "Nothing to
   report this period." as the placeholder.
-- **Comment post fails**: display markdown for manual copy-paste and
-  report the error.
+- **Comment post fails**: save ADF JSON and instruct the user to paste content
+  into the Jira rich-text editor manually. Report the error.
 - **Jira MCP tools unavailable** (running outside Ambient): fall back to
   the Jira REST API via curl for both data gathering and comment posting.
   If credentials are not available, report the error and display

--- a/.claude/skills/pilot-update/SKILL.md
+++ b/.claude/skills/pilot-update/SKILL.md
@@ -338,17 +338,22 @@ sessions). Source credentials from `.claude/scripts/jira-ops.sh` locations:
 `JIRA_API_TOKEN` env var (or `~/.config/acli/token.txt` / `~/.acli-token`),
 and `JIRA_EMAIL` (defaults to `quay-devel@redhat.com` if not set).
 
-The ADF document must be wrapped in a `body` field:
+The ADF document must be wrapped in a `body` field. Set the default
+email if not already configured:
 
 ```bash
-adf_content=$(cat /tmp/pilot-update-adf.json)
+: "\${JIRA_EMAIL:=quay-devel@redhat.com}"
+```
+
+```bash
 resp_file="$(mktemp)"
 http_code="$(
+  jq -n --argjson body "$(cat /tmp/pilot-update-adf.json)" '{body: $body}' | \
   curl -sS -o "$resp_file" -w "%{http_code}" -X POST \
     -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
     -H "Content-Type: application/json" \
     "https://redhat.atlassian.net/rest/api/3/issue/PROJQUAY-11352/comment" \
-    -d "{\"body\": ${adf_content}}"
+    -d @-
 )"
 
 if [[ "$http_code" != 2* ]]; then
@@ -357,8 +362,12 @@ if [[ "$http_code" != 2* ]]; then
 fi
 ```
 
-If both methods fail, save the ADF JSON file and instruct the user to
-paste the content into the Jira rich-text editor manually. Report the error.
+If both methods fail, save the ADF JSON to a file and provide the user
+with both options:
+- A manual curl command they can run with their own credentials
+- The original Markdown so they can format it manually in the Jira editor
+
+Report the error.
 
 Confirm success with: "Comment posted to PROJQUAY-11352."
 
@@ -375,8 +384,8 @@ Confirm success with: "Comment posted to PROJQUAY-11352."
 - **Jira batch changelog limit**: if >20 keys, batch in groups of 20.
 - **User provides empty input for a subjective section**: use "Nothing to
   report this period." as the placeholder.
-- **Comment post fails**: save ADF JSON and instruct the user to paste content
-  into the Jira rich-text editor manually. Report the error.
+- **Comment post fails**: save ADF JSON, provide a manual curl command
+  and the original Markdown for Jira editor formatting. Report the error.
 - **Jira MCP tools unavailable** (running outside Ambient): fall back to
   the Jira REST API via curl for both data gathering and comment posting.
   If credentials are not available, report the error and display


### PR DESCRIPTION
## Summary
- Fix `/pilot-update` skill to post Jira comments using Atlassian Document Format (ADF) instead of Markdown, which renders as raw unformatted text in Jira Cloud
- Add `acli` (pre-authenticated CLI) as the primary comment posting method, with curl as fallback
- Include ADF conversion reference table mapping Markdown elements to ADF nodes

## Test plan
- [ ] Run `/pilot-update` in an Ambient session and verify the posted Jira comment renders with proper headings, bold text, bullet lists, and links
- [ ] Verify `acli jira workitem comment create --body-file` accepts ADF JSON and posts correctly
- [ ] Confirm the ADF conversion table covers all formatting used in the 5-section template

🤖 Generated with [Claude Code](https://claude.com/claude-code)