### PR TITLE
PROJQUAY-10315: fix(proxy-cache): verify blob exists in storage before serving

### DIFF
--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -734,8 +734,7 @@ class ProxyModel(OCIModel):
                     needs_download = True
             except Exception:
                 logger.exception(
-                    "Failed to verify blob %s existence in storage, "
-                    "re-fetching from upstream",
+                    "Failed to verify blob %s existence in storage, " "re-fetching from upstream",
                     blob_digest,
                 )
                 needs_download = True

--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -36,7 +36,12 @@ from data.model.quota import (
     update_quota,
 )
 from data.model.repository import create_repository, get_repository
-from data.model.storage import get_or_create_blob_with_lock, with_blob_lock_or_fallback
+from data.model.storage import (
+    get_layer_path,
+    get_or_create_blob_with_lock,
+    get_storage_locations,
+    with_blob_lock_or_fallback,
+)
 from data.registry_model.blobuploader import (
     BlobDigestMismatchException,
     BlobRangeMismatchException,
@@ -710,9 +715,32 @@ class ProxyModel(OCIModel):
             except ImageStorage.DoesNotExist:
                 return None
 
+        needs_download = False
         try:
             ImageStoragePlacement.select().where(ImageStoragePlacement.storage == blob).get()
         except ImageStoragePlacement.DoesNotExist:
+            needs_download = True
+
+        if not needs_download:
+            try:
+                layer_path = get_layer_path(blob)
+                locations = get_storage_locations(blob.uuid)
+                if not locations or not storage.exists(locations, layer_path):
+                    logger.warning(
+                        "Blob %s has placements in DB but is missing from storage, "
+                        "re-fetching from upstream",
+                        blob_digest,
+                    )
+                    needs_download = True
+            except Exception:
+                logger.exception(
+                    "Failed to verify blob %s existence in storage, "
+                    "re-fetching from upstream",
+                    blob_digest,
+                )
+                needs_download = True
+
+        if needs_download:
             try:
                 self._download_blob(repository_ref, blob_digest)
             except BlobDigestMismatchException:

--- a/data/registry_model/registry_proxy_model.py
+++ b/data/registry_model/registry_proxy_model.py
@@ -37,9 +37,9 @@ from data.model.quota import (
 )
 from data.model.repository import create_repository, get_repository
 from data.model.storage import (
+    get_image_location_for_id,
     get_layer_path,
     get_or_create_blob_with_lock,
-    get_storage_locations,
     with_blob_lock_or_fallback,
 )
 from data.registry_model.blobuploader import (
@@ -717,24 +717,25 @@ class ProxyModel(OCIModel):
 
         needs_download = False
         try:
-            ImageStoragePlacement.select().where(ImageStoragePlacement.storage == blob).get()
+            placement = (
+                ImageStoragePlacement.select().where(ImageStoragePlacement.storage == blob).get()
+            )
         except ImageStoragePlacement.DoesNotExist:
             needs_download = True
 
         if not needs_download:
             try:
                 layer_path = get_layer_path(blob)
-                locations = get_storage_locations(blob.uuid)
-                if not locations or not storage.exists(locations, layer_path):
+                location_name = get_image_location_for_id(placement.location_id).name
+                if not storage.exists([location_name], layer_path):
                     logger.warning(
-                        "Blob %s has placements in DB but is missing from storage, "
-                        "re-fetching from upstream",
+                        "Blob %s has placements in DB but is missing from storage, re-fetching from upstream",
                         blob_digest,
                     )
                     needs_download = True
-            except Exception:
+            except (IOError, OSError):
                 logger.exception(
-                    "Failed to verify blob %s existence in storage, " "re-fetching from upstream",
+                    "Failed to verify blob %s existence in storage, re-fetching from upstream",
                     blob_digest,
                 )
                 needs_download = True

--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -10,6 +10,7 @@ from app import storage
 from data.database import (
     ImageStorage,
     ImageStorageLocation,
+    ImageStoragePlacement,
     Manifest,
     ManifestBlob,
     ManifestChild,
@@ -2007,3 +2008,155 @@ def test_proxy_cache_create_blob_uses_lock(mock_get_config, initialized_db):
         )
         .exists()
     )
+
+
+@patch("data.registry_model.registry_proxy_model.Proxy", MagicMock())
+class TestGetRepoBlobByDigestMissingFromStorage:
+    orgname = "quayio-cache"
+    upstream_repository = "app-sre/ubi8-ubi"
+    upstream_registry = "quay.io"
+
+    @pytest.fixture(autouse=True)
+    def setup(self, app, create_repo):
+        self.user = get_user("devtable")
+        self.org = create_organization(self.orgname, "{self.orgname}@devtable.com", self.user)
+        self.org.save()
+        self.config = create_proxy_cache_config(
+            org_name=self.orgname,
+            upstream_registry=self.upstream_registry,
+            expiration_s=3600,
+        )
+        self.repo_ref = create_repo(self.orgname, self.upstream_repository, self.user)
+
+    def test_refetches_blob_missing_from_storage(self):
+        """
+        When a blob has a placement record in DB but the file is missing from
+        storage, the proxy model should re-download it from upstream instead of
+        returning a reference to a non-existent file (PROJQUAY-10315).
+        """
+        content = b"test blob content for proxy cache"
+        digest = str(sha256_digest(content))
+        blob = store_blob_record_and_temp_link(
+            self.orgname,
+            self.upstream_repository,
+            digest,
+            ImageStorageLocation.get(name="local_us"),
+            len(content),
+            120,
+        )
+        layer_path = get_layer_path(blob)
+        storage.put_content(["local_us"], layer_path, content)
+
+        manifest_bytes = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "config": {
+                    "mediaType": "application/vnd.docker.container.image.v1+json",
+                    "size": len(content),
+                    "digest": digest,
+                },
+                "layers": [],
+            }
+        )
+        media_type, _ = MediaType.get_or_create(
+            name="application/vnd.docker.distribution.manifest.v2+json"
+        )
+        from data.database import Repository
+
+        repo = Repository.get(id=self.repo_ref.id)
+        manifest = Manifest.create(
+            repository=repo,
+            digest=_get_digest(manifest_bytes.encode("utf-8")),
+            manifest_bytes=manifest_bytes,
+            media_type=media_type,
+        )
+        ManifestBlob.create(
+            manifest=manifest,
+            repository=repo,
+            blob=blob,
+        )
+
+        assert storage.exists(["local_us"], layer_path)
+        assert ImageStoragePlacement.select().where(
+            ImageStoragePlacement.storage == blob
+        ).exists()
+
+        storage.remove(["local_us"], layer_path)
+        assert not storage.exists(["local_us"], layer_path)
+
+        proxy_model = ProxyModel(
+            self.orgname,
+            self.upstream_repository,
+            self.user,
+        )
+
+        with patch.object(proxy_model, "_download_blob") as mock_download:
+            proxy_model.get_repo_blob_by_digest(
+                self.repo_ref, digest, include_placements=True
+            )
+            mock_download.assert_called_once_with(self.repo_ref, digest)
+
+    def test_does_not_refetch_blob_present_in_storage(self):
+        """
+        When a blob has a placement record and the file exists in storage,
+        the proxy model should NOT re-download it.
+        """
+        content = b"test blob content that exists"
+        digest = str(sha256_digest(content))
+        blob = store_blob_record_and_temp_link(
+            self.orgname,
+            self.upstream_repository,
+            digest,
+            ImageStorageLocation.get(name="local_us"),
+            len(content),
+            120,
+        )
+        layer_path = get_layer_path(blob)
+        storage.put_content(["local_us"], layer_path, content)
+
+        manifest_bytes = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "config": {
+                    "mediaType": "application/vnd.docker.container.image.v1+json",
+                    "size": len(content),
+                    "digest": digest,
+                },
+                "layers": [],
+            }
+        )
+        media_type, _ = MediaType.get_or_create(
+            name="application/vnd.docker.distribution.manifest.v2+json"
+        )
+        from data.database import Repository
+
+        repo = Repository.get(id=self.repo_ref.id)
+        manifest = Manifest.create(
+            repository=repo,
+            digest=_get_digest(manifest_bytes.encode("utf-8")),
+            manifest_bytes=manifest_bytes,
+            media_type=media_type,
+        )
+        ManifestBlob.create(
+            manifest=manifest,
+            repository=repo,
+            blob=blob,
+        )
+
+        assert storage.exists(["local_us"], layer_path)
+
+        proxy_model = ProxyModel(
+            self.orgname,
+            self.upstream_repository,
+            self.user,
+        )
+
+        with patch.object(proxy_model, "_download_blob") as mock_download:
+            result = proxy_model.get_repo_blob_by_digest(
+                self.repo_ref, digest, include_placements=True
+            )
+            mock_download.assert_not_called()
+            assert result is not None
+            assert result.digest == digest

--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -2157,3 +2157,68 @@ class TestGetRepoBlobByDigestMissingFromStorage:
             mock_download.assert_not_called()
             assert result is not None
             assert result.digest == digest
+
+    def test_refetches_blob_when_storage_check_raises(self):
+        """
+        When storage.exists() raises an exception (e.g. storage backend
+        unavailable), the proxy model should re-download from upstream
+        rather than serving a potentially missing blob.
+        """
+        content = b"test blob content for storage error"
+        digest = str(sha256_digest(content))
+        blob = store_blob_record_and_temp_link(
+            self.orgname,
+            self.upstream_repository,
+            digest,
+            ImageStorageLocation.get(name="local_us"),
+            len(content),
+            120,
+        )
+        layer_path = get_layer_path(blob)
+        storage.put_content(["local_us"], layer_path, content)
+
+        manifest_bytes = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "config": {
+                    "mediaType": "application/vnd.docker.container.image.v1+json",
+                    "size": len(content),
+                    "digest": digest,
+                },
+                "layers": [],
+            }
+        )
+        media_type, _ = MediaType.get_or_create(
+            name="application/vnd.docker.distribution.manifest.v2+json"
+        )
+        from data.database import Repository
+
+        repo = Repository.get(id=self.repo_ref.id)
+        manifest = Manifest.create(
+            repository=repo,
+            digest=_get_digest(manifest_bytes.encode("utf-8")),
+            manifest_bytes=manifest_bytes,
+            media_type=media_type,
+        )
+        ManifestBlob.create(
+            manifest=manifest,
+            repository=repo,
+            blob=blob,
+        )
+
+        proxy_model = ProxyModel(
+            self.orgname,
+            self.upstream_repository,
+            self.user,
+        )
+
+        with (
+            patch(
+                "data.registry_model.registry_proxy_model.storage.exists",
+                side_effect=IOError("storage unavailable"),
+            ),
+            patch.object(proxy_model, "_download_blob") as mock_download,
+        ):
+            proxy_model.get_repo_blob_by_digest(self.repo_ref, digest, include_placements=True)
+            mock_download.assert_called_once_with(self.repo_ref, digest)

--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -2150,7 +2150,9 @@ class TestGetRepoBlobByDigestMissingFromStorage:
         )
 
         with patch.object(proxy_model, "_download_blob") as mock_download:
-            result = proxy_model.get_repo_blob_by_digest(self.repo_ref, digest, include_placements=True)
+            result = proxy_model.get_repo_blob_by_digest(
+                self.repo_ref, digest, include_placements=True
+            )
             mock_download.assert_not_called()
             assert result is not None
             assert result.digest == digest

--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -2010,6 +2010,7 @@ def test_proxy_cache_create_blob_uses_lock(mock_get_config, initialized_db):
     )
 
 
+@pytest.mark.xdist_group("registry_proxy_serial")
 @patch("data.registry_model.registry_proxy_model.Proxy", MagicMock())
 class TestGetRepoBlobByDigestMissingFromStorage:
     orgname = "quayio-cache"

--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -2078,9 +2078,7 @@ class TestGetRepoBlobByDigestMissingFromStorage:
         )
 
         assert storage.exists(["local_us"], layer_path)
-        assert ImageStoragePlacement.select().where(
-            ImageStoragePlacement.storage == blob
-        ).exists()
+        assert ImageStoragePlacement.select().where(ImageStoragePlacement.storage == blob).exists()
 
         storage.remove(["local_us"], layer_path)
         assert not storage.exists(["local_us"], layer_path)
@@ -2092,9 +2090,7 @@ class TestGetRepoBlobByDigestMissingFromStorage:
         )
 
         with patch.object(proxy_model, "_download_blob") as mock_download:
-            proxy_model.get_repo_blob_by_digest(
-                self.repo_ref, digest, include_placements=True
-            )
+            proxy_model.get_repo_blob_by_digest(self.repo_ref, digest, include_placements=True)
             mock_download.assert_called_once_with(self.repo_ref, digest)
 
     def test_does_not_refetch_blob_present_in_storage(self):
@@ -2154,9 +2150,7 @@ class TestGetRepoBlobByDigestMissingFromStorage:
         )
 
         with patch.object(proxy_model, "_download_blob") as mock_download:
-            result = proxy_model.get_repo_blob_by_digest(
-                self.repo_ref, digest, include_placements=True
-            )
+            result = proxy_model.get_repo_blob_by_digest(self.repo_ref, digest, include_placements=True)
             mock_download.assert_not_called()
             assert result is not None
             assert result.digest == digest

--- a/workers/proxycacheblobworker.py
+++ b/workers/proxycacheblobworker.py
@@ -168,8 +168,7 @@ class ProxyCacheBlobWorker(QueueWorker):
             locations = get_storage_locations(blob.uuid)
             if not locations or not storage.exists(locations, layer_path):
                 logger.warning(
-                    "Blob %s has placements in DB but is missing from storage, "
-                    "will re-download",
+                    "Blob %s has placements in DB but is missing from storage, " "will re-download",
                     digest,
                 )
                 return True

--- a/workers/proxycacheblobworker.py
+++ b/workers/proxycacheblobworker.py
@@ -4,7 +4,7 @@ import time
 from peewee import JOIN
 
 import features
-from app import app, proxy_cache_blob_queue
+from app import app, proxy_cache_blob_queue, storage
 from data.database import (
     ImageStorage,
     ImageStoragePlacement,
@@ -15,6 +15,7 @@ from data.database import (
     db_transaction,
 )
 from data.model import repository, user
+from data.model.storage import get_layer_path, get_storage_locations
 from data.registry_model.datatypes import RepositoryReference
 from data.registry_model.registry_proxy_model import ProxyModel
 from util.locking import GlobalLock
@@ -160,6 +161,23 @@ class ProxyCacheBlobWorker(QueueWorker):
         try:
             ImageStoragePlacement.select().where(ImageStoragePlacement.storage == blob).get()
         except ImageStoragePlacement.DoesNotExist:
+            return True
+
+        try:
+            layer_path = get_layer_path(blob)
+            locations = get_storage_locations(blob.uuid)
+            if not locations or not storage.exists(locations, layer_path):
+                logger.warning(
+                    "Blob %s has placements in DB but is missing from storage, "
+                    "will re-download",
+                    digest,
+                )
+                return True
+        except Exception:
+            logger.exception(
+                "Failed to verify blob %s existence in storage",
+                digest,
+            )
             return True
 
         return False

--- a/workers/proxycacheblobworker.py
+++ b/workers/proxycacheblobworker.py
@@ -15,7 +15,7 @@ from data.database import (
     db_transaction,
 )
 from data.model import repository, user
-from data.model.storage import get_layer_path, get_storage_locations
+from data.model.storage import get_image_location_for_id, get_layer_path
 from data.registry_model.datatypes import RepositoryReference
 from data.registry_model.registry_proxy_model import ProxyModel
 from util.locking import GlobalLock
@@ -159,20 +159,22 @@ class ProxyCacheBlobWorker(QueueWorker):
                 return False
 
         try:
-            ImageStoragePlacement.select().where(ImageStoragePlacement.storage == blob).get()
+            placement = (
+                ImageStoragePlacement.select().where(ImageStoragePlacement.storage == blob).get()
+            )
         except ImageStoragePlacement.DoesNotExist:
             return True
 
         try:
             layer_path = get_layer_path(blob)
-            locations = get_storage_locations(blob.uuid)
-            if not locations or not storage.exists(locations, layer_path):
+            location_name = get_image_location_for_id(placement.location_id).name
+            if not storage.exists([location_name], layer_path):
                 logger.warning(
-                    "Blob %s has placements in DB but is missing from storage, " "will re-download",
+                    "Blob %s has placements in DB but is missing from storage, will re-download",
                     digest,
                 )
                 return True
-        except Exception:
+        except (IOError, OSError):
             logger.exception(
                 "Failed to verify blob %s existence in storage",
                 digest,

--- a/workers/test/test_proxycacheblobworker.py
+++ b/workers/test/test_proxycacheblobworker.py
@@ -566,6 +566,4 @@ def test_should_download_blob_storage_error(proxy_cache_blob_worker, initialized
         "workers.proxycacheblobworker.storage.exists",
         side_effect=IOError("storage unavailable"),
     ):
-        assert proxy_cache_blob_worker._should_download_blob(
-            digest, repo.id, registry_proxy_model
-        )
+        assert proxy_cache_blob_worker._should_download_blob(digest, repo.id, registry_proxy_model)

--- a/workers/test/test_proxycacheblobworker.py
+++ b/workers/test/test_proxycacheblobworker.py
@@ -2,11 +2,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app import storage
+from data.model.blob import store_blob_record_and_temp_link
 from data.model.organization import create_organization
 from data.model.proxy_cache import create_proxy_cache_config
 from data.model.repository import create_repository
+from data.model.storage import get_layer_path
 from data.model.user import get_user
 from data.registry_model.registry_proxy_model import ProxyModel
+from digest.digest_tools import sha256_digest
 from test.fixtures import *
 from workers.proxycacheblobworker import ProxyCacheBlobWorker
 
@@ -435,3 +439,133 @@ def test_reset_security_status_only_affects_unsupported(proxy_cache_blob_worker,
         ManifestSecurityStatus.repository == repo,
     )
     assert status.index_status == IndexStatus.FAILED
+
+
+def test_should_download_blob_missing_from_storage(proxy_cache_blob_worker, initialized_db):
+    """
+    When a blob has a placement record in DB but the file is missing from
+    storage, _should_download_blob should return True (PROJQUAY-10315).
+    """
+    from data.database import (
+        ImageStorage,
+        ImageStorageLocation,
+        ImageStoragePlacement,
+        Manifest,
+        ManifestBlob,
+        MediaType,
+        Repository,
+    )
+
+    repo = Repository.get(Repository.name == "simple")
+    location = ImageStorageLocation.get(name="local_us")
+
+    content = b"worker test blob missing from storage"
+    digest = str(sha256_digest(content))
+    blob = store_blob_record_and_temp_link(
+        repo.namespace_user.username,
+        repo.name,
+        digest,
+        location,
+        len(content),
+        120,
+    )
+    layer_path = get_layer_path(blob)
+    storage.put_content(["local_us"], layer_path, content)
+
+    media_type, _ = MediaType.get_or_create(
+        name="application/vnd.docker.distribution.manifest.v2+json"
+    )
+    manifest = Manifest.create(
+        digest="sha256:worker_test_missing",
+        manifest_bytes='{"test": "manifest"}',
+        media_type=media_type,
+        repository=repo,
+    )
+    ManifestBlob.create(manifest=manifest, blob=blob, repository=repo)
+
+    assert ImageStoragePlacement.select().where(ImageStoragePlacement.storage == blob).exists()
+
+    orgname = "testorg-worker-missing"
+    user = get_user("devtable")
+    org = create_organization(orgname, f"{orgname}@devtable.com", user)
+    org.save()
+    create_proxy_cache_config(
+        org_name=orgname,
+        upstream_registry="quay.io",
+        expiration_s=3600,
+    )
+    with patch("data.registry_model.registry_proxy_model.Proxy", MagicMock()):
+        registry_proxy_model = ProxyModel(orgname, "app-sre/ubi8-ubi", user)
+
+    # File exists → should not download
+    assert not proxy_cache_blob_worker._should_download_blob(digest, repo.id, registry_proxy_model)
+
+    # Remove file from storage
+    storage.remove(["local_us"], layer_path)
+    assert not storage.exists(["local_us"], layer_path)
+
+    # File missing → should download
+    assert proxy_cache_blob_worker._should_download_blob(digest, repo.id, registry_proxy_model)
+
+
+def test_should_download_blob_storage_error(proxy_cache_blob_worker, initialized_db):
+    """
+    When storage.exists() raises an exception, _should_download_blob should
+    return True to trigger a re-download rather than serving stale data.
+    """
+    from data.database import (
+        ImageStorage,
+        ImageStorageLocation,
+        ImageStoragePlacement,
+        Manifest,
+        ManifestBlob,
+        MediaType,
+        Repository,
+    )
+
+    repo = Repository.get(Repository.name == "simple")
+    location = ImageStorageLocation.get(name="local_us")
+
+    content = b"worker test blob storage error"
+    digest = str(sha256_digest(content))
+    blob = store_blob_record_and_temp_link(
+        repo.namespace_user.username,
+        repo.name,
+        digest,
+        location,
+        len(content),
+        120,
+    )
+    layer_path = get_layer_path(blob)
+    storage.put_content(["local_us"], layer_path, content)
+
+    media_type, _ = MediaType.get_or_create(
+        name="application/vnd.docker.distribution.manifest.v2+json"
+    )
+    manifest = Manifest.create(
+        digest="sha256:worker_test_error",
+        manifest_bytes='{"test": "manifest"}',
+        media_type=media_type,
+        repository=repo,
+    )
+    ManifestBlob.create(manifest=manifest, blob=blob, repository=repo)
+
+    orgname = "testorg-worker-error"
+    user = get_user("devtable")
+    org = create_organization(orgname, f"{orgname}@devtable.com", user)
+    org.save()
+    create_proxy_cache_config(
+        org_name=orgname,
+        upstream_registry="quay.io",
+        expiration_s=3600,
+    )
+    with patch("data.registry_model.registry_proxy_model.Proxy", MagicMock()):
+        registry_proxy_model = ProxyModel(orgname, "app-sre/ubi8-ubi", user)
+
+    with patch(
+        "workers.proxycacheblobworker.storage.exists",
+        side_effect=IOError("storage unavailable"),
+    ):
+        assert proxy_cache_blob_worker._should_download_blob(
+            digest, repo.id, registry_proxy_model
+        )


### PR DESCRIPTION
## Summary
- Fix proxy cache image pulls failing with 404 when blobs are referenced in DB but missing from storage
- Add storage existence verification before serving cached blobs
- Apply same fix to the background blob download worker

## Root Cause / Rationale
When pulling images from proxy cache organizations, the proxy model checks for an `ImageStoragePlacement` record to determine if a blob has been downloaded. If a placement record exists, the blob is assumed to be present in storage. However, the actual file can be missing from storage due to failed downloads, incomplete garbage collection, or storage issues. This causes `stream_read()` to fail with a 404/500 error instead of re-fetching the blob from the upstream registry.

## Changes
- `data/registry_model/registry_proxy_model.py`: In `get_repo_blob_by_digest()`, after confirming a placement record exists, verify the blob file actually exists in storage via `storage.exists()`. If missing, re-download from upstream.
- `workers/proxycacheblobworker.py`: In `_should_download_blob()`, apply the same storage existence check so the background worker also re-downloads blobs with stale placement records.
- `data/registry_model/test/test_registry_proxy_model.py`: Add tests verifying that missing blobs trigger re-download and present blobs do not.

## Test Plan
- [x] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [ ] Manual testing performed
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-10315

## Backport
- [ ] Backport required
- [x] No backport needed