### PR TITLE
[redhat-3.17] NO-ISSUE: test(web): backport Playwright tests from master

### DIFF
--- a/web/playwright/e2e/auth/ldap-login.spec.ts
+++ b/web/playwright/e2e/auth/ldap-login.spec.ts
@@ -1,0 +1,89 @@
+import {test, expect} from '../../fixtures';
+import {TEST_USERS_LDAP} from '../../global-setup';
+
+test.describe('LDAP Login', {tag: ['@auth', '@auth:LDAP', '@critical']}, () => {
+  test('logs in with LDAP credentials', async ({browser}) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto('/signin');
+
+    await page
+      .getByRole('textbox', {name: /username/i})
+      .fill(TEST_USERS_LDAP.user.username);
+    await page.getByLabel(/password/i).fill(TEST_USERS_LDAP.user.password);
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page).toHaveURL(/\/(organization|updateuser|repository)/, {
+      timeout: 15000,
+    });
+
+    await expect(page).not.toHaveURL(/\/signin/);
+
+    await page.close();
+    await context.close();
+  });
+
+  test('superuser can log in with LDAP credentials', async ({browser}) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto('/signin');
+
+    await page
+      .getByRole('textbox', {name: /username/i})
+      .fill(TEST_USERS_LDAP.admin.username);
+    await page.getByLabel(/password/i).fill(TEST_USERS_LDAP.admin.password);
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page).toHaveURL(/\/(organization|updateuser|repository)/, {
+      timeout: 15000,
+    });
+
+    await expect(page).not.toHaveURL(/\/signin/);
+
+    await page.close();
+    await context.close();
+  });
+
+  test('rejects invalid LDAP credentials', async ({browser}) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto('/signin');
+
+    await page
+      .getByRole('textbox', {name: /username/i})
+      .fill('nonexistentuser');
+    await page.getByLabel(/password/i).fill('wrongpassword');
+    await page.locator('button[type="submit"]').click();
+
+    await expect(page.getByText('Invalid Username or Password')).toBeVisible();
+    await expect(page).toHaveURL(/\/signin/);
+
+    await page.close();
+    await context.close();
+  });
+
+  test('does not show create account link for LDAP auth', async ({
+    unauthenticatedPage: page,
+  }) => {
+    await page.goto('/signin');
+
+    await expect(page.getByRole('textbox', {name: /username/i})).toBeVisible();
+    await expect(
+      page.getByTestId('signin-create-account-link'),
+    ).not.toBeVisible();
+  });
+
+  test('does not show forgot password link for LDAP auth', async ({
+    unauthenticatedPage: page,
+  }) => {
+    await page.goto('/signin');
+
+    await expect(page.getByRole('textbox', {name: /username/i})).toBeVisible();
+    await expect(
+      page.getByTestId('signin-forgot-password-link'),
+    ).not.toBeVisible();
+  });
+});

--- a/web/playwright/e2e/organization/permission-dropdown-navigation.spec.ts
+++ b/web/playwright/e2e/organization/permission-dropdown-navigation.spec.ts
@@ -1,0 +1,131 @@
+import {test, expect} from '../../fixtures';
+
+test.describe(
+  'Permission dropdown does not navigate away',
+  {tag: ['@organization', '@critical']},
+  () => {
+    test('inline permission change stays on page', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      // Setup: org with repo, team, and a read permission
+      const org = await api.organization('dropnav');
+      const repo = await api.repository(org.name, 'navrepo');
+      const team = await api.team(org.name, 'navteam');
+      await api.repositoryPermission(
+        org.name,
+        repo.name,
+        'team',
+        team.name,
+        'read',
+      );
+
+      // Navigate to repository settings
+      const settingsUrl = `/repository/${org.name}/${repo.name}?tab=settings`;
+      await authenticatedPage.goto(settingsUrl);
+
+      // Click the permission dropdown to change role
+      const teamRow = authenticatedPage.locator('tr', {hasText: team.name});
+      await teamRow.getByText('read').click();
+
+      // Click a permission option — this is where Firefox would navigate away
+      await authenticatedPage.getByRole('menuitem', {name: 'Write'}).click();
+
+      // Verify we stayed on the same page (no navigation occurred)
+      await expect(authenticatedPage).toHaveURL(settingsUrl);
+
+      // Verify the permission was actually updated
+      await expect(teamRow.locator('[data-label="role"]')).toHaveText('write');
+    });
+
+    test('default permission dropdown stays on page', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      // Setup: org with team, robot, and a default permission
+      const org = await api.organization('dropnav2');
+      const team = await api.team(org.name, 'navteam');
+      const robot = await api.robot(org.name, 'navbot');
+      await api.prototype(
+        org.name,
+        'read',
+        {name: team.name, kind: 'team'},
+        {name: robot.fullName},
+      );
+
+      // Navigate to default permissions tab
+      const defaultPermsUrl = `/organization/${org.name}?tab=Defaultpermissions`;
+      await authenticatedPage.goto(defaultPermsUrl);
+
+      // Wait for data to load
+      const tabPanel = authenticatedPage.getByRole('tabpanel', {
+        name: 'Default permissions',
+      });
+      await expect(
+        tabPanel.locator('.pf-v6-c-pagination__total-items').first(),
+      ).toContainText('1 - 1 of 1', {timeout: 15000});
+
+      // Click permission dropdown toggle
+      await authenticatedPage
+        .getByTestId(`${robot.fullName}-permission-dropdown-toggle`)
+        .click();
+
+      // Click a permission option — this is where Firefox would navigate away
+      await authenticatedPage.getByTestId(`${robot.fullName}-WRITE`).click();
+
+      // Verify we stayed on the same page
+      await expect(authenticatedPage).toHaveURL(defaultPermsUrl);
+
+      // Verify success alert confirms the change worked
+      await expect(
+        authenticatedPage.locator('.pf-v6-c-alert.pf-m-success').last(),
+      ).toContainText('Permission updated successfully');
+    });
+
+    test('create default permission dropdown stays on page', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      // Setup: org with team
+      const org = await api.organization('dropnav3');
+      const team = await api.team(org.name, 'navteam');
+
+      // Navigate to default permissions tab
+      const defaultPermsUrl = `/organization/${org.name}?tab=Defaultpermissions`;
+      await authenticatedPage.goto(defaultPermsUrl);
+
+      // Open create default permission drawer
+      await authenticatedPage
+        .getByTestId('create-default-permissions-btn')
+        .click();
+
+      // Select "Anyone" type
+      await authenticatedPage.getByTestId('Anyone').click();
+
+      // Select team
+      await authenticatedPage.locator('#applied-to-dropdown').click();
+      await authenticatedPage.getByTestId(`${team.name}-team`).click();
+
+      // Click the permission level dropdown
+      await authenticatedPage
+        .getByTestId('create-default-permission-dropdown-toggle')
+        .click();
+
+      // Click "Write" — this is where Firefox would navigate away
+      await authenticatedPage
+        .getByTestId('create-default-permission-dropdown')
+        .getByText('Write')
+        .click();
+
+      // Verify we stayed on the same page
+      await expect(authenticatedPage).toHaveURL(defaultPermsUrl);
+
+      // Verify the dropdown shows the selected value
+      await expect(
+        authenticatedPage.getByTestId(
+          'create-default-permission-dropdown-toggle',
+        ),
+      ).toContainText('Write');
+    });
+  },
+);

--- a/web/playwright/global-setup.ts
+++ b/web/playwright/global-setup.ts
@@ -58,6 +58,24 @@ export const TEST_USERS_OIDC = {
   },
 } as const;
 
+export const TEST_USERS_LDAP = {
+  admin: {
+    username: 'admin_ldap',
+    password: 'password',
+    email: 'admin_ldap@example.com',
+  },
+  user: {
+    username: 'testuser_ldap',
+    password: 'password',
+    email: 'testuser_ldap@example.com',
+  },
+  readonly: {
+    username: 'readonly_ldap',
+    password: 'password',
+    email: 'readonly_ldap@example.com',
+  },
+} as const;
+
 async function globalSetup(config: FullConfig) {
   const baseURL = config.projects[0].use.baseURL || 'http://localhost:9000';
 


### PR DESCRIPTION
## Summary
- Backport 2 Playwright e2e tests from master that were missing on redhat-3.17
- Add `TEST_USERS_LDAP` constant to `web/playwright/global-setup.ts` for LDAP test support

### Tests added

| Test File | Feature Tested |
|-----------|---------------|
| `e2e/auth/ldap-login.spec.ts` | LDAP authentication flow |
| `e2e/organization/permission-dropdown-navigation.spec.ts` | Permission dropdown does not trigger page navigation |

### Tests intentionally skipped

| Test File | Reason |
|-----------|--------|
| `e2e/legacy-ui/angular-smoke.spec.ts` | Skipped per reviewer decision |
| `e2e/legacy-ui/ui-toggle.spec.ts` | Skipped per reviewer decision |

## Root Cause / Rationale
The redhat-3.17 branch had full Playwright infrastructure but was missing 4 test files present on master. After auditing, all 4 features exist on the branch. Two legacy-UI tests were excluded by reviewer request; the remaining 2 are backported as-is with no non-test source code changes.

## Test plan
- [ ] `npx tsc --noEmit` passes in `web/` (0 new type errors)
- [ ] `npx eslint` passes on new test files
- [ ] `npx playwright test ldap-login` passes against LDAP-configured instance
- [ ] `npx playwright test permission-dropdown-navigation` passes