### PR TITLE
NO-ISSUE: fix(test): harden flaky Playwright tests for tags

### DIFF
--- a/web/playwright/e2e/tags/expanded-view.spec.ts
+++ b/web/playwright/e2e/tags/expanded-view.spec.ts
@@ -4,6 +4,8 @@ import {ApiClient} from '../../utils/api';
 import {pushMultiArchImage, pushImage} from '../../utils/container';
 
 test.describe('Tags - Expanded View', {tag: ['@tags', '@container']}, () => {
+  test.slow();
+
   let testRepo: {namespace: string; name: string; fullName: string};
 
   test.beforeAll(async ({userContext, cachedContainerAvailable}) => {

--- a/web/playwright/e2e/tags/tag-immutability.spec.ts
+++ b/web/playwright/e2e/tags/tag-immutability.spec.ts
@@ -1043,7 +1043,7 @@ test.describe(
       const saveLabelsButton = authenticatedPage.getByRole('button', {
         name: 'Save Labels',
       });
-      await expect(saveLabelsButton).toBeEnabled({timeout: 5000});
+      await expect(saveLabelsButton).toBeEnabled({timeout: 15000});
 
       // Save
       await saveLabelsButton.click();

--- a/web/playwright/e2e/tags/tag-immutability.spec.ts
+++ b/web/playwright/e2e/tags/tag-immutability.spec.ts
@@ -6,6 +6,8 @@ test.describe(
   'Tag Immutability',
   {tag: ['@tags', '@immutability', '@feature:IMMUTABLE_TAGS', '@container']},
   () => {
+    test.slow();
+
     test('can make a tag immutable via kebab menu', async ({
       authenticatedPage,
       api,

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -1121,13 +1121,16 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   api: async ({authenticatedRequest, quayConfig}, use) => {
     const client = new ApiClient(authenticatedRequest);
     const users = getTestUsers(quayConfig);
+    client.setCredentials(users.user.username, users.user.password);
     const testApi = new TestApi(client, users.user.username);
     await use(testApi);
     await testApi.cleanup();
   },
 
-  superuserApi: async ({superuserRequest}, use) => {
+  superuserApi: async ({superuserRequest, cachedQuayConfig}, use) => {
     const client = new ApiClient(superuserRequest);
+    const users = getTestUsers(cachedQuayConfig);
+    client.setCredentials(users.admin.username, users.admin.password);
     const testApi = new TestApi(client);
     await use(testApi);
     await testApi.cleanup();

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -1042,20 +1042,15 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   ],
 
   cachedQuayConfig: [
-    async ({playwright}, use) => {
-      const request = await playwright.request.newContext({
-        ignoreHTTPSErrors: true,
-      });
-      try {
-        const response = await request.get(`${API_URL}/config`);
-        if (!response.ok()) {
-          throw new Error(`Failed to fetch Quay config: ${response.status()}`);
-        }
-        const config = (await response.json()) as QuayConfig;
-        await use(config);
-      } finally {
-        await request.dispose();
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      const raw = process.env.QUAY_CONFIG_JSON;
+      if (!raw) {
+        throw new Error(
+          'QUAY_CONFIG_JSON not set -- globalSetup must run before workers',
+        );
       }
+      await use(JSON.parse(raw) as QuayConfig);
     },
     {scope: 'worker'},
   ],

--- a/web/playwright/global-setup.ts
+++ b/web/playwright/global-setup.ts
@@ -104,6 +104,7 @@ async function globalSetup(config: FullConfig) {
           const quayConfig = await configResponse.json();
           mailingEnabled = quayConfig?.features?.MAILING === true;
           authType = quayConfig?.config?.AUTHENTICATION_TYPE || 'Database';
+          process.env.QUAY_CONFIG_JSON = JSON.stringify(quayConfig);
           break;
         }
       } catch {

--- a/web/playwright/utils/api/client.ts
+++ b/web/playwright/utils/api/client.ts
@@ -4,7 +4,7 @@
  * Provides API interactions with CSRF token caching to reduce redundant requests.
  */
 
-import {APIRequestContext} from '@playwright/test';
+import {APIRequestContext, APIResponse} from '@playwright/test';
 import {requestCsrfToken} from './csrf';
 import {API_URL} from '../config';
 
@@ -208,9 +208,14 @@ export interface ProxyCacheConfig {
 export class ApiClient {
   private request: APIRequestContext;
   private csrfToken: string | null = null;
+  private credentials: {username: string; password: string} | null = null;
 
   constructor(request: APIRequestContext) {
     this.request = request;
+  }
+
+  setCredentials(username: string, password: string): void {
+    this.credentials = {username, password};
   }
 
   private async fetchToken(): Promise<string> {
@@ -226,6 +231,36 @@ export class ApiClient {
    */
   async getToken(): Promise<string> {
     return this.fetchToken();
+  }
+
+  private isFreshLoginRequired(status: number, body: string): boolean {
+    if (status !== 401) return false;
+    try {
+      return JSON.parse(body).error_type === 'fresh_login_required';
+    } catch {
+      return false;
+    }
+  }
+
+  private async ensureFreshSession(): Promise<void> {
+    if (!this.credentials) {
+      throw new Error('Cannot refresh session: no credentials stored');
+    }
+    await this.signIn(this.credentials.username, this.credentials.password);
+  }
+
+  private async withFreshLoginRetry(
+    doRequest: () => Promise<APIResponse>,
+  ): Promise<APIResponse> {
+    const response = await doRequest();
+    if (this.credentials && response.status() === 401) {
+      const body = await response.text();
+      if (this.isFreshLoginRequired(response.status(), body)) {
+        await this.ensureFreshSession();
+        return doRequest();
+      }
+    }
+    return response;
   }
 
   // Organization methods
@@ -260,16 +295,15 @@ export class ApiClient {
   }
 
   async deleteOrganization(name: string): Promise<void> {
-    const token = await this.fetchToken();
-    const response = await this.request.delete(
-      `${API_URL}/api/v1/organization/${name}`,
-      {
+    const response = await this.withFreshLoginRetry(async () => {
+      const token = await this.fetchToken();
+      return this.request.delete(`${API_URL}/api/v1/organization/${name}`, {
         timeout: 5000,
         headers: {
           'X-CSRF-Token': token,
         },
-      },
-    );
+      });
+    });
 
     if (!response.ok() && response.status() !== 404) {
       const body = await response.text();
@@ -889,16 +923,18 @@ export class ApiClient {
   }
 
   async deleteUser(username: string): Promise<void> {
-    const token = await this.fetchToken();
-    const response = await this.request.delete(
-      `${API_URL}/api/v1/superuser/users/${username}`,
-      {
-        timeout: 10000,
-        headers: {
-          'X-CSRF-Token': token,
+    const response = await this.withFreshLoginRetry(async () => {
+      const token = await this.fetchToken();
+      return this.request.delete(
+        `${API_URL}/api/v1/superuser/users/${username}`,
+        {
+          timeout: 10000,
+          headers: {
+            'X-CSRF-Token': token,
+          },
         },
-      },
-    );
+      );
+    });
 
     if (!response.ok() && response.status() !== 404) {
       const body = await response.text();
@@ -939,6 +975,7 @@ export class ApiClient {
         `Failed to sign in as ${username}: ${response.status()} - ${body}`,
       );
     }
+    this.csrfToken = null;
   }
 
   // User notification methods
@@ -1096,19 +1133,21 @@ export class ApiClient {
     severity: MessageSeverity = 'info',
     mediaType: MessageMediaType = 'text/markdown',
   ): Promise<GlobalMessage> {
-    const token = await this.fetchToken();
-    const response = await this.request.post(`${API_URL}/api/v1/messages`, {
-      timeout: 5000,
-      headers: {
-        'X-CSRF-Token': token,
-      },
-      data: {
-        message: {
-          content,
-          media_type: mediaType,
-          severity,
+    const response = await this.withFreshLoginRetry(async () => {
+      const token = await this.fetchToken();
+      return this.request.post(`${API_URL}/api/v1/messages`, {
+        timeout: 5000,
+        headers: {
+          'X-CSRF-Token': token,
         },
-      },
+        data: {
+          message: {
+            content,
+            media_type: mediaType,
+            severity,
+          },
+        },
+      });
     });
 
     if (response.status() !== 201) {
@@ -1128,16 +1167,15 @@ export class ApiClient {
   }
 
   async deleteMessage(uuid: string): Promise<void> {
-    const token = await this.fetchToken();
-    const response = await this.request.delete(
-      `${API_URL}/api/v1/message/${uuid}`,
-      {
+    const response = await this.withFreshLoginRetry(async () => {
+      const token = await this.fetchToken();
+      return this.request.delete(`${API_URL}/api/v1/message/${uuid}`, {
         timeout: 5000,
         headers: {
           'X-CSRF-Token': token,
         },
-      },
-    );
+      });
+    });
 
     if (!response.ok() && response.status() !== 404) {
       const body = await response.text();
@@ -2205,15 +2243,17 @@ export class ApiClient {
     teamName: string,
     groupName: string,
   ): Promise<void> {
-    const token = await this.fetchToken();
-    const response = await this.request.post(
-      `${API_URL}/api/v1/organization/${orgName}/team/${teamName}/syncing`,
-      {
-        timeout: 5000,
-        headers: {'X-CSRF-Token': token},
-        data: {group_dn: groupName},
-      },
-    );
+    const response = await this.withFreshLoginRetry(async () => {
+      const token = await this.fetchToken();
+      return this.request.post(
+        `${API_URL}/api/v1/organization/${orgName}/team/${teamName}/syncing`,
+        {
+          timeout: 5000,
+          headers: {'X-CSRF-Token': token},
+          data: {group_dn: groupName},
+        },
+      );
+    });
 
     if (!response.ok()) {
       const body = await response.text();
@@ -2224,14 +2264,16 @@ export class ApiClient {
   }
 
   async disableTeamSync(orgName: string, teamName: string): Promise<void> {
-    const token = await this.fetchToken();
-    const response = await this.request.delete(
-      `${API_URL}/api/v1/organization/${orgName}/team/${teamName}/syncing`,
-      {
-        timeout: 5000,
-        headers: {'X-CSRF-Token': token},
-      },
-    );
+    const response = await this.withFreshLoginRetry(async () => {
+      const token = await this.fetchToken();
+      return this.request.delete(
+        `${API_URL}/api/v1/organization/${orgName}/team/${teamName}/syncing`,
+        {
+          timeout: 5000,
+          headers: {'X-CSRF-Token': token},
+        },
+      );
+    });
 
     if (!response.ok() && response.status() !== 404) {
       const body = await response.text();

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -48,7 +48,7 @@ async function detectContainerRuntime(): Promise<string | null> {
 }
 
 /**
- * Execute a shell command, retrying with exponential backoff on failure.
+ * Execute a shell command, retrying with fixed 1s delays on failure.
  *
  * @param cmd - Shell command to run
  * @param maxAttempts - Maximum number of attempts (default: 5)
@@ -61,7 +61,7 @@ async function retryPush(cmd: string, maxAttempts = 5): Promise<void> {
       return;
     } catch (err) {
       lastErr = err;
-      await new Promise((r) => setTimeout(r, 500 * 2 ** i));
+      await new Promise((r) => setTimeout(r, 1000));
     }
   }
   throw lastErr;
@@ -117,8 +117,10 @@ export async function pushImage(
   // Quay's backend committing the repo, especially with many parallel workers.
   await retryPush(`${runtime} push ${image} ${tlsFlag}`.trim());
 
-  // Cleanup local image
-  await execAsync(`${runtime} rmi ${image}`);
+  // Cleanup local image (skip in CI — ephemeral runners don't need disk reclaimed)
+  if (!process.env.CI) {
+    await execAsync(`${runtime} rmi ${image}`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Reduce `retryPush()` backoff from exponential (500ms × 2^i = 15.5s worst-case) to fixed 1s delays (5s worst-case), saving ~10s per test in CI
- Skip `rmi` cleanup in CI environments — ephemeral runners don't need disk space reclaimed, and this avoids races when parallel tests share base images
- Add `test.slow()` to the Tag Immutability and Expanded View describe blocks, tripling the default 60s timeout to 180s for container-heavy tests
- Add `withFreshLoginRetry()` to `ApiClient` — detects `fresh_login_required` 401 errors from stale worker-scoped sessions, re-signs in, and retries the request once
- Increase Save Labels button enabled timeout from 5s to 15s to accommodate the blur → React state update → re-render race
- Cache Quay config globally via `process.env.QUAY_CONFIG_JSON` — globalSetup already fetches `/config` once, so workers now read from env instead of making redundant HTTP calls, eliminating the 12-17s cold-start fetch per worker

## Root Cause / Rationale
Multiple Playwright tag tests consistently fail/flake in CI:

1. **Timeout exceeded** (`tag-immutability.spec.ts`, `expanded-view.spec.ts`): `pushImage()` setup consumes 32-62s (12-17s config fixture cold start + 20-45s podman push + up to 15.5s retry backoff), leaving 0-28s for actual test logic within the default 60s timeout.
2. **401 fresh_login_required** (cleanup phase): Worker-scoped fixtures sign in once, but Quay's `@require_fresh_login` decorator invalidates sessions after 10 minutes. Long-running suites hit 401s during `deleteOrganization`, `deleteUser`, etc.
3. **Save Labels button stays disabled** (`tag-immutability.spec.ts:990`): The blur → `onEditComplete` → React state update → button re-render race doesn't complete within the 5s timeout.

## Changes
- `web/playwright/utils/container.ts`: Replace exponential backoff with fixed 1s delay in `retryPush()`; skip `rmi` when `CI` env var is set
- `web/playwright/e2e/tags/tag-immutability.spec.ts`: Add `test.slow()`; increase Save Labels timeout to 15s
- `web/playwright/e2e/tags/expanded-view.spec.ts`: Add `test.slow()`
- `web/playwright/utils/api/client.ts`: Add `withFreshLoginRetry()`, `ensureFreshSession()`, `isFreshLoginRequired()` helpers; wrap 6 cleanup-path methods (`deleteOrganization`, `deleteUser`, `createMessage`, `deleteMessage`, `enableTeamSync`, `disableTeamSync`)
- `web/playwright/fixtures.ts`: Wire `setCredentials()` into `api` and `superuserApi` fixtures; replace `cachedQuayConfig` HTTP call with `process.env.QUAY_CONFIG_JSON` lookup
- `web/playwright/global-setup.ts`: Persist fetched config as `process.env.QUAY_CONFIG_JSON`

## Test Plan
- [ ] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [ ] Manual testing performed
- [x] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

## JIRA
N/A — no associated ticket

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-13a9d0ea-ac4d-4814-adaf-fdb3730bef1b

🤖 Generated with [Claude Code](https://claude.com/claude-code)