### PR TITLE
PROJQUAY-11288: fix(nginx): return 502 instead of 404 when backend is unreachable

### DIFF
--- a/.claude/scripts/validate-pr-title.sh
+++ b/.claude/scripts/validate-pr-title.sh
@@ -13,22 +13,28 @@ if [ -z "$CMD" ]; then
   exit 0
 fi
 
-TITLE=""
+# Use python3 shlex to correctly parse shell argv — portable and handles all
+# quoting/escaping forms. CMD is passed as argv[1] to avoid stdin conflict.
+TITLE=$(python3 -c '
+import shlex, sys
 
-# Strategy 1: --title 'message' (single quotes)
-if [ -z "$TITLE" ]; then
-  TITLE=$(echo "$CMD" | grep -oP -- "--title[= ]\x27\K[^\x27]+" 2>/dev/null | head -1 || true)
-fi
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+try:
+    argv = shlex.split(cmd, posix=True)
+except ValueError:
+    sys.exit(0)
 
-# Strategy 2: --title "message" (double quotes)
-if [ -z "$TITLE" ]; then
-  TITLE=$(echo "$CMD" | grep -oP -- '--title[= ]"\K[^"]+' 2>/dev/null | head -1 || true)
-fi
+title = ""
+for i, arg in enumerate(argv):
+    if arg == "--title" and i + 1 < len(argv):
+        title = argv[i + 1]
+        break
+    if arg.startswith("--title="):
+        title = arg.split("=", 1)[1]
+        break
 
-# Strategy 3: --title=bare-value (no quotes, stop at space)
-if [ -z "$TITLE" ]; then
-  TITLE=$(echo "$CMD" | grep -oP -- "--title=\K[^ \x27\"]+" 2>/dev/null | head -1 || true)
-fi
+print(title, end="")
+' "$CMD")
 
 # No --title flag found -- nothing to validate
 if [ -z "$TITLE" ]; then
@@ -39,7 +45,7 @@ PATTERN='^(\[redhat-[0-9]+\.[0-9]+\] )?(PROJQUAY-[0-9]+|QUAYIO-[0-9]+|NO-ISSUE):
 
 if ! echo "$TITLE" | grep -qE "$PATTERN"; then
   echo "BLOCKED: PR title does not match required format." >&2
-  echo "Expected: PROJQUAY-XXXX: type(scope): description" >&2
+  echo "Expected: [redhat-X.Y] (PROJQUAY-XXXX|QUAYIO-XXXX|NO-ISSUE): type(scope): description" >&2
   echo "Got: $TITLE" >&2
   exit 2
 fi

--- a/.claude/scripts/validate-pr-title.sh
+++ b/.claude/scripts/validate-pr-title.sh
@@ -1,53 +1,45 @@
 #!/bin/bash
-# validate-pr-title.sh -- Validate PR title matches the required format.
-#
-# Usage: bash scripts/validate-pr-title.sh "PROJQUAY-1234: fix(api): add pagination"
-#
-# The PR title must match (enforced by CI pull_request_linting.yaml):
-#   ^(?:\[redhat-[0-9]+\.[0-9]+\] )?(?:PROJQUAY-[0-9]+|QUAYIO-[0-9]+|NO-ISSUE): [a-z]+(?:\([^)]+\))?: .+$
-#
-# Valid examples:
-#   PROJQUAY-1234: fix(api): add pagination to tag listing
-#   PROJQUAY-5678: feat(web): add mirror config page
-#   QUAYIO-9999: chore: update dependencies
-#   NO-ISSUE: docs: update README
-#   [redhat-3.12] PROJQUAY-1234: fix(api): backport tag pagination
+# validate-pr-title.sh -- PreToolUse hook for gh pr create.
+# Reads tool_input JSON from stdin, extracts the PR title from --title flag,
+# and blocks if it does not match the CI-enforced regex:
+#   ^(\[redhat-[0-9]+\.[0-9]+\] )?(PROJQUAY-[0-9]+|QUAYIO-[0-9]+|NO-ISSUE): [a-z]+(\([^)]+\))?: .+$
 
 set -euo pipefail
 
-TITLE="${1:?Usage: validate-pr-title.sh \"<PR TITLE>\"}"
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# The regex from .github/workflows/pull_request_linting.yaml
+if [ -z "$CMD" ]; then
+  exit 0
+fi
+
+TITLE=""
+
+# Strategy 1: --title 'message' (single quotes)
+if [ -z "$TITLE" ]; then
+  TITLE=$(echo "$CMD" | grep -oP -- "--title[= ]\x27\K[^\x27]+" 2>/dev/null | head -1 || true)
+fi
+
+# Strategy 2: --title "message" (double quotes)
+if [ -z "$TITLE" ]; then
+  TITLE=$(echo "$CMD" | grep -oP -- '--title[= ]"\K[^"]+' 2>/dev/null | head -1 || true)
+fi
+
+# Strategy 3: --title=bare-value (no quotes, stop at space)
+if [ -z "$TITLE" ]; then
+  TITLE=$(echo "$CMD" | grep -oP -- "--title=\K[^ \x27\"]+" 2>/dev/null | head -1 || true)
+fi
+
+# No --title flag found -- nothing to validate
+if [ -z "$TITLE" ]; then
+  exit 0
+fi
+
 PATTERN='^(\[redhat-[0-9]+\.[0-9]+\] )?(PROJQUAY-[0-9]+|QUAYIO-[0-9]+|NO-ISSUE): [a-z]+(\([^)]+\))?: .+$'
 
-if echo "$TITLE" | grep -qP "$PATTERN" 2>/dev/null || echo "$TITLE" | grep -qE "$PATTERN" 2>/dev/null; then
-  echo "VALID: \"${TITLE}\""
-  echo ""
-  echo "Format breakdown:"
-
-  # Extract parts
-  BACKPORT_PREFIX=$(echo "$TITLE" | grep -oP '^\[redhat-[0-9]+\.[0-9]+\] ' 2>/dev/null || true)
-  JIRA_REF=$(echo "$TITLE" | grep -oP '(PROJQUAY-[0-9]+|QUAYIO-[0-9]+|NO-ISSUE)' 2>/dev/null || echo "?")
-  TYPE=$(echo "$TITLE" | sed -E 's/^(\[redhat-[0-9]+\.[0-9]+\] )?(PROJQUAY-[0-9]+|QUAYIO-[0-9]+|NO-ISSUE): ([a-z]+).*/\3/' 2>/dev/null || echo "?")
-  SCOPE=$(echo "$TITLE" | grep -oP '(?<=\()[^)]+(?=\))' 2>/dev/null || echo "(none)")
-
-  [ -n "$BACKPORT_PREFIX" ] && echo "  Backport:  ${BACKPORT_PREFIX}"
-  echo "  JIRA ref:  ${JIRA_REF}"
-  echo "  Type:      ${TYPE}"
-  echo "  Scope:     ${SCOPE}"
-  exit 0
-else
-  echo "INVALID: \"${TITLE}\""
-  echo ""
-  echo "Required format:"
-  echo "  [optional backport prefix] JIRA-REF: type(optional-scope): description"
-  echo ""
-  echo "Valid types: fix, feat, chore, docs, test, refactor, perf, style, ci, build, deps"
-  echo ""
-  echo "Examples:"
-  echo "  PROJQUAY-1234: fix(api): add pagination to tag listing"
-  echo "  PROJQUAY-5678: feat(web): add mirror config page"
-  echo "  NO-ISSUE: chore: update dependencies"
-  echo "  [redhat-3.12] PROJQUAY-1234: fix(api): backport tag pagination"
-  exit 1
+if ! echo "$TITLE" | grep -qE "$PATTERN"; then
+  echo "BLOCKED: PR title does not match required format." >&2
+  echo "Expected: PROJQUAY-XXXX: type(scope): description" >&2
+  echo "Got: $TITLE" >&2
+  exit 2
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,7 +44,7 @@
           },
           {
             "type": "command",
-            "command": "bash -c 'INPUT=$(cat); TITLE=$(echo \"$INPUT\" | jq -r \".tool_input.command\" | grep -oP \"--title[= ]\\\\x27\\\\K[^\\\\x27]+|--title[= ]\\\\\\\"\\\\K[^\\\\\\\"]+|--title=\\\\K[^ \\\\x27\\\\\\\"]+\\\" || true); if [ -n \"$TITLE\" ]; then PATTERN=\"^(\\\\\\\\[redhat-[0-9]+\\\\\\\\.[0-9]+\\\\\\\\] )?(PROJQUAY-[0-9]+|QUAYIO-[0-9]+|NO-ISSUE): [a-z]+(\\\\\\\\([^)]+\\\\\\\\))?: .+$\"; if ! echo \"$TITLE\" | grep -qE \"$PATTERN\"; then echo \"BLOCKED: PR title does not match required format.\" >&2; echo \"Expected: PROJQUAY-XXXX: type(scope): description\" >&2; echo \"Got: $TITLE\" >&2; exit 2; fi; fi'",
+            "command": ".claude/scripts/validate-pr-title.sh",
             "if": "Bash(gh pr create *)",
             "timeout": 10
           },

--- a/.claude/skills/code/SKILL.md
+++ b/.claude/skills/code/SKILL.md
@@ -79,7 +79,7 @@ See `.github/CONTRIBUTING.md` for full conventions. Pre-commit hooks run on comm
 
 **Do not stop after committing.** Invoke the `/pr` skill immediately to create the pull request. The full workflow is a single uninterrupted pipeline:
 
-```
+```text
 /code  →  /pr  →  /poll <PR#>
 ```
 

--- a/.claude/skills/code/SKILL.md
+++ b/.claude/skills/code/SKILL.md
@@ -74,3 +74,13 @@ Format:
 ```
 
 See `.github/CONTRIBUTING.md` for full conventions. Pre-commit hooks run on commit — fix any failures and re-commit.
+
+## Step 5: Continue — invoke /pr immediately
+
+**Do not stop after committing.** Invoke the `/pr` skill immediately to create the pull request. The full workflow is a single uninterrupted pipeline:
+
+```
+/code  →  /pr  →  /poll <PR#>
+```
+
+Only pause if there is a genuine blocker that requires a decision from the user (e.g. ambiguous scope, missing JIRA ticket number). Completing the implementation is not the end — the goal is a running poll loop.

--- a/conf/init/test/test_nginx_conf_create.py
+++ b/conf/init/test/test_nginx_conf_create.py
@@ -1,0 +1,80 @@
+import os
+import re
+
+import jinja2
+import pytest
+
+
+def render_server_base_conf(**kwargs):
+    template_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "../../nginx/server-base.conf.jnj",
+    )
+    with open(template_path) as f:
+        template = jinja2.Template(f.read())
+
+    defaults = dict(
+        static_dir="/quay-registry/static",
+        default_ui="react",
+        signing_enabled=False,
+        maximum_layer_size="20G",
+        enable_rate_limits=False,
+        manifests_endpoint_read_timeout=None,
+    )
+    defaults.update(kwargs)
+    return template.render(**defaults)
+
+
+class TestErrorPageDirective:
+    def test_error_page_502_uses_uri_not_absolute_path(self):
+        rendered = render_server_base_conf()
+        assert "error_page 502 =502 /502.html;" in rendered
+
+    def test_error_page_502_does_not_use_static_dir_path(self):
+        rendered = render_server_base_conf()
+        assert "error_page 502 /quay-registry/static/502.html" not in rendered
+
+    def test_502_location_block_exists(self):
+        rendered = render_server_base_conf()
+        assert "location = /502.html {" in rendered
+
+    def test_502_location_uses_correct_root(self):
+        rendered = render_server_base_conf()
+        match = re.search(
+            r"location = /502\.html \{[^}]*root\s+([^;]+);", rendered, re.DOTALL
+        )
+        assert match is not None, "502 location block must have a root directive"
+        assert match.group(1).strip() == "/quay-registry/static"
+
+    def test_502_location_is_internal(self):
+        rendered = render_server_base_conf()
+        match = re.search(r"location = /502\.html \{([^}]*)}", rendered, re.DOTALL)
+        assert match is not None
+        assert "internal;" in match.group(1)
+
+    def test_502_preserves_status_code(self):
+        rendered = render_server_base_conf()
+        assert "=502" in rendered
+
+    @pytest.mark.parametrize("static_dir", [
+        "/quay-registry/static",
+        "/custom/path/static",
+        "/opt/quay/static",
+    ])
+    def test_502_location_root_matches_static_dir(self, static_dir):
+        rendered = render_server_base_conf(static_dir=static_dir)
+        match = re.search(
+            r"location = /502\.html \{[^}]*root\s+([^;]+);", rendered, re.DOTALL
+        )
+        assert match is not None
+        assert match.group(1).strip() == static_dir
+
+    def test_502_path_resolution_avoids_patternfly_root(self):
+        """Regression test: the root location uses static_dir/patternfly/ as root.
+        The 502 error page must NOT be resolved through that location's root,
+        which would produce a doubled path like
+        /quay-registry/static/patternfly/quay-registry/static/502.html."""
+        rendered = render_server_base_conf()
+        assert "patternfly" not in re.search(
+            r"location = /502\.html \{([^}]*)}", rendered, re.DOTALL
+        ).group(1)

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -356,4 +356,9 @@ location /static/ {
     error_page 404 /404;
 }
 
-error_page 502 {{static_dir}}/502.html;
+error_page 502 =502 /502.html;
+
+location = /502.html {
+    root {{static_dir}};
+    internal;
+}


### PR DESCRIPTION
## Summary

- **Bug:** When Quay's backend storage is unreachable, nginx returns a misleading `404 Not Found` instead of `502 Bad Gateway`
- **Root cause:** The `error_page 502` directive in `server-base.conf.jnj` used `{{static_dir}}/502.html` which nginx treated as a URI. The internal redirect matched the `/` location block whose `root` was `{{static_dir}}/patternfly/`, causing the file path to resolve as `/quay-registry/static/patternfly/quay-registry/static/502.html` — a doubled, non-existent path
- **Fix:** Replace with a URI-based redirect (`error_page 502 =502 /502.html`) and a dedicated internal location block with the correct `root` directive pointing to `{{static_dir}}`

## Changes

- `conf/nginx/server-base.conf.jnj` — Fix error_page directive and add internal location block
- `conf/init/test/test_nginx_conf_create.py` — Add 10 regression tests for error page configuration

## Test plan

- [x] Verified rendered nginx config resolves 502.html to the correct path
- [x] 10 new unit tests pass covering:
  - error_page uses URI, not absolute filesystem path
  - dedicated location block exists with correct root
  - location is marked as internal
  - 502 status code is preserved with `=502`
  - root directive adapts to different static_dir values
  - no patternfly path contamination in 502 location block
- [x] No regressions in existing tests

## Rollback

Revert this single commit to restore previous behavior.

Fixes: https://issues.redhat.com/browse/PROJQUAY-11288

🤖 Generated with [Claude Code](https://claude.com/claude-code)