### PR TITLE
PROJQUAY-11288: fix(nginx): return 502 instead of 404 when backend is unreachable

### DIFF
--- a/conf/init/test/test_nginx_conf_create.py
+++ b/conf/init/test/test_nginx_conf_create.py
@@ -1,0 +1,80 @@
+import os
+import re
+
+import jinja2
+import pytest
+
+
+def render_server_base_conf(**kwargs):
+    template_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "../../nginx/server-base.conf.jnj",
+    )
+    with open(template_path) as f:
+        template = jinja2.Template(f.read())
+
+    defaults = dict(
+        static_dir="/quay-registry/static",
+        default_ui="react",
+        signing_enabled=False,
+        maximum_layer_size="20G",
+        enable_rate_limits=False,
+        manifests_endpoint_read_timeout=None,
+    )
+    defaults.update(kwargs)
+    return template.render(**defaults)
+
+
+class TestErrorPageDirective:
+    def test_error_page_502_uses_uri_not_absolute_path(self):
+        rendered = render_server_base_conf()
+        assert "error_page 502 =502 /502.html;" in rendered
+
+    def test_error_page_502_does_not_use_static_dir_path(self):
+        rendered = render_server_base_conf()
+        assert "error_page 502 /quay-registry/static/502.html" not in rendered
+
+    def test_502_location_block_exists(self):
+        rendered = render_server_base_conf()
+        assert "location = /502.html {" in rendered
+
+    def test_502_location_uses_correct_root(self):
+        rendered = render_server_base_conf()
+        match = re.search(
+            r"location = /502\.html \{[^}]*root\s+([^;]+);", rendered, re.DOTALL
+        )
+        assert match is not None, "502 location block must have a root directive"
+        assert match.group(1).strip() == "/quay-registry/static"
+
+    def test_502_location_is_internal(self):
+        rendered = render_server_base_conf()
+        match = re.search(r"location = /502\.html \{([^}]*)}", rendered, re.DOTALL)
+        assert match is not None
+        assert "internal;" in match.group(1)
+
+    def test_502_preserves_status_code(self):
+        rendered = render_server_base_conf()
+        assert "=502" in rendered
+
+    @pytest.mark.parametrize("static_dir", [
+        "/quay-registry/static",
+        "/custom/path/static",
+        "/opt/quay/static",
+    ])
+    def test_502_location_root_matches_static_dir(self, static_dir):
+        rendered = render_server_base_conf(static_dir=static_dir)
+        match = re.search(
+            r"location = /502\.html \{[^}]*root\s+([^;]+);", rendered, re.DOTALL
+        )
+        assert match is not None
+        assert match.group(1).strip() == static_dir
+
+    def test_502_path_resolution_avoids_patternfly_root(self):
+        """Regression test: the root location uses static_dir/patternfly/ as root.
+        The 502 error page must NOT be resolved through that location's root,
+        which would produce a doubled path like
+        /quay-registry/static/patternfly/quay-registry/static/502.html."""
+        rendered = render_server_base_conf()
+        assert "patternfly" not in re.search(
+            r"location = /502\.html \{([^}]*)}", rendered, re.DOTALL
+        ).group(1)

--- a/conf/init/test/test_nginx_conf_create.py
+++ b/conf/init/test/test_nginx_conf_create.py
@@ -40,9 +40,7 @@ class TestErrorPageDirective:
 
     def test_502_location_uses_correct_root(self):
         rendered = render_server_base_conf()
-        match = re.search(
-            r"location = /502\.html \{[^}]*root\s+([^;]+);", rendered, re.DOTALL
-        )
+        match = re.search(r"location = /502\.html \{[^}]*root\s+([^;]+);", rendered, re.DOTALL)
         assert match is not None, "502 location block must have a root directive"
         assert match.group(1).strip() == "/quay-registry/static"
 
@@ -56,16 +54,17 @@ class TestErrorPageDirective:
         rendered = render_server_base_conf()
         assert "=502" in rendered
 
-    @pytest.mark.parametrize("static_dir", [
-        "/quay-registry/static",
-        "/custom/path/static",
-        "/opt/quay/static",
-    ])
+    @pytest.mark.parametrize(
+        "static_dir",
+        [
+            "/quay-registry/static",
+            "/custom/path/static",
+            "/opt/quay/static",
+        ],
+    )
     def test_502_location_root_matches_static_dir(self, static_dir):
         rendered = render_server_base_conf(static_dir=static_dir)
-        match = re.search(
-            r"location = /502\.html \{[^}]*root\s+([^;]+);", rendered, re.DOTALL
-        )
+        match = re.search(r"location = /502\.html \{[^}]*root\s+([^;]+);", rendered, re.DOTALL)
         assert match is not None
         assert match.group(1).strip() == static_dir
 

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -356,4 +356,9 @@ location /static/ {
     error_page 404 /404;
 }
 
-error_page 502 {{static_dir}}/502.html;
+error_page 502 =502 /502.html;
+
+location = /502.html {
+    root {{static_dir}};
+    internal;
+}


### PR DESCRIPTION
## Summary

- **Bug:** When Quay's backend storage is unreachable, nginx returns a misleading `404 Not Found` instead of `502 Bad Gateway`
- **Root cause:** The `error_page 502` directive in `server-base.conf.jnj` used `{{static_dir}}/502.html` which nginx treated as a URI. The internal redirect matched the `/` location block whose `root` was `{{static_dir}}/patternfly/`, causing the file path to resolve as `/quay-registry/static/patternfly/quay-registry/static/502.html` — a doubled, non-existent path
- **Fix:** Replace with a URI-based redirect (`error_page 502 =502 /502.html`) and a dedicated internal location block with the correct `root` directive pointing to `{{static_dir}}`

## Changes

- `conf/nginx/server-base.conf.jnj` — Fix error_page directive and add internal location block
- `conf/init/test/test_nginx_conf_create.py` — Add 10 regression tests for error page configuration

## Test plan

- [x] Verified rendered nginx config resolves 502.html to the correct path
- [x] 10 new unit tests pass covering:
  - error_page uses URI, not absolute filesystem path
  - dedicated location block exists with correct root
  - location is marked as internal
  - 502 status code is preserved with `=502`
  - root directive adapts to different static_dir values
  - no patternfly path contamination in 502 location block
- [x] No regressions in existing tests

## Rollback

Revert this single commit to restore previous behavior.

Fixes: https://issues.redhat.com/browse/PROJQUAY-11288

🤖 Generated with [Claude Code](https://claude.com/claude-code)