### PR TITLE
NO-ISSUE: fix(hooks): self-gate enforce-pr-skill.sh to only run on gh pr create

### DIFF
--- a/.claude/scripts/enforce-pr-skill.sh
+++ b/.claude/scripts/enforce-pr-skill.sh
@@ -16,6 +16,13 @@ if [ -z "$CMD" ]; then
   exit 0
 fi
 
+# Self-gate: only enforce on gh pr create commands.
+# The settings.json `if` field may not be honored on all Claude Code versions,
+# so the script must guard itself.
+if ! echo "$CMD" | grep -q 'gh pr create'; then
+  exit 0
+fi
+
 ERRORS=()
 
 # --- Check 1: PR title matches CI-enforced regex ---


### PR DESCRIPTION
## Summary
- The `enforce-pr-skill.sh` hook was firing on every Bash tool call, not just `gh pr create` commands, causing unrelated commands (e.g. `ls`, `echo`, `base64`) to be blocked
- Added a self-gate at the top of the script so it exits 0 immediately for any command that isn't a `gh pr create`

## Root Cause / Rationale
The `"if": "Bash(gh pr create *)"` condition in `settings.json` is not enforced by all Claude Code versions — the hook was being invoked unconditionally for every Bash tool call. Without an internal guard, checks 2–5 (pr-body.md existence, body reference, ambient-session label, --base flag) always failed for non-PR commands, blocking legitimate shell usage entirely.

## Changes
- `.claude/scripts/enforce-pr-skill.sh`: added `grep -q 'gh pr create'` guard after the empty-CMD check; any non-PR command exits 0 immediately

## Test Plan
- [ ] Manual testing performed
  - `echo '{"tool_input":{"command":"ls /tmp"}}' | bash .claude/scripts/enforce-pr-skill.sh` → exits 0 (unrelated command passes through)
  - `echo '{"tool_input":{"command":"gh pr create --title \"foo\""}}' | bash .claude/scripts/enforce-pr-skill.sh` → exits 2 with full validation errors (PR conventions still enforced)

## JIRA
N/A — tooling fix, no JIRA ticket

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-f0c73d36-7fb5-4521-9cd0-f382c3f2de28