### PR TITLE
NO-ISSUE: chore(workflow): require tests in /code skill

### DIFF
--- a/.claude/skills/code/SKILL.md
+++ b/.claude/skills/code/SKILL.md
@@ -3,7 +3,7 @@ name: code
 description: >
   Implement changes following Quay conventions. Reads the relevant AGENTS.md
   and agent_docs/ for the area being worked on, then guides implementation,
-  quality checks (pre-commit, tests), and commit with proper message format.
+  testing, quality checks (pre-commit, tests), and commit with proper message format.
 allowed-tools:
   - Bash(bash .claude/scripts/format-and-lint.sh *)
   - Bash(git *)
@@ -45,7 +45,48 @@ Follow `AGENTS.md` conventions:
 - Never hand-write migration files — run `alembic revision -m "description"` first
 - No secrets in code
 
-## Step 3: Quality Checks
+## Step 3: Write Tests
+
+**Every code change must include tests.** Choose the right test type for the area:
+
+### Backend (Python)
+
+| Change | Test type | Location |
+|--------|-----------|----------|
+| API endpoint | pytest API test | `endpoints/api/test/` |
+| Data model / query | pytest model test | `data/model/test/` |
+| Worker logic | pytest unit test | `workers/test/` |
+| Auth change | pytest auth test | `auth/test/` |
+| Registry protocol | pytest registry test | `test/registry/` |
+
+Run: `TEST=true PYTHONPATH="." pytest path/to/test.py -v`
+
+### Frontend (React/TypeScript)
+
+| Change | Test type | Location |
+|--------|-----------|----------|
+| UI interaction, page flow, bug fix | **Playwright E2E** | `web/playwright/e2e/` |
+| Pure utility function | Vitest unit test | Co-located `*.test.ts` |
+| Data transformation helper | Vitest unit test | Co-located `*.test.ts` |
+| Custom hook (no UI) | Vitest unit test with `renderHook` | Co-located `*.test.tsx` |
+
+**Default to Playwright E2E for frontend changes.** Use vitest only for pure logic with no UI interaction. Most bug fixes and feature work should have E2E coverage.
+
+### Playwright E2E guidelines
+
+- Read `web/playwright/MIGRATION.md` for conventions and patterns
+- **Add to existing spec files** when the feature area already has one (check `web/playwright/e2e/`)
+- Use the `api` fixture for test data setup (auto-cleanup)
+- Use `data-testid` attributes for selectors — add them to components if missing
+- Tag tests with `@PROJQUAY-XXXX` to link back to the JIRA ticket
+
+### Test scope
+
+- Cover the happy path of the change
+- Cover the specific bug scenario for bug fixes (e.g. duplicate names, edge cases)
+- Verify via API when possible (not just UI assertions)
+
+## Step 4: Quality Checks
 
 Pre-commit hooks run automatically on `git commit`. To run manually:
 
@@ -63,7 +104,7 @@ make registry-test                                   # Registry protocol
 make types-test                                      # mypy
 ```
 
-## Step 4: Commit
+## Step 5: Commit
 
 Format:
 
@@ -75,7 +116,7 @@ Format:
 
 See `.github/CONTRIBUTING.md` for full conventions. Pre-commit hooks run on commit — fix any failures and re-commit.
 
-## Step 5: Continue — invoke /pr immediately
+## Step 6: Continue — invoke /pr immediately
 
 **Do not stop after committing.** Invoke the `/pr` skill immediately to create the pull request. The full workflow is a single uninterrupted pipeline:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ make types-test                      # Type checking (mypy)
 
 ## Universal Conventions
 
-1. **Testing:** Always run relevant tests before committing
+1. **Testing:** Every code change must include tests. Default to Playwright E2E tests for frontend changes (add to existing spec files in `web/playwright/e2e/`). Use vitest only for pure logic with no UI interaction. For backend changes, add pytest tests in the appropriate `test/` directory. Always run relevant tests before committing.
 2. **Formatting:** Rely on pre-commit hook to format code on commit
 3. **No secrets:** Never commit credentials, API keys, or sensitive config
 4. **Imports:** Follow existing import ordering patterns in each file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ make types-test                      # Type checking (mypy)
 
 ## Universal Conventions
 
-1. **Testing:** Every code change must include tests. Default to Playwright E2E tests for frontend changes (add to existing spec files in `web/playwright/e2e/`). Use vitest only for pure logic with no UI interaction. For backend changes, add pytest tests in the appropriate `test/` directory. Always run relevant tests before committing.
+1. **Testing:** Every code change must include tests. For frontend: use **Playwright** for all E2E and full-flow testing (add to existing spec files in `web/playwright/e2e/`); use vitest only for pure unit logic with no UI interaction (utilities, data transformers). For backend: add pytest tests in the appropriate `test/` directory. Always run relevant tests before committing.
 2. **Formatting:** Rely on pre-commit hook to format code on commit
 3. **No secrets:** Never commit credentials, API keys, or sensitive config
 4. **Imports:** Follow existing import ordering patterns in each file


### PR DESCRIPTION
## Summary
- Adds a **Step 3: Write Tests** to the `/code` skill, requiring tests alongside every code change
- Frontend changes default to **Playwright E2E** tests (added to existing spec files in `web/playwright/e2e/`); vitest is reserved for pure logic with no UI interaction
- Backend changes use pytest in the appropriate `test/` directory
- Updates `AGENTS.md` Universal Convention #1 to match

## Root Cause / Rationale
During a recent bug fix ([PROJQUAY-9246](https://redhat.atlassian.net/browse/PROJQUAY-9246)), tests were initially omitted from the implementation and then created as vitest unit tests when they should have been Playwright E2E tests. The `/code` skill had no explicit test-writing step, so there was no guidance on when or what type of tests to write.

## Changes
- `.claude/skills/code/SKILL.md`: New Step 3 with decision tables for backend (pytest by area) and frontend (Playwright E2E vs vitest), Playwright E2E guidelines, and test scope guidance. Steps 3-5 renumbered to 4-6.
- `AGENTS.md`: Convention #1 updated from "run tests before committing" to "every code change must include tests" with type guidance.

## Test plan
- [ ] Verify `/code` skill loads the updated step list
- [ ] Confirm future `/code` runs include test writing before quality checks

## Automation
- **Session ID**: session-71ed56d0-9739-4554-9645-989562125772

🤖 Generated with [Claude Code](https://claude.com/claude-code)