### PR TITLE
NO-ISSUE: fix(hooks): use anchored regex in enforce-pr-skill.sh self-gate

### DIFF
--- a/.claude/scripts/enforce-pr-skill.sh
+++ b/.claude/scripts/enforce-pr-skill.sh
@@ -19,7 +19,7 @@ fi
 # Self-gate: only enforce on gh pr create commands.
 # The settings.json `if` field may not be honored on all Claude Code versions,
 # so the script must guard itself.
-if ! echo "$CMD" | grep -q 'gh pr create'; then
+if ! echo "$CMD" | grep -qE "(^|[|&;]\s*)gh pr create"; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Tighten the self-gate in `enforce-pr-skill.sh` to use an anchored regex instead of a plain substring match

## Root Cause / Rationale
The existing guard used `grep -q 'gh pr create'` which is a substring match and could produce false positives if a command mentions `gh pr create` as a string argument or comment rather than actually invoking it.

## Changes
- Replace `grep -q 'gh pr create'` with `grep -qE "(^|[|&;]\s*)gh pr create"` so the guard only fires when `gh pr create` appears at the start of the command or after a shell operator (`|`, `&`, `;`)

## Test Plan
- [ ] Manual testing performed

## JIRA
NO-ISSUE

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-15726bc2-0263-461d-9477-f21ed07c8ff9