### PR TITLE
NO-ISSUE: feat(hooks): add CodeRabbit review gate for pre-PR AI code review

### DIFF
--- a/.claude/scripts/coderabbit-review-gate.sh
+++ b/.claude/scripts/coderabbit-review-gate.sh
@@ -41,9 +41,18 @@ fi
 
 echo "[coderabbit-review-gate] Running CodeRabbit review before PR creation..." >&2
 
-CR_OUTPUT=$(cd "$REPO_ROOT" && coderabbit review --agent --base "$BASE_BRANCH" 2>&1 || true)
+CR_ERR=$(mktemp)
+CR_OUTPUT=$(cd "$REPO_ROOT" && coderabbit review --agent --base "$BASE_BRANCH" 2>"$CR_ERR" || true)
 
 CR_JSON=$(echo "$CR_OUTPUT" | jq -c '.' 2>/dev/null || true)
+
+if [ -z "$CR_JSON" ] && [ -s "$CR_ERR" ]; then
+  echo "[coderabbit-review-gate] CodeRabbit produced no parseable output — allowing PR creation" >&2
+  cat "$CR_ERR" >&2
+  rm -f "$CR_ERR"
+  exit 0
+fi
+rm -f "$CR_ERR"
 
 CR_ERROR_TYPE=$(echo "$CR_JSON" | jq -r 'select(.type == "error") | .errorType' 2>/dev/null | head -1 || true)
 

--- a/.claude/scripts/coderabbit-review-gate.sh
+++ b/.claude/scripts/coderabbit-review-gate.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# coderabbit-review-gate.sh -- PreToolUse hook for gh pr create.
+# Runs CodeRabbit AI review before PR creation and blocks on error-level findings.
+#
+# Exit codes:
+#   0 = pass (or non-matching command, or graceful skip)
+#   2 = blocked — CodeRabbit found error-level issues
+
+set -uo pipefail
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$CMD" ]; then
+  exit 0
+fi
+
+if ! echo "$CMD" | grep -q 'gh pr create'; then
+  exit 0
+fi
+
+if ! command -v coderabbit &>/dev/null; then
+  echo "[coderabbit-review-gate] CodeRabbit CLI not found — skipping review gate" >&2
+  exit 0
+fi
+
+if [ -z "${CODERABBIT_API_KEY:-}" ]; then
+  echo "[coderabbit-review-gate] CODERABBIT_API_KEY not set — skipping review gate" >&2
+  echo "[coderabbit-review-gate] Connect your key in ACP Integrations or run: coderabbit auth login" >&2
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+BASE_BRANCH="master"
+
+CHANGED_FILES=$(git diff "$BASE_BRANCH"...HEAD --name-only 2>/dev/null || git diff HEAD~1 --name-only 2>/dev/null || true)
+if [ -z "$CHANGED_FILES" ]; then
+  echo "[coderabbit-review-gate] No changed files — skipping review" >&2
+  exit 0
+fi
+
+echo "[coderabbit-review-gate] Running CodeRabbit review before PR creation..." >&2
+
+CR_OUTPUT=$(cd "$REPO_ROOT" && coderabbit review --agent --base "$BASE_BRANCH" 2>&1 || true)
+
+CR_JSON=$(echo "$CR_OUTPUT" | grep -E '^\{' || true)
+
+CR_ERROR_TYPE=$(echo "$CR_JSON" | jq -r 'select(.type == "error") | .errorType' 2>/dev/null || true)
+
+if [ "$CR_ERROR_TYPE" = "rate_limit" ]; then
+  echo "[coderabbit-review-gate] Rate-limited — allowing PR creation" >&2
+  exit 0
+fi
+
+if [ "$CR_ERROR_TYPE" = "auth" ]; then
+  echo "[coderabbit-review-gate] Auth failed — allowing PR creation" >&2
+  exit 0
+fi
+
+if [ -n "$CR_JSON" ]; then
+  BLOCKING=$(echo "$CR_JSON" | jq -r \
+    'select(.type == "finding" or .findings != null) |
+     (.findings[]? // .) | select(.severity == "error") |
+     "  \(.file):\(.line) — \(.message)"' \
+    2>/dev/null || true)
+
+  if [ -n "$BLOCKING" ]; then
+    echo "" >&2
+    echo "=================================================" >&2
+    echo "BLOCKED: CodeRabbit found error-level issues" >&2
+    echo "=================================================" >&2
+    echo "$BLOCKING" >&2
+    echo "" >&2
+    echo "Fix these issues and retry gh pr create." >&2
+    exit 2
+  fi
+fi
+
+echo "[coderabbit-review-gate] CodeRabbit review passed" >&2
+exit 0

--- a/.claude/scripts/coderabbit-review-gate.sh
+++ b/.claude/scripts/coderabbit-review-gate.sh
@@ -43,9 +43,9 @@ echo "[coderabbit-review-gate] Running CodeRabbit review before PR creation..." 
 
 CR_OUTPUT=$(cd "$REPO_ROOT" && coderabbit review --agent --base "$BASE_BRANCH" 2>&1 || true)
 
-CR_JSON=$(echo "$CR_OUTPUT" | grep -E '^\{' || true)
+CR_JSON=$(echo "$CR_OUTPUT" | jq -c '.' 2>/dev/null || true)
 
-CR_ERROR_TYPE=$(echo "$CR_JSON" | jq -r 'select(.type == "error") | .errorType' 2>/dev/null || true)
+CR_ERROR_TYPE=$(echo "$CR_JSON" | jq -r 'select(.type == "error") | .errorType' 2>/dev/null | head -1 || true)
 
 if [ "$CR_ERROR_TYPE" = "rate_limit" ]; then
   echo "[coderabbit-review-gate] Rate-limited — allowing PR creation" >&2

--- a/.claude/scripts/coderabbit-review-gate.sh
+++ b/.claude/scripts/coderabbit-review-gate.sh
@@ -8,6 +8,12 @@
 
 set -uo pipefail
 
+if ! command -v jq &>/dev/null; then
+  cat >/dev/null
+  echo "[coderabbit-review-gate] jq not found — skipping review gate" >&2
+  exit 0
+fi
+
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
@@ -31,7 +37,8 @@ if [ -z "${CODERABBIT_API_KEY:-}" ]; then
 fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
-BASE_BRANCH="master"
+BASE_BRANCH=$(echo "$CMD" | grep -oE '(--base|-B)[= ]+[^ ]+' | sed -E 's/(--base|-B)[= ]+//' | head -1)
+BASE_BRANCH="${BASE_BRANCH:-master}"
 
 CHANGED_FILES=$(git diff "$BASE_BRANCH"...HEAD --name-only 2>/dev/null || git diff HEAD~1 --name-only 2>/dev/null || true)
 if [ -z "$CHANGED_FILES" ]; then

--- a/.claude/scripts/session-setup.sh
+++ b/.claude/scripts/session-setup.sh
@@ -98,6 +98,16 @@ else
   echo "  Warning: gh CLI not found."
 fi
 
+# ── CodeRabbit CLI ─────────────────────────────────────────────
+if ! command -v coderabbit &>/dev/null; then
+  echo "Installing CodeRabbit CLI..."
+  curl -fsSL https://cli.coderabbit.ai/install.sh | sh 2>/dev/null \
+    && echo "  CodeRabbit CLI installed." \
+    || echo "  Warning: CodeRabbit CLI install failed (non-fatal)."
+else
+  echo "CodeRabbit CLI already installed."
+fi
+
 # Mark complete
 touch "$SETUP_MARKER"
 echo "=== Bootstrap complete ==="

--- a/.claude/scripts/session-setup.sh
+++ b/.claude/scripts/session-setup.sh
@@ -101,9 +101,15 @@ fi
 # ── CodeRabbit CLI ─────────────────────────────────────────────
 if ! command -v coderabbit &>/dev/null; then
   echo "Installing CodeRabbit CLI..."
-  curl -fsSL https://cli.coderabbit.ai/install.sh | sh 2>/dev/null \
-    && echo "  CodeRabbit CLI installed." \
-    || echo "  Warning: CodeRabbit CLI install failed (non-fatal)."
+  _cr_tmp=$(mktemp /tmp/coderabbit-install.XXXX.sh)
+  if curl -fsSL https://cli.coderabbit.ai/install.sh -o "$_cr_tmp"; then
+    sh "$_cr_tmp" 2>/dev/null \
+      && echo "  CodeRabbit CLI installed." \
+      || echo "  Warning: CodeRabbit CLI install failed (non-fatal)."
+  else
+    echo "  Warning: Failed to download CodeRabbit CLI installer (non-fatal)."
+  fi
+  rm -f "$_cr_tmp"
 else
   echo "CodeRabbit CLI already installed."
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,12 @@
           },
           {
             "type": "command",
+            "command": ".claude/scripts/coderabbit-review-gate.sh",
+            "if": "Bash(gh pr create *)",
+            "timeout": 120
+          },
+          {
+            "type": "command",
             "command": ".claude/scripts/validate-commit-msg.sh",
             "if": "Bash(git commit *)",
             "timeout": 5


### PR DESCRIPTION
## Summary
- Adds a CodeRabbit AI review gate as a PreToolUse hook on `gh pr create`
- Runs `coderabbit review --agent --base master` before PR creation, blocking on error-level findings
- Gracefully skips if CodeRabbit CLI or `CODERABBIT_API_KEY` is not available (non-breaking for users without setup)
- Allows PR creation on rate limits or auth failures (non-blocking for transient issues)

## Rationale
This enables a faster feedback loop for the quay ambient workspace — sessions can catch security, performance, and logic issues *before* creating a PR, reducing review round-trips. Complements the existing `enforce-pr-skill.sh` convention checks with AI-powered code review.

## Changes
- **`.claude/scripts/coderabbit-review-gate.sh`** (NEW): Hook script following the same stdin/JSON pattern as `enforce-pr-skill.sh`
- **`.claude/settings.json`** (MODIFIED): Added PreToolUse hook entry with 120s timeout

## Prerequisites for full functionality
- CodeRabbit GitHub App installed on the quay org
- CodeRabbit CLI available in the runner container image
- Each user connects their CodeRabbit API key via ACP Integrations UI

Without these, the hook silently skips — no breakage.

## Test Plan
- [x] Non-PR command passes through: `echo '{"tool_input":{"command":"ls"}}' | bash .claude/scripts/coderabbit-review-gate.sh` → exit 0
- [x] PR command without CLI skips gracefully: exits 0 with informational message
- [x] shellcheck and shfmt pass via pre-commit hooks
- [ ] End-to-end test with CodeRabbit CLI + API key in an ambient session

## JIRA
N/A — tooling improvement

## Backport
- [x] No backport needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)