### PR TITLE
PROJQUAY-11478: fix(web): treat all 4xx as org-mirror-not-configured in proxy cache UI

### DIFF
--- a/web/playwright/e2e/organization/proxy-cache.spec.ts
+++ b/web/playwright/e2e/organization/proxy-cache.spec.ts
@@ -120,6 +120,50 @@ test.describe(
       ).toBeEnabled();
     });
 
+    test('proxy cache form is functional when FEATURE_ORG_MIRROR is disabled (PROJQUAY-11478)', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('proxynomirr');
+
+      // Override config to disable ORG_MIRROR (the bug scenario)
+      await authenticatedPage.route('**/config', async (route) => {
+        const response = await route.fetch();
+        const body = await response.json();
+        body.features.ORG_MIRROR = false;
+        body.features.PROXY_CACHE = true;
+        await route.fulfill({response, body: JSON.stringify(body)});
+      });
+
+      // Intercept the org mirror endpoint to return 405 (simulates unregistered route)
+      await authenticatedPage.route(
+        `**/api/v1/organization/${org.name}/mirror`,
+        async (route) => {
+          await route.fulfill({
+            status: 405,
+            contentType: 'application/json',
+            body: JSON.stringify({error_message: 'Method Not Allowed'}),
+          });
+        },
+      );
+
+      await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
+      await authenticatedPage.getByText('Proxy Cache').click();
+
+      // The org mirror error alert should NOT be visible
+      await expect(
+        authenticatedPage.getByTestId('org-mirror-error-alert'),
+      ).not.toBeAttached();
+
+      // Save button should be enabled (not blocked by org mirror check)
+      await authenticatedPage
+        .getByTestId('remote-registry-input')
+        .fill('docker.io');
+      await expect(
+        authenticatedPage.getByTestId('save-proxy-cache-btn'),
+      ).toBeEnabled();
+    });
+
     test('proxy cache tab not visible for user namespaces', async ({
       authenticatedPage,
     }) => {

--- a/web/src/hooks/UseOrgMirrorExists.test.ts
+++ b/web/src/hooks/UseOrgMirrorExists.test.ts
@@ -23,6 +23,13 @@ function wrapper({children}: {children: React.ReactNode}) {
   );
 }
 
+function axiosError(status: number) {
+  const err: any = new Error(`Request failed with status ${status}`);
+  err._isAxiosError = true;
+  err.response = {status};
+  return err;
+}
+
 describe('useOrgMirrorExists', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -36,6 +43,54 @@ describe('useOrgMirrorExists', () => {
     const {result} = renderHook(() => useOrgMirrorExists('myorg'), {wrapper});
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.isOrgMirrored).toBe(true);
+  });
+
+  it('returns isOrgMirrored=false on 404 (no mirror config)', async () => {
+    vi.mocked(getOrgMirrorConfig).mockRejectedValueOnce(axiosError(404));
+    const {result} = renderHook(() => useOrgMirrorExists('myorg'), {wrapper});
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.isOrgMirrored).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('returns isOrgMirrored=false on 403 (PROJQUAY-11478: feature flag off)', async () => {
+    vi.mocked(getOrgMirrorConfig).mockRejectedValueOnce(axiosError(403));
+    const {result} = renderHook(() => useOrgMirrorExists('myorg'), {wrapper});
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.isOrgMirrored).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('returns isOrgMirrored=false on 405 (endpoint not registered)', async () => {
+    vi.mocked(getOrgMirrorConfig).mockRejectedValueOnce(axiosError(405));
+    const {result} = renderHook(() => useOrgMirrorExists('myorg'), {wrapper});
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.isOrgMirrored).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('returns isOrgMirrored=false on 400 (bad request)', async () => {
+    vi.mocked(getOrgMirrorConfig).mockRejectedValueOnce(axiosError(400));
+    const {result} = renderHook(() => useOrgMirrorExists('myorg'), {wrapper});
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.isOrgMirrored).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('propagates 5xx errors as query errors', async () => {
+    vi.mocked(getOrgMirrorConfig).mockRejectedValueOnce(axiosError(500));
+    const {result} = renderHook(() => useOrgMirrorExists('myorg'), {wrapper});
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isOrgMirrored).toBeUndefined();
+  });
+
+  it('propagates network errors (no response) as query errors', async () => {
+    const networkError: any = new Error('Network Error');
+    networkError._isAxiosError = true;
+    vi.mocked(getOrgMirrorConfig).mockRejectedValueOnce(networkError);
+    const {result} = renderHook(() => useOrgMirrorExists('myorg'), {wrapper});
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isOrgMirrored).toBeUndefined();
   });
 
   it('does not fetch when enabled=false', () => {

--- a/web/src/hooks/UseOrgMirrorExists.ts
+++ b/web/src/hooks/UseOrgMirrorExists.ts
@@ -16,7 +16,12 @@ export function useOrgMirrorExists(orgName: string, enabled = true) {
         await getOrgMirrorConfig(orgName);
         return true;
       } catch (err) {
-        if (isAxiosError(err) && err.response?.status === 404) {
+        if (
+          isAxiosError(err) &&
+          err.response?.status &&
+          err.response.status >= 400 &&
+          err.response.status < 500
+        ) {
           return false;
         }
         throw err;


### PR DESCRIPTION
## Summary

Fixes [PROJQUAY-11478](https://issues.redhat.com/browse/PROJQUAY-11478): UI disallows creation of proxy cache configuration even when organization mirroring (`FEATURE_ORG_MIRROR`) is turned off.

### Root Cause

When `FEATURE_ORG_MIRROR` is not set in `config.yaml`, the backend endpoint `GET /api/v1/organization/{orgName}/mirror` is never registered (due to the `@show_if(features.ORG_MIRROR)` decorator in `endpoints/api/org_mirror.py`). The response is not a clean 404.

The frontend hook `useOrgMirrorExists` (`web/src/hooks/UseOrgMirrorExists.ts`) only handled 404 specifically. Any other error bubbled up and set `isOrgMirrorError = true` in `ProxyCacheConfig.tsx`, which:
- Displayed a misleading "Unable to determine organization mirror status" error banner
- Disabled the Save button, blocking proxy cache configuration entirely

### Fix

Widen the catch block in `useOrgMirrorExists` to treat **all 4xx responses** as "org mirroring not configured" (`isOrgMirrored = false`) instead of only 404. Server errors (5xx) and network errors still propagate as query errors so genuine issues are still surfaced.

### Testing

- **Unit tests** (`UseOrgMirrorExists.test.ts`): Added tests for 404, 403, 405, 400 (all return `isOrgMirrored=false`), 500 (propagates error), and network error (propagates error)
- **Playwright e2e** (`proxy-cache.spec.ts`): Added test that verifies Save button is enabled when `FEATURE_ORG_MIRROR` is disabled and the mirror endpoint returns 405

Fixes: https://issues.redhat.com/browse/PROJQUAY-11478
