### PR TITLE
[redhat-3.15] PROJQUAY-11416: fix(security): bump node forge to 1.4.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17304,6 +17304,16 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -19743,16 +19753,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/selfsigned/node_modules/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/semver": {

--- a/web/package.json
+++ b/web/package.json
@@ -124,7 +124,7 @@
     "@patternfly/react-core": "^5.1.0",
     "@patternfly/react-icons": "^5.1.0",
     "@patternfly/react-table": "^5.1.0",
-    "node-forge": "^1.3.2",
+    "node-forge": "^1.4.0",
     "minimatch": "3.1.5",
     "immutable": "^5.1.5",
     "svgo": "4.0.1"


### PR DESCRIPTION
This fix addresses the [CVE-2026-33894](https://nvd.nist.gov/vuln/detail/CVE-2026-33894)

```
$ npm list node-forge
quay-ui@0.1.0 /Users/namsharm/RedHat/quay/quay/web
└── node-forge@1.4.0 
```