### PR TITLE
[redhat-3.14] PROJQUAY-11155: fix(security): bump node forge to 1.4.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19117,9 +19117,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/web/package.json
+++ b/web/package.json
@@ -124,7 +124,7 @@
     "@patternfly/react-core": "^5.1.0",
     "@patternfly/react-icons": "^5.1.0",
     "@patternfly/react-table": "^5.1.0",
-    "node-forge": "^1.3.2",
+    "node-forge": "^1.4.0",
     "minimatch": "^3.1.5",
     "filelist": {
       "minimatch": "^5.0.1"


### PR DESCRIPTION
This fix addresses the [CVE-2026-33894](https://nvd.nist.gov/vuln/detail/CVE-2026-33894)

```
$ npm list node-forge
quay-ui@0.1.0 /Users/namsharm/RedHat/quay/quay/web
└── node-forge@1.4.0 
```