### PR TITLE
PROJQUAY-11217: fix(ui): show empty state instead of spinner when repository search has no results

### DIFF
--- a/web/playwright/e2e/repository/repositories-list.spec.ts
+++ b/web/playwright/e2e/repository/repositories-list.spec.ts
@@ -501,5 +501,33 @@ test.describe('Repositories List', {tag: ['@repository']}, () => {
       const count = await rows.count();
       expect(count).toBeGreaterThanOrEqual(2);
     });
+
+    test('shows empty state instead of spinner when search matches nothing (PROJQUAY-11217)', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('searchnomatch');
+      await api.repositoryWithName(org.name, 'exists-repo');
+
+      await authenticatedPage.goto(`/organization/${org.name}`);
+
+      const reposPanel = authenticatedPage.getByRole('tabpanel', {
+        name: 'Repositories',
+      });
+
+      // Wait for initial load to complete — repo should be visible
+      await expect(reposPanel.getByText('exists-repo')).toBeVisible();
+
+      // Search for a name that will never match
+      await getSearchInput(authenticatedPage).fill('zzz-no-such-repo');
+
+      // Regression: old code showed a spinner here forever
+      await expect(reposPanel.getByRole('progressbar')).not.toBeVisible();
+      await expect(reposPanel.getByText('No repositories found')).toBeVisible();
+
+      // Clear search — repo should reappear
+      await getSearchInput(authenticatedPage).fill('');
+      await expect(reposPanel.getByText('exists-repo')).toBeVisible();
+    });
   });
 });

--- a/web/src/routes/RepositoriesList/RepositoriesList.test.tsx
+++ b/web/src/routes/RepositoriesList/RepositoriesList.test.tsx
@@ -1,0 +1,155 @@
+import {render, screen} from 'src/test-utils';
+import RepositoriesList from './RepositoriesList';
+
+// Minimal stubs for hooks unrelated to the spinner logic
+// Breaks: RepositoriesList → Breadcrumb → NavigationPath → OrganizationsList → Organizations.scss (Sass compat issue in test env)
+vi.mock('src/components/breadcrumb/Breadcrumb', () => ({
+  QuayBreadcrumb: () => null,
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: () => ({pathname: '/repository', search: '', hash: ''}),
+    Link: ({children, to}: {children: React.ReactNode; to: string}) => (
+      <a href={to}>{children}</a>
+    ),
+  };
+});
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: () => ({
+    features: {QUOTA_MANAGEMENT: false, EDIT_QUOTA: false},
+  }),
+}));
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: () => ({user: {username: 'testuser'}}),
+}));
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: () => ({isReadOnlySuperUser: false}),
+}));
+
+vi.mock('src/hooks/UseQuotaManagement', () => ({
+  useFetchOrganizationQuota: () => ({organizationQuota: null}),
+}));
+
+vi.mock('src/hooks/UseDeleteRepositories', () => ({
+  useDeleteRepositories: () => ({
+    deleteRepositories: vi.fn(),
+    errorDeleteRepositories: null,
+    successDeleteRepositories: false,
+  }),
+}));
+
+const mockSetSearch = vi.fn();
+const baseReposHook = {
+  repos: [
+    {namespace: 'testorg', name: 'my-repo', is_public: true, last_modified: 0},
+  ],
+  loading: false,
+  error: null,
+  search: {query: '', field: 'name', isRegEx: false},
+  setSearch: mockSetSearch,
+  searchFilter: null,
+  truncated: false,
+};
+
+const mockUseRepositories = vi.fn(() => baseReposHook);
+vi.mock('src/hooks/UseRepositories', () => ({
+  useRepositories: (...args: unknown[]) => mockUseRepositories(...args),
+}));
+
+// usePaginatedSortableTable controls filteredData (what the table renders)
+const mockPaginatedTable = vi.fn();
+vi.mock('../../hooks/usePaginatedSortableTable', () => ({
+  usePaginatedSortableTable: (...args: unknown[]) =>
+    mockPaginatedTable(...args),
+}));
+
+const basePaginatedReturn = {
+  filteredData: [],
+  paginatedData: [],
+  getSortableSort: () => undefined,
+  paginationProps: {
+    total: 0,
+    perPage: 25,
+    page: 1,
+    setPage: vi.fn(),
+    setPerPage: vi.fn(),
+  },
+};
+
+const oneRepo = {
+  namespace: 'testorg',
+  name: 'my-repo',
+  is_public: true,
+  size: 0,
+  last_modified: 0,
+};
+
+describe('RepositoriesList — search empty state (PROJQUAY-11217)', () => {
+  beforeEach(() => {
+    mockUseRepositories.mockReturnValue(baseReposHook);
+    mockPaginatedTable.mockReturnValue(basePaginatedReturn);
+  });
+
+  it('shows a spinner while data is loading', () => {
+    mockUseRepositories.mockReturnValue({
+      ...baseReposHook,
+      loading: true,
+      repos: [],
+    });
+    mockPaginatedTable.mockReturnValue({
+      ...basePaginatedReturn,
+      filteredData: [],
+    });
+
+    render(<RepositoriesList organizationName="testorg" />);
+
+    expect(screen.queryByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByText('No repositories found')).not.toBeInTheDocument();
+  });
+
+  it('shows "No repositories found" when search returns no results (regression: PROJQUAY-11217)', () => {
+    // loading=false, repos has items, but the filter matched nothing → filteredData=[]
+    mockUseRepositories.mockReturnValue({
+      ...baseReposHook,
+      loading: false,
+      repos: [
+        {
+          namespace: 'testorg',
+          name: 'my-repo',
+          is_public: true,
+          last_modified: 0,
+        },
+      ],
+    });
+    mockPaginatedTable.mockReturnValue({
+      ...basePaginatedReturn,
+      filteredData: [],
+    });
+
+    render(<RepositoriesList organizationName="testorg" />);
+
+    expect(screen.getByText('No repositories found')).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('renders repository rows when results are present', () => {
+    mockUseRepositories.mockReturnValue({...baseReposHook, loading: false});
+    mockPaginatedTable.mockReturnValue({
+      ...basePaginatedReturn,
+      filteredData: [oneRepo],
+      paginatedData: [oneRepo],
+    });
+
+    render(<RepositoriesList organizationName="testorg" />);
+
+    expect(screen.getByText('my-repo')).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.queryByText('No repositories found')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/web/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -398,12 +398,17 @@ export default function RepositoriesList(props: RepositoriesListProps) {
           </Thead>
           <Tbody data-testid="repository-list-table">
             {filteredRepos.length === 0 ? (
-              // Repo table loading icon
-              <Tr>
-                <Td>
-                  <Spinner size="lg" />
-                </Td>
-              </Tr>
+              loading ? (
+                <Tr>
+                  <Td>
+                    <Spinner size="lg" />
+                  </Td>
+                </Tr>
+              ) : (
+                <Tr>
+                  <Td>No repositories found</Td>
+                </Tr>
+              )
             ) : (
               paginatedRepositoryList.map((repo, rowIndex) => (
                 <Tr key={rowIndex}>

--- a/web/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/web/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -400,13 +400,13 @@ export default function RepositoriesList(props: RepositoriesListProps) {
             {filteredRepos.length === 0 ? (
               loading ? (
                 <Tr>
-                  <Td>
+                  <Td colSpan={5}>
                     <Spinner size="lg" />
                   </Td>
                 </Tr>
               ) : (
                 <Tr>
-                  <Td>No repositories found</Td>
+                  <Td colSpan={5}>No repositories found</Td>
                 </Tr>
               )
             ) : (

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -5,6 +5,20 @@ export default defineConfig({
   plugins: [
     {
       name: 'stub-assets',
+      enforce: 'pre',
+      resolveId(id: string) {
+        if (/\.scss$/i.test(id)) {
+          return '\0virtual:empty-scss';
+        }
+      },
+      load(id: string) {
+        if (id === '\0virtual:empty-scss') {
+          return 'export default {}';
+        }
+        if (/\.(svg|png|jpe?g|gif|webp|ico|ttf|eot|woff2?)(\?.*)?$/i.test(id)) {
+          return 'export default ""';
+        }
+      },
       transform(_code: string, id: string) {
         if (/\.(svg|png|jpe?g|gif|webp|ico|ttf|eot|woff2?)(\?.*)?$/i.test(id)) {
           return {code: 'export default ""', map: null};


### PR DESCRIPTION
## Summary

- When a user searches for a repository name that doesn't exist, the repository list table displayed a permanent loading spinner instead of an empty state message
- Fixed by gating the `<Spinner>` on the `loading` flag from `useRepositories`; when loading is complete and the filter matched nothing, "No repositories found" is shown instead

## Root Cause / Rationale

`RepositoriesList.tsx:400` unconditionally rendered `<Spinner size="lg" />` whenever `filteredRepos.length === 0`, without consulting the `loading` flag. When a search returned no results, `loading` was already `false` and the spinner was never dismissed.

The two empty-state guards are now complementary:
- `RepositoriesList.tsx:299` — `if (!loading && !repos?.length)` → full `<Empty>` component for "org has no repos at all"
- `RepositoriesList.tsx:400` — `filteredRepos.length === 0 && !loading` → inline "No repositories found" for "search matched nothing"

## Changes

- `web/src/routes/RepositoriesList/RepositoriesList.tsx` — Added `loading` guard inside the `filteredRepos.length === 0` branch (lines 400–411)
- `web/src/routes/RepositoriesList/RepositoriesList.test.tsx` — New file: 3 unit tests covering spinner/empty/populated states
- `web/vitest.config.ts` — Added `resolveId` hook to stub `.scss` imports as virtual modules in the test environment (prevents SCSS compilation errors via the `Breadcrumb → OrganizationsList → Organizations.scss` import chain)

## Test Plan

- [x] Unit tests added/updated — 3 regression tests in `RepositoriesList.test.tsx`
- [x] Frontend tests pass — full Vitest suite (146 files, 1073 tests) passes
- [ ] Registry tests pass (`make registry-test`) — backend-only, not affected
- [ ] Type checking passes (`make types-test`) — no type changes
- [ ] Manual testing performed — no running Quay instance available in CI environment

**Manual verification steps:**
1. Navigate to any organization's repository list
2. Type a search term that matches no repositories
3. Confirm "No repositories found" appears instead of a spinner

## JIRA
https://issues.redhat.com/browse/PROJQUAY-11217

## Backport
- [x] No backport needed (no Target Version set on JIRA ticket)

## Notes

The "No repositories found" text rendered in `<Td>` is intentionally minimal to fix the regression. A follow-up improvement could use a full PatternFly `EmptyState` component (with icon, title, and body) to match the UX of the truly-empty org path at line 299. Tracked separately.

## Automation
- **Session ID**: session-c568011e-deff-4e47-9185-15d34568e746