### PR TITLE
PROJQUAY-9256: fix(mirror): allow clearing skopeo timeout interval field

### DIFF
--- a/web/src/hooks/UseMirroringConfig.ts
+++ b/web/src/hooks/UseMirroringConfig.ts
@@ -111,7 +111,7 @@ export const useMirroringConfig = (
         : timestampToISO(Math.floor(Date.now() / 1000)),
       sync_interval: convertToSeconds(Number(data.syncValue), data.syncUnit),
       robot_username: data.robotUsername,
-      skopeo_timeout_interval: data.skopeoTimeoutInterval,
+      skopeo_timeout_interval: data.skopeoTimeoutInterval ?? undefined,
       external_registry_config: {
         verify_tls: data.verifyTls,
         unsigned_images: data.unsignedImages,

--- a/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.test.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import {useForm} from 'react-hook-form';
+import {render, screen, userEvent} from 'src/test-utils';
+import {MirroringConfiguration} from './MirroringConfiguration';
+import {MirroringFormData} from './types';
+
+vi.mock('src/resources/MirroringResource', () => ({
+  getMirrorConfig: vi.fn(),
+  toggleMirroring: vi.fn(),
+  syncMirror: vi.fn(),
+}));
+
+vi.mock('src/components/EntitySearch', () => ({
+  __esModule: true,
+  default: () => <div data-testid="entity-search" />,
+}));
+
+vi.mock('src/components/forms/FormTextInput', () => ({
+  FormTextInput: ({label}: {label: string}) => <div>{label}</div>,
+}));
+
+vi.mock('src/components/forms/FormCheckbox', () => ({
+  FormCheckbox: () => <div data-testid="form-checkbox" />,
+}));
+
+vi.mock('src/components/FormDateTimePicker', () => ({
+  FormDateTimePicker: () => <div data-testid="datetime-picker" />,
+}));
+
+vi.mock('./ArchitectureFilter', () => ({
+  ArchitectureFilter: () => <div data-testid="arch-filter" />,
+}));
+
+const defaultFormValues: MirroringFormData = {
+  isEnabled: true,
+  externalReference: '',
+  tags: '',
+  syncStartDate: '',
+  syncValue: '24',
+  syncUnit: 'hours',
+  robotUsername: '',
+  username: '',
+  password: '',
+  verifyTls: false,
+  httpProxy: '',
+  httpsProxy: '',
+  noProxy: '',
+  unsignedImages: false,
+  skopeoTimeoutInterval: 300,
+  architectureFilter: [],
+};
+
+function TestHarness({
+  onFormChange,
+}: {
+  onFormChange?: (values: MirroringFormData) => void;
+}) {
+  const {control, formState, watch} = useForm<MirroringFormData>({
+    defaultValues: defaultFormValues,
+    mode: 'onChange',
+  });
+  const formValues = watch();
+
+  React.useEffect(() => {
+    onFormChange?.(formValues);
+  }, [formValues, onFormChange]);
+
+  return (
+    <MirroringConfiguration
+      control={control}
+      errors={formState.errors}
+      formValues={formValues}
+      config={null}
+      namespace="testorg"
+      repoName="testrepo"
+      selectedRobot={null}
+      setSelectedRobot={vi.fn()}
+      isSelectOpen={false}
+      setIsSelectOpen={vi.fn()}
+      isHovered={false}
+      setIsHovered={vi.fn()}
+      robotOptions={[]}
+      setConfig={vi.fn()}
+      addAlert={vi.fn()}
+      architectureFilter={[]}
+      setArchitectureFilter={vi.fn()}
+    />
+  );
+}
+
+describe('MirroringConfiguration - skopeo timeout interval', () => {
+  it('renders with the default timeout value', () => {
+    render(<TestHarness />);
+    const input = screen.getByTestId('skopeo-timeout-input');
+    expect(input).toHaveValue(300);
+  });
+
+  it('clears the field to empty when user deletes the value', async () => {
+    render(<TestHarness />);
+    const input = screen.getByTestId('skopeo-timeout-input');
+    await userEvent.clear(input);
+    expect(input).toHaveValue(null);
+  });
+
+  it('does not snap back to 300 after clearing', async () => {
+    render(<TestHarness />);
+    const input = screen.getByTestId('skopeo-timeout-input');
+    await userEvent.clear(input);
+    expect(input).not.toHaveValue(300);
+  });
+
+  it('accepts a new numeric value typed after clearing', async () => {
+    render(<TestHarness />);
+    const input = screen.getByTestId('skopeo-timeout-input');
+    await userEvent.clear(input);
+    await userEvent.type(input, '600');
+    expect(input).toHaveValue(600);
+  });
+
+  it('shows validation error when field is below minimum', async () => {
+    render(<TestHarness />);
+    const input = screen.getByTestId('skopeo-timeout-input');
+    await userEvent.clear(input);
+    await userEvent.type(input, '100');
+    expect(
+      await screen.findByText(/Minimum timeout is 300 seconds/),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx
@@ -351,8 +351,14 @@ export const MirroringConfiguration: React.FC<MirroringConfigurationProps> = ({
                 id="skopeo_timeout_interval"
                 value={value?.toString() || ''}
                 onChange={(_event, newValue) => {
-                  const numericValue = parseInt(newValue) || 300;
-                  onChange(numericValue);
+                  if (newValue === '') {
+                    onChange(null);
+                    return;
+                  }
+                  const parsed = parseInt(newValue, 10);
+                  if (!isNaN(parsed)) {
+                    onChange(parsed);
+                  }
                 }}
                 min="300"
                 max="43200"

--- a/web/src/routes/RepositoryDetails/Mirroring/types.ts
+++ b/web/src/routes/RepositoryDetails/Mirroring/types.ts
@@ -14,6 +14,6 @@ export interface MirroringFormData {
   httpsProxy: string;
   noProxy: string;
   unsignedImages: boolean;
-  skopeoTimeoutInterval: number;
+  skopeoTimeoutInterval: number | null;
   architectureFilter: string[];
 }


### PR DESCRIPTION
## Summary
- Fix the Skopeo timeout interval field in the repository mirroring tab not allowing users to clear and re-enter a value

## Root Cause / Rationale
The `onChange` handler used `parseInt(newValue) || 300`. When the user cleared the field, `parseInt('')` returns `NaN`, and `NaN || 300` evaluates to `300` — causing the field to immediately snap back to the default value, making it impossible to type a new number.

## Changes
- `web/src/routes/RepositoryDetails/Mirroring/types.ts` — Changed `skopeoTimeoutInterval: number` to `number | null` to allow an empty/cleared state
- `web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx` — Replaced the buggy `onChange` with the correct pattern (matching the existing `OrgMirroringSyncSchedule` sibling): empty input sets `null`, valid parsed number calls `onChange(parsed)`, mid-edit NaN is a no-op
- `web/src/hooks/UseMirroringConfig.ts` — Added `?? undefined` on submit to convert `null` → `undefined` for the backend type (`skopeo_timeout_interval?: number`)

## Test Plan
- [ ] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [x] Manual testing performed
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

**Manual test:** Navigate to a mirrored repository → Mirroring tab → clear the Skopeo timeout interval field → confirm the field clears and allows typing a new value. Entering a value below 300 or leaving it empty should show validation errors; entering a valid value (300–43200) should allow saving.

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-9256

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-6421affb-fcb2-47ef-832b-0bdcb031e27e