### PR TITLE
PROJQUAY-9883: fix(web): fix service keys filter not working for multi-word key names

### DIFF
--- a/web/src/hooks/UseServiceKeys.test.ts
+++ b/web/src/hooks/UseServiceKeys.test.ts
@@ -8,6 +8,7 @@ import {
   createServiceKey,
   deleteServiceKey,
   approveServiceKey,
+  IServiceKey,
 } from 'src/resources/ServiceKeysResource';
 
 vi.mock('src/resources/ServiceKeysResource', () => ({
@@ -54,6 +55,28 @@ describe('useServiceKeys', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.serviceKeys).toEqual(mockKeys);
     expect(result.current.totalResults).toBe(2);
+  });
+
+  it('resets to page 1 when search query changes', async () => {
+    const mockKeys: IServiceKey[] = Array.from({length: 25}, (_, i) => ({
+      kid: `kid${i}`,
+      name: i < 20 ? 'Common Name' : 'Other Name',
+      service: `svc${i}`,
+      created_date: '2024-01-01',
+    }));
+    vi.mocked(fetchServiceKeys).mockResolvedValueOnce(mockKeys);
+    const {result} = renderHook(() => useServiceKeys(), {wrapper});
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Advance to page 2
+    act(() => {
+      result.current.setPage(2);
+    });
+    expect(result.current.page).toBe(2);
+    // Apply a search filter — page should reset to 1
+    act(() => {
+      result.current.setSearch({query: 'Common', field: 'name'});
+    });
+    await waitFor(() => expect(result.current.page).toBe(1));
   });
 
   it('filters keys by search query', async () => {

--- a/web/src/hooks/UseServiceKeys.ts
+++ b/web/src/hooks/UseServiceKeys.ts
@@ -1,5 +1,5 @@
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
 import {
   fetchServiceKeys,
@@ -44,7 +44,7 @@ export function useServiceKeys() {
   // Apply search filter
   const filteredKeys = search.query
     ? serviceKeys.filter((key) => {
-        const searchQuery = search.query.toLowerCase();
+        const searchQuery = search.query.trim().toLowerCase();
         return (
           (key.name && key.name.toLowerCase().includes(searchQuery)) ||
           key.service.toLowerCase().includes(searchQuery) ||
@@ -136,6 +136,11 @@ export function useServiceKeys() {
       queryClient.invalidateQueries({queryKey: ['serviceKeys']});
     },
   });
+
+  // Reset to first page when search query changes
+  useEffect(() => {
+    setPage(1);
+  }, [search.query]);
 
   // Sort handler function following PatternFly pattern
   const handleSort = (

--- a/web/src/routes/Superuser/ServiceKeys/ServiceKeys.test.tsx
+++ b/web/src/routes/Superuser/ServiceKeys/ServiceKeys.test.tsx
@@ -1,0 +1,127 @@
+import {render, screen, userEvent, waitFor} from 'src/test-utils';
+import {MemoryRouter} from 'react-router-dom';
+import ServiceKeys from './ServiceKeys';
+import {fetchServiceKeys, IServiceKey} from 'src/resources/ServiceKeysResource';
+
+vi.mock('src/resources/ServiceKeysResource', () => ({
+  fetchServiceKeys: vi.fn(),
+  createServiceKey: vi.fn(),
+  updateServiceKey: vi.fn(),
+  deleteServiceKey: vi.fn(),
+  approveServiceKey: vi.fn(),
+}));
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: () => ({
+    isSuperUser: true,
+    loading: false,
+    error: null,
+    user: {super_user: true, global_readonly_super_user: false},
+  }),
+  useUpdateUser: vi.fn(),
+}));
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: () => ({
+    isSuperUser: true,
+    canModify: true,
+    isReadOnlySuperUser: false,
+    inReadOnlyMode: false,
+  }),
+}));
+
+vi.mock('src/components/breadcrumb/Breadcrumb', () => ({
+  QuayBreadcrumb: () => null,
+}));
+
+const mockKeys: IServiceKey[] = [
+  {
+    kid: 'kid1',
+    name: 'Alpha Key',
+    service: 'alpha-service',
+    created_date: '2024-01-01T00:00:00Z',
+  },
+  {
+    kid: 'kid2',
+    name: 'Beta Key',
+    service: 'beta-service',
+    created_date: '2024-01-02T00:00:00Z',
+  },
+];
+
+function renderComponent() {
+  return render(
+    <MemoryRouter>
+      <ServiceKeys />
+    </MemoryRouter>,
+  );
+}
+
+describe('ServiceKeys filter', () => {
+  beforeEach(() => {
+    vi.mocked(fetchServiceKeys).mockResolvedValue(mockKeys);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all keys initially', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Alpha Key')).toBeInTheDocument();
+      expect(screen.getByText('Beta Key')).toBeInTheDocument();
+    });
+  });
+
+  it('filters displayed keys when text is typed in search input', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha Key')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByTestId('service-keys-search');
+    await user.type(searchInput, 'alpha');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Beta Key')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Alpha Key')).toBeInTheDocument();
+  });
+
+  it('filters by service name', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Beta Key')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByTestId('service-keys-search');
+    await user.type(searchInput, 'beta-service');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Alpha Key')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Beta Key')).toBeInTheDocument();
+  });
+
+  it('supports multi-word key names in search', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Alpha Key')).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByTestId('service-keys-search');
+    await user.type(searchInput, 'Alpha Key');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Beta Key')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Alpha Key')).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/Superuser/ServiceKeys/ServiceKeys.tsx
+++ b/web/src/routes/Superuser/ServiceKeys/ServiceKeys.tsx
@@ -395,7 +395,7 @@ export default function ServiceKeys() {
                 placeholder="Filter Keys..."
                 value={search.query}
                 onChange={(_event, val) =>
-                  setSearch((prev) => ({...prev, query: val.trim()}))
+                  setSearch((prev) => ({...prev, query: val}))
                 }
               />
             </ToolbarItem>


### PR DESCRIPTION
## Summary

- Fix Superuser Service Keys search filter that had no effect when text was typed
- Multi-word key names (containing spaces) now filter correctly
- Pagination now resets to page 1 when a search query is applied

## Root Cause / Rationale

`val.trim()` was applied inside the `TextInput` `onChange` handler on every
keystroke. Because the input is a controlled React component (`value={search.query}`),
trimming the space character prevented spaces from ever entering the query
string. Typing "Alpha Key" produced query state `"AlphaKey"`, which matches
nothing — making the filter appear completely broken for any multi-word name.

Single-word queries were unaffected (trim has no effect on non-space characters).
The filter hook logic (`UseServiceKeys.ts`) was correct and already covered by
unit tests; the bug was entirely in the UI layer's `onChange` handler.

Secondary: the hook did not call `setPage(1)` when `search.query` changed, so
users on page 2+ who applied a filter saw an empty table.

## Changes

- `web/src/routes/Superuser/ServiceKeys/ServiceKeys.tsx` — remove `val.trim()`
  from `onChange`; pass `val` directly to `setSearch`
- `web/src/hooks/UseServiceKeys.ts` — apply `.trim()` at filter evaluation time
  (`search.query.trim().toLowerCase()`) so leading/trailing whitespace is
  tolerated without breaking input; add `useEffect` to reset `page` to 1 on
  `search.query` change
- `web/src/routes/Superuser/ServiceKeys/ServiceKeys.test.tsx` (new) — 4
  component-level regression tests, including multi-word search
- `web/src/hooks/UseServiceKeys.test.ts` — add page-reset regression test

## Test Plan

- [x] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [ ] Manual testing performed
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

**Regression test:** `ServiceKeys filter > supports multi-word key names in search`
fails without the fix (DOM shows `value="AlphaKey"` after typing "Alpha Key")
and passes with it. Verified by reverting and re-running.

Full vitest suite: 1087/1087 pass.

To manually verify:
1. Log in as a superuser
2. Navigate to Superuser → Service Keys
3. Type a multi-word key name (e.g., part of "My Auth Key") in the filter input
4. Confirm the list narrows correctly

## JIRA

https://issues.redhat.com/browse/PROJQUAY-9883

## Backport

- [ ] Backport required: `redhat-3.16` (verify Target Version on ticket — label `quay-3.16-qe-ui-bugs` suggests 3.16 scope; run `/cherrypick redhat-3.16` after merge if confirmed)
- [ ] No backport needed

---

## Automation

Generated by Amber (Quay bugfix workflow). Session: `session-c6e560c5-14fd-4569-af4d-31af011206c8`