### PR TITLE
fix: add react-redux to package.json to fix hermetic Konflux build

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -33,6 +33,7 @@
         "react-google-recaptcha": "^3.1.0",
         "react-hook-form": "^7.60.0",
         "react-markdown": "^10.1.0",
+        "react-redux": "^9.2.0",
         "react-router-dom": "^7.13.0",
         "recoil": "^0.7.7",
         "recoil-persist": "^4.2.0",
@@ -3799,6 +3800,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -14559,6 +14566,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router": {

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "react-google-recaptcha": "^3.1.0",
     "react-hook-form": "^7.60.0",
     "react-markdown": "^10.1.0",
+    "react-redux": "^9.2.0",
     "react-router-dom": "^7.13.0",
     "recoil": "^0.7.7",
     "recoil-persist": "^4.2.0",


### PR DESCRIPTION
## Summary

- `react-redux` is a required peer dependency of `@redhat-cloud-services/frontend-components@6.0.9` but was missing from `web/package.json`
- After a Nexus repository path change for cachi2 npm prefetching, packages absent from `package-lock.json` can no longer be resolved during the hermetic build — npm falls back to `registry.npmjs.org` which is blocked, causing `ENOTFOUND`
- This has caused every `quay-quay-v3-16` Konflux build to fail since May 4 (5 consecutive failures), each running for ~75 min before hitting the error in Containerfile stage `[4/8]` (`build-ui` / `ubi9/nodejs-22`)

**Root cause log snippet:**
```
npm error code ENOTFOUND
npm error network request to https://registry.npmjs.org/react-redux failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org
Error: building at STEP "RUN . /cachi2/cachi2.env && CYPRESS_INSTALL_BINARY=0 npm clean-install --ignore-scripts": exit status 1
```

## Changes

- `web/package.json`: add `react-redux@^9.2.0` as an explicit dependency (within the `^7.0.0 || ^8.0.0 || ^9.0.0` peer dep range)
- `web/package-lock.json`: regenerated to include `react-redux` and its sub-deps

## Test plan

- [ ] Merge triggers a new `quay-quay-v3-16` Konflux PipelineRun
- [ ] `prefetch-dependencies` TaskRun completes and includes `react-redux` in the cachi2 bundle
- [ ] `build-images` `step-build` passes the `build-ui` stage without network errors
- [ ] PipelineRun completes successfully