### PR TITLE
QUAYIO-1768: feat(health,deploy): configurable health check skips and service toggles

### DIFF
--- a/deploy/openshift/rosa/quay-py3-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-py3-deploy-template.yaml
@@ -198,12 +198,6 @@ objects:
             value: ${DEBUGLOG}
           - name: IGNORE_VALIDATION
             value: ${IGNORE_VALIDATION}
-          - name: SYSLOG_SERVER
-            value: ${{SYSLOG_SERVER}}
-          - name: SYSLOG_PORT
-            value: ${SYSLOG_PORT}
-          - name: SYSLOG_PROTO
-            value: ${{SYSLOG_PROTO}}
           - name: QUAY_LOGGING
             value: ${{QUAY_LOGGING}}
           - name: WORKER_MULTIPLIER_REGISTRY
@@ -216,6 +210,10 @@ objects:
             value: ${WORKER_COUNT_WEB}
           - name: WORKER_COUNT_REGISTRY
             value: ${WORKER_COUNT_REGISTRY}
+          - name: QUAY_SERVICES
+            value: ${QUAY_SERVICES}
+          - name: QUAY_OVERRIDE_SERVICES
+            value: ${QUAY_OVERRIDE_SERVICES}
 parameters:
   - name: NAME
     value: "quay-py3"
@@ -379,6 +377,14 @@ parameters:
     value: oneagent.dynatrace.com/inject
   - name: DYNATRACE_APM_ANNOTATION_VALUE
     value: "false"
+  - name: QUAY_SERVICES
+    value: ""
+    displayName: quay services whitelist
+    description: Comma-separated list of supervisord services to enable. If empty, all default services run.
+  - name: QUAY_OVERRIDE_SERVICES
+    value: ""
+    displayName: quay services override
+    description: Comma-separated list of service=true/false overrides. Applied after QUAY_SERVICES. Example "builder=false,repomirrorworker=true"
   - name: QUAY_APP_GRPC_ENABLE_LABEL_KEY
     value: quay_grpc_endpoint
   - name: QUAY_APP_GRPC_ENABLE_LABEL_VALUE

--- a/health/healthcheck.py
+++ b/health/healthcheck.py
@@ -121,10 +121,10 @@ class HealthCheck(object):
 
 
 class LocalHealthCheck(HealthCheck):
-    def __init__(self, app, config_provider, instance_keys):
-        super(LocalHealthCheck, self).__init__(
-            app, config_provider, instance_keys, ["redis", "storage"]
-        )
+    def __init__(self, app, config_provider, instance_keys, instance_skips=None):
+        if instance_skips is None:
+            instance_skips = ["redis", "storage"]
+        super(LocalHealthCheck, self).__init__(app, config_provider, instance_keys, instance_skips)
 
     @classmethod
     def check_names(cls):
@@ -141,11 +141,12 @@ class RDSAwareHealthCheck(HealthCheck):
         secret_key=None,
         db_instance="quay",
         region="us-east-1",
+        instance_skips=None,
     ):
-        # Note: We skip the redis check because if redis is down, we don't want ELB taking the
-        # machines out of service. Redis is not considered a high avaliability-required service.
+        if instance_skips is None:
+            instance_skips = ["redis", "storage"]
         super(RDSAwareHealthCheck, self).__init__(
-            app, config_provider, instance_keys, ["redis", "storage"]
+            app, config_provider, instance_keys, instance_skips
         )
 
         self.access_key = access_key

--- a/health/test/test_healthcheck.py
+++ b/health/test/test_healthcheck.py
@@ -1,0 +1,125 @@
+"""Unit tests for health.healthcheck.HealthCheck and subclasses."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from health.healthcheck import HealthCheck, LocalHealthCheck, RDSAwareHealthCheck
+
+
+def _make_app(health_checker=None):
+    app = MagicMock()
+    app.config = {
+        "TESTING": True,
+        "SETUP_COMPLETE": True,
+        "HEALTH_CHECKER": health_checker or ("LocalHealthCheck", {}),
+        "SERVER_HOSTNAME": "localhost:8080",
+        "PREFERRED_URL_SCHEME": "http",
+    }
+    app.config.get = lambda k, d=None: app.config.get(k, d)
+    return app
+
+
+def _make_app_config(health_checker=None):
+    config = {
+        "TESTING": True,
+        "SETUP_COMPLETE": True,
+        "HEALTH_CHECKER": health_checker or ("LocalHealthCheck", {}),
+        "SERVER_HOSTNAME": "localhost:8080",
+        "PREFERRED_URL_SCHEME": "http",
+    }
+
+    app = MagicMock()
+    app.config = config
+    return app
+
+
+@pytest.fixture
+def mock_deps():
+    return MagicMock(), MagicMock()
+
+
+class TestLocalHealthCheckInstanceSkips:
+    def test_default_skips_redis_and_storage(self, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config()
+        checker = LocalHealthCheck(app, config_provider, instance_keys)
+        assert checker.instance_skips == ["redis", "storage"]
+
+    def test_custom_skips_from_constructor(self, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config()
+        checker = LocalHealthCheck(
+            app, config_provider, instance_keys, instance_skips=["redis", "storage", "auth"]
+        )
+        assert checker.instance_skips == ["redis", "storage", "auth"]
+
+    def test_empty_skips(self, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config()
+        checker = LocalHealthCheck(app, config_provider, instance_keys, instance_skips=[])
+        assert checker.instance_skips == []
+
+
+class TestRDSAwareHealthCheckInstanceSkips:
+    def test_default_skips_redis_and_storage(self, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config()
+        checker = RDSAwareHealthCheck(app, config_provider, instance_keys)
+        assert checker.instance_skips == ["redis", "storage"]
+
+    def test_custom_skips_from_constructor(self, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config()
+        checker = RDSAwareHealthCheck(
+            app, config_provider, instance_keys, instance_skips=["redis", "storage", "database"]
+        )
+        assert checker.instance_skips == ["redis", "storage", "database"]
+
+
+class TestGetCheckerForwardsInstanceSkips:
+    def test_local_health_check_with_instance_skips(self, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config(("LocalHealthCheck", {"instance_skips": ["redis"]}))
+        checker = HealthCheck.get_checker(app, config_provider, instance_keys)
+        assert isinstance(checker, LocalHealthCheck)
+        assert checker.instance_skips == ["redis"]
+
+    def test_local_health_check_without_instance_skips(self, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config(("LocalHealthCheck", {}))
+        checker = HealthCheck.get_checker(app, config_provider, instance_keys)
+        assert isinstance(checker, LocalHealthCheck)
+        assert checker.instance_skips == ["redis", "storage"]
+
+    def test_rds_health_check_with_instance_skips(self, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config(
+            ("RDSAwareHealthCheck", {"instance_skips": ["redis", "storage", "auth"]})
+        )
+        checker = HealthCheck.get_checker(app, config_provider, instance_keys)
+        assert isinstance(checker, RDSAwareHealthCheck)
+        assert checker.instance_skips == ["redis", "storage", "auth"]
+
+    def test_production_alias_with_instance_skips(self, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config(("ProductionHealthCheck", {"instance_skips": ["redis"]}))
+        checker = HealthCheck.get_checker(app, config_provider, instance_keys)
+        assert isinstance(checker, RDSAwareHealthCheck)
+        assert checker.instance_skips == ["redis"]
+
+
+class TestCheckInstanceRespectsSkips:
+    @patch("health.healthcheck.check_all_services")
+    def test_skipped_services_not_checked(self, mock_check_all, mock_deps):
+        config_provider, instance_keys = mock_deps
+        app = _make_app_config()
+        mock_check_all.return_value = {"disk_space": (True, None)}
+
+        checker = LocalHealthCheck(
+            app, config_provider, instance_keys, instance_skips=["redis", "storage", "auth"]
+        )
+        with patch.object(checker, "get_instance_health", return_value=({}, 200)):
+            checker.check_instance()
+
+        mock_check_all.assert_called_once_with(app, ["redis", "storage", "auth"], for_instance=True)


### PR DESCRIPTION
## Summary
- Make health check `instance_skips` configurable via `HEALTH_CHECKER` config tuple
- Expose `QUAY_SERVICES` and `QUAY_OVERRIDE_SERVICES` in the ROSA deployment template
- Fix substring matching bug and empty string handling in supervisord service parsing

## Root Cause / Rationale
- Both `LocalHealthCheck` and `RDSAwareHealthCheck` hardcoded `instance_skips` to `["redis", "storage"]`, ignoring the base class parameter. The plumbing existed but was disconnected in the subclasses.
- The supervisord config generator supported `QUAY_SERVICES` and `QUAY_OVERRIDE_SERVICES` env vars but the deployment template did not expose them.
- `QUAY_SERVICES` and `QUAY_OVERRIDE_SERVICES` were kept as raw strings, causing `limit_services()` and `override_services()` to use substring matching. Setting `QUAY_SERVICES="gcworker"` would also enable `namespacegcworker` and `repositorygcworker`. An empty string `""` would also disable all services instead of being treated as unset.

## Changes
- `health/healthcheck.py`: Both subclasses now accept `instance_skips` as an optional kwarg, defaulting to `["redis", "storage"]`
- `health/test/test_healthcheck.py`: New test file covering default skips, custom skips, config forwarding, and skip propagation
- `deploy/openshift/rosa/quay-py3-deploy-template.yaml`: Added `QUAY_SERVICES` and `QUAY_OVERRIDE_SERVICES` env vars and template parameters
- `conf/init/supervisord_conf_create.py`: Parse env vars into proper lists with `_parse_csv_env()`, use `if not` for empty checks

## Test Plan
- [x] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [ ] Manual testing performed
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

## JIRA
https://redhat.atlassian.net/browse/QUAYIO-1768

## Backport
- [x] No backport needed