### PR TITLE
PROJQUAY-11486: fix(config-tool): s3 validator always uses https matching python backend

### DIFF
--- a/config-tool/pkg/lib/shared/storage_validators.go
+++ b/config-tool/pkg/lib/shared/storage_validators.go
@@ -56,14 +56,16 @@ func buildEndpoint(endpointURL string, host string, port int, defaultIsSecure bo
 }
 
 // buildSTSEndpointConfig builds endpoint configuration for STS-based storage types (IRSA and STS).
-func buildSTSEndpointConfig(args *DistributedStorageArgs) (string, bool, *aws.Config, error) {
+// defaultIsSecure controls TLS when no explicit scheme is present in the endpoint; callers should
+// pass true for S3Storage (mirrors Python's hardcoded is_secure=True) and args.IsSecure otherwise.
+func buildSTSEndpointConfig(args *DistributedStorageArgs, defaultIsSecure bool) (string, bool, *aws.Config, error) {
 	var s3Endpoint string
 	var isSecure bool
 	awsConfig := &aws.Config{}
 
 	if args.EndpointURL != "" || args.Host != "" {
 		var err error
-		s3Endpoint, isSecure, err = buildEndpoint(args.EndpointURL, args.Host, args.Port, args.IsSecure)
+		s3Endpoint, isSecure, err = buildEndpoint(args.EndpointURL, args.Host, args.Port, defaultIsSecure)
 		if err != nil {
 			return "", false, nil, err
 		}
@@ -159,11 +161,12 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 		secretKey = args.S3SecretKey
 		bucketName = args.S3Bucket
 
-		// Build endpoint from either endpoint_url (boto3) or host+port (boto2)
+		// Build endpoint from either endpoint_url (boto3) or host+port (boto2).
+		// S3Storage always uses HTTPS (matching Python storage/cloud.py:L803 is_secure=True).
 		var awsConfig *aws.Config
 		if args.EndpointURL != "" || args.Host != "" {
 			var err error
-			endpoint, isSecure, awsConfig, err = buildSTSEndpointConfig(args)
+			endpoint, isSecure, awsConfig, err = buildSTSEndpointConfig(args, true)
 			if err != nil {
 				errors = append(errors, ValidationError{
 					Tags:       []string{"DISTRIBUTED_STORAGE_CONFIG"},
@@ -253,7 +256,7 @@ func ValidateStorage(opts Options, storageName string, storageType string, args 
 
 		// Build endpoint configuration for STS and S3
 		var awsConfig *aws.Config
-		endpoint, isSecure, awsConfig, err := buildSTSEndpointConfig(args)
+		endpoint, isSecure, awsConfig, err := buildSTSEndpointConfig(args, args.IsSecure)
 		if err != nil {
 			errors = append(errors, ValidationError{
 				Tags:       []string{"DISTRIBUTED_STORAGE_CONFIG"},

--- a/config-tool/pkg/lib/shared/storage_validators_test.go
+++ b/config-tool/pkg/lib/shared/storage_validators_test.go
@@ -1,0 +1,156 @@
+package shared
+
+import (
+	"testing"
+)
+
+func TestBuildEndpoint(t *testing.T) {
+	tests := []struct {
+		name            string
+		endpointURL     string
+		host            string
+		port            int
+		defaultIsSecure bool
+		wantEndpoint    string
+		wantIsSecure    bool
+		wantErr         bool
+	}{
+		{
+			name:            "https scheme in endpoint_url forces isSecure=true",
+			endpointURL:     "https://s3.ap-southeast-2.amazonaws.com",
+			defaultIsSecure: false,
+			wantEndpoint:    "s3.ap-southeast-2.amazonaws.com",
+			wantIsSecure:    true,
+		},
+		{
+			name:            "http scheme in endpoint_url forces isSecure=false",
+			endpointURL:     "http://minio.internal:9000",
+			defaultIsSecure: true,
+			wantEndpoint:    "minio.internal:9000",
+			wantIsSecure:    false,
+		},
+		{
+			name:            "no scheme in endpoint_url uses defaultIsSecure=true",
+			endpointURL:     "s3.amazonaws.com",
+			defaultIsSecure: true,
+			wantEndpoint:    "s3.amazonaws.com",
+			wantIsSecure:    true,
+		},
+		{
+			name:            "no scheme in endpoint_url uses defaultIsSecure=false",
+			endpointURL:     "minio.internal",
+			defaultIsSecure: false,
+			wantEndpoint:    "minio.internal",
+			wantIsSecure:    false,
+		},
+		{
+			name:            "host with port uses defaultIsSecure",
+			host:            "minio.internal",
+			port:            9000,
+			defaultIsSecure: true,
+			wantEndpoint:    "minio.internal:9000",
+			wantIsSecure:    true,
+		},
+		{
+			// Regression test for PROJQUAY-11486: host-based S3Storage config with is_secure=false
+			// must still resolve to isSecure=true when defaultIsSecure=true is passed by the caller.
+			name:            "host with is_secure=false, defaultIsSecure=true yields HTTPS (S3Storage fix)",
+			host:            "s3.ap-southeast-2.amazonaws.com",
+			defaultIsSecure: true,
+			wantEndpoint:    "s3.ap-southeast-2.amazonaws.com",
+			wantIsSecure:    true,
+		},
+		{
+			name:    "neither endpoint_url nor host returns error",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, isSecure, err := buildEndpoint(tt.endpointURL, tt.host, tt.port, tt.defaultIsSecure)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildEndpoint() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if endpoint != tt.wantEndpoint {
+				t.Errorf("endpoint = %q, want %q", endpoint, tt.wantEndpoint)
+			}
+			if isSecure != tt.wantIsSecure {
+				t.Errorf("isSecure = %v, want %v", isSecure, tt.wantIsSecure)
+			}
+		})
+	}
+}
+
+func TestBuildSTSEndpointConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            *DistributedStorageArgs
+		defaultIsSecure bool
+		wantEndpoint    string
+		wantIsSecure    bool
+		wantErr         bool
+	}{
+		{
+			// Regression test for PROJQUAY-11486: S3Storage passes defaultIsSecure=true so that
+			// a host-based config with is_secure=false still validates over HTTPS, matching the
+			// Python S3Storage backend which hardcodes is_secure=True.
+			name: "S3Storage with host and is_secure=false uses HTTPS when defaultIsSecure=true",
+			args: &DistributedStorageArgs{
+				Host:     "s3.ap-southeast-2.amazonaws.com",
+				IsSecure: false,
+			},
+			defaultIsSecure: true,
+			wantEndpoint:    "s3.ap-southeast-2.amazonaws.com",
+			wantIsSecure:    true,
+		},
+		{
+			name: "explicit http:// endpoint_url overrides defaultIsSecure=true",
+			args: &DistributedStorageArgs{
+				EndpointURL: "http://minio.internal:9000",
+			},
+			defaultIsSecure: true,
+			wantEndpoint:    "minio.internal:9000",
+			wantIsSecure:    false,
+		},
+		{
+			name: "no endpoint falls back to s3.amazonaws.com with HTTPS",
+			args: &DistributedStorageArgs{},
+			// defaultIsSecure value doesn't matter for the no-endpoint path
+			defaultIsSecure: false,
+			wantEndpoint:    "s3.amazonaws.com",
+			wantIsSecure:    true,
+		},
+		{
+			name: "STSS3Storage with is_secure=false preserves HTTP when defaultIsSecure=false",
+			args: &DistributedStorageArgs{
+				Host:     "sts.internal",
+				IsSecure: false,
+			},
+			defaultIsSecure: false,
+			wantEndpoint:    "sts.internal",
+			wantIsSecure:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, isSecure, _, err := buildSTSEndpointConfig(tt.args, tt.defaultIsSecure)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildSTSEndpointConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if endpoint != tt.wantEndpoint {
+				t.Errorf("endpoint = %q, want %q", endpoint, tt.wantEndpoint)
+			}
+			if isSecure != tt.wantIsSecure {
+				t.Errorf("isSecure = %v, want %v", isSecure, tt.wantIsSecure)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix S3 storage validator in config-tool always probing over HTTPS, matching
  the Python `S3Storage` backend behavior which hardcodes `is_secure=True`
- Add unit tests for `buildEndpoint` and `buildSTSEndpointConfig` covering all
  TLS-selection branches including the bug scenario

## Root Cause / Rationale

The Go config-tool validator (`storage_validators.go`) builds an S3 endpoint
for connection probing via `buildSTSEndpointConfig(args)`. That function
forwarded `args.IsSecure` as the TLS default, so a user's `is_secure: false`
config caused the validator to probe over HTTP and log `TLS enabled: false`.

Meanwhile, the Python `S3Storage` backend (`storage/cloud.py:L803`) ignores
`is_secure` for the `host` field and always constructs an `https://` endpoint.
boto3 confirms it sends all requests over HTTPS regardless. The validator and
the runtime were inconsistent, causing spurious validation failures that
required `IGNORE_VALIDATION: true` workarounds on QuayRegistry CRs.

## Changes

- `config-tool/pkg/lib/shared/storage_validators.go`:
  - `buildSTSEndpointConfig`: added `defaultIsSecure bool` parameter
  - `S3Storage` case: passes `true` (matches Python behavior)
  - `STSS3Storage` case: unchanged, still passes `args.IsSecure`
  - Explicit `http://` in `endpoint_url` still forces HTTP (escape hatch preserved)
- `config-tool/pkg/lib/shared/storage_validators_test.go` *(new file)*:
  - `TestBuildEndpoint` — 7 subtests, all branches of endpoint URL building
  - `TestBuildSTSEndpointConfig` — 4 subtests including direct regression for
    the `host=s3.ap-southeast-2.amazonaws.com, is_secure=false` scenario

## Test Plan

- [x] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`) — not applicable (Go config-tool change)
- [ ] Type checking passes (`make types-test`) — not applicable (Go config-tool change)
- [x] Manual testing performed — traced call path; confirmed validator probe matches runtime behavior
- [ ] Frontend tests pass — not applicable
- [ ] Migration tested — not applicable

```bash
# Run the regression tests
cd config-tool && go test ./pkg/lib/shared/... -run "TestBuildEndpoint|TestBuildSTSEndpointConfig" -v
```

## JIRA

https://issues.redhat.com/browse/PROJQUAY-11486

## Backport

- [x] Backport required: `quay-v3.17.z`
- After merge, comment: `/cherrypick quay-v3.17.z`

## Automation

- **Session ID**: session-2585f5d4-4222-4141-a2b7-c710256e98da