### PR TITLE
PROJQUAY-11179: fix(security): validate blob upload repository ownership

### DIFF
--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -1158,12 +1158,15 @@ class OCIModel(RegistryDataInterface):
 
     def lookup_blob_upload(self, repository_ref, blob_upload_id):
         """
-        Looks up the blob upload withn the given ID under the specified repository and returns it or
+        Looks up the blob upload with the given ID under the specified repository and returns it or
         None if none.
         """
         with db_disallow_replica_use():
             upload_record = model.blob.get_blob_upload_by_uuid(blob_upload_id)
             if upload_record is None:
+                return None
+
+            if upload_record.repository_id != repository_ref._db_id:
                 return None
 
             return BlobUpload.for_upload(upload_record)

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -653,6 +653,21 @@ def test_blob_uploads(registry_model):
     assert not registry_model.lookup_blob_upload(repository_ref, blob_upload.upload_id)
 
 
+def test_blob_upload_repository_isolation(registry_model):
+    repo_a = registry_model.lookup_repository("devtable", "simple")
+    repo_b = registry_model.lookup_repository("devtable", "complex")
+
+    blob_upload = registry_model.create_blob_upload(
+        repo_a, str(uuid.uuid4()), "local_us", {"some": "metadata"}
+    )
+    assert blob_upload
+
+    assert registry_model.lookup_blob_upload(repo_a, blob_upload.upload_id) == blob_upload
+    assert registry_model.lookup_blob_upload(repo_b, blob_upload.upload_id) is None
+
+    registry_model.delete_blob_upload(blob_upload)
+
+
 def test_commit_blob_upload(registry_model):
     repository_ref = registry_model.lookup_repository("devtable", "simple")
     blob_upload = registry_model.create_blob_upload(


### PR DESCRIPTION
## Summary
- Fix CVE-2026-32589: Insecure Direct Object Reference (IDOR) in OCI blob upload protocol
- Add repository ownership validation in `lookup_blob_upload()` to prevent cross-tenant access to in-progress blob uploads
- Add regression test verifying repository isolation of blob uploads

## Root Cause / Rationale
`get_blob_upload_by_uuid()` in `data/model/blob.py` queries blob uploads by UUID only, without filtering by repository. Its caller `lookup_blob_upload()` in `data/registry_model/registry_oci_model.py` accepts a `repository_ref` parameter but never validates that the returned upload belongs to that repository. This allows any authenticated user with push access to any repository to read, modify, or delete in-progress blob uploads belonging to other tenants.

## Changes
- `data/registry_model/registry_oci_model.py`: Added repository ownership check in `lookup_blob_upload()` — verifies `upload_record.repository_id` matches `repository_ref._db_id` before returning the upload. Returns `None` on mismatch.
- `data/registry_model/test/test_interface.py`: Added `test_blob_upload_repository_isolation` regression test that creates a blob upload in one repository and verifies it cannot be accessed from a different repository.

## Test Plan
- [x] Unit tests added/updated
- [ ] Integration/registry tests pass
- [ ] Type checking passes
- [ ] Manual testing performed
- [ ] Frontend tests pass
- [ ] Migration tested (upgrade and downgrade)

## JIRA
https://issues.redhat.com/browse/PROJQUAY-11179

## Backport
- [x] Backport required: `redhat-3.17` (Target Version quay-v3.17.2)

## Automation
- **Session ID**: session-ee37f1a9-7d4d-40e6-90d2-c51b68bc8581