### PR TITLE
PROJQUAY-11519: test(image): add logging reset fixture to prevent test pollution

### DIFF
--- a/image/shared/test/conftest.py
+++ b/image/shared/test/conftest.py
@@ -32,10 +32,16 @@ def reset_logging():
         logger.setLevel(logging.NOTSET)
         # Ensure propagation is enabled (default)
         logger.propagate = True
-        # Remove any handlers that were added
-        logger.handlers.clear()
+        # Close and remove any handlers that were added
+        # Must close handlers explicitly to release file descriptors
+        for handler in logger.handlers[:]:
+            logger.removeHandler(handler)
+            handler.close()
 
     # Also reset the root logger
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.WARNING)  # Python's default
-    root_logger.handlers.clear()
+    # Close and remove root logger handlers
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+        handler.close()

--- a/image/shared/test/conftest.py
+++ b/image/shared/test/conftest.py
@@ -1,0 +1,41 @@
+"""
+Pytest configuration for image.shared tests.
+
+Provides fixtures to prevent test pollution from logging state modifications.
+"""
+
+import logging
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_logging():
+    """
+    Reset logging configuration after each test to prevent state pollution.
+
+    This fixture ensures that tests which modify logger configuration
+    (e.g., changing log levels, disabling propagation, adding handlers)
+    do not affect subsequent tests.
+
+    The fixture runs after each test in this directory and restores all
+    loggers to their default state.
+    """
+    # Yield to run the test first
+    yield
+
+    # After test completes, reset all loggers to default state
+    # This prevents logging configuration changes from leaking between tests
+    for logger_name in list(logging.Logger.manager.loggerDict.keys()):
+        logger = logging.getLogger(logger_name)
+        # Reset to NOTSET so it inherits from parent
+        logger.setLevel(logging.NOTSET)
+        # Ensure propagation is enabled (default)
+        logger.propagate = True
+        # Remove any handlers that were added
+        logger.handlers.clear()
+
+    # Also reset the root logger
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.WARNING)  # Python's default
+    root_logger.handlers.clear()


### PR DESCRIPTION
## Summary
- Adds autouse pytest fixture to reset logging configuration after each test in `image/shared/test/`
- Prevents logging state pollution from affecting subsequent tests
- Fixes flaky test: `test_logs_debug_message_for_skipped_manifest`

## Root Cause / Rationale
The test `image/shared/test/test_sparse_index.py::TestDebugLogging::test_logs_debug_message_for_skipped_manifest` fails intermittently in CI when run after approximately 1055 other tests, but passes consistently in isolation. The root cause is logging state pollution: one or more tests running before this test modify logger configuration (level, propagation, or handlers), and those changes leak into subsequent tests because the global logging state is not reset.

## Changes
- Created `image/shared/test/conftest.py` with `reset_logging()` autouse fixture
- The fixture runs after each test and resets all loggers to default state:
  - Sets level to `NOTSET` (inherit from parent)
  - Enables propagation (default behavior)
  - Clears any added handlers
  - Resets root logger to `WARNING` level

## Test Plan
- [x] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [x] Manual testing performed (20 consecutive runs, all passed)
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

Verified locally:
- Test passes in isolation (100% success rate)
- Test passes in 20 consecutive runs with fixture in place
- CI will validate behavior after ~1055 tests

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11519

## Backport
- [ ] Backport required:
- [x] No backport needed