### PR TITLE
QUAYIO-1768: fix(supervisord): parse QUAY_SERVICES as list to prevent substring matching

### DIFF
--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -1,7 +1,7 @@
 import os
 import os.path
 import sys
-from typing import List, Union
+from typing import List
 
 import jinja2
 
@@ -13,8 +13,14 @@ QUAYRUN_DIR = os.getenv("QUAYRUN", QUAYCONF_DIR)
 QUAY_LOGGING = os.getenv("QUAY_LOGGING", "stdout")  # or "syslog"
 QUAY_HOTRELOAD: bool = os.getenv("QUAY_HOTRELOAD", "false") == "true"
 
-QUAY_SERVICES: Union[List, str] = os.getenv("QUAY_SERVICES", [])
-QUAY_OVERRIDE_SERVICES: Union[List, str] = os.getenv("QUAY_OVERRIDE_SERVICES", [])
+
+def _parse_csv_env(name):
+    val = os.getenv(name, "")
+    return [s.strip() for s in val.split(",") if s.strip()] if val else []
+
+
+QUAY_SERVICES: List[str] = _parse_csv_env("QUAY_SERVICES")
+QUAY_OVERRIDE_SERVICES: List[str] = _parse_csv_env("QUAY_OVERRIDE_SERVICES")
 
 
 def registry_services():
@@ -109,7 +115,7 @@ def generate_supervisord_config(filename, config, logdriver, hotreload):
 
 
 def limit_services(config, enabled_services):
-    if enabled_services == []:
+    if not enabled_services:
         return
 
     for service in list(config.keys()):
@@ -120,7 +126,7 @@ def limit_services(config, enabled_services):
 
 
 def override_services(config, override_services):
-    if override_services == []:
+    if not override_services:
         return
 
     for service in list(config.keys()):

--- a/deploy/openshift/rosa/quay-py3-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-py3-deploy-template.yaml
@@ -168,11 +168,8 @@ objects:
             timeoutSeconds: ${{QUAY_APP_STARTUP_PROBE_TIMEOUT_SECONDS}}
             periodSeconds: ${{QUAY_APP_STARTUP_PROBE_PERIOD_SECONDS}}
           livenessProbe:
-            httpGet:
-              path: /health/instance
+            tcpSocket:
               port: 8443
-              scheme: HTTPS
-            initialDelaySeconds: ${{QUAY_APP_LIVENESS_PROBE_INITIAL_DELAY_SECONDS}}
             periodSeconds: ${{QUAY_APP_LIVENESS_PROBE_PERIOD_SECONDS}}
             timeoutSeconds: ${{QUAY_APP_LIVENESS_PROBE_TIMEOUT_SECONDS}}
           readinessProbe:
@@ -296,9 +293,6 @@ parameters:
   - name: QUAY_APP_STARTUP_PROBE_PERIOD_SECONDS
     value: "60"
     displayName: quay app startup probe initial delay seconds
-  - name: QUAY_APP_LIVENESS_PROBE_INITIAL_DELAY_SECONDS
-    value: "15"
-    displayName: quay app liveness probe initial delay seconds
   - name: QUAY_APP_LIVENESS_PROBE_PERIOD_SECONDS
     value: "30"
     displayName: quay app liveness probe period seconds


### PR DESCRIPTION
## Summary
- Fix substring matching bug in supervisord service parsing
- Fix empty string handling for `QUAY_SERVICES` and `QUAY_OVERRIDE_SERVICES`
- Switch liveness probe from `/health/instance` to `tcpSocket` to prevent restart storms

## Root Cause / Rationale
`QUAY_SERVICES` and `QUAY_OVERRIDE_SERVICES` were stored as raw strings from `os.getenv`. This caused `limit_services()` and `override_services()` to use Python's `str.__contains__` (substring matching) instead of list membership. Setting `QUAY_SERVICES="gcworker"` would also enable `namespacegcworker` and `repositorygcworker`. Similarly, `QUAY_SERVICES="notificationworker"` would also enable `securityscanningnotificationworker`.

Additionally, an empty string `""` (e.g. from a deployment template parameter default) was not treated as unset, which would disable all services.

The liveness probe was using `/health/instance` which checks external dependencies (database, Redis, storage, auth). During an infrastructure outage (e.g. database lock or Redis failure), all pods fail liveness simultaneously and Kubernetes restarts them — a restart storm that cannot fix the underlying issue. Switched to `tcpSocket` on port 8443 (nginx), which only verifies the container process is alive without touching gunicorn or backend services. External dependency failures are correctly handled by the readiness probe, which removes the pod from the service without killing it. Also removed the redundant `initialDelaySeconds` since the startup probe already gates liveness checks.

## Changes
- `conf/init/supervisord_conf_create.py`: Added `_parse_csv_env()` to parse comma-separated env vars into proper `List[str]`. Both `limit_services()` and `override_services()` now use `if not` for empty checks. Removed unused `Union` import.
- `deploy/openshift/rosa/quay-py3-deploy-template.yaml`: Changed liveness probe from `httpGet /health/instance` to `tcpSocket:8443`. Removed redundant `initialDelaySeconds` and its parameter definition.

## JIRA
https://redhat.atlassian.net/browse/QUAYIO-1768