### PR TITLE
NO-ISSUE: ci: fix duplicate env key in branch-sync workflow

### DIFF
--- a/.github/workflows/branch-sync.yaml
+++ b/.github/workflows/branch-sync.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Merge master into release
         env:
           BRANCH_NAME: ${{ vars.BRANCH_SYNC_TARGET }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "$BRANCH_NAME" ]; then echo "BRANCH_SYNC_TARGET variable is not set" && exit 1; fi
           echo "Syncing master to $BRANCH_NAME"
@@ -41,5 +42,3 @@ jobs:
           git push origin $BRANCH_NAME
 
           echo "Merged master ($MASTER_COMMIT) into $BRANCH_NAME ($RELEASE_COMMIT)"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fix invalid GitHub Actions workflow file `.github/workflows/branch-sync.yaml`
- The "Merge master into release" step had two `env` blocks (lines 26 and 44), which GitHub Actions rejects with: `'env' is already defined`
- Merged `GITHUB_TOKEN` into the existing `env` block alongside `BRANCH_NAME`

## Root Cause / Rationale
The step defined `env` twice — once before `run:` (with `BRANCH_NAME`) and once after (with `GITHUB_TOKEN`). YAML mapping keys must be unique, and GitHub Actions validates this strictly. The second `env` key shadows the first, making the workflow invalid.

## Changes
- Consolidated the two `env` blocks into a single block containing both `BRANCH_NAME` and `GITHUB_TOKEN`

## Test Plan
- [x] YAML syntax validated locally (`yaml.safe_load` passes)
- [x] Verified the workflow file has exactly one `env` key per step
- [ ] GitHub Actions should no longer report the workflow as invalid

## JIRA
No JIRA ticket — CI-only fix.

## Backport
- [ ] Backport required
- [x] No backport needed

## Automation
- **Session ID**: session-11567f65-6da8-41dd-8adc-d70d5e3044b2