### PR TITLE
PROJQUAY-11619: fix(ldap): Redact passwords in LDAP output when USERS_DEBUG=1 is set

### DIFF
--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -182,9 +182,6 @@ class LDAPConnection(object):
         else:
             self._conn = ldap.initialize(self._ldap_uri, trace_level=trace_level)
 
-        trace_file = _LDAPTraceRedactor() if trace_level else sys.stdout
-
-        self._conn = ldap.initialize(self._ldap_uri, trace_level=trace_level, trace_file=trace_file)
         self._conn.set_option(ldap.OPT_REFERRALS, self._referrals)
         self._conn.set_option(
             ldap.OPT_NETWORK_TIMEOUT, self._network_timeout or _DEFAULT_NETWORK_TIMEOUT

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -175,6 +175,13 @@ class LDAPConnection(object):
     def __enter__(self):
         trace_level = 2 if os.environ.get("USERS_DEBUG") == "1" else 0
 
+        if trace_level:
+            self._conn = ldap.initialize(
+                self._ldap_uri, trace_level=trace_level, trace_file=_LDAPTraceRedactor()
+            )
+        else:
+            self._conn = ldap.initialize(self._ldap_uri, trace_level=trace_level)
+
         trace_file = _LDAPTraceRedactor() if trace_level else sys.stdout
 
         self._conn = ldap.initialize(self._ldap_uri, trace_level=trace_level, trace_file=trace_file)

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -1,6 +1,8 @@
 import hashlib
 import logging
 import os
+import re
+import sys
 import threading
 from collections import OrderedDict, namedtuple
 from datetime import datetime, timedelta
@@ -40,6 +42,25 @@ _TRANSIENT_ERROR_MESSAGES = frozenset(
         "Failed to follow referral when looking up username",
     ]
 )
+
+
+class _LDAPTraceRedactor:
+    """
+    Wraps the LDAP output for password redaction when USERS_DEBUG is set.
+    """
+
+    _BIND_PW_RE = re.compile(
+        r"(SimpleLDAPObject\.simple_bind\s*\n\(\('[^']*',\s*\n\s+')[^']*(')",
+    )
+
+    def __init__(self, stream=None):
+        self._stream = stream or sys.stdout
+
+    def write(self, data):
+        self._stream.write(self._BIND_PW_RE.sub(r"\1******\2", data))
+
+    def flush(self):
+        self._stream.flush()
 
 
 class LDAPCache:
@@ -154,7 +175,9 @@ class LDAPConnection(object):
     def __enter__(self):
         trace_level = 2 if os.environ.get("USERS_DEBUG") == "1" else 0
 
-        self._conn = ldap.initialize(self._ldap_uri, trace_level=trace_level)
+        trace_file = _LDAPTraceRedactor() if trace_level else sys.stdout
+
+        self._conn = ldap.initialize(self._ldap_uri, trace_level=trace_level, trace_file=trace_file)
         self._conn.set_option(ldap.OPT_REFERRALS, self._referrals)
         self._conn.set_option(
             ldap.OPT_NETWORK_TIMEOUT, self._network_timeout or _DEFAULT_NETWORK_TIMEOUT

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -50,7 +50,7 @@ class _LDAPTraceRedactor:
     """
 
     _BIND_PW_RE = re.compile(
-        r"(SimpleLDAPObject\.simple_bind\s*\n\(\('[^']*',\s*\n\s*')((?:\\.|[^'])*)(')",
+        r"(SimpleLDAPObject\.simple_bind\s*\n\(\('[^']*',\s*\n\s*')((?:\\.|[^'\\])*)(')",
     )
 
     def __init__(self, stream=None):

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -50,14 +50,14 @@ class _LDAPTraceRedactor:
     """
 
     _BIND_PW_RE = re.compile(
-        r"(SimpleLDAPObject\.simple_bind\s*\n\(\('[^']*',\s*\n\s+')[^']*(')",
+        r"(SimpleLDAPObject\.simple_bind\s*\n\(\('[^']*',\s*\n\s*')((?:\\.|[^'])*)(')",
     )
 
     def __init__(self, stream=None):
         self._stream = stream or sys.stdout
 
     def write(self, data):
-        self._stream.write(self._BIND_PW_RE.sub(r"\1******\2", data))
+        self._stream.write(self._BIND_PW_RE.sub(r"\1******\3", data))
 
     def flush(self):
         self._stream.flush()

--- a/test/test_ldap.py
+++ b/test/test_ldap.py
@@ -1,5 +1,7 @@
 import unittest
 from contextlib import contextmanager
+from io import StringIO
+from unittest.mock import MagicMock
 
 import ldap
 from ldap.filter import filter_format
@@ -9,6 +11,7 @@ from mockldap import MockLdap
 from app import app
 from data import model
 from data.users import LDAPUsers
+from data.users.externalldap import _LDAPTraceRedactor
 from initdb import finished_database_for_testing, setup_database_for_testing
 
 
@@ -1158,6 +1161,74 @@ class TestLDAPCache(unittest.TestCase):
 
             # Verify cache has the entry
             self.assertEqual(ldap._cache.size(), 1)
+
+
+class TestLDAPPasswordRedaction(unittest.TestCase):
+    """
+    Unit tests for password redaction
+    """
+
+    def _make_bind_trace(self, dn, password):
+        return (
+            f"*** <ldap.ldapobject.SimpleLDAPObject object at 0x7f> "
+            f"ldaps://ldap.example.com - SimpleLDAPObject.simple_bind\n"
+            f"(('{dn}',\n"
+            f"  '{password}',\n"
+            f"  None,\n"
+            f"  None),\n"
+            f" {{}})\n"
+        )
+
+    def test_redacts_simple_password(self):
+        buf = StringIO()
+        redactor = _LDAPTraceRedactor(stream=buf)
+
+        redactor.write(self._make_bind_trace("uid=user,dc=example", "s3cret"))
+        output = buf.getvalue()
+
+        self.assertNotIn("s3cret", output)
+        self.assertIn("*****", output)
+        self.assertIn("uid=user,dc=example", output)
+
+    def test_redacts_complex_password(self):
+        buf = StringIO()
+        super_secret_password = "#HRx-u9r>W+?.?QTtN_X"
+        redactor = _LDAPTraceRedactor(stream=buf)
+
+        redactor.write(self._make_bind_trace("uid=user,dc=example", super_secret_password))
+        output = buf.getvalue()
+
+        self.assertNotIn(super_secret_password, output)
+        self.assertIn("*****", output)
+        self.assertIn("uid=user,dc=example", output)
+
+    def test_redacts_passwords_with_escaped_quotes(self):
+        buf = StringIO()
+        super_secret_password = "pa'ssword"
+        redactor = _LDAPTraceRedactor(stream=buf)
+
+        redactor.write(self._make_bind_trace("uid=user,dc=example", super_secret_password))
+        output = buf.getvalue()
+
+        self.assertNotIn(super_secret_password, output)
+        self.assertIn("*****", output)
+        self.assertIn("uid=user,dc=example", output)
+
+    def test_trace_pass_unchanged(self):
+        buf = StringIO()
+        redactor = _LDAPTraceRedactor(stream=buf)
+
+        search_trace = "*** <ldap...> - SimpleLDAPObject.search_ext\n(('dc=example',), {})\n"
+        redactor.write(search_trace)
+
+        self.assertEqual(buf.getvalue(), search_trace)
+
+    def test_flush_delegates_to_stream(self):
+        mock_stream = MagicMock()
+        redactor = _LDAPTraceRedactor(stream=mock_stream)
+        redactor.flush()
+
+        mock_stream.flush.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously, when `USERS_DEBUG=1` was set (LDAP debugging turned on), we would capture passwords in clear text due to library constraints. The output would look like:

~~~
gunicorn-web stdout | *** <ldap.ldapobject.SimpleLDAPObject object at 0x7f3f337a5be0> ldaps://LDAP_SERVER - SimpleLDAPObject.simple_bind
  gunicorn-web stdout | (('uid=ibazulic,ou=Users,...',
  gunicorn-web stdout |   'password_here',
  gunicorn-web stdout |   None,
  gunicorn-web stdout |   None),
  gunicorn-web stdout |  {})
  gunicorn-web stdout | => result:
  gunicorn-web stdout | 1
 ~~~

With this change, the password tuple should be redacted and replaced with stars. The solution here works both for the registry and web workers. Example output:

~~~
gunicorn-web stdout | *** <ldap.ldapobject.SimpleLDAPObject object at 0x7fe84b7a8e30> ldaps://LDAP_SERVER - SimpleLDAPObject.simple_bind 
gunicorn-web stdout | (('uid=ibazulic,ou=Users,...',
gunicorn-web stdout |   '******',
gunicorn-web stdout |   None,
gunicorn-web stdout |   None),
gunicorn-web stdout |  {})
gunicorn-web stdout | => result:
gunicorn-web stdout | 1
~~~

Co-Authored-By: Claude <noreply@anthropic.com>