### PR TITLE
PROJQUAY-11522: chore(web): bump axios to 1.15.1 [master/quay-3.18] 

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,7 +18,7 @@
         "@tanstack/react-query": "^4.13.5",
         "@types/node": "^20.6.5",
         "@types/react": "^18.2.0",
-        "axios": "^1.15.0",
+        "axios": "^1.15.1",
         "https-proxy-agent": "^5.0.1",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.7.6",
@@ -4494,7 +4494,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -11199,14 +11201,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-forge": {

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-query": "^4.13.5",
     "@types/node": "^20.6.5",
     "@types/react": "^18.2.0",
-    "axios": "^1.15.0",
+    "axios": "^1.15.1",
     "https-proxy-agent": "^5.0.1",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.7.6",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -53,8 +53,8 @@ importers:
         specifier: ^18.2.0
         version: 18.3.20
       axios:
-        specifier: ^1.15.0
-        version: 1.15.0
+        specifier: ^1.15.1
+        version: 1.15.1
       https-proxy-agent:
         specifier: ^5.0.1
         version: 5.0.1
@@ -154,7 +154,7 @@ importers:
         version: 4.1.4(vitest@4.1.4)
       axios-mock-adapter:
         specifier: ^1.22.0
-        version: 1.22.0(axios@1.15.0)
+        version: 1.22.0(axios@1.15.1)
       copy-webpack-plugin:
         specifier: ^10.2.4
         version: 10.2.4(webpack@5.105.0)
@@ -2031,6 +2031,9 @@ packages:
 
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+
+  axios@1.15.1:
+    resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
 
   axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
@@ -8220,13 +8223,21 @@ snapshots:
 
   axe-core@4.7.2: {}
 
-  axios-mock-adapter@1.22.0(axios@1.15.0):
+  axios-mock-adapter@1.22.0(axios@1.15.1):
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.1
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
 
   axios@1.15.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.15.1:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5


### PR DESCRIPTION
Changes:

web/package.json: "axios": "^1.15.0" -> "^1.15.1" in dependencies
web/package-lock.json: updated axios version (1.15.0 -> 1.15.1), resolved URL, and integrity hash