### PR TITLE
PROJQUAY-10510: fix(auth): OIDCUsers.has_password_set returns False to bypass fresh-login check

### DIFF
--- a/data/users/externaloidc.py
+++ b/data/users/externaloidc.py
@@ -61,6 +61,12 @@ class OIDCUsers(FederatedUsers):
         """
         return (None, "Not supported")
 
+    def has_password_set(self, username):
+        # OIDC users authenticate via token flows; they have no Quay-local password.
+        # Returning False lets require_fresh_login bypass the fresh-login check so
+        # OIDC browser users are not prompted for a password they cannot provide.
+        return False
+
     def verify_credentials(self, username_or_email, password):
         """
         Unsupported to login via username/email and password

--- a/test/test_external_oidc.py
+++ b/test/test_external_oidc.py
@@ -318,6 +318,13 @@ class OIDCAuthTests(unittest.TestCase):
         assert self.oidc_instance.has_password_set("another_user") is False
 
 
+def test_has_password_set_returns_false_standalone():
+    # Standalone (no DB) variant so codecov/patch sees the method covered.
+    oidc_instance = OIDCAuthTests().fake_oidc()
+    assert oidc_instance.has_password_set("any_oidc_user") is False
+    assert oidc_instance.has_password_set("another_user") is False
+
+
 def test_verify_credentials(discovery_handler, token_handler_password_grant, userinfo_handler):
     oidc_instance = OIDCAuthTests().fake_oidc()
     with HTTMock(discovery_handler, token_handler_password_grant, userinfo_handler):

--- a/test/test_external_oidc.py
+++ b/test/test_external_oidc.py
@@ -310,6 +310,13 @@ class OIDCAuthTests(unittest.TestCase):
         assert service == "oidc"
         assert error_msg == "Not supported"
 
+    def test_has_password_set_returns_false(self):
+        # PROJQUAY-10510: OIDCUsers must return False so require_fresh_login
+        # skips the fresh-login check for OIDC browser users (who have no
+        # Quay-local password and cannot complete password verification).
+        assert self.oidc_instance.has_password_set("any_oidc_user") is False
+        assert self.oidc_instance.has_password_set("another_user") is False
+
 
 def test_verify_credentials(discovery_handler, token_handler_password_grant, userinfo_handler):
     oidc_instance = OIDCAuthTests().fake_oidc()


### PR DESCRIPTION
## Summary

- `OIDCUsers.has_password_set()` now returns `False`, preventing `require_fresh_login` from raising `FreshLoginRequired` for OIDC browser users after the 10-minute session timeout
- OIDC users can now perform sensitive operations (org management, superuser actions, app token management, etc.) without being prompted for a Quay-local password they cannot provide

## Root Cause / Rationale

`OIDCUsers` (introduced in [PROJQUAY-6298](https://redhat.atlassian.net/browse/PROJQUAY-6298)) extends `FederatedUsers` without overriding `has_password_set()`. `FederatedUsers.has_password_set()` unconditionally returns `True` — correct for LDAP/JWT/Keystone which authenticate via real external passwords, but **incorrect for OIDC** where users authenticate exclusively via token flows and have no Quay-local password.

The `require_fresh_login` decorator in `endpoints/api/__init__.py` bypasses the fresh-login check when `not authentication.has_password_set(username)`. Because `OIDCUsers` inherited `has_password_set = True`, this bypass never activated for OIDC users. After the 10-minute timeout, every `@require_fresh_login`-decorated endpoint raised `FreshLoginRequired`, which the new UI surfaced as a password prompt that OIDC users cannot complete.

Two prior partial fixes addressed the symptom:
- [PROJQUAY-9748](https://redhat.atlassian.net/browse/PROJQUAY-9748) (`fc913d0f`): Frontend redirect to `/signin` for `AUTHENTICATION_TYPE=OIDC` (loses pending requests)
- [PROJQUAY-7804](https://redhat.atlassian.net/browse/PROJQUAY-7804) (`c23ab615`): `get_sso_token()` bypass for OIDC Bearer-token API clients (browser sessions unaffected)

This PR fixes the backend root cause.

## Changes

- `data/users/externaloidc.py`: Added `has_password_set()` override to `OIDCUsers` returning `False`
- `test/test_external_oidc.py`: Added `test_has_password_set_returns_false` regression test to `OIDCAuthTests`

## Test Plan

- [x] Unit tests added/updated — `OIDCAuthTests.test_has_password_set_returns_false` verifies the override
- [ ] Integration/registry tests pass
- [ ] Type checking passes
- [ ] Manual testing performed

**Manual verification steps:**
1. Configure Quay with `AUTHENTICATION_TYPE: OIDC`
2. Log in via the OIDC provider (browser flow)
3. Wait 10+ minutes
4. Attempt a sensitive operation (e.g., delete organization, manage global messages)
5. **Expected:** Operation proceeds without a password prompt or `/signin` redirect
6. **Previously:** `FreshLoginRequired` raised → UI showed password modal or redirected to `/signin`

## JIRA

https://redhat.atlassian.net/browse/PROJQUAY-10510

## Backport

- [x] Backport required: `quay-v3.17.2` (Target Version set on JIRA ticket)

## Automation

- **Session ID**: session-16fb8698-4acf-479a-8e04-9a863e4536fc