### PR TITLE
PROJQUAY-11373: ci(workflows): add agent PR metrics for DevLake

### DIFF
--- a/.github/workflows/agent-pr-metrics.yaml
+++ b/.github/workflows/agent-pr-metrics.yaml
@@ -120,10 +120,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: '1.24'
-
       - name: Compute complexity and post metrics
         env:
           GH_TOKEN: ${{ github.token }}
@@ -135,9 +131,11 @@ jobs:
 
           PR_NUMBER="${{ github.event.pull_request.number }}"
 
-          # Fetch changed .go files (exclude tests, generated, vendor, config-tool)
-          CHANGED=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
-            --paginate --jq '.[].filename' \
+          ALL_FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[].filename')
+
+          # Go: exclude tests, generated protobufs, vendor, config-tool
+          CHANGED_GO=$(echo "$ALL_FILES" \
             | grep '\.go$' \
             | grep -v '_test\.go' \
             | grep -v '\.pb\.go' \
@@ -145,32 +143,42 @@ jobs:
             | grep -v '^config-tool/' \
             | xargs -I{} sh -c 'test -f "{}" && echo "{}"' 2>/dev/null || true)
 
+          # Python: exclude test files and vendor
+          CHANGED_PY=$(echo "$ALL_FILES" \
+            | grep '\.py$' \
+            | grep -v '_test\.py' \
+            | grep -v '^vendor/' \
+            | xargs -I{} sh -c 'test -f "{}" && echo "{}"' 2>/dev/null || true)
+
+          CHANGED=$(printf '%s\n%s' "$CHANGED_GO" "$CHANGED_PY" | grep -v '^$' || true)
+
           if [ -z "$CHANGED" ]; then
             MAX_COMPLEXITY=0
             AVG_COMPLEXITY=0
             ABOVE_THRESHOLD=0
             COMPLEXITY_JSON="{}"
           else
-            go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+            pip install lizard --quiet
 
-            GOCYCLO_OUT=$(echo "$CHANGED" | xargs gocyclo 2>/dev/null || true)
+            # lizard --csv columns (no header): NLOC,CCN,token,PARAM,length,location
+            LIZARD_OUT=$(echo "$CHANGED" | xargs lizard --csv 2>/dev/null || true)
 
-            if [ -z "$GOCYCLO_OUT" ]; then
+            if [ -z "$LIZARD_OUT" ]; then
               MAX_COMPLEXITY=0
               AVG_COMPLEXITY=0
               ABOVE_THRESHOLD=0
               COMPLEXITY_JSON="{}"
             else
-              # Parse: complexity function file:line
-              MAX_COMPLEXITY=$(echo "$GOCYCLO_OUT" | awk '{print $1}' | sort -n | tail -1)
-              TOTAL=$(echo "$GOCYCLO_OUT" | awk '{s+=$1} END {print s}')
-              COUNT=$(echo "$GOCYCLO_OUT" | wc -l | tr -d ' ')
-              AVG_COMPLEXITY=$(echo "scale=2; $TOTAL / $COUNT" | bc)
-              ABOVE_THRESHOLD=$(echo "$GOCYCLO_OUT" | awk '$1 > 15 {n++} END {print n+0}')
+              # Only process data lines (start with a digit)
+              MAX_COMPLEXITY=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{print $2}' | sort -n | tail -1)
+              TOTAL=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{s+=$2} END {print s+0}')
+              COUNT=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{n++} END {print n+0}')
+              AVG_COMPLEXITY=$([ "$COUNT" -gt 0 ] && echo "scale=2; $TOTAL / $COUNT" | bc || echo "0")
+              ABOVE_THRESHOLD=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/ && $2 > 15 {n++} END {print n+0}')
 
               COMPLEXITY_JSON=$(jq -n \
-                --argjson max "$MAX_COMPLEXITY" \
-                --argjson avg "$AVG_COMPLEXITY" \
+                --argjson max "${MAX_COMPLEXITY:-0}" \
+                --argjson avg "${AVG_COMPLEXITY:-0}" \
                 --argjson above "$ABOVE_THRESHOLD" \
                 --argjson count "$COUNT" \
                 '{max_complexity: $max, avg_complexity: $avg, above_threshold: $above, functions_analyzed: $count}')

--- a/.github/workflows/agent-pr-metrics.yaml
+++ b/.github/workflows/agent-pr-metrics.yaml
@@ -63,8 +63,7 @@ jobs:
             for (const comment of [...reviewComments, ...issueComments]) {
               const author = comment.user.login;
               if (author === prAuthor) continue;
-              if (author !== 'coderabbitai[bot]' && !author.endsWith('[bot]') &&
-                  author === prAuthor) continue;
+              if (author.endsWith('[bot]') && author !== 'coderabbitai[bot]') continue;
 
               total++;
               let category;
@@ -93,14 +92,22 @@ jobs:
               description,
             };
 
-            const response = await fetch(url, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${process.env.DEVLAKE_API_KEY}`,
-              },
-              body: JSON.stringify(payload),
-            });
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 30_000);
+            let response;
+            try {
+              response = await fetch(url, {
+                method: 'POST',
+                signal: controller.signal,
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Authorization': `Bearer ${process.env.DEVLAKE_API_KEY}`,
+                },
+                body: JSON.stringify(payload),
+              });
+            } finally {
+              clearTimeout(timeout);
+            }
 
             if (!response.ok) {
               core.warning(`DevLake POST failed: ${response.status} ${await response.text()}`);
@@ -173,7 +180,10 @@ jobs:
               MAX_COMPLEXITY=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{print $2}' | sort -n | tail -1)
               TOTAL=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{s+=$2} END {print s+0}')
               COUNT=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{n++} END {print n+0}')
-              AVG_COMPLEXITY=$([ "$COUNT" -gt 0 ] && echo "scale=2; $TOTAL / $COUNT" | bc || echo "0")
+              AVG_COMPLEXITY=$(awk -v total="$TOTAL" -v count="$COUNT" 'BEGIN {
+                if (count > 0) printf "%.2f", total / count;
+                else print "0"
+              }')
               ABOVE_THRESHOLD=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/ && $2 > 15 {n++} END {print n+0}')
 
               COMPLEXITY_JSON=$(jq -n \
@@ -209,6 +219,8 @@ jobs:
             }')
 
           HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            --connect-timeout 10 \
+            --max-time 30 \
             -X POST "$URL" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${DEVLAKE_API_KEY}" \

--- a/.github/workflows/agent-pr-metrics.yaml
+++ b/.github/workflows/agent-pr-metrics.yaml
@@ -2,7 +2,7 @@ name: Agent PR Metrics
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [closed]
 
 permissions:
   contents: read
@@ -11,7 +11,7 @@ permissions:
 jobs:
   cyclomatic-complexity:
     name: Cyclomatic Complexity
-    if: github.event.pull_request.user.login == 'quay-devel'
+    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'quay-devel'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -89,12 +89,9 @@ jobs:
             --argjson count "$COUNT" \
             '{max_complexity: $max, avg_complexity: $avg, above_threshold: $above, functions_analyzed: $count}')
 
-          # Build comment body — visible table for reviewers, hidden JSON for DevLake.
-          # DevLake GitHub connection ingests this into pull_request_comments.body;
-          # Grafana queries filter by account (github-actions[bot]) and extract
-          # the agent-metrics JSON. This bot comment should be excluded from any
-          # comment-severity analysis to avoid muddying human review metrics.
-          COMMENT_BODY=$(cat <<EOF
+          # Post as PR comment — DevLake GitHub connection ingests this into
+          # pull_request_comments.body; Grafana extracts the agent-metrics JSON.
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$(cat <<EOF
           ## Cyclomatic Complexity Report
 
           | Metric | Value |
@@ -115,20 +112,6 @@ jobs:
 
           <!-- agent-metrics:${METRICS_JSON} -->
           EOF
-          )
+          )"
 
-          # Update existing comment in-place if one exists, otherwise create new.
-          # This avoids duplicate comments on each push and keeps a single entry
-          # for DevLake to ingest (one comment per PR, not one per push).
-          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --paginate --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("agent-metrics:"))) | .id' \
-            | head -1)
-
-          if [ -n "$EXISTING_COMMENT_ID" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" \
-              -X PATCH -f body="$COMMENT_BODY" --silent
-            echo "Updated complexity comment (id=${EXISTING_COMMENT_ID}) on PR #${PR_NUMBER}: max=${MAX_COMPLEXITY}"
-          else
-            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$COMMENT_BODY"
-            echo "Posted complexity comment on PR #${PR_NUMBER}: max=${MAX_COMPLEXITY}"
-          fi
+          echo "Posted complexity comment on PR #${PR_NUMBER}: max=${MAX_COMPLEXITY}"

--- a/.github/workflows/agent-pr-metrics.yaml
+++ b/.github/workflows/agent-pr-metrics.yaml
@@ -6,133 +6,21 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
-  classify-comments:
-    name: Classify PR Comments
-    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'quay-devel'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Classify and post comment metrics
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          DEVLAKE_ENDPOINT: ${{ secrets.DEVLAKE_ENDPOINT }}
-          DEVLAKE_CONNECTION_ID: ${{ secrets.DEVLAKE_CONNECTION_ID }}
-          DEVLAKE_API_KEY: ${{ secrets.DEVLAKE_API_KEY }}
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const prAuthor = context.payload.pull_request.user.login;
-
-            // Fetch all review comments and issue comments
-            const reviewComments = await github.paginate(
-              github.rest.pulls.listReviewComments,
-              { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
-            );
-            const issueComments = await github.paginate(
-              github.rest.issues.listComments,
-              { owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber }
-            );
-
-            const counts = { major: 0, minor: 0, nit: 0, suggestion: 0, question: 0, other: 0 };
-            let total = 0;
-
-            function classifyCodeRabbit(body) {
-              if (body.includes('🟠')) return 'major';
-              if (body.includes('🟡')) return 'minor';
-              return 'other';
-            }
-
-            function classifyHuman(body) {
-              const lower = body.toLowerCase();
-              const majorKw = ['bug', 'breaks', 'broken', 'wrong', 'incorrect', 'security',
-                               'vulnerability', 'crash', 'data loss', 'race condition'];
-              if (majorKw.some(k => lower.includes(k))) return 'major';
-              if (['minor', 'small', 'trivial'].some(k => lower.includes(k))) return 'minor';
-              if (['nit', 'nitpick', 'style', 'formatting', 'whitespace'].some(k => lower.includes(k))) return 'nit';
-              if (['consider', 'could', 'might want', 'suggestion', 'what about',
-                   'how about', 'alternatively'].some(k => lower.includes(k))) return 'suggestion';
-              if (['why', 'what does', 'how does', 'is this'].some(k => lower.includes(k)) ||
-                  lower.trim().endsWith('?')) return 'question';
-              return 'other';
-            }
-
-            for (const comment of [...reviewComments, ...issueComments]) {
-              const author = comment.user.login;
-              if (author === prAuthor) continue;
-              if (author.endsWith('[bot]') && author !== 'coderabbitai[bot]') continue;
-
-              total++;
-              let category;
-              if (author === 'coderabbitai[bot]') {
-                category = classifyCodeRabbit(comment.body || '');
-              } else {
-                category = classifyHuman(comment.body || '');
-              }
-              counts[category]++;
-            }
-
-            const description = JSON.stringify({ ...counts, total_comments: total });
-            const issueKey = `quay-pr-comments-${prNumber}`;
-
-            if (!process.env.DEVLAKE_ENDPOINT || !process.env.DEVLAKE_CONNECTION_ID || !process.env.DEVLAKE_API_KEY) {
-              core.warning('DEVLAKE secrets not configured — skipping POST');
-              return;
-            }
-
-            const url = `${process.env.DEVLAKE_ENDPOINT}/api/plugins/webhook/connections/${process.env.DEVLAKE_CONNECTION_ID}/issues`;
-            const payload = {
-              issueKey,
-              status: 'DONE',
-              originalStatus: 'analyzed',
-              type: 'REQUIREMENT',
-              description,
-            };
-
-            const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), 30_000);
-            let response;
-            try {
-              response = await fetch(url, {
-                method: 'POST',
-                signal: controller.signal,
-                headers: {
-                  'Content-Type': 'application/json',
-                  'Authorization': `Bearer ${process.env.DEVLAKE_API_KEY}`,
-                },
-                body: JSON.stringify(payload),
-              });
-            } finally {
-              clearTimeout(timeout);
-            }
-
-            if (!response.ok) {
-              core.warning(`DevLake POST failed: ${response.status} ${await response.text()}`);
-            } else {
-              core.info(`Posted comment metrics for PR #${prNumber}: ${description}`);
-            }
-
   cyclomatic-complexity:
     name: Cyclomatic Complexity
     if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'quay-devel'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Compute complexity and post metrics
+      - name: Compute complexity and comment on PR
         env:
           GH_TOKEN: ${{ github.token }}
-          DEVLAKE_ENDPOINT: ${{ secrets.DEVLAKE_ENDPOINT }}
-          DEVLAKE_CONNECTION_ID: ${{ secrets.DEVLAKE_CONNECTION_ID }}
-          DEVLAKE_API_KEY: ${{ secrets.DEVLAKE_API_KEY }}
         run: |
           set -euo pipefail
 
@@ -162,74 +50,68 @@ jobs:
           CHANGED=$(printf '%s\n%s' "$CHANGED_GO" "$CHANGED_PY" | grep -v '^$' || true)
 
           if [ -z "$CHANGED" ]; then
-            MAX_COMPLEXITY=0
-            AVG_COMPLEXITY=0
-            ABOVE_THRESHOLD=0
-            COMPLEXITY_JSON="{}"
-          else
-            pip install lizard --quiet
-
-            # lizard --csv columns (no header): NLOC,CCN,token,PARAM,length,location
-            LIZARD_OUT=$(echo "$CHANGED" | xargs lizard --csv 2>/dev/null || true)
-
-            if [ -z "$LIZARD_OUT" ]; then
-              MAX_COMPLEXITY=0
-              AVG_COMPLEXITY=0
-              ABOVE_THRESHOLD=0
-              COMPLEXITY_JSON="{}"
-            else
-              # Only process data lines (start with a digit)
-              MAX_COMPLEXITY=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{print $2}' | sort -n | tail -1)
-              TOTAL=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{s+=$2} END {print s+0}')
-              COUNT=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{n++} END {print n+0}')
-              AVG_COMPLEXITY=$(awk -v total="$TOTAL" -v count="$COUNT" 'BEGIN {
-                if (count > 0) printf "%.2f", total / count;
-                else print "0"
-              }')
-              ABOVE_THRESHOLD=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/ && $2 > 15 {n++} END {print n+0}')
-
-              COMPLEXITY_JSON=$(jq -n \
-                --argjson max "${MAX_COMPLEXITY:-0}" \
-                --argjson avg "${AVG_COMPLEXITY:-0}" \
-                --argjson above "$ABOVE_THRESHOLD" \
-                --argjson count "$COUNT" \
-                '{max_complexity: $max, avg_complexity: $avg, above_threshold: $above, functions_analyzed: $count}')
-            fi
-          fi
-
-          echo "Complexity results: $COMPLEXITY_JSON"
-
-          if [ -z "${DEVLAKE_ENDPOINT:-}" ] || [ -z "${DEVLAKE_CONNECTION_ID:-}" ] || [ -z "${DEVLAKE_API_KEY:-}" ]; then
-            echo "::warning::DEVLAKE secrets not configured — skipping POST"
+            echo "No Go/Python source files changed — skipping"
             exit 0
           fi
 
-          ISSUE_KEY="quay-pr-complexity-${PR_NUMBER}"
-          URL="${DEVLAKE_ENDPOINT}/api/plugins/webhook/connections/${DEVLAKE_CONNECTION_ID}/issues"
+          pip install lizard --quiet
 
-          PAYLOAD=$(jq -n \
-            --arg issueKey "$ISSUE_KEY" \
-            --arg description "$COMPLEXITY_JSON" \
-            --argjson storyPoint "${MAX_COMPLEXITY:-0}" \
-            '{
-              issueKey: $issueKey,
-              status: "DONE",
-              originalStatus: "analyzed",
-              type: "REQUIREMENT",
-              description: $description,
-              storyPoint: $storyPoint
-            }')
+          # lizard --csv columns (no header): NLOC,CCN,token,PARAM,length,location
+          LIZARD_OUT=$(echo "$CHANGED" | xargs lizard --csv 2>/dev/null || true)
 
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            --connect-timeout 10 \
-            --max-time 30 \
-            -X POST "$URL" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${DEVLAKE_API_KEY}" \
-            -d "$PAYLOAD")
-
-          if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
-            echo "::warning::DevLake POST failed with HTTP ${HTTP_STATUS}"
-          else
-            echo "Posted complexity metrics for PR #${PR_NUMBER}: max=${MAX_COMPLEXITY:-0}"
+          if [ -z "$LIZARD_OUT" ]; then
+            echo "lizard produced no output — skipping"
+            exit 0
           fi
+
+          # Only process data lines (start with a digit)
+          MAX_COMPLEXITY=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{print $2}' | sort -n | tail -1)
+          TOTAL=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{s+=$2} END {print s+0}')
+          COUNT=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/{n++} END {print n+0}')
+          AVG_COMPLEXITY=$(awk -v total="$TOTAL" -v count="$COUNT" 'BEGIN {
+            if (count > 0) printf "%.2f", total / count;
+            else print "0"
+          }')
+          ABOVE_THRESHOLD=$(echo "$LIZARD_OUT" | awk -F',' '/^[0-9]/ && $2 > 15 {n++} END {print n+0}')
+
+          # Build the top-5 most complex functions table
+          TOP_FUNCTIONS=$(echo "$LIZARD_OUT" \
+            | awk -F',' '/^[0-9]/{print $2","$6}' \
+            | sort -t',' -k1 -nr \
+            | head -5 \
+            | awk -F',' '{printf "| %s | %s |\n", $2, $1}')
+
+          # Build embedded JSON for DevLake ingestion via GitHub connection
+          METRICS_JSON=$(jq -cn \
+            --argjson max "${MAX_COMPLEXITY:-0}" \
+            --argjson avg "${AVG_COMPLEXITY:-0}" \
+            --argjson above "$ABOVE_THRESHOLD" \
+            --argjson count "$COUNT" \
+            '{max_complexity: $max, avg_complexity: $avg, above_threshold: $above, functions_analyzed: $count}')
+
+          # Post as PR comment — DevLake GitHub connection ingests this into
+          # pull_request_comments.body; Grafana extracts the agent-metrics JSON.
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$(cat <<EOF
+          ## Cyclomatic Complexity Report
+
+          | Metric | Value |
+          |--------|-------|
+          | Functions analyzed | ${COUNT} |
+          | Max complexity | ${MAX_COMPLEXITY} |
+          | Avg complexity | ${AVG_COMPLEXITY} |
+          | Above threshold (>15) | ${ABOVE_THRESHOLD} |
+
+          <details>
+          <summary>Top 5 most complex functions</summary>
+
+          | Function | CCN |
+          |----------|-----|
+          ${TOP_FUNCTIONS}
+
+          </details>
+
+          <!-- agent-metrics:${METRICS_JSON} -->
+          EOF
+          )"
+
+          echo "Posted complexity comment on PR #${PR_NUMBER}: max=${MAX_COMPLEXITY}"

--- a/.github/workflows/agent-pr-metrics.yaml
+++ b/.github/workflows/agent-pr-metrics.yaml
@@ -117,6 +117,8 @@ jobs:
       pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/agent-pr-metrics.yaml
+++ b/.github/workflows/agent-pr-metrics.yaml
@@ -2,7 +2,7 @@ name: Agent PR Metrics
 
 on:
   pull_request:
-    types: [closed]
+    types: [opened, synchronize]
 
 permissions:
   contents: read
@@ -11,7 +11,7 @@ permissions:
 jobs:
   cyclomatic-complexity:
     name: Cyclomatic Complexity
-    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'quay-devel'
+    if: github.event.pull_request.user.login == 'quay-devel'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -89,9 +89,12 @@ jobs:
             --argjson count "$COUNT" \
             '{max_complexity: $max, avg_complexity: $avg, above_threshold: $above, functions_analyzed: $count}')
 
-          # Post as PR comment — DevLake GitHub connection ingests this into
-          # pull_request_comments.body; Grafana extracts the agent-metrics JSON.
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$(cat <<EOF
+          # Build comment body — visible table for reviewers, hidden JSON for DevLake.
+          # DevLake GitHub connection ingests this into pull_request_comments.body;
+          # Grafana queries filter by account (github-actions[bot]) and extract
+          # the agent-metrics JSON. This bot comment should be excluded from any
+          # comment-severity analysis to avoid muddying human review metrics.
+          COMMENT_BODY=$(cat <<EOF
           ## Cyclomatic Complexity Report
 
           | Metric | Value |
@@ -112,6 +115,20 @@ jobs:
 
           <!-- agent-metrics:${METRICS_JSON} -->
           EOF
-          )"
+          )
 
-          echo "Posted complexity comment on PR #${PR_NUMBER}: max=${MAX_COMPLEXITY}"
+          # Update existing comment in-place if one exists, otherwise create new.
+          # This avoids duplicate comments on each push and keeps a single entry
+          # for DevLake to ingest (one comment per PR, not one per push).
+          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("agent-metrics:"))) | .id' \
+            | head -1)
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" \
+              -X PATCH -f body="$COMMENT_BODY" --silent
+            echo "Updated complexity comment (id=${EXISTING_COMMENT_ID}) on PR #${PR_NUMBER}: max=${MAX_COMPLEXITY}"
+          else
+            gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$COMMENT_BODY"
+            echo "Posted complexity comment on PR #${PR_NUMBER}: max=${MAX_COMPLEXITY}"
+          fi

--- a/.github/workflows/agent-pr-metrics.yaml
+++ b/.github/workflows/agent-pr-metrics.yaml
@@ -1,0 +1,211 @@
+name: Agent PR Metrics
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  classify-comments:
+    name: Classify PR Comments
+    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'quay-devel'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Classify and post comment metrics
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DEVLAKE_ENDPOINT: ${{ secrets.DEVLAKE_ENDPOINT }}
+          DEVLAKE_CONNECTION_ID: ${{ secrets.DEVLAKE_CONNECTION_ID }}
+          DEVLAKE_API_KEY: ${{ secrets.DEVLAKE_API_KEY }}
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const prAuthor = context.payload.pull_request.user.login;
+
+            // Fetch all review comments and issue comments
+            const reviewComments = await github.paginate(
+              github.rest.pulls.listReviewComments,
+              { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+            );
+            const issueComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber }
+            );
+
+            const counts = { major: 0, minor: 0, nit: 0, suggestion: 0, question: 0, other: 0 };
+            let total = 0;
+
+            function classifyCodeRabbit(body) {
+              if (body.includes('🟠')) return 'major';
+              if (body.includes('🟡')) return 'minor';
+              return 'other';
+            }
+
+            function classifyHuman(body) {
+              const lower = body.toLowerCase();
+              const majorKw = ['bug', 'breaks', 'broken', 'wrong', 'incorrect', 'security',
+                               'vulnerability', 'crash', 'data loss', 'race condition'];
+              if (majorKw.some(k => lower.includes(k))) return 'major';
+              if (['minor', 'small', 'trivial'].some(k => lower.includes(k))) return 'minor';
+              if (['nit', 'nitpick', 'style', 'formatting', 'whitespace'].some(k => lower.includes(k))) return 'nit';
+              if (['consider', 'could', 'might want', 'suggestion', 'what about',
+                   'how about', 'alternatively'].some(k => lower.includes(k))) return 'suggestion';
+              if (['why', 'what does', 'how does', 'is this'].some(k => lower.includes(k)) ||
+                  lower.trim().endsWith('?')) return 'question';
+              return 'other';
+            }
+
+            for (const comment of [...reviewComments, ...issueComments]) {
+              const author = comment.user.login;
+              if (author === prAuthor) continue;
+              if (author !== 'coderabbitai[bot]' && !author.endsWith('[bot]') &&
+                  author === prAuthor) continue;
+
+              total++;
+              let category;
+              if (author === 'coderabbitai[bot]') {
+                category = classifyCodeRabbit(comment.body || '');
+              } else {
+                category = classifyHuman(comment.body || '');
+              }
+              counts[category]++;
+            }
+
+            const description = JSON.stringify({ ...counts, total_comments: total });
+            const issueKey = `quay-pr-comments-${prNumber}`;
+
+            if (!process.env.DEVLAKE_ENDPOINT || !process.env.DEVLAKE_CONNECTION_ID || !process.env.DEVLAKE_API_KEY) {
+              core.warning('DEVLAKE secrets not configured — skipping POST');
+              return;
+            }
+
+            const url = `${process.env.DEVLAKE_ENDPOINT}/api/plugins/webhook/connections/${process.env.DEVLAKE_CONNECTION_ID}/issues`;
+            const payload = {
+              issueKey,
+              status: 'DONE',
+              originalStatus: 'analyzed',
+              type: 'REQUIREMENT',
+              description,
+            };
+
+            const response = await fetch(url, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${process.env.DEVLAKE_API_KEY}`,
+              },
+              body: JSON.stringify(payload),
+            });
+
+            if (!response.ok) {
+              core.warning(`DevLake POST failed: ${response.status} ${await response.text()}`);
+            } else {
+              core.info(`Posted comment metrics for PR #${prNumber}: ${description}`);
+            }
+
+  cyclomatic-complexity:
+    name: Cyclomatic Complexity
+    if: github.event.pull_request.merged == true && github.event.pull_request.user.login == 'quay-devel'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: '1.24'
+
+      - name: Compute complexity and post metrics
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEVLAKE_ENDPOINT: ${{ secrets.DEVLAKE_ENDPOINT }}
+          DEVLAKE_CONNECTION_ID: ${{ secrets.DEVLAKE_CONNECTION_ID }}
+          DEVLAKE_API_KEY: ${{ secrets.DEVLAKE_API_KEY }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          # Fetch changed .go files (exclude tests, generated, vendor, config-tool)
+          CHANGED=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[].filename' \
+            | grep '\.go$' \
+            | grep -v '_test\.go' \
+            | grep -v '\.pb\.go' \
+            | grep -v '^vendor/' \
+            | grep -v '^config-tool/' \
+            | xargs -I{} sh -c 'test -f "{}" && echo "{}"' 2>/dev/null || true)
+
+          if [ -z "$CHANGED" ]; then
+            MAX_COMPLEXITY=0
+            AVG_COMPLEXITY=0
+            ABOVE_THRESHOLD=0
+            COMPLEXITY_JSON="{}"
+          else
+            go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+
+            GOCYCLO_OUT=$(echo "$CHANGED" | xargs gocyclo 2>/dev/null || true)
+
+            if [ -z "$GOCYCLO_OUT" ]; then
+              MAX_COMPLEXITY=0
+              AVG_COMPLEXITY=0
+              ABOVE_THRESHOLD=0
+              COMPLEXITY_JSON="{}"
+            else
+              # Parse: complexity function file:line
+              MAX_COMPLEXITY=$(echo "$GOCYCLO_OUT" | awk '{print $1}' | sort -n | tail -1)
+              TOTAL=$(echo "$GOCYCLO_OUT" | awk '{s+=$1} END {print s}')
+              COUNT=$(echo "$GOCYCLO_OUT" | wc -l | tr -d ' ')
+              AVG_COMPLEXITY=$(echo "scale=2; $TOTAL / $COUNT" | bc)
+              ABOVE_THRESHOLD=$(echo "$GOCYCLO_OUT" | awk '$1 > 15 {n++} END {print n+0}')
+
+              COMPLEXITY_JSON=$(jq -n \
+                --argjson max "$MAX_COMPLEXITY" \
+                --argjson avg "$AVG_COMPLEXITY" \
+                --argjson above "$ABOVE_THRESHOLD" \
+                --argjson count "$COUNT" \
+                '{max_complexity: $max, avg_complexity: $avg, above_threshold: $above, functions_analyzed: $count}')
+            fi
+          fi
+
+          echo "Complexity results: $COMPLEXITY_JSON"
+
+          if [ -z "${DEVLAKE_ENDPOINT:-}" ] || [ -z "${DEVLAKE_CONNECTION_ID:-}" ] || [ -z "${DEVLAKE_API_KEY:-}" ]; then
+            echo "::warning::DEVLAKE secrets not configured — skipping POST"
+            exit 0
+          fi
+
+          ISSUE_KEY="quay-pr-complexity-${PR_NUMBER}"
+          URL="${DEVLAKE_ENDPOINT}/api/plugins/webhook/connections/${DEVLAKE_CONNECTION_ID}/issues"
+
+          PAYLOAD=$(jq -n \
+            --arg issueKey "$ISSUE_KEY" \
+            --arg description "$COMPLEXITY_JSON" \
+            --argjson storyPoint "${MAX_COMPLEXITY:-0}" \
+            '{
+              issueKey: $issueKey,
+              status: "DONE",
+              originalStatus: "analyzed",
+              type: "REQUIREMENT",
+              description: $description,
+              storyPoint: $storyPoint
+            }')
+
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "$URL" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${DEVLAKE_API_KEY}" \
+            -d "$PAYLOAD")
+
+          if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+            echo "::warning::DevLake POST failed with HTTP ${HTTP_STATUS}"
+          else
+            echo "Posted complexity metrics for PR #${PR_NUMBER}: max=${MAX_COMPLEXITY:-0}"
+          fi

--- a/.github/workflows/agent-pr-metrics.yaml
+++ b/.github/workflows/agent-pr-metrics.yaml
@@ -150,10 +150,12 @@ jobs:
             | grep -v '^config-tool/' \
             | xargs -I{} sh -c 'test -f "{}" && echo "{}"' 2>/dev/null || true)
 
-          # Python: exclude test files and vendor
+          # Python: exclude test files (test_*.py and *_test.py) and vendor
           CHANGED_PY=$(echo "$ALL_FILES" \
             | grep '\.py$' \
             | grep -v '_test\.py' \
+            | grep -v '/test_[^/]*\.py$' \
+            | grep -v '^test_[^/]*\.py$' \
             | grep -v '^vendor/' \
             | xargs -I{} sh -c 'test -f "{}" && echo "{}"' 2>/dev/null || true)
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/agent-pr-metrics.yaml` that fires on merged PRs from `quay-devel`
- Single job (`cyclomatic-complexity`): runs `lizard` on changed `.go` and `.py` files, computes max/avg complexity and count above threshold (15), and posts results as a **PR comment**
- Comment classification is handled natively by DevLake's GitHub connection — no custom job needed

## Root Cause / Rationale
[PROJQUAY-11373](https://redhat.atlassian.net/browse/PROJQUAY-11373) tracks pilot program metrics for the agentic SDLC — specifically code complexity written by the agent. This workflow surfaces those metrics as PR comments that DevLake ingests via its GitHub connection, making them queryable in Grafana dashboards.

No `DEVLAKE_*` repository secrets are required — the workflow uses only the built-in `github.token`.

## Changes
- `.github/workflows/agent-pr-metrics.yaml` (new file)
  - Trigger: `pull_request` type `closed`, guarded to `merged == true && user.login == 'quay-devel'`
  - `cyclomatic-complexity` job: checks out code (`persist-credentials: false`), filters changed `.go` and `.py` files (excluding tests, vendor, protobufs), runs `lizard --csv`, and posts a PR comment via `gh pr comment`
  - Comment includes a human-readable markdown table and an embedded HTML comment with JSON for DevLake/Grafana ingestion
  - Skips gracefully (no comment, no failure) if no Go/Python source files were changed

## Example comment

The workflow posts a comment like this on each merged agent PR:

> ## Cyclomatic Complexity Report
>
> | Metric | Value |
> |--------|-------|
> | Functions analyzed | 12 |
> | Max complexity | 18 |
> | Avg complexity | 6.42 |
> | Above threshold (>15) | 1 |
>
> <details>
> <summary>Top 5 most complex functions</summary>
>
> | Function | CCN |
> |----------|-----|
> |  endpoints/api/repository.py:fetch_repository | 18 |
> |  data/model/repository.py:create_repository | 11 |
> |  workers/gc/gcworker.py:_garbage_collect | 9 |
> |  auth/permissions.py:check_access | 7 |
> |  util/config/validator.py:validate_config | 5 |
>
> </details>

The comment also includes an invisible HTML comment with structured JSON that DevLake ingests via the GitHub connection:

\`\`\`html
<!-- agent-metrics:{"max_complexity":18,"avg_complexity":6.42,"above_threshold":1,"functions_analyzed":12} -->
\`\`\`

## Test Plan
- [ ] Unit tests added/updated
- [ ] Registry tests pass (\`make registry-test\`)
- [ ] Type checking passes (\`make types-test\`)
- [x] Manual testing performed — lizard/awk/jq pipeline validated locally (see below)
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

<details>
<summary>Local pipeline validation</summary>

**lizard + awk + jq pipeline** (the core of the \`cyclomatic-complexity\` job):

\`\`\`
$ echo /tmp/test_complexity.py | xargs lizard --csv
2,1,...  simple_func
15,8,... moderate_func
6,3,...  another_func

MAX_COMPLEXITY = 8
AVG_COMPLEXITY = 4.00
ABOVE_THRESHOLD = 0
COUNT = 3

COMPLEXITY_JSON = {
  \"max_complexity\": 8,
  \"avg_complexity\": 4.00,
  \"above_threshold\": 0,
  \"functions_analyzed\": 3
}
\`\`\`

**YAML-only PR path** (this PR's actual behaviour): \`CHANGED=<none>\` → no comment posted, exits cleanly.

</details>

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11373

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-22bbf20d-313e-4740-ad1c-43b71b5e4326