### PR TITLE
PROJQUAY-11499: test(workers): add integration tests for GC + quota recalculation

### DIFF
--- a/workers/test/gc_quota_test_helpers.py
+++ b/workers/test/gc_quota_test_helpers.py
@@ -1,0 +1,258 @@
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+from app import storage
+from data.database import (
+    ImageStorageLocation,
+    QuotaNamespaceSize,
+    QuotaRepositorySize,
+    Tag,
+)
+from data.model.blob import store_blob_record_and_temp_link
+from data.model.namespacequota import get_namespace_size
+from data.model.oci.manifest import get_or_create_manifest
+from data.model.oci.tag import create_or_update_tag
+from data.model.organization import create_organization
+from data.model.quota import get_namespace_size as get_namespace_size_row
+from data.model.quota import get_repository_size as get_repository_size_row
+from data.model.quota import run_backfill
+from data.model.repository import create_repository, get_repository_size
+from data.model.storage import get_layer_path
+from data.model.user import get_namespace_user_by_user_id, get_user
+from digest.digest_tools import sha256_digest
+from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
+from util.bytes import Bytes
+from workers.gc.gcworker import GarbageCollectionWorker
+from workers.quotatotalworker import QuotaTotalWorker
+
+CONFIG_LAYER_JSON = json.dumps(
+    {
+        "config": {},
+        "rootfs": {"type": "layers", "diff_ids": []},
+        "history": [],
+    }
+)
+
+
+def create_manifest_with_blobs(repository, blobs):
+    """
+    Create a test manifest with specified blobs.
+
+    Args:
+        repository: Repository object to create manifest in
+        blobs: List of blob content strings
+
+    Returns:
+        Created manifest object
+    """
+    remote_digest = sha256_digest(b"something")
+    builder = DockerSchema2ManifestBuilder()
+    namespace = get_namespace_user_by_user_id(repository.namespace_user)
+    _, config_digest = _populate_blob(CONFIG_LAYER_JSON, namespace.username, repository.name)
+    builder.set_config_digest(config_digest, len(CONFIG_LAYER_JSON.encode("utf-8")))
+    builder.add_layer(remote_digest, 1234, urls=["http://hello/world"])
+    for blob in blobs:
+        _, blob_digest = _populate_blob(blob, namespace.username, repository.name)
+        builder.add_layer(blob_digest, len(blob))
+
+    manifest = builder.build()
+    created = get_or_create_manifest(repository.id, manifest, storage)
+    assert created
+    return created.manifest
+
+
+def create_tag_for_manifest(repository, manifest, tag_name, expiration_ms=None):
+    """
+    Create a tag pointing to a manifest.
+
+    Args:
+        repository: Repository object
+        manifest: Manifest object to tag
+        tag_name: Name of the tag
+        expiration_ms: Optional expiration time in milliseconds
+
+    Returns:
+        Created tag object
+    """
+    tag = create_or_update_tag(
+        repository.id,
+        tag_name,
+        manifest_digest=manifest.digest,
+        lifetime_end_ms=expiration_ms,
+    )
+    return tag
+
+
+def delete_tag_by_name(repository, tag_name):
+    """
+    Delete a tag by name.
+
+    Args:
+        repository: Repository object
+        tag_name: Name of tag to delete
+
+    Returns:
+        True if tag was deleted, False otherwise
+    """
+    try:
+        count = Tag.delete().where(Tag.repository == repository, Tag.name == tag_name).execute()
+        return count > 0
+    except Tag.DoesNotExist:
+        return False
+
+
+def run_gc_worker(skip_lock=True):
+    """
+    Execute the garbage collection worker.
+
+    Args:
+        skip_lock: If True, skip locking for testing
+
+    Returns:
+        GarbageCollectionWorker instance
+    """
+    worker = GarbageCollectionWorker()
+    worker._garbage_collection_repos(skip_lock_for_testing=skip_lock)
+    return worker
+
+
+def run_quota_worker():
+    """
+    Execute the quota total worker to recalculate quotas.
+
+    Returns:
+        QuotaTotalWorker instance
+    """
+    worker = QuotaTotalWorker()
+    worker.backfill()
+    return worker
+
+
+def get_namespace_quota(org_or_user):
+    """
+    Get the current quota size for a namespace.
+
+    Args:
+        org_or_user: Organization or User object
+
+    Returns:
+        Quota size in bytes, or 0 if not found
+    """
+    quota_row = get_namespace_size_row(org_or_user.id)
+    return quota_row.size_bytes if quota_row else 0
+
+
+def get_repo_quota(repository):
+    """
+    Get the current quota size for a repository.
+
+    Args:
+        repository: Repository object
+
+    Returns:
+        Quota size in bytes, or 0 if not found
+    """
+    quota_row = get_repository_size_row(repository.id)
+    return quota_row.size_bytes if quota_row else 0
+
+
+def set_namespace_quota_limit(org_or_user, limit_bytes):
+    """
+    Set quota limit for a namespace (organization or user).
+
+    This is a placeholder - actual implementation would set the quota limit
+    in the appropriate table.
+
+    Args:
+        org_or_user: Organization or User object
+        limit_bytes: Quota limit in bytes
+    """
+    # TODO: Implement actual quota limit setting if needed for tests
+    pass
+
+
+def expire_tag(repository, tag_name):
+    """
+    Expire a tag by setting its lifetime_end_ms to the past.
+
+    Args:
+        repository: Repository object
+        tag_name: Name of tag to expire
+
+    Returns:
+        True if tag was expired, False otherwise
+    """
+    try:
+        past_time = int((time.time() - 3600) * 1000)  # 1 hour ago
+        count = (
+            Tag.update(lifetime_end_ms=past_time)
+            .where(Tag.repository == repository, Tag.name == tag_name)
+            .execute()
+        )
+        return count > 0
+    except Tag.DoesNotExist:
+        return False
+
+
+def calculate_expected_size(*blobs):
+    """
+    Calculate expected size of blobs including config layer.
+
+    Args:
+        *blobs: Variable number of blob content strings
+
+    Returns:
+        Total size in bytes
+    """
+    size = len(CONFIG_LAYER_JSON)
+    for blob in blobs:
+        size += len(blob)
+    return size
+
+
+def _populate_blob(content, namespace_name, repository_name):
+    """
+    Store a blob in storage.
+
+    Args:
+        content: Blob content (string or bytes)
+        namespace_name: Namespace name
+        repository_name: Repository name
+
+    Returns:
+        Tuple of (blob object, digest)
+    """
+    content = Bytes.for_string_or_unicode(content).as_encoded_str()
+    digest = str(sha256_digest(content))
+    location = ImageStorageLocation.get(name="local_us")
+    blob = store_blob_record_and_temp_link(
+        namespace_name, repository_name, digest, location, len(content), 120
+    )
+    storage.put_content(["local_us"], get_layer_path(blob), content)
+    return blob, digest
+
+
+def enable_quota_management():
+    """
+    Context manager to enable quota management for testing.
+
+    Usage:
+        with enable_quota_management():
+            # quota management is enabled here
+    """
+    return patch("data.model.quota.features", MagicMock(QUOTA_MANAGEMENT=True))
+
+
+def enable_gc_and_quota():
+    """
+    Context manager to enable both GC and quota management for testing.
+
+    Usage:
+        with enable_gc_and_quota():
+            # both features are enabled here
+    """
+    return patch(
+        "data.model.gc.features",
+        MagicMock(QUOTA_MANAGEMENT=True, GARBAGE_COLLECTION=True),
+    )

--- a/workers/test/gc_quota_test_helpers.py
+++ b/workers/test/gc_quota_test_helpers.py
@@ -19,7 +19,7 @@ from data.model.namespacequota import (
     get_namespace_size,
 )
 from data.model.oci.manifest import get_or_create_manifest
-from data.model.oci.tag import find_repository_with_garbage, get_tag, retarget_tag
+from data.model.oci.tag import find_repository_with_garbage, retarget_tag
 from data.model.organization import create_organization
 from data.model.quota import get_namespace_size as get_namespace_size_row
 from data.model.quota import get_repository_size as get_repository_size_row
@@ -85,7 +85,11 @@ def create_tag_for_manifest(repository, manifest, tag_name, expiration_ms=None):
     tag = retarget_tag(tag_name, manifest.id, raise_on_error=True)
     if expiration_ms is not None:
         Tag.update(lifetime_end_ms=expiration_ms).where(Tag.id == tag.id).execute()
-        tag = get_tag(repository.id, tag_name)
+        # Reflect the new expiration on the returned object directly. Reloading
+        # via get_tag would apply an alive-only filter and return None for a
+        # tag expired in the past, dropping the created tag's ID that callers
+        # rely on (e.g. when seeding an already-expired GC root).
+        tag.lifetime_end_ms = expiration_ms
     return tag
 
 

--- a/workers/test/gc_quota_test_helpers.py
+++ b/workers/test/gc_quota_test_helpers.py
@@ -19,7 +19,7 @@ from data.model.namespacequota import (
     get_namespace_size,
 )
 from data.model.oci.manifest import get_or_create_manifest
-from data.model.oci.tag import find_repository_with_garbage, retarget_tag
+from data.model.oci.tag import find_repository_with_garbage, get_tag, retarget_tag
 from data.model.organization import create_organization
 from data.model.quota import get_namespace_size as get_namespace_size_row
 from data.model.quota import get_repository_size as get_repository_size_row
@@ -251,7 +251,11 @@ def expire_tag(repository, tag_name):
     try:
         past_time = int((time.time() - 3600) * 1000)  # 1 hour ago
 
-        target = Tag.select().where(Tag.repository == repository, Tag.name == tag_name).first()
+        # Resolve the *live* tag by name: after retarget_tag the repository can
+        # hold an expired historical row alongside the live row with the same
+        # name, and an unordered select could pick the historical one and expire
+        # the wrong manifest. get_tag applies the alive-only filter.
+        target = get_tag(repository.id, tag_name)
         if target is None:
             return False
 

--- a/workers/test/gc_quota_test_helpers.py
+++ b/workers/test/gc_quota_test_helpers.py
@@ -7,10 +7,16 @@ from data.database import (
     ImageStorageLocation,
     QuotaNamespaceSize,
     QuotaRepositorySize,
+    QuotaTypes,
     Tag,
 )
 from data.model.blob import store_blob_record_and_temp_link
-from data.model.namespacequota import get_namespace_size
+from data.model.namespacequota import (
+    check_limits,
+    create_namespace_quota,
+    create_namespace_quota_limit,
+    get_namespace_size,
+)
 from data.model.oci.manifest import get_or_create_manifest
 from data.model.oci.tag import create_or_update_tag
 from data.model.organization import create_organization
@@ -157,19 +163,44 @@ def get_repo_quota(repository):
     return quota_row.size_bytes if quota_row else 0
 
 
-def set_namespace_quota_limit(org_or_user, limit_bytes):
+def set_namespace_quota_limit(org_or_user, limit_bytes, warning_percent=80, reject_percent=100):
     """
-    Set quota limit for a namespace (organization or user).
+    Persist a real quota limit for a namespace (organization or user).
 
-    This is a placeholder - actual implementation would set the quota limit
-    in the appropriate table.
+    Creates a UserOrganizationQuota row with the given limit and, unless
+    disabled, the warning/reject QuotaLimits thresholds, so that the actual
+    quota enforcement state can be asserted via get_namespace_quota_severity.
 
     Args:
         org_or_user: Organization or User object
         limit_bytes: Quota limit in bytes
+        warning_percent: Percent of the limit at which a warning fires
+            (pass None to skip creating the warning threshold)
+        reject_percent: Percent of the limit at which pushes are rejected
+            (pass None to skip creating the reject threshold)
+
+    Returns:
+        The created UserOrganizationQuota row
     """
-    # TODO: Implement actual quota limit setting if needed for tests
-    pass
+    quota = create_namespace_quota(org_or_user, limit_bytes)
+    if warning_percent is not None:
+        create_namespace_quota_limit(quota, QuotaTypes.WARNING, warning_percent)
+    if reject_percent is not None:
+        create_namespace_quota_limit(quota, QuotaTypes.REJECT, reject_percent)
+    return quota
+
+
+def get_namespace_quota_severity(org_or_user):
+    """
+    Return the current quota enforcement severity for a namespace based on its
+    real persisted usage and configured limits.
+
+    Returns:
+        QuotaTypes.REJECT, QuotaTypes.WARNING, or None depending on how the
+        current namespace size compares to the configured quota thresholds.
+    """
+    namespace_size = get_namespace_size(org_or_user.username)
+    return check_limits(org_or_user.username, namespace_size)["severity_level"]
 
 
 def expire_tag(repository, tag_name):

--- a/workers/test/gc_quota_test_helpers.py
+++ b/workers/test/gc_quota_test_helpers.py
@@ -18,7 +18,7 @@ from data.model.namespacequota import (
     get_namespace_size,
 )
 from data.model.oci.manifest import get_or_create_manifest
-from data.model.oci.tag import create_or_update_tag
+from data.model.oci.tag import get_tag, retarget_tag
 from data.model.organization import create_organization
 from data.model.quota import get_namespace_size as get_namespace_size_row
 from data.model.quota import get_repository_size as get_repository_size_row
@@ -81,12 +81,10 @@ def create_tag_for_manifest(repository, manifest, tag_name, expiration_ms=None):
     Returns:
         Created tag object
     """
-    tag = create_or_update_tag(
-        repository.id,
-        tag_name,
-        manifest_digest=manifest.digest,
-        lifetime_end_ms=expiration_ms,
-    )
+    tag = retarget_tag(tag_name, manifest.id, raise_on_error=True)
+    if expiration_ms is not None:
+        Tag.update(lifetime_end_ms=expiration_ms).where(Tag.id == tag.id).execute()
+        tag = get_tag(repository.id, tag_name)
     return tag
 
 

--- a/workers/test/gc_quota_test_helpers.py
+++ b/workers/test/gc_quota_test_helpers.py
@@ -9,6 +9,7 @@ from data.database import (
     QuotaRepositorySize,
     QuotaTypes,
     Tag,
+    User,
 )
 from data.model.blob import store_blob_record_and_temp_link
 from data.model.namespacequota import (
@@ -18,7 +19,7 @@ from data.model.namespacequota import (
     get_namespace_size,
 )
 from data.model.oci.manifest import get_or_create_manifest
-from data.model.oci.tag import get_tag, retarget_tag
+from data.model.oci.tag import find_repository_with_garbage, get_tag, retarget_tag
 from data.model.organization import create_organization
 from data.model.quota import get_namespace_size as get_namespace_size_row
 from data.model.quota import get_repository_size as get_repository_size_row
@@ -108,7 +109,15 @@ def delete_tag_by_name(repository, tag_name):
 
 def run_gc_worker(skip_lock=True):
     """
-    Execute the garbage collection worker.
+    Execute the garbage collection worker deterministically.
+
+    The GC worker normally (1) selects a *random* namespace GC policy via
+    ``get_random_gc_policy`` and (2) collects at most one repository per
+    invocation. That is unusable for deterministic tests. Tests make expired
+    tags immediately collectable by dropping the owning namespace's
+    ``removed_tag_expiration_s`` to 0 (see ``expire_tag``), so here we force the
+    worker onto the 0-second policy and loop until no repository has
+    collectable garbage left under that policy.
 
     Args:
         skip_lock: If True, skip locking for testing
@@ -117,7 +126,13 @@ def run_gc_worker(skip_lock=True):
         GarbageCollectionWorker instance
     """
     worker = GarbageCollectionWorker()
-    worker._garbage_collection_repos(skip_lock_for_testing=skip_lock)
+    with patch("workers.gc.gcworker.get_random_gc_policy", return_value=0):
+        # Each call collects at most one repository; drain them all. The bound
+        # is a safety net against an unexpected non-terminating condition.
+        for _ in range(1000):
+            if find_repository_with_garbage(0) is None:
+                break
+            worker._garbage_collection_repos(skip_lock_for_testing=skip_lock)
     return worker
 
 
@@ -203,23 +218,51 @@ def get_namespace_quota_severity(org_or_user):
 
 def expire_tag(repository, tag_name):
     """
-    Expire a tag by setting its lifetime_end_ms to the past.
+    Expire a tag and make its manifest immediately eligible for GC.
+
+    Expires the named tag *and* every other tag that still references the same
+    manifest, then drops the owning namespace's removed_tag_expiration_s to 0.
+
+    Expiring all tags on the manifest is required because get_or_create_manifest
+    creates a temporary hidden "$temp-*" tag (with a short future expiration) to
+    protect a freshly-pushed manifest. In real usage that temp tag expires soon
+    after the push and a later GC pass collects the now-unreferenced manifest;
+    here we simulate that elapsed time so the manifest becomes fully
+    unreferenced and its blobs are collectable in a single GC run. Only tags for
+    this specific manifest are touched, so other manifests in the repository are
+    unaffected.
+
+    GC only collects tags expired *beyond* the namespace's expiration window
+    (default 14 days); setting the window to 0 means a tag expired even one
+    second ago is past the window and collectable on the next GC run (see
+    find_repository_with_garbage / run_gc_worker).
 
     Args:
         repository: Repository object
         tag_name: Name of tag to expire
 
     Returns:
-        True if tag was expired, False otherwise
+        True if the tag was found and expired, False otherwise
     """
     try:
         past_time = int((time.time() - 3600) * 1000)  # 1 hour ago
-        count = (
-            Tag.update(lifetime_end_ms=past_time)
-            .where(Tag.repository == repository, Tag.name == tag_name)
-            .execute()
-        )
-        return count > 0
+
+        target = Tag.select().where(Tag.repository == repository, Tag.name == tag_name).first()
+        if target is None:
+            return False
+
+        # Expire the named tag along with any temporary/hidden tag protecting
+        # the same manifest.
+        Tag.update(lifetime_end_ms=past_time).where(
+            Tag.repository == repository, Tag.manifest == target.manifest_id
+        ).execute()
+
+        # Collapse the namespace's expiration window so the just-expired tags
+        # are past it and can be collected immediately.
+        User.update(removed_tag_expiration_s=0).where(
+            User.id == repository.namespace_user_id
+        ).execute()
+        return True
     except Tag.DoesNotExist:
         return False
 

--- a/workers/test/test_gc_quota_interaction.py
+++ b/workers/test/test_gc_quota_interaction.py
@@ -1,0 +1,515 @@
+"""
+Integration tests for GC + Quota Recalculation Worker Interaction.
+
+These tests verify the critical workflow:
+    fill quota → delete content → run GC → recalculate quota → verify quota is freed
+
+Tests ensure that:
+- Quota is recalculated correctly after GC runs
+- Users can push new images after deleting old content and running GC
+- Quota warning thresholds are cleared after GC frees space
+- Shared blob deduplication works correctly in quota calculations after GC
+- Orphaned blobs are removed by GC and quota is updated accordingly
+- Concurrent operations (e.g., push during GC) maintain quota consistency
+- Cross-org quota isolation is preserved during GC operations
+"""
+
+import json
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from data.database import QuotaNamespaceSize, QuotaRepositorySize, Tag
+from data.model.organization import create_organization
+from data.model.quota import run_backfill
+from data.model.repository import create_repository
+from data.model.user import get_user
+from test.fixtures import *
+from workers.test.gc_quota_test_helpers import (
+    calculate_expected_size,
+    create_manifest_with_blobs,
+    create_tag_for_manifest,
+    delete_tag_by_name,
+    enable_gc_and_quota,
+    enable_quota_management,
+    expire_tag,
+    get_namespace_quota,
+    get_repo_quota,
+    run_gc_worker,
+    run_quota_worker,
+)
+
+pytestmark = pytest.mark.workers
+
+
+@pytest.fixture
+def setup_orgs(initialized_db):
+    """
+    Create test organizations and users.
+
+    Returns:
+        Dict with 'user', 'org1', and 'org2' objects
+    """
+    user = get_user("devtable")
+    org1 = create_organization("gcquotatest1", "gcquotatest1@devtable.com", user)
+    org2 = create_organization("gcquotatest2", "gcquotatest2@devtable.com", user)
+    return {"user": user, "org1": org1, "org2": org2}
+
+
+class TestGCQuotaInteraction:
+    """Integration tests for GC + Quota recalculation worker coordination."""
+
+    def test_quota_freed_after_delete_gc_and_recalculation(self, setup_orgs):
+        """
+        Test 1: Fill quota → delete tags → run GC → quota worker → verify quota freed → new push succeeds.
+
+        Verifies the complete end-to-end workflow:
+        1. Fill quota with 8 MB of content
+        2. Delete tags
+        3. Run GC to remove blobs
+        4. Run quota worker to recalculate
+        5. Verify quota shows ~0 MB used
+        6. Verify new 8 MB push succeeds
+
+        This is the primary integration test validating the core GC + quota interaction.
+        """
+        user = setup_orgs["user"]
+        org = setup_orgs["org1"]
+
+        # Create repository
+        repo = create_repository(org.username, "test-repo", user)
+
+        # Create large blobs (8 MB total)
+        blob1 = "A" * (4 * 1024 * 1024)  # 4 MB
+        blob2 = "B" * (4 * 1024 * 1024)  # 4 MB
+
+        # Disable quota initially to set up test data
+        with patch("data.model.quota.features", MagicMock(QUOTA_MANAGEMENT=False)):
+            manifest1 = create_manifest_with_blobs(repo, [blob1, blob2])
+            tag1 = create_tag_for_manifest(repo, manifest1, "v1.0")
+
+        # Run initial quota backfill
+        run_backfill(org.id)
+        initial_quota = get_namespace_quota(org)
+        expected_initial = calculate_expected_size(blob1, blob2)
+        assert (
+            initial_quota == expected_initial
+        ), f"Initial quota should be ~8 MB, got {initial_quota}"
+
+        # Delete the tag to make blobs eligible for GC
+        expire_tag(repo, "v1.0")
+
+        # Run GC with quota management enabled
+        with enable_gc_and_quota():
+            run_gc_worker()
+
+        # Run quota worker to recalculate
+        run_quota_worker()
+
+        # Verify quota is freed
+        quota_after_gc = get_namespace_quota(org)
+        assert quota_after_gc == 0, f"Quota should be 0 after GC, got {quota_after_gc}"
+
+        # Verify new push succeeds with same content size
+        with enable_quota_management():
+            blob3 = "C" * (4 * 1024 * 1024)  # 4 MB
+            blob4 = "D" * (4 * 1024 * 1024)  # 4 MB
+            manifest2 = create_manifest_with_blobs(repo, [blob3, blob4])
+            tag2 = create_tag_for_manifest(repo, manifest2, "v2.0")
+
+        # Run quota recalculation
+        run_backfill(org.id)
+        final_quota = get_namespace_quota(org)
+        expected_final = calculate_expected_size(blob3, blob4)
+        assert (
+            final_quota == expected_final
+        ), f"New push should register in quota, got {final_quota}"
+
+    def test_quota_warning_threshold_cleared_after_gc(self, setup_orgs):
+        """
+        Test 2: Set quota warning threshold (80%) → fill to 85% → delete tags → run GC → verify warning cleared.
+
+        Verifies that:
+        1. Quota warning threshold logic works
+        2. After GC and quota recalculation, usage drops below threshold
+        3. Warning state is cleared
+
+        Note: This test simulates the warning threshold behavior. Actual warning implementation
+        may vary based on Quay's quota enforcement system.
+        """
+        user = setup_orgs["user"]
+        org = setup_orgs["org1"]
+
+        # Create repository
+        repo = create_repository(org.username, "threshold-test", user)
+
+        # Create blobs to fill quota to 85% (assuming 10 MB limit, fill 8.5 MB)
+        # For testing purposes, we'll use 8.5 MB of content
+        blob1 = "A" * (4 * 1024 * 1024)  # 4 MB
+        blob2 = "B" * (4 * 1024 * 1024)  # 4 MB
+        blob3 = "C" * (512 * 1024)  # 0.5 MB
+
+        # Set up initial content
+        with patch("data.model.quota.features", MagicMock(QUOTA_MANAGEMENT=False)):
+            manifest1 = create_manifest_with_blobs(repo, [blob1, blob2, blob3])
+            tag1 = create_tag_for_manifest(repo, manifest1, "v1.0")
+
+        # Run initial quota backfill
+        run_backfill(org.id)
+        initial_quota = get_namespace_quota(org)
+        expected_initial = calculate_expected_size(blob1, blob2, blob3)
+        assert initial_quota == expected_initial
+
+        # Simulate warning threshold at 80% of 10 MB = 8 MB
+        warning_threshold = 8 * 1024 * 1024
+        is_over_threshold = initial_quota > warning_threshold
+        assert is_over_threshold, "Quota should be over warning threshold"
+
+        # Delete tag and run GC
+        expire_tag(repo, "v1.0")
+        with enable_gc_and_quota():
+            run_gc_worker()
+
+        # Run quota worker to recalculate
+        run_quota_worker()
+
+        # Verify quota is below warning threshold
+        quota_after_gc = get_namespace_quota(org)
+        assert (
+            quota_after_gc < warning_threshold
+        ), "Quota should be below warning threshold after GC"
+
+    def test_shared_blob_deduplication_after_gc(self, setup_orgs):
+        """
+        Test 3: Multiple repos same org → shared blob GC → quota deduplicated.
+
+        Verifies that:
+        1. Shared blobs are counted only once in namespace quota
+        2. When one repo deletes a tag using shared blob, blob is not removed if other repo uses it
+        3. Quota reflects correct deduplication after GC
+        """
+        user = setup_orgs["user"]
+        org = setup_orgs["org1"]
+
+        # Create two repositories in same org
+        repo1 = create_repository(org.username, "shared-repo1", user)
+        repo2 = create_repository(org.username, "shared-repo2", user)
+
+        # Create shared blob
+        shared_blob = "SHARED" * (1024 * 1024)  # 6 MB shared blob
+        unique_blob1 = "UNIQUE1" * (1024 * 1024)  # 7 MB unique to repo1
+        unique_blob2 = "UNIQUE2" * (1024 * 1024)  # 7 MB unique to repo2
+
+        # Disable quota to set up test data
+        with patch("data.model.quota.features", MagicMock(QUOTA_MANAGEMENT=False)):
+            # Repo1 has shared_blob + unique_blob1
+            manifest1 = create_manifest_with_blobs(repo1, [shared_blob, unique_blob1])
+            tag1 = create_tag_for_manifest(repo1, manifest1, "v1.0")
+
+            # Repo2 has shared_blob + unique_blob2
+            manifest2 = create_manifest_with_blobs(repo2, [shared_blob, unique_blob2])
+            tag2 = create_tag_for_manifest(repo2, manifest2, "v1.0")
+
+        # Run initial quota backfill
+        run_backfill(org.id)
+        initial_quota = get_namespace_quota(org)
+
+        # Namespace quota should count shared_blob only once
+        expected_initial = calculate_expected_size(shared_blob, unique_blob1, unique_blob2)
+        assert (
+            initial_quota == expected_initial
+        ), f"Shared blob should be counted once, got {initial_quota}"
+
+        # Delete tag from repo1
+        expire_tag(repo1, "v1.0")
+
+        # Run GC
+        with enable_gc_and_quota():
+            run_gc_worker()
+
+        # Run quota worker
+        run_quota_worker()
+
+        # Verify quota after GC
+        quota_after_gc = get_namespace_quota(org)
+
+        # shared_blob should still exist (used by repo2), only unique_blob1 should be removed
+        expected_after_gc = calculate_expected_size(shared_blob, unique_blob2)
+        assert (
+            quota_after_gc == expected_after_gc
+        ), f"Shared blob should remain, got {quota_after_gc}"
+
+        # Verify repo quotas
+        repo1_quota = get_repo_quota(repo1)
+        repo2_quota = get_repo_quota(repo2)
+        assert repo1_quota == 0, f"Repo1 should have 0 quota after GC, got {repo1_quota}"
+        expected_repo2 = calculate_expected_size(shared_blob, unique_blob2)
+        assert repo2_quota == expected_repo2, f"Repo2 quota incorrect, got {repo2_quota}"
+
+    def test_orphaned_blob_removal_and_quota_update(self, setup_orgs):
+        """
+        Test 4: Delete all tags pointing to a blob → verify blob becomes orphaned → run GC → verify quota decreased.
+
+        Verifies that:
+        1. Blobs become orphaned when no tags reference them
+        2. GC removes orphaned blobs
+        3. Quota is updated to reflect removed blobs
+        """
+        user = setup_orgs["user"]
+        org = setup_orgs["org1"]
+
+        # Create repository
+        repo = create_repository(org.username, "orphan-test", user)
+
+        # Create blob that will become orphaned
+        blob1 = "ORPHAN" * (2 * 1024 * 1024)  # 12 MB
+
+        # Disable quota to set up test data
+        with patch("data.model.quota.features", MagicMock(QUOTA_MANAGEMENT=False)):
+            manifest1 = create_manifest_with_blobs(repo, [blob1])
+            tag1 = create_tag_for_manifest(repo, manifest1, "orphan-tag")
+
+        # Run initial quota backfill
+        run_backfill(org.id)
+        initial_quota = get_namespace_quota(org)
+        expected_initial = calculate_expected_size(blob1)
+        assert initial_quota == expected_initial
+
+        # Delete the tag, making the blob orphaned
+        expire_tag(repo, "orphan-tag")
+
+        # Verify blob is now orphaned (no tags point to it)
+        tag_count = Tag.select().where(Tag.repository == repo).count()
+        assert tag_count >= 0  # Tag might still exist with expired lifetime_end_ms
+
+        # Run GC to remove orphaned blob
+        with enable_gc_and_quota():
+            run_gc_worker()
+
+        # Run quota worker to recalculate
+        run_quota_worker()
+
+        # Verify quota decreased (blob removed)
+        quota_after_gc = get_namespace_quota(org)
+        assert (
+            quota_after_gc == 0
+        ), f"Orphaned blob should be removed, quota should be 0, got {quota_after_gc}"
+
+    def test_partial_gc_failure_quota_reflects_actual_removal(self, setup_orgs):
+        """
+        Test 5: Partial GC (inject failure for some blobs) → quota reflects only successfully removed blobs.
+
+        Verifies that:
+        1. If GC partially fails, quota only reflects successfully removed blobs
+        2. Failed blob removal doesn't incorrectly update quota
+        3. System handles partial failures gracefully
+
+        Note: This test simulates failure by using mock patches.
+        """
+        user = setup_orgs["user"]
+        org = setup_orgs["org1"]
+
+        # Create repository with multiple manifests
+        repo = create_repository(org.username, "partial-gc-test", user)
+
+        blob1 = "A" * (2 * 1024 * 1024)  # 2 MB
+        blob2 = "B" * (2 * 1024 * 1024)  # 2 MB
+        blob3 = "C" * (2 * 1024 * 1024)  # 2 MB
+
+        # Disable quota to set up test data
+        with patch("data.model.quota.features", MagicMock(QUOTA_MANAGEMENT=False)):
+            manifest1 = create_manifest_with_blobs(repo, [blob1])
+            tag1 = create_tag_for_manifest(repo, manifest1, "v1.0")
+
+            manifest2 = create_manifest_with_blobs(repo, [blob2])
+            tag2 = create_tag_for_manifest(repo, manifest2, "v2.0")
+
+            manifest3 = create_manifest_with_blobs(repo, [blob3])
+            tag3 = create_tag_for_manifest(repo, manifest3, "v3.0")
+
+        # Run initial quota backfill
+        run_backfill(org.id)
+        initial_quota = get_namespace_quota(org)
+        expected_initial = calculate_expected_size(blob1, blob2, blob3)
+        assert initial_quota == expected_initial
+
+        # Expire two tags
+        expire_tag(repo, "v1.0")
+        expire_tag(repo, "v2.0")
+
+        # Run GC - both blobs should be removed
+        with enable_gc_and_quota():
+            run_gc_worker()
+
+        # Run quota worker
+        run_quota_worker()
+
+        # Verify quota reflects removal of blob1 and blob2, but blob3 remains
+        quota_after_gc = get_namespace_quota(org)
+        expected_after_gc = calculate_expected_size(blob3)
+        assert (
+            quota_after_gc == expected_after_gc
+        ), f"Quota should reflect only blob3, got {quota_after_gc}"
+
+    def test_concurrent_push_during_gc_maintains_consistency(self, setup_orgs):
+        """
+        Test 6: Start blob upload → trigger GC in separate thread → complete upload → verify consistency.
+
+        Verifies that:
+        1. GC doesn't remove newly pushed blobs
+        2. Quota includes new blobs correctly
+        3. Concurrent operations don't corrupt quota state
+
+        Note: This is a simplified version. Full concurrent testing would require more complex setup.
+        """
+        user = setup_orgs["user"]
+        org = setup_orgs["org1"]
+
+        # Create repository
+        repo = create_repository(org.username, "concurrent-test", user)
+
+        # Create old blob to be GC'd
+        old_blob = "OLD" * (2 * 1024 * 1024)  # 2 MB
+
+        # Disable quota to set up test data
+        with patch("data.model.quota.features", MagicMock(QUOTA_MANAGEMENT=False)):
+            manifest1 = create_manifest_with_blobs(repo, [old_blob])
+            tag1 = create_tag_for_manifest(repo, manifest1, "old-tag")
+
+        # Run initial quota backfill
+        run_backfill(org.id)
+        initial_quota = get_namespace_quota(org)
+
+        # Expire old tag
+        expire_tag(repo, "old-tag")
+
+        # Push new content while GC is running
+        new_blob = "NEW" * (2 * 1024 * 1024)  # 2 MB
+
+        with enable_quota_management():
+            # Create new manifest (simulating concurrent push)
+            manifest2 = create_manifest_with_blobs(repo, [new_blob])
+            tag2 = create_tag_for_manifest(repo, manifest2, "new-tag")
+
+            # Run GC
+            with enable_gc_and_quota():
+                run_gc_worker()
+
+        # Run quota worker
+        run_quota_worker()
+
+        # Verify new blob is NOT removed and quota is correct
+        quota_after = get_namespace_quota(org)
+        expected_after = calculate_expected_size(new_blob)
+        assert quota_after == expected_after, f"New blob should be preserved, got {quota_after}"
+
+    def test_quota_overflow_corrected_by_gc(self, setup_orgs):
+        """
+        Test 7: Fill quota to 105% (overflow) → delete tags → run GC → verify quota corrected.
+
+        Verifies that:
+        1. Quota can be corrected even when in overflow state
+        2. GC + quota recalculation brings quota back to normal
+        3. Overflow scenarios are handled correctly
+        """
+        user = setup_orgs["user"]
+        org = setup_orgs["org1"]
+
+        # Create repository
+        repo = create_repository(org.username, "overflow-test", user)
+
+        # Create blobs that exceed typical limits
+        blob1 = "A" * (6 * 1024 * 1024)  # 6 MB
+        blob2 = "B" * (6 * 1024 * 1024)  # 6 MB
+
+        # Disable quota to set up test data
+        with patch("data.model.quota.features", MagicMock(QUOTA_MANAGEMENT=False)):
+            manifest1 = create_manifest_with_blobs(repo, [blob1, blob2])
+            tag1 = create_tag_for_manifest(repo, manifest1, "overflow-tag")
+
+        # Run initial quota backfill
+        run_backfill(org.id)
+        initial_quota = get_namespace_quota(org)
+        expected_initial = calculate_expected_size(blob1, blob2)
+        assert initial_quota == expected_initial
+
+        # Simulate overflow situation (quota > limit)
+        # For testing, we just verify current state
+        assert initial_quota > (10 * 1024 * 1024), "Quota should be over 10 MB (simulated limit)"
+
+        # Delete tag and run GC
+        expire_tag(repo, "overflow-tag")
+        with enable_gc_and_quota():
+            run_gc_worker()
+
+        # Run quota worker to recalculate
+        run_quota_worker()
+
+        # Verify quota is corrected to actual usage (0)
+        quota_after_gc = get_namespace_quota(org)
+        assert quota_after_gc == 0, f"Quota should be corrected to 0, got {quota_after_gc}"
+
+    def test_cross_org_quota_isolation_during_gc(self, setup_orgs):
+        """
+        Test 8: Create two orgs → fill quota in org A → run GC in org A → verify org B unchanged.
+
+        Verifies that:
+        1. GC operations in one org don't affect other orgs
+        2. Quota isolation is maintained across organizations
+        3. Cross-org quota state remains independent
+        """
+        user = setup_orgs["user"]
+        org_a = setup_orgs["org1"]
+        org_b = setup_orgs["org2"]
+
+        # Create repositories in both orgs
+        repo_a = create_repository(org_a.username, "repo-a", user)
+        repo_b = create_repository(org_b.username, "repo-b", user)
+
+        blob_a = "A" * (4 * 1024 * 1024)  # 4 MB
+        blob_b = "B" * (4 * 1024 * 1024)  # 4 MB
+
+        # Disable quota to set up test data
+        with patch("data.model.quota.features", MagicMock(QUOTA_MANAGEMENT=False)):
+            manifest_a = create_manifest_with_blobs(repo_a, [blob_a])
+            tag_a = create_tag_for_manifest(repo_a, manifest_a, "v1.0")
+
+            manifest_b = create_manifest_with_blobs(repo_b, [blob_b])
+            tag_b = create_tag_for_manifest(repo_b, manifest_b, "v1.0")
+
+        # Run initial quota backfill for both orgs
+        run_backfill(org_a.id)
+        run_backfill(org_b.id)
+
+        quota_a_initial = get_namespace_quota(org_a)
+        quota_b_initial = get_namespace_quota(org_b)
+
+        expected_a = calculate_expected_size(blob_a)
+        expected_b = calculate_expected_size(blob_b)
+
+        assert (
+            quota_a_initial == expected_a
+        ), f"Org A quota should be {expected_a}, got {quota_a_initial}"
+        assert (
+            quota_b_initial == expected_b
+        ), f"Org B quota should be {expected_b}, got {quota_b_initial}"
+
+        # Delete tag in org A and run GC
+        expire_tag(repo_a, "v1.0")
+        with enable_gc_and_quota():
+            run_gc_worker()
+
+        # Run quota worker (processes all orgs)
+        run_quota_worker()
+
+        # Verify org A quota is freed
+        quota_a_after = get_namespace_quota(org_a)
+        assert quota_a_after == 0, f"Org A quota should be 0 after GC, got {quota_a_after}"
+
+        # Verify org B quota is UNCHANGED
+        quota_b_after = get_namespace_quota(org_b)
+        assert (
+            quota_b_after == expected_b
+        ), f"Org B quota should remain {expected_b}, got {quota_b_after}"

--- a/workers/test/test_gc_quota_interaction.py
+++ b/workers/test/test_gc_quota_interaction.py
@@ -15,13 +15,14 @@ Tests ensure that:
 """
 
 import json
-import threading
 import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from data.database import QuotaNamespaceSize, QuotaRepositorySize, Tag
+from data.database import QuotaNamespaceSize, QuotaRepositorySize, QuotaTypes, Tag
+from data.model import gc as gc_model
+from data.model import storage as storage_model
 from data.model.organization import create_organization
 from data.model.quota import run_backfill
 from data.model.repository import create_repository
@@ -36,9 +37,11 @@ from workers.test.gc_quota_test_helpers import (
     enable_quota_management,
     expire_tag,
     get_namespace_quota,
+    get_namespace_quota_severity,
     get_repo_quota,
     run_gc_worker,
     run_quota_worker,
+    set_namespace_quota_limit,
 )
 
 pytestmark = pytest.mark.workers
@@ -136,8 +139,8 @@ class TestGCQuotaInteraction:
         2. After GC and quota recalculation, usage drops below threshold
         3. Warning state is cleared
 
-        Note: This test simulates the warning threshold behavior. Actual warning implementation
-        may vary based on Quay's quota enforcement system.
+        Configures a real UserOrganizationQuota with warning/reject thresholds and
+        asserts the actual enforcement severity (via check_limits) before and after GC.
         """
         user = setup_orgs["user"]
         org = setup_orgs["org1"]
@@ -162,10 +165,14 @@ class TestGCQuotaInteraction:
         expected_initial = calculate_expected_size(blob1, blob2, blob3)
         assert initial_quota == expected_initial
 
-        # Simulate warning threshold at 80% of 10 MB = 8 MB
-        warning_threshold = 8 * 1024 * 1024
-        is_over_threshold = initial_quota > warning_threshold
-        assert is_over_threshold, "Quota should be over warning threshold"
+        # Configure a real 10 MB namespace quota with an 80% (8 MB) warning
+        # threshold, then assert the warning state is actually triggered by the
+        # persisted usage rather than comparing against a local constant.
+        quota_limit_bytes = 10 * 1024 * 1024
+        set_namespace_quota_limit(org, quota_limit_bytes, warning_percent=80, reject_percent=100)
+        assert (
+            get_namespace_quota_severity(org) == QuotaTypes.WARNING
+        ), "Usage above 80% of the limit should trigger the warning threshold before GC"
 
         # Delete tag and run GC
         expire_tag(repo, "v1.0")
@@ -175,11 +182,15 @@ class TestGCQuotaInteraction:
         # Run quota worker to recalculate
         run_quota_worker()
 
-        # Verify quota is below warning threshold
+        # Verify usage dropped below the limit and the warning state is cleared
+        # based on the real quota limits (severity is no longer Warning/Reject).
         quota_after_gc = get_namespace_quota(org)
         assert (
-            quota_after_gc < warning_threshold
-        ), "Quota should be below warning threshold after GC"
+            quota_after_gc < quota_limit_bytes
+        ), "Usage should drop below the quota limit after GC"
+        assert (
+            get_namespace_quota_severity(org) is None
+        ), "Warning state should be cleared after GC frees space"
 
     def test_shared_blob_deduplication_after_gc(self, setup_orgs):
         """
@@ -339,19 +350,35 @@ class TestGCQuotaInteraction:
         expire_tag(repo, "v1.0")
         expire_tag(repo, "v2.0")
 
-        # Run GC - both blobs should be removed
-        with enable_gc_and_quota():
-            run_gc_worker()
+        # Inject a removal failure for manifest1 (blob1) while allowing
+        # manifest2 (blob2) to be collected normally. Quay counts a blob toward
+        # quota via its ManifestBlob rows, and GC deletes those rows during the
+        # manifest-purge step (before the later storage-removal step). So to
+        # keep the failed blob counted, the failure must be injected at the
+        # manifest-purge step, not at storage removal.
+        real_gc_manifest = gc_model._garbage_collect_manifest
+
+        def _fail_manifest1(manifest_id, context):
+            if manifest_id == manifest1.id:
+                # Simulate a failed/skipped collection of this manifest.
+                return False
+            return real_gc_manifest(manifest_id, context)
+
+        with patch.object(gc_model, "_garbage_collect_manifest", side_effect=_fail_manifest1):
+            with enable_gc_and_quota():
+                run_gc_worker()
 
         # Run quota worker
         run_quota_worker()
 
-        # Verify quota reflects removal of blob1 and blob2, but blob3 remains
+        # blob2 was removed successfully, but blob1's collection "failed" so its
+        # ManifestBlob rows survive and it remains counted alongside the never-
+        # expired blob3.
         quota_after_gc = get_namespace_quota(org)
-        expected_after_gc = calculate_expected_size(blob3)
+        expected_after_gc = calculate_expected_size(blob1, blob3)
         assert (
             quota_after_gc == expected_after_gc
-        ), f"Quota should reflect only blob3, got {quota_after_gc}"
+        ), f"Failed blob1 should remain counted with blob3, got {quota_after_gc}"
 
     def test_concurrent_push_during_gc_maintains_consistency(self, setup_orgs):
         """
@@ -362,7 +389,8 @@ class TestGCQuotaInteraction:
         2. Quota includes new blobs correctly
         3. Concurrent operations don't corrupt quota state
 
-        Note: This is a simplified version. Full concurrent testing would require more complex setup.
+        The concurrent push is injected mid-GC via a synchronization hook (deterministic,
+        since the test DB fixture is single-connection and cannot be shared across threads).
         """
         user = setup_orgs["user"]
         org = setup_orgs["org1"]
@@ -385,22 +413,41 @@ class TestGCQuotaInteraction:
         # Expire old tag
         expire_tag(repo, "old-tag")
 
-        # Push new content while GC is running
+        # New content that lands "concurrently" while GC is in progress.
         new_blob = "NEW" * (2 * 1024 * 1024)  # 2 MB
 
-        with enable_quota_management():
-            # Create new manifest (simulating concurrent push)
-            manifest2 = create_manifest_with_blobs(repo, [new_blob])
-            tag2 = create_tag_for_manifest(repo, manifest2, "new-tag")
+        # Coordinate the concurrent push via a synchronization hook: the first
+        # time GC reaches its storage-removal step (i.e. after it has already
+        # computed the set of blobs to remove for the expired tag), the push is
+        # injected. GC is therefore in progress when the new blob is written.
+        # A synchronization hook is used instead of real threads because the
+        # test DB fixture is single-connection and cannot be shared across
+        # threads; this keeps the interleaving deterministic while still
+        # exercising the race: GC must not remove a blob pushed after it
+        # computed its removal set.
+        real_gc_storage = storage_model.garbage_collect_storage
+        push_state = {}
 
-            # Run GC
+        def _push_during_gc(storage_id_whitelist):
+            if "manifest" not in push_state:
+                with enable_quota_management():
+                    push_state["manifest"] = create_manifest_with_blobs(repo, [new_blob])
+                    push_state["tag"] = create_tag_for_manifest(
+                        repo, push_state["manifest"], "new-tag"
+                    )
+            return real_gc_storage(storage_id_whitelist)
+
+        with patch.object(storage_model, "garbage_collect_storage", side_effect=_push_during_gc):
             with enable_gc_and_quota():
                 run_gc_worker()
+
+        # The push must have actually been injected during GC.
+        assert "manifest" in push_state, "Concurrent push hook did not fire during GC"
 
         # Run quota worker
         run_quota_worker()
 
-        # Verify new blob is NOT removed and quota is correct
+        # Verify the concurrently-pushed blob is NOT removed and quota is correct
         quota_after = get_namespace_quota(org)
         expected_after = calculate_expected_size(new_blob)
         assert quota_after == expected_after, f"New blob should be preserved, got {quota_after}"
@@ -435,9 +482,14 @@ class TestGCQuotaInteraction:
         expected_initial = calculate_expected_size(blob1, blob2)
         assert initial_quota == expected_initial
 
-        # Simulate overflow situation (quota > limit)
-        # For testing, we just verify current state
-        assert initial_quota > (10 * 1024 * 1024), "Quota should be over 10 MB (simulated limit)"
+        # Configure a real 10 MB namespace quota. With ~12 MB of content the
+        # namespace is in overflow, so the reject threshold (100%) must fire.
+        quota_limit_bytes = 10 * 1024 * 1024
+        set_namespace_quota_limit(org, quota_limit_bytes, warning_percent=80, reject_percent=100)
+        assert initial_quota > quota_limit_bytes, "Usage should exceed the quota limit (overflow)"
+        assert (
+            get_namespace_quota_severity(org) == QuotaTypes.REJECT
+        ), "Overflow usage should trigger the reject threshold before GC"
 
         # Delete tag and run GC
         expire_tag(repo, "overflow-tag")
@@ -447,9 +499,12 @@ class TestGCQuotaInteraction:
         # Run quota worker to recalculate
         run_quota_worker()
 
-        # Verify quota is corrected to actual usage (0)
+        # Verify quota is corrected to actual usage (0) and enforcement cleared.
         quota_after_gc = get_namespace_quota(org)
         assert quota_after_gc == 0, f"Quota should be corrected to 0, got {quota_after_gc}"
+        assert (
+            get_namespace_quota_severity(org) is None
+        ), "Reject/overflow state should be cleared after GC frees space"
 
     def test_cross_org_quota_isolation_during_gc(self, setup_orgs):
         """


### PR DESCRIPTION
## Summary
Implements 8 integration tests for GC + quota recalculation worker interaction to verify the complete end-to-end workflow:
- Fill quota → delete content → run GC → recalculate quota → verify quota is freed

## Root Cause / Rationale
Currently, Quay has separate tests for the garbage collection (GC) worker and quota calculation, but **no integration tests verify the interaction between these two critical workers**. This creates production risk for organizations using quota limits:

**Production Risk:**
- **"Phantom quota" issues** - Users hit quota limits even after deleting content because quota isn't recalculated
- **Push failures** - New pushes rejected despite having freed space through deletion + GC  
- **Incorrect quota reporting** - Organizations can't trust quota metrics for capacity planning
- **Quota leaks** - Deleted content not reflected in quota totals, causing artificial limits

## Changes
- **Created** `workers/test/test_gc_quota_interaction.py` with 8 integration tests
- **Created** `workers/test/gc_quota_test_helpers.py` with reusable test utilities

**Tests implemented:**
1. **Basic workflow** - Fill quota → delete tags → GC → quota freed → new push succeeds
2. **Warning thresholds** - Quota warning cleared after GC frees space
3. **Shared blob deduplication** - Multiple repos sharing blobs, quota deduplicated correctly
4. **Orphaned blob removal** - Orphaned blobs removed by GC, quota updated  
5. **Partial GC failures** - Quota reflects only successfully removed blobs
6. **Concurrent operations** - Push during GC maintains quota consistency
7. **Quota overflow** - Overflow corrected by GC
8. **Cross-org isolation** - GC in org A doesn't affect org B quota

## Test Plan
- [x] All 8 integration tests implemented with comprehensive docstrings
- [x] Tests follow Quay testing patterns (use `initialized_db` fixture, proper mocking)
- [x] Pre-commit hooks pass (black, flake8, mypy)
- [x] Proper pytest markers applied (`@pytest.mark.workers`)
- [x] No N+1 query issues (using batch operations)
- [ ] CI tests pass (will verify in this PR)
- [ ] Code coverage ≥ 80% for GC and quota paths (will verify in CI)

## JIRA Link
https://redhat.atlassian.net/browse/PROJQUAY-11499

## Backport
Not required - test-only change for v3.18.0
