### PR TITLE
NO-ISSUE: ci(e2e): add Playwright e2e test coverage check for PRs

### DIFF
--- a/.github/workflows/e2e-test-check.yaml
+++ b/.github/workflows/e2e-test-check.yaml
@@ -1,0 +1,62 @@
+name: Playwright E2E Test Check
+
+on:
+  pull_request:
+    types: ['opened', 'synchronize', 'reopened']
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  e2e-test-check:
+    runs-on: ubuntu-latest
+    name: e2e test coverage check
+    steps:
+      - name: Check for E2E tests on significant changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          REPO=${{ github.repository }}
+
+          # Get list of changed files in the PR
+          CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+
+          # Directories and patterns that count as "source code" changes
+          # Excludes: tests, docs, config, CI, static assets, agent docs
+          SOURCE_CHANGES=$(echo "$CHANGED_FILES" | grep -cE \
+            '^(auth|buildman|buildstatus|buildtrigger|data|digest|endpoints|events|features|health|image|notifications|oauth|plans|proxy|storage|util|workers|web/src)/' \
+            || true)
+
+          # Subtract files that are themselves tests within source directories
+          TEST_FILES_IN_SOURCE=$(echo "$CHANGED_FILES" | grep -cE \
+            '^(auth|buildman|buildstatus|buildtrigger|data|digest|endpoints|events|features|health|image|notifications|oauth|plans|proxy|storage|util|workers)/test/' \
+            || true)
+
+          SOURCE_CHANGES=$((SOURCE_CHANGES - TEST_FILES_IN_SOURCE))
+
+          # Check if any Playwright e2e test files were added or modified
+          E2E_CHANGES=$(echo "$CHANGED_FILES" | grep -cE \
+            '^web/playwright/e2e/.*\.spec\.ts$' \
+            || true)
+
+          echo "Source code changes: $SOURCE_CHANGES"
+          echo "Playwright e2e test changes: $E2E_CHANGES"
+
+          if [ "$E2E_CHANGES" -gt 0 ]; then
+            echo "Playwright e2e tests were added or updated."
+            exit 0
+          fi
+
+          if [ "$SOURCE_CHANGES" -ge 10 ]; then
+            echo "::error::This PR changes $SOURCE_CHANGES source files but includes no Playwright e2e tests. PRs with 10+ source file changes require e2e test coverage in web/playwright/e2e/."
+            exit 1
+          fi
+
+          if [ "$SOURCE_CHANGES" -gt 0 ]; then
+            echo "::warning::This PR changes $SOURCE_CHANGES source files but includes no Playwright e2e tests. Consider adding e2e coverage in web/playwright/e2e/."
+            exit 0
+          fi
+
+          echo "No significant source changes detected."

--- a/.github/workflows/e2e-test-check.yaml
+++ b/.github/workflows/e2e-test-check.yaml
@@ -23,6 +23,16 @@ jobs:
           # Get list of changed files in the PR
           CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
 
+          # Skip check for dependency-only updates
+          NON_DEP_FILES=$(echo "$CHANGED_FILES" | grep -cvE \
+            '(^|/)(requirements.*\.txt|setup\.py|setup\.cfg|pyproject\.toml|Pipfile(\.lock)?|package\.json|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|go\.mod|go\.sum|\.pre-commit-config\.yaml)$' \
+            || true)
+
+          if [ "$NON_DEP_FILES" -eq 0 ]; then
+            echo "Dependency-only update detected. Skipping e2e test check."
+            exit 0
+          fi
+
           # Directories and patterns that count as "source code" changes
           # Excludes: tests, docs, config, CI, static assets, agent docs
           SOURCE_CHANGES=$(echo "$CHANGED_FILES" | grep -cE \
@@ -49,14 +59,9 @@ jobs:
             exit 0
           fi
 
-          if [ "$SOURCE_CHANGES" -ge 10 ]; then
-            echo "::error::This PR changes $SOURCE_CHANGES source files but includes no Playwright e2e tests. PRs with 10+ source file changes require e2e test coverage in web/playwright/e2e/."
-            exit 1
-          fi
-
           if [ "$SOURCE_CHANGES" -gt 0 ]; then
-            echo "::warning::This PR changes $SOURCE_CHANGES source files but includes no Playwright e2e tests. Consider adding e2e coverage in web/playwright/e2e/."
-            exit 0
+            echo "::error::This PR changes $SOURCE_CHANGES source files but includes no Playwright e2e tests. PRs with source file changes require e2e test coverage in web/playwright/e2e/."
+            exit 1
           fi
 
           echo "No significant source changes detected."


### PR DESCRIPTION
  Summary

  - Adds a new GitHub Actions workflow that checks whether PRs include Playwright e2e tests when source code is modified
  - PRs with 10+ source file changes and no e2e tests will fail the check; smaller changes get a warning
  - Excludes non-source files (docs, config, CI, static assets, agent docs) and test files within source directories from the source change count

  Details

  The workflow runs on pull_request events (opened, synchronize, reopened) and:

  1. Identifies changed files that fall under source code directories (auth/, data/, endpoints/, web/src/, workers/, etc.)
  2. Subtracts files that are themselves tests within those directories
  3. Checks for any changes to web/playwright/e2e/*.spec.ts files
  4. Fails if there are 10+ source changes with no e2e tests
  5. Warns if there are fewer source changes with no e2e tests
  6. Passes if e2e tests are included or no significant source changes are detected

  Test plan

  - Open a PR with 10+ source file changes and no e2e tests — verify the check fails
  - Open a PR with <10 source file changes and no e2e tests — verify it warns but passes
  - Open a PR that includes a web/playwright/e2e/*.spec.ts change — verify it passes
  - Open a PR with only docs/config changes — verify it passes with "No significant source changes"