### PR TITLE
NO-ISSUE: test(web): partial migration of superuser-build-logs Cypress tests to Playwright

### DIFF
--- a/web/cypress/e2e/superuser-build-logs.cy.ts
+++ b/web/cypress/e2e/superuser-build-logs.cy.ts
@@ -2,7 +2,6 @@
 
 describe('Superuser Build Logs', () => {
   const validBuildUuid = 'abc-123-valid-build-uuid';
-  const invalidBuildUuid = 'invalid-uuid-does-not-exist';
 
   const mockBuildInfo = {
     id: '12345',
@@ -53,94 +52,6 @@ describe('Superuser Build Logs', () => {
       .then((token) => {
         cy.loginByCSRF(token);
       });
-  });
-
-  describe('Access Control', () => {
-    it('should show access denied for non-superusers', () => {
-      cy.fixture('config.json').then((config) => {
-        config.features.SUPERUSERS_FULL_ACCESS = true;
-        config.features.BUILD_SUPPORT = true;
-        cy.intercept('GET', '/config', config).as('getConfig');
-      });
-
-      cy.fixture('user.json').then((user) => {
-        user.super_user = false;
-        cy.intercept('GET', '/api/v1/user/', user).as('getUser');
-      });
-
-      cy.visit('/build-logs');
-      cy.wait('@getConfig');
-      cy.wait('@getUser');
-
-      cy.contains('Access Denied').should('exist');
-      cy.contains('You must be a superuser to access build logs').should(
-        'exist',
-      );
-    });
-
-    it('should allow superusers access', () => {
-      cy.fixture('config.json').then((config) => {
-        config.features.SUPERUSERS_FULL_ACCESS = true;
-        config.features.BUILD_SUPPORT = true;
-        cy.intercept('GET', '/config', config).as('getConfig');
-      });
-
-      cy.fixture('superuser.json').then((user) => {
-        cy.intercept('GET', '/api/v1/user/', user).as('getSuperUser');
-      });
-
-      cy.visit('/build-logs');
-      cy.wait('@getConfig');
-      cy.wait('@getSuperUser');
-
-      cy.contains('Build Logs').should('exist');
-      cy.get('[data-testid="build-uuid-input"]').should('exist');
-    });
-  });
-
-  describe('Feature Flag - BUILD_SUPPORT', () => {
-    it('should show warning when BUILD_SUPPORT is disabled', () => {
-      cy.fixture('config.json').then((config) => {
-        config.features.SUPERUSERS_FULL_ACCESS = true;
-        config.features.BUILD_SUPPORT = false;
-        cy.intercept('GET', '/config', config).as('getConfig');
-      });
-
-      cy.fixture('superuser.json').then((user) => {
-        cy.intercept('GET', '/api/v1/user/', user).as('getSuperUser');
-      });
-
-      cy.visit('/build-logs');
-      cy.wait('@getConfig');
-      cy.wait('@getSuperUser');
-
-      cy.contains('Build support not enabled').should('exist');
-      cy.contains(
-        'BUILD_SUPPORT is not enabled in the registry configuration',
-      ).should('exist');
-    });
-
-    it('should hide Build Logs in sidebar when BUILD_SUPPORT is disabled', () => {
-      cy.fixture('config.json').then((config) => {
-        config.features.SUPERUSERS_FULL_ACCESS = true;
-        config.features.BUILD_SUPPORT = false;
-        cy.intercept('GET', '/config', config).as('getConfig');
-      });
-
-      cy.fixture('superuser.json').then((user) => {
-        cy.intercept('GET', '/api/v1/user/', user).as('getSuperUser');
-      });
-
-      cy.visit('/organization');
-      cy.wait('@getConfig');
-      cy.wait('@getSuperUser');
-
-      // Expand superuser section
-      cy.contains('Superuser').click();
-
-      // Build Logs should not be visible
-      cy.get('[data-testid="build-logs-nav"]').should('not.exist');
-    });
   });
 
   describe('Load Valid Build Logs', () => {
@@ -257,73 +168,6 @@ describe('Superuser Build Logs', () => {
 
       // Loading state should disappear
       cy.contains('Loading...').should('not.exist');
-    });
-
-    it('should disable button when input is empty', () => {
-      cy.visit('/build-logs');
-      cy.wait('@getConfig');
-      cy.wait('@getSuperUser');
-
-      // Button should be disabled initially
-      cy.get('[data-testid="load-build-button"]').should('be.disabled');
-
-      // Type some text
-      cy.get('[data-testid="build-uuid-input"]').type('some-uuid');
-
-      // Button should be enabled
-      cy.get('[data-testid="load-build-button"]').should('not.be.disabled');
-
-      // Clear input
-      cy.get('[data-testid="build-uuid-input"]').clear();
-
-      // Button should be disabled again
-      cy.get('[data-testid="load-build-button"]').should('be.disabled');
-    });
-  });
-
-  describe('Load Invalid Build UUID', () => {
-    beforeEach(() => {
-      cy.fixture('config.json').then((config) => {
-        config.features.SUPERUSERS_FULL_ACCESS = true;
-        config.features.BUILD_SUPPORT = true;
-        cy.intercept('GET', '/config', config).as('getConfig');
-      });
-
-      cy.fixture('superuser.json').then((user) => {
-        cy.intercept('GET', '/api/v1/user/', user).as('getSuperUser');
-      });
-    });
-
-    it('should show error for invalid build UUID', () => {
-      cy.intercept('GET', `/api/v1/superuser/${invalidBuildUuid}/build`, {
-        statusCode: 404,
-        body: {
-          error: 'Build not found',
-          message: 'No build exists with this UUID',
-        },
-      }).as('getBuildInfoError');
-
-      cy.intercept('GET', `/api/v1/superuser/${invalidBuildUuid}/logs`, {
-        statusCode: 404,
-        body: {
-          error: 'Build not found',
-          message: 'No build exists with this UUID',
-        },
-      }).as('getBuildLogsError');
-
-      cy.visit('/build-logs');
-      cy.wait('@getConfig');
-      cy.wait('@getSuperUser');
-
-      cy.get('[data-testid="build-uuid-input"]').type(invalidBuildUuid);
-      cy.get('[data-testid="load-build-button"]').click();
-
-      // Either endpoint failing should show error
-      cy.wait('@getBuildInfoError');
-
-      // Should show error alert
-      cy.get('[data-testid="build-error-alert"]').should('exist');
-      cy.contains('Cannot find or load build').should('exist');
     });
   });
 
@@ -491,43 +335,4 @@ describe('Superuser Build Logs', () => {
     });
   });
 
-  describe('Sidebar Navigation', () => {
-    beforeEach(() => {
-      cy.fixture('config.json').then((config) => {
-        config.features.SUPERUSERS_FULL_ACCESS = true;
-        config.features.BUILD_SUPPORT = true;
-        cy.intercept('GET', '/config', config).as('getConfig');
-      });
-
-      cy.fixture('superuser.json').then((user) => {
-        cy.intercept('GET', '/api/v1/user/', user).as('getSuperUser');
-      });
-    });
-
-    it('should navigate to Build Logs via sidebar', () => {
-      cy.visit('/organization');
-      cy.wait('@getConfig');
-      cy.wait('@getSuperUser');
-
-      // Expand superuser section
-      cy.contains('Superuser').click();
-
-      // Click Build Logs
-      cy.get('[data-testid="build-logs-nav"]').click();
-
-      // Should navigate to build logs page
-      cy.url().should('include', '/build-logs');
-      cy.contains('Build Logs').should('exist');
-      cy.get('[data-testid="build-uuid-input"]').should('exist');
-    });
-
-    it('should auto-expand Superuser section when on Build Logs page', () => {
-      cy.visit('/build-logs');
-      cy.wait('@getConfig');
-      cy.wait('@getSuperUser');
-
-      // Superuser section should be expanded
-      cy.get('[data-testid="build-logs-nav"]').should('be.visible');
-    });
-  });
 });

--- a/web/cypress/e2e/superuser-build-logs.cy.ts
+++ b/web/cypress/e2e/superuser-build-logs.cy.ts
@@ -334,5 +334,4 @@ describe('Superuser Build Logs', () => {
       cy.contains('This site is temporarily unavailable').should('not.exist');
     });
   });
-
 });

--- a/web/playwright/MIGRATION.md
+++ b/web/playwright/MIGRATION.md
@@ -757,7 +757,7 @@ Track migration progress from Cypress to Playwright.
 | ✅ | `security-scanner-feature-toggle.cy.ts` | `tags/security-scan.spec.ts` | @feature:SECURITY_SCANNER, @container, consolidated 12→3 tests, Cypress file deleted |
 | ⬚ | `service-status.cy.ts` | | |
 | ✅ | `signin.cy.ts` | `auth/signin.spec.ts` | @feature:MAILING, @auth:Database, @feature:SUPERUSERS_FULL_ACCESS, consolidated 30→18 tests |
-| ⬚ | `superuser-build-logs.cy.ts` | | Superuser required |
+| 🚧 | `superuser-build-logs.cy.ts` | `superuser/build-logs.spec.ts` | Partial: 12→8 tests (access control, button state, error handling, sidebar nav, BUILD_SUPPORT disabled, checkbox toggle). Build-dependent tests (load/display logs, timestamps with data, loading state, empty logs, object messages PROJQUAY-9714) not migrated |
 | ✅ | `superuser-change-log.cy.ts` | `superuser/change-log.spec.ts` | Superuser required, 7→2 tests (access control in framework.spec.ts) |
 | ✅ | `superuser-framework.cy.ts` | `superuser/framework.spec.ts` | Superuser required, consolidated 7→4 tests |
 | ✅ | `superuser-messages.cy.ts` | `superuser/messages.spec.ts` | Superuser required, consolidated 14→6 tests |

--- a/web/playwright/e2e/superuser/build-logs.spec.ts
+++ b/web/playwright/e2e/superuser/build-logs.spec.ts
@@ -4,14 +4,23 @@ test.describe(
   'Superuser Build Logs',
   {tag: ['@superuser', '@feature:BUILD_SUPPORT']},
   () => {
+    test('denies access to non-superusers', async ({authenticatedPage}) => {
+      await authenticatedPage.goto('/build-logs');
+
+      await expect(authenticatedPage.getByText('Access Denied')).toBeVisible();
+      await expect(
+        authenticatedPage.getByText(
+          'You must be a superuser to access build logs',
+        ),
+      ).toBeVisible();
+    });
+
     test('superuser can access build logs page', async ({superuserPage}) => {
       await superuserPage.goto('/build-logs');
 
       await expect(
         superuserPage.getByRole('heading', {name: 'Build Logs', level: 1}),
       ).toBeVisible();
-
-      // UUID input form
       await expect(superuserPage.getByTestId('build-uuid-input')).toBeVisible();
       await expect(
         superuserPage.getByTestId('show-timestamps-checkbox'),
@@ -19,15 +28,27 @@ test.describe(
       await expect(
         superuserPage.getByTestId('load-build-button'),
       ).toBeVisible();
+      await expect(superuserPage.getByTestId('build-logs-nav')).toBeVisible();
     });
 
-    test('load button disabled when UUID input is empty', async ({
+    test('disables load button when input is empty', async ({
       superuserPage,
     }) => {
       await superuserPage.goto('/build-logs');
 
-      const loadBtn = superuserPage.getByTestId('load-build-button');
-      await expect(loadBtn).toBeDisabled();
+      await expect(
+        superuserPage.getByTestId('load-build-button'),
+      ).toBeDisabled();
+
+      await superuserPage.getByTestId('build-uuid-input').fill('some-uuid');
+      await expect(
+        superuserPage.getByTestId('load-build-button'),
+      ).toBeEnabled();
+
+      await superuserPage.getByTestId('build-uuid-input').fill('');
+      await expect(
+        superuserPage.getByTestId('load-build-button'),
+      ).toBeDisabled();
     });
 
     test('shows error for invalid build UUID', async ({superuserPage}) => {
@@ -35,59 +56,93 @@ test.describe(
 
       await superuserPage
         .getByTestId('build-uuid-input')
-        .fill('nonexistent-uuid');
+        .fill('invalid-uuid-does-not-exist');
       await superuserPage.getByTestId('load-build-button').click();
 
       await expect(
         superuserPage.getByTestId('build-error-alert'),
       ).toBeVisible();
-    });
-
-    test('shows error or build info when UUID is submitted', async ({
-      superuserPage,
-      superuserApi,
-    }) => {
-      const org = await superuserApi.organization('subldlogs');
-      const repo = await superuserApi.repository(org.name, 'bldlogs-repo');
-      const build = await superuserApi.build(org.name, repo.name);
-
-      await superuserPage.goto('/build-logs');
-
-      await superuserPage.getByTestId('build-uuid-input').fill(build.buildId);
-      await superuserPage.getByTestId('load-build-button').click();
-
-      // The API may return build info or an error depending on backend support
       await expect(
-        superuserPage
-          .getByText('Build Information')
-          .or(superuserPage.getByTestId('build-error-alert')),
+        superuserPage.getByText('Cannot find or load build'),
       ).toBeVisible();
     });
 
-    test('timestamps checkbox toggles log timestamps', async ({
-      superuserPage,
-    }) => {
+    test('timestamps checkbox defaults to checked', async ({superuserPage}) => {
       await superuserPage.goto('/build-logs');
 
       const checkbox = superuserPage.getByTestId('show-timestamps-checkbox');
-      await expect(checkbox).toBeVisible();
-
-      // Default is checked
       await expect(checkbox).toBeChecked();
 
-      // Uncheck
       await checkbox.click();
       await expect(checkbox).not.toBeChecked();
 
-      // Re-check
       await checkbox.click();
       await expect(checkbox).toBeChecked();
     });
 
-    test('non-superuser sees access denied', async ({authenticatedPage}) => {
-      await authenticatedPage.goto('/build-logs');
+    test('navigates to Build Logs via sidebar', async ({superuserPage}) => {
+      await superuserPage.goto('/organization');
 
-      await expect(authenticatedPage.getByText('Access Denied')).toBeVisible();
+      const superuserNavSection = superuserPage.getByRole('button', {
+        name: 'Superuser',
+      });
+      await superuserNavSection.click();
+
+      await superuserPage.getByTestId('build-logs-nav').click();
+
+      await expect(superuserPage).toHaveURL(/.*\/build-logs.*/);
+      await expect(
+        superuserPage.getByRole('heading', {name: 'Build Logs'}),
+      ).toBeVisible();
+      await expect(superuserPage.getByTestId('build-uuid-input')).toBeVisible();
+    });
+  },
+);
+
+test.describe(
+  'Superuser Build Logs - BUILD_SUPPORT disabled',
+  {tag: ['@superuser', '@feature:SUPERUSERS_FULL_ACCESS']},
+  () => {
+    test('shows warning when BUILD_SUPPORT is disabled', async ({
+      superuserPage,
+      quayConfig,
+    }) => {
+      test.skip(
+        quayConfig?.features?.BUILD_SUPPORT === true,
+        'BUILD_SUPPORT is enabled',
+      );
+
+      await superuserPage.goto('/build-logs');
+
+      await expect(
+        superuserPage.getByText('Build support not enabled'),
+      ).toBeVisible();
+      await expect(
+        superuserPage.getByText(
+          'BUILD_SUPPORT is not enabled in the registry configuration',
+        ),
+      ).toBeVisible();
+    });
+
+    test('hides Build Logs in sidebar when BUILD_SUPPORT is disabled', async ({
+      superuserPage,
+      quayConfig,
+    }) => {
+      test.skip(
+        quayConfig?.features?.BUILD_SUPPORT === true,
+        'BUILD_SUPPORT is enabled',
+      );
+
+      await superuserPage.goto('/organization');
+
+      const superuserNavSection = superuserPage.getByRole('button', {
+        name: 'Superuser',
+      });
+      await superuserNavSection.click();
+
+      await expect(
+        superuserPage.getByTestId('build-logs-nav'),
+      ).not.toBeVisible();
     });
   },
 );

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -787,7 +787,8 @@ export type QuayFeature =
   | 'SPARSE_INDEX'
   | 'TEAM_SYNCING'
   | 'DIRECT_LOGIN'
-  | 'NONSUPERUSER_TEAM_SYNCING_SETUP';
+  | 'NONSUPERUSER_TEAM_SYNCING_SETUP'
+  | 'BUILD_SUPPORT';
 
 /**
  * Quay configuration from /config endpoint


### PR DESCRIPTION
## Summary
- Partial migration of `superuser-build-logs.cy.ts` Cypress tests to Playwright
- Migrates 8 tests that work against real infrastructure without mocks (access control, feature flag, button state, error handling, checkbox toggle, sidebar navigation)
- Removes migrated tests from Cypress file; 4 build-dependent tests remain

## Root Cause / Rationale
Ongoing Cypress → Playwright migration per the MIGRATION.md guide. These tests don't require real build data or config mocking, making them straightforward to port.

## Changes
- `web/playwright/e2e/superuser/build-logs.spec.ts`: Rewrote with 8 tests in 2 describe blocks — one for BUILD_SUPPORT enabled (6 tests), one for BUILD_SUPPORT disabled (2 tests using `test.skip` with real config check)
- `web/cypress/e2e/superuser-build-logs.cy.ts`: Removed migrated tests (access control, feature flag, button disabled, invalid UUID, sidebar nav); 4 build-dependent tests remain
- `web/playwright/MIGRATION.md`: Updated checklist to 🚧 partial status

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration/registry tests pass
- [ ] Type checking passes
- [ ] Manual testing performed
- [x] Frontend tests pass
- [ ] Migration tested (upgrade and downgrade)

## JIRA
N/A — test migration, no associated ticket

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-a5054760-05d8-4ca3-b816-479d1fb95818