### PR TITLE
[redhat-3.9] PROJQUAY-11187: fix(data): prevent RCE via unsafe pickle deserialization

### DIFF
--- a/data/fields.py
+++ b/data/fields.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import pickle
 import string
 import json
@@ -15,6 +16,18 @@ from util.bytes import Bytes
 def random_string(length=16):
     random = SystemRandom()
     return "".join([random.choice(string.ascii_uppercase + string.digits) for _ in range(length)])
+
+
+class _SafeUnpickler(pickle.Unpickler):
+    """
+    Restricted unpickler that only allows deserializing resumablesha256.sha256 objects.
+    Prevents arbitrary code execution via crafted pickle payloads (CVE-2026-32590).
+    """
+
+    def find_class(self, module, name):
+        if module == "resumablesha256" and name == "sha256":
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(f"Forbidden class: {module}.{name}")
 
 
 class _ResumableSHAField(TextField):
@@ -44,7 +57,8 @@ class _ResumableSHAField(TextField):
         if value is None:
             return None
 
-        hasher = pickle.loads(base64.b64decode(value.encode("ascii")))
+        data = base64.b64decode(value.encode("ascii"))
+        hasher = _SafeUnpickler(io.BytesIO(data)).load()
         return hasher
 
 

--- a/data/test/test_fields.py
+++ b/data/test/test_fields.py
@@ -1,0 +1,34 @@
+import base64
+import pickle
+
+import pytest
+import resumablesha256
+
+from data.fields import ResumableSHA256Field
+
+
+def test_resumable_sha256_field_roundtrip():
+    field = ResumableSHA256Field()
+    hasher = resumablesha256.sha256()
+    hasher.update(b"hello world")
+
+    db_val = field.db_value(hasher)
+    restored = field.python_value(db_val)
+
+    assert restored.hexdigest() == hasher.hexdigest()
+
+
+def test_resumable_sha256_field_rejects_malicious_payload():
+    """Verify that arbitrary classes cannot be deserialized (CVE-2026-32590)."""
+    field = ResumableSHA256Field()
+
+    class Exploit:
+        def __reduce__(self):
+            import os
+
+            return (os.system, ("echo pwned",))
+
+    malicious = base64.b64encode(pickle.dumps(Exploit())).decode("ascii")
+
+    with pytest.raises(pickle.UnpicklingError, match="Forbidden class"):
+        field.python_value(malicious)


### PR DESCRIPTION
Replace bare pickle.loads() in _ResumableSHAField with a restricted unpickler that only allows resumablesha256.sha256 objects, blocking arbitrary code execution from crafted payloads in BlobUpload sha_state columns.

