### PR TITLE
PROJQUAY-11583: feat(test): add geo-replication e2e testing with Garage S3

### DIFF
--- a/.github/actions/setup-quay/action.yaml
+++ b/.github/actions/setup-quay/action.yaml
@@ -67,6 +67,11 @@ inputs:
     required: false
     default: 'true'
 
+  with-georep:
+    description: 'Start Garage S3 and configure geo-replication with two storage regions'
+    required: false
+    default: 'false'
+
 outputs:
   quay-url:
     description: 'URL where Quay is accessible'
@@ -192,11 +197,60 @@ runs:
         rm -f "${INLINE_CONFIG}"
         echo "Inline config merged successfully"
 
+    - name: Configure geo-replication storage
+      if: inputs.with-georep == 'true'
+      shell: bash
+      run: |
+        BASE_CONFIG="local-dev/stack/config.yaml"
+        GEOREP_CONFIG="local-dev/garage/georep-config.yaml"
+
+        pip install pyyaml -q
+        python3 ${{ github.action_path }}/merge-yaml.py \
+          "${BASE_CONFIG}" "${GEOREP_CONFIG}" > "${BASE_CONFIG}.tmp"
+        mv "${BASE_CONFIG}.tmp" "${BASE_CONFIG}"
+
+        # Remove the default LocalStorage entry — the replication worker
+        # refuses to start when any backend is LocalStorage.
+        python3 -c "
+        import yaml, sys
+        with open('${BASE_CONFIG}') as f:
+            cfg = yaml.safe_load(f)
+        cfg.get('DISTRIBUTED_STORAGE_CONFIG', {}).pop('default', None)
+        with open('${BASE_CONFIG}', 'w') as f:
+            yaml.dump(cfg, f, default_flow_style=False, sort_keys=False)
+        "
+        echo "Geo-replication storage configuration merged (LocalStorage removed)"
+
     - name: Start database services
       shell: bash
       run: |
         docker compose up -d redis quay-db
         docker exec quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
+
+    - name: Start Garage S3
+      if: inputs.with-georep == 'true'
+      shell: bash
+      run: |
+        # HACK: Quay generates S3 pre-signed URLs using the configured hostname
+        # ("garage"). Podman/docker on the runner follows these 302 redirects and
+        # needs to resolve "garage" to reach the Garage container's exposed port.
+        # Adding it to /etc/hosts is the simplest way to bridge container DNS and
+        # host DNS without coupling Garage's lifecycle to Quay's network namespace.
+        echo "127.0.0.1 garage" | sudo tee -a /etc/hosts
+
+        docker compose up -d garage
+        echo "Waiting for Garage to be healthy..."
+        for i in $(seq 1 30); do
+          STATUS=$(docker inspect --format='{{.State.Health.Status}}' quay-garage 2>/dev/null || echo "starting")
+          if [ "${STATUS}" = "healthy" ]; then
+            echo "Garage is healthy!"
+            break
+          fi
+          [ "$i" -eq 30 ] && { echo "::error::Garage failed to become healthy"; docker logs quay-garage 2>&1 | tail -50; exit 1; }
+          sleep 2
+        done
+        GARAGE_CONTAINER=quay-garage CONTAINER_RUNTIME=docker bash local-dev/garage/init-garage.sh
+        echo "Garage S3 initialized with geo-replication buckets"
 
     - name: Start Keycloak
       if: inputs.with-keycloak == 'true'

--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -13,6 +13,9 @@ jobs:
     runs-on: quay-003-medium-ubuntu-24-x64
     env:
       QUAY_HOTRELOAD: "false"
+      AWS_ACCESS_KEY_ID: GKe2e0123456789abcdef01234
+      AWS_SECRET_ACCESS_KEY: e2e0123456789abcdef0123456789abcdef0123456789abcdef01234567890ab
+      S3_ENDPOINT: http://localhost:3900
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -26,6 +29,7 @@ jobs:
           with-keycloak: true
           with-jaeger: true
           with-repomirror: true
+          with-georep: true
           use-gha-cache: false
           extra-config: |
             FEATURE_MAILING: true

--- a/app.py
+++ b/app.py
@@ -117,10 +117,23 @@ app.config.update(environ_config)
 if app.config.get("PROXY_COUNT", 1):
     app.wsgi_app = ProxyFix(app.wsgi_app)  # type: ignore[method-assign]
 
-# Allow user to define a custom storage preference for the local instance.
-_distributed_storage_preference = os.environ.get("QUAY_DISTRIBUTED_STORAGE_PREFERENCE", "").split()
-if _distributed_storage_preference:
-    app.config["DISTRIBUTED_STORAGE_PREFERENCE"] = _distributed_storage_preference
+
+def apply_storage_replication_config(config):
+    """Apply env var override and validate storage replication settings."""
+    pref = os.environ.get("QUAY_DISTRIBUTED_STORAGE_PREFERENCE", "").split()
+    if pref:
+        config["DISTRIBUTED_STORAGE_PREFERENCE"] = pref
+
+    if not config.get("DISTRIBUTED_STORAGE_PREFERENCE") and config.get(
+        "FEATURE_STORAGE_REPLICATION", False
+    ):
+        raise Exception(
+            "Missing storage preference for geo-replication. Set DISTRIBUTED_STORAGE_PREFERENCE "
+            "in config.yaml or the QUAY_DISTRIBUTED_STORAGE_PREFERENCE environment variable."
+        )
+
+
+apply_storage_replication_config(app.config)
 
 # Generate a secret key if none was specified.
 if app.config["SECRET_KEY"] is None:
@@ -336,14 +349,6 @@ if os.path.exists(_v2_key_path):
         docker_v2_signing_key = JsonWebKey.import_key(key_file.read())
 else:
     docker_v2_signing_key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
-
-# Check if georeplication is turned on and whether env. variables exist:
-if os.environ.get("QUAY_DISTRIBUTED_STORAGE_PREFERENCE") is None and app.config.get(
-    "FEATURE_STORAGE_REPLICATION", False
-):
-    raise Exception(
-        "Missing storage preference, did you perhaps forget to define QUAY_DISTRIBUTED_STORAGE_PREFERENCE variable?"
-    )
 
 # Configure the database.
 if app.config.get("DATABASE_SECRET_KEY") is None and app.config.get("SETUP_COMPLETE", False):

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -121,6 +121,20 @@ services:
       - "4317:4317"    # OTLP gRPC
       - "4318:4318"    # OTLP HTTP
 
+  garage:
+    container_name: quay-garage
+    image: dxflrs/garage:v1.0.1
+    volumes:
+      - "./local-dev/garage/garage.toml:/etc/garage.toml:ro,z"
+    ports:
+      - "3900:3900"
+    healthcheck:
+      test: ["CMD", "/garage", "status"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
   keycloak:
     container_name: quay-keycloak
     image: quay.io/keycloak/keycloak:26.2
@@ -199,6 +213,7 @@ services:
     environment:
       QUAY_VERSION: local-dev
       QUAY_HOTRELOAD: "${QUAY_HOTRELOAD:-true}"
+      QUAY_DISTRIBUTED_STORAGE_PREFERENCE: "${QUAY_DISTRIBUTED_STORAGE_PREFERENCE:-}"
       DEBUGLOG: "true"
       IGNORE_VALIDATION: "true"
       QUAYRUN: /tmp

--- a/local-dev/garage/garage.toml
+++ b/local-dev/garage/garage.toml
@@ -1,0 +1,19 @@
+replication_factor = 1
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+rpc_bind_addr = "[::]:3901"
+rpc_secret = "5c61c8739e9c6a1046347438ca7a1c77fc3ea1af4b0ef21573a1a11c8e8f4a08"
+
+[s3_api]
+api_bind_addr = "[::]:3900"
+s3_region = "us-east-1"
+root_domain = ".s3.garage.localhost"
+
+[s3_web]
+bind_addr = "[::]:3902"
+root_domain = ".web.garage.localhost"
+
+[admin]
+api_bind_addr = "[::]:3903"
+admin_token = "admin-token"

--- a/local-dev/garage/georep-config.yaml
+++ b/local-dev/garage/georep-config.yaml
@@ -1,0 +1,30 @@
+FEATURE_STORAGE_REPLICATION: true
+DISTRIBUTED_STORAGE_CONFIG:
+  us_east:
+    - RadosGWStorage
+    - hostname: garage
+      is_secure: false
+      storage_path: /datastorage/registry
+      access_key: GKe2e0123456789abcdef01234
+      secret_key: e2e0123456789abcdef0123456789abcdef0123456789abcdef01234567890ab
+      bucket_name: quay-us-east
+      port: 3900
+      signature_version: s3v4
+  eu_west:
+    - RadosGWStorage
+    - hostname: garage
+      is_secure: false
+      storage_path: /datastorage/registry
+      access_key: GKe2e0123456789abcdef01234
+      secret_key: e2e0123456789abcdef0123456789abcdef0123456789abcdef01234567890ab
+      bucket_name: quay-eu-west
+      port: 3900
+      signature_version: s3v4
+DISTRIBUTED_STORAGE_PREFERENCE:
+  - us_east
+DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS:
+  - us_east
+  - eu_west
+USERFILES_LOCATION: us_east
+LOG_ARCHIVE_LOCATION: us_east
+ACTION_LOG_ARCHIVE_LOCATION: us_east

--- a/local-dev/garage/init-garage.sh
+++ b/local-dev/garage/init-garage.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# init-garage.sh — Initialize Garage S3 for geo-replication testing.
+# Creates two buckets (simulating two storage regions) and a fixed access key.
+# Adapted from quay-operator hack/setup-kind-e2e.sh for docker-compose.
+set -euo pipefail
+
+CONTAINER="${GARAGE_CONTAINER:-quay-garage}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-$(command -v docker 2>/dev/null || command -v podman 2>/dev/null)}"
+if [[ -z "${CONTAINER_RUNTIME}" ]]; then
+  echo "ERROR: docker or podman is required" >&2
+  exit 1
+fi
+ACCESS_KEY_ID="GKe2e0123456789abcdef01234"
+SECRET_KEY="e2e0123456789abcdef0123456789abcdef0123456789abcdef01234567890ab"
+BUCKETS=("quay-us-east" "quay-eu-west")
+
+garage_exec() {
+  "${CONTAINER_RUNTIME}" exec "${CONTAINER}" /garage "$@" 2>&1
+}
+
+echo "=== Initializing Garage S3 ==="
+
+# Wait for Garage to be ready
+for i in $(seq 1 30); do
+  if garage_exec status >/dev/null 2>&1; then
+    break
+  fi
+  [ "$i" -eq 30 ] && { echo "ERROR: Garage not ready after 30 attempts"; exit 1; }
+  sleep 2
+done
+
+# Get node ID and assign layout
+NODE_ID=$(garage_exec node id -q | tr -d '[:space:]')
+echo "Node ID: ${NODE_ID}"
+garage_exec layout assign -z dc1 -c 1G "${NODE_ID}" || true
+
+# Apply layout (idempotent version loop — same pattern as operator)
+applied=false
+for v in 1 2 3 4 5; do
+  if garage_exec layout apply --version "$v" 2>/dev/null; then
+    echo "Layout applied (version $v)"
+    applied=true
+    break
+  fi
+done
+if [[ "${applied}" != "true" ]]; then
+  echo "ERROR: failed to apply Garage layout" >&2
+  exit 1
+fi
+
+# Create buckets
+for bucket in "${BUCKETS[@]}"; do
+  garage_exec bucket create "${bucket}" || true
+  echo "Bucket: ${bucket}"
+done
+
+# Import fixed access key (deterministic — no parsing needed)
+garage_exec key import --yes "${ACCESS_KEY_ID}" "${SECRET_KEY}" -n quay-e2e 2>/dev/null || true
+
+# Grant permissions on all buckets
+for bucket in "${BUCKETS[@]}"; do
+  garage_exec bucket allow --read --write --owner "${bucket}" --key "${ACCESS_KEY_ID}"
+done
+
+echo "=== Garage S3 ready ==="
+echo "Endpoint: http://${CONTAINER}:3900"
+echo "Access Key: ${ACCESS_KEY_ID}"
+echo "Buckets: ${BUCKETS[*]}"

--- a/test/test_storage_replication_config.py
+++ b/test/test_storage_replication_config.py
@@ -1,0 +1,52 @@
+import pytest
+
+from app import apply_storage_replication_config
+
+
+def test_env_var_overrides_missing_config(monkeypatch):
+    monkeypatch.setenv("QUAY_DISTRIBUTED_STORAGE_PREFERENCE", "us_east eu_west")
+    config = {"FEATURE_STORAGE_REPLICATION": True}
+    apply_storage_replication_config(config)
+    assert config["DISTRIBUTED_STORAGE_PREFERENCE"] == ["us_east", "eu_west"]
+
+
+def test_env_var_overrides_existing_config(monkeypatch):
+    monkeypatch.setenv("QUAY_DISTRIBUTED_STORAGE_PREFERENCE", "us_east eu_west")
+    config = {
+        "FEATURE_STORAGE_REPLICATION": True,
+        "DISTRIBUTED_STORAGE_PREFERENCE": ["eu_central"],
+    }
+    apply_storage_replication_config(config)
+    assert config["DISTRIBUTED_STORAGE_PREFERENCE"] == ["us_east", "eu_west"]
+
+
+def test_config_preference_sufficient_without_env_var(monkeypatch):
+    monkeypatch.delenv("QUAY_DISTRIBUTED_STORAGE_PREFERENCE", raising=False)
+    config = {
+        "FEATURE_STORAGE_REPLICATION": True,
+        "DISTRIBUTED_STORAGE_PREFERENCE": ["us_east"],
+    }
+    apply_storage_replication_config(config)
+
+
+def test_raises_without_any_preference(monkeypatch):
+    monkeypatch.delenv("QUAY_DISTRIBUTED_STORAGE_PREFERENCE", raising=False)
+    config = {"FEATURE_STORAGE_REPLICATION": True}
+    with pytest.raises(Exception, match="Missing storage preference"):
+        apply_storage_replication_config(config)
+
+
+def test_raises_with_empty_preference_list(monkeypatch):
+    monkeypatch.delenv("QUAY_DISTRIBUTED_STORAGE_PREFERENCE", raising=False)
+    config = {
+        "FEATURE_STORAGE_REPLICATION": True,
+        "DISTRIBUTED_STORAGE_PREFERENCE": [],
+    }
+    with pytest.raises(Exception, match="Missing storage preference"):
+        apply_storage_replication_config(config)
+
+
+def test_replication_disabled_skips_validation(monkeypatch):
+    monkeypatch.delenv("QUAY_DISTRIBUTED_STORAGE_PREFERENCE", raising=False)
+    apply_storage_replication_config({"FEATURE_STORAGE_REPLICATION": False})
+    apply_storage_replication_config({})

--- a/web/playwright/e2e/repository/geo-replication.spec.ts
+++ b/web/playwright/e2e/repository/geo-replication.spec.ts
@@ -1,0 +1,231 @@
+import {expect, test} from '../../fixtures';
+import {TEST_USERS} from '../../global-setup';
+import {
+  pushUniqueImage,
+  pushMultiArchImage,
+  pullImage,
+} from '../../utils/container';
+import {getV2Token} from '../../utils/api';
+import {
+  isAwscliAvailable,
+  listBucketObjects,
+  listBuckets,
+  deleteObject,
+} from '../../utils/s3';
+import {API_URL} from '../../utils/config';
+
+function digestToS3Key(digest: string): string {
+  const hash = digest.replace('sha256:', '');
+  return `datastorage/registry/sha256/${hash.substring(0, 2)}/${hash}`;
+}
+
+function extractBlobDigests(manifest: Record<string, unknown>): string[] {
+  if (manifest.layers) {
+    return [
+      (manifest.config as {digest: string}).digest,
+      ...(manifest.layers as {digest: string}[]).map((l) => l.digest),
+    ];
+  }
+  throw new Error(
+    `Unexpected manifest format (expected v2): ${JSON.stringify(manifest).slice(0, 200)}`,
+  );
+}
+
+async function fetchManifestDigests(
+  request: import('@playwright/test').APIRequestContext,
+  repo: string,
+  tag: string,
+  token: string,
+): Promise<string[]> {
+  const resp = await request.get(`${API_URL}/v2/${repo}/manifests/${tag}`, {
+    headers: {
+      Accept: 'application/vnd.docker.distribution.manifest.v2+json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  expect(resp.ok()).toBe(true);
+  return extractBlobDigests(await resp.json());
+}
+
+async function waitForReplication(
+  expectedKeys: string[],
+  bucketList: string[],
+) {
+  for (const bucket of bucketList) {
+    await expect
+      .poll(
+        async () => {
+          const objects = new Set(await listBucketObjects(bucket));
+          return expectedKeys.every((key) => objects.has(key));
+        },
+        {
+          message: `waiting for ${expectedKeys.length} blobs in "${bucket}"`,
+          timeout: 60_000,
+          intervals: [2_000, 5_000, 10_000],
+        },
+      )
+      .toBe(true);
+  }
+}
+
+test.describe(
+  'Geo-Replication',
+  {tag: ['@feature:STORAGE_REPLICATION', '@container']},
+  () => {
+    let buckets: string[];
+
+    test.beforeAll(async () => {
+      const awsAvailable = await isAwscliAvailable();
+      test.skip(!awsAvailable, 'awscli not available');
+
+      buckets = await listBuckets();
+      test.skip(
+        buckets.length < 2,
+        `Need at least 2 buckets for geo-replication, found ${buckets.length}`,
+      );
+    });
+
+    test('pushed image blobs replicate to all storage regions', async ({
+      api,
+      authenticatedRequest,
+    }) => {
+      test.setTimeout(120_000);
+
+      const org = await api.organization();
+      const repo = await api.repository(org.name);
+
+      await pushUniqueImage(
+        org.name,
+        repo.name,
+        'v1.0',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+
+      const token = await getV2Token(
+        authenticatedRequest,
+        API_URL,
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+        `repository:${org.name}/${repo.name}:pull`,
+      );
+
+      const digests = await fetchManifestDigests(
+        authenticatedRequest,
+        `${org.name}/${repo.name}`,
+        'v1.0',
+        token,
+      );
+      await waitForReplication(digests.map(digestToS3Key), buckets);
+    });
+
+    test('pull succeeds when primary blob is deleted (fallback to replica)', async ({
+      api,
+      authenticatedRequest,
+    }) => {
+      test.setTimeout(120_000);
+
+      const org = await api.organization();
+      const repo = await api.repository(org.name);
+
+      await pushUniqueImage(
+        org.name,
+        repo.name,
+        'fallback',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+
+      const token = await getV2Token(
+        authenticatedRequest,
+        API_URL,
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+        `repository:${org.name}/${repo.name}:pull`,
+      );
+
+      const digests = await fetchManifestDigests(
+        authenticatedRequest,
+        `${org.name}/${repo.name}`,
+        'fallback',
+        token,
+      );
+      const expectedKeys = digests.map(digestToS3Key);
+      await waitForReplication(expectedKeys, buckets);
+
+      // Delete one blob from one bucket to test fallback
+      const testKey = expectedKeys[0];
+      await deleteObject(buckets[0], testKey);
+
+      const objectsAfterDelete = await listBucketObjects(buckets[0]);
+      expect(objectsAfterDelete).not.toContain(testKey);
+
+      await pullImage(
+        org.name,
+        repo.name,
+        'fallback',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+    });
+
+    test('multi-arch manifest list blobs replicate to all storage regions', async ({
+      api,
+      authenticatedRequest,
+    }) => {
+      test.setTimeout(120_000);
+
+      const org = await api.organization();
+      const repo = await api.repository(org.name);
+
+      await pushMultiArchImage(
+        org.name,
+        repo.name,
+        'multiarch',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+
+      const token = await getV2Token(
+        authenticatedRequest,
+        API_URL,
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+        `repository:${org.name}/${repo.name}:pull`,
+      );
+
+      // Fetch manifest list and walk each platform manifest
+      const listResp = await authenticatedRequest.get(
+        `${API_URL}/v2/${org.name}/${repo.name}/manifests/multiarch`,
+        {
+          headers: {
+            Accept:
+              'application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json',
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+      expect(listResp.ok()).toBe(true);
+
+      const manifestList = await listResp.json();
+      const allDigests: string[] = [];
+
+      for (const entry of manifestList.manifests) {
+        const platformResp = await authenticatedRequest.get(
+          `${API_URL}/v2/${org.name}/${repo.name}/manifests/${entry.digest}`,
+          {
+            headers: {
+              Accept: 'application/vnd.docker.distribution.manifest.v2+json',
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        );
+        expect(platformResp.ok()).toBe(true);
+        allDigests.push(...extractBlobDigests(await platformResp.json()));
+      }
+
+      const uniqueKeys = [...new Set(allDigests)].map(digestToS3Key);
+      await waitForReplication(uniqueKeys, buckets);
+    });
+  },
+);

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -788,7 +788,8 @@ export type QuayFeature =
   | 'TEAM_SYNCING'
   | 'DIRECT_LOGIN'
   | 'NONSUPERUSER_TEAM_SYNCING_SETUP'
-  | 'BUILD_SUPPORT';
+  | 'BUILD_SUPPORT'
+  | 'STORAGE_REPLICATION';
 
 /**
  * Quay configuration from /config endpoint

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -5,7 +5,7 @@
  * to the registry during e2e tests. Supports both podman and docker.
  */
 
-import {exec, execFileSync, execSync} from 'child_process';
+import {exec, execFileSync} from 'child_process';
 import {promisify} from 'util';
 import {API_URL} from './config';
 
@@ -121,6 +121,86 @@ export async function pushImage(
   if (!process.env.CI) {
     await execAsync(`${runtime} rmi ${image}`);
   }
+}
+
+/**
+ * Push an image with a unique layer to the registry, guaranteeing
+ * unique blob digests (no deduplication with prior pushes).
+ */
+export async function pushUniqueImage(
+  namespace: string,
+  repo: string,
+  tag: string,
+  username: string,
+  password: string,
+): Promise<void> {
+  const runtime = await detectContainerRuntime();
+  if (!runtime) {
+    throw new Error('No container runtime available (podman or docker)');
+  }
+
+  const image = `${REGISTRY_HOST}/${namespace}/${repo}:${tag}`;
+  const tlsFlag = runtime === 'podman' ? '--tls-verify=false' : '';
+  const loginKey = `${runtime}:${REGISTRY_HOST}:${username}`;
+
+  if (!loggedInRegistries.has(loginKey)) {
+    await execAsync(
+      `${runtime} login ${REGISTRY_HOST} -u ${username} -p ${password} ${tlsFlag}`.trim(),
+    );
+    loggedInRegistries.add(loginKey);
+  }
+
+  const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const tmpDir = `/tmp/quay-unique-img-${uniqueId}`;
+  await execAsync(
+    `mkdir -p ${tmpDir} && echo "${uniqueId}" > ${tmpDir}/unique && ` +
+      `printf 'FROM busybox\\nCOPY unique /unique\\n' > ${tmpDir}/Dockerfile`,
+  );
+  try {
+    // --format docker is podman-only (forces Docker v2 manifest instead of OCI).
+    // Docker always produces Docker v2 format natively, so skip the flag there.
+    const formatFlag = runtime === 'podman' ? '--format docker' : '';
+    await execAsync(
+      `${runtime} build ${formatFlag} --tag ${image} ${tmpDir}`.trim(),
+    );
+    await retryPush(`${runtime} push ${image} ${tlsFlag}`.trim());
+  } finally {
+    await execAsync(`rm -rf ${tmpDir}`).catch(() => undefined);
+    if (!process.env.CI) {
+      await execAsync(`${runtime} rmi ${image}`).catch(() => undefined);
+    }
+  }
+}
+
+/**
+ * Pull an image from the registry. Removes it afterwards to avoid
+ * polluting the local image store during tests.
+ */
+export async function pullImage(
+  namespace: string,
+  repo: string,
+  tag: string,
+  username: string,
+  password: string,
+): Promise<void> {
+  const runtime = await detectContainerRuntime();
+  if (!runtime) {
+    throw new Error('No container runtime available (podman or docker)');
+  }
+
+  const image = `${REGISTRY_HOST}/${namespace}/${repo}:${tag}`;
+  const tlsFlag = runtime === 'podman' ? '--tls-verify=false' : '';
+  const loginKey = `${runtime}:${REGISTRY_HOST}:${username}`;
+
+  if (!loggedInRegistries.has(loginKey)) {
+    await execAsync(
+      `${runtime} login ${REGISTRY_HOST} -u ${username} -p ${password} ${tlsFlag}`.trim(),
+    );
+    loggedInRegistries.add(loginKey);
+  }
+
+  await execAsync(`${runtime} pull ${image} ${tlsFlag}`.trim());
+  await execAsync(`${runtime} rmi ${image}`).catch(() => undefined);
 }
 
 /**

--- a/web/playwright/utils/s3.ts
+++ b/web/playwright/utils/s3.ts
@@ -1,0 +1,53 @@
+/**
+ * S3 utilities for verifying geo-replication in Playwright e2e tests.
+ *
+ * Uses awscli via child_process to stay portable across any S3-compatible
+ * backend (Garage, MinIO, real S3, etc.). Follows the same exec pattern
+ * as container.ts.
+ *
+ * Configure via environment variables:
+ *   S3_ENDPOINT       - S3 API endpoint (default: http://localhost:3900)
+ *   S3_REGION         - AWS region (default: us-east-1)
+ *   AWS_ACCESS_KEY_ID - Access key
+ *   AWS_SECRET_ACCESS_KEY - Secret key
+ */
+
+import {exec} from 'child_process';
+import {promisify} from 'util';
+
+const execAsync = promisify(exec);
+
+const S3_ENDPOINT = process.env.S3_ENDPOINT ?? 'http://localhost:3900';
+const S3_REGION = process.env.S3_REGION ?? 'us-east-1';
+const AWS_BASE = `AWS_PAGER="" aws --endpoint-url ${S3_ENDPOINT} --region ${S3_REGION}`;
+
+export async function isAwscliAvailable(): Promise<boolean> {
+  try {
+    await execAsync('aws --version');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function listBuckets(): Promise<string[]> {
+  const {stdout} = await execAsync(
+    `${AWS_BASE} s3api list-buckets --output json`,
+  );
+  const resp = JSON.parse(stdout);
+  return (resp.Buckets ?? []).map((b: {Name: string}) => b.Name);
+}
+
+export async function listBucketObjects(bucket: string): Promise<string[]> {
+  const {stdout} = await execAsync(
+    `${AWS_BASE} s3api list-objects-v2 --bucket ${bucket} --output json`,
+  );
+  const resp = JSON.parse(stdout);
+  return (resp.Contents ?? []).map((o: {Key: string}) => o.Key);
+}
+
+export async function deleteObject(bucket: string, key: string): Promise<void> {
+  await execAsync(
+    `${AWS_BASE} s3api delete-object --bucket ${bucket} --key ${key}`,
+  );
+}


### PR DESCRIPTION
Add always-on geo-replication testing to the Playwright CI pipeline
using Garage as an S3-compatible object store with two buckets
simulating two storage regions (us_east, eu_west).

- Add Garage service to docker-compose.yaml
- Add Garage config, init script, and georep config overlay
- Add Playwright S3 helper (awscli-based, dynamic bucket discovery)
- Add 3 georep e2e tests: basic replication, pull fallback, multi-arch
- Add pushUniqueImage() helper for parallel-safe blob verification
- Fix app.py bug: check config value for storage preference instead
  of requiring QUAY_DISTRIBUTED_STORAGE_PREFERENCE env var
- Update setup-quay action with with-georep input and LocalStorage
  removal after config merge

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
