### PR TITLE
PROJQUAY-11577: fix(ui): move usage logs chart legend outside chart SVG to prevent overlap

### DIFF
--- a/web/playwright/e2e/usage-logs.spec.ts
+++ b/web/playwright/e2e/usage-logs.spec.ts
@@ -291,6 +291,17 @@ test.describe('Usage Logs', {tag: ['@logs']}, () => {
       const today = new Date().toISOString().slice(0, 10) + 'T12:00:00Z';
 
       await authenticatedPage.route(
+        `**/api/v1/organization/${org.name}/logs*`,
+        async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({logs: [], is_truncated: false}),
+          });
+        },
+      );
+
+      await authenticatedPage.route(
         `**/api/v1/organization/${org.name}/aggregatelogs*`,
         async (route) => {
           await route.fulfill({
@@ -315,6 +326,17 @@ test.describe('Usage Logs', {tag: ['@logs']}, () => {
       // Legend must be in the dedicated scrollable container, not inside the SVG
       const legendContainer = chart.locator('.usage-logs-legend-container');
       await expect(legendContainer).toBeVisible();
+
+      // Verify legend items from the mocked data appear inside the container
+      await expect(
+        legendContainer.getByText('Create Repository'),
+      ).toBeVisible();
+      await expect(
+        legendContainer.getByText('Delete repository'),
+      ).toBeVisible();
+      await expect(
+        legendContainer.getByText('Create Robot Account'),
+      ).toBeVisible();
 
       // The chart SVG must still be present at full height
       await expect(chart.locator('svg').first()).toBeVisible();

--- a/web/playwright/e2e/usage-logs.spec.ts
+++ b/web/playwright/e2e/usage-logs.spec.ts
@@ -283,6 +283,44 @@ test.describe('Usage Logs', {tag: ['@logs']}, () => {
     );
   });
 
+  test(
+    'chart legend renders in scrollable container below chart SVG',
+    {tag: ['@PROJQUAY-11577']},
+    async ({authenticatedPage, api}) => {
+      const org = await api.organization('legendlayout');
+      const today = new Date().toISOString().slice(0, 10) + 'T12:00:00Z';
+
+      await authenticatedPage.route(
+        `**/api/v1/organization/${org.name}/aggregatelogs*`,
+        async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              aggregated: [
+                {kind: 'create_repo', count: 3, datetime: today},
+                {kind: 'delete_repo', count: 1, datetime: today},
+                {kind: 'create_robot', count: 2, datetime: today},
+              ],
+            }),
+          });
+        },
+      );
+
+      await authenticatedPage.goto(`/organization/${org.name}?tab=Logs`);
+
+      const chart = authenticatedPage.getByTestId('usage-logs-chart');
+      await expect(chart).toBeVisible();
+
+      // Legend must be in the dedicated scrollable container, not inside the SVG
+      const legendContainer = chart.locator('.usage-logs-legend-container');
+      await expect(legendContainer).toBeVisible();
+
+      // The chart SVG must still be present at full height
+      await expect(chart.locator('svg').first()).toBeVisible();
+    },
+  );
+
   test('shows info alert when Splunk search is not configured', async ({
     authenticatedPage,
     api,

--- a/web/src/routes/UsageLogs/UsageLogsGraph.tsx
+++ b/web/src/routes/UsageLogs/UsageLogsGraph.tsx
@@ -26,6 +26,7 @@ interface UsageLogsGraphProps {
   enabled?: boolean;
 }
 
+/** Renders aggregate usage log data as a bar chart with a scrollable legend below the SVG. */
 export default function UsageLogsGraph(props: UsageLogsGraphProps) {
   // D3 Category20 colors (same as Angular)
   const d3Category20Colors = [

--- a/web/src/routes/UsageLogs/UsageLogsGraph.tsx
+++ b/web/src/routes/UsageLogs/UsageLogsGraph.tsx
@@ -163,25 +163,12 @@ export default function UsageLogsGraph(props: UsageLogsGraphProps) {
               x: [new Date(props.starttime), new Date(props.endtime)],
               y: [0, maxRange],
             }}
-            legendAllowWrap
-            legendComponent={
-              <ChartLegend
-                data={getLegendData()}
-                itemsPerRow={6}
-                style={{
-                  labels: {fontSize: 11},
-                }}
-              />
-            }
-            // @ts-expect-error PatternFly's type definitions are incomplete, but "top" works in practice
-            legendPosition="top"
-            legendOrientation="horizontal"
             name="usage-logs-graph"
             padding={{
               bottom: 50,
               left: 80,
               right: 50,
-              top: 120, // More space for legend above chart
+              top: 50,
             }}
             domainPadding={{x: 5 * Object.keys(logData).length}}
             height={500}
@@ -206,6 +193,15 @@ export default function UsageLogsGraph(props: UsageLogsGraphProps) {
               ))}
             </ChartGroup>
           </Chart>
+          <div className="usage-logs-legend-container">
+            <ChartLegend
+              data={getLegendData()}
+              itemsPerRow={6}
+              orientation="horizontal"
+              style={{labels: {fontSize: 11}}}
+              width={1200}
+            />
+          </div>
         </FlexItem>
       </Flex>
     );

--- a/web/src/routes/UsageLogs/css/UsageLogs.scss
+++ b/web/src/routes/UsageLogs/css/UsageLogs.scss
@@ -6,6 +6,12 @@
   margin: 20px;
 }
 
+.usage-logs-legend-container {
+  overflow-y: auto;
+  max-height: 200px;
+  width: 1200px;
+}
+
 .pf-v6-theme-dark {
   --pf-v6-chart-global--label--Fill: var(--pf-t--global--text--color--brand--hover);
 }


### PR DESCRIPTION
## Summary
- Fixes legend overlap on the Superuser > Usage Logs chart when there are many distinct log action types (60+)
- Legend is now rendered below the chart in a scrollable container, keeping the full chart height intact

## Root Cause / Rationale
The Victory/PatternFly `ChartLegend` was embedded inside the chart's fixed-height SVG canvas via the `legendComponent` prop. With 60 action types arranged 6 per row, the legend alone consumed ~200px inside the 500px SVG, leaving the actual bar chart compressed to an unreadable strip at the bottom.

## Changes
- `web/src/routes/UsageLogs/UsageLogsGraph.tsx`: Removed `legendComponent`, `legendAllowWrap`, `legendPosition`, and `legendOrientation` props from the `<Chart>` element; added a standalone `<ChartLegend>` below the chart wrapped in a scrollable `div`; reduced chart `padding.top` from 120→50 to reclaim space
- `web/src/routes/UsageLogs/css/UsageLogs.scss`: Added `.usage-logs-legend-container` CSS class with `overflow-y: auto; max-height: 200px; width: 1200px` so the legend scrolls independently when there are many items

## Test Plan
- [ ] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [x] Manual testing performed
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

Manual test steps:
1. Log in as a superuser
2. Navigate to Superuser > Usage Logs
3. Click "Show Chart" — verify bar chart displays at full height with no legend overlap
4. Scroll the legend container below the chart to see all action types
5. Confirm chart bars and Y-axis labels are fully readable

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11577

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-c34afa2e-eb13-4780-b545-0b24a6af2388