### PR TITLE
NO-ISSUE: revert(data): revert push query and tag locking changes

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -1,12 +1,10 @@
 # pylint: disable=old-style-class,no-init
 from __future__ import annotations
 
-import hashlib
 import inspect
 import logging
 import os
 import string
-import struct
 import sys
 import time
 import uuid
@@ -221,37 +219,6 @@ SCHEME_SPECIALIZED_FOR_UPDATE = {
 }
 
 
-def real_advisory_xact_lock(lock_id):
-    """Acquire a PostgreSQL transaction-scoped advisory lock.
-
-    The lock is automatically released when the transaction ends (commit or rollback).
-    Unlike row-level locks (SELECT FOR UPDATE), advisory locks do not block readers
-    and do not require locking an actual row.
-    """
-    db.execute_sql("SELECT pg_advisory_xact_lock(%s)", (lock_id,))
-
-
-def null_advisory_xact_lock(lock_id):
-    """No-op advisory lock for databases that don't support it (e.g. SQLite)."""
-    pass
-
-
-def compute_advisory_lock_id(namespace, key):
-    """Compute a deterministic 64-bit signed integer lock ID from a namespace string and
-    an integer key. The namespace prevents collisions between different lock use cases.
-
-    Returns a value in the range of a PostgreSQL bigint (-2^63 to 2^63-1).
-    """
-    h = hashlib.sha256(f"{namespace}:{key}".encode()).digest()
-    # Unpack as signed 64-bit integer to match PostgreSQL bigint range
-    return struct.unpack(">q", h[:8])[0]
-
-
-SCHEME_SPECIALIZED_ADVISORY_LOCK = {
-    "sqlite": null_advisory_xact_lock,
-}
-
-
 class CallableProxy(Proxy):
     def __call__(self, *args, **kwargs):
         if self.obj is None:
@@ -421,7 +388,6 @@ db_disallow_replica_use = CallableProxy()
 db_concat_func = CallableProxy()
 db_encrypter = Proxy()
 db_count_estimator = CallableProxy()
-db_advisory_xact_lock = CallableProxy()
 ensure_under_transaction = CallableProxy()
 
 
@@ -690,9 +656,6 @@ def configure(config_object, testing=False):
     )
     db_concat_func.initialize(
         SCHEME_SPECIALIZED_CONCAT.get(parsed_write_uri.drivername, function_concat)
-    )
-    db_advisory_xact_lock.initialize(
-        SCHEME_SPECIALIZED_ADVISORY_LOCK.get(parsed_write_uri.drivername, real_advisory_xact_lock)
     )
     db_encrypter.initialize(FieldEncrypter(config_object.get("DATABASE_SECRET_KEY")))
     db_count_estimator.initialize(SCHEME_ESTIMATOR_FUNCTION[parsed_write_uri.drivername])

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -16,8 +16,6 @@ from data.database import (
     Tag,
     TagPullStatistics,
     User,
-    compute_advisory_lock_id,
-    db_advisory_xact_lock,
     db_random_func,
     db_regex_search,
     db_transaction,
@@ -463,34 +461,30 @@ def retarget_tag(
     now_ms = now_ms or get_epoch_timestamp_ms()
 
     with db_transaction():
-        # Acquire an advisory lock keyed on the repository ID to serialize
-        # tag mutations for this repo. Unlike SELECT FOR UPDATE on the
-        # Repository row, advisory locks don't block unrelated reads and
-        # avoid lock-queue pileups under heavy push traffic.
-        lock_id = compute_advisory_lock_id("retarget_tag", manifest.repository_id)
-        db_advisory_xact_lock(lock_id)
-
-        try:
-            repo = Repository.select().where(Repository.id == manifest.repository_id).get()
-        except Repository.DoesNotExist:
-            if raise_on_error:
-                raise RetargetTagException("Repository no longer exists")
-            return None
-
-        # Now safe to read/modify tags - we hold the advisory lock
+        # Lookup an existing tag in the repository with the same name and, if present, mark it
+        # as expired.
         existing_tag = get_tag(manifest.repository_id, tag_name)
         if existing_tag is not None:
+            # Check if the existing tag is immutable
             if features.IMMUTABLE_TAGS and existing_tag.immutable:
                 if raise_on_error:
                     raise ImmutableTagException(tag_name, "overwrite", manifest.repository_id)
                 return None
 
-            delete_tag_notifications_for_tag(existing_tag)
-            Tag.update(lifetime_end_ms=now_ms).where(Tag.id == existing_tag.id).execute()
+            _, okay = set_tag_end_ms(existing_tag, now_ms)
+
+            # TODO: should we retry here and/or use a for-update?
+            if not okay:
+                return None
 
         # Check if tag should be immutable based on manifest label or policies
         immutable = False
         immutable_from_policy = False
+        repo = (
+            Repository.select(Repository.namespace_user)
+            .where(Repository.id == manifest.repository_id)
+            .get()
+        )
         if features.IMMUTABLE_TAGS:
             immutable_from_policy = immutability.evaluate_immutability_policies(
                 manifest.repository_id, repo.namespace_user_id, tag_name

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -8,7 +8,7 @@ from playhouse.test_utils import assert_query_count
 
 from app import storage
 from data import model
-from data.database import ImageStorageLocation, ManifestChild, Repository, Tag, User, db
+from data.database import ImageStorageLocation, ManifestChild, Repository, Tag, User
 from data.model import ImmutableTagException
 from data.model.blob import store_blob_record_and_temp_link
 from data.model.oci.manifest import get_or_create_manifest
@@ -49,26 +49,6 @@ from image.docker.schema2.list import DockerSchema2ManifestListBuilder
 from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
 from test.fixtures import *
 from util.bytes import Bytes
-
-
-def _force_delete_repository(repo_id):
-    """Delete a repository while bypassing FK constraints (works on SQLite and PostgreSQL).
-
-    Used to simulate a race condition where a repository is deleted between
-    manifest lookup and repository lookup inside retarget_tag.
-    """
-    is_sqlite = "sqlite" in type(db.obj).__name__.lower()
-    if is_sqlite:
-        db.execute_sql("PRAGMA foreign_keys = OFF")
-    else:
-        db.execute_sql("SET session_replication_role = 'replica'")
-    try:
-        Repository.delete().where(Repository.id == repo_id).execute()
-    finally:
-        if is_sqlite:
-            db.execute_sql("PRAGMA foreign_keys = ON")
-        else:
-            db.execute_sql("SET session_replication_role = 'origin'")
 
 
 def _populate_blob(content):
@@ -1188,96 +1168,3 @@ class TestSetTagsImmutabilityForManifest:
         updated = Tag.get_by_id(tag.id)
         assert updated.immutable is True
         assert updated.lifetime_end_ms is None
-
-
-class TestRetargetTagRaceCondition:
-    """Tests for retarget_tag race condition protection via repository locking."""
-
-    def test_retarget_tag_creates_single_active_tag(self, initialized_db):
-        """Test that multiple retarget_tag calls produce only one active tag."""
-        repo = model.repository.create_repository("devtable", "newrepo", None)
-        manifest1, _ = create_manifest_for_testing(repo, "race1")
-        manifest2, _ = create_manifest_for_testing(repo, "race2")
-
-        tag1 = retarget_tag("racelatest", manifest1.id)
-        assert tag1 is not None
-        assert tag1.lifetime_end_ms is None
-
-        tag2 = retarget_tag("racelatest", manifest2.id)
-        assert tag2 is not None
-        assert tag2.lifetime_end_ms is None
-
-        active_tags = list(
-            Tag.select().where(
-                Tag.repository == repo.id, Tag.name == "racelatest", Tag.lifetime_end_ms >> None
-            )
-        )
-        assert len(active_tags) == 1
-        assert active_tags[0].id == tag2.id
-
-        tag1_refreshed = Tag.get_by_id(tag1.id)
-        assert tag1_refreshed.lifetime_end_ms is not None
-
-    def test_retarget_tag_new_tag_no_duplicate(self, initialized_db):
-        """Test that creating a new tag doesn't create duplicates."""
-        repo = model.repository.create_repository("devtable", "newrepo", None)
-        manifest, _ = create_manifest_for_testing(repo, "newtag1")
-
-        tag = retarget_tag("noduptag", manifest.id)
-        assert tag is not None
-        assert tag.lifetime_end_ms is None
-
-        active_tags = list(
-            Tag.select().where(
-                Tag.repository == repo.id, Tag.name == "noduptag", Tag.lifetime_end_ms >> None
-            )
-        )
-        assert len(active_tags) == 1
-
-    def test_retarget_tag_expires_previous_correctly(self, initialized_db):
-        """Test that previous tag is expired with correct timestamp."""
-        repo = model.repository.create_repository("devtable", "newrepo", None)
-        manifest1, _ = create_manifest_for_testing(repo, "expire1")
-        manifest2, _ = create_manifest_for_testing(repo, "expire2")
-
-        now_ms = get_epoch_timestamp_ms()
-        tag1 = retarget_tag("expiretag", manifest1.id, now_ms=now_ms)
-        assert tag1.lifetime_start_ms == now_ms
-
-        later_ms = now_ms + 10000
-        tag2 = retarget_tag("expiretag", manifest2.id, now_ms=later_ms)
-        assert tag2.lifetime_start_ms == later_ms
-
-        tag1_refreshed = Tag.get_by_id(tag1.id)
-        assert tag1_refreshed.lifetime_end_ms == later_ms
-
-    def test_retarget_tag_repository_not_found_returns_none(self, initialized_db):
-        """Test that retarget_tag returns None when repository no longer exists."""
-        repo = model.repository.create_repository("devtable", "newrepo", None)
-        manifest, _ = create_manifest_for_testing(repo, "reponotfound1")
-
-        # Delete the repository to simulate it being removed between manifest
-        # lookup and repository lookup inside retarget_tag.
-        # Temporarily disable FK constraints so we can remove the repo while
-        # the manifest row still exists (mimicking a race condition).
-        _force_delete_repository(repo.id)
-
-        result = retarget_tag("failingtag", manifest.id, raise_on_error=False)
-        assert result is None
-
-    def test_retarget_tag_repository_not_found_raises_exception(self, initialized_db):
-        """Test that retarget_tag raises exception when repository not found and raise_on_error=True."""
-        from data.model.oci.tag import RetargetTagException
-
-        repo = model.repository.create_repository("devtable", "newrepo", None)
-        manifest, _ = create_manifest_for_testing(repo, "reponotfound2")
-
-        # Delete the repository to simulate it being removed between manifest
-        # lookup and repository lookup inside retarget_tag.
-        # Temporarily disable FK constraints so we can remove the repo while
-        # the manifest row still exists (mimicking a race condition).
-        _force_delete_repository(repo.id)
-
-        with pytest.raises(RetargetTagException) as exc_info:
-            retarget_tag("failingtag", manifest.id, raise_on_error=True)
-        assert "Repository no longer exists" in str(exc_info.value)

--- a/data/model/quota.py
+++ b/data/model/quota.py
@@ -76,33 +76,22 @@ def update_sizes(repository_id: int, manifest_id: int, blobs: dict, operation: s
         )
         return
 
-    # Batch-check which blobs already exist in the namespace and repository
-    # using two set-based queries instead of 2N individual queries.
-    blob_ids = set(blobs.keys())
-    existing_in_namespace = _blobs_existing_in_namespace(namespace_id, manifest_id, blob_ids)
-    # Only check repo existence for blobs that DO exist in the namespace,
-    # since blobs not in namespace can't be in the repo either.
-    blobs_to_check_in_repo = blob_ids & existing_in_namespace
-    existing_in_repo = (
-        _blobs_existing_in_repository(repository_id, manifest_id, blobs_to_check_in_repo)
-        if blobs_to_check_in_repo
-        else set()
-    )
-
     # Addition - if the blob already referenced it's already been counted
     # Subtraction - should only happen on the deletion of the last blob, if another exists
     # don't subtract
     namespace_total = 0
     repository_total = 0
     for blob_id, blob_image_size in blobs.items():
+
+        # If the blob doesn't exist in the namespace it doesn't exist in the repo either
+        # so add the total to both. If it exists in the namespace we need to check
+        # if it exists in the repository.
         blob_size = blob_image_size if blob_image_size is not None else 0
-        if blob_id not in existing_in_namespace:
-            # New to both namespace and repo
-            namespace_total += blob_size
-            repository_total += blob_size
-        elif blob_id not in existing_in_repo:
-            # Exists in namespace but new to this repo
-            repository_total += blob_size
+        if not blob_exists_in_namespace(namespace_id, manifest_id, blob_id):
+            namespace_total = namespace_total + blob_size
+            repository_total = repository_total + blob_size
+        elif not blob_exists_in_repository(repository_id, manifest_id, blob_id):
+            repository_total = repository_total + blob_size
 
     write_namespace_total(namespace_id, manifest_id, namespace_total, operation)
 
@@ -110,42 +99,32 @@ def update_sizes(repository_id: int, manifest_id: int, blobs: dict, operation: s
     write_repository_total(repository_id, manifest_id, repository_total, operation)
 
 
-def _blobs_existing_in_namespace(namespace_id: int, manifest_id: int, blob_ids: set) -> set:
-    """Return the subset of blob_ids that are already referenced by other manifests
-    in the namespace. Uses a single query instead of one per blob."""
-    if not blob_ids:
-        return set()
-    return set(
-        row.blob_id
-        for row in (
-            ManifestBlob.select(ManifestBlob.blob)
-            .join(Repository, on=(ManifestBlob.repository == Repository.id))
-            .where(
-                Repository.namespace_user == namespace_id,
-                ManifestBlob.blob << blob_ids,
-                ManifestBlob.manifest != manifest_id,
-            )
-            .distinct()
+def blob_exists_in_namespace(namespace_id: int, manifest_id: int, blob_id: int):
+    # Return true if there exists some other manifest within the namespace that
+    # references this blob
+    return (
+        ManifestBlob.select(1)
+        .join(Repository, on=(ManifestBlob.repository == Repository.id))
+        .where(
+            Repository.namespace_user == namespace_id,
+            ManifestBlob.blob == blob_id,
+            ManifestBlob.manifest != manifest_id,
         )
+        .exists()
     )
 
 
-def _blobs_existing_in_repository(repository_id: int, manifest_id: int, blob_ids: set) -> set:
-    """Return the subset of blob_ids that are already referenced by other manifests
-    in the repository. Uses a single query instead of one per blob."""
-    if not blob_ids:
-        return set()
-    return set(
-        row.blob_id
-        for row in (
-            ManifestBlob.select(ManifestBlob.blob)
-            .where(
-                ManifestBlob.repository == repository_id,
-                ManifestBlob.blob << blob_ids,
-                ManifestBlob.manifest != manifest_id,
-            )
-            .distinct()
+def blob_exists_in_repository(repository_id: int, manifest_id: int, blob_id: int):
+    # Return true if there exists some other manifest within the repository that
+    # references this blob
+    return (
+        ManifestBlob.select(1)
+        .where(
+            ManifestBlob.repository == repository_id,
+            ManifestBlob.blob == blob_id,
+            ManifestBlob.manifest != manifest_id,
         )
+        .exists()
     )
 
 

--- a/data/model/test/test_quota.py
+++ b/data/model/test/test_quota.py
@@ -284,7 +284,7 @@ class TestQuota:
         repository_size_row = get_repository_size_row(self.org2repo1.id)
         assert repository_size_row is None
 
-        with assert_query_count(9):
+        with assert_query_count(10):
             with patch("data.model.quota.logger.info", MagicMock()) as mock_logger:
                 update_quota(
                     self.org2repo1.id,
@@ -313,7 +313,7 @@ class TestQuota:
         repository_size_row = get_repository_size_row(self.org2repo1.id)
         assert repository_size_row is None
 
-        with assert_query_count(7):
+        with assert_query_count(8):
             with patch("data.model.quota.logger.info", MagicMock()) as mock_logger:
                 update_quota(
                     self.org2repo1.id, org2repo1manifest2.id, {1: 10, 2: 20}, QuotaOperation.ADD


### PR DESCRIPTION
## Summary
- Reverts PR #5667 (batched blob existence queries in quota calculation, advisory locks for tag serialization)
- Reverts PR #4966 (repository row locking via `SELECT FOR UPDATE` in `retarget_tag`)
- Restores original `set_tag_end_ms` flow and per-blob quota queries

## Root Cause / Rationale
Rolling back the push query optimizations and tag locking changes introduced in PRs #5667 and #4966.

## Changes
- `data/database.py`: Remove `_advisory_xact_lock` and `_stable_hash_id` helpers added by #5667
- `data/model/oci/tag.py`: Remove `db_for_update` locking in `retarget_tag`, restore original `set_tag_end_ms` call and per-query repo lookup
- `data/model/oci/test/test_oci_tag.py`: Remove `TestRetargetTagRaceCondition` test class from #4966, restore original mock-based race condition tests from #5667
- `data/model/quota.py`: Restore original per-blob `blob_exists_in_namespace`/`blob_exists_in_repository` functions, remove batched query approach
- `data/model/test/test_quota.py`: Restore original quota test assertions

## Test Plan
- [ ] Unit tests added/updated
- [ ] Registry tests pass (`make registry-test`)
- [ ] Type checking passes (`make types-test`)
- [ ] Manual testing performed
- [ ] Frontend tests pass (Playwright/Cypress)
- [ ] Migration tested (upgrade and downgrade)

## JIRA
N/A (NO-ISSUE)

## Backport
- [x] No backport needed