### PR TITLE
NO-ISSUE: ci(workflows): add bot PR approval policy check

### DIFF
--- a/.github/workflows/bot-approval-check.yaml
+++ b/.github/workflows/bot-approval-check.yaml
@@ -1,0 +1,58 @@
+name: PR Approval Policy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  approval-policy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check approval count
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+            const botUsers = ['quay-devel'];
+            const requiredApprovals = botUsers.includes(prAuthor) ? 2 : 1;
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            const latestReviewByUser = reviews
+              .sort((a, b) => new Date(b.submitted_at) - new Date(a.submitted_at))
+              .reduce((acc, review) => {
+                if (!acc[review.user.login]) {
+                  acc[review.user.login] = review;
+                }
+                return acc;
+              }, {});
+
+            const approvalCount = Object.values(latestReviewByUser)
+              .filter(r => r.state === 'APPROVED')
+              .filter(r => r.user.login !== prAuthor)
+              .length;
+
+            const passed = approvalCount >= requiredApprovals;
+
+            core.info(`PR #${prNumber} by ${prAuthor}`);
+            core.info(`Approvals: ${approvalCount}/${requiredApprovals}`);
+
+            if (!passed) {
+              const needed = requiredApprovals - approvalCount;
+              core.setFailed(
+                botUsers.includes(prAuthor)
+                  ? `Bot PR requires ${requiredApprovals} approvals (${approvalCount} received, ${needed} more needed)`
+                  : `PR requires ${requiredApprovals} approval (${approvalCount} received, ${needed} more needed)`
+              );
+            }


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that requires 2 approvals for PRs authored by `quay-devel` (bot user) while keeping the standard 1-approval requirement for human-authored PRs
- Uses the job name (`approval-policy`) as a required status check — no `checks.create()` API call needed
- Counts only the latest review per user to correctly handle approve → request-changes flows

## Root Cause / Rationale
`quay-devel` is an autonomous bot user that creates PRs. As a safety layer for AI-generated code changes, we want to require an additional human approval before merge. GitHub's native rulesets, branch protection, and CODEOWNERS cannot differentiate approval counts by PR author, so a custom GitHub Actions check is needed.

## Changes
- Added `.github/workflows/bot-approval-check.yaml` — a workflow triggered on `pull_request` and `pull_request_review` events that:
  - Checks if the PR author is in the `botUsers` list (`quay-devel`)
  - Fetches all reviews and keeps only the latest per reviewer (handles approve → request-changes correctly)
  - Excludes self-approvals (bot can't approve its own PR)
  - Fails the job if the approval threshold is not met (2 for bots, 1 for humans)

## Test Plan
- [ ] Manual testing performed
- [ ] Verify check runs on a PR from `quay-devel` and requires 2 approvals
- [ ] Verify check runs on a human PR and requires 1 approval
- [ ] After merge, mark `approval-policy` as required in branch protection settings

## JIRA
N/A — NO-ISSUE

## Backport
- [x] No backport needed