### PR TITLE
[redhat-3.16] PROJQUAY-11492: chore(web): bump axios to 1.15.2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^20.6.5",
         "@types/react": "^18.2.0",
         "@types/react-google-recaptcha": "^2.1.9",
-        "axios": "^1.15.1",
+        "axios": "^1.15.2",
         "https-proxy-agent": "^5.0.1",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.7.6",
@@ -5060,9 +5060,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^20.6.5",
     "@types/react": "^18.2.0",
     "@types/react-google-recaptcha": "^2.1.9",
-    "axios": "^1.15.1",
+    "axios": "^1.15.2",
     "https-proxy-agent": "^5.0.1",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.7.6",


### PR DESCRIPTION
Bumping axios version to 1.15.2, which is resolves [PROJQUAY-11492](https://redhat.atlassian.net/browse/PROJQUAY-11492)


