### PR TITLE
[redhat-3.12] PROJQUAY-11488: chore(web): bump axios to 1.15.2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@types/jest": "^29.5.3",
         "@types/node": "^20.6.5",
         "@types/react": "^17.0.2",
-        "axios": "^1.15.1",
+        "axios": "^1.15.2",
         "buffer": "^4.9.2",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.7.6",
@@ -6964,9 +6964,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -30224,7 +30224,7 @@
         "@redhat-cloud-services/types": "^0.0.24",
         "@sentry/browser": "^5.30.0",
         "awesome-debounce-promise": "^2.1.0",
-        "axios": "^1.15.1",
+        "axios": "^1.15.2",
         "commander": "^2.20.3",
         "mkdirp": "^1.0.4",
         "react-content-loader": "^6.2.0"
@@ -30248,7 +30248,7 @@
       "integrity": "sha512-zFTumiNZdgxAuihm53JwUM37nF5yMyMsDxlJ9EMD11SXLKh1LkNZVScie3y7JT7VQ6D8C8y74TAn/n5B25Vq4w==",
       "peer": true,
       "requires": {
-        "axios": "^1.15.1"
+        "axios": "^1.15.2"
       }
     },
     "@redhat-cloud-services/types": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^29.5.3",
     "@types/node": "^20.6.5",
     "@types/react": "^17.0.2",
-    "axios": "^1.15.1",
+    "axios": "^1.15.2",
     "buffer": "^4.9.2",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.7.6",
@@ -117,7 +117,7 @@
     "@patternfly/react-icons": "^5.1.0",
     "@patternfly/react-table": "^5.1.0",
     "node-forge": "^1.4.0",
-    "axios": "^1.15.1",
+    "axios": "^1.15.2",
     "minimatch": "^3.1.5",
     "filelist": {
       "minimatch": "^5.0.1"


### PR DESCRIPTION
Bumping axios version to 1.15.2, this resolves [PROJQUAY-11488](https://redhat.atlassian.net/browse/PROJQUAY-11488)