### PR TITLE
PROJQUAY-11588: feat(oauth): allow any authenticated user to authorize OAuth apps

### DIFF
--- a/config.py
+++ b/config.py
@@ -999,7 +999,7 @@ class DefaultConfig(ImmutableConfig):
     ROBOTS_WHITELIST: Optional[List[str]] = []
 
     FEATURE_ASSIGN_OAUTH_TOKEN = True
-    FEATURE_PUBLIC_OAUTH_APPS = True
+    FEATURE_PUBLIC_OAUTH_APPS = False
     DEFAULT_NAMESPACE_AUTOPRUNE_POLICY: Optional[Dict[str, str]] = None
 
     # Allows users to set up notifications on image expiry, can remove flag once feature is tested

--- a/config.py
+++ b/config.py
@@ -54,6 +54,7 @@ CLIENT_WHITELIST = [
     "FOOTER_LINKS",
     "UI_DELAY_AFTER_WRITE_SECONDS",
     "FEATURE_ASSIGN_OAUTH_TOKEN",
+    "FEATURE_PUBLIC_OAUTH_APPS",
     "FEATURE_IMAGE_EXPIRY_TRIGGER",
     "FEATURE_AUTO_PRUNE",
     "DEFAULT_NAMESPACE_AUTOPRUNE_POLICY",
@@ -998,6 +999,7 @@ class DefaultConfig(ImmutableConfig):
     ROBOTS_WHITELIST: Optional[List[str]] = []
 
     FEATURE_ASSIGN_OAUTH_TOKEN = True
+    FEATURE_PUBLIC_OAUTH_APPS = True
     DEFAULT_NAMESPACE_AUTOPRUNE_POLICY: Optional[Dict[str, str]] = None
 
     # Allows users to set up notifications on image expiry, can remove flag once feature is tested

--- a/data/model/oauth.py
+++ b/data/model/oauth.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote, urlparse
 from flask import url_for
 from peewee import PeeweeException
 
+import features
 from auth import scopes
 from data.database import (
     OAuthAccessToken,
@@ -251,7 +252,12 @@ class DatabaseAuthorizationProvider(AuthorizationProvider):
         # Check for a valid client ID.
         oauth_application = self.get_application_for_client_id(client_id)
 
-        if oauth_application is None or not self.is_org_admin_or_has_token_assignment(
+        if oauth_application is None:
+            err = "unauthorized_client"
+            return self._make_redirect_error_response(redirect_uri, err)
+
+        # If PUBLIC_OAUTH_APPS is disabled, require org admin or token assignment.
+        if not features.PUBLIC_OAUTH_APPS and not self.is_org_admin_or_has_token_assignment(
             oauth_application.organization, assignment_uuid
         ):
             err = "unauthorized_client"

--- a/data/model/oauth.py
+++ b/data/model/oauth.py
@@ -244,34 +244,42 @@ class DatabaseAuthorizationProvider(AuthorizationProvider):
     def get_token_response(
         self, response_type, client_id, redirect_uri, assignment_uuid=None, **params
     ):
-        # Ensure proper response_type
-        if response_type != "token":
-            err = "unsupported_response_type"
-            return self._make_redirect_error_response(redirect_uri, err)
-
         # Check for a valid client ID.
         oauth_application = self.get_application_for_client_id(client_id)
-
         if oauth_application is None:
-            err = "unauthorized_client"
-            return self._make_redirect_error_response(redirect_uri, err)
-
-        # If PUBLIC_OAUTH_APPS is disabled, require org admin or token assignment.
-        if not features.PUBLIC_OAUTH_APPS and not self.is_org_admin_or_has_token_assignment(
-            oauth_application.organization, assignment_uuid
-        ):
-            err = "unauthorized_client"
-            return self._make_redirect_error_response(redirect_uri, err)
+            return self._make_json_error_response("unauthorized_client")
 
         # Check for a valid redirect URI.
         is_valid_redirect_uri = self.validate_redirect_uri(client_id, redirect_uri)
         if not is_valid_redirect_uri:
             return self._invalid_redirect_uri_response()
 
+        # Ensure proper response_type
+        if response_type != "token":
+            err = "unsupported_response_type"
+            return self._make_redirect_error_response(redirect_uri, err)
+
         # Check conditions
         is_valid_access = self.validate_access()
         scope = params.get("scope", "")
         are_valid_scopes = self.validate_scope(client_id, scope)
+
+        user_obj = self.get_authorized_user()
+        token_assignment = get_token_assignment_for_request(
+            assignment_uuid,
+            user_obj,
+            client_id,
+            redirect_uri,
+            response_type,
+            scope,
+        )
+
+        # If PUBLIC_OAUTH_APPS is disabled, require org admin or an exact token assignment.
+        if not features.PUBLIC_OAUTH_APPS and not (
+            is_org_admin(user_obj, oauth_application.organization) or token_assignment is not None
+        ):
+            err = "unauthorized_client"
+            return self._make_redirect_error_response(redirect_uri, err)
 
         # Return proper error responses on invalid conditions
         if not is_valid_access:
@@ -301,12 +309,9 @@ class DatabaseAuthorizationProvider(AuthorizationProvider):
             data=data,
         )
 
-        # check for assignment_id and delete it if it exists
-        if assignment_uuid is not None:
-            user_obj = self.get_authorized_user()
-            assign = get_token_assignment_for_client_id(assignment_uuid, user_obj, client_id)
-            if assign is not None:
-                assign.delete_instance()
+        # Check for an exact assignment and delete it if it exists.
+        if token_assignment is not None:
+            token_assignment.delete_instance()
 
         url = utils.build_url(redirect_uri, params)
         url += "#access_token=%s&token_type=%s&expires_in=%s" % (
@@ -316,6 +321,50 @@ class DatabaseAuthorizationProvider(AuthorizationProvider):
         )
 
         return self._make_response(headers={"Location": url}, status_code=302)
+
+    def get_authorization_code(self, response_type, client_id, redirect_uri, **params):
+        # Check for a valid client ID.
+        oauth_application = self.get_application_for_client_id(client_id)
+        if oauth_application is None:
+            return self._make_json_error_response("unauthorized_client")
+
+        # Check for a valid redirect URI before redirecting any error to the client.
+        is_valid_redirect_uri = self.validate_redirect_uri(client_id, redirect_uri)
+        if not is_valid_redirect_uri:
+            return self._invalid_redirect_uri_response()
+
+        # Ensure proper response_type.
+        if response_type != "code":
+            err = "unsupported_response_type"
+            return self._make_redirect_error_response(redirect_uri, err)
+
+        # If PUBLIC_OAUTH_APPS is disabled, code grants require org admin approval.
+        if not features.PUBLIC_OAUTH_APPS and not is_org_admin(
+            self.get_authorized_user(), oauth_application.organization
+        ):
+            err = "unauthorized_client"
+            return self._make_redirect_error_response(redirect_uri, err)
+
+        is_valid_access = self.validate_access()
+        scope = params.get("scope", "")
+        is_valid_scope = self.validate_scope(client_id, scope)
+
+        if not is_valid_access:
+            err = "access_denied"
+            return self._make_redirect_error_response(redirect_uri, err)
+
+        if not is_valid_scope:
+            err = "invalid_scope"
+            return self._make_redirect_error_response(redirect_uri, err)
+
+        code = self.generate_authorization_code()
+        self.persist_authorization_code(client_id=client_id, code=code, scope=scope)
+
+        params.update(
+            {"code": code, "response_type": None, "client_id": None, "redirect_uri": None}
+        )
+        redirect = utils.build_url(redirect_uri, params)
+        return self._make_response(headers={"Location": redirect}, status_code=302)
 
     def generate_refresh_token(self):
         return None
@@ -342,13 +391,6 @@ class DatabaseAuthorizationProvider(AuthorizationProvider):
 
     def discard_refresh_token(self, client_id, refresh_token):
         raise NotImplementedError()
-
-    def is_org_admin_or_has_token_assignment(self, organization, assignment_uuid):
-        return (
-            is_org_admin(self.get_authorized_user(), organization)
-            or get_token_assignment(assignment_uuid, self.get_authorized_user(), organization)
-            is not None
-        )
 
 
 def get_bootstrap_app_name() -> str:
@@ -885,6 +927,32 @@ def get_token_assignment(uuid, db_user, org):
         )
     except OauthAssignedToken.DoesNotExist:
         return None
+
+
+def get_token_assignment_for_request(uuid, db_user, client_id, redirect_uri, response_type, scope):
+    if uuid is None or response_type != "token" or not scopes.validate_scope_string(scope):
+        return None
+
+    try:
+        assignment = (
+            OauthAssignedToken.select()
+            .join(OAuthApplication)
+            .where(
+                OauthAssignedToken.uuid == uuid,
+                OauthAssignedToken.assigned_user == db_user,
+                OAuthApplication.client_id == client_id,
+                OauthAssignedToken.redirect_uri == redirect_uri,
+                OauthAssignedToken.response_type == "token",
+            )
+            .get()
+        )
+    except OauthAssignedToken.DoesNotExist:
+        return None
+
+    if not scopes.is_subset_string(assignment.scope, scope):
+        return None
+
+    return assignment
 
 
 def get_token_assignment_for_client_id(uuid, user, client_id):

--- a/data/model/test/test_oauth.py
+++ b/data/model/test/test_oauth.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
-from auth.scopes import READ_REPO
+from auth.scopes import READ_REPO, WRITE_REPO
 from data import model
 from data.database import LogEntryKind, OAuthAccessToken
 from data.model.oauth import DatabaseAuthorizationProvider
@@ -11,8 +11,11 @@ REDIRECT_URI = "http://foo/bar/baz"
 
 
 class MockDatabaseAuthorizationProvider(DatabaseAuthorizationProvider):
+    def __init__(self, user=None):
+        self._user = user
+
     def get_authorized_user(self):
-        return model.user.get_user("devtable")
+        return self._user or model.user.get_user("devtable")
 
 
 def setup(num_assignments=0):
@@ -246,6 +249,150 @@ def test_get_token_assignment_for_client_id(initialized_db):
         )
         == token_assignment
     )
+
+
+def test_get_token_assignment_for_request_matches_exact_request(initialized_db):
+    application, token_assignment, user, org = setup()
+
+    assert (
+        model.oauth.get_token_assignment_for_request(
+            token_assignment.uuid,
+            user,
+            application.client_id,
+            REDIRECT_URI,
+            "token",
+            READ_REPO.scope,
+        )
+        == token_assignment
+    )
+    assert (
+        model.oauth.get_token_assignment_for_request(
+            token_assignment.uuid,
+            user,
+            application.client_id,
+            REDIRECT_URI,
+            "code",
+            READ_REPO.scope,
+        )
+        is None
+    )
+    assert (
+        model.oauth.get_token_assignment_for_request(
+            token_assignment.uuid,
+            user,
+            application.client_id,
+            "http://foo/other",
+            "token",
+            READ_REPO.scope,
+        )
+        is None
+    )
+
+
+def test_token_assignment_for_app_a_cannot_authorize_app_b(initialized_db):
+    org = model.organization.get_organization("buynlarge")
+    user = model.user.get_user("freshuser")
+    app_a = model.oauth.create_application(org, "test-a", "http://foo/a", REDIRECT_URI)
+    app_b = model.oauth.create_application(org, "test-b", "http://foo/b", REDIRECT_URI)
+    assignment = model.oauth.assign_token_to_user(
+        app_a, user, REDIRECT_URI, READ_REPO.scope, "token"
+    )
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = False
+            db_auth_provider = MockDatabaseAuthorizationProvider(user)
+            response = db_auth_provider.get_token_response(
+                "token",
+                app_b.client_id,
+                REDIRECT_URI,
+                assignment.uuid,
+                scope=READ_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error=unauthorized_client" in response.headers["Location"]
+    assert model.oauth.get_assigned_authorization_for_user(user, assignment.uuid) is not None
+
+
+def test_token_assignment_scope_must_cover_requested_scope(initialized_db):
+    org = model.organization.get_organization("buynlarge")
+    user = model.user.get_user("freshuser")
+    application = model.oauth.create_application(org, "test-scope", "http://foo/bar", REDIRECT_URI)
+
+    narrower_assignment = model.oauth.assign_token_to_user(
+        application, user, REDIRECT_URI, READ_REPO.scope, "token"
+    )
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = False
+            db_auth_provider = MockDatabaseAuthorizationProvider(user)
+            response = db_auth_provider.get_token_response(
+                "token",
+                application.client_id,
+                REDIRECT_URI,
+                narrower_assignment.uuid,
+                scope=WRITE_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error=unauthorized_client" in response.headers["Location"]
+    assert model.oauth.get_assigned_authorization_for_user(user, narrower_assignment.uuid)
+
+    broader_assignment = model.oauth.assign_token_to_user(
+        application, user, REDIRECT_URI, WRITE_REPO.scope, "token"
+    )
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = False
+            db_auth_provider = MockDatabaseAuthorizationProvider(user)
+            response = db_auth_provider.get_token_response(
+                "token",
+                application.client_id,
+                REDIRECT_URI,
+                broader_assignment.uuid,
+                scope=READ_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error" not in response.headers["Location"]
+    assert "access_token=" in response.headers["Location"]
+    assert model.oauth.get_assigned_authorization_for_user(user, broader_assignment.uuid) is None
+
+
+def test_only_exact_assignment_is_consumed_after_successful_token_issuance(initialized_db):
+    application, token_assignment, user, org = setup()
+    mismatched_assignment = model.oauth.assign_token_to_user(
+        application, user, "http://foo/other", READ_REPO.scope, "token"
+    )
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        db_auth_provider = MockDatabaseAuthorizationProvider(user)
+        response = db_auth_provider.get_token_response(
+            "token",
+            application.client_id,
+            REDIRECT_URI,
+            mismatched_assignment.uuid,
+            scope=READ_REPO.scope,
+        )
+
+    assert response.status_code == 302
+    assert "access_token=" in response.headers["Location"]
+    assert model.oauth.get_assigned_authorization_for_user(user, mismatched_assignment.uuid)
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        db_auth_provider = MockDatabaseAuthorizationProvider(user)
+        response = db_auth_provider.get_token_response(
+            "token",
+            application.client_id,
+            REDIRECT_URI,
+            token_assignment.uuid,
+            scope=READ_REPO.scope,
+        )
+
+    assert response.status_code == 302
+    assert "access_token=" in response.headers["Location"]
+    assert model.oauth.get_assigned_authorization_for_user(user, token_assignment.uuid) is None
 
 
 # Security tests for PROJQUAY-9849: OAuth Redirect URI Validation Bypass

--- a/data/model/test/test_oauth_public_apps.py
+++ b/data/model/test/test_oauth_public_apps.py
@@ -24,7 +24,7 @@ def setup_app():
     return application, org
 
 
-def test_non_admin_blocked_when_feature_disabled(initialized_db):
+def test_non_admin_token_blocked_when_feature_disabled(initialized_db):
     """Non-org-admin cannot get a token when FEATURE_PUBLIC_OAUTH_APPS is disabled."""
     application, org = setup_app()
     non_admin = model.user.get_user("freshuser")
@@ -47,7 +47,29 @@ def test_non_admin_blocked_when_feature_disabled(initialized_db):
     assert "error=unauthorized_client" in response.headers["Location"]
 
 
-def test_non_admin_allowed_when_feature_enabled(initialized_db):
+def test_non_admin_code_blocked_when_feature_disabled(initialized_db):
+    """Non-org-admin cannot get a code when FEATURE_PUBLIC_OAUTH_APPS is disabled."""
+    application, org = setup_app()
+    non_admin = model.user.get_user("freshuser")
+
+    assert not is_org_admin(non_admin, org)
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = False
+            provider = MockDatabaseAuthorizationProvider(non_admin)
+            response = provider.get_authorization_code(
+                "code",
+                application.client_id,
+                REDIRECT_URI,
+                scope=READ_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error=unauthorized_client" in response.headers["Location"]
+
+
+def test_non_admin_token_allowed_when_feature_enabled(initialized_db):
     """Non-org-admin can get a token when FEATURE_PUBLIC_OAUTH_APPS is enabled."""
     application, org = setup_app()
     non_admin = model.user.get_user("freshuser")
@@ -70,7 +92,30 @@ def test_non_admin_allowed_when_feature_enabled(initialized_db):
     assert "access_token=" in response.headers["Location"]
 
 
-def test_org_admin_allowed_regardless_of_feature_flag(initialized_db):
+def test_non_admin_code_allowed_when_feature_enabled(initialized_db):
+    """Non-org-admin can get a code when FEATURE_PUBLIC_OAUTH_APPS is enabled."""
+    application, org = setup_app()
+    non_admin = model.user.get_user("freshuser")
+
+    assert not is_org_admin(non_admin, org)
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = True
+            provider = MockDatabaseAuthorizationProvider(non_admin)
+            response = provider.get_authorization_code(
+                "code",
+                application.client_id,
+                REDIRECT_URI,
+                scope=READ_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error" not in response.headers["Location"]
+    assert "code=" in response.headers["Location"]
+
+
+def test_org_admin_token_allowed_regardless_of_feature_flag(initialized_db):
     """Org admin can always get a token, regardless of the flag."""
     application, org = setup_app()
     admin_user = model.user.get_user("devtable")
@@ -92,6 +137,29 @@ def test_org_admin_allowed_regardless_of_feature_flag(initialized_db):
         assert response.status_code == 302
         assert "error" not in response.headers["Location"]
         assert "access_token=" in response.headers["Location"]
+
+
+def test_org_admin_code_allowed_when_feature_disabled(initialized_db):
+    """Org admin can always get a code, regardless of the flag."""
+    application, org = setup_app()
+    admin_user = model.user.get_user("devtable")
+
+    assert is_org_admin(admin_user, org)
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = False
+            provider = MockDatabaseAuthorizationProvider(admin_user)
+            response = provider.get_authorization_code(
+                "code",
+                application.client_id,
+                REDIRECT_URI,
+                scope=READ_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error" not in response.headers["Location"]
+    assert "code=" in response.headers["Location"]
 
 
 def test_token_assignment_still_works_when_feature_enabled(initialized_db):
@@ -123,8 +191,8 @@ def test_token_assignment_still_works_when_feature_enabled(initialized_db):
     assert model.oauth.get_token_assignment(token_assignment.uuid, non_admin, org) is None
 
 
-def test_invalid_client_id_rejected_regardless_of_feature(initialized_db):
-    """Invalid client_id is always rejected, even with feature enabled."""
+def test_invalid_client_id_rejected_locally_regardless_of_feature(initialized_db):
+    """Invalid client_id is always rejected locally, even with feature enabled."""
     non_admin = model.user.get_user("freshuser")
 
     with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
@@ -138,5 +206,6 @@ def test_invalid_client_id_rejected_regardless_of_feature(initialized_db):
                 scope=READ_REPO.scope,
             )
 
-    assert response.status_code == 302
-    assert "error=unauthorized_client" in response.headers["Location"]
+    assert response.status_code == 400
+    assert "Location" not in response.headers
+    assert "unauthorized_client" in response.raw.getvalue()

--- a/data/model/test/test_oauth_public_apps.py
+++ b/data/model/test/test_oauth_public_apps.py
@@ -1,0 +1,142 @@
+from unittest.mock import patch
+
+from auth.scopes import READ_REPO
+from data import model
+from data.model.oauth import DatabaseAuthorizationProvider
+from data.model.organization import is_org_admin
+from test.fixtures import *
+
+REDIRECT_URI = "http://foo/bar/baz"
+
+
+class MockDatabaseAuthorizationProvider(DatabaseAuthorizationProvider):
+    def __init__(self, user):
+        self._user = user
+
+    def get_authorized_user(self):
+        return self._user
+
+
+def setup_app():
+    """Create an OAuth app owned by buynlarge (devtable is admin)."""
+    org = model.organization.get_organization("buynlarge")
+    application = model.oauth.create_application(org, "test", "http://foo/bar", REDIRECT_URI)
+    return application, org
+
+
+def test_non_admin_blocked_when_feature_disabled(initialized_db):
+    """Non-org-admin cannot get a token when FEATURE_PUBLIC_OAUTH_APPS is disabled."""
+    application, org = setup_app()
+    non_admin = model.user.get_user("freshuser")
+
+    # Confirm this user is NOT an admin of buynlarge
+    assert not is_org_admin(non_admin, org)
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = False
+            provider = MockDatabaseAuthorizationProvider(non_admin)
+            response = provider.get_token_response(
+                "token",
+                application.client_id,
+                REDIRECT_URI,
+                scope=READ_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error=unauthorized_client" in response.headers["Location"]
+
+
+def test_non_admin_allowed_when_feature_enabled(initialized_db):
+    """Non-org-admin can get a token when FEATURE_PUBLIC_OAUTH_APPS is enabled."""
+    application, org = setup_app()
+    non_admin = model.user.get_user("freshuser")
+
+    assert not is_org_admin(non_admin, org)
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = True
+            provider = MockDatabaseAuthorizationProvider(non_admin)
+            response = provider.get_token_response(
+                "token",
+                application.client_id,
+                REDIRECT_URI,
+                scope=READ_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error" not in response.headers["Location"]
+    assert "access_token=" in response.headers["Location"]
+
+
+def test_org_admin_allowed_regardless_of_feature_flag(initialized_db):
+    """Org admin can always get a token, regardless of the flag."""
+    application, org = setup_app()
+    admin_user = model.user.get_user("devtable")
+
+    assert is_org_admin(admin_user, org)
+
+    for flag_value in (True, False):
+        with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+            with patch("data.model.oauth.features") as mock_features:
+                mock_features.PUBLIC_OAUTH_APPS = flag_value
+                provider = MockDatabaseAuthorizationProvider(admin_user)
+                response = provider.get_token_response(
+                    "token",
+                    application.client_id,
+                    REDIRECT_URI,
+                    scope=READ_REPO.scope,
+                )
+
+        assert response.status_code == 302
+        assert "error" not in response.headers["Location"]
+        assert "access_token=" in response.headers["Location"]
+
+
+def test_token_assignment_still_works_when_feature_enabled(initialized_db):
+    """Token assignment mechanism still works alongside the public apps feature."""
+    application, org = setup_app()
+    non_admin = model.user.get_user("freshuser")
+
+    assert not is_org_admin(non_admin, org)
+
+    token_assignment = model.oauth.assign_token_to_user(
+        application, non_admin, REDIRECT_URI, READ_REPO.scope, "token"
+    )
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = True
+            provider = MockDatabaseAuthorizationProvider(non_admin)
+            response = provider.get_token_response(
+                "token",
+                application.client_id,
+                REDIRECT_URI,
+                token_assignment.uuid,
+                scope=READ_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error" not in response.headers["Location"]
+    # Token assignment should be consumed (deleted)
+    assert model.oauth.get_token_assignment(token_assignment.uuid, non_admin, org) is None
+
+
+def test_invalid_client_id_rejected_regardless_of_feature(initialized_db):
+    """Invalid client_id is always rejected, even with feature enabled."""
+    non_admin = model.user.get_user("freshuser")
+
+    with patch("data.model.oauth.url_for", return_value="http://foo/bar/baz"):
+        with patch("data.model.oauth.features") as mock_features:
+            mock_features.PUBLIC_OAUTH_APPS = True
+            provider = MockDatabaseAuthorizationProvider(non_admin)
+            response = provider.get_token_response(
+                "token",
+                "nonexistent_client_id",
+                REDIRECT_URI,
+                scope=READ_REPO.scope,
+            )
+
+    assert response.status_code == 302
+    assert "error=unauthorized_client" in response.headers["Location"]

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -745,13 +745,16 @@ def request_authorization_code():
     if not oauth_app:
         abort(404)
 
-    # check if user is org admin, if not check for user_assignment_id, then check that user belongs that assignment, if none exit with 401
-    if (
-        not is_org_admin(current_user.db_user(), oauth_app.organization)
-        and get_token_assignment(assignment_uuid, current_user.db_user(), oauth_app.organization)
-        is None
-    ):
-        abort(403)
+    # If PUBLIC_OAUTH_APPS is disabled, require org admin or a pre-assigned token.
+    if not features.PUBLIC_OAUTH_APPS:
+        if (
+            not is_org_admin(current_user.db_user(), oauth_app.organization)
+            and get_token_assignment(
+                assignment_uuid, current_user.db_user(), oauth_app.organization
+            )
+            is None
+        ):
+            abort(403)
 
     if not provider.validate_has_scopes(client_id, current_user.db_user().username, scope):
         if not provider.validate_redirect_uri(client_id, redirect_uri):

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -53,7 +53,7 @@ from data.database import User, db, random_string_generator
 from data.model.oauth import (
     assign_token_to_user,
     get_oauth_application_for_client_id,
-    get_token_assignment,
+    get_token_assignment_for_request,
 )
 from data.model.organization import is_org_admin
 from data.model.user import get_nonrobot_user, get_user
@@ -745,14 +745,20 @@ def request_authorization_code():
     if not oauth_app:
         abort(404)
 
+    token_assignment = get_token_assignment_for_request(
+        assignment_uuid,
+        current_user.db_user(),
+        client_id,
+        redirect_uri,
+        response_type,
+        scope,
+    )
+
     # If PUBLIC_OAUTH_APPS is disabled, require org admin or a pre-assigned token.
     if not features.PUBLIC_OAUTH_APPS:
         if (
             not is_org_admin(current_user.db_user(), oauth_app.organization)
-            and get_token_assignment(
-                assignment_uuid, current_user.db_user(), oauth_app.organization
-            )
-            is None
+            and token_assignment is None
         ):
             abort(403)
 

--- a/features/__init__.pyi
+++ b/features/__init__.pyi
@@ -226,6 +226,7 @@ REFERRERS_API: FeatureNameValue
 
 SUPERUSERS_FULL_ACCESS: FeatureNameValue
 ASSIGN_OAUTH_TOKEN: FeatureNameValue
+PUBLIC_OAUTH_APPS: FeatureNameValue
 
 # Feature Flag: If set to true, supports setting notifications on image expiry
 IMAGE_EXPIRY_TRIGGER: FeatureNameValue

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -107,6 +107,7 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_AGGREGATED_LOG_COUNT_RETRIEVAL":        true,
 	"FEATURE_ACTION_LOG_ROTATION":                   true,
 	"FEATURE_ASSIGN_OAUTH_TOKEN":                    true,
+	"FEATURE_PUBLIC_OAUTH_APPS":                     true,
 	"FEATURE_AUTO_PRUNE":                            true,
 	"FEATURE_BITBUCKET_BUILD":                       true,
 	"FEATURE_BLACKLISTED_EMAILS":                    true,

--- a/local-dev/stack/config.yaml
+++ b/local-dev/stack/config.yaml
@@ -97,6 +97,7 @@ BROWSER_API_CALLS_XHR_ONLY: False
 CORS_ORIGIN:
   - "https://stage.foo.redhat.com:1337"
   - "http://localhost:9000"
+FEATURE_PUBLIC_OAUTH_APPS: true
 FEATURE_UI_V2: True
 FEATURE_USER_METADATA: True
 # Local Keycloak OIDC provider (PKCE disabled initially)

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -602,13 +602,88 @@ class OAuthTestCase(EndpointTestCase):
             "redirect_uri": "http://localhost:8000/o2c.html",
             "scope": "user:admin",
             "response_type": response_type,
+            "state": "xyzzy",
         }
 
         resp = self.postResponse(
             "web.authorize_application", form=form, with_csrf=True, expected_code=302
         )
         expected_value = "access_token=" if response_type == "token" else "code="
-        self.assertTrue(expected_value in resp.headers["Location"])
+        location = resp.headers["Location"]
+        self.assertTrue(expected_value in location)
+        if response_type == "code":
+            self.assertEqual(["xyzzy"], parse_qs(urlparse(location).query)["state"])
+
+    def test_public_oauth_code_grant_can_be_exchanged_for_token(self):
+        self.login("freshuser", "password")
+
+        org = model.organization.get_organization("buynlarge")
+        oauth_app = model.oauth.create_application(
+            org,
+            "public-code-test",
+            "http://foo/bar",
+            "http://foo/bar/baz",
+            client_secret="correct-secret",
+        )
+
+        with toggle_feature("PUBLIC_OAUTH_APPS", True):
+            authorize_response = self.postResponse(
+                "web.authorize_application",
+                form={
+                    "client_id": oauth_app.client_id,
+                    "redirect_uri": oauth_app.redirect_uri,
+                    "scope": "repo:read",
+                    "response_type": "code",
+                    "state": "xyzzy",
+                },
+                with_csrf=True,
+                expected_code=302,
+            )
+
+            location = authorize_response.headers["Location"]
+            parsed_query = parse_qs(urlparse(location).query)
+            self.assertEqual(["xyzzy"], parsed_query["state"])
+            code = parsed_query["code"][0]
+
+            invalid_secret_response = self.postResponse(
+                "web.exchange_code_for_token",
+                form={
+                    "grant_type": "authorization_code",
+                    "client_id": oauth_app.client_id,
+                    "client_secret": "wrong-secret",
+                    "redirect_uri": oauth_app.redirect_uri,
+                    "code": code,
+                    "scope": "repo:read",
+                },
+                with_csrf=False,
+                expected_code=400,
+            )
+            self.assertEqual(
+                {"error": "invalid_client"}, py_json.loads(invalid_secret_response.data)
+            )
+
+            token_response = self.postResponse(
+                "web.exchange_code_for_token",
+                form={
+                    "grant_type": "authorization_code",
+                    "client_id": oauth_app.client_id,
+                    "client_secret": "correct-secret",
+                    "redirect_uri": oauth_app.redirect_uri,
+                    "code": code,
+                    "scope": "repo:read",
+                },
+                with_csrf=False,
+                expected_code=200,
+            )
+
+        token_body = py_json.loads(token_response.data)
+        self.assertEqual("Bearer", token_body["token_type"])
+        self.assertIn("access_token", token_body)
+        token = model.oauth.validate_access_token(token_body["access_token"])
+        self.assertIsNotNone(token)
+        self.assertEqual("freshuser", token.authorized_user.username)
+        self.assertEqual(oauth_app, token.application)
+        self.assertEqual("repo:read", token.scope)
 
     @parameterized.expand(["token", "code"])
     def test_authorize_nocsrf(self, response_type):

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -389,6 +389,27 @@ class WebEndpointTestCase(EndpointTestCase):
         )
         assert "Are you sure you want to authorize this application?" in str(response)
 
+    def test_request_authorization_code_assignment_must_match_app(self):
+        self.login("devtable", "password")
+        devtable = get_user("devtable")
+        user = get_user("randomuser")
+        org = model.organization.create_organization("testorg", "testorg@devtable.com", user)
+        app_a = model.oauth.create_application(org, "test-a", "http://foo/a", "http://foo/bar/baz")
+        app_b = model.oauth.create_application(org, "test-b", "http://foo/b", "http://foo/bar/baz")
+        assignment = model.oauth.assign_token_to_user(
+            app_a, devtable, app_a.redirect_uri, "repo:read", "token"
+        )
+        self.getResponse(
+            "web.request_authorization_code",
+            client_id=app_b.client_id,
+            redirect_uri=app_b.redirect_uri,
+            scope="repo:read",
+            assignment_uuid=assignment.uuid,
+            response_type="token",
+            expected_code=403,
+        )
+        assert model.oauth.get_assigned_authorization_for_user(devtable, assignment.uuid)
+
     def test_request_authorization_code_assigned_authorization_disabled(self):
         self.login("devtable", "password")
         devtable = get_user("devtable")
@@ -534,11 +555,10 @@ class OAuthTestCase(EndpointTestCase):
         }
 
         resp = self.postResponse(
-            "web.authorize_application", form=form, with_csrf=True, expected_code=302
+            "web.authorize_application", form=form, with_csrf=True, expected_code=400
         )
-        self.assertEqual(
-            "http://localhost:5000/foobar?error=unauthorized_client", resp.headers["Location"]
-        )
+        self.assertNotIn("Location", resp.headers)
+        self.assertIn(b"unauthorized_client", resp.data)
 
     @parameterized.expand(["token", "code"])
     def test_authorize_invalidscope(self, response_type):
@@ -698,7 +718,7 @@ class OAuthTestCase(EndpointTestCase):
         form = {
             "client_id": app.client_id,
             "redirect_uri": app.redirect_uri,
-            "scope": "user:admin",
+            "scope": "repo:read",
             "assignment_uuid": assignment.uuid,
             "response_type": "token",
         }

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1848,8 +1848,8 @@ CONFIG_SCHEMA = {
         },
         "FEATURE_PUBLIC_OAUTH_APPS": {
             "type": "boolean",
-            "description": "When enabled, any authenticated user can authorize OAuth applications regardless of organization membership",
-            "x-example": True,
+            "description": "When enabled, any authenticated user can authorize OAuth applications regardless of organization membership. Administrators should review the security considerations in the documentation before enabling.",
+            "x-example": False,
         },
         "DEFAULT_NAMESPACE_AUTOPRUNE_POLICY": {
             "type": "object",

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1846,6 +1846,11 @@ CONFIG_SCHEMA = {
             "description": "Allows organization administrators to assign OAuth tokens to other users",
             "x-example": False,
         },
+        "FEATURE_PUBLIC_OAUTH_APPS": {
+            "type": "boolean",
+            "description": "When enabled, any authenticated user can authorize OAuth applications regardless of organization membership",
+            "x-example": True,
+        },
         "DEFAULT_NAMESPACE_AUTOPRUNE_POLICY": {
             "type": "object",
             "description": "Default auto-prune policy applied to all organizations and repositories",

--- a/web/playwright/e2e/organization/oauth-applications.spec.ts
+++ b/web/playwright/e2e/organization/oauth-applications.spec.ts
@@ -1,4 +1,5 @@
 import {test, expect} from '../../fixtures';
+import {API_URL} from '../../utils/config';
 
 test.describe('OAuth Applications', {tag: ['@organization']}, () => {
   test('OAuth app lifecycle: create, view, update, delete', async ({
@@ -179,5 +180,33 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
     if (secretBefore) {
       expect(updatedApp?.client_secret).not.toBe(secretBefore);
     }
+  });
+
+  test('non-admin user can authorize an OAuth app (PUBLIC_OAUTH_APPS)', async ({
+    authenticatedPage: page,
+    superuserApi,
+  }) => {
+    // Admin creates org + OAuth app — testuser is NOT an admin of this org
+    const org = await superuserApi.organization('public-oauth');
+    const app = await superuserApi.oauthApplication(org.name, 'public-app');
+    const redirectUri = `${API_URL}/oauth/localapp`;
+
+    // Navigate to the OAuth authorize page as the non-admin user
+    await page.goto(
+      `/oauth/authorize?client_id=${app.clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=repo:read&response_type=token`,
+    );
+
+    // Should see the consent page with the authorize button
+    await expect(
+      page.getByRole('button', {name: 'Authorize Application'}),
+    ).toBeVisible();
+
+    // Click "Authorize Application" to grant access
+    await page.getByRole('button', {name: 'Authorize Application'}).click();
+
+    // Should redirect to the local OAuth handler with the token in the URL fragment
+    await page.waitForURL(/\/oauth\/localapp/);
+    const url = page.url();
+    expect(url).toContain('access_token=');
   });
 });

--- a/web/playwright/e2e/organization/oauth-applications.spec.ts
+++ b/web/playwright/e2e/organization/oauth-applications.spec.ts
@@ -1,5 +1,18 @@
-import {test, expect} from '../../fixtures';
+import type {APIResponse} from '@playwright/test';
+import {test, expect, uniqueName} from '../../fixtures';
 import {API_URL} from '../../utils/config';
+
+const ATTACKER_REDIRECT_URI = 'https://example.invalid/callback';
+
+function expectLocalOAuthError(response: APIResponse): void {
+  const location = response.headers()['location'];
+  expect(
+    location,
+    `OAuth authorize unexpectedly redirected to ${location ?? '(no location)'}`,
+  ).toBeUndefined();
+  expect(response.status()).toBeGreaterThanOrEqual(400);
+  expect(response.status()).toBeLessThan(500);
+}
 
 test.describe('OAuth Applications', {tag: ['@organization']}, () => {
   test('OAuth app lifecycle: create, view, update, delete', async ({
@@ -214,6 +227,90 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
       expect(url).toContain('access_token=');
     },
   );
+
+  test(
+    'non-admin user can authorize an OAuth app with code flow (PUBLIC_OAUTH_APPS)',
+    {tag: ['@feature:PUBLIC_OAUTH_APPS']},
+    async ({authenticatedPage: page, superuserApi}) => {
+      const org = await superuserApi.organization('public-oauth-code');
+      const redirectUri = `${API_URL}/oauth/localapp`;
+      const app = await superuserApi.oauthApplication(
+        org.name,
+        'public-code-app',
+        redirectUri,
+        API_URL,
+      );
+
+      await page.goto(
+        `/oauth/authorize?client_id=${
+          app.clientId
+        }&redirect_uri=${encodeURIComponent(
+          redirectUri,
+        )}&scope=repo:read&response_type=code`,
+      );
+
+      await expect(
+        page.getByRole('button', {name: 'Authorize Application'}),
+      ).toBeVisible();
+
+      await page.getByRole('button', {name: 'Authorize Application'}).click();
+
+      await page.waitForURL(/\/oauth\/localapp/);
+      const url = page.url();
+      expect(url).toContain('code=');
+      expect(url).not.toContain('access_token=');
+    },
+  );
+
+  test('unknown OAuth client_id returns a local error without redirecting', async ({
+    authenticatedRequest,
+  }) => {
+    const response = await authenticatedRequest.get(
+      `${API_URL}/oauth/authorize`,
+      {
+        maxRedirects: 0,
+        params: {
+          client_id: uniqueName('missing-oauth-client'),
+          redirect_uri: ATTACKER_REDIRECT_URI,
+          scope: 'repo:read',
+          response_type: 'token',
+        },
+      },
+    );
+
+    expectLocalOAuthError(response);
+  });
+
+  test('OAuth client with mismatched redirect_uri returns a local error without redirecting', async ({
+    authenticatedRequest,
+    csrfToken,
+    api,
+  }) => {
+    const org = await api.organization('bad-oauth-redirect');
+    const redirectUri = `${API_URL}/oauth/localapp`;
+    const app = await api.oauthApplication(
+      org.name,
+      'redirect-boundary-app',
+      redirectUri,
+      API_URL,
+    );
+
+    const response = await authenticatedRequest.post(
+      `${API_URL}/oauth/authorizeapp`,
+      {
+        maxRedirects: 0,
+        headers: {'X-CSRF-Token': csrfToken},
+        form: {
+          client_id: app.clientId,
+          redirect_uri: ATTACKER_REDIRECT_URI,
+          scope: 'repo:read',
+          response_type: 'token',
+        },
+      },
+    );
+
+    expectLocalOAuthError(response);
+  });
 
   test('non-admin user cannot create OAuth apps', async ({
     superuserApi,

--- a/web/playwright/e2e/organization/oauth-applications.spec.ts
+++ b/web/playwright/e2e/organization/oauth-applications.spec.ts
@@ -197,7 +197,7 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
 
   test(
     'non-admin user can authorize an OAuth app (PUBLIC_OAUTH_APPS)',
-    {tag: ['@feature:PUBLIC_OAUTH_APPS']},
+    {tag: ['@feature:PUBLIC_OAUTH_APPS', '@superuser']},
     async ({authenticatedPage: page, superuserApi}) => {
       // Admin creates org + OAuth app — testuser is NOT an admin of this org
       const org = await superuserApi.organization('public-oauth');
@@ -230,7 +230,7 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
 
   test(
     'non-admin user can authorize an OAuth app with code flow (PUBLIC_OAUTH_APPS)',
-    {tag: ['@feature:PUBLIC_OAUTH_APPS']},
+    {tag: ['@feature:PUBLIC_OAUTH_APPS', '@superuser']},
     async ({authenticatedPage: page, superuserApi}) => {
       const org = await superuserApi.organization('public-oauth-code');
       const redirectUri = `${API_URL}/oauth/localapp`;
@@ -312,20 +312,21 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
     expectLocalOAuthError(response);
   });
 
-  test('non-admin user cannot create OAuth apps', async ({
-    superuserApi,
-    userClient,
-  }) => {
-    // Create org as superuser so testuser is NOT an admin
-    const org = await superuserApi.organization('no-create-oauth');
+  test(
+    'non-admin user cannot create OAuth apps',
+    {tag: '@superuser'},
+    async ({superuserApi, userClient}) => {
+      // Create org as superuser so testuser is NOT an admin
+      const org = await superuserApi.organization('no-create-oauth');
 
-    // Attempt to create an OAuth app as the non-admin user
-    const response = await userClient.post(
-      `/api/v1/organization/${org.name}/applications`,
-      {name: 'should-fail', redirect_uri: '', application_uri: ''},
-    );
+      // Attempt to create an OAuth app as the non-admin user
+      const response = await userClient.post(
+        `/api/v1/organization/${org.name}/applications`,
+        {name: 'should-fail', redirect_uri: '', application_uri: ''},
+      );
 
-    // Should be forbidden — only org admins can manage OAuth apps
-    expect(response.status()).toBe(403);
-  });
+      // Should be forbidden — only org admins can manage OAuth apps
+      expect(response.status()).toBe(403);
+    },
+  );
 });

--- a/web/playwright/e2e/organization/oauth-applications.spec.ts
+++ b/web/playwright/e2e/organization/oauth-applications.spec.ts
@@ -209,4 +209,21 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
     const url = page.url();
     expect(url).toContain('access_token=');
   });
+
+  test('non-admin user cannot create OAuth apps', async ({
+    superuserApi,
+    userClient,
+  }) => {
+    // Create org as superuser so testuser is NOT an admin
+    const org = await superuserApi.organization('no-create-oauth');
+
+    // Attempt to create an OAuth app as the non-admin user
+    const response = await userClient.post(
+      `/api/v1/organization/${org.name}/applications`,
+      {name: 'should-fail', redirect_uri: '', application_uri: ''},
+    );
+
+    // Should be forbidden — only org admins can manage OAuth apps
+    expect(response.status()).toBe(403);
+  });
 });

--- a/web/playwright/e2e/organization/oauth-applications.spec.ts
+++ b/web/playwright/e2e/organization/oauth-applications.spec.ts
@@ -182,7 +182,7 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
     }
   });
 
-  test('non-admin user can authorize an OAuth app (PUBLIC_OAUTH_APPS)', async ({
+  test('non-admin user can authorize an OAuth app (PUBLIC_OAUTH_APPS)', {tag: ['@feature:PUBLIC_OAUTH_APPS']}, async ({
     authenticatedPage: page,
     superuserApi,
   }) => {

--- a/web/playwright/e2e/organization/oauth-applications.spec.ts
+++ b/web/playwright/e2e/organization/oauth-applications.spec.ts
@@ -182,33 +182,38 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
     }
   });
 
-  test('non-admin user can authorize an OAuth app (PUBLIC_OAUTH_APPS)', {tag: ['@feature:PUBLIC_OAUTH_APPS']}, async ({
-    authenticatedPage: page,
-    superuserApi,
-  }) => {
-    // Admin creates org + OAuth app — testuser is NOT an admin of this org
-    const org = await superuserApi.organization('public-oauth');
-    const app = await superuserApi.oauthApplication(org.name, 'public-app');
-    const redirectUri = `${API_URL}/oauth/localapp`;
+  test(
+    'non-admin user can authorize an OAuth app (PUBLIC_OAUTH_APPS)',
+    {tag: ['@feature:PUBLIC_OAUTH_APPS']},
+    async ({authenticatedPage: page, superuserApi}) => {
+      // Admin creates org + OAuth app — testuser is NOT an admin of this org
+      const org = await superuserApi.organization('public-oauth');
+      const app = await superuserApi.oauthApplication(org.name, 'public-app');
+      const redirectUri = `${API_URL}/oauth/localapp`;
 
-    // Navigate to the OAuth authorize page as the non-admin user
-    await page.goto(
-      `/oauth/authorize?client_id=${app.clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=repo:read&response_type=token`,
-    );
+      // Navigate to the OAuth authorize page as the non-admin user
+      await page.goto(
+        `/oauth/authorize?client_id=${
+          app.clientId
+        }&redirect_uri=${encodeURIComponent(
+          redirectUri,
+        )}&scope=repo:read&response_type=token`,
+      );
 
-    // Should see the consent page with the authorize button
-    await expect(
-      page.getByRole('button', {name: 'Authorize Application'}),
-    ).toBeVisible();
+      // Should see the consent page with the authorize button
+      await expect(
+        page.getByRole('button', {name: 'Authorize Application'}),
+      ).toBeVisible();
 
-    // Click "Authorize Application" to grant access
-    await page.getByRole('button', {name: 'Authorize Application'}).click();
+      // Click "Authorize Application" to grant access
+      await page.getByRole('button', {name: 'Authorize Application'}).click();
 
-    // Should redirect to the local OAuth handler with the token in the URL fragment
-    await page.waitForURL(/\/oauth\/localapp/);
-    const url = page.url();
-    expect(url).toContain('access_token=');
-  });
+      // Should redirect to the local OAuth handler with the token in the URL fragment
+      await page.waitForURL(/\/oauth\/localapp/);
+      const url = page.url();
+      expect(url).toContain('access_token=');
+    },
+  );
 
   test('non-admin user cannot create OAuth apps', async ({
     superuserApi,

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -868,7 +868,8 @@ export type QuayFeature =
   | 'DIRECT_LOGIN'
   | 'NONSUPERUSER_TEAM_SYNCING_SETUP'
   | 'BUILD_SUPPORT'
-  | 'STORAGE_REPLICATION';
+  | 'STORAGE_REPLICATION'
+  | 'PUBLIC_OAUTH_APPS';
 
 /**
  * Quay configuration from /config endpoint

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -140,6 +140,7 @@ export interface CreatedOAuthApp {
   name: string;
   clientId: string;
   clientSecret?: string;
+  redirectUri?: string;
 }
 
 /**
@@ -806,10 +807,17 @@ export class TestApi {
   async oauthApplication(
     orgName: string,
     namePrefix = 'oauth-app',
+    redirectUri?: string,
+    appUri?: string,
   ): Promise<CreatedOAuthApp> {
     const name = uniqueName(namePrefix);
 
-    const result = await this.client.createOAuthApplication(orgName, name);
+    const result = await this.client.createOAuthApplication(
+      orgName,
+      name,
+      redirectUri,
+      appUri,
+    );
 
     this.cleanupStack.push(async () => {
       try {
@@ -824,6 +832,7 @@ export class TestApi {
       name,
       clientId: result.client_id,
       clientSecret: result.client_secret,
+      redirectUri: result.redirect_uri,
     };
   }
 


### PR DESCRIPTION
## Description

### Problem

Quay's OAuth authorization flow (`/oauth/authorize`) currently requires the authorizing user to be an **organization administrator** of the org that owns the OAuth app, or to have been explicitly pre-assigned a token by an org admin. This prevents third-party integrations (Backstage/Developer Hub, CI/CD tools, security scanners, etc.) from working because users outside the app-owning org cannot authorize the app.

This is inconsistent with how OAuth works on GitHub, GitLab, and other platforms, where any authenticated user can authorize any registered OAuth app regardless of who created it.

### Solution

Introduces a new feature flag `FEATURE_PUBLIC_OAUTH_APPS` (default: `True`) that, when enabled, removes the org-admin requirement from the OAuth **authorization** flow. Any authenticated user can authorize any registered OAuth app.

- App **management** (create, edit, delete) remains restricted to org admins — unchanged.
- The existing `FEATURE_ASSIGN_OAUTH_TOKEN` mechanism is preserved as a complementary opt-in flow.
- Setting `FEATURE_PUBLIC_OAUTH_APPS: false` in `config.yaml` restores the previous restrictive behavior.

### Changes

| File | Change |
|------|--------|
| `features/__init__.pyi` | Declare `PUBLIC_OAUTH_APPS` feature flag |
| `config.py` | Set default `True`, add to `CLIENT_WHITELIST` |
| `endpoints/web.py` | Wrap org-admin check on `/oauth/authorize` with feature flag guard |
| `data/model/oauth.py` | Wrap org-admin check in `get_token_response()` with feature flag guard; add `import features` |
| `data/model/test/test_oauth_public_apps.py` | 5 new test cases |

### Security Considerations

- **No scope escalation:** OAuth tokens are user-scoped. A token can only access resources the authorizing user already has permission to access. Opening authorization to all users does not grant any additional privileges beyond what the user themselves can do.
- **Invalid client IDs are still rejected** regardless of the feature flag.
- App management (CRUD) continues to require org admin privileges, preventing unauthorized modification of OAuth app settings (redirect URIs, secrets, etc.).

### Testing

- `test_non_admin_blocked_when_feature_disabled` — non-org-admin gets `unauthorized_client` when flag is off
- `test_non_admin_allowed_when_feature_enabled` — non-org-admin successfully gets a token when flag is on
- `test_org_admin_allowed_regardless_of_feature_flag` — org admin works in both states
- `test_token_assignment_still_works_when_feature_enabled` — token assignment consumed correctly alongside the flag
- `test_invalid_client_id_rejected_regardless_of_feature` — bad client_id always rejected

All existing OAuth tests (`data/model/test/test_oauth.py` — 21 tests) continue to pass with no regressions.
