### PR TITLE
PROJQUAY-11586: nginx: Add proper forwarding of IP addresses when nginx is bound to 8080

### DIFF
--- a/conf/nginx/nginx.conf.jnj
+++ b/conf/nginx/nginx.conf.jnj
@@ -210,6 +210,8 @@ http {
         listen [::]:8080 default;
         {% endif %}
 
+        real_ip_header X-Forwarded-For;
+
         access_log /var/log/nginx/access.log lb_logs;
     }
 }


### PR DESCRIPTION
The IP addresses were not properly forwarded to Quay's action logs when Quay was running behind a load balancer with external TLS termination. This was caused by a missing forwarding statement for the 8080 block (port where Quay's nginx listens on when external termination is used).

This change should allow Quay to properly ingest the forwarded IP address and mark it in the audit logs; it follows the same principle as blocks for ports 8443 and 7443.