### PR TITLE
NO-ISSUE: chore: add CODEOWNERS for tiered review requirements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @quay/downstream @quay/service
+/data/migrations/ @quay/service


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` to enforce team-based code review requirements
- Any PR requires approval from either `@quay/downstream` or `@quay/service`
- PRs touching `data/migrations/` specifically require `@quay/service` approval

## Root Cause / Rationale
Branch protection already has `require_code_owner_reviews` enabled on master and redhat-3.* branches, but without a CODEOWNERS file this was a no-op. Adding CODEOWNERS activates tiered review enforcement so that migration changes are gated by the service team.

## Changes
- Created `.github/CODEOWNERS` with two rules:
  - `* @quay/downstream @quay/service` — either team can approve any PR
  - `data/migrations/ @quay/service` — service team is required for migration changes (last-match-wins replaces the global rule for these files)

## Test Plan
- [ ] Manual testing performed
- [ ] Open a test PR touching non-migration files — verify either team can approve
- [ ] Open a test PR touching `data/migrations/` — verify only `@quay/service` review is accepted
- [ ] Confirm CODEOWNERS is recognized under Settings > Code review

## JIRA
N/A — NO-ISSUE

## Backport
- [x] No backport needed