### PR TITLE
PROJQUAY-11216: fix(mirror): strip skopeo_timeout_interval without rejecting request [redhat-3.14]

### DIFF
--- a/endpoints/api/mirror.py
+++ b/endpoints/api/mirror.py
@@ -191,7 +191,6 @@ class RepoMirrorResource(RepositoryParamResource):
             "type": "object",
             "required": ["external_reference", "sync_interval", "sync_start_date", "root_rule"],
             "properties": common_properties,
-            "additionalProperties": False,
         },
         "UpdateMirrorConfig": {
             "description": "Update the repository mirroring configuration.",

--- a/endpoints/api/test/test_mirror.py
+++ b/endpoints/api/test/test_mirror.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from test.fixtures import *
 
 import pytest
 
@@ -7,6 +6,7 @@ from data import model
 from endpoints.api.mirror import RepoMirrorResource
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
+from test.fixtures import *
 
 
 def _setup_mirror():
@@ -76,6 +76,26 @@ def test_create_mirror_sets_permissions(existing_robot_permission, expected_perm
 
     config = model.repo_mirror.get_mirror(model.repository.get_repository("devtable", "simple"))
     assert config.root_rule.rule_value == ["latest", "foo", "bar"]
+
+
+def test_create_mirror_with_unknown_field_succeeds(app):
+    """Regression test: skopeo_timeout_interval is not supported on 3.14 but must be silently
+    stripped rather than causing a 400 (schema rejection) or 500 (TypeError in model call)."""
+    mirror_bot, _ = model.user.create_robot(
+        "unknownfieldbot", model.user.get_namespace_user("devtable")
+    )
+
+    with client_with_identity("devtable", app) as cl:
+        params = {"repository": "devtable/simple"}
+        request_body = {
+            "external_reference": "quay.io/foobar/barbaz",
+            "sync_interval": 100,
+            "sync_start_date": "2019-08-20T17:51:00Z",
+            "root_rule": {"rule_kind": "tag_glob_csv", "rule_value": ["latest"]},
+            "robot_username": "devtable+unknownfieldbot",
+            "skopeo_timeout_interval": 300,
+        }
+        conduct_api_call(cl, RepoMirrorResource, "POST", params, request_body, 201)
 
 
 def test_get_mirror_does_not_exist(app):


### PR DESCRIPTION
## Summary

Fixes the regression introduced by PR #5683 where `additionalProperties: false` was added to the `CreateMirrorConfig` JSON schema. Because `jsonschema` enforces this rule at request validation time (before the handler body runs), any POST containing `skopeo_timeout_interval` received a **400** validation error instead of succeeding — leaving the `data.pop()` guard in the handler body as dead code. QA confirmed the 500 was gone but mirroring was still broken.

This PR:
- **Removes** `additionalProperties: false` from `CreateMirrorConfig` so schema validation passes when clients (running a newer UI) include `skopeo_timeout_interval`
- **Keeps** the `data.pop("skopeo_timeout_interval", None)` in the handler, which now actually runs and strips the unsupported field before it reaches `enable_mirroring_for_repository()`
- **Adds** a regression test (`test_create_mirror_with_unknown_field_succeeds`) that POSTs with `skopeo_timeout_interval` and asserts 201

## Root Cause

`additionalProperties: false` + `jsonschema.validate()` (used by `@validate_json_request`) rejects the request before the handler body is reached, so the `data.pop()` fix from #5683 was never executed.

## Test Plan

- [ ] `endpoints/api/test/test_mirror.py::test_create_mirror_with_unknown_field_succeeds` — POST with `skopeo_timeout_interval` returns 201
- [ ] All existing `test_mirror.py` tests pass
- [ ] Manual: enable mirroring via UI on a 3.14 build with this fix — no 400/500 error

## JIRA

https://issues.redhat.com/browse/PROJQUAY-11216

🤖 Generated with [Claude Code](https://claude.com/claude-code)