### PR TITLE
NO-ISSUE: fix(ci): use commit status API to fix stale approval check

### DIFF
--- a/.github/workflows/bot-approval-check.yaml
+++ b/.github/workflows/bot-approval-check.yaml
@@ -1,7 +1,7 @@
 name: PR Approval Policy
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted, dismissed]
@@ -9,9 +9,10 @@ on:
 permissions:
   pull-requests: read
   contents: read
+  statuses: write
 
 jobs:
-  approval-policy:
+  check-approvals:
     runs-on: ubuntu-latest
     steps:
       - name: Check approval count
@@ -20,6 +21,7 @@ jobs:
           script: |
             const prAuthor = context.payload.pull_request.user.login;
             const prNumber = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
             const botUsers = ['quay-devel'];
             const requiredApprovals = botUsers.includes(prAuthor) ? 2 : 1;
 
@@ -48,11 +50,17 @@ jobs:
             core.info(`PR #${prNumber} by ${prAuthor}`);
             core.info(`Approvals: ${approvalCount}/${requiredApprovals}`);
 
-            if (!passed) {
-              const needed = requiredApprovals - approvalCount;
-              core.setFailed(
-                botUsers.includes(prAuthor)
-                  ? `Bot PR requires ${requiredApprovals} approvals (${approvalCount} received, ${needed} more needed)`
-                  : `PR requires ${requiredApprovals} approval (${approvalCount} received, ${needed} more needed)`
-              );
-            }
+            const description = passed
+              ? `${approvalCount}/${requiredApprovals} approvals received`
+              : botUsers.includes(prAuthor)
+                ? `Bot PR requires ${requiredApprovals} approvals (${approvalCount} received)`
+                : `PR requires ${requiredApprovals} approval (${approvalCount} received)`;
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: headSha,
+              state: passed ? 'success' : 'failure',
+              context: 'approval-policy',
+              description: description
+            });


### PR DESCRIPTION
## Summary
- Switch approval policy workflow from `pull_request` to `pull_request_target` trigger to get write permissions for fork PRs
- Replace `core.setFailed()` with `createCommitStatus()` API so both triggers (`pull_request_target` + `pull_request_review`) update a **single commit status** instead of creating two separate check runs
- Rename workflow job to `check-approvals` to avoid name collision with the `approval-policy` commit status context

## Problem
The workflow had two triggers creating two independent check runs both named `approval-policy`. After a reviewer approved, only the `pull_request_review` check run turned green — the `pull_request` check run stayed stale/failed, requiring manual retrigger to merge.

## How it works now
Both triggers run the same job, which always succeeds and writes the approval state to a single commit status (`approval-policy`). Branch protection gates on that status, so it always reflects the latest approval state regardless of which trigger fired last.

## Security
`pull_request_target` is safe here because the workflow **never checks out PR code** — it only calls the GitHub API via `actions/github-script` to count reviews and set a commit status.

## Post-merge action
Verify that `approval-policy` in branch protection settings resolves to the commit status (not the old check run). May need to remove and re-add it.

## Test plan
- [ ] Open a test PR and verify the commit status appears as `approval-policy`
- [ ] Approve the PR and verify the status updates to success without manual retrigger
- [ ] Verify fork PRs also get the status updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)