### PR TITLE
NO-ISSUE: chore(_init): use str.startswith for version line detection

### DIFF
--- a/_init.py
+++ b/_init.py
@@ -51,7 +51,7 @@ def _get_version_number_changelog():
     try:
         with open(os.path.join(ROOT_DIR, "CHANGELOG.md")) as f:
             for line in f:
-                if line[0:5] == "## [v":
+                if line.startswith("## [v"):
                     return line.split("[")[1].split("]")[0]
     except IOError:
         return ""


### PR DESCRIPTION
## Summary

- Replace `line[0:5] == "## [v"` with `line.startswith("## [v")` in `_init.py` for clarity.

> **WIP / Draft** — This is a dummy PR to validate the Amber bug-fix workflow setup (branch, commit format, PR creation, CI polling).

## Test plan

- [ ] Existing unit tests pass
- [ ] No functional change — pure style micro-improvement

🤖 Generated with [Amber / Claude Code](https://claude.ai/claude-code)