### PR TITLE
NO-ISSUE: fix(ci): use larger runner for build-and-publish multi-arch job

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -23,7 +23,7 @@ jobs:
       REGISTRY: ${{ secrets.REGISTRY || 'quay.io/projectquay' }}
       REPO_NAME: ${{ github.event.repository.name }}
       TAG_SUFFIX: -unstable
-    runs-on: 'ubuntu-latest'
+    runs-on: quay-001-large-ubuntu-24-x64
     outputs:
       digest: ${{ steps.docker_build.outputs.digest }}
     steps:


### PR DESCRIPTION
## Summary
- Switch `build-amd64-ppc64le-s390x` job from `ubuntu-latest` to `quay-001-large-ubuntu-24-x64` to fix persistent "no space left on device" failures during Docker Buildx setup

## Context
All recent `build-and-publish` runs have failed with:
```
ERROR: Error response from daemon: mkdir /var/lib/docker/overlay2/...-init: no space left on device
```
The `ubuntu-latest` runner doesn't have enough disk for multi-arch Docker builds. Other CI jobs in this repo (Registry Protocol Test, Playwright E2E) already use larger runners.

## Backport required
This workflow triggers via `workflow_dispatch` with `ref: redhat-3.x`, so GitHub reads the workflow file **from the release branch**. This fix must be cherry-picked to `redhat-3.16` (and other active `redhat-*` branches) to unblock release builds.

## Test plan
- [ ] Re-run build-and-publish on `redhat-3.16` after backport
- [ ] Verify multi-arch image is pushed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)