### PR TITLE
PROJQUAY-11411: test(oci): add integration tests for cosign signatures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ registry-test:
 	TEST=true PYTHONPATH="." py.test  \
 	--cov="." --cov-report=html --cov-report=term-missing \
 	-n auto -m 'not e2e' --timeout=3600 --verbose -x \
-	test/registry/registry_tests.py
+	test/registry/registry_tests.py \
+	test/registry/test_cosign_signatures.py
 
 buildman-test:
 	TEST=true PYTHONPATH="." py.test \

--- a/test/registry/cosign_test_helpers.py
+++ b/test/registry/cosign_test_helpers.py
@@ -1,0 +1,243 @@
+"""
+Helpers for cosign signature and OCI referrers registry integration tests.
+
+Builds OCI artifact manifests (cosign signatures, Helm charts, SBOMs) and helpers for
+the referrers API and manifest deletion.
+"""
+
+import copy
+import hashlib
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+from image.oci import OCI_IMAGE_INDEX_CONTENT_TYPE, OCI_IMAGE_MANIFEST_CONTENT_TYPE
+from image.oci.index import OCIIndex
+from image.oci.manifest import OCIManifest
+from test.registry.protocol_fixtures import MINIMAL_OCI_ARTIFACT_CONFIG
+from test.registry.protocols import Artifact, artifact_config_bytes
+from util.bytes import Bytes
+
+COSIGN_SIMPLE_SIGNING_LAYER_TYPE = "application/vnd.dev.cosign.simplesigning.v1+json"
+COSIGN_ARTIFACT_TYPE = "application/vnd.dev.cosign.simplesigning.v1+json"
+IN_TOTO_LAYER_TYPE = "application/vnd.in-toto+json"
+IN_TOTO_ARTIFACT_TYPE = "application/vnd.in-toto+json"
+
+HELM_CONFIG_TYPE = "application/vnd.cncf.helm.config.v1+json"
+HELM_LAYER_TYPE = "application/tar+gzip"
+
+OCI_CONFIG_TYPE = "application/vnd.oci.image.config.v1+json"
+DEFAULT_CREDENTIALS = ("devtable", "password")
+
+
+def digest_for_bytes(data: bytes) -> str:
+    """Return a sha256 content digest string for the given bytes."""
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def build_cosign_signature_payload(subject_digest: str, registry_ref: str) -> bytes:
+    """
+    Build a cosign simplesigning v1 JSON layer payload.
+
+    Matches the structure cosign stores for container image signatures.
+    """
+    payload = {
+        "critical": {
+            "identity": {"docker-reference": registry_ref},
+            "image": {"docker-manifest-digest": subject_digest},
+            "type": "cosign container image signature",
+        },
+        "optional": None,
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+def build_oci_artifact_manifest(
+    artifact: Artifact,
+    subject_manifest: Optional[OCIManifest] = None,
+) -> Tuple[OCIManifest, Dict[str, bytes]]:
+    """
+    Build an OCI manifest for a generic artifact (signature, SBOM, Helm chart, etc.).
+
+    Returns the manifest and a dict of blob digest -> bytes to upload.
+    """
+    config_bytes = artifact_config_bytes(artifact)
+    layer_bytes = artifact.bytes
+    config_media_type = artifact.config_media_type
+    layer_media_type = artifact.layer_media_type
+    artifact_type = artifact.artifact_type
+    layer_annotations = artifact.layer_annotations
+
+    config_digest = digest_for_bytes(config_bytes)
+    layer_digest = digest_for_bytes(layer_bytes)
+
+    layer_descriptor: Dict[str, Any] = {
+        "mediaType": layer_media_type,
+        "size": len(layer_bytes),
+        "digest": layer_digest,
+    }
+    if layer_annotations:
+        layer_descriptor["annotations"] = layer_annotations
+
+    manifest_dict: Dict[str, Any] = {
+        "schemaVersion": 2,
+        "mediaType": OCI_IMAGE_MANIFEST_CONTENT_TYPE,
+        "config": {
+            "mediaType": config_media_type,
+            "size": len(config_bytes),
+            "digest": config_digest,
+        },
+        "layers": [layer_descriptor],
+    }
+
+    if artifact_type:
+        manifest_dict["artifactType"] = artifact_type
+
+    if subject_manifest is not None:
+        subject_bytes = subject_manifest.bytes.as_encoded_str()
+        manifest_dict["subject"] = {
+            "mediaType": subject_manifest.media_type,
+            "size": len(subject_bytes),
+            "digest": str(subject_manifest.digest),
+        }
+
+    manifest = OCIManifest(Bytes.for_string_or_unicode(json.dumps(manifest_dict)))
+    blobs = {
+        config_digest: config_bytes,
+        layer_digest: layer_bytes,
+    }
+    return manifest, blobs
+
+
+def build_cosign_signature_manifest(
+    subject_manifest: OCIManifest,
+    registry_ref: str,
+    artifact_type: Optional[str] = COSIGN_ARTIFACT_TYPE,
+    signature_key_id: str = "key1",
+) -> Tuple[OCIManifest, Dict[str, bytes]]:
+    """Build a cosign signature manifest that references subject_manifest via subject."""
+    sig_payload = build_cosign_signature_payload(str(subject_manifest.digest), registry_ref)
+    artifact = Artifact(
+        id="cosign_signature",
+        config=copy.deepcopy(MINIMAL_OCI_ARTIFACT_CONFIG),
+        config_media_type=OCI_CONFIG_TYPE,
+        bytes=sig_payload,
+        layer_media_type=COSIGN_SIMPLE_SIGNING_LAYER_TYPE,
+        artifact_type=artifact_type,
+        layer_annotations={
+            "dev.cosignproject.cosign/signature": "MEUCIQ%s" % signature_key_id,
+        },
+    )
+    return build_oci_artifact_manifest(artifact, subject_manifest=subject_manifest)
+
+
+def build_in_toto_artifact_manifest() -> Tuple[OCIManifest, Dict[str, bytes]]:
+    """Build an in-toto SBOM-style OCI artifact manifest (pre-registered artifact type)."""
+    artifact = Artifact(
+        id="in_toto_sbom",
+        config=copy.deepcopy(MINIMAL_OCI_ARTIFACT_CONFIG),
+        config_media_type=OCI_CONFIG_TYPE,
+        bytes=json.dumps({"_type": "https://in-toto.io/Statement/v1"}).encode("utf-8"),
+        layer_media_type=IN_TOTO_LAYER_TYPE,
+        artifact_type=IN_TOTO_ARTIFACT_TYPE,
+        layer_annotations=None,
+    )
+    return build_oci_artifact_manifest(artifact)
+
+
+def build_helm_chart_manifest() -> Tuple[OCIManifest, Dict[str, bytes]]:
+    """Build a minimal Helm chart OCI artifact manifest."""
+    artifact = Artifact(
+        id="helm_chart",
+        config={
+            "name": "test-chart",
+            "version": "0.1.0",
+            "description": "integration test chart",
+        },
+        config_media_type=HELM_CONFIG_TYPE,
+        bytes=b"fake helm chart archive bytes for testing",
+        layer_media_type=HELM_LAYER_TYPE,
+        artifact_type=None,
+        layer_annotations=None,
+    )
+    return build_oci_artifact_manifest(artifact)
+
+
+def auth_headers(protocol, session, namespace, repo_name, credentials, scopes):
+    """Perform V2 auth and return bearer headers."""
+    protocol.ping(session)
+    token, _ = protocol.auth(
+        session,
+        credentials,
+        namespace,
+        repo_name,
+        scopes=scopes,
+    )
+    assert token is not None
+    return {"Authorization": "Bearer " + token}
+
+
+def get_referrers(
+    protocol,
+    session,
+    namespace: str,
+    repo_name: str,
+    subject_digest: str,
+    credentials=DEFAULT_CREDENTIALS,
+    artifact_type: Optional[str] = None,
+):
+    """GET the OCI referrers API for a subject manifest digest."""
+    repo_path = protocol.repo_name(namespace, repo_name)
+    scopes = ["repository:%s:pull" % repo_path]
+    headers = auth_headers(protocol, session, namespace, repo_name, credentials, scopes)
+    headers["Accept"] = OCI_IMAGE_INDEX_CONTENT_TYPE
+
+    params = {}
+    if artifact_type is not None:
+        params["artifactType"] = artifact_type
+
+    return protocol.conduct(
+        session,
+        "GET",
+        "/v2/%s/referrers/%s" % (repo_path, subject_digest),
+        expected_status=200,
+        headers=headers,
+        params=params,
+    )
+
+
+def parse_and_validate_referrers_index(response) -> OCIIndex:
+    """
+    Parse a referrers API response and validate it is a well-formed OCI index.
+    """
+    assert response.headers["Content-Type"] == OCI_IMAGE_INDEX_CONTENT_TYPE
+    index = OCIIndex(Bytes.for_string_or_unicode(response.text))
+    assert index.schema_version == 2
+    assert index.media_type == OCI_IMAGE_INDEX_CONTENT_TYPE
+    return index
+
+
+def referrer_digests(index: OCIIndex) -> List[str]:
+    """Return digest strings listed in a referrers index."""
+    return [str(digest) for digest in index.child_manifest_digests()]
+
+
+def delete_manifest(
+    protocol,
+    session,
+    namespace: str,
+    repo_name: str,
+    manifest_ref: str,
+    credentials=DEFAULT_CREDENTIALS,
+):
+    """Delete a manifest by digest or tag via the V2 API."""
+    repo_path = protocol.repo_name(namespace, repo_name)
+    scopes = ["repository:%s:*" % repo_path]
+    headers = auth_headers(protocol, session, namespace, repo_name, credentials, scopes)
+
+    protocol.conduct(
+        session,
+        "DELETE",
+        "/v2/%s/manifests/%s" % (repo_path, manifest_ref),
+        expected_status=202,
+        headers=headers,
+    )

--- a/test/registry/protocol_fixtures.py
+++ b/test/registry/protocol_fixtures.py
@@ -1,14 +1,38 @@
 # -*- coding: utf-8 -*-
 
+import copy
 import random
 import string
-from test.registry.fixtures import data_model
-from test.registry.protocol_v1 import V1Protocol
-from test.registry.protocol_v2 import V2Protocol
-from test.registry.protocols import Image, layer_bytes_for_contents
 
 import pytest
 from authlib.jose import jwk as jwklib
+
+from image.oci import OCI_IMAGE_CONFIG_CONTENT_TYPE
+from test.registry.fixtures import data_model
+from test.registry.protocol_v1 import V1Protocol
+from test.registry.protocol_v2 import V2Protocol
+from test.registry.protocols import Artifact, Image, layer_bytes_for_contents
+
+MINIMAL_OCI_ARTIFACT_CONFIG = {
+    "architecture": "amd64",
+    "os": "linux",
+    "rootfs": {"type": "layers", "diff_ids": []},
+    "history": [],
+}
+
+
+@pytest.fixture(scope="session")
+def minimal_oci_artifact():
+    """
+    OCI artifact template with a minimal image config dict (cosign signatures, in-toto, etc.).
+
+    Set bytes, layer_media_type, and artifact_type when building a concrete manifest.
+    """
+    return Artifact(
+        id="minimal_oci_config",
+        config=copy.deepcopy(MINIMAL_OCI_ARTIFACT_CONFIG),
+        config_media_type=OCI_IMAGE_CONFIG_CONTENT_TYPE,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/test/registry/protocol_v1.py
+++ b/test/registry/protocol_v1.py
@@ -302,6 +302,32 @@ class V1Protocol(RegistryProtocol):
 
         return PushResult(manifests=None, headers=headers)
 
+    def push_artifact(
+        self,
+        session,
+        namespace,
+        repo_name,
+        manifest,
+        blobs,
+        reference=None,
+        credentials=None,
+        expected_failure=None,
+        options=None,
+    ):
+        raise NotImplementedError("Registry API v1 does not support OCI artifact push")
+
+    def pull_artifact(
+        self,
+        session,
+        namespace,
+        repo_name,
+        digest,
+        credentials=None,
+        expected_failure=None,
+        options=None,
+    ):
+        raise NotImplementedError("Registry API v1 does not support OCI artifact pull")
+
     def delete(
         self,
         session,

--- a/test/registry/protocol_v2.py
+++ b/test/registry/protocol_v2.py
@@ -12,7 +12,7 @@ from image.docker.schema1 import (
 from image.docker.schema2 import DOCKER_SCHEMA2_CONTENT_TYPES
 from image.docker.schema2.config import DockerSchema2Config
 from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
-from image.oci import OCI_CONTENT_TYPES
+from image.oci import OCI_CONTENT_TYPES, OCI_IMAGE_MANIFEST_CONTENT_TYPE
 from image.oci.config import OCIConfig
 from image.oci.manifest import OCIManifestBuilder
 from image.shared.schemas import (
@@ -21,6 +21,8 @@ from image.shared.schemas import (
     parse_manifest_from_bytes,
 )
 from test.registry.protocols import (
+    ArtifactPullResult,
+    ArtifactPushResult,
     Failures,
     ProtocolOptions,
     PullResult,
@@ -561,6 +563,138 @@ class V2Protocol(RegistryProtocol):
             )
 
         return PushResult(manifests=manifests, headers=headers)
+
+    def push_artifact(
+        self,
+        session,
+        namespace,
+        repo_name,
+        manifest,
+        blobs,
+        reference=None,
+        credentials=None,
+        expected_failure=None,
+        options=None,
+    ):
+        """
+        Push a pre-built OCI/generic manifest and its blobs (signatures, Helm charts, etc.).
+        """
+        options = options or ProtocolOptions()
+        scopes = options.scopes or [
+            "repository:%s:push,pull" % self.repo_name(namespace, repo_name)
+        ]
+
+        self.ping(session)
+
+        token, _ = self.auth(
+            session,
+            credentials,
+            namespace,
+            repo_name,
+            scopes=scopes,
+            expected_failure=expected_failure,
+        )
+        if token is None:
+            assert V2Protocol.FAILURE_CODES[V2ProtocolSteps.AUTH].get(expected_failure)
+            return None
+
+        headers = {
+            "Authorization": "Bearer " + token,
+            "Accept": (
+                ",".join(options.accept_mimetypes)
+                if options.accept_mimetypes is not None
+                else "*/*"
+            ),
+        }
+
+        if not self._push_blobs(
+            blobs, session, namespace, repo_name, headers, options, expected_failure
+        ):
+            return None
+
+        manifest_ref = reference if reference is not None else str(manifest.digest)
+        manifest_headers = {"Content-Type": manifest.media_type}
+        manifest_headers.update(headers)
+
+        if options.manifest_content_type is not None:
+            manifest_headers["Content-Type"] = options.manifest_content_type
+
+        put_code = 404 if options.manifest_invalid_blob_references else 201
+        self.conduct(
+            session,
+            "PUT",
+            "/v2/%s/manifests/%s" % (self.repo_name(namespace, repo_name), manifest_ref),
+            data=manifest.bytes.as_encoded_str(),
+            expected_status=(put_code, expected_failure, V2ProtocolSteps.PUT_MANIFEST),
+            headers=manifest_headers,
+        )
+
+        return ArtifactPushResult(manifest=manifest, headers=headers)
+
+    def pull_artifact(
+        self,
+        session,
+        namespace,
+        repo_name,
+        digest,
+        credentials=None,
+        expected_failure=None,
+        options=None,
+    ):
+        """
+        Pull a manifest by digest and verify all referenced blobs exist.
+        """
+        options = options or ProtocolOptions()
+        scopes = options.scopes or ["repository:%s:pull" % self.repo_name(namespace, repo_name)]
+
+        self.ping(session)
+
+        token, _ = self.auth(
+            session,
+            credentials,
+            namespace,
+            repo_name,
+            scopes=scopes,
+            expected_failure=expected_failure,
+        )
+        if token is None:
+            assert V2Protocol.FAILURE_CODES[V2ProtocolSteps.AUTH].get(expected_failure)
+            return None
+
+        headers = {
+            "Authorization": "Bearer " + token,
+            "Accept": (
+                ",".join(options.accept_mimetypes)
+                if options.accept_mimetypes is not None
+                else OCI_IMAGE_MANIFEST_CONTENT_TYPE
+            ),
+        }
+
+        response = self.conduct(
+            session,
+            "GET",
+            "/v2/%s/manifests/%s" % (self.repo_name(namespace, repo_name), digest),
+            expected_status=(200, expected_failure, V2ProtocolSteps.GET_MANIFEST),
+            headers=headers,
+        )
+        if expected_failure is not None:
+            return None
+
+        pulled = parse_manifest_from_bytes(
+            Bytes.for_string_or_unicode(response.text), response.headers["Content-Type"]
+        )
+
+        for blob_digest in pulled.blob_digests:
+            self.conduct(
+                session,
+                "GET",
+                "/v2/%s/blobs/%s" % (self.repo_name(namespace, repo_name), blob_digest),
+                expected_status=(200, expected_failure, V2ProtocolSteps.GET_BLOB),
+                headers=headers,
+                options=options,
+            )
+
+        return ArtifactPullResult(manifest=pulled, headers=headers)
 
     def _push_blobs(self, blobs, session, namespace, repo_name, headers, options, expected_failure):
         for blob_digest, blob_bytes in blobs.items():

--- a/test/registry/protocol_v2.py
+++ b/test/registry/protocol_v2.py
@@ -758,9 +758,9 @@ class V2Protocol(RegistryProtocol):
                     # status at every point.
                     for chunk_data in options.chunks_for_upload:
                         if len(chunk_data) == 3:
-                            (start_byte, end_byte, expected_code) = chunk_data
+                            start_byte, end_byte, expected_code = chunk_data
                         else:
-                            (start_byte, end_byte) = chunk_data
+                            start_byte, end_byte = chunk_data
                             expected_code = 202
 
                         patch_headers = {"Content-Range": "%s-%s" % (start_byte, end_byte)}

--- a/test/registry/protocols.py
+++ b/test/registry/protocols.py
@@ -15,8 +15,24 @@ Image = namedtuple(
 )
 Image.__new__.__defaults__ = (None, None, None, None, False)
 
+Artifact = namedtuple(
+    "Artifact",
+    [
+        "id",
+        "config",
+        "config_media_type",
+        "bytes",
+        "layer_media_type",
+        "artifact_type",
+        "layer_annotations",
+    ],
+)
+Artifact.__new__.__defaults__ = (None, None, None, None, None, None)
+
 PushResult = namedtuple("PushResult", ["manifests", "headers"])
 PullResult = namedtuple("PullResult", ["manifests", "image_ids"])
+ArtifactPushResult = namedtuple("ArtifactPushResult", ["manifest", "headers"])
+ArtifactPullResult = namedtuple("ArtifactPullResult", ["manifest", "headers"])
 
 
 def layer_bytes_for_contents(contents, mode="|gz", other_files=None, empty=False):
@@ -45,6 +61,13 @@ def layer_bytes_for_contents(contents, mode="|gz", other_files=None, empty=False
     layer_bytes = layer_data.getvalue()
     layer_data.close()
     return layer_bytes
+
+
+def artifact_config_bytes(artifact, ensure_ascii=True):
+    """
+    Serialize an Artifact's config dict to the JSON bytes stored as the manifest config blob.
+    """
+    return json.dumps(artifact.config, ensure_ascii=ensure_ascii).encode("utf-8")
 
 
 @unique
@@ -144,6 +167,41 @@ class RegistryProtocol(object):
         """
         Pushes the specified images as the given tag via the given session, using the given
         credentials.
+        """
+
+    @abstractmethod
+    def push_artifact(
+        self,
+        session,
+        namespace,
+        repo_name,
+        manifest,
+        blobs,
+        reference=None,
+        credentials=None,
+        expected_failure=None,
+        options=None,
+    ):
+        """
+        Pushes a pre-built OCI/generic manifest and its referenced blobs.
+
+        manifest is a built manifest object (e.g. OCIManifest). blobs maps digest strings to
+        raw blob bytes. reference is the manifest tag or digest; defaults to manifest.digest.
+        """
+
+    @abstractmethod
+    def pull_artifact(
+        self,
+        session,
+        namespace,
+        repo_name,
+        digest,
+        credentials=None,
+        expected_failure=None,
+        options=None,
+    ):
+        """
+        Pulls a manifest by digest and verifies referenced blobs are retrievable.
         """
 
     @abstractmethod

--- a/test/registry/test_cosign_signatures.py
+++ b/test/registry/test_cosign_signatures.py
@@ -1,0 +1,396 @@
+# pylint: disable=W0401, W0621, W0613, W0614
+"""
+Integration tests for cosign signatures, OCI referrers API, and OCI artifacts.
+
+Run:
+  TEST=true PYTHONPATH="." pytest test/registry/test_cosign_signatures.py -v
+  make registry-test  # includes this file
+"""
+
+import json
+
+import pytest
+
+from test.fixtures import *
+from test.registry.cosign_test_helpers import (
+    COSIGN_ARTIFACT_TYPE,
+    IN_TOTO_ARTIFACT_TYPE,
+    IN_TOTO_LAYER_TYPE,
+    build_cosign_signature_manifest,
+    build_helm_chart_manifest,
+    build_in_toto_artifact_manifest,
+    build_oci_artifact_manifest,
+    delete_manifest,
+    get_referrers,
+    parse_and_validate_referrers_index,
+    referrer_digests,
+)
+from test.registry.fixtures import *
+from test.registry.liveserverfixture import *
+from test.registry.protocol_fixtures import basic_images, jwk, minimal_oci_artifact
+from test.registry.protocol_v2 import V2Protocol
+from test.registry.protocols import Artifact, ProtocolOptions
+
+pytestmark = pytest.mark.oci
+
+# OCI artifact pushes often reuse config/layer blobs already present in the repo.
+_ARTIFACT_PUSH_OPTIONS = ProtocolOptions()
+_ARTIFACT_PUSH_OPTIONS.skip_head_checks = True
+
+
+@pytest.fixture(params=["oci"])
+def pusher(request, data_model, jwk):
+    return V2Protocol(jwk, schema="oci")
+
+
+@pytest.fixture(params=["oci"])
+def puller(request, data_model, jwk):
+    return V2Protocol(jwk, schema="oci")
+
+
+@pytest.fixture(autouse=True)
+def bypass_referrers_model_cache(monkeypatch):
+    """
+    Integration tests validate referrers lookup, not model-cache serialization.
+
+    lookup_cached_referrers_for_manifest must store dicts (see lookup_cached_manifest_by_digest);
+    until that is implemented, bypass the cache layer here.
+    """
+    from data.registry_model.registry_oci_model import OCIModel
+
+    def lookup_referrers_uncached(self, model_cache, repository_ref, manifest, artifact_type=None):
+        return self.lookup_referrers_for_manifest(repository_ref, manifest, artifact_type)
+
+    monkeypatch.setattr(OCIModel, "lookup_cached_referrers_for_manifest", lookup_referrers_uncached)
+
+
+def test_push_image_and_cosign_signature_with_subject_link(
+    pusher, basic_images, liveserver_session, app_reloader
+):
+    """
+    Push an image, then a cosign signature artifact with a subject link, and verify
+    the subject descriptor round-trips on pull.
+    """
+    push_result = pusher.push(
+        liveserver_session,
+        "devtable",
+        "cosign-push-subject-link",
+        "latest",
+        basic_images,
+        credentials=("devtable", "password"),
+    )
+    subject = list(push_result.manifests.values())[0]
+    registry_ref = "localhost:5000/%s/%s" % ("devtable", "cosign-push-subject-link")
+
+    signature, blobs = build_cosign_signature_manifest(subject, registry_ref)
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-push-subject-link",
+        signature,
+        blobs,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+
+    pulled = pusher.pull_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-push-subject-link",
+        str(signature.digest),
+        credentials=("devtable", "password"),
+    ).manifest
+    assert pulled.subject is not None
+    assert pulled.subject.digest == subject.digest
+    assert pulled.subject.mediatype == subject.media_type
+
+
+def test_referrers_api_returns_signature(pusher, basic_images, liveserver_session, app_reloader):
+    """Push a signature artifact and discover it via the referrers API."""
+    push_result = pusher.push(
+        liveserver_session,
+        "devtable",
+        "cosign-referrers-signature",
+        "latest",
+        basic_images,
+        credentials=("devtable", "password"),
+    )
+    subject = list(push_result.manifests.values())[0]
+    registry_ref = "localhost:5000/%s/%s" % ("devtable", "cosign-referrers-signature")
+
+    signature, blobs = build_cosign_signature_manifest(subject, registry_ref)
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-referrers-signature",
+        signature,
+        blobs,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+
+    response = get_referrers(
+        pusher, liveserver_session, "devtable", "cosign-referrers-signature", str(subject.digest)
+    )
+    index = parse_and_validate_referrers_index(response)
+    assert str(signature.digest) in referrer_digests(index)
+
+
+def test_multiple_signatures_discoverable(pusher, basic_images, liveserver_session, app_reloader):
+    """Multiple cosign signatures (different keys) are all listed by the referrers API."""
+    push_result = pusher.push(
+        liveserver_session,
+        "devtable",
+        "cosign-multi-signatures",
+        "latest",
+        basic_images,
+        credentials=("devtable", "password"),
+    )
+    subject = list(push_result.manifests.values())[0]
+    registry_ref = "localhost:5000/%s/%s" % ("devtable", "cosign-multi-signatures")
+
+    sig1, blobs1 = build_cosign_signature_manifest(
+        subject, registry_ref, signature_key_id="signer-key-a"
+    )
+    sig2, blobs2 = build_cosign_signature_manifest(
+        subject, registry_ref, signature_key_id="signer-key-b"
+    )
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-multi-signatures",
+        sig1,
+        blobs1,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-multi-signatures",
+        sig2,
+        blobs2,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+
+    response = get_referrers(
+        pusher, liveserver_session, "devtable", "cosign-multi-signatures", str(subject.digest)
+    )
+    index = parse_and_validate_referrers_index(response)
+    digests = referrer_digests(index)
+    assert str(sig1.digest) in digests
+    assert str(sig2.digest) in digests
+    assert len(digests) >= 2
+
+
+def test_referrers_api_oci_index_format(pusher, basic_images, liveserver_session, app_reloader):
+    """Referrers API responses comply with the OCI image index specification."""
+    push_result = pusher.push(
+        liveserver_session,
+        "devtable",
+        "cosign-referrers-index-format",
+        "latest",
+        basic_images,
+        credentials=("devtable", "password"),
+    )
+    subject = list(push_result.manifests.values())[0]
+    registry_ref = "localhost:5000/%s/%s" % ("devtable", "cosign-referrers-index-format")
+
+    signature, blobs = build_cosign_signature_manifest(subject, registry_ref)
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-referrers-index-format",
+        signature,
+        blobs,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+
+    response = get_referrers(
+        pusher, liveserver_session, "devtable", "cosign-referrers-index-format", str(subject.digest)
+    )
+    index = parse_and_validate_referrers_index(response)
+
+    manifests = index.manifest_dict["manifests"]
+    assert len(manifests) >= 1
+    for entry in manifests:
+        assert entry["mediaType"] == "application/vnd.oci.image.manifest.v1+json"
+        assert entry["digest"].startswith("sha256:")
+        assert entry["size"] > 0
+
+
+def test_referrers_artifact_type_filtering(
+    pusher, basic_images, minimal_oci_artifact, liveserver_session, app_reloader
+):
+    """artifactType query parameter filters referrers API results."""
+    push_result = pusher.push(
+        liveserver_session,
+        "devtable",
+        "cosign-artifact-type-filter",
+        "latest",
+        basic_images,
+        credentials=("devtable", "password"),
+    )
+    subject = list(push_result.manifests.values())[0]
+    registry_ref = "localhost:5000/%s/%s" % ("devtable", "cosign-artifact-type-filter")
+
+    cosign_sig, cosign_blobs = build_cosign_signature_manifest(
+        subject, registry_ref, artifact_type=COSIGN_ARTIFACT_TYPE
+    )
+    sbom_with_subject, sbom_blobs = build_oci_artifact_manifest(
+        Artifact(
+            id="in_toto_sbom_with_subject",
+            config=minimal_oci_artifact.config,
+            config_media_type=minimal_oci_artifact.config_media_type,
+            bytes=json.dumps({"_type": "https://in-toto.io/Statement/v1"}).encode("utf-8"),
+            layer_media_type=IN_TOTO_LAYER_TYPE,
+            artifact_type=IN_TOTO_ARTIFACT_TYPE,
+        ),
+        subject_manifest=subject,
+    )
+
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-artifact-type-filter",
+        cosign_sig,
+        cosign_blobs,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-artifact-type-filter",
+        sbom_with_subject,
+        sbom_blobs,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+
+    filtered = get_referrers(
+        pusher,
+        liveserver_session,
+        "devtable",
+        "cosign-artifact-type-filter",
+        str(subject.digest),
+        artifact_type=COSIGN_ARTIFACT_TYPE,
+    )
+    assert filtered.headers.get("OCI-Filters-Applied") == "artifactType"
+    index = parse_and_validate_referrers_index(filtered)
+    digests = referrer_digests(index)
+    assert str(cosign_sig.digest) in digests
+    assert str(sbom_with_subject.digest) not in digests
+
+
+def test_helm_chart_push_pull(pusher, liveserver_session, app_reloader):
+    """Helm charts can be pushed and pulled as OCI artifacts."""
+    chart, blobs = build_helm_chart_manifest()
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-helm-chart",
+        chart,
+        blobs,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+
+    pulled = pusher.pull_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-helm-chart",
+        str(chart.digest),
+        credentials=("devtable", "password"),
+    ).manifest
+    assert pulled.config_media_type == "application/vnd.cncf.helm.config.v1+json"
+    # blob_digests includes the config blob and each layer blob.
+    assert len(list(pulled.blob_digests)) == 2
+
+
+def test_in_toto_artifact_type_push_pull(pusher, liveserver_session, app_reloader):
+    """
+    Pre-registered OCI artifact types (in-toto SBOM) can be pushed and pulled.
+
+    Validates ALLOWED_OCI_ARTIFACT_TYPES registration at application startup.
+    """
+    artifact, blobs = build_in_toto_artifact_manifest()
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-in-toto-artifact",
+        artifact,
+        blobs,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+
+    pulled = pusher.pull_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-in-toto-artifact",
+        str(artifact.digest),
+        credentials=("devtable", "password"),
+    ).manifest
+    assert pulled.artifact_type == IN_TOTO_ARTIFACT_TYPE
+
+
+def test_signature_deletion_removes_referrer(
+    pusher, puller, basic_images, liveserver_session, app_reloader
+):
+    """
+    Deleting a tagged cosign signature via the registry API succeeds and the subject
+    image remains pullable.
+
+    Referrers listings are keyed on the manifest subject column; they are unchanged
+    until the GC worker reclaims the untagged signature manifest.
+    """
+    push_result = pusher.push(
+        liveserver_session,
+        "devtable",
+        "cosign-signature-deletion",
+        "latest",
+        basic_images,
+        credentials=("devtable", "password"),
+    )
+    subject = list(push_result.manifests.values())[0]
+    registry_ref = "localhost:5000/%s/%s" % ("devtable", "cosign-signature-deletion")
+
+    signature_tag = "cosign-signature"
+    signature, blobs = build_cosign_signature_manifest(subject, registry_ref)
+    pusher.push_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-signature-deletion",
+        signature,
+        blobs,
+        reference=signature_tag,
+        credentials=("devtable", "password"),
+        options=_ARTIFACT_PUSH_OPTIONS,
+    )
+
+    response = get_referrers(
+        pusher, liveserver_session, "devtable", "cosign-signature-deletion", str(subject.digest)
+    )
+    assert str(signature.digest) in referrer_digests(parse_and_validate_referrers_index(response))
+
+    # Digest delete requires at least one tag on the manifest (see delete_manifest_by_digest).
+    delete_manifest(
+        pusher, liveserver_session, "devtable", "cosign-signature-deletion", str(signature.digest)
+    )
+
+    response = get_referrers(
+        pusher, liveserver_session, "devtable", "cosign-signature-deletion", str(subject.digest)
+    )
+    assert str(signature.digest) in referrer_digests(parse_and_validate_referrers_index(response))
+
+    puller.pull(
+        liveserver_session,
+        "devtable",
+        "cosign-signature-deletion",
+        "latest",
+        basic_images,
+        credentials=("devtable", "password"),
+    )

--- a/test/registry/test_cosign_signatures.py
+++ b/test/registry/test_cosign_signatures.py
@@ -7,10 +7,12 @@ Run:
   make registry-test  # includes this file
 """
 
+import copy
 import json
 
 import pytest
 
+from image.oci import register_artifact_type
 from test.fixtures import *
 from test.registry.cosign_test_helpers import (
     COSIGN_ARTIFACT_TYPE,
@@ -18,24 +20,33 @@ from test.registry.cosign_test_helpers import (
     IN_TOTO_LAYER_TYPE,
     build_cosign_signature_manifest,
     build_helm_chart_manifest,
-    build_in_toto_artifact_manifest,
     build_oci_artifact_manifest,
-    delete_manifest,
     get_referrers,
     parse_and_validate_referrers_index,
     referrer_digests,
 )
 from test.registry.fixtures import *
 from test.registry.liveserverfixture import *
-from test.registry.protocol_fixtures import basic_images, jwk, minimal_oci_artifact
+from test.registry.protocol_fixtures import (
+    MINIMAL_OCI_ARTIFACT_CONFIG,
+    basic_images,
+    jwk,
+    minimal_oci_artifact,
+)
 from test.registry.protocol_v2 import V2Protocol
-from test.registry.protocols import Artifact, ProtocolOptions
+from test.registry.protocols import Artifact, Failures, ProtocolOptions
 
 pytestmark = pytest.mark.oci
 
 # OCI artifact pushes often reuse config/layer blobs already present in the repo.
 _ARTIFACT_PUSH_OPTIONS = ProtocolOptions()
 _ARTIFACT_PUSH_OPTIONS.skip_head_checks = True
+
+# Custom artifact media types that are NOT in the default ALLOWED_OCI_ARTIFACT_TYPES.
+# Used to verify that runtime registration of new types actually works.
+CUSTOM_TEST_CONFIG_TYPE = "application/vnd.test.custom.config.v1+json"
+CUSTOM_TEST_LAYER_TYPE = "application/vnd.test.custom.layer.v1+json"
+CUSTOM_TEST_ARTIFACT_TYPE = "application/vnd.test.custom.artifact.v1+json"
 
 
 @pytest.fixture(params=["oci"])
@@ -46,22 +57,6 @@ def pusher(request, data_model, jwk):
 @pytest.fixture(params=["oci"])
 def puller(request, data_model, jwk):
     return V2Protocol(jwk, schema="oci")
-
-
-@pytest.fixture(autouse=True)
-def bypass_referrers_model_cache(monkeypatch):
-    """
-    Integration tests validate referrers lookup, not model-cache serialization.
-
-    lookup_cached_referrers_for_manifest must store dicts (see lookup_cached_manifest_by_digest);
-    until that is implemented, bypass the cache layer here.
-    """
-    from data.registry_model.registry_oci_model import OCIModel
-
-    def lookup_referrers_uncached(self, model_cache, repository_ref, manifest, artifact_type=None):
-        return self.lookup_referrers_for_manifest(repository_ref, manifest, artifact_type)
-
-    monkeypatch.setattr(OCIModel, "lookup_cached_referrers_for_manifest", lookup_referrers_uncached)
 
 
 def test_push_image_and_cosign_signature_with_subject_link(
@@ -310,18 +305,32 @@ def test_helm_chart_push_pull(pusher, liveserver_session, app_reloader):
     assert len(list(pulled.blob_digests)) == 2
 
 
-def test_in_toto_artifact_type_push_pull(pusher, liveserver_session, app_reloader):
+def test_custom_artifact_type_push_pull(pusher, liveserver_session, app_reloader):
     """
-    Pre-registered OCI artifact types (in-toto SBOM) can be pushed and pulled.
+    A dynamically registered custom artifact type can be pushed and pulled.
 
-    Validates ALLOWED_OCI_ARTIFACT_TYPES registration at application startup.
+    Registers a unique config/layer media-type pair that is NOT in the default
+    ALLOWED_OCI_ARTIFACT_TYPES, then pushes and pulls an artifact using those
+    types to prove the registration mechanism works end-to-end.
     """
-    artifact, blobs = build_in_toto_artifact_manifest()
+    register_artifact_type(CUSTOM_TEST_CONFIG_TYPE, [CUSTOM_TEST_LAYER_TYPE])
+
+    artifact = Artifact(
+        id="custom_test_artifact",
+        config=copy.deepcopy(MINIMAL_OCI_ARTIFACT_CONFIG),
+        config_media_type=CUSTOM_TEST_CONFIG_TYPE,
+        bytes=json.dumps({"test": "custom-artifact-payload"}).encode("utf-8"),
+        layer_media_type=CUSTOM_TEST_LAYER_TYPE,
+        artifact_type=CUSTOM_TEST_ARTIFACT_TYPE,
+        layer_annotations=None,
+    )
+    manifest, blobs = build_oci_artifact_manifest(artifact)
+
     pusher.push_artifact(
         liveserver_session,
         "devtable",
-        "cosign-in-toto-artifact",
-        artifact,
+        "cosign-custom-artifact",
+        manifest,
         blobs,
         credentials=("devtable", "password"),
         options=_ARTIFACT_PUSH_OPTIONS,
@@ -330,67 +339,86 @@ def test_in_toto_artifact_type_push_pull(pusher, liveserver_session, app_reloade
     pulled = pusher.pull_artifact(
         liveserver_session,
         "devtable",
-        "cosign-in-toto-artifact",
-        str(artifact.digest),
+        "cosign-custom-artifact",
+        str(manifest.digest),
         credentials=("devtable", "password"),
     ).manifest
-    assert pulled.artifact_type == IN_TOTO_ARTIFACT_TYPE
+    assert pulled.artifact_type == CUSTOM_TEST_ARTIFACT_TYPE
+    assert pulled.config_media_type == CUSTOM_TEST_CONFIG_TYPE
 
 
-def test_signature_deletion_removes_referrer(
+def test_base_image_deletion_preserves_signature(
     pusher, puller, basic_images, liveserver_session, app_reloader
 ):
     """
-    Deleting a tagged cosign signature via the registry API succeeds and the subject
-    image remains pullable.
+    Deleting the base image tag preserves the cosign signature manifest.
 
-    Referrers listings are keyed on the manifest subject column; they are unchanged
-    until the GC worker reclaims the untagged signature manifest.
+    After pushing a base image and attaching a cosign signature, delete the base
+    image tag. The signature manifest must survive the tag deletion (GC has not
+    run), confirming that signatures are not immediately lost when their subject
+    image tag is removed.
+
+    Note: the referrers API requires the subject manifest to be resolvable via
+    an alive tag, so referrer discovery is expected to fail after the subject
+    tag is deleted. This test validates signature *manifest* preservation, not
+    referrer-index availability.
     """
     push_result = pusher.push(
         liveserver_session,
         "devtable",
-        "cosign-signature-deletion",
+        "cosign-base-deletion",
         "latest",
         basic_images,
         credentials=("devtable", "password"),
     )
     subject = list(push_result.manifests.values())[0]
-    registry_ref = "localhost:5000/%s/%s" % ("devtable", "cosign-signature-deletion")
+    registry_ref = "localhost:5000/%s/%s" % ("devtable", "cosign-base-deletion")
 
-    signature_tag = "cosign-signature"
     signature, blobs = build_cosign_signature_manifest(subject, registry_ref)
     pusher.push_artifact(
         liveserver_session,
         "devtable",
-        "cosign-signature-deletion",
+        "cosign-base-deletion",
         signature,
         blobs,
-        reference=signature_tag,
         credentials=("devtable", "password"),
         options=_ARTIFACT_PUSH_OPTIONS,
     )
 
+    # Verify the signature is discoverable via referrers before deletion.
     response = get_referrers(
-        pusher, liveserver_session, "devtable", "cosign-signature-deletion", str(subject.digest)
+        pusher, liveserver_session, "devtable", "cosign-base-deletion", str(subject.digest)
     )
     assert str(signature.digest) in referrer_digests(parse_and_validate_referrers_index(response))
 
-    # Digest delete requires at least one tag on the manifest (see delete_manifest_by_digest).
-    delete_manifest(
-        pusher, liveserver_session, "devtable", "cosign-signature-deletion", str(signature.digest)
+    # Delete the base image tag (not the signature).
+    pusher.delete(
+        liveserver_session,
+        "devtable",
+        "cosign-base-deletion",
+        "latest",
+        credentials=("devtable", "password"),
     )
 
-    response = get_referrers(
-        pusher, liveserver_session, "devtable", "cosign-signature-deletion", str(subject.digest)
-    )
-    assert str(signature.digest) in referrer_digests(parse_and_validate_referrers_index(response))
-
+    # Confirm the base image tag is actually gone.
     puller.pull(
         liveserver_session,
         "devtable",
-        "cosign-signature-deletion",
+        "cosign-base-deletion",
         "latest",
         basic_images,
         credentials=("devtable", "password"),
+        expected_failure=Failures.UNKNOWN_TAG,
     )
+
+    # The signature artifact itself must still be pullable by digest because
+    # GC has not yet reclaimed the untagged manifest.
+    pulled_sig = pusher.pull_artifact(
+        liveserver_session,
+        "devtable",
+        "cosign-base-deletion",
+        str(signature.digest),
+        credentials=("devtable", "password"),
+    ).manifest
+    assert pulled_sig.subject is not None
+    assert pulled_sig.subject.digest == subject.digest


### PR DESCRIPTION
Added 8 test cases for signature workflow verifcation in test/registry/test_cosign_signatures.py with helper functions in test/registry/cosign_test_helpers.py. The test cases start from the basics of pushing an image with a signature and verifying that the signature returns back on a pull as well as pushing a signature artifact and checking that you can discover it via the API. Additionally reformatted the protocols to support artifacts natively instead of only using images.