### PR TITLE
NO-ISSUE: chore(_init): use str.startswith for version line detection

### DIFF
--- a/_init.py
+++ b/_init.py
@@ -51,7 +51,7 @@ def _get_version_number_changelog():
     try:
         with open(os.path.join(ROOT_DIR, "CHANGELOG.md")) as f:
             for line in f:
-                if line[0:5] == "## [v":
+                if line.startswith("## [v"):
                     return line.split("[")[1].split("]")[0]
     except IOError:
         return ""


### PR DESCRIPTION
## Summary
- Replace `line[0:5] == "## [v"` with `line.startswith("## [v")` in `_init.py` for readability

## Root Cause / Rationale
Style micro-improvement: `str.startswith()` is more idiomatic Python and self-documenting than a
slice-based prefix comparison. No functional change — both expressions are semantically identical.

## Changes
- `_init.py`: `_get_version_number_changelog()` — replace slice comparison with `str.startswith()`

## Test Plan
- [x] Integration/registry tests pass
- [x] Type checking passes
- No unit tests added — zero functional change, existing suite covers the behaviour

## JIRA
https://redhat.atlassian.net/browse/NO-ISSUE

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-bee4b2b2-4a11-4b9b-acef-87d4bffd78fc