### PR TITLE
PROJQUAY-11235: fix(templates): remove hardcoded external CDN references

### DIFF
--- a/endpoints/test/test_template_external_cdn.py
+++ b/endpoints/test/test_template_external_cdn.py
@@ -71,77 +71,78 @@ class TestNoHardcodedCDN:
 try:
     from test.fixtures import *
 
-    class TestTemplateRendering:
-        @pytest.mark.parametrize(
-            "template_name",
-            [
-                "generatedtoken.html",
-                "message.html",
-            ],
-        )
-        def test_template_renders_with_local_styles(self, template_name, app):
-            from flask import render_template
-
-            local_styles = [
-                "/static/ldn/font-awesome.css-abc123",
-                "/static/ldn/bootstrap.min.css-def456",
-            ]
-
-            config_set = {
-                "BRANDING": {"logo": "/static/img/quay_logo.png"},
-            }
-
-            with app.app_context():
-                html = render_template(
-                    template_name,
-                    external_styles=local_styles,
-                    config_set=config_set,
-                    onprem=True,
-                    message="Test message",
-                )
-
-            for style_url in local_styles:
-                assert (
-                    style_url in html
-                ), f"{template_name} did not render local style URL {style_url}"
-
-            for domain in EXTERNAL_CDN_DOMAINS:
-                assert (
-                    domain not in html
-                ), f"{template_name} rendered with hardcoded CDN domain {domain}"
-
-        def test_error_template_renders_with_local_styles(self, app):
-            from flask import render_template
-
-            local_styles = [
-                "/static/ldn/font-awesome.css-abc123",
-                "/static/ldn/bootstrap.min.css-def456",
-            ]
-
-            config_set = {
-                "BRANDING": {
-                    "logo": "/static/img/quay_logo.png",
-                },
-            }
-
-            with app.app_context():
-                html = render_template(
-                    "500.html",
-                    external_styles=local_styles,
-                    config_set=config_set,
-                    onprem=True,
-                    has_billing=False,
-                )
-
-            for style_url in local_styles:
-                assert (
-                    style_url in html
-                ), f"500.html (extends error.html) did not render local style URL {style_url}"
-
-            for domain in EXTERNAL_CDN_DOMAINS:
-                assert (
-                    domain not in html
-                ), f"500.html (extends error.html) rendered with hardcoded CDN domain {domain}"
-
+    _has_fixtures = True
 except ImportError:
-    pass
+    _has_fixtures = False
+
+
+@pytest.mark.skipif(not _has_fixtures, reason="test.fixtures unavailable (missing Flask deps)")
+class TestTemplateRendering:
+    @pytest.mark.parametrize(
+        "template_name",
+        [
+            "generatedtoken.html",
+            "message.html",
+        ],
+    )
+    def test_template_renders_with_local_styles(self, template_name, app):
+        from flask import render_template
+
+        local_styles = [
+            "/static/ldn/font-awesome.css-abc123",
+            "/static/ldn/bootstrap.min.css-def456",
+        ]
+
+        config_set = {
+            "BRANDING": {"logo": "/static/img/quay_logo.png"},
+        }
+
+        with app.app_context():
+            html = render_template(
+                template_name,
+                external_styles=local_styles,
+                config_set=config_set,
+                onprem=True,
+                message="Test message",
+            )
+
+        for style_url in local_styles:
+            assert style_url in html, f"{template_name} did not render local style URL {style_url}"
+
+        for domain in EXTERNAL_CDN_DOMAINS:
+            assert (
+                domain not in html
+            ), f"{template_name} rendered with hardcoded CDN domain {domain}"
+
+    def test_error_template_renders_with_local_styles(self, app):
+        from flask import render_template
+
+        local_styles = [
+            "/static/ldn/font-awesome.css-abc123",
+            "/static/ldn/bootstrap.min.css-def456",
+        ]
+
+        config_set = {
+            "BRANDING": {
+                "logo": "/static/img/quay_logo.png",
+            },
+        }
+
+        with app.app_context():
+            html = render_template(
+                "500.html",
+                external_styles=local_styles,
+                config_set=config_set,
+                onprem=True,
+                has_billing=False,
+            )
+
+        for style_url in local_styles:
+            assert (
+                style_url in html
+            ), f"500.html (extends error.html) did not render local style URL {style_url}"
+
+        for domain in EXTERNAL_CDN_DOMAINS:
+            assert (
+                domain not in html
+            ), f"500.html (extends error.html) rendered with hardcoded CDN domain {domain}"

--- a/endpoints/test/test_template_external_cdn.py
+++ b/endpoints/test/test_template_external_cdn.py
@@ -1,0 +1,147 @@
+import os
+import re
+
+import pytest
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+
+EXTERNAL_CDN_DOMAINS = [
+    "fonts.googleapis.com",
+    "netdna.bootstrapcdn.com",
+    "maxcdn.bootstrapcdn.com",
+]
+
+EXTERNAL_CDN_PATTERN = re.compile(
+    r'(?:href|src)\s*=\s*["\'](?:https?:)?//(?:'
+    + "|".join(re.escape(d) for d in EXTERNAL_CDN_DOMAINS)
+    + r")",
+    re.IGNORECASE,
+)
+
+JINJA_TEMPLATES = [
+    "templates/generatedtoken.html",
+    "templates/message.html",
+    "templates/error.html",
+]
+
+STATIC_PAGES = [
+    "static/502.html",
+]
+
+
+class TestNoHardcodedCDN:
+    @pytest.mark.parametrize("template_path", JINJA_TEMPLATES + STATIC_PAGES)
+    def test_no_hardcoded_external_cdn_urls(self, template_path):
+        filepath = os.path.join(REPO_ROOT, template_path)
+        with open(filepath) as f:
+            content = f.read()
+
+        matches = EXTERNAL_CDN_PATTERN.findall(content)
+        assert not matches, (
+            f"{template_path} contains hardcoded external CDN references: {matches}. "
+            f"Jinja templates should use the external_styles variable instead. "
+            f"Static pages should use inline CSS. (PROJQUAY-11235)"
+        )
+
+    @pytest.mark.parametrize("template_path", JINJA_TEMPLATES)
+    def test_jinja_templates_use_external_styles_variable(self, template_path):
+        filepath = os.path.join(REPO_ROOT, template_path)
+        with open(filepath) as f:
+            content = f.read()
+
+        assert "external_styles" in content, (
+            f"{template_path} does not reference the external_styles template variable. "
+            f"Templates rendered via render_page_template must use external_styles "
+            f"to respect the USE_CDN config flag. (PROJQUAY-11235)"
+        )
+
+    def test_502_has_no_external_dependencies(self):
+        filepath = os.path.join(REPO_ROOT, "static/502.html")
+        with open(filepath) as f:
+            content = f.read()
+
+        protocol_relative = re.findall(r'(?:href|src)\s*=\s*["\'](?:https?:)?//', content)
+        assert not protocol_relative, (
+            f"static/502.html contains external resource references: {protocol_relative}. "
+            f"This file is served by nginx as a static page and cannot use Jinja variables. "
+            f"All styling must be inline. (PROJQUAY-11235)"
+        )
+
+
+try:
+    from test.fixtures import *
+
+    class TestTemplateRendering:
+        @pytest.mark.parametrize(
+            "template_name",
+            [
+                "generatedtoken.html",
+                "message.html",
+            ],
+        )
+        def test_template_renders_with_local_styles(self, template_name, app):
+            from flask import render_template
+
+            local_styles = [
+                "/static/ldn/font-awesome.css-abc123",
+                "/static/ldn/bootstrap.min.css-def456",
+            ]
+
+            config_set = {
+                "BRANDING": {"logo": "/static/img/quay_logo.png"},
+            }
+
+            with app.app_context():
+                html = render_template(
+                    template_name,
+                    external_styles=local_styles,
+                    config_set=config_set,
+                    onprem=True,
+                    message="Test message",
+                )
+
+            for style_url in local_styles:
+                assert (
+                    style_url in html
+                ), f"{template_name} did not render local style URL {style_url}"
+
+            for domain in EXTERNAL_CDN_DOMAINS:
+                assert (
+                    domain not in html
+                ), f"{template_name} rendered with hardcoded CDN domain {domain}"
+
+        def test_error_template_renders_with_local_styles(self, app):
+            from flask import render_template
+
+            local_styles = [
+                "/static/ldn/font-awesome.css-abc123",
+                "/static/ldn/bootstrap.min.css-def456",
+            ]
+
+            config_set = {
+                "BRANDING": {
+                    "logo": "/static/img/quay_logo.png",
+                },
+            }
+
+            with app.app_context():
+                html = render_template(
+                    "500.html",
+                    external_styles=local_styles,
+                    config_set=config_set,
+                    onprem=True,
+                    has_billing=False,
+                )
+
+            for style_url in local_styles:
+                assert (
+                    style_url in html
+                ), f"500.html (extends error.html) did not render local style URL {style_url}"
+
+            for domain in EXTERNAL_CDN_DOMAINS:
+                assert (
+                    domain not in html
+                ), f"500.html (extends error.html) rendered with hardcoded CDN domain {domain}"
+
+except ImportError:
+    pass

--- a/endpoints/test/test_template_external_cdn.py
+++ b/endpoints/test/test_template_external_cdn.py
@@ -76,6 +76,12 @@ except ImportError:
     _has_fixtures = False
 
 
+@pytest.fixture()
+def template_app(app):
+    app.template_folder = os.path.join(REPO_ROOT, "templates")
+    yield app
+
+
 @pytest.mark.skipif(not _has_fixtures, reason="test.fixtures unavailable (missing Flask deps)")
 class TestTemplateRendering:
     @pytest.mark.parametrize(
@@ -85,7 +91,7 @@ class TestTemplateRendering:
             "message.html",
         ],
     )
-    def test_template_renders_with_local_styles(self, template_name, app):
+    def test_template_renders_with_local_styles(self, template_name, template_app):
         from flask import render_template
 
         local_styles = [
@@ -97,7 +103,7 @@ class TestTemplateRendering:
             "BRANDING": {"logo": "/static/img/quay_logo.png"},
         }
 
-        with app.app_context():
+        with template_app.app_context():
             html = render_template(
                 template_name,
                 external_styles=local_styles,
@@ -114,7 +120,7 @@ class TestTemplateRendering:
                 domain not in html
             ), f"{template_name} rendered with hardcoded CDN domain {domain}"
 
-    def test_error_template_renders_with_local_styles(self, app):
+    def test_error_template_renders_with_local_styles(self, template_app):
         from flask import render_template
 
         local_styles = [
@@ -128,7 +134,7 @@ class TestTemplateRendering:
             },
         }
 
-        with app.app_context():
+        with template_app.app_context():
             html = render_template(
                 "500.html",
                 external_styles=local_styles,

--- a/static/502.html
+++ b/static/502.html
@@ -1,9 +1,6 @@
 <html>
   <head>
     <title>Quay Loading</title>
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.no-icons.min.css">
-    <link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
     <style type="text/css">
       .information {
          padding: 30px;

--- a/templates/error.html
+++ b/templates/error.html
@@ -3,9 +3,9 @@
     {% block title %}
 
     {% endblock %}
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.no-icons.min.css">
-    <link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
+    {% for style_url in external_styles %}
+      <link rel="stylesheet" href="{{ style_url }}" type="text/css">
+    {% endfor %}
     <style type="text/css">
       .ship-header {
         width: 100%;

--- a/templates/generatedtoken.html
+++ b/templates/generatedtoken.html
@@ -1,9 +1,9 @@
 <html>
   <title>OAuth Access Token · Quay</title>
   <head>
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.no-icons.min.css">
-    <link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
+    {% for style_url in external_styles %}
+      <link rel="stylesheet" href="{{ style_url }}" type="text/css">
+    {% endfor %}
     <script type="text/javascript">
       function setToken() {
         var hash = document.location.hash.substr(1);

--- a/templates/message.html
+++ b/templates/message.html
@@ -1,9 +1,9 @@
 <html class="{% if onprem %}onprem{% else %}hosted{% endif %}">
   <title>Quay</title>
   <head>
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
-    <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.no-icons.min.css">
-    <link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
+    {% for style_url in external_styles %}
+      <link rel="stylesheet" href="{{ style_url }}" type="text/css">
+    {% endfor %}
   </head>
   <body>
     <div class="container" style="margin-top: 20px">


### PR DESCRIPTION
## Summary
- Remove hardcoded external CDN references from standalone HTML templates that bypass the `USE_CDN` config flag
- Replace with `external_styles` Jinja variable in 3 templates, remove entirely from static `502.html`
- Add 8 regression tests to prevent reintroduction

## Root Cause / Rationale
Four standalone templates (`generatedtoken.html`, `message.html`, `error.html`, `static/502.html`) hardcoded `<link>` tags pointing to `fonts.googleapis.com` and `netdna.bootstrapcdn.com`. These templates predate the `USE_CDN` / `external_libraries.py` localization mechanism and were never updated. Since `USE_CDN=False` is the default for all enterprise deployments, these external requests always fail in air-gapped environments, causing 30-40 second page load timeouts.

The main app template (`base.html`) already handles this correctly via `{% for style_url in external_styles %}`, and `render_page_template()` already passes `external_styles` to all templates.

## Changes
- `templates/generatedtoken.html` — replaced 3 hardcoded CDN links with `external_styles` loop
- `templates/message.html` — replaced 3 hardcoded CDN links with `external_styles` loop
- `templates/error.html` — replaced 3 hardcoded CDN links with `external_styles` loop
- `static/502.html` — removed 3 CDN links (page uses only inline CSS, no Bootstrap/FA dependency)
- `endpoints/test/test_template_external_cdn.py` — 8 regression tests (new file)

## Test Plan
- [x] Unit tests added/updated
- [x] Type checking passes
- [x] Manual testing performed
- [ ] Integration/registry tests pass
- [ ] Frontend tests pass
- [ ] Migration tested (upgrade and downgrade)

### Regression test details
- `TestNoHardcodedCDN`: 8 tests verify no CDN URLs remain and Jinja templates use `external_styles`
- `TestTemplateRendering`: 3 Flask rendering tests verify templates render with local style URLs (requires full fixture, runs in CI)
- Tests confirmed to **fail without the fix** (3 CDN matches per file on pre-fix code)
- Existing nginx config tests (10/10) and Playwright 502 test continue to pass

## JIRA
https://issues.redhat.com/browse/PROJQUAY-11235

## Backport
- [ ] Backport required
- [x] No backport needed

## Automation
- **Session ID**: session-b20b63d0-379f-4456-b887-cf7372ad9974