### PR TITLE
PROJQUAY-11624: test(playwright): add robot credential execution tests

### DIFF
--- a/web/playwright/e2e/organization/robot-accounts.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts.spec.ts
@@ -1,6 +1,7 @@
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
 import {API_URL} from '../../utils/config';
+import {pushImage, pullImage} from '../../utils/container';
 
 test.describe(
   'Robot Accounts',
@@ -782,6 +783,83 @@ test.describe(
       // The repo list search should still show the original search text
       // (not polluted by the wizard's search)
       await expect(repoSearchAfter).toHaveValue(repo1.name);
+    });
+
+    test.describe('robot credential execution', {tag: ['@container']}, () => {
+      test('robot credentials can authenticate via container login', async ({
+        api,
+      }) => {
+        const org = await api.organization('robotloginorg');
+        const robot = await api.robot(
+          org.name,
+          'loginbot',
+          'Robot for login test',
+        );
+
+        await pushImage(
+          org.name,
+          'logintestrepo',
+          'latest',
+          robot.fullName,
+          robot.token,
+        );
+      });
+
+      test('robot credentials can push and pull images', async ({api}) => {
+        const org = await api.organization('robotpushpullorg');
+        const repo = await api.repository(org.name, 'pushpullrepo');
+        const robot = await api.robot(
+          org.name,
+          'pushpullbot',
+          'Robot for push/pull test',
+        );
+
+        await api.repositoryPermission(
+          org.name,
+          repo.name,
+          'user',
+          robot.fullName,
+          'write',
+        );
+
+        await pushImage(
+          org.name,
+          repo.name,
+          'v1.0',
+          robot.fullName,
+          robot.token,
+        );
+
+        await pullImage(
+          org.name,
+          repo.name,
+          'v1.0',
+          robot.fullName,
+          robot.token,
+        );
+      });
+
+      test('robot token format is valid and non-empty', async ({
+        authenticatedRequest,
+        api,
+      }) => {
+        const org = await api.organization('robottokenorg');
+        const robot = await api.robot(
+          org.name,
+          'tokenbot',
+          'Robot for token validation',
+        );
+
+        expect(robot.fullName).toMatch(/^.+\+.+$/);
+        expect(robot.token).toBeTruthy();
+        expect(robot.token.length).toBeGreaterThan(0);
+
+        const robotResponse = await authenticatedRequest.get(
+          `${API_URL}/api/v1/organization/${org.name}/robots/${robot.shortname}`,
+        );
+        const robotData = await robotResponse.json();
+        expect(robotData.token).toBe(robot.token);
+      });
     });
 
     test.describe(

--- a/web/playwright/e2e/organization/robot-accounts.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts.spec.ts
@@ -790,15 +790,24 @@ test.describe(
         api,
       }) => {
         const org = await api.organization('robotloginorg');
+        const repo = await api.repository(org.name, 'logintestrepo');
         const robot = await api.robot(
           org.name,
           'loginbot',
           'Robot for login test',
         );
 
+        await api.repositoryPermission(
+          org.name,
+          repo.name,
+          'user',
+          robot.fullName,
+          'write',
+        );
+
         await pushImage(
           org.name,
-          'logintestrepo',
+          repo.name,
           'latest',
           robot.fullName,
           robot.token,

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -81,6 +81,7 @@ export interface CreatedRobot {
   orgName: string;
   shortname: string;
   fullName: string;
+  token: string;
 }
 
 /**
@@ -327,7 +328,11 @@ export class TestApi {
     // Robot names can't have dashes, only underscores
     const shortname = uniqueName(namePrefix).replace(/-/g, '_');
 
-    await this.client.createRobot(orgName, shortname, description);
+    const result = await this.client.createRobot(
+      orgName,
+      shortname,
+      description,
+    );
 
     this.cleanupStack.push(async () => {
       try {
@@ -341,6 +346,7 @@ export class TestApi {
       orgName,
       shortname,
       fullName: `${orgName}+${shortname}`,
+      token: result.token,
     };
   }
 


### PR DESCRIPTION
## Summary
- Add 3 Playwright tests that verify robot account credentials work for actual container operations (login, push, pull)
- Port coverage from Cypress tests OCP-67229, OCP-67233, OCP-67235
- Expose robot token from `TestApi.robot()` fixture for direct use in tests

## Root Cause / Rationale
Existing Playwright robot account tests cover CRUD, wizard flows, and credential display (K8s secrets, Docker auth.json), but none execute real container operations using robot credentials. This gap means a broken token or auth flow could pass all existing tests. The old Cypress suite had this coverage; it needs to be ported.

## Changes
- `web/playwright/fixtures.ts`: Add `token` field to `CreatedRobot` interface; update `TestApi.robot()` to capture and return the token from the `createRobot()` API response
- `web/playwright/e2e/organization/robot-accounts.spec.ts`: Add `robot credential execution` describe block with `@container` tag containing 3 tests:
  1. **Robot credentials can authenticate via container login** — creates a robot and pushes an image using its credentials
  2. **Robot credentials can push and pull images** — creates a robot with write permission on a repo, pushes an image, then pulls it back
  3. **Robot token format is valid and non-empty** — validates robot name format (`org+name`) and verifies the token matches what the API returns

## Test Plan
- [x] Frontend tests pass (ESLint + pre-commit hooks)
- [ ] Playwright E2E tests pass (requires running Quay stack with container runtime)
- [x] No unit test changes needed (test-only change)

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11624

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-7fb77d33-7f21-4375-a4d5-0cc60e1441f0