### PR TITLE
PROJQUAY-11625: test(web): add duplicate org email validation Playwright tests

### DIFF
--- a/web/playwright/e2e/organization/create-organization.spec.ts
+++ b/web/playwright/e2e/organization/create-organization.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect} from '../../fixtures';
+import {test, expect, uniqueName} from '../../fixtures';
 
 test.describe('Create Organization', {tag: ['@organization']}, () => {
   test('modal opens and shows form fields', async ({authenticatedPage}) => {
@@ -139,4 +139,56 @@ test.describe('Create Organization', {tag: ['@organization']}, () => {
       authenticatedPage.locator('#create-org-name-input'),
     ).not.toBeVisible();
   });
+
+  test.describe(
+    'Duplicate Email Validation',
+    {tag: ['@feature:MAILING']},
+    () => {
+      test('rejects creating organization with an email already in use (OCP-73835)', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const existingOrg = await api.organization('dupemail');
+
+        await authenticatedPage.goto('/organization');
+        await authenticatedPage
+          .getByRole('button', {name: 'Create Organization'})
+          .click();
+
+        const orgName = uniqueName('dupeorg');
+        await authenticatedPage.locator('#create-org-name-input').fill(orgName);
+        await authenticatedPage
+          .locator('#create-org-email-input')
+          .fill(existingOrg.email);
+        await authenticatedPage.locator('#create-org-confirm').click();
+
+        await expect(
+          authenticatedPage.getByText('Email has already been used'),
+        ).toBeVisible();
+      });
+
+      test("rejects email already used by another user's organization (OCP-74424)", async ({
+        authenticatedPage,
+        superuserApi,
+      }) => {
+        const otherOrg = await superuserApi.organization('xorg');
+
+        await authenticatedPage.goto('/organization');
+        await authenticatedPage
+          .getByRole('button', {name: 'Create Organization'})
+          .click();
+
+        const orgName = uniqueName('dupeorg');
+        await authenticatedPage.locator('#create-org-name-input').fill(orgName);
+        await authenticatedPage
+          .locator('#create-org-email-input')
+          .fill(otherOrg.email);
+        await authenticatedPage.locator('#create-org-confirm').click();
+
+        await expect(
+          authenticatedPage.getByText('Email has already been used'),
+        ).toBeVisible();
+      });
+    },
+  );
 });

--- a/web/playwright/e2e/organization/settings.spec.ts
+++ b/web/playwright/e2e/organization/settings.spec.ts
@@ -570,7 +570,7 @@ test.describe('Organization Settings', {tag: ['@organization']}, () => {
         await saveButton.click();
 
         await expect(
-          authenticatedPage.getByText('E-mail address already used'),
+          authenticatedPage.getByText('E-mail address already used').first(),
         ).toBeVisible();
       });
     },

--- a/web/playwright/e2e/organization/settings.spec.ts
+++ b/web/playwright/e2e/organization/settings.spec.ts
@@ -547,6 +547,36 @@ test.describe('Organization Settings', {tag: ['@organization']}, () => {
   );
 
   test.describe(
+    'Duplicate Email on Update',
+    {tag: ['@feature:MAILING']},
+    () => {
+      test('rejects updating organization email to one already in use (OCP-73836)', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const org1 = await api.organization('emaildup');
+        const org2 = await api.organization('emaildup');
+
+        await authenticatedPage.goto(`/organization/${org2.name}?tab=Settings`);
+
+        const emailInput = authenticatedPage.locator('#org-settings-email');
+        await expect(emailInput).toBeVisible();
+
+        await emailInput.clear();
+        await emailInput.fill(org1.email);
+
+        const saveButton = authenticatedPage.locator('#save-org-settings');
+        await expect(saveButton).toBeEnabled();
+        await saveButton.click();
+
+        await expect(
+          authenticatedPage.getByText('E-mail address already used'),
+        ).toBeVisible();
+      });
+    },
+  );
+
+  test.describe(
     'Repository Settings: Org Mirror Mutual Exclusion',
     {
       tag: ['@repository', '@feature:ORG_MIRROR', '@feature:IMMUTABLE_TAGS'],


### PR DESCRIPTION
## Summary
- Add 3 Playwright e2e tests for duplicate organization email validation
- Ports Cypress tests OCP-73835, OCP-73836, and OCP-74424 to Playwright
- All tests gated behind `@feature:MAILING` (auto-skipped when FEATURE_MAILING is disabled)

## Root Cause / Rationale
The Playwright test suite conditionally handles the email field during org creation when `FEATURE_MAILING` is enabled, but does not test duplicate email validation. The backend rejects duplicate emails at the data model layer (`unique=True` constraint on User.email), but no e2e tests verify the UI surfaces these errors correctly.

## Changes
- `web/playwright/e2e/organization/create-organization.spec.ts`: Added `Duplicate Email Validation` describe block with two tests:
  - Same-user duplicate: creates org via API, attempts second org with same email via UI, asserts error
  - Cross-user duplicate: creates org via superuser API, attempts org creation as regular user with same email, asserts error
- `web/playwright/e2e/organization/settings.spec.ts`: Added `Duplicate Email on Update` describe block with one test:
  - Creates two orgs with different emails, updates org2's email to org1's email via settings UI, asserts error

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration/registry tests pass
- [x] Type checking passes
- [ ] Manual testing performed
- [x] Frontend tests pass
- [ ] Migration tested (upgrade and downgrade)

**Note:** These are Playwright e2e tests that require a running Quay stack with `FEATURE_MAILING: true`. They auto-skip in environments where MAILING is not enabled.

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11625

## Backport
- [ ] Backport required
- [x] No backport needed

## Automation
- **Session ID**: ambient/session-434b042c-dd9c-4652-aec2-2c7ce89145e7