### PR TITLE
PROJQUAY-11636: feat(ui): implement invite code flow for new React UI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -21,7 +21,6 @@ coverage:
     patch:
       default:
         target: 60%
-        informational: true
 
 flags:
   unit:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -21,6 +21,7 @@ coverage:
     patch:
       default:
         target: 60%
+        informational: true
 
 flags:
   unit:

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -63,7 +63,7 @@ location / {
 }
 
 # Capture traffic that needs to go to web_app, see /web.py
-location ~* ^(/config|/csrf_token|/oauth/authorize|/oauth/authorizeapp|/oauth/authorize/assignuser|/oauth/denyapp|/oauth1|/oauth2|/webhooks|/keys|/.well-known|/customtrigger|/authrepoemail|/confirm|/recovery|/userfiles/(.*)|/health(/.*)?|/status|/_internal_ping|/buildlogs|/logarchive) {
+location ~* ^(/config|/csrf_token|/oauth/authorize|/oauth/authorizeapp|/oauth/authorize/assignuser|/oauth/denyapp|/oauth1|/oauth2|/webhooks|/keys|/.well-known|/customtrigger|/authrepoemail|/confirm$|/recovery|/userfiles/(.*)|/health(/.*)?|/status|/_internal_ping|/buildlogs|/logarchive) {
     proxy_pass   http://web_app_server;
 }
 

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -240,7 +240,7 @@ def updateuser():
 @web.route("/confirminvite")
 @no_cache
 def confirm_invite():
-    code = request.values["code"]
+    code = request.values.get("code", "")
     return index("", code=code)
 
 

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -273,6 +273,12 @@ class WebEndpointTestCase(EndpointTestCase):
     def test_user_view(self):
         self.getResponse("web.user_view", path="devtable")
 
+    def test_confirm_invite_with_code(self):
+        self.getResponse("web.confirm_invite", code="someinvitecode")
+
+    def test_confirm_invite_without_code(self):
+        self.getResponse("web.confirm_invite")
+
     def test_confirm_repo_email(self):
         code = model.repository.create_email_authorization_for_repo(
             "devtable", "simple", "foo@bar.com"

--- a/web/playwright/e2e/auth/confirm-invite.spec.ts
+++ b/web/playwright/e2e/auth/confirm-invite.spec.ts
@@ -1,0 +1,160 @@
+import {test, expect} from '../../fixtures';
+
+/**
+ * Confirm Invite tests verify the /confirminvite route added for
+ * PROJQUAY-11636. Tests that need a real invite code use the
+ * @feature:INVITE_ONLY_USER_CREATION tag.
+ */
+
+test.describe('Confirm Invite Page', {tag: ['@auth']}, () => {
+  test('shows error when no invite code is in the URL', async ({
+    unauthenticatedPage,
+  }) => {
+    await unauthenticatedPage.goto('/confirminvite');
+
+    await expect(
+      unauthenticatedPage.getByTestId('confirm-invite-error'),
+    ).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      unauthenticatedPage.getByText(/No invite code/i),
+    ).toBeVisible();
+  });
+
+  test('shows sign-in and create-account options for unauthenticated user', async ({
+    unauthenticatedPage,
+  }) => {
+    await unauthenticatedPage.goto('/confirminvite?code=somefakecode');
+
+    await expect(
+      unauthenticatedPage.getByTestId('confirm-invite-unauthenticated'),
+    ).toBeVisible({timeout: 10_000});
+
+    await expect(
+      unauthenticatedPage.getByTestId('confirm-invite-signin-btn'),
+    ).toBeVisible();
+    await expect(
+      unauthenticatedPage.getByTestId('confirm-invite-create-account-btn'),
+    ).toBeVisible();
+  });
+
+  test('sign-in and create-account buttons preserve invite code in URL', async ({
+    unauthenticatedPage,
+  }) => {
+    await unauthenticatedPage.goto('/confirminvite?code=myinvitecode');
+
+    await expect(
+      unauthenticatedPage.getByTestId('confirm-invite-signin-btn'),
+    ).toBeVisible({timeout: 10_000});
+
+    const signinHref = await unauthenticatedPage
+      .getByTestId('confirm-invite-signin-btn')
+      .getAttribute('href');
+    expect(signinHref).toContain('code=myinvitecode');
+
+    const createHref = await unauthenticatedPage
+      .getByTestId('confirm-invite-create-account-btn')
+      .getAttribute('href');
+    expect(createHref).toContain('code=myinvitecode');
+  });
+
+  test('sign-in button navigates to /signin with code param', async ({
+    unauthenticatedPage,
+  }) => {
+    await unauthenticatedPage.goto('/confirminvite?code=nav-test-code');
+
+    await expect(
+      unauthenticatedPage.getByTestId('confirm-invite-signin-btn'),
+    ).toBeVisible({timeout: 10_000});
+
+    await unauthenticatedPage.getByTestId('confirm-invite-signin-btn').click();
+
+    await expect(unauthenticatedPage).toHaveURL(/\/signin\?code=nav-test-code/);
+  });
+
+  test('create-account button navigates to /createaccount with code param', async ({
+    unauthenticatedPage,
+  }) => {
+    await unauthenticatedPage.goto('/confirminvite?code=nav-create-code');
+
+    await expect(
+      unauthenticatedPage.getByTestId('confirm-invite-create-account-btn'),
+    ).toBeVisible({timeout: 10_000});
+
+    await unauthenticatedPage
+      .getByTestId('confirm-invite-create-account-btn')
+      .click();
+
+    await expect(unauthenticatedPage).toHaveURL(
+      /\/createaccount\?code=nav-create-code/,
+    );
+
+    await expect(
+      unauthenticatedPage.getByTestId('invite-code-alert'),
+    ).toBeVisible();
+    await expect(
+      unauthenticatedPage.getByText("You've been invited to join a team"),
+    ).toBeVisible();
+  });
+
+  test('authenticated user with invalid code sees error', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/confirminvite?code=invalid-code-xyz');
+
+    await expect(
+      authenticatedPage.getByTestId('confirm-invite-error'),
+    ).toBeVisible({timeout: 10_000});
+  });
+
+  test('create-account page shows invite banner when code is present', async ({
+    unauthenticatedPage,
+  }) => {
+    await unauthenticatedPage.goto('/createaccount?code=testcode');
+
+    await expect(
+      unauthenticatedPage.getByTestId('invite-code-alert'),
+    ).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(
+      unauthenticatedPage.getByText("You've been invited to join a team"),
+    ).toBeVisible();
+  });
+
+  test(
+    'create-account page preserves invite code in sign-in link',
+    {
+      tag: '@auth:Database',
+    },
+    async ({unauthenticatedPage}) => {
+      await unauthenticatedPage.goto('/createaccount?code=link-code');
+
+      const signinLink = unauthenticatedPage.getByRole('link', {
+        name: 'Sign in',
+      });
+      await expect(signinLink).toBeVisible({timeout: 10_000});
+
+      const href = await signinLink.getAttribute('href');
+      expect(href).toContain('code=link-code');
+    },
+  );
+
+  test(
+    'signin page shows create-account link when invite code is present',
+    {tag: '@feature:INVITE_ONLY_USER_CREATION'},
+    async ({unauthenticatedPage}) => {
+      await unauthenticatedPage.goto('/signin?code=somecode');
+
+      await expect(
+        unauthenticatedPage.getByTestId('signin-create-account-link'),
+      ).toBeVisible({timeout: 10_000});
+
+      const href = await unauthenticatedPage
+        .getByTestId('signin-create-account-link')
+        .getAttribute('href');
+      expect(href).toContain('code=somecode');
+    },
+  );
+});

--- a/web/playwright/e2e/organization/team-members.spec.ts
+++ b/web/playwright/e2e/organization/team-members.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect} from '../../fixtures';
+import {test, expect, uniqueName} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
 import type {Page} from '@playwright/test';
 
@@ -256,3 +256,111 @@ test.describe('Manage Team Members', {tag: ['@organization']}, () => {
     );
   });
 });
+
+test.describe(
+  'Team Email Invites',
+  {tag: ['@organization', '@feature:MAILING']},
+  () => {
+    test('email invite shows in team members table', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('testorg');
+      const team = await api.team(org.name, 'emailshow');
+      const email = `${uniqueName('show')}@example.com`;
+
+      await api.teamEmailInvite(org.name, team.name, email);
+
+      await navigateToManageTeamMembers(authenticatedPage, org.name, team.name);
+
+      await expect(authenticatedPage.getByTestId(email)).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(
+        authenticatedPage
+          .getByTestId(email)
+          .locator('xpath=ancestor::tr')
+          .locator('[data-label="Account"]'),
+      ).toContainText('(Invited)');
+    });
+
+    test('can invite by email via drawer', async ({authenticatedPage, api}) => {
+      const org = await api.organization('testorg');
+      const team = await api.team(org.name, 'emaildrawer');
+      const email = `${uniqueName('drawer')}@example.com`;
+
+      await navigateToManageTeamMembers(authenticatedPage, org.name, team.name);
+
+      await authenticatedPage.getByTestId('add-new-member-button').click();
+
+      const emailInput = authenticatedPage.getByTestId('email-invite-input');
+      const inviteBtn = authenticatedPage.getByTestId('invite-by-email-btn');
+
+      // Button should be disabled with no input
+      await expect(inviteBtn).toBeDisabled();
+
+      await emailInput.fill(email);
+      await expect(inviteBtn).toBeEnabled();
+      await inviteBtn.click();
+
+      const alert = authenticatedPage
+        .locator('.pf-v6-c-alert.pf-m-success')
+        .last();
+      await expect(alert).toContainText('was invited to join the team', {
+        timeout: 10_000,
+      });
+      await expect(alert).toContainText(email);
+    });
+
+    test('invited tab shows only invited members', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('testorg');
+      const team = await api.team(org.name, 'emailfilter');
+      const email = `${uniqueName('filter')}@example.com`;
+
+      await api.teamMember(org.name, team.name, TEST_USERS.user.username);
+      await api.teamEmailInvite(org.name, team.name, email);
+
+      await navigateToManageTeamMembers(authenticatedPage, org.name, team.name);
+
+      await authenticatedPage.getByTestId('Invited').click();
+
+      const paginationInfo = authenticatedPage
+        .locator('.pf-v6-c-pagination__total-items')
+        .first();
+
+      await expect(paginationInfo).toContainText('1 - 1 of 1', {
+        timeout: 10_000,
+      });
+      await expect(authenticatedPage.getByTestId(email)).toBeVisible();
+    });
+
+    test('can revoke email invite via delete icon', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('testorg');
+      const team = await api.team(org.name, 'emailrevoke');
+      const email = `${uniqueName('revoke')}@example.com`;
+
+      await api.teamEmailInvite(org.name, team.name, email);
+
+      await navigateToManageTeamMembers(authenticatedPage, org.name, team.name);
+
+      await expect(authenticatedPage.getByTestId(email)).toBeVisible({
+        timeout: 10_000,
+      });
+
+      await authenticatedPage.getByTestId(`${email}-delete-icon`).click();
+      await authenticatedPage.getByTestId(`${email}-del-btn`).click();
+
+      await expect(
+        authenticatedPage.locator('.pf-v6-c-alert.pf-m-success').last(),
+      ).toContainText('Successfully revoked invitation', {
+        timeout: 10_000,
+      });
+    });
+  },
+);

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -318,6 +318,28 @@ export class TestApi {
   }
 
   /**
+   * Invite an email address to a team.
+   * Automatically revoked after test.
+   */
+  async teamEmailInvite(
+    orgName: string,
+    teamName: string,
+    email: string,
+  ): Promise<{orgName: string; teamName: string; email: string}> {
+    await this.client.inviteTeamMemberByEmail(orgName, teamName, email);
+
+    this.cleanupStack.push(async () => {
+      try {
+        await this.client.deleteTeamEmailInvite(orgName, teamName, email);
+      } catch {
+        /* ignore cleanup errors */
+      }
+    });
+
+    return {orgName, teamName, email};
+  }
+
+  /**
    * Create a robot account in an organization.
    * Automatically deleted after test.
    */
@@ -1185,6 +1207,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   unauthenticatedPage: async ({browser}, use) => {
     // Create a fresh browser context without any authentication
     const context = await browser.newContext();
+    await setReactUICookie(context);
     const page = await context.newPage();
     await use(page);
     await page.close();

--- a/web/playwright/utils/api/client.ts
+++ b/web/playwright/utils/api/client.ts
@@ -1079,6 +1079,58 @@ export class ApiClient {
     }
   }
 
+  async inviteTeamMemberByEmail(
+    orgName: string,
+    teamName: string,
+    email: string,
+  ): Promise<void> {
+    const token = await this.fetchToken();
+    const response = await this.request.put(
+      `${API_URL}/api/v1/organization/${orgName}/team/${teamName}/invite/${encodeURIComponent(
+        email,
+      )}`,
+      {
+        timeout: 5000,
+        headers: {
+          'X-CSRF-Token': token,
+        },
+      },
+    );
+
+    if (!response.ok()) {
+      const body = await response.text();
+      throw new Error(
+        `Failed to invite ${email} to team ${teamName}: ${response.status()} - ${body}`,
+      );
+    }
+  }
+
+  async deleteTeamEmailInvite(
+    orgName: string,
+    teamName: string,
+    email: string,
+  ): Promise<void> {
+    const token = await this.fetchToken();
+    const response = await this.request.delete(
+      `${API_URL}/api/v1/organization/${orgName}/team/${teamName}/invite/${encodeURIComponent(
+        email,
+      )}`,
+      {
+        timeout: 5000,
+        headers: {
+          'X-CSRF-Token': token,
+        },
+      },
+    );
+
+    if (!response.ok() && response.status() !== 404) {
+      const body = await response.text();
+      throw new Error(
+        `Failed to delete email invite ${email} from team ${teamName}: ${response.status()} - ${body}`,
+      );
+    }
+  }
+
   // Repository permission methods
 
   async addRepositoryPermission(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import {LoadingPage} from 'src/components/LoadingPage';
 import {useAnalytics} from 'src/hooks/UseAnalytics';
 import {Signin} from 'src/routes/Signin/Signin';
 import {CreateAccount} from 'src/routes/CreateAccount/CreateAccount';
+import {ConfirmInvite} from 'src/routes/ConfirmInvite/ConfirmInvite';
 import UpdateUser from 'src/routes/UpdateUser/UpdateUser';
 import {OAuthCallbackHandler} from 'src/routes/OAuthCallback/OAuthCallbackHandler';
 import {OAuthError} from 'src/routes/OAuthCallback/OAuthError';
@@ -25,6 +26,7 @@ export default function App() {
             <Routes>
               <Route path="/signin" element={<Signin />} />
               <Route path="/createaccount" element={<CreateAccount />} />
+              <Route path="/confirminvite" element={<ConfirmInvite />} />
               <Route path="/updateuser" element={<UpdateUser />} />
               <Route path="/oauth-error" element={<OAuthError />} />
               <Route path="/oauth/localapp" element={<OAuthLocalHandler />} />

--- a/web/src/hooks/UseCreateAccount.test.ts
+++ b/web/src/hooks/UseCreateAccount.test.ts
@@ -1,0 +1,40 @@
+import {renderHook} from '@testing-library/react';
+import React from 'react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {MemoryRouter} from 'react-router-dom';
+import {createTestQueryClient} from 'src/test-utils';
+import {useCreateAccount} from './UseCreateAccount';
+
+vi.mock('src/resources/UserResource', () => ({
+  createUser: vi.fn(),
+  fetchUser: vi.fn(),
+}));
+
+vi.mock('src/resources/AuthResource', () => ({
+  loginUser: vi.fn(),
+  GlobalAuthState: {csrfToken: null, isLoggedIn: false},
+  getCsrfToken: vi.fn(),
+}));
+
+vi.mock('src/resources/ErrorHandling', () => ({
+  addDisplayError: vi.fn((msg: string) => msg),
+}));
+
+function wrapper({children}: {children: React.ReactNode}) {
+  const [queryClient] = React.useState(() => createTestQueryClient());
+  return React.createElement(
+    MemoryRouter,
+    null,
+    React.createElement(QueryClientProvider, {client: queryClient}, children),
+  );
+}
+
+describe('useCreateAccount', () => {
+  it('returns initial state', () => {
+    const {result} = renderHook(() => useCreateAccount(), {wrapper});
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.createAccountWithAutoLogin).toBe('function');
+    expect(typeof result.current.setError).toBe('function');
+  });
+});

--- a/web/src/hooks/UseCreateAccount.ts
+++ b/web/src/hooks/UseCreateAccount.ts
@@ -64,7 +64,10 @@ export function useCreateAccount() {
 
           // If user has prompts (e.g., confirm_username, enter_name, enter_company), redirect to updateuser
           if (user.prompts && user.prompts.length > 0) {
-            navigate('/updateuser');
+            const updateUrl = inviteCode
+              ? `/updateuser?code=${encodeURIComponent(inviteCode)}`
+              : '/updateuser';
+            navigate(updateUrl);
             return {success: true};
           }
 

--- a/web/src/hooks/UseCreateAccount.ts
+++ b/web/src/hooks/UseCreateAccount.ts
@@ -20,13 +20,14 @@ export function useCreateAccount() {
     username: string,
     password: string,
     email: string,
+    inviteCode?: string,
   ) => {
     setIsLoading(true);
     setError(null);
 
     try {
       // Create the user account
-      const response = await createUser(username, password, email);
+      const response = await createUser(username, password, email, inviteCode);
 
       // Clear CSRF token after account creation (session state changed)
       GlobalAuthState.csrfToken = null;
@@ -39,7 +40,7 @@ export function useCreateAccount() {
 
       // Auto-login after successful account creation
       try {
-        const loginResponse = await loginUser(username, password);
+        const loginResponse = await loginUser(username, password, inviteCode);
 
         if (loginResponse.success === true) {
           // Login successful, set auth state
@@ -64,6 +65,12 @@ export function useCreateAccount() {
           // If user has prompts (e.g., confirm_username, enter_name, enter_company), redirect to updateuser
           if (user.prompts && user.prompts.length > 0) {
             navigate('/updateuser');
+            return {success: true};
+          }
+
+          // If there's an invite code, redirect to confirminvite to accept it
+          if (inviteCode) {
+            navigate(`/confirminvite?code=${encodeURIComponent(inviteCode)}`);
             return {success: true};
           }
 

--- a/web/src/hooks/UseMembers.test.ts
+++ b/web/src/hooks/UseMembers.test.ts
@@ -8,6 +8,8 @@ import {
   useFetchCollaborators,
   useDeleteTeamMember,
   useDeleteCollaborator,
+  useInviteTeamMemberByEmail,
+  useDeleteEmailInvite,
 } from './UseMembers';
 import {
   addMemberToTeamForOrg,
@@ -15,15 +17,19 @@ import {
   fetchCollaboratorsForOrg,
   deleteTeamMemberForOrg,
   deleteCollaboratorForOrg,
+  inviteTeamMemberByEmailForOrg,
+  deleteTeamMemberEmailInviteForOrg,
 } from 'src/resources/MembersResource';
 
 vi.mock('src/resources/MembersResource', () => ({
   addMemberToTeamForOrg: vi.fn(),
   deleteCollaboratorForOrg: vi.fn(),
   deleteTeamMemberForOrg: vi.fn(),
+  deleteTeamMemberEmailInviteForOrg: vi.fn(),
   fetchCollaboratorsForOrg: vi.fn(),
   fetchMembersForOrg: vi.fn(),
   fetchTeamMembersForOrg: vi.fn(),
+  inviteTeamMemberByEmailForOrg: vi.fn(),
 }));
 
 vi.mock(
@@ -161,6 +167,72 @@ describe('UseMembers', () => {
         expect(result.current.successDeleteCollaborator).toBe(true),
       );
       expect(deleteCollaboratorForOrg).toHaveBeenCalledWith('myorg', 'extuser');
+    });
+  });
+
+  describe('useInviteTeamMemberByEmail', () => {
+    it('calls inviteTeamMemberByEmailForOrg on mutate', async () => {
+      vi.mocked(inviteTeamMemberByEmailForOrg).mockResolvedValueOnce(undefined);
+      const {result} = renderHook(() => useInviteTeamMemberByEmail('myorg'), {
+        wrapper,
+      });
+      act(() => {
+        result.current.inviteMemberByEmail({
+          team: 'myteam',
+          email: 'test@example.com',
+        });
+      });
+      await waitFor(() =>
+        expect(result.current.successInvitingMember).toBe(true),
+      );
+      expect(inviteTeamMemberByEmailForOrg).toHaveBeenCalledWith(
+        'myorg',
+        'myteam',
+        'test@example.com',
+      );
+    });
+
+    it('sets error state on failure', async () => {
+      vi.mocked(inviteTeamMemberByEmailForOrg).mockRejectedValueOnce(
+        new Error('invite failed'),
+      );
+      const {result} = renderHook(() => useInviteTeamMemberByEmail('myorg'), {
+        wrapper,
+      });
+      act(() => {
+        result.current.inviteMemberByEmail({
+          team: 'myteam',
+          email: 'bad@example.com',
+        });
+      });
+      await waitFor(() =>
+        expect(result.current.errorInvitingMember).toBe(true),
+      );
+    });
+  });
+
+  describe('useDeleteEmailInvite', () => {
+    it('calls deleteTeamMemberEmailInviteForOrg on mutate', async () => {
+      vi.mocked(deleteTeamMemberEmailInviteForOrg).mockResolvedValueOnce(
+        undefined,
+      );
+      const {result} = renderHook(() => useDeleteEmailInvite('myorg'), {
+        wrapper,
+      });
+      act(() => {
+        result.current.removeEmailInvite({
+          teamName: 'myteam',
+          email: 'test@example.com',
+        });
+      });
+      await waitFor(() =>
+        expect(result.current.successDeleteEmailInvite).toBe(true),
+      );
+      expect(deleteTeamMemberEmailInviteForOrg).toHaveBeenCalledWith(
+        'myorg',
+        'myteam',
+        'test@example.com',
+      );
     });
   });
 });

--- a/web/src/hooks/UseMembers.ts
+++ b/web/src/hooks/UseMembers.ts
@@ -6,9 +6,11 @@ import {
   addMemberToTeamForOrg,
   deleteCollaboratorForOrg,
   deleteTeamMemberForOrg,
+  deleteTeamMemberEmailInviteForOrg,
   fetchCollaboratorsForOrg,
   fetchMembersForOrg,
   fetchTeamMembersForOrg,
+  inviteTeamMemberByEmailForOrg,
 } from 'src/resources/MembersResource';
 import {IAvatar} from 'src/resources/OrganizationResource';
 import {collaboratorViewColumnNames} from 'src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/CollaboratorsView/CollaboratorsViewList';
@@ -93,9 +95,10 @@ export function useFetchMembers(orgName: string) {
 }
 
 export interface ITeamMember {
-  name: string;
+  name?: string;
+  email?: string;
   kind: string;
-  is_robot: false;
+  is_robot: boolean;
   avatar?: IAvatar;
   invited?: boolean;
 }
@@ -158,7 +161,11 @@ export function useFetchTeamMembersForOrg(orgName: string, teamName: string) {
 
   const filteredAllMembers =
     search.query !== ''
-      ? allMembers?.filter((member) => member.name.includes(search.query))
+      ? allMembers?.filter(
+          (member) =>
+            member.name?.includes(search.query) ||
+            member.email?.includes(search.query),
+        )
       : allMembers;
   const paginatedAllMembers = filteredAllMembers?.slice(
     page * perPage - perPage,
@@ -171,7 +178,11 @@ export function useFetchTeamMembersForOrg(orgName: string, teamName: string) {
   );
   const filteredTeamMembers =
     search.query !== ''
-      ? teamMembers?.filter((member) => member.name.includes(search.query))
+      ? teamMembers?.filter(
+          (member) =>
+            member.name?.includes(search.query) ||
+            member.email?.includes(search.query),
+        )
       : teamMembers;
   const paginatedTeamMembers = filteredTeamMembers?.slice(
     page * perPage - perPage,
@@ -182,7 +193,11 @@ export function useFetchTeamMembersForOrg(orgName: string, teamName: string) {
   const robotAccounts = allMembers?.filter((team) => team.is_robot);
   const filteredRobotAccounts =
     search.query !== ''
-      ? robotAccounts?.filter((member) => member.name.includes(search.query))
+      ? robotAccounts?.filter(
+          (member) =>
+            member.name?.includes(search.query) ||
+            member.email?.includes(search.query),
+        )
       : robotAccounts;
   const paginatedRobotAccounts = filteredRobotAccounts?.slice(
     page * perPage - perPage,
@@ -193,7 +208,11 @@ export function useFetchTeamMembersForOrg(orgName: string, teamName: string) {
   const invited = allMembers?.filter((team) => team.invited);
   const filteredInvited =
     search.query !== ''
-      ? invited?.filter((member) => member.name.includes(search.query))
+      ? invited?.filter(
+          (member) =>
+            member.name?.includes(search.query) ||
+            member.email?.includes(search.query),
+        )
       : invited;
   const paginatedInvited = filteredInvited?.slice(
     page * perPage - perPage,
@@ -292,6 +311,58 @@ export function useDeleteTeamMember(orgName: string) {
     errorDeleteTeamMember,
     successDeleteTeamMember,
     resetDeleteTeamMember,
+  };
+}
+
+export function useInviteTeamMemberByEmail(org: string) {
+  const queryClient = useQueryClient();
+  const {
+    mutate: inviteMemberByEmail,
+    isError: errorInvitingMember,
+    isSuccess: successInvitingMember,
+    reset: resetInvitingMember,
+  } = useMutation(
+    async ({team, email}: {team: string; email: string}) => {
+      return inviteTeamMemberByEmailForOrg(org, team, email);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['teams']);
+        queryClient.invalidateQueries(['members']);
+        queryClient.invalidateQueries(['teamMembers']);
+      },
+    },
+  );
+  return {
+    inviteMemberByEmail,
+    errorInvitingMember,
+    successInvitingMember,
+    resetInvitingMember,
+  };
+}
+
+export function useDeleteEmailInvite(orgName: string) {
+  const queryClient = useQueryClient();
+  const {
+    mutate: removeEmailInvite,
+    isError: errorDeleteEmailInvite,
+    isSuccess: successDeleteEmailInvite,
+    reset: resetDeleteEmailInvite,
+  } = useMutation(
+    async ({teamName, email}: {teamName: string; email: string}) => {
+      return deleteTeamMemberEmailInviteForOrg(orgName, teamName, email);
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['teamMembers']);
+      },
+    },
+  );
+  return {
+    removeEmailInvite,
+    errorDeleteEmailInvite,
+    successDeleteEmailInvite,
+    resetDeleteEmailInvite,
   };
 }
 

--- a/web/src/libs/axios.ts
+++ b/web/src/libs/axios.ts
@@ -103,6 +103,7 @@ axiosIns.interceptors.response.use(
           const isOnAuthPage =
             currentPath === '/signin' ||
             currentPath === '/createaccount' ||
+            currentPath === '/confirminvite' ||
             currentPath.startsWith('/oauth');
           if (!isOnAuthPage) {
             window.location.href = '/signin';

--- a/web/src/resources/AuthResource.test.ts
+++ b/web/src/resources/AuthResource.test.ts
@@ -55,6 +55,19 @@ describe('AuthResource', () => {
       expect(GlobalAuthState.isLoggedIn).toBe(true);
     });
 
+    it('includes invite_code when provided', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(
+        mockResponse({success: true}),
+      );
+
+      await loginUser('alice', 'password', 'invite123');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/signin', {
+        username: 'alice',
+        password: 'password',
+        invite_code: 'invite123',
+      });
+    });
+
     it('does not set isLoggedIn on failed login', async () => {
       vi.mocked(axios.post).mockResolvedValueOnce(
         mockResponse({success: false}),

--- a/web/src/resources/AuthResource.ts
+++ b/web/src/resources/AuthResource.ts
@@ -17,11 +17,19 @@ export const GlobalAuthState: AuthResource = {
   bearerToken: null,
 };
 
-export async function loginUser(username: string, password: string) {
-  const response = await axios.post(signinApiUrl, {
+export async function loginUser(
+  username: string,
+  password: string,
+  inviteCode?: string,
+) {
+  const body: Record<string, string> = {
     username: username,
     password: password,
-  });
+  };
+  if (inviteCode) {
+    body.invite_code = inviteCode;
+  }
+  const response = await axios.post(signinApiUrl, body);
   if (response.data.success === true) {
     GlobalAuthState.isLoggedIn = true;
     GlobalAuthState.csrfToken = undefined;

--- a/web/src/resources/MembersResource.test.ts
+++ b/web/src/resources/MembersResource.test.ts
@@ -8,6 +8,8 @@ import {
   deleteTeamMemberForOrg,
   deleteCollaboratorForOrg,
   addMemberToTeamForOrg,
+  inviteTeamMemberByEmailForOrg,
+  deleteTeamMemberEmailInviteForOrg,
 } from './MembersResource';
 
 vi.mock('src/libs/axios', () => ({
@@ -119,6 +121,53 @@ describe('MembersResource', () => {
         {},
       );
       expect(result).toEqual({added: true});
+    });
+  });
+
+  describe('inviteTeamMemberByEmailForOrg', () => {
+    it('invites a member by email', async () => {
+      const inviteData = {email: 'test@example.com', kind: 'invite'};
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse(inviteData));
+
+      const result = await inviteTeamMemberByEmailForOrg(
+        'myorg',
+        'devs',
+        'test@example.com',
+      );
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/team/devs/invite/test%40example.com',
+        {},
+      );
+      expect(result).toEqual(inviteData);
+    });
+
+    it('encodes special characters in email', async () => {
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse({}));
+
+      await inviteTeamMemberByEmailForOrg(
+        'myorg',
+        'devs',
+        'user+tag@example.com',
+      );
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/team/devs/invite/user%2Btag%40example.com',
+        {},
+      );
+    });
+  });
+
+  describe('deleteTeamMemberEmailInviteForOrg', () => {
+    it('deletes an email invite', async () => {
+      vi.mocked(axios.delete).mockResolvedValueOnce(mockResponse(null, 204));
+
+      await deleteTeamMemberEmailInviteForOrg(
+        'myorg',
+        'devs',
+        'test@example.com',
+      );
+      expect(axios.delete).toHaveBeenCalledWith(
+        '/api/v1/organization/myorg/team/devs/invite/test%40example.com',
+      );
     });
   });
 });

--- a/web/src/resources/MembersResource.ts
+++ b/web/src/resources/MembersResource.ts
@@ -80,3 +80,29 @@ export async function addMemberToTeamForOrg(
   assertHttpCode(response.status, 200);
   return response.data;
 }
+
+export async function inviteTeamMemberByEmailForOrg(
+  orgName: string,
+  teamName: string,
+  email: string,
+) {
+  const url = `/api/v1/organization/${orgName}/team/${teamName}/invite/${encodeURIComponent(
+    email,
+  )}`;
+  const response: AxiosResponse = await axios.put(url, {});
+  assertHttpCode(response.status, 200);
+  return response.data;
+}
+
+export async function deleteTeamMemberEmailInviteForOrg(
+  orgName: string,
+  teamName: string,
+  email: string,
+) {
+  const response = await axios.delete(
+    `/api/v1/organization/${orgName}/team/${teamName}/invite/${encodeURIComponent(
+      email,
+    )}`,
+  );
+  assertHttpCode(response.status, 204);
+}

--- a/web/src/resources/TeamResources.test.ts
+++ b/web/src/resources/TeamResources.test.ts
@@ -10,6 +10,7 @@ import {
   deleteTeamForOrg,
   bulkDeleteTeams,
   TeamDeleteError,
+  acceptTeamInvite,
 } from './TeamResources';
 import {ResourceError} from './ErrorHandling';
 
@@ -183,6 +184,19 @@ describe('TeamResources', () => {
       await expect(
         bulkDeleteTeams('org', [{name: 'devs'}, {name: 'ops'}] as any),
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('acceptTeamInvite', () => {
+    it('accepts a team invite via PUT', async () => {
+      const response = {org: 'myorg', team: 'devs'};
+      vi.mocked(axios.put).mockResolvedValueOnce(mockResponse(response));
+
+      const result = await acceptTeamInvite('invite-code-123');
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/v1/teaminvite/invite-code-123',
+      );
+      expect(result).toEqual(response);
     });
   });
 

--- a/web/src/resources/TeamResources.ts
+++ b/web/src/resources/TeamResources.ts
@@ -137,3 +137,18 @@ export async function bulkDeleteTeams(orgName: string, teams: ITeams[]) {
   );
   throwIfError(responses, 'Error deleting teams');
 }
+
+export interface AcceptTeamInviteResponse {
+  org: string;
+  team: string;
+}
+
+export async function acceptTeamInvite(
+  code: string,
+): Promise<AcceptTeamInviteResponse> {
+  const response: AxiosResponse = await axios.put(
+    `/api/v1/teaminvite/${encodeURIComponent(code)}`,
+  );
+  assertHttpCode(response.status, 200);
+  return response.data;
+}

--- a/web/src/resources/UserResource.test.ts
+++ b/web/src/resources/UserResource.test.ts
@@ -166,6 +166,18 @@ describe('UserResource', () => {
       });
       expect(result).toEqual(response);
     });
+
+    it('includes invite_code when provided', async () => {
+      vi.mocked(axios.post).mockResolvedValueOnce(mockResponse({}));
+
+      await createUser('alice', 'pass123', 'alice@test.com', 'invite456');
+      expect(axios.post).toHaveBeenCalledWith('/api/v1/user/', {
+        username: 'alice',
+        password: 'pass123',
+        email: 'alice@test.com',
+        invite_code: 'invite456',
+      });
+    });
   });
 
   describe('createSuperuserUser', () => {

--- a/web/src/resources/UserResource.ts
+++ b/web/src/resources/UserResource.ts
@@ -126,19 +126,20 @@ export interface CreateUserRequest {
 
 export interface CreateUserResponse {
   awaiting_verification?: boolean;
-  [key: string]: any; // Allow other fields from the API response
+  [key: string]: unknown;
 }
 
 export async function createUser(
   username: string,
   password: string,
   email: string,
+  inviteCode?: string,
 ): Promise<CreateUserResponse> {
-  const response = await axios.post('/api/v1/user/', {
-    username,
-    password,
-    email,
-  });
+  const body: Record<string, string> = {username, password, email};
+  if (inviteCode) {
+    body.invite_code = inviteCode;
+  }
+  const response = await axios.post('/api/v1/user/', body);
   assertHttpCode(response.status, 200);
   return response.data;
 }

--- a/web/src/routes/ConfirmInvite/ConfirmInvite.test.tsx
+++ b/web/src/routes/ConfirmInvite/ConfirmInvite.test.tsx
@@ -1,0 +1,142 @@
+import {render, screen, waitFor} from 'src/test-utils';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {ConfirmInvite} from './ConfirmInvite';
+import {acceptTeamInvite} from 'src/resources/TeamResources';
+import {useCurrentUser} from 'src/hooks/UseCurrentUser';
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: vi.fn(),
+}));
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfigWithLoading: () => ({isLoading: false, config: {}}),
+}));
+
+vi.mock('src/resources/TeamResources', () => ({
+  acceptTeamInvite: vi.fn(),
+}));
+
+vi.mock('src/components/LoginPageLayout', () => ({
+  LoginPageLayout: ({children}: {children: React.ReactNode}) => (
+    <div>{children}</div>
+  ),
+}));
+
+const mockedUseCurrentUser = vi.mocked(useCurrentUser);
+const mockedAcceptTeamInvite = vi.mocked(acceptTeamInvite);
+
+const baseUserState = {loading: false, error: undefined, isSuperUser: false};
+const anonymousUser = {anonymous: true} as any;
+const authenticatedUser = {anonymous: false, username: 'testuser'} as any;
+
+function renderConfirmInvite(search = '?code=testcode123') {
+  return render(
+    <MemoryRouter initialEntries={[`/confirminvite${search}`]}>
+      <Routes>
+        <Route path="/confirminvite" element={<ConfirmInvite />} />
+        <Route
+          path="/organization/:org/teams/:team"
+          element={<div>Team Page</div>}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ConfirmInvite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseCurrentUser.mockReturnValue({
+      user: undefined,
+      ...baseUserState,
+    });
+  });
+
+  it('shows error when no code is present in URL', async () => {
+    renderConfirmInvite('');
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-invite-error')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/No invite code/i)).toBeInTheDocument();
+  });
+
+  it('shows sign-in and create-account buttons for unauthenticated users', async () => {
+    mockedUseCurrentUser.mockReturnValue({
+      user: anonymousUser,
+      ...baseUserState,
+    });
+    renderConfirmInvite('?code=abc123');
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('confirm-invite-unauthenticated'),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('confirm-invite-signin-btn')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('confirm-invite-create-account-btn'),
+    ).toBeInTheDocument();
+  });
+
+  it('sign-in button href includes invite code', async () => {
+    mockedUseCurrentUser.mockReturnValue({
+      user: anonymousUser,
+      ...baseUserState,
+    });
+    renderConfirmInvite('?code=mycode');
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('confirm-invite-signin-btn'),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('confirm-invite-signin-btn')).toHaveAttribute(
+      'href',
+      '/signin?code=mycode',
+    );
+    expect(
+      screen.getByTestId('confirm-invite-create-account-btn'),
+    ).toHaveAttribute('href', '/createaccount?code=mycode');
+  });
+
+  it('accepts invite and navigates to team page for authenticated users', async () => {
+    mockedUseCurrentUser.mockReturnValue({
+      user: authenticatedUser,
+      ...baseUserState,
+    });
+    mockedAcceptTeamInvite.mockResolvedValue({org: 'myorg', team: 'myteam'});
+    renderConfirmInvite('?code=validcode');
+    await waitFor(() => {
+      expect(mockedAcceptTeamInvite).toHaveBeenCalledWith('validcode');
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Team Page')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when invite acceptance fails', async () => {
+    mockedUseCurrentUser.mockReturnValue({
+      user: authenticatedUser,
+      ...baseUserState,
+    });
+    mockedAcceptTeamInvite.mockRejectedValue({
+      response: {data: {message: 'Invalid invitation code'}},
+    });
+    renderConfirmInvite('?code=badcode');
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-invite-error')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Invalid invitation code')).toBeInTheDocument();
+  });
+
+  it('shows generic error when invite fetch fails with no message', async () => {
+    mockedUseCurrentUser.mockReturnValue({
+      user: authenticatedUser,
+      ...baseUserState,
+    });
+    mockedAcceptTeamInvite.mockRejectedValue(new Error('Network error'));
+    renderConfirmInvite('?code=badcode');
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-invite-error')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Invalid or expired/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/ConfirmInvite/ConfirmInvite.tsx
+++ b/web/src/routes/ConfirmInvite/ConfirmInvite.tsx
@@ -1,0 +1,143 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {Alert, Button, Spinner} from '@patternfly/react-core';
+import {useNavigate, useSearchParams} from 'react-router-dom';
+import {useMutation} from '@tanstack/react-query';
+import {AxiosError} from 'axios';
+import {acceptTeamInvite} from 'src/resources/TeamResources';
+import {useCurrentUser} from 'src/hooks/UseCurrentUser';
+import {useQuayConfigWithLoading} from 'src/hooks/UseQuayConfig';
+import {LoginPageLayout} from 'src/components/LoginPageLayout';
+
+export function ConfirmInvite(): React.ReactElement {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const code = searchParams.get('code') || '';
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const hasAttemptedAccept = useRef(false);
+
+  const {isLoading: configLoading} = useQuayConfigWithLoading();
+  const {user, loading: userLoading, error: userError} = useCurrentUser(!!code);
+
+  const {mutate: doAcceptInvite, isLoading: isAccepting} = useMutation(
+    () => acceptTeamInvite(code),
+    {
+      onSuccess: (resp) => {
+        navigate(`/organization/${resp.org}/teams/${resp.team}`);
+      },
+      onError: (err: AxiosError<{message?: string}>) => {
+        setErrorMessage(
+          err?.response?.data?.message || 'Invalid or expired invite code.',
+        );
+      },
+    },
+  );
+
+  useEffect(() => {
+    if (
+      !code ||
+      userLoading ||
+      user === undefined ||
+      hasAttemptedAccept.current
+    )
+      return;
+    if (!user.anonymous) {
+      hasAttemptedAccept.current = true;
+      doAcceptInvite();
+    }
+  }, [code, user, userLoading]);
+
+  if (!code) {
+    return (
+      <LoginPageLayout
+        title="Confirm Invitation"
+        description="Accept your team invitation to collaborate on Quay."
+      >
+        <Alert
+          variant="danger"
+          isInline
+          title="Unable to process invitation"
+          data-testid="confirm-invite-error"
+        >
+          No invite code found in the URL.
+        </Alert>
+      </LoginPageLayout>
+    );
+  }
+
+  if (configLoading || userLoading) {
+    return (
+      <LoginPageLayout
+        title="Confirm Invitation"
+        description="Accept your team invitation to collaborate on Quay."
+      >
+        <div style={{textAlign: 'center', padding: '40px'}}>
+          <Spinner size="xl" data-testid="confirm-invite-loading" />
+        </div>
+      </LoginPageLayout>
+    );
+  }
+
+  const signinUrl = `/signin?code=${encodeURIComponent(code)}`;
+  const createAccountUrl = `/createaccount?code=${encodeURIComponent(code)}`;
+  const showUnauthenticated =
+    !isAccepting && !errorMessage && (userError || user?.anonymous);
+
+  return (
+    <LoginPageLayout
+      title="Confirm Invitation"
+      description="Accept your team invitation to collaborate on Quay."
+    >
+      {isAccepting && (
+        <div style={{textAlign: 'center', padding: '40px'}}>
+          <Spinner size="xl" data-testid="confirm-invite-accepting" />
+          <p style={{marginTop: '16px'}}>Accepting invitation…</p>
+        </div>
+      )}
+
+      {showUnauthenticated && (
+        <div data-testid="confirm-invite-unauthenticated">
+          <Alert
+            variant="info"
+            isInline
+            title="Sign in or create an account to accept this invitation"
+            style={{marginBottom: '24px'}}
+          >
+            You have been invited to join a team. Please sign in or create a new
+            account to accept this invitation.
+          </Alert>
+          <div style={{display: 'flex', gap: '12px', flexDirection: 'column'}}>
+            <Button
+              variant="primary"
+              isBlock
+              component="a"
+              href={signinUrl}
+              data-testid="confirm-invite-signin-btn"
+            >
+              Sign in
+            </Button>
+            <Button
+              variant="secondary"
+              isBlock
+              component="a"
+              href={createAccountUrl}
+              data-testid="confirm-invite-create-account-btn"
+            >
+              Create account
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {errorMessage && (
+        <Alert
+          variant="danger"
+          isInline
+          title="Unable to process invitation"
+          data-testid="confirm-invite-error"
+        >
+          {errorMessage}
+        </Alert>
+      )}
+    </LoginPageLayout>
+  );
+}

--- a/web/src/routes/CreateAccount/CreateAccount.test.tsx
+++ b/web/src/routes/CreateAccount/CreateAccount.test.tsx
@@ -1,0 +1,57 @@
+import {render, screen} from 'src/test-utils';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {CreateAccount} from './CreateAccount';
+
+vi.mock('src/hooks/UseCreateAccount', () => ({
+  useCreateAccount: () => ({
+    createAccountWithAutoLogin: vi.fn(),
+    isLoading: false,
+    error: null,
+    setError: vi.fn(),
+  }),
+}));
+
+vi.mock('src/components/LoginPageLayout', () => ({
+  LoginPageLayout: ({children}: {children: React.ReactNode}) => (
+    <div>{children}</div>
+  ),
+}));
+
+function renderCreateAccount(search = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/createaccount${search}`]}>
+      <Routes>
+        <Route path="/createaccount" element={<CreateAccount />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('CreateAccount', () => {
+  it('shows invite banner when code param is present', () => {
+    renderCreateAccount('?code=testinvite123');
+    expect(screen.getByTestId('invite-code-alert')).toBeInTheDocument();
+    expect(
+      screen.getByText("You've been invited to join a team"),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show invite banner when no code param', () => {
+    renderCreateAccount();
+    expect(screen.queryByTestId('invite-code-alert')).not.toBeInTheDocument();
+  });
+
+  it('preserves invite code in sign-in link', () => {
+    renderCreateAccount('?code=mycode');
+    const signinLinks = screen.getAllByRole('link', {name: /sign in/i});
+    expect(signinLinks.length).toBeGreaterThan(0);
+    expect(signinLinks[0]).toHaveAttribute('href', '/signin?code=mycode');
+  });
+
+  it('sign-in link has no code param when no invite code', () => {
+    renderCreateAccount();
+    const signinLinks = screen.getAllByRole('link', {name: /sign in/i});
+    expect(signinLinks.length).toBeGreaterThan(0);
+    expect(signinLinks[0]).toHaveAttribute('href', '/signin');
+  });
+});

--- a/web/src/routes/CreateAccount/CreateAccount.tsx
+++ b/web/src/routes/CreateAccount/CreateAccount.tsx
@@ -12,7 +12,7 @@ import {
   ValidatedOptions,
 } from '@patternfly/react-core';
 import {ExclamationCircleIcon} from '@patternfly/react-icons';
-import {Link} from 'react-router-dom';
+import {Link, useSearchParams} from 'react-router-dom';
 import './CreateAccount.css';
 import {useCreateAccount} from 'src/hooks/UseCreateAccount';
 import {LoginPageLayout} from 'src/components/LoginPageLayout';
@@ -23,6 +23,11 @@ export function CreateAccount() {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [awaitingVerification, setAwaitingVerification] = useState(false);
+  const [searchParams] = useSearchParams();
+  const inviteCode = searchParams.get('code') || undefined;
+  const signinUrl = inviteCode
+    ? `/signin?code=${encodeURIComponent(inviteCode)}`
+    : '/signin';
 
   const {createAccountWithAutoLogin, isLoading, error, setError} =
     useCreateAccount();
@@ -76,7 +81,12 @@ export function CreateAccount() {
       return;
     }
 
-    const result = await createAccountWithAutoLogin(username, password, email);
+    const result = await createAccountWithAutoLogin(
+      username,
+      password,
+      email,
+      inviteCode,
+    );
     if (result.success && result.awaitingVerification) {
       setAwaitingVerification(true);
     }
@@ -94,6 +104,18 @@ export function CreateAccount() {
 
   const createAccountForm = (
     <>
+      {inviteCode && !awaitingVerification && (
+        <Alert
+          variant="info"
+          isInline
+          title="You've been invited to join a team"
+          style={{marginBottom: '20px'}}
+          data-testid="invite-code-alert"
+        >
+          Create your account to accept the invitation.
+        </Alert>
+      )}
+
       {awaitingVerification && (
         <Alert
           variant="info"
@@ -276,7 +298,7 @@ export function CreateAccount() {
           <div style={{textAlign: 'center', marginTop: '16px'}}>
             Already have an account?{' '}
             <Link
-              to="/signin"
+              to={signinUrl}
               style={{color: 'var(--pf-t--global--text--color--link--default)'}}
             >
               Sign in
@@ -289,7 +311,7 @@ export function CreateAccount() {
         <div style={{textAlign: 'center', marginTop: '16px'}}>
           Already have an account?{' '}
           <Link
-            to="/signin"
+            to={signinUrl}
             style={{color: 'var(--pf-t--global--text--color--link--default)'}}
           >
             Sign in

--- a/web/src/routes/NavigationPath.tsx
+++ b/web/src/routes/NavigationPath.tsx
@@ -37,6 +37,9 @@ const Breadcrumb = {
 };
 
 export enum NavigationPath {
+  // Auth flows
+  confirmInvite = '/confirminvite',
+
   // Side Nav
   home = '/',
   overviewList = '/overview',

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer.tsx
@@ -13,6 +13,9 @@ import {
   SelectGroup,
   SelectOption,
   Spinner,
+  TextInput,
+  Split,
+  SplitItem,
 } from '@patternfly/react-core';
 import {DesktopIcon} from '@patternfly/react-icons';
 import React, {useState} from 'react';
@@ -24,6 +27,7 @@ import Conditional from 'src/components/empty/Conditional';
 import CreateRobotAccountModal from 'src/components/modals/CreateRobotAccountModal';
 import {
   useAddMembersToTeam,
+  useInviteTeamMemberByEmail,
   useFetchTeamMembersForOrg,
 } from 'src/hooks/UseMembers';
 import {useFetchTeams} from 'src/hooks/UseTeams';
@@ -39,6 +43,7 @@ export default function AddNewTeamMemberDrawer(
   const [selectedEntity, setSelectedEntity] = useState<Entity>(null);
   const [isCreateRobotModalOpen, setIsCreateRobotModalOpen] = useState(false);
   const [error, setError] = useState<string>('');
+  const [emailInput, setEmailInput] = useState<string>('');
   const {teamName} = useParams();
 
   // Fetch team sync info to determine if team is in read-only mode
@@ -169,11 +174,39 @@ export default function AddNewTeamMemberDrawer(
     },
   });
 
+  const {inviteMemberByEmail} = useInviteTeamMemberByEmail(props.orgName);
+
   const addTeamMemberHandler = async () => {
     await addMemberToTeam({
       team: teamName,
       member: selectedEntity.name,
     });
+  };
+
+  const isValidEmail = (value: string) =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+  const inviteByEmailHandler = () => {
+    const email = emailInput;
+    inviteMemberByEmail(
+      {team: teamName, email},
+      {
+        onSuccess: () => {
+          addAlert({
+            variant: AlertVariant.Success,
+            title: `E-mail address ${email} was invited to join the team`,
+          });
+          setEmailInput('');
+          props.closeDrawer();
+        },
+        onError: () => {
+          addAlert({
+            variant: AlertVariant.Failure,
+            title: `Unable to invite "${email}" to team`,
+          });
+        },
+      },
+    );
   };
 
   return (
@@ -207,8 +240,12 @@ export default function AddNewTeamMemberDrawer(
               accounts can be added to this team.
             </Alert>
           </Conditional>
-          <Form id="add-new-member-form">
-            <FormGroup fieldId="creator" label="Repository creator" isRequired>
+          <Form id="add-new-member-form" onSubmit={(e) => e.preventDefault()}>
+            <FormGroup
+              fieldId="creator"
+              label="Add a registered user or robot"
+              isRequired
+            >
               {dropdownForCreator}
             </FormGroup>
             <ActionGroup>
@@ -225,6 +262,48 @@ export default function AddNewTeamMemberDrawer(
               </Button>
             </ActionGroup>
           </Form>
+          <Conditional
+            if={quayConfig?.features?.MAILING && !pageInReadOnlyMode}
+          >
+            <Divider style={{marginTop: '1rem', marginBottom: '1rem'}} />
+            <Form
+              id="invite-by-email-form"
+              onSubmit={(e) => {
+                e.preventDefault();
+                if (isValidEmail(emailInput)) {
+                  inviteByEmailHandler();
+                }
+              }}
+            >
+              <FormGroup
+                fieldId="email-invite"
+                label="Or invite by email address"
+              >
+                <Split hasGutter>
+                  <SplitItem isFilled>
+                    <TextInput
+                      id="email-invite-input"
+                      data-testid="email-invite-input"
+                      type="email"
+                      value={emailInput}
+                      onChange={(_event, value) => setEmailInput(value)}
+                      placeholder="Enter an email address to invite"
+                    />
+                  </SplitItem>
+                  <SplitItem>
+                    <Button
+                      data-testid="invite-by-email-btn"
+                      isDisabled={!isValidEmail(emailInput)}
+                      onClick={inviteByEmailHandler}
+                      variant="secondary"
+                    >
+                      Invite
+                    </Button>
+                  </SplitItem>
+                </Split>
+              </FormGroup>
+            </Form>
+          </Conditional>
         </DrawerPanelBody>
       </DrawerPanelContent>
     </>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.test.tsx
@@ -1,0 +1,238 @@
+import {render, screen, userEvent} from 'src/test-utils';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import ManageMembersList from './ManageMembersList';
+
+const mockRemoveTeamMember = vi.fn();
+const mockRemoveEmailInvite = vi.fn();
+
+vi.mock('src/hooks/UseMembers', () => ({
+  useFetchTeamMembersForOrg: () => ({
+    allMembers: [
+      {name: 'alice', kind: 'user', is_robot: false, invited: false},
+      {
+        name: 'testorg+bot1',
+        kind: 'user',
+        is_robot: true,
+        invited: false,
+      },
+      {
+        email: 'invited@example.com',
+        kind: 'invite',
+        is_robot: false,
+        invited: true,
+      },
+    ],
+    teamMembers: [
+      {name: 'alice', kind: 'user', is_robot: false, invited: false},
+    ],
+    robotAccounts: [
+      {
+        name: 'testorg+bot1',
+        kind: 'user',
+        is_robot: true,
+        invited: false,
+      },
+    ],
+    invited: [
+      {
+        email: 'invited@example.com',
+        kind: 'invite',
+        is_robot: false,
+        invited: true,
+      },
+    ],
+    teamCanSync: null,
+    teamSyncInfo: null,
+    loading: false,
+    search: {query: '', field: 'teamMember'},
+    setSearch: vi.fn(),
+  }),
+  useDeleteTeamMember: () => ({
+    removeTeamMember: mockRemoveTeamMember,
+    errorDeleteTeamMember: false,
+    successDeleteTeamMember: false,
+    resetDeleteTeamMember: vi.fn(),
+  }),
+  useDeleteEmailInvite: () => ({
+    removeEmailInvite: mockRemoveEmailInvite,
+    errorDeleteEmailInvite: false,
+    successDeleteEmailInvite: false,
+    resetDeleteEmailInvite: vi.fn(),
+  }),
+}));
+
+vi.mock('src/hooks/UseTeams', () => ({
+  useFetchTeams: () => ({teams: [{name: 'testteam', role: 'member'}]}),
+  useUpdateTeamDetails: () => ({
+    updateTeamDetails: vi.fn(),
+    errorUpdatingTeam: false,
+    successUpdatingTeam: false,
+    resetUpdateTeam: vi.fn(),
+  }),
+}));
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: () => ({
+    registry_state: 'normal',
+    features: {MAILING: true},
+    config: {REGISTRY_TITLE_SHORT: 'Quay'},
+  }),
+}));
+
+vi.mock('src/hooks/UseOrganization', () => ({
+  useOrganization: () => ({
+    organization: {is_admin: true},
+  }),
+}));
+
+vi.mock('src/hooks/UseTeamSync', () => ({
+  useTeamSync: () => ({
+    enableTeamSync: vi.fn(),
+    isError: false,
+    isSuccess: false,
+  }),
+  useRemoveTeamSync: () => ({
+    removeTeamSync: vi.fn(),
+    isError: false,
+    isSuccess: false,
+  }),
+}));
+
+vi.mock('src/components/modals/DirectoryTeamSyncModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('src/components/modals/ConfirmationModal', () => ({
+  ConfirmationModal: () => null,
+}));
+
+vi.mock('./ManageMembersToolbar', () => ({
+  default: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+}));
+
+vi.mock('src/components/modals/DeleteModalForRowTemplate', () => ({
+  default: ({
+    isModalOpen,
+    deleteHandler,
+    itemToBeDeleted,
+  }: {
+    isModalOpen: boolean;
+    deleteHandler: (item: any) => void;
+    itemToBeDeleted: any;
+  }) =>
+    isModalOpen ? (
+      <div data-testid="delete-modal">
+        <span data-testid="delete-modal-member">
+          {itemToBeDeleted?.memberName}
+        </span>
+        <button
+          data-testid="delete-modal-confirm"
+          onClick={() => deleteHandler(itemToBeDeleted)}
+        />
+      </div>
+    ) : null,
+}));
+
+vi.mock('src/components/empty/Conditional', () => ({
+  default: ({
+    if: condition,
+    children,
+  }: {
+    if: boolean;
+    children: React.ReactNode;
+  }) => (condition ? <>{children}</> : null),
+}));
+
+vi.mock('src/components/empty/Empty', () => ({
+  default: () => <div>Empty</div>,
+}));
+
+vi.mock('src/resources/TeamSyncResource', () => ({
+  SupportedService: {},
+}));
+
+function renderManageMembersList() {
+  return render(
+    <MemoryRouter
+      initialEntries={[
+        '/organization/testorg/teams/testteam?tab=Teamsandmembership',
+      ]}
+    >
+      <Routes>
+        <Route
+          path="/organization/:organizationName/teams/:teamName"
+          element={<ManageMembersList />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ManageMembersList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('displays email for invited members in the table', () => {
+    renderManageMembersList();
+    expect(screen.getByTestId('invited@example.com')).toBeInTheDocument();
+    expect(screen.getByText('invited@example.com')).toBeInTheDocument();
+  });
+
+  it('displays username for regular members', () => {
+    renderManageMembersList();
+    expect(screen.getByTestId('alice')).toBeInTheDocument();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+  });
+
+  it('shows (Invited) account type for email invites', () => {
+    renderManageMembersList();
+    expect(screen.getByText('(Invited)')).toBeInTheDocument();
+  });
+
+  it('renders all view mode toggle buttons', () => {
+    renderManageMembersList();
+    expect(screen.getByTestId('All Members')).toBeInTheDocument();
+    expect(screen.getByTestId('Team Member')).toBeInTheDocument();
+    expect(screen.getByTestId('Robot Accounts')).toBeInTheDocument();
+    expect(screen.getByTestId('Invited')).toBeInTheDocument();
+  });
+
+  it('shows robot account in table with correct account type', () => {
+    renderManageMembersList();
+    expect(screen.getByTestId('testorg+bot1')).toBeInTheDocument();
+    expect(screen.getByText('Robot account')).toBeInTheDocument();
+  });
+
+  it('opens delete modal for invited member and confirms calls removeEmailInvite', async () => {
+    renderManageMembersList();
+    await userEvent.click(
+      screen.getByTestId('invited@example.com-delete-icon'),
+    );
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('delete-modal-member')).toHaveTextContent(
+      'invited@example.com',
+    );
+    await userEvent.click(screen.getByTestId('delete-modal-confirm'));
+    expect(mockRemoveEmailInvite).toHaveBeenCalledWith({
+      teamName: 'testteam',
+      email: 'invited@example.com',
+    });
+    expect(mockRemoveTeamMember).not.toHaveBeenCalled();
+  });
+
+  it('opens delete modal for regular member and confirms calls removeTeamMember', async () => {
+    renderManageMembersList();
+    await userEvent.click(screen.getByTestId('alice-delete-icon'));
+    expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('delete-modal-member')).toHaveTextContent(
+      'alice',
+    );
+    await userEvent.click(screen.getByTestId('delete-modal-confirm'));
+    expect(mockRemoveTeamMember).toHaveBeenCalledWith({
+      teamName: 'testteam',
+      memberName: 'alice',
+    });
+    expect(mockRemoveEmailInvite).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
@@ -30,6 +30,7 @@ import './css/ManageMembers.css';
 import {
   ITeamMember,
   useDeleteTeamMember,
+  useDeleteEmailInvite,
   useFetchTeamMembersForOrg,
 } from 'src/hooks/UseMembers';
 import {
@@ -97,6 +98,13 @@ export const manageMemberColumnNames = {
 interface IMemberInfo {
   teamName: string;
   memberName: string;
+  isEmailInvite?: boolean;
+}
+
+function getMemberDisplayName(member: ITeamMember): string {
+  const name = member.name || member.email;
+  if (!name) console.warn('TeamMember has neither name nor email:', member);
+  return name || '(unknown)';
 }
 
 export default function ManageMembersList(props: ManageMembersListProps) {
@@ -143,13 +151,15 @@ export default function ManageMembersList(props: ManageMembersListProps) {
     totalCount,
   } = usePaginatedSortableTable(currentDataSource, {
     columns: {
-      1: (item: ITeamMember) => item.name, // Team member
+      1: (item: ITeamMember) => item.name || item.email, // Team member
       2: (item: ITeamMember) => getAccountTypeForMember(item), // Account
     },
     initialPerPage: 20,
     initialSort: {columnIndex: 1, direction: 'asc'}, // Default sort: Team member ascending
     filter: search.query
-      ? (item: ITeamMember) => item.name.includes(search.query)
+      ? (item: ITeamMember) =>
+          item.name?.includes(search.query) ||
+          item.email?.includes(search.query)
       : undefined,
   });
 
@@ -192,8 +202,9 @@ export default function ManageMembersList(props: ManageMembersListProps) {
     isSelecting: boolean,
   ) => {
     setSelectedTeamMembers((prevSelected) => {
+      const displayName = getMemberDisplayName(teamMember);
       const otherSelectedTeamMembers = prevSelected.filter(
-        (t) => t.name !== teamMember.name,
+        (t) => getMemberDisplayName(t) !== displayName,
       );
       return isSelecting
         ? [...otherSelectedTeamMembers, teamMember]
@@ -201,8 +212,19 @@ export default function ManageMembersList(props: ManageMembersListProps) {
     });
   };
 
-  const {removeTeamMember, errorDeleteTeamMember, successDeleteTeamMember} =
-    useDeleteTeamMember(organizationName);
+  const {
+    removeTeamMember,
+    errorDeleteTeamMember,
+    successDeleteTeamMember,
+    resetDeleteTeamMember,
+  } = useDeleteTeamMember(organizationName);
+
+  const {
+    removeEmailInvite,
+    errorDeleteEmailInvite,
+    successDeleteEmailInvite,
+    resetDeleteEmailInvite,
+  } = useDeleteEmailInvite(organizationName);
 
   useEffect(() => {
     if (successDeleteTeamMember) {
@@ -211,6 +233,7 @@ export default function ManageMembersList(props: ManageMembersListProps) {
         variant: AlertVariant.Success,
         title: `Successfully deleted team member: ${memberToBeDeleted.memberName}`,
       });
+      resetDeleteTeamMember();
     }
   }, [successDeleteTeamMember]);
 
@@ -220,15 +243,45 @@ export default function ManageMembersList(props: ManageMembersListProps) {
         variant: AlertVariant.Failure,
         title: `Error deleting team member:  ${memberToBeDeleted.memberName}`,
       });
+      resetDeleteTeamMember();
     }
   }, [errorDeleteTeamMember]);
+
+  useEffect(() => {
+    if (successDeleteEmailInvite) {
+      setIsDeleteModalForRowOpen(false);
+      addAlert({
+        variant: AlertVariant.Success,
+        title: `Successfully revoked invitation for: ${memberToBeDeleted.memberName}`,
+      });
+      resetDeleteEmailInvite();
+    }
+  }, [successDeleteEmailInvite]);
+
+  useEffect(() => {
+    if (errorDeleteEmailInvite) {
+      addAlert({
+        variant: AlertVariant.Failure,
+        title: `Error revoking invitation for: ${memberToBeDeleted.memberName}`,
+      });
+      resetDeleteEmailInvite();
+    }
+  }, [errorDeleteEmailInvite]);
+
+  const handleDeleteMember = (info: IMemberInfo) => {
+    if (info.isEmailInvite) {
+      removeEmailInvite({teamName: info.teamName, email: info.memberName});
+    } else {
+      removeTeamMember({teamName: info.teamName, memberName: info.memberName});
+    }
+  };
 
   const deleteRowModal = (
     <DeleteModalForRowTemplate
       deleteMsgTitle={'Remove member from team'}
       isModalOpen={isDeleteModalForRowOpen}
       toggleModal={() => setIsDeleteModalForRowOpen(!isDeleteModalForRowOpen)}
-      deleteHandler={removeTeamMember}
+      deleteHandler={handleDeleteMember}
       itemToBeDeleted={memberToBeDeleted}
       keyToDisplay="memberName"
     />
@@ -698,51 +751,57 @@ export default function ManageMembersList(props: ManageMembersListProps) {
               </Tr>
             </Thead>
             <Tbody>
-              {tableMembersList?.map((teamMember, rowIndex) => (
-                <Tr key={rowIndex}>
-                  <Td
-                    select={{
-                      rowIndex,
-                      onSelect: (_event, isSelecting) =>
-                        onSelectTeamMember(teamMember, rowIndex, isSelecting),
-                      isSelected: selectedTeamMembers.some(
-                        (t) => t.name === teamMember.name,
-                      ),
-                    }}
-                  />
-                  <Td
-                    dataLabel={manageMemberColumnNames.teamMember}
-                    data-testid={teamMember.name}
-                  >
-                    {teamMember.name}
-                  </Td>
-                  <Td dataLabel={manageMemberColumnNames.account}>
-                    {getAccountTypeForMember(teamMember)}
-                  </Td>
-                  <Conditional
-                    if={
-                      config?.registry_state !== 'readonly' &&
-                      organization.is_admin &&
-                      displayDeleteIcon(getAccountTypeForMember(teamMember))
-                    }
-                  >
-                    <Td>
-                      <Button
-                        icon={<TrashIcon />}
-                        variant="plain"
-                        onClick={() => {
-                          setMemberToBeDeleted({
-                            teamName: teamName,
-                            memberName: teamMember.name,
-                          });
-                          setIsDeleteModalForRowOpen(!isDeleteModalForRowOpen);
-                        }}
-                        data-testid={`${teamMember.name}-delete-icon`}
-                      />
+              {tableMembersList?.map((teamMember, rowIndex) => {
+                const displayName = getMemberDisplayName(teamMember);
+                return (
+                  <Tr key={rowIndex}>
+                    <Td
+                      select={{
+                        rowIndex,
+                        onSelect: (_event, isSelecting) =>
+                          onSelectTeamMember(teamMember, rowIndex, isSelecting),
+                        isSelected: selectedTeamMembers.some(
+                          (t) => getMemberDisplayName(t) === displayName,
+                        ),
+                      }}
+                    />
+                    <Td
+                      dataLabel={manageMemberColumnNames.teamMember}
+                      data-testid={displayName}
+                    >
+                      {displayName}
                     </Td>
-                  </Conditional>
-                </Tr>
-              ))}
+                    <Td dataLabel={manageMemberColumnNames.account}>
+                      {getAccountTypeForMember(teamMember)}
+                    </Td>
+                    <Conditional
+                      if={
+                        config?.registry_state !== 'readonly' &&
+                        organization.is_admin &&
+                        displayDeleteIcon(getAccountTypeForMember(teamMember))
+                      }
+                    >
+                      <Td>
+                        <Button
+                          icon={<TrashIcon />}
+                          variant="plain"
+                          onClick={() => {
+                            setMemberToBeDeleted({
+                              teamName: teamName,
+                              memberName: displayName,
+                              isEmailInvite: teamMember.kind === 'invite',
+                            });
+                            setIsDeleteModalForRowOpen(
+                              !isDeleteModalForRowOpen,
+                            );
+                          }}
+                          data-testid={`${displayName}-delete-icon`}
+                        />
+                      </Td>
+                    </Conditional>
+                  </Tr>
+                );
+              })}
             </Tbody>
           </Table>
         </ManageMembersToolbar>

--- a/web/src/routes/Signin/Signin.test.tsx
+++ b/web/src/routes/Signin/Signin.test.tsx
@@ -166,13 +166,17 @@ describe('Signin', () => {
     vi.mocked(getCsrfToken).mockResolvedValue({csrf_token: 'token'});
     vi.mocked(fetchUser).mockResolvedValue({prompts: []});
 
-    renderSignin('?code=testinvite');
+    const {container} = renderSignin('?code=testinvite');
 
-    await userEvent.type(screen.getByLabelText('Username'), 'testuser');
-    await userEvent.type(screen.getByLabelText('Password'), 'testpass');
-    await userEvent.click(
-      screen.getByRole('button', {name: /sign in/i}),
+    await userEvent.type(
+      container.querySelector('#pf-login-username-id')!,
+      'testuser',
     );
+    await userEvent.type(
+      container.querySelector('#pf-login-password-id')!,
+      'testpass',
+    );
+    await userEvent.click(screen.getByRole('button', {name: /sign in/i}));
 
     await waitFor(() => {
       expect(screen.getByTestId('confirminvite-page')).toBeInTheDocument();
@@ -186,13 +190,17 @@ describe('Signin', () => {
       prompts: ['confirm_username'],
     });
 
-    renderSignin('?code=testinvite');
+    const {container} = renderSignin('?code=testinvite');
 
-    await userEvent.type(screen.getByLabelText('Username'), 'testuser');
-    await userEvent.type(screen.getByLabelText('Password'), 'testpass');
-    await userEvent.click(
-      screen.getByRole('button', {name: /sign in/i}),
+    await userEvent.type(
+      container.querySelector('#pf-login-username-id')!,
+      'testuser',
     );
+    await userEvent.type(
+      container.querySelector('#pf-login-password-id')!,
+      'testpass',
+    );
+    await userEvent.click(screen.getByRole('button', {name: /sign in/i}));
 
     await waitFor(() => {
       expect(screen.getByTestId('updateuser-page')).toBeInTheDocument();
@@ -204,13 +212,17 @@ describe('Signin', () => {
     vi.mocked(getCsrfToken).mockResolvedValue({csrf_token: 'token'});
     vi.mocked(fetchUser).mockResolvedValue({prompts: []});
 
-    renderSignin();
+    const {container} = renderSignin();
 
-    await userEvent.type(screen.getByLabelText('Username'), 'testuser');
-    await userEvent.type(screen.getByLabelText('Password'), 'testpass');
-    await userEvent.click(
-      screen.getByRole('button', {name: /sign in/i}),
+    await userEvent.type(
+      container.querySelector('#pf-login-username-id')!,
+      'testuser',
     );
+    await userEvent.type(
+      container.querySelector('#pf-login-password-id')!,
+      'testpass',
+    );
+    await userEvent.click(screen.getByRole('button', {name: /sign in/i}));
 
     await waitFor(() => {
       expect(screen.getByTestId('org-page')).toBeInTheDocument();

--- a/web/src/routes/Signin/Signin.test.tsx
+++ b/web/src/routes/Signin/Signin.test.tsx
@@ -1,6 +1,9 @@
-import {render, screen} from 'src/test-utils';
+import {render, screen, userEvent, waitFor} from 'src/test-utils';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Signin} from './Signin';
+import {loginUser} from 'src/resources/AuthResource';
+import {fetchUser} from 'src/resources/UserResource';
+import {getCsrfToken} from 'src/libs/axios';
 
 const mockFeatures = {
   DIRECT_LOGIN: true,
@@ -81,6 +84,18 @@ function renderSignin(search = '') {
     <MemoryRouter initialEntries={[`/signin${search}`]}>
       <Routes>
         <Route path="/signin" element={<Signin />} />
+        <Route
+          path="/confirminvite"
+          element={<div data-testid="confirminvite-page">ConfirmInvite</div>}
+        />
+        <Route
+          path="/updateuser"
+          element={<div data-testid="updateuser-page">UpdateUser</div>}
+        />
+        <Route
+          path="/organization"
+          element={<div data-testid="org-page">Organizations</div>}
+        />
       </Routes>
     </MemoryRouter>,
   );
@@ -144,5 +159,61 @@ describe('Signin', () => {
     expect(
       screen.queryByTestId('signin-invitation-message'),
     ).not.toBeInTheDocument();
+  });
+
+  it('redirects to confirminvite after login with invite code', async () => {
+    vi.mocked(loginUser).mockResolvedValue({success: true});
+    vi.mocked(getCsrfToken).mockResolvedValue({csrf_token: 'token'});
+    vi.mocked(fetchUser).mockResolvedValue({prompts: []});
+
+    renderSignin('?code=testinvite');
+
+    await userEvent.type(screen.getByLabelText('Username'), 'testuser');
+    await userEvent.type(screen.getByLabelText('Password'), 'testpass');
+    await userEvent.click(
+      screen.getByRole('button', {name: /sign in/i}),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirminvite-page')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to updateuser with invite code when user has prompts', async () => {
+    vi.mocked(loginUser).mockResolvedValue({success: true});
+    vi.mocked(getCsrfToken).mockResolvedValue({csrf_token: 'token'});
+    vi.mocked(fetchUser).mockResolvedValue({
+      prompts: ['confirm_username'],
+    });
+
+    renderSignin('?code=testinvite');
+
+    await userEvent.type(screen.getByLabelText('Username'), 'testuser');
+    await userEvent.type(screen.getByLabelText('Password'), 'testpass');
+    await userEvent.click(
+      screen.getByRole('button', {name: /sign in/i}),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('updateuser-page')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to organization after login without invite code', async () => {
+    vi.mocked(loginUser).mockResolvedValue({success: true});
+    vi.mocked(getCsrfToken).mockResolvedValue({csrf_token: 'token'});
+    vi.mocked(fetchUser).mockResolvedValue({prompts: []});
+
+    renderSignin();
+
+    await userEvent.type(screen.getByLabelText('Username'), 'testuser');
+    await userEvent.type(screen.getByLabelText('Password'), 'testpass');
+    await userEvent.click(
+      screen.getByRole('button', {name: /sign in/i}),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('org-page')).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/routes/Signin/Signin.test.tsx
+++ b/web/src/routes/Signin/Signin.test.tsx
@@ -1,0 +1,111 @@
+import {render, screen} from 'src/test-utils';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {Signin} from './Signin';
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfigWithLoading: () => ({
+    isLoading: false,
+    config: {
+      features: {
+        DIRECT_LOGIN: true,
+        INVITE_ONLY_USER_CREATION: false,
+        USER_CREATION: true,
+        MAILING: true,
+      },
+      config: {
+        AUTHENTICATION_TYPE: 'Database',
+      },
+    },
+  }),
+}));
+
+vi.mock('src/hooks/UseQuayState', () => ({
+  useQuayState: () => ({inReadOnlyMode: false, inAccountRecoveryMode: false}),
+}));
+
+vi.mock('src/hooks/UseExternalLogins', () => ({
+  useExternalLogins: () => ({
+    externalLogins: [],
+    hasExternalLogins: () => false,
+    shouldShowDirectLogin: () => true,
+    shouldAutoRedirectSSO: () => false,
+  }),
+}));
+
+vi.mock('src/hooks/UseExternalLoginAuth', () => ({
+  useExternalLoginAuth: () => ({
+    startExternalLogin: vi.fn(),
+    isAuthenticating: false,
+    error: null,
+  }),
+}));
+
+vi.mock('src/hooks/UsePasswordRecovery', () => ({
+  usePasswordRecovery: () => ({
+    requestRecovery: vi.fn(),
+    isLoading: false,
+    error: null,
+    result: null,
+    setError: vi.fn(),
+  }),
+}));
+
+vi.mock('src/resources/AuthResource', () => ({
+  loginUser: vi.fn(),
+  GlobalAuthState: {isLoggedIn: false, csrfToken: null, bearerToken: null},
+}));
+
+vi.mock('src/resources/UserResource', () => ({
+  fetchUser: vi.fn(),
+}));
+
+vi.mock('src/libs/axios', () => ({
+  getCsrfToken: vi.fn(),
+  default: {get: vi.fn(), post: vi.fn()},
+}));
+
+vi.mock('src/components/LoginPageLayout', () => ({
+  LoginPageLayout: ({children}: {children: React.ReactNode}) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('src/components/ExternalLoginButton', () => ({
+  ExternalLoginButton: () => null,
+}));
+
+function renderSignin(search = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/signin${search}`]}>
+      <Routes>
+        <Route path="/signin" element={<Signin />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('Signin', () => {
+  it('renders login form', () => {
+    renderSignin();
+    expect(screen.getByText(/Sign in/i)).toBeInTheDocument();
+  });
+
+  it('shows create-account link with invite code preserved', () => {
+    renderSignin('?code=invitecode123');
+    const createAccountLink = screen.getByRole('link', {
+      name: /create account/i,
+    });
+    expect(createAccountLink).toHaveAttribute(
+      'href',
+      '/createaccount?code=invitecode123',
+    );
+  });
+
+  it('shows create-account link without code when no invite', () => {
+    renderSignin();
+    const createAccountLink = screen.getByRole('link', {
+      name: /create account/i,
+    });
+    expect(createAccountLink).toHaveAttribute('href', '/createaccount');
+  });
+});

--- a/web/src/routes/Signin/Signin.test.tsx
+++ b/web/src/routes/Signin/Signin.test.tsx
@@ -2,16 +2,18 @@ import {render, screen} from 'src/test-utils';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import {Signin} from './Signin';
 
+const mockFeatures = {
+  DIRECT_LOGIN: true,
+  INVITE_ONLY_USER_CREATION: false,
+  USER_CREATION: true,
+  MAILING: true,
+};
+
 vi.mock('src/hooks/UseQuayConfig', () => ({
   useQuayConfigWithLoading: () => ({
     isLoading: false,
     config: {
-      features: {
-        DIRECT_LOGIN: true,
-        INVITE_ONLY_USER_CREATION: false,
-        USER_CREATION: true,
-        MAILING: true,
-      },
+      features: mockFeatures,
       config: {
         AUTHENTICATION_TYPE: 'Database',
       },
@@ -85,6 +87,13 @@ function renderSignin(search = '') {
 }
 
 describe('Signin', () => {
+  beforeEach(() => {
+    mockFeatures.DIRECT_LOGIN = true;
+    mockFeatures.INVITE_ONLY_USER_CREATION = false;
+    mockFeatures.USER_CREATION = true;
+    mockFeatures.MAILING = true;
+  });
+
   it('renders login form', () => {
     renderSignin();
     expect(screen.getByText(/Sign in/i)).toBeInTheDocument();
@@ -107,5 +116,35 @@ describe('Signin', () => {
       name: /create account/i,
     });
     expect(createAccountLink).toHaveAttribute('href', '/createaccount');
+  });
+
+  it('shows invitation message when INVITE_ONLY_USER_CREATION is true and no code', () => {
+    mockFeatures.INVITE_ONLY_USER_CREATION = true;
+    renderSignin();
+    expect(
+      screen.getByTestId('signin-invitation-message'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Invitation required to sign up'),
+    ).toBeInTheDocument();
+  });
+
+  it('hides create-account link when invite-only and no code', () => {
+    mockFeatures.INVITE_ONLY_USER_CREATION = true;
+    renderSignin();
+    expect(
+      screen.queryByRole('link', {name: /create account/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows create-account link when invite-only but code is present', () => {
+    mockFeatures.INVITE_ONLY_USER_CREATION = true;
+    renderSignin('?code=validcode');
+    expect(
+      screen.getByRole('link', {name: /create account/i}),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('signin-invitation-message'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/routes/Signin/Signin.test.tsx
+++ b/web/src/routes/Signin/Signin.test.tsx
@@ -121,9 +121,7 @@ describe('Signin', () => {
   it('shows invitation message when INVITE_ONLY_USER_CREATION is true and no code', () => {
     mockFeatures.INVITE_ONLY_USER_CREATION = true;
     renderSignin();
-    expect(
-      screen.getByTestId('signin-invitation-message'),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('signin-invitation-message')).toBeInTheDocument();
     expect(
       screen.getByText('Invitation required to sign up'),
     ).toBeInTheDocument();

--- a/web/src/routes/Signin/Signin.tsx
+++ b/web/src/routes/Signin/Signin.tsx
@@ -131,14 +131,17 @@ export function Signin() {
     );
   };
 
+  const inviteCode = searchParams.get('code') || undefined;
+
   const showCreateAccount = () => {
     if (!quayConfig) return false;
+    const hasInvite = Boolean(inviteCode);
     return (
       !inReadOnlyMode &&
       quayConfig.features?.USER_CREATION === true &&
       quayConfig.config?.AUTHENTICATION_TYPE === 'Database' &&
       shouldShowDirectLogin() &&
-      !quayConfig.features?.INVITE_ONLY_USER_CREATION &&
+      (!quayConfig.features?.INVITE_ONLY_USER_CREATION || hasInvite) &&
       !inAccountRecoveryMode
     );
   };
@@ -146,6 +149,7 @@ export function Signin() {
   const showInvitationMessage = () => {
     if (!quayConfig) return false;
     return (
+      !inviteCode &&
       quayConfig.features?.USER_CREATION === true &&
       quayConfig.config?.AUTHENTICATION_TYPE === 'Database' &&
       quayConfig.features?.DIRECT_LOGIN === true &&
@@ -178,7 +182,7 @@ export function Signin() {
   ) => {
     e.preventDefault();
     try {
-      const response = await loginUser(username, password);
+      const response = await loginUser(username, password, inviteCode);
       if (response.success === true) {
         setAuthState((old) => ({...old, isSignedIn: true, username: username}));
         await getCsrfToken();
@@ -425,7 +429,11 @@ export function Signin() {
               <>
                 Don&apos;t have an account?{' '}
                 <Link
-                  to="/createaccount"
+                  to={
+                    inviteCode
+                      ? `/createaccount?code=${encodeURIComponent(inviteCode)}`
+                      : '/createaccount'
+                  }
                   data-testid="signin-create-account-link"
                   style={{
                     color: 'var(--pf-t--global--text--color--link--default)',

--- a/web/src/routes/Signin/Signin.tsx
+++ b/web/src/routes/Signin/Signin.tsx
@@ -75,6 +75,10 @@ export function Signin() {
     if (shouldAutoRedirectSSO() && externalLogins.length > 0) {
       const singleProvider = externalLogins[0];
       const redirectUrl = searchParams.get('redirect_url') || undefined;
+      const code = searchParams.get('code');
+      if (code) {
+        sessionStorage.setItem('pendingInviteCode', code);
+      }
       startExternalLogin(singleProvider, redirectUrl);
     }
   }, [shouldAutoRedirectSSO, externalLogins, startExternalLogin, searchParams]);
@@ -403,6 +407,11 @@ export function Signin() {
               redirectUrl={searchParams.get('redirect_url') || undefined}
               disabled={isExternalAuth}
               onClearErrors={() => setExternalLoginError(null)}
+              onSignInStarted={() => {
+                if (inviteCode) {
+                  sessionStorage.setItem('pendingInviteCode', inviteCode);
+                }
+              }}
             />
           ))}
 

--- a/web/src/routes/Signin/Signin.tsx
+++ b/web/src/routes/Signin/Signin.tsx
@@ -205,7 +205,16 @@ export function Signin() {
 
         // If user has prompts (e.g., confirm_username), redirect to updateuser
         if (user.prompts && user.prompts.length > 0) {
-          navigate('/updateuser');
+          const updateUrl = inviteCode
+            ? `/updateuser?code=${encodeURIComponent(inviteCode)}`
+            : '/updateuser';
+          navigate(updateUrl);
+          return;
+        }
+
+        // If there's an invite code, redirect to confirminvite to accept it
+        if (inviteCode) {
+          navigate(`/confirminvite?code=${encodeURIComponent(inviteCode)}`);
           return;
         }
 

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -90,7 +90,12 @@ function getReservedRoutePrefixes(): string[] {
     .filter((prefix) => prefix && !prefix.startsWith(':')); // Filter out empty and param placeholders
 
   // Additional static routes not in NavigationPath enum
-  const staticPrefixes = ['signin', 'createaccount', 'oauth-error'];
+  const staticPrefixes = [
+    'signin',
+    'createaccount',
+    'confirminvite',
+    'oauth-error',
+  ];
 
   // Combine and deduplicate
   return [...new Set([...navigationPrefixes, ...staticPrefixes])];

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -16,6 +16,7 @@ import {
   Routes,
   useParams,
   useLocation,
+  useNavigate,
 } from 'react-router-dom';
 
 import {QuayHeader} from 'src/components/header/QuayHeader';
@@ -226,10 +227,21 @@ export function StandaloneMain() {
   const quayConfig = useQuayConfig();
   const {loading, error} = useCurrentUser();
   const location = useLocation();
+  const navigate = useNavigate();
   const {clearAllAlerts} = useUI();
 
   // Load external scripts (Stripe, StatusPage) only when BILLING feature is enabled (PROJQUAY-9803)
   useExternalScripts();
+
+  // Check for pending invite code from OAuth/SSO flow
+  useEffect(() => {
+    if (loading) return;
+    const pendingCode = sessionStorage.getItem('pendingInviteCode');
+    if (pendingCode) {
+      sessionStorage.removeItem('pendingInviteCode');
+      navigate(`/confirminvite?code=${encodeURIComponent(pendingCode)}`);
+    }
+  }, [loading, navigate]);
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 

--- a/web/src/routes/UpdateUser/UpdateUser.test.tsx
+++ b/web/src/routes/UpdateUser/UpdateUser.test.tsx
@@ -1,0 +1,104 @@
+import {render, screen, waitFor} from 'src/test-utils';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import UpdateUser from './UpdateUser';
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: vi.fn(),
+  useUpdateUser: () => ({
+    updateUser: vi.fn(),
+  }),
+}));
+
+vi.mock('src/hooks/UseUsernameValidation', () => ({
+  useUsernameValidation: () => ({
+    state: 'editing',
+    validateUsername: vi.fn(),
+  }),
+}));
+
+import {useCurrentUser} from 'src/hooks/UseCurrentUser';
+
+function renderUpdateUser(search = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/updateuser${search}`]}>
+      <Routes>
+        <Route path="/updateuser" element={<UpdateUser />} />
+        <Route
+          path="/confirminvite"
+          element={<div data-testid="confirminvite-page">ConfirmInvite</div>}
+        />
+        <Route
+          path="/signin"
+          element={<div data-testid="signin-page">Signin</div>}
+        />
+        <Route path="/" element={<div data-testid="home-page">Home</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('UpdateUser', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('redirects to / when user has no prompts and no invite code', async () => {
+    vi.mocked(useCurrentUser).mockReturnValue({
+      user: {anonymous: false, prompts: [], username: 'testuser'},
+      loading: false,
+      error: null,
+    } as any);
+
+    renderUpdateUser();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-page')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to confirminvite when user has no prompts and code query param', async () => {
+    vi.mocked(useCurrentUser).mockReturnValue({
+      user: {anonymous: false, prompts: [], username: 'testuser'},
+      loading: false,
+      error: null,
+    } as any);
+
+    renderUpdateUser('?code=invite123');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirminvite-page')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to confirminvite when user has no prompts and sessionStorage has pending invite', async () => {
+    sessionStorage.setItem('pendingInviteCode', 'session-invite');
+
+    vi.mocked(useCurrentUser).mockReturnValue({
+      user: {anonymous: false, prompts: [], username: 'testuser'},
+      loading: false,
+      error: null,
+    } as any);
+
+    renderUpdateUser();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirminvite-page')).toBeInTheDocument();
+    });
+    expect(sessionStorage.getItem('pendingInviteCode')).toBeNull();
+  });
+
+  it('redirects to signin when user is anonymous', async () => {
+    vi.mocked(useCurrentUser).mockReturnValue({
+      user: {anonymous: true, prompts: [], username: ''},
+      loading: false,
+      error: null,
+    } as any);
+
+    renderUpdateUser();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('signin-page')).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/routes/UpdateUser/UpdateUser.test.tsx
+++ b/web/src/routes/UpdateUser/UpdateUser.test.tsx
@@ -1,4 +1,5 @@
-import {render, screen, waitFor, act} from 'src/test-utils';
+import {render, screen, waitFor} from 'src/test-utils';
+import {act} from '@testing-library/react';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import UpdateUser from './UpdateUser';
 

--- a/web/src/routes/UpdateUser/UpdateUser.test.tsx
+++ b/web/src/routes/UpdateUser/UpdateUser.test.tsx
@@ -1,12 +1,15 @@
-import {render, screen, waitFor} from 'src/test-utils';
+import {render, screen, waitFor, act} from 'src/test-utils';
 import {MemoryRouter, Route, Routes} from 'react-router-dom';
 import UpdateUser from './UpdateUser';
 
+let capturedOnSuccess: (user: any) => void;
+
 vi.mock('src/hooks/UseCurrentUser', () => ({
   useCurrentUser: vi.fn(),
-  useUpdateUser: () => ({
-    updateUser: vi.fn(),
-  }),
+  useUpdateUser: ({onSuccess}: {onSuccess: (user: any) => void}) => {
+    capturedOnSuccess = onSuccess;
+    return {updateUser: vi.fn()};
+  },
 }));
 
 vi.mock('src/hooks/UseUsernameValidation', () => ({
@@ -81,6 +84,53 @@ describe('UpdateUser', () => {
     } as any);
 
     renderUpdateUser();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirminvite-page')).toBeInTheDocument();
+    });
+    expect(sessionStorage.getItem('pendingInviteCode')).toBeNull();
+  });
+
+  it('onSuccess redirects to confirminvite when code query param is present', async () => {
+    vi.mocked(useCurrentUser).mockReturnValue({
+      user: {
+        anonymous: false,
+        prompts: ['confirm_username'],
+        username: 'testuser',
+      },
+      loading: false,
+      error: null,
+    } as any);
+
+    renderUpdateUser('?code=query-invite');
+
+    act(() => {
+      capturedOnSuccess({prompts: []});
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('confirminvite-page')).toBeInTheDocument();
+    });
+  });
+
+  it('onSuccess redirects to confirminvite when sessionStorage has pending invite', async () => {
+    sessionStorage.setItem('pendingInviteCode', 'oauth-invite');
+
+    vi.mocked(useCurrentUser).mockReturnValue({
+      user: {
+        anonymous: false,
+        prompts: ['confirm_username'],
+        username: 'testuser',
+      },
+      loading: false,
+      error: null,
+    } as any);
+
+    renderUpdateUser();
+
+    act(() => {
+      capturedOnSuccess({prompts: []});
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('confirminvite-page')).toBeInTheDocument();

--- a/web/src/routes/UpdateUser/UpdateUser.tsx
+++ b/web/src/routes/UpdateUser/UpdateUser.tsx
@@ -48,9 +48,12 @@ export default function UpdateUser() {
       if (updatedUser?.prompts?.length) {
         setIsUpdating(false);
       } else {
-        // Check for pending invite code (passed via query param from signin/signup)
-        const inviteCode = searchParams.get('code');
+        // Check for pending invite code (query param from signin/signup, or sessionStorage from OAuth)
+        const inviteCode =
+          searchParams.get('code') ||
+          sessionStorage.getItem('pendingInviteCode');
         if (inviteCode) {
+          sessionStorage.removeItem('pendingInviteCode');
           navigate(`/confirminvite?code=${encodeURIComponent(inviteCode)}`);
           return;
         }
@@ -107,8 +110,11 @@ export default function UpdateUser() {
       }
 
       if (!user.prompts || user.prompts.length === 0) {
-        const inviteCode = searchParams.get('code');
+        const inviteCode =
+          searchParams.get('code') ||
+          sessionStorage.getItem('pendingInviteCode');
         if (inviteCode) {
+          sessionStorage.removeItem('pendingInviteCode');
           navigate(`/confirminvite?code=${encodeURIComponent(inviteCode)}`);
         } else {
           navigate('/');

--- a/web/src/routes/UpdateUser/UpdateUser.tsx
+++ b/web/src/routes/UpdateUser/UpdateUser.tsx
@@ -14,7 +14,7 @@ import {
   ExclamationTriangleIcon,
   BanIcon,
 } from '@patternfly/react-icons';
-import {useNavigate} from 'react-router-dom';
+import {useNavigate, useSearchParams} from 'react-router-dom';
 import {useCurrentUser, useUpdateUser} from 'src/hooks/UseCurrentUser';
 import {useUsernameValidation} from 'src/hooks/UseUsernameValidation';
 import {UpdateUserRequest} from 'src/resources/UserResource';
@@ -28,6 +28,7 @@ function isValidUsername(username: string): boolean {
 
 export default function UpdateUser() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const {user, loading: userLoading} = useCurrentUser();
   const [isUpdating, setIsUpdating] = useState(false);
   const [username, setUsername] = useState('');
@@ -47,6 +48,13 @@ export default function UpdateUser() {
       if (updatedUser?.prompts?.length) {
         setIsUpdating(false);
       } else {
+        // Check for pending invite code (passed via query param from signin/signup)
+        const inviteCode = searchParams.get('code');
+        if (inviteCode) {
+          navigate(`/confirminvite?code=${encodeURIComponent(inviteCode)}`);
+          return;
+        }
+
         // Check for stored redirect URL (set by external login flow)
         const redirectUrl = localStorage.getItem('quay.redirectAfterLoad');
         localStorage.removeItem('quay.redirectAfterLoad');
@@ -99,7 +107,12 @@ export default function UpdateUser() {
       }
 
       if (!user.prompts || user.prompts.length === 0) {
-        navigate('/');
+        const inviteCode = searchParams.get('code');
+        if (inviteCode) {
+          navigate(`/confirminvite?code=${encodeURIComponent(inviteCode)}`);
+        } else {
+          navigate('/');
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary

Implement the invite code flow for the new React UI (`FEATURE_INVITE_ONLY_USER_CREATION`) and fix email invite support on the team members page.

## Quay Local Validation Testing
<img width="2351" height="1260" alt="image" src="https://github.com/user-attachments/assets/f800193a-cb1c-4404-8a7f-030dd4cb59b3" />
<img width="1345" height="780" alt="image" src="https://github.com/user-attachments/assets/b8ac94d3-aeb4-4b2c-b117-f8802982c48f" />
<img width="1345" height="780" alt="image" src="https://github.com/user-attachments/assets/80cbfedb-49ad-4608-a242-5eeabd344349" />



### Invite Code Flow (new feature for React UI)

- **Root cause:** The new React UI had no `/confirminvite` route and never forwarded `invite_code` to the backend, making `FEATURE_INVITE_ONLY_USER_CREATION` non-functional in the new UI.
- Add a `/confirminvite` route (`ConfirmInvite` component) that accepts the invite for already-authenticated users, or shows sign-in/create-account options for unauthenticated users with the `code` query param preserved.
- Forward `invite_code` in `POST /api/v1/signin` and `POST /api/v1/user/` when a `code` param is present in the URL.
- Show the "Create account" link on the Sign In page even when `INVITE_ONLY_USER_CREATION` is enabled, provided an invite code is in the URL.
- Show an invitation banner on the Create Account page when arriving via an invite link.
- Add `/confirminvite` to the axios auth-page list to prevent 401 redirect loops for unauthenticated users.

### Email Invite Support on Team Members Page (bug fixes)

- **Bug 1 — Blank "Team member" column:** The backend returns `{email, kind: "invite"}` with no `name` field for raw email invites. The UI only rendered `teamMember.name`, leaving the column blank. Fixed by adding `email?` to the `ITeamMember` interface (and making `name` optional) and using a `getMemberDisplayName()` helper that falls back to `email` across table rendering, sorting, filtering, selection, and deletion.
- **Bug 2 — No invite email sent:** The new UI only called `PUT /members/{username}` (for existing users). The separate `PUT /invite/{email}` endpoint was never called. Added `inviteTeamMemberByEmailForOrg()` resource function, `useInviteTeamMemberByEmail` hook, and an "Invite by email" section in the Add Member drawer (gated behind the `MAILING` feature flag).
- **Bug 3 — No success notification:** The old UI showed "E-mail address X was invited to join the team" but the new UI showed nothing. Added success/error alerts matching the old UI message format, using per-call mutation callbacks to avoid stale closure on the email input.
- **Delete email invites:** Added `deleteTeamMemberEmailInviteForOrg()` resource and `useDeleteEmailInvite` hook. The delete handler now routes email invites (`kind === 'invite'`) to `DELETE /invite/{email}` instead of `DELETE /members/{name}`.

### Nginx & Backend

- Fix nginx `server-base.conf.jnj`: change `/confirm` to `/confirm$` to prevent `/confirminvite` from matching the Flask proxy rule (so it reaches the React SPA).
- Fix `endpoints/web.py`: use `request.values.get("code", "")` to gracefully handle missing code param instead of raising KeyError.

### Test Fixtures & Infrastructure

- Set React UI cookie (`setReactUICookie`) in the base `unauthenticatedPage` Playwright fixture (consistent with all authenticated fixtures).
- Add `inviteTeamMemberByEmail` / `deleteTeamEmailInvite` methods to Playwright `ApiClient` and `teamEmailInvite` helper to `TestApi` with auto-cleanup.

## Files Changed (31 files, +1503 / -77)

| Area | Files |
|------|-------|
| **New components** | `ConfirmInvite.tsx` |
| **Routing** | `NavigationPath.tsx`, `StandaloneMain.tsx`, `App.tsx` |
| **Auth flow** | `Signin.tsx`, `CreateAccount.tsx`, `axios.ts` |
| **API resources** | `AuthResource.ts`, `UserResource.ts`, `TeamResources.ts`, `MembersResource.ts` |
| **Hooks** | `UseMembers.ts`, `UseCreateAccount.ts` |
| **Team members UI** | `AddNewTeamMemberDrawer.tsx`, `ManageMembersList.tsx` |
| **Backend** | `endpoints/web.py`, `conf/nginx/server-base.conf.jnj` |
| **Vitest unit tests** | `ConfirmInvite.test.tsx`, `ManageMembersList.test.tsx`, `Signin.test.tsx`, `CreateAccount.test.tsx`, `UseMembers.test.ts`, `MembersResource.test.ts`, `AuthResource.test.ts`, `TeamResources.test.ts`, `UserResource.test.ts` |
| **Playwright E2E tests** | `confirm-invite.spec.ts` (9 tests), `team-members.spec.ts` (4 tests) |
| **Playwright infra** | `fixtures.ts`, `utils/api/client.ts` |
| **Backend tests** | `test_endpoints.py` |

## Test Plan

**Invite code flow:**
- [x] Enable `FEATURE_INVITE_ONLY_USER_CREATION: true` in Quay config
- [x] Invite a user to a team (sends `/confirminvite?code=xxx` email link)
- [x] Click the invite link as an unauthenticated user → `ConfirmInvite` page shows sign-in / create-account options
- [x] Click "Sign in" → arrives at `/signin?code=xxx`, signs in → invite is accepted, redirected to org/team page
- [x] Click "Create account" → arrives at `/createaccount?code=xxx`, sees invitation banner, creates account → invite is accepted
- [x] Click the invite link as an already-authenticated user → invite is accepted immediately, redirected to org/team page

**Email invite on team members page:**
- [x] Navigate to New UI → Organization → Teams and membership → team page
- [x] Verify existing email-invited members show their email address in the "Team member" column
- [x] Use "Add new member" drawer → enter email → click "Invite" → verify success alert and invite email is sent
- [x] Delete an email-invited member → verify correct API endpoint called and success alert shown
- [x] Switch to "Invited" tab → search by email address → verify filtering works

**Automated tests:**
- [x] All vitest unit tests pass
- [x] Playwright E2E tests pass for confirm-invite flow (9 tests)
- [x] Playwright E2E tests pass for email invite flow (4 tests, `@feature:MAILING`)

Fixes: https://redhat.atlassian.net/browse/PROJQUAY-11636

🤖 Generated with [Claude Code](https://claude.com/claude-code)