### PR TITLE
NO-ISSUE: fix(api): block SSRF in proxy cache upstream registry

### DIFF
--- a/data/model/proxy_cache.py
+++ b/data/model/proxy_cache.py
@@ -2,6 +2,7 @@ import features
 from data.database import DEFAULT_PROXY_CACHE_EXPIRATION, ProxyCacheConfig, User
 from data.model import DataModelException, InvalidProxyCacheConfigException
 from data.model.organization import get_organization
+from util.security.ssrf import validate_upstream_registry
 
 
 def has_proxy_cache_config(org_name):
@@ -19,10 +20,20 @@ def create_proxy_cache_config(
     upstream_registry_password=None,
     expiration_s=DEFAULT_PROXY_CACHE_EXPIRATION,
     insecure=False,
+    allowed_hosts=None,
 ):
     """
     Creates proxy cache configuration for the given organization name
     """
+    # Validate hostname to prevent SSRF (CWE-918) - defense-in-depth.
+    # DNS resolution is skipped here; the API layer performs the full check.
+    try:
+        validate_upstream_registry(
+            upstream_registry, resolve_dns=False, allowed_hosts=allowed_hosts
+        )
+    except ValueError as e:
+        raise DataModelException(str(e))
+
     if features.ORG_MIRROR:
         from data.model.org_mirror import is_namespace_org_mirrored
 

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -53,6 +53,27 @@ from proxy import Proxy, UpstreamRegistryError
 from util.marketplace import MarketplaceSubscriptionApi
 from util.names import parse_robot_username
 from util.request import get_request_ip
+from util.security.ssrf import SSRFBlockedError, validate_upstream_registry
+
+# Generic error for SSRF rejections; avoids leaking internal network topology.
+_PROXY_CACHE_SSRF_ERROR = "The provided upstream registry is not allowed"
+
+
+def _get_ssrf_allowed_hosts():
+    return app.config.get("SSRF_ALLOWED_HOSTS", [])
+
+
+def _validate_proxy_cache_upstream_registry(upstream_registry):
+    try:
+        validate_upstream_registry(
+            upstream_registry,
+            allowed_hosts=_get_ssrf_allowed_hosts(),
+        )
+    except SSRFBlockedError:
+        raise request_error(_PROXY_CACHE_SSRF_ERROR)
+    except ValueError as e:
+        raise request_error(str(e))
+
 
 logger = logging.getLogger(__name__)
 
@@ -1054,6 +1075,7 @@ class OrganizationProxyCacheConfig(ApiResource):
                 )
 
         data = request.get_json()
+        _validate_proxy_cache_upstream_registry(data.get("upstream_registry"))
 
         try:
             config = model.proxy_cache.create_proxy_cache_config(
@@ -1063,6 +1085,7 @@ class OrganizationProxyCacheConfig(ApiResource):
                 upstream_registry_password=data.get("upstream_registry_password"),
                 expiration_s=data.get("expiration_s", 86400),
                 insecure=data.get("insecure", False),
+                allowed_hosts=_get_ssrf_allowed_hosts(),
             )
             if config is not None:
                 log_action(
@@ -1139,6 +1162,7 @@ class ProxyCacheConfigValidation(ApiResource):
             pass
 
         data = request.get_json()
+        _validate_proxy_cache_upstream_registry(data.get("upstream_registry"))
 
         # filter None values
         data = {k: v for k, v in data.items() if v is not None}

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -10,6 +10,7 @@ from endpoints.api.organization import (
     OrganizationCollaboratorList,
     OrganizationList,
     OrganizationProxyCacheConfig,
+    ProxyCacheConfigValidation,
 )
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity, toggle_feature
@@ -299,3 +300,72 @@ class TestProxyCacheConfigWithImmutableTags:
         has_immutable = namespace_has_immutable_tags(org.id)
         # Initially there should be no immutable tags
         assert isinstance(has_immutable, bool)
+
+
+@pytest.fixture()
+def _mock_dns_for_ssrf_validation():
+    with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+        mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        yield mock_dns
+
+
+@pytest.mark.usefixtures("_mock_dns_for_ssrf_validation")
+class TestProxyCacheSSRFProtection:
+    """Tests for SSRF protection in proxy cache API endpoints (CWE-918)."""
+
+    def _cleanup_proxy_cache_config(self, orgname):
+        try:
+            model.proxy_cache.delete_proxy_cache_config(orgname)
+        except Exception:
+            pass
+
+    def test_create_with_localhost_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "localhost"}
+                resp = conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_create_with_private_ip_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "10.0.0.1"}
+                resp = conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_create_with_aws_metadata_ip_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "169.254.169.254"}
+                resp = conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_validate_with_private_ip_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "192.168.1.1"}
+                resp = conduct_api_call(cl, ProxyCacheConfigValidation, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_create_with_valid_registry_succeeds(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "docker.io"}
+                conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 201)
+
+        self._cleanup_proxy_cache_config("buynlarge")

--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -11,9 +11,10 @@ from urllib.parse import urlencode
 import requests
 from requests.exceptions import RequestException
 
-from app import model_cache
+from app import app, model_cache
 from data.cache import cache_key
 from data.database import ProxyCacheConfig
+from util.security.ssrf import SSRFBlockedError, validate_upstream_registry
 
 WWW_AUTHENTICATE_REGEX = re.compile(r'(\w+)[=] ?"?([^",]+)"?')
 TOKEN_VALIDITY_LIFETIME_S = 60 * 60  # 1 hour, in seconds - Quay's default
@@ -54,6 +55,17 @@ class Proxy:
     ):
         self._config = config
         self._validation = validation
+
+        # Re-validate at connection time to prevent TOCTOU/DNS rebinding (CWE-918).
+        try:
+            validate_upstream_registry(
+                config.upstream_registry,
+                allowed_hosts=app.config.get("SSRF_ALLOWED_HOSTS", []),
+            )
+        except SSRFBlockedError:
+            raise UpstreamRegistryError("The upstream registry hostname is not allowed")
+        except ValueError as e:
+            raise UpstreamRegistryError(str(e))
 
         hostname = REGISTRY_URLS.get(
             config.upstream_registry_hostname,

--- a/proxy/test_proxy.py
+++ b/proxy/test_proxy.py
@@ -187,6 +187,12 @@ def docker_registry_mock(url, request):
 
 class TestProxy(unittest.TestCase):
     def setUp(self):
+        self._dns_patcher = mock.patch(
+            "util.security.ssrf._getaddrinfo",
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        )
+        self._dns_patcher.start()
+
         registry_url = "docker.io"
 
         self.config = ProxyCacheConfig(
@@ -212,6 +218,9 @@ class TestProxy(unittest.TestCase):
             upstream_registry_password=password,
             organization=User(username="cache-org", organization=True),
         )
+
+    def tearDown(self):
+        self._dns_patcher.stop()
 
     def test_anonymous_auth_sets_session_token(self):
         with HTTMock(docker_registry_mock):

--- a/util/security/ssrf.py
+++ b/util/security/ssrf.py
@@ -248,3 +248,56 @@ def validate_external_registry_url(
                     ip_str,
                 )
                 raise SSRFBlockedError("URL resolves to a private or reserved IP address")
+
+
+def _parse_upstream_registry_hostname(upstream_registry: str) -> str:
+    """
+    Extract the hostname from a proxy cache upstream registry identifier.
+
+    Accepts bare hostnames (docker.io), hostnames with namespace paths
+    (docker.io/library), or URLs with a scheme (https://registry.example.com).
+    """
+    if not upstream_registry or not isinstance(upstream_registry, str):
+        raise ValueError("Upstream registry is required")
+
+    upstream_registry = upstream_registry.strip()
+    if not upstream_registry:
+        raise ValueError("Upstream registry is required")
+
+    if "://" in upstream_registry:
+        parsed = urlparse(upstream_registry)
+        hostname = parsed.hostname
+        if not hostname:
+            raise ValueError("Upstream registry must include a hostname")
+        return hostname
+
+    hostname = upstream_registry.split("/", 1)[0].strip()
+    if not hostname:
+        raise ValueError("Upstream registry must include a hostname")
+    return hostname
+
+
+def validate_upstream_registry(
+    upstream_registry: str,
+    resolve_dns: bool = True,
+    allowed_hosts: Optional[List[str]] = None,
+) -> None:
+    """
+    Validate a proxy cache upstream registry hostname to prevent SSRF (CWE-918).
+
+    Args:
+        upstream_registry: Upstream registry identifier (hostname, hostname/path, or URL)
+        resolve_dns: Whether to resolve hostnames via DNS and check resulting IPs
+        allowed_hosts: Optional list of hostnames or CIDR ranges that bypass the
+            blocklist (from SSRF_ALLOWED_HOSTS config)
+
+    Raises:
+        SSRFBlockedError: If blocked by SSRF protection
+        ValueError: If the identifier is invalid or DNS resolution fails
+    """
+    hostname = _parse_upstream_registry_hostname(upstream_registry)
+    validate_external_registry_url(
+        f"https://{hostname}",
+        resolve_dns=resolve_dns,
+        allowed_hosts=allowed_hosts,
+    )

--- a/util/security/test/test_ssrf.py
+++ b/util/security/test/test_ssrf.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from util.security.ssrf import SSRFBlockedError, validate_external_registry_url
+from util.security.ssrf import (
+    SSRFBlockedError,
+    validate_external_registry_url,
+    validate_upstream_registry,
+)
 
 
 class TestSSRFBlockedError:
@@ -382,3 +386,33 @@ class TestSSRFAllowlist:
                     "https://registry.internal",
                     allowed_hosts=["192.168.0.0/16"],
                 )
+
+
+class TestValidateUpstreamRegistry:
+    """Tests for validate_upstream_registry() used by proxy cache."""
+
+    def test_bare_hostname_with_namespace_path(self):
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+            validate_upstream_registry("docker.io/library")
+
+    def test_url_form_hostname(self):
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+            validate_upstream_registry("https://registry.example.com")
+
+    def test_localhost_rejected(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_upstream_registry("localhost", resolve_dns=False)
+
+    def test_private_ip_rejected(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_upstream_registry("10.0.0.1", resolve_dns=False)
+
+    def test_aws_metadata_ip_rejected(self):
+        with pytest.raises(SSRFBlockedError):
+            validate_upstream_registry("169.254.169.254", resolve_dns=False)
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError, match="required"):
+            validate_upstream_registry("")


### PR DESCRIPTION
## Summary
- Add SSRF validation for proxy cache `upstream_registry` on create and validate API endpoints
- Re-validate at `Proxy` connection time to mitigate DNS rebinding
- Reuse existing `SSRF_ALLOWED_HOSTS` allowlist and blocklist from org mirror / export logs

## Root Cause / Rationale
Proxy cache accepted attacker-controlled upstream hostnames without checking private IP ranges, link-local/metadata addresses, or blocked hostnames. Organization mirror already had this protection; proxy cache did not.

## Changes
- `validate_upstream_registry()` in `util/security/ssrf.py`
- API validation in `OrganizationProxyCacheConfig` and `ProxyCacheConfigValidation`
- Defense-in-depth in `data/model/proxy_cache.py` and `proxy/__init__.py`
- Unit and API tests

## Test Plan
- [x] Unit tests added/updated (`TestValidateUpstreamRegistry` — 6 passed locally)
- [ ] `TEST=true PYTHONPATH="." pytest endpoints/api/test/test_organization.py::TestProxyCacheSSRFProtection proxy/test_proxy.py::TestProxy -v` (requires venv)

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11180

## Backport
- [ ] Backport required: per Target Version on ticket
- [x] No backport needed
