### PR TITLE
NO-ISSUE: fix(test): remove flaky geo-rep fallback test, add pull to replication test

### DIFF
--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -165,6 +165,7 @@ jobs:
           cat > /tmp/ldap-auth-overlay.yaml <<'EOF'
           FEATURE_TEAM_SYNCING: true
           FEATURE_NONSUPERUSER_TEAM_SYNCING_SETUP: true
+          STAGGER_WORKERS: false
           SUPER_USERS:
             - admin
             - admin_ldap

--- a/web/playwright/e2e/repository/geo-replication.spec.ts
+++ b/web/playwright/e2e/repository/geo-replication.spec.ts
@@ -10,7 +10,6 @@ import {
   isAwscliAvailable,
   listBucketObjects,
   listBuckets,
-  deleteObject,
 } from '../../utils/s3';
 import {API_URL} from '../../utils/config';
 
@@ -120,58 +119,11 @@ test.describe(
         token,
       );
       await waitForReplication(digests.map(digestToS3Key), buckets);
-    });
-
-    test('pull succeeds when replica blob is deleted (data survives single-region loss)', async ({
-      api,
-      authenticatedRequest,
-    }) => {
-      test.setTimeout(120_000);
-
-      const org = await api.organization();
-      const repo = await api.repository(org.name);
-
-      await pushUniqueImage(
-        org.name,
-        repo.name,
-        'fallback',
-        TEST_USERS.user.username,
-        TEST_USERS.user.password,
-      );
-
-      const token = await getV2Token(
-        authenticatedRequest,
-        API_URL,
-        TEST_USERS.user.username,
-        TEST_USERS.user.password,
-        `repository:${org.name}/${repo.name}:pull`,
-      );
-
-      const digests = await fetchManifestDigests(
-        authenticatedRequest,
-        `${org.name}/${repo.name}`,
-        'fallback',
-        token,
-      );
-      const expectedKeys = digests.map(digestToS3Key);
-      await waitForReplication(expectedKeys, buckets);
-
-      // Delete from the last bucket (non-preferred replica).
-      // Quay's _location_aware always serves from the preferred location
-      // (DISTRIBUTED_STORAGE_PREFERENCE[0]) when it's in the placements list,
-      // so deleting from a non-preferred replica verifies replication happened
-      // while ensuring the pull still succeeds through the preferred path.
-      const replicaBucket = buckets[buckets.length - 1];
-      const testKey = expectedKeys[0];
-      await deleteObject(replicaBucket, testKey);
-
-      const objectsAfterDelete = await listBucketObjects(replicaBucket);
-      expect(objectsAfterDelete).not.toContain(testKey);
 
       await pullImage(
         org.name,
         repo.name,
-        'fallback',
+        'v1.0',
         TEST_USERS.user.username,
         TEST_USERS.user.password,
       );


### PR DESCRIPTION
The "data survives single-region loss" test was flaky and misleading.
Quay's _location_aware storage decorator has no read fallback — it
always serves from the preferred location. Deleting from a non-preferred
bucket and pulling exercises the exact same code path as a normal pull,
providing no coverage beyond what the replication test already verifies.

Removed the test and added a pullImage call to the replication test to
verify end-to-end pull after replication completes.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
