### PR TITLE
PROJQUAY-11637: oci: Fix lazy manifest loader for OCI images to properly accept mixed indexes

### DIFF
--- a/image/docker/schema2/list.py
+++ b/image/docker/schema2/list.py
@@ -159,7 +159,7 @@ class DockerSchema2ManifestList(ManifestListInterface):
         ],
     }
 
-    def __init__(self, manifest_bytes):
+    def __init__(self, manifest_bytes, validate=False):
         assert isinstance(manifest_bytes, Bytes)
 
         self._layers = None

--- a/image/oci/index.py
+++ b/image/oci/index.py
@@ -45,6 +45,8 @@ from image.docker.schema2 import (
     DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE,
     DOCKER_SCHEMA2_MANIFESTLIST_CONTENT_TYPE,
 )
+from image.docker.schema2.list import DockerSchema2ManifestList
+from image.docker.schema2.manifest import DockerSchema2Manifest
 from image.oci import OCI_IMAGE_INDEX_CONTENT_TYPE, OCI_IMAGE_MANIFEST_CONTENT_TYPE
 from image.oci.descriptor import get_descriptor_schema
 from image.oci.manifest import OCIManifest, OCIManifestDescriptor
@@ -296,6 +298,8 @@ class OCIIndex(ManifestListInterface):
         supported_types = {}
         supported_types[OCI_IMAGE_MANIFEST_CONTENT_TYPE] = OCIManifest
         supported_types[OCI_IMAGE_INDEX_CONTENT_TYPE] = OCIIndex
+        supported_types[DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE] = DockerSchema2Manifest
+        supported_types[DOCKER_SCHEMA2_MANIFESTLIST_CONTENT_TYPE] = DockerSchema2ManifestList
         return [
             LazyManifestLoader(
                 m,

--- a/image/oci/test/test_oci_index.py
+++ b/image/oci/test/test_oci_index.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from image.docker.schema2 import DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE
+from image.docker.schema2.list import DockerSchema2ManifestList
 from image.docker.schema2.manifest import DockerSchema2Manifest
 from image.oci.index import MalformedIndex, OCIIndex, OCIIndexBuilder
 from image.oci.manifest import OCIManifest
@@ -119,6 +120,21 @@ DOCKER_SCHEMA2_CHILD_BYTES = json.dumps(
     }
 ).encode("utf-8")
 
+DOCKER_SCHEMA2_MANIFEST_LIST_CHILD_BYTES = json.dumps(
+    {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+                "size": 7143,
+                "platform": {"architecture": "amd64", "os": "linux"},
+            },
+        ],
+    }
+).encode("utf-8")
+
 OCI_CHILD_BYTES = json.dumps(
     {
         "schemaVersion": 2,
@@ -169,6 +185,11 @@ MIXED_MEDIA_TYPE_INDEX_BYTES = json.dumps(
                     "os": "linux",
                 },
             },
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+                "size": len(DOCKER_SCHEMA2_MANIFEST_LIST_CHILD_BYTES),
+                "digest": "sha256:ddd444",
+            },
         ],
     }
 ).encode("utf-8")
@@ -184,6 +205,7 @@ def test_oci_index_with_mixed_docker_and_oci_children():
         "sha256:aaa111",
         "sha256:bbb222",
         "sha256:ccc333",
+        "sha256:ddd444",
     ]
 
     retriever = ContentRetrieverForTesting(
@@ -191,16 +213,19 @@ def test_oci_index_with_mixed_docker_and_oci_children():
             "sha256:aaa111": DOCKER_SCHEMA2_CHILD_BYTES,
             "sha256:bbb222": OCI_CHILD_BYTES,
             "sha256:ccc333": OCI_CHILD_BYTES,
+            "sha256:ddd444": DOCKER_SCHEMA2_MANIFEST_LIST_CHILD_BYTES,
         }
     )
 
     manifests = index.manifests(retriever)
-    assert len(manifests) == 3
+    assert len(manifests) == 4
 
     assert isinstance(manifests[0].manifest_obj, DockerSchema2Manifest)
     assert manifests[0].manifest_obj.media_type == DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE
 
     assert isinstance(manifests[1].manifest_obj, OCIManifest)
     assert isinstance(manifests[2].manifest_obj, OCIManifest)
+
+    assert isinstance(manifests[3].manifest_obj, DockerSchema2ManifestList)
 
     assert index.amd64_linux_manifest_digest == "sha256:aaa111"

--- a/image/oci/test/test_oci_index.py
+++ b/image/oci/test/test_oci_index.py
@@ -2,7 +2,10 @@ import json
 
 import pytest
 
+from image.docker.schema2 import DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE
+from image.docker.schema2.manifest import DockerSchema2Manifest
 from image.oci.index import MalformedIndex, OCIIndex, OCIIndexBuilder
+from image.oci.manifest import OCIManifest
 from image.oci.test.testdata import (
     OCI_IMAGE_INDEX_MANIFEST,
     OCI_IMAGE_INDEX_MANIFEST_WITH_ARTIFACT_TYPE_AND_SUBJECT,
@@ -10,6 +13,7 @@ from image.oci.test.testdata import (
     OCI_IMAGE_WITH_ARTIFACT_TYPES_AND_ANNOTATIONS,
 )
 from image.shared.schemas import parse_manifest_from_bytes
+from image.shared.schemautil import ContentRetrieverForTesting
 from util.bytes import Bytes
 
 
@@ -94,3 +98,109 @@ def test_index_builder_with_artifact_type_and_annotations():
     for manifest in manifests:
         assert manifest.get("artifactType") is not None
         assert manifest.get("annotations") is not None
+
+
+DOCKER_SCHEMA2_CHILD_BYTES = json.dumps(
+    {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 1234,
+            "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7",
+        },
+        "layers": [
+            {
+                "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                "size": 1234,
+                "digest": "sha256:ec4b8955958665577945c89419d1af06b5f7636b4ac3da7f12184802ad867736",
+            },
+        ],
+    }
+).encode("utf-8")
+
+OCI_CHILD_BYTES = json.dumps(
+    {
+        "schemaVersion": 2,
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "size": 7023,
+            "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7",
+        },
+        "layers": [
+            {
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "size": 32654,
+                "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",
+            },
+        ],
+    }
+).encode("utf-8")
+
+# OCI index with both the Docker v2 image and OCI image in one
+MIXED_MEDIA_TYPE_INDEX_BYTES = json.dumps(
+    {
+        "schemaVersion": 2,
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": len(DOCKER_SCHEMA2_CHILD_BYTES),
+                "digest": "sha256:aaa111",
+                "platform": {
+                    "architecture": "amd64",
+                    "os": "linux",
+                },
+            },
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "size": len(OCI_CHILD_BYTES),
+                "digest": "sha256:bbb222",
+                "platform": {
+                    "architecture": "arm64",
+                    "os": "linux",
+                },
+            },
+            {
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "size": len(OCI_CHILD_BYTES),
+                "digest": "sha256:ccc333",
+                "platform": {
+                    "architecture": "s390x",
+                    "os": "linux",
+                },
+            },
+        ],
+    }
+).encode("utf-8")
+
+
+def test_oci_index_with_mixed_docker_and_oci_children():
+    """
+    Tests that validation of an OCI image with mixed entries (Docker v2 schema 2 and OCI image) passes.
+    """
+    index = OCIIndex(Bytes.for_string_or_unicode(MIXED_MEDIA_TYPE_INDEX_BYTES))
+    assert index.is_manifest_list
+    assert index.child_manifest_digests() == [
+        "sha256:aaa111",
+        "sha256:bbb222",
+        "sha256:ccc333",
+    ]
+
+    retriever = ContentRetrieverForTesting(
+        {
+            "sha256:aaa111": DOCKER_SCHEMA2_CHILD_BYTES,
+            "sha256:bbb222": OCI_CHILD_BYTES,
+            "sha256:ccc333": OCI_CHILD_BYTES,
+        }
+    )
+
+    manifests = index.manifests(retriever)
+    assert len(manifests) == 3
+
+    assert isinstance(manifests[0].manifest_obj, DockerSchema2Manifest)
+    assert manifests[0].manifest_obj.media_type == DOCKER_SCHEMA2_MANIFEST_CONTENT_TYPE
+
+    assert isinstance(manifests[1].manifest_obj, OCIManifest)
+    assert isinstance(manifests[2].manifest_obj, OCIManifest)
+
+    assert index.amd64_linux_manifest_digest == "sha256:aaa111"


### PR DESCRIPTION
The OCI image spec allows mixed manifest types to be present in the same image index and our JSON validator also allows it. However, when the `LazyManifestLoader._load_manifest()` tries to instantiate the manifest, it calls the `oci.index.manifests()` function which hard codes the supported media types only to OCI image types, omitting the perfectly valid Docker v2 schema 2 media types. This creates a problem when pushing images that have mixed content, the manifest push fails with an exception similar to this one:

~~~
gunicorn-registry stdout | 2026-05-28 14:52:50,752 [370] [ERROR] [data.model.oci.manifest] Could not load manifest list for manifest `sha256:23f252f06a1805d71140a7023f5c46175ad3e3c1581ea97e80c6800665c7fb05` gunicorn-registry stdout | Traceback (most recent call last):
gunicorn-registry stdout |   File "/quay-registry/data/model/oci/manifest.py", line 329, in _create_manifest
gunicorn-registry stdout |     child_manifest = child_manifest_ref.manifest_obj
gunicorn-registry stdout |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gunicorn-registry stdout |   File "/quay-registry/image/shared/schemautil.py", line 108, in manifest_obj
gunicorn-registry stdout |     self._loaded_manifest = self._load_manifest()
gunicorn-registry stdout |                             ^^^^^^^^^^^^^^^^^^^^^
gunicorn-registry stdout |   File "/quay-registry/image/shared/schemautil.py", line 134, in _load_manifest
gunicorn-registry stdout |     raise ManifestException(
gunicorn-registry stdout | image.shared.ManifestException: Unknown or unsupported manifest media type `application/vnd.docker.distribution.manifest.v2+json` not found in dict_keys(['application/vnd.oci.image.manifest.v1+json',
'application/vnd.oci.image.index.v1+json'])
~~~

This PR adds the missing media types to the index allowed list allowing these mixed images to be successfully pushed to Quay.

Co-Authored-By: Claude noreply@anthropic.com