### PR TITLE
PROJQUAY-10242: fix(mirroring): keep Update Mirror button disabled when toggling Enabled checkbox

### DIFF
--- a/web/playwright/e2e/repository/mirroring.spec.ts
+++ b/web/playwright/e2e/repository/mirroring.spec.ts
@@ -11,7 +11,7 @@
  * Requires REPO_MIRROR feature to be enabled in Quay config.
  */
 
-import {test, expect, skipUnlessFeature} from '../../fixtures';
+import {test, expect, skipUnlessFeature, uniqueName} from '../../fixtures';
 
 test.describe(
   'Repository Mirroring',
@@ -242,6 +242,86 @@ test.describe(
       await expect(
         authenticatedPage.getByText('Sync scheduled successfully'),
       ).toBeVisible();
+    });
+
+    test('keeps Update Mirror button disabled when toggling Enabled checkbox', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      // Setup: create org, repo, robot, set MIRROR state, create mirror config via API
+      const org = await api.organization(uniqueName('toggle'));
+      const repo = await api.repository(org.name, uniqueName('repo'));
+      const robot = await api.robot(org.name, uniqueName('bot'));
+      await api.setMirrorState(org.name, repo.name);
+
+      // Create mirror config via API
+      const syncStartDate = new Date();
+      syncStartDate.setMinutes(syncStartDate.getMinutes() + 5);
+      await api.raw.createMirrorConfig(org.name, repo.name, {
+        external_reference: 'quay.io/library/alpine',
+        sync_interval: 3600,
+        sync_start_date: syncStartDate.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+        root_rule: {
+          rule_kind: 'tag_glob_csv',
+          rule_value: ['latest'],
+        },
+        robot_username: robot.fullName,
+        skopeo_timeout_interval: 300,
+        is_enabled: true,
+      });
+
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}?tab=mirroring`,
+      );
+
+      // Wait for form to load with existing data
+      await expect(authenticatedPage.getByTestId('mirror-form')).toBeVisible();
+
+      // Verify Update Mirror button is initially disabled (no changes)
+      await expect(
+        authenticatedPage.getByTestId('submit-button'),
+      ).toBeDisabled();
+
+      // Verify enabled checkbox is checked
+      await expect(
+        authenticatedPage.getByTestId('mirror-enabled-checkbox'),
+      ).toBeChecked();
+
+      // Toggle the Enabled checkbox OFF
+      await authenticatedPage.getByTestId('mirror-enabled-checkbox').click();
+
+      // Wait for the toggle API call to complete and success alert
+      await expect(
+        authenticatedPage.getByText('Mirror disabled successfully'),
+      ).toBeVisible();
+
+      // Verify button remains disabled after toggle (no pending changes)
+      await expect(
+        authenticatedPage.getByTestId('submit-button'),
+      ).toBeDisabled();
+
+      // Toggle back ON
+      await authenticatedPage.getByTestId('mirror-enabled-checkbox').click();
+
+      // Wait for success alert
+      await expect(
+        authenticatedPage.getByText('Mirror enabled successfully'),
+      ).toBeVisible();
+
+      // Verify button still disabled
+      await expect(
+        authenticatedPage.getByTestId('submit-button'),
+      ).toBeDisabled();
+
+      // Now make a real change to another field
+      await authenticatedPage
+        .getByTestId('registry-location-input')
+        .fill('quay.io/library/nginx');
+
+      // Button should now be enabled (pending changes exist)
+      await expect(
+        authenticatedPage.getByTestId('submit-button'),
+      ).toBeEnabled();
     });
 
     test('displays error on mirror configuration failure', async ({

--- a/web/src/components/forms/FormTextInput.test.tsx
+++ b/web/src/components/forms/FormTextInput.test.tsx
@@ -15,6 +15,7 @@ function TestWrapper({
   customValidation,
   disabled = false,
   showNoneWhenEmpty = false,
+  autoComplete,
 }: {
   required?: boolean;
   type?: 'text' | 'password';
@@ -23,6 +24,7 @@ function TestWrapper({
   customValidation?: (v: string) => string | boolean;
   disabled?: boolean;
   showNoneWhenEmpty?: boolean;
+  autoComplete?: string;
 }) {
   const {
     control,
@@ -41,6 +43,7 @@ function TestWrapper({
       customValidation={customValidation}
       disabled={disabled}
       showNoneWhenEmpty={showNoneWhenEmpty}
+      autoComplete={autoComplete}
     />
   );
 }
@@ -87,5 +90,16 @@ describe('FormTextInput', () => {
     const input = screen.getByRole('textbox');
     await userEvent.type(input, 'myuser');
     expect(input).toHaveValue('myuser');
+  });
+
+  it('applies autoComplete attribute when provided', () => {
+    render(<TestWrapper autoComplete="off" />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('autocomplete', 'off');
+  });
+
+  it('applies autoComplete new-password when provided', () => {
+    render(<TestWrapper type="password" autoComplete="new-password" />);
+    const input = document.querySelector('input[type="password"]');
+    expect(input).toHaveAttribute('autocomplete', 'new-password');
   });
 });

--- a/web/src/components/forms/FormTextInput.tsx
+++ b/web/src/components/forms/FormTextInput.tsx
@@ -40,6 +40,7 @@ interface FormTextInputProps<T extends FieldValues> {
   'aria-label'?: string;
   showNoneWhenEmpty?: boolean;
   disabled?: boolean;
+  autoComplete?: string;
 }
 
 export function FormTextInput<T extends FieldValues>({
@@ -60,7 +61,8 @@ export function FormTextInput<T extends FieldValues>({
   'aria-label': ariaLabel,
   showNoneWhenEmpty = false,
   disabled = false,
-}: FormTextInputProps<T>) {
+  autoComplete,
+}: FormTextInputProps<T>): JSX.Element {
   const rules = {
     ...(required && {
       required: 'This field is required',
@@ -112,6 +114,7 @@ export function FormTextInput<T extends FieldValues>({
                 inputMode={inputMode}
                 aria-label={ariaLabel}
                 isDisabled={disabled}
+                autoComplete={autoComplete}
               />
               {fieldError && (
                 <FormHelperText>

--- a/web/src/hooks/UseMirroringConfig.ts
+++ b/web/src/hooks/UseMirroringConfig.ts
@@ -1,4 +1,5 @@
 import {useState, useEffect} from 'react';
+import {UseFormReset, UseFormGetValues} from 'react-hook-form';
 import {
   MirroringConfig,
   MirroringConfigResponse,
@@ -18,13 +19,23 @@ import {
 } from 'src/resources/MirroringResource';
 import {Entity, EntityKind} from 'src/resources/UserResource';
 
+export interface UseMirroringConfigReturn {
+  config: MirroringConfigResponse | null;
+  setConfig: (config: MirroringConfigResponse | null) => void;
+  isLoading: boolean;
+  error: string | null;
+  setError: (error: string | null) => void;
+  submitConfig: (data: MirroringFormData) => Promise<void>;
+}
+
 export const useMirroringConfig = (
   namespace: string,
   repoName: string,
   repoState: string | undefined,
-  reset: (data: MirroringFormData) => void,
+  reset: UseFormReset<MirroringFormData>,
   setSelectedRobot: (robot: Entity | null) => void,
-) => {
+  getValues: UseFormGetValues<MirroringFormData>,
+): UseMirroringConfigReturn => {
   const [config, setConfig] = useState<MirroringConfigResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -40,7 +51,7 @@ export const useMirroringConfig = (
         // Populate form with existing values
         const {value, unit} = convertFromSeconds(response.sync_interval);
 
-        reset({
+        const formData: MirroringFormData = {
           isEnabled: response.is_enabled,
           externalReference: response.external_reference || '',
           tags: response.root_rule.rule_value.join(', '),
@@ -59,7 +70,9 @@ export const useMirroringConfig = (
             response.external_registry_config?.unsigned_images ?? false,
           skopeoTimeoutInterval: response.skopeo_timeout_interval || 300,
           architectureFilter: response.architecture_filter || [],
-        });
+        };
+
+        reset(formData);
 
         // Set selected robot if there's one configured
         if (response.robot_username) {

--- a/web/src/routes/RepositoryDetails/Mirroring/Mirroring.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/Mirroring.tsx
@@ -60,6 +60,7 @@ export const Mirroring: React.FC<MirroringProps> = ({namespace, repoName}) => {
     repoDetails?.state,
     formHook.reset,
     formHook.setSelectedRobot,
+    formHook.getValues,
   );
 
   // Fetch robot accounts and teams
@@ -190,6 +191,8 @@ export const Mirroring: React.FC<MirroringProps> = ({namespace, repoName}) => {
           setArchitectureFilter={(archs) =>
             formHook.setValue('architectureFilter', archs, {shouldDirty: true})
           }
+          getValues={formHook.getValues}
+          reset={formHook.reset}
         />
         <MirroringCredentials
           control={formHook.control}

--- a/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx
@@ -1,5 +1,11 @@
-import React from 'react';
-import {Control, FieldErrors, Controller} from 'react-hook-form';
+import React, {useCallback} from 'react';
+import {Controller} from 'react-hook-form';
+import type {
+  Control,
+  FieldErrors,
+  UseFormGetValues,
+  UseFormReset,
+} from 'react-hook-form';
 import {
   FormGroup,
   FormHelperText,
@@ -51,6 +57,8 @@ interface MirroringConfigurationProps {
   }) => void;
   architectureFilter: string[];
   setArchitectureFilter: (archs: string[]) => void;
+  getValues: UseFormGetValues<MirroringFormData>;
+  reset: UseFormReset<MirroringFormData>;
 }
 
 export const MirroringConfiguration: React.FC<MirroringConfigurationProps> = ({
@@ -71,7 +79,33 @@ export const MirroringConfiguration: React.FC<MirroringConfigurationProps> = ({
   addAlert,
   architectureFilter,
   setArchitectureFilter,
+  getValues,
+  reset,
 }) => {
+  const handleToggleMirroring = useCallback(
+    async (checked: boolean, _onChange: (value: boolean) => void) => {
+      try {
+        await toggleMirroring(namespace, repoName, checked);
+        const currentValues = getValues();
+        reset({...currentValues, isEnabled: checked});
+        if (config) {
+          setConfig({...config, is_enabled: checked});
+        }
+        addAlert({
+          variant: AlertVariant.Success,
+          title: `Mirror ${checked ? 'enabled' : 'disabled'} successfully`,
+        });
+      } catch (err) {
+        addAlert({
+          variant: AlertVariant.Failure,
+          title: 'Error toggling mirror',
+          message: err.message,
+        });
+      }
+    },
+    [namespace, repoName, getValues, reset, config, setConfig, addAlert],
+  );
+
   return (
     <>
       <Title headingLevel="h3">
@@ -90,24 +124,7 @@ export const MirroringConfiguration: React.FC<MirroringConfigurationProps> = ({
               : 'Scheduled mirroring disabled. Immediate sync available via Sync Now.'
           }
           data-testid="mirror-enabled-checkbox"
-          customOnChange={async (checked, onChange) => {
-            try {
-              await toggleMirroring(namespace, repoName, checked);
-              onChange(checked);
-              addAlert({
-                variant: AlertVariant.Success,
-                title: `Mirror ${
-                  checked ? 'enabled' : 'disabled'
-                } successfully`,
-              });
-            } catch (err) {
-              addAlert({
-                variant: AlertVariant.Failure,
-                title: 'Error toggling mirror',
-                message: err.message,
-              });
-            }
-          }}
+          customOnChange={handleToggleMirroring}
         />
       )}
 

--- a/web/src/routes/RepositoryDetails/Mirroring/MirroringCredentials.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/MirroringCredentials.tsx
@@ -35,6 +35,7 @@ export const MirroringCredentials: React.FC<MirroringCredentialsProps> = ({
         fieldId="username"
         showNoneWhenEmpty={!!config}
         data-testid="username-input"
+        autoComplete="off"
       />
 
       <FormTextInput
@@ -44,8 +45,9 @@ export const MirroringCredentials: React.FC<MirroringCredentialsProps> = ({
         label="Password"
         fieldId="external_registry_password"
         type="password"
-        showNoneWhenEmpty={!!config}
+        placeholder={config ? 'Enter new password to update' : ''}
         data-testid="password-input"
+        autoComplete="new-password"
       />
     </>
   );


### PR DESCRIPTION
## Summary
  Fixes the "Update Mirror" button incorrectly becoming enabled after toggling the
  "Enabled" checkbox or when navigating to the mirroring page, even though there were
  no pending changes to save.

  ## Root Cause
  Browser autofill was automatically populating the password field with saved
  credentials after the page loaded. React Hook Form detected this as a user change
  and marked the form as dirty, which enabled the "Update Mirror" button.

  ## Changes
  - Added `autoComplete` prop support to `FormTextInput` component
  - Set `autoComplete="off"` on username field to prevent autofill
  - Set `autoComplete="new-password"` on password field to prevent autofill
  - Updated password field placeholder to "Enter new password to update" for better UX

  ## Test Plan
  1. Navigate to a repository's mirroring tab with existing configuration
  2. Verify the "Update Mirror" button remains disabled on page load
  3. Toggle the "Enabled" checkbox - button should stay disabled
  4. Modify other fields - button should become enabled
  5. Verify browser does not autofill username/password fields
