### PR TITLE
PROJQUAY-11633: test(playwright): add CLI interoperability tests for skopeo and regctl

### DIFF
--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -109,7 +109,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y skopeo
 
       - name: Install regctl for CLI interop tests
-        uses: regclient/actions/regctl-installer@main
+        uses: regclient/actions/regctl-installer@1b705e32d40851370799ea5814e83d0a5f6a70dc # v0.1.0
 
       - name: Run Database auth tests (React + Legacy UI)
         env:

--- a/.github/workflows/web-playwright-ci.yaml
+++ b/.github/workflows/web-playwright-ci.yaml
@@ -108,6 +108,9 @@ jobs:
       - name: Install skopeo for multi-arch image tests
         run: sudo apt-get update && sudo apt-get install -y skopeo
 
+      - name: Install regctl for CLI interop tests
+        uses: regclient/actions/regctl-installer@main
+
       - name: Run Database auth tests (React + Legacy UI)
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-results/db

--- a/web/playwright/e2e/repository/cli-interop.spec.ts
+++ b/web/playwright/e2e/repository/cli-interop.spec.ts
@@ -42,7 +42,10 @@ test.describe(
       }
     });
 
-    test('skopeo list-tags returns pushed tags (OCP-81035)', async () => {
+    test('skopeo list-tags returns pushed tags (OCP-81035)', async ({
+      containerAvailable,
+    }) => {
+      test.skip(!containerAvailable, 'container runtime required');
       const available = await isSkopeoAvailable();
       test.skip(!available, 'skopeo CLI required');
 
@@ -50,7 +53,10 @@ test.describe(
       expect(tags).toContain(tag);
     });
 
-    test('regctl tag ls returns tags (OCP-81036)', async () => {
+    test('regctl tag ls returns tags (OCP-81036)', async ({
+      containerAvailable,
+    }) => {
+      test.skip(!containerAvailable, 'container runtime required');
       const available = await isRegctlAvailable();
       test.skip(!available, 'regctl CLI required');
 

--- a/web/playwright/e2e/repository/cli-interop.spec.ts
+++ b/web/playwright/e2e/repository/cli-interop.spec.ts
@@ -1,0 +1,61 @@
+import {test, expect} from '../../fixtures';
+import {TEST_USERS} from '../../global-setup';
+import {ApiClient} from '../../utils/api';
+import {
+  pushImage,
+  isSkopeoAvailable,
+  isRegctlAvailable,
+  skopeoListTags,
+  regctlListTags,
+} from '../../utils/container';
+
+test.describe(
+  'CLI Interoperability',
+  {tag: ['@container', '@repository']},
+  () => {
+    let orgName: string;
+    let repoName: string;
+    const tag = 'latest';
+    const username = TEST_USERS.user.username;
+    const password = TEST_USERS.user.password;
+
+    test.beforeAll(async ({userContext, cachedContainerAvailable}) => {
+      test.setTimeout(120000);
+      if (!cachedContainerAvailable) return;
+
+      const api = new ApiClient(userContext.request);
+
+      orgName = username;
+      repoName = `cli-interop-${Date.now()}`;
+      await api.createRepository(orgName, repoName, 'private');
+
+      await pushImage(orgName, repoName, tag, username, password);
+    });
+
+    test.afterAll(async ({userContext}) => {
+      if (!repoName) return;
+      const api = new ApiClient(userContext.request);
+      try {
+        await api.deleteRepository(orgName, repoName);
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    test('skopeo list-tags returns pushed tags (OCP-81035)', async () => {
+      const available = await isSkopeoAvailable();
+      test.skip(!available, 'skopeo CLI required');
+
+      const tags = await skopeoListTags(orgName, repoName, username, password);
+      expect(tags).toContain(tag);
+    });
+
+    test('regctl tag ls returns tags (OCP-81036)', async () => {
+      const available = await isRegctlAvailable();
+      test.skip(!available, 'regctl CLI required');
+
+      const tags = await regctlListTags(orgName, repoName, username, password);
+      expect(tags).toContain(tag);
+    });
+  },
+);

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -348,3 +348,67 @@ export async function isOrasAvailable(): Promise<boolean> {
     return false;
   }
 }
+
+/**
+ * Check if skopeo CLI is available on the system.
+ */
+export async function isSkopeoAvailable(): Promise<boolean> {
+  try {
+    await execAsync('skopeo --version');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if regctl CLI is available on the system.
+ */
+export async function isRegctlAvailable(): Promise<boolean> {
+  try {
+    await execAsync('regctl version');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List tags for a repository using skopeo.
+ *
+ * @returns Array of tag name strings
+ */
+export async function skopeoListTags(
+  namespace: string,
+  repo: string,
+  username: string,
+  password: string,
+): Promise<string[]> {
+  const ref = `docker://${REGISTRY_HOST}/${namespace}/${repo}`;
+  const {stdout} = await execAsync(
+    `skopeo list-tags ${ref} --tls-verify=false --creds=${username}:${password}`,
+  );
+  const result = JSON.parse(stdout);
+  return result.Tags ?? [];
+}
+
+/**
+ * List tags for a repository using regctl.
+ *
+ * @returns Array of tag name strings
+ */
+export async function regctlListTags(
+  namespace: string,
+  repo: string,
+  username: string,
+  password: string,
+): Promise<string[]> {
+  const ref = `${REGISTRY_HOST}/${namespace}/${repo}`;
+  const {stdout} = await execAsync(
+    `regctl tag ls ${ref} --tls-verify=false --user ${username}:${password}`,
+  );
+  return stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -404,9 +404,8 @@ export async function regctlListTags(
   password: string,
 ): Promise<string[]> {
   const ref = `${REGISTRY_HOST}/${namespace}/${repo}`;
-  const {stdout} = await execAsync(
-    `regctl tag ls ${ref} --tls-verify=false --user ${username}:${password}`,
-  );
+  const hostCfg = `reg=${REGISTRY_HOST},user=${username},pass=${password},tls=disabled`;
+  const {stdout} = await execAsync(`regctl tag ls --host ${hostCfg} ${ref}`);
   return stdout
     .split('\n')
     .map((line) => line.trim())


### PR DESCRIPTION
## Summary
- Add `skopeoListTags()` and `regctlListTags()` utilities to `web/playwright/utils/container.ts`
- Add `isSkopeoAvailable()` and `isRegctlAvailable()` availability checks following the existing `isOrasAvailable()` pattern
- Create `cli-interop.spec.ts` with two `@container`-tagged tests porting Cypress OCP-81035 and OCP-81036

## Root Cause / Rationale
The Playwright e2e suite was missing CLI interoperability tests that verify external tools (`skopeo list-tags`, `regctl tag ls`) can query tags from the Quay registry. These existed in the Cypress suite but had not been migrated.

## Changes
- `web/playwright/utils/container.ts`: Added 4 new exported functions:
  - `isSkopeoAvailable()` / `isRegctlAvailable()` — check if CLI tools are installed
  - `skopeoListTags()` — runs `skopeo list-tags` and parses JSON output
  - `regctlListTags()` — runs `regctl tag ls` and parses line-separated output
- `web/playwright/e2e/repository/cli-interop.spec.ts`: New test file with:
  - Shared `beforeAll` that pushes an image with tag `latest`
  - OCP-81035: verifies `skopeo list-tags` returns the pushed tag
  - OCP-81036: verifies `regctl tag ls` returns the pushed tag
  - Tests auto-skip when CLI tools or container runtime are unavailable

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration/registry tests pass
- [ ] Type checking passes
- [ ] Manual testing performed
- [x] Frontend tests pass
- [ ] Migration tested (upgrade and downgrade)

Tests are designed to auto-skip gracefully:
- `@container` tag skips if no container runtime (podman/docker) is available
- Per-test `isSkopeoAvailable()` / `isRegctlAvailable()` skips if the CLI is not installed

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11633

## Backport
- [ ] Backport required
- [x] No backport needed

## Automation
- **Session ID**: session-a2ce1102-7d44-49a2-ab7e-51228dbd6b39