### PR TITLE
PROJQUAY-11521: fix(web): add aria-label to mirroring sync start date input

### DIFF
--- a/web/cypress/e2e/mirroring.cy.ts
+++ b/web/cypress/e2e/mirroring.cy.ts
@@ -189,6 +189,9 @@ describe('Repository Mirroring', () => {
       cy.get('[data-testid="username-input"]').should('have.value', '');
       cy.get('[data-testid="password-input"]').should('have.value', '');
 
+      // Verify sync start date input has aria-label (PROJQUAY-11521)
+      cy.get('input[aria-label="Sync start date"]').should('exist');
+
       // Check button says "Enable Mirror"
       cy.get('[data-testid="submit-button"]').should(
         'contain.text',
@@ -352,6 +355,9 @@ describe('Repository Mirroring', () => {
       );
       cy.get('[data-testid="username-input"]').should('have.value', 'testuser');
       cy.get('[data-testid="sync-interval-input"]').should('have.value', '1');
+
+      // Verify sync start date input has aria-label (PROJQUAY-11521)
+      cy.get('input[aria-label="Sync start date"]').should('exist');
 
       // Check button says "Update Mirror"
       cy.get('[data-testid="submit-button"]').should(

--- a/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx
+++ b/web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx
@@ -26,6 +26,7 @@ import {
   syncMirror,
 } from 'src/resources/MirroringResource';
 import {MirroringFormData} from './types';
+import {FormDateTimePicker} from 'src/components/FormDateTimePicker';
 
 interface MirroringConfigurationProps {
   control: Control<MirroringFormData>;
@@ -145,16 +146,11 @@ export const MirroringConfiguration: React.FC<MirroringConfigurationProps> = ({
               }}
               render={({field: {value, onChange}}) => (
                 <div style={{flex: 1}}>
-                  <TextInput
-                    type="datetime-local"
-                    id="sync_start_date"
+                  <FormDateTimePicker
                     value={value}
-                    onChange={(_event, newValue) => onChange(newValue)}
-                    validated={
-                      errors.syncStartDate
-                        ? ValidatedOptions.error
-                        : ValidatedOptions.default
-                    }
+                    onChange={onChange}
+                    dateAriaLabel="Sync start date"
+                    timeAriaLabel="Sync start time"
                   />
                   {errors.syncStartDate && (
                     <FormHelperText>
@@ -200,15 +196,31 @@ export const MirroringConfiguration: React.FC<MirroringConfigurationProps> = ({
             </Button>
           </div>
         ) : (
-          <FormTextInput
+          <Controller
             name="syncStartDate"
             control={control}
-            errors={errors}
-            label=""
-            fieldId="sync_start_date"
-            type="datetime-local"
-            required
-            isStack={false}
+            rules={{
+              required: 'This field is required',
+              validate: (value) =>
+                value?.trim() !== '' || 'This field is required',
+            }}
+            render={({field: {value, onChange}}) => (
+              <>
+                <FormDateTimePicker
+                  value={value}
+                  onChange={onChange}
+                  dateAriaLabel="Sync start date"
+                  timeAriaLabel="Sync start time"
+                />
+                {errors.syncStartDate && (
+                  <FormHelperText>
+                    <Content component="p" className="pf-m-error">
+                      {errors.syncStartDate.message}
+                    </Content>
+                  </FormHelperText>
+                )}
+              </>
+            )}
           />
         )}
       </FormGroup>


### PR DESCRIPTION
## Summary

- Replace `TextInput type="datetime-local"` with `FormDateTimePicker` in the mirroring configuration form to add `aria-label="Sync start date"` required by OCP-85085 interop Cypress tests
- Standalone backport of the relevant part of [PROJQUAY-9750](https://redhat.atlassian.net/browse/PROJQUAY-9750) without the `ArchitectureFilter` feature whose backend deps (`FEATURE_SPARSE_INDEX`, `CapabilitiesResource`) do not exist on `redhat-3.16`
- `FormDateTimePicker` component already exists on `redhat-3.16` — just not wired up to the mirroring form

## Changes

**`web/src/routes/RepositoryDetails/Mirroring/MirroringConfiguration.tsx`**

1. Added `FormDateTimePicker` import
2. Replaced `TextInput` with `FormDateTimePicker` in existing mirror config path, passing `dateAriaLabel="Sync start date"` and `timeAriaLabel="Sync start time"`
3. Replaced `FormTextInput` with `Controller` + `FormDateTimePicker` in new mirror config path, preserving validation rules and error display

## Testing

- TypeScript compilation: no new errors introduced
- Existing Cypress/Playwright mirroring tests: unaffected (use `data-testid` selectors)
- `aria-label` propagation verified at source level through `FormDateTimePicker` → PatternFly `DatePicker` → `<input>`

## Verification

After this change, the DOM renders `<input aria-label="Sync start date">` inside the mirroring configuration form for both new and existing mirror configs.

Fixes: [PROJQUAY-11521](https://redhat.atlassian.net/browse/PROJQUAY-11521)