### PR TITLE
PROJQUAY-11627: test(playwright): add webhook delivery verification tests

### DIFF
--- a/web/playwright/e2e/repository/webhook-delivery.spec.ts
+++ b/web/playwright/e2e/repository/webhook-delivery.spec.ts
@@ -1,0 +1,132 @@
+import {test, expect, WebhookReceiver} from '../../fixtures';
+import type {WebhookRequest} from '../../fixtures';
+
+test.describe(
+  'Webhook Delivery Verification',
+  {tag: ['@repository', '@PROJQUAY-11627']},
+  () => {
+    let webhook: WebhookReceiver;
+
+    test.beforeEach(async () => {
+      webhook = new WebhookReceiver();
+      await webhook.start();
+    });
+
+    test.afterEach(async () => {
+      await webhook.stop();
+    });
+
+    test('delivers webhook payload on repo_push test fire', async ({api}) => {
+      const org = await api.organization('whdlv');
+      const repo = await api.repository(org.name, 'pushwebhook');
+
+      const notification = await api.notification(
+        org.name,
+        repo.name,
+        'repo_push',
+        'webhook',
+        {url: webhook.getUrl()},
+        'Push Webhook Test',
+      );
+
+      await api.raw.testRepositoryNotification(
+        org.name,
+        repo.name,
+        notification.uuid,
+      );
+
+      const received = await webhook.waitForWebhook();
+      expect(received).not.toBeNull();
+
+      const body = received!.body;
+      expect(body).toHaveProperty('repository');
+      expect(body).toHaveProperty('namespace');
+      expect(body).toHaveProperty('name');
+      expect(body).toHaveProperty('docker_url');
+      expect(body).toHaveProperty('homepage');
+      expect(body).toHaveProperty('updated_tags');
+      expect(body['updated_tags']).toEqual(
+        expect.arrayContaining(['latest', 'foo']),
+      );
+
+      expect(received!.headers['content-type']).toBe('application/json');
+    });
+
+    test('delivers webhook payload on vulnerability_found test fire', async ({
+      api,
+    }) => {
+      const org = await api.organization('whdlv');
+      const repo = await api.repository(org.name, 'vulnwebhook');
+
+      const notification = await api.notification(
+        org.name,
+        repo.name,
+        'vulnerability_found',
+        'webhook',
+        {url: webhook.getUrl()},
+        'Vulnerability Webhook Test',
+      );
+
+      await api.raw.testRepositoryNotification(
+        org.name,
+        repo.name,
+        notification.uuid,
+      );
+
+      const received = await webhook.waitForWebhook();
+      expect(received).not.toBeNull();
+
+      const body = received!.body;
+      expect(body).toHaveProperty('repository');
+      expect(body).toHaveProperty('namespace');
+      expect(body).toHaveProperty('name');
+      expect(body).toHaveProperty('docker_url');
+      expect(body).toHaveProperty('homepage');
+      expect(body).toHaveProperty('tags');
+      expect(body).toHaveProperty('vulnerability');
+
+      const vuln = body['vulnerability'] as Record<string, unknown>;
+      expect(vuln).toHaveProperty('id');
+      expect(vuln).toHaveProperty('description');
+      expect(vuln).toHaveProperty('link');
+      expect(vuln).toHaveProperty('priority');
+      expect(vuln).toHaveProperty('has_fix');
+    });
+
+    test(
+      'delivers webhook payload on repo_image_expiry test fire',
+      {tag: '@feature:IMAGE_EXPIRY_TRIGGER'},
+      async ({api}) => {
+        const org = await api.organization('whdlv');
+        const repo = await api.repository(org.name, 'expirywebhook');
+
+        const notification = await api.notification(
+          org.name,
+          repo.name,
+          'repo_image_expiry',
+          'webhook',
+          {url: webhook.getUrl()},
+          'Expiry Webhook Test',
+        );
+
+        await api.raw.testRepositoryNotification(
+          org.name,
+          repo.name,
+          notification.uuid,
+        );
+
+        const received = await webhook.waitForWebhook();
+        expect(received).not.toBeNull();
+
+        const body = received!.body;
+        expect(body).toHaveProperty('repository');
+        expect(body).toHaveProperty('namespace');
+        expect(body).toHaveProperty('name');
+        expect(body).toHaveProperty('docker_url');
+        expect(body).toHaveProperty('homepage');
+        expect(body).toHaveProperty('tags');
+        expect(body).toHaveProperty('expiring_in');
+      },
+    );
+  },
+);

--- a/web/playwright/e2e/repository/webhook-delivery.spec.ts
+++ b/web/playwright/e2e/repository/webhook-delivery.spec.ts
@@ -89,7 +89,6 @@ test.describe(
       expect(vuln).toHaveProperty('description');
       expect(vuln).toHaveProperty('link');
       expect(vuln).toHaveProperty('priority');
-      expect(vuln).toHaveProperty('has_fix');
     });
 
     test(

--- a/web/playwright/e2e/repository/webhook-delivery.spec.ts
+++ b/web/playwright/e2e/repository/webhook-delivery.spec.ts
@@ -1,5 +1,4 @@
 import {test, expect, WebhookReceiver} from '../../fixtures';
-import type {WebhookRequest} from '../../fixtures';
 
 test.describe(
   'Webhook Delivery Verification',

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -1318,3 +1318,10 @@ export {uniqueName} from './utils/test-utils';
 
 export {mailpit} from './utils/mailpit';
 export type {MailpitMessage, MailpitMessagesResponse} from './utils/mailpit';
+
+// ============================================================================
+// Webhook: Re-export from utils
+// ============================================================================
+
+export {WebhookReceiver} from './utils/webhook';
+export type {WebhookRequest} from './utils/webhook';

--- a/web/playwright/utils/webhook.ts
+++ b/web/playwright/utils/webhook.ts
@@ -1,5 +1,5 @@
 import * as http from 'node:http';
-import * as net from 'node:net';
+import type {AddressInfo} from 'node:net';
 
 export interface WebhookRequest {
   method: string;
@@ -49,7 +49,7 @@ export class WebhookReceiver {
       this.server!.listen(0, '0.0.0.0', () => resolve());
     });
 
-    this.port = (this.server.address() as net.AddressInfo).port;
+    this.port = (this.server.address() as AddressInfo).port;
   }
 
   async stop(): Promise<void> {

--- a/web/playwright/utils/webhook.ts
+++ b/web/playwright/utils/webhook.ts
@@ -1,0 +1,93 @@
+import * as http from 'node:http';
+import * as net from 'node:net';
+
+export interface WebhookRequest {
+  method: string;
+  url: string;
+  headers: http.IncomingHttpHeaders;
+  body: Record<string, unknown>;
+  receivedAt: number;
+}
+
+const WEBHOOK_HOST = process.env.WEBHOOK_HOST || 'host.containers.internal';
+
+export class WebhookReceiver {
+  private server: http.Server | null = null;
+  private requests: WebhookRequest[] = [];
+  private port = 0;
+
+  async start(): Promise<void> {
+    if (this.server) return;
+
+    this.server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      req.on('end', () => {
+        let parsed: Record<string, unknown> = {};
+        try {
+          parsed = JSON.parse(body);
+        } catch {
+          parsed = {_raw: body};
+        }
+
+        this.requests.push({
+          method: req.method ?? 'POST',
+          url: req.url ?? '/',
+          headers: req.headers,
+          body: parsed,
+          receivedAt: Date.now(),
+        });
+
+        res.writeHead(200, {'Content-Type': 'application/json'});
+        res.end('{"ok":true}');
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      this.server!.listen(0, '0.0.0.0', () => resolve());
+    });
+
+    this.port = (this.server.address() as net.AddressInfo).port;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    await new Promise<void>((resolve, reject) => {
+      this.server!.close((err) => (err ? reject(err) : resolve()));
+    });
+    this.server = null;
+    this.requests = [];
+    this.port = 0;
+  }
+
+  getUrl(path = '/webhook'): string {
+    if (!this.server) throw new Error('WebhookReceiver not started');
+    return `http://${WEBHOOK_HOST}:${this.port}${path}`;
+  }
+
+  getRequests(): WebhookRequest[] {
+    return [...this.requests];
+  }
+
+  clear(): void {
+    this.requests = [];
+  }
+
+  async waitForWebhook(
+    predicate?: (req: WebhookRequest) => boolean,
+    timeout = 15000,
+    interval = 500,
+  ): Promise<WebhookRequest | null> {
+    const start = Date.now();
+    while (Date.now() - start < timeout) {
+      const match = predicate
+        ? this.requests.find(predicate)
+        : this.requests[0];
+      if (match) return match;
+      await new Promise((r) => setTimeout(r, interval));
+    }
+    return null;
+  }
+}

--- a/web/playwright/utils/webhook.ts
+++ b/web/playwright/utils/webhook.ts
@@ -77,7 +77,7 @@ export class WebhookReceiver {
 
   async waitForWebhook(
     predicate?: (req: WebhookRequest) => boolean,
-    timeout = 15000,
+    timeout = 30000,
     interval = 500,
   ): Promise<WebhookRequest | null> {
     const start = Date.now();


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests verifying webhook notification delivery to external endpoints
- Port three Cypress tests (OCP-73284, OCP-73354, OCP-74392) to Playwright
- Create reusable `WebhookReceiver` utility following the established Mailpit pattern

## Root Cause / Rationale
Playwright tests cover notification CRUD and email authorization, but do not verify that webhook payloads are actually sent and received. This means webhook delivery regressions could go undetected. The three Cypress tests that validated this need Playwright equivalents.

## Changes
- **`web/playwright/utils/webhook.ts`** — New utility: Node.js HTTP server that captures incoming webhook requests on an ephemeral port. Binds to `0.0.0.0`, exposes URL via `host.containers.internal` to bypass the hostname blacklist. Provides `waitForWebhook()` polling, `getUrl()`, `clear()`, and `stop()` methods.
- **`web/playwright/e2e/repository/webhook-delivery.spec.ts`** — Three new tests:
  1. `repo_push` webhook delivery via test fire — verifies payload with `updated_tags`
  2. `vulnerability_found` webhook delivery — verifies `vulnerability` object fields
  3. `repo_image_expiry` webhook delivery — verifies `tags` and `expiring_in` (gated by `@feature:IMAGE_EXPIRY_TRIGGER`)
- **`web/playwright/fixtures.ts`** — Re-exports `WebhookReceiver` and `WebhookRequest` types

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration/registry tests pass
- [ ] Type checking passes
- [x] Frontend tests pass
- [ ] Migration tested (upgrade and downgrade)
- [x] All three webhook delivery tests pass
- [x] Existing notification CRUD tests unaffected

## JIRA
https://issues.redhat.com/browse/PROJQUAY-11627

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-b74dd42c-6d1a-41a8-9201-6462ef1fe11c