### PR TITLE
PROJQUAY-11628: test(playwright): add robot wizard pagination tests with large datasets

### DIFF
--- a/web/playwright/e2e/organization/robot-accounts.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts.spec.ts
@@ -794,7 +794,8 @@ test.describe(
       }) => {
         const org = await api.organization('paginateteam');
 
-        for (let i = 0; i < ITEM_COUNT; i++) {
+        // Orgs start with an auto-created "owners" team
+        for (let i = 0; i < ITEM_COUNT - 1; i++) {
           await api.team(org.name, `team${String(i).padStart(2, '0')}`);
         }
 

--- a/web/playwright/e2e/organization/robot-accounts.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts.spec.ts
@@ -785,6 +785,153 @@ test.describe(
       await expect(repoSearchAfter).toHaveValue(repo1.name);
     });
 
+    test.describe('pagination with large datasets', () => {
+      const ITEM_COUNT = 21;
+
+      test('pagination in "Add to team" wizard step with >20 teams', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const org = await api.organization('paginateteam');
+
+        for (let i = 0; i < ITEM_COUNT; i++) {
+          await api.team(org.name, `team${String(i).padStart(2, '0')}`);
+        }
+
+        await authenticatedPage.goto(
+          `/organization/${org.name}?tab=Robotaccounts`,
+        );
+
+        await authenticatedPage
+          .getByRole('button', {name: 'Create robot account'})
+          .click();
+        await expect(
+          authenticatedPage.locator('#create-robot-account-modal'),
+        ).toBeVisible();
+
+        await authenticatedPage
+          .getByTestId('robot-wizard-form-name')
+          .fill('paginatebot');
+
+        const wizardNav = authenticatedPage.locator(
+          'nav[aria-label="Wizard steps"]',
+        );
+        await wizardNav.getByText('Add to team (optional)').click();
+
+        const modal = authenticatedPage.locator('#create-robot-account-modal');
+        const paginationInfo = modal
+          .locator('.pf-v6-c-pagination__total-items')
+          .first();
+        await expect(paginationInfo).toContainText(`1 - 20 of ${ITEM_COUNT}`);
+
+        await modal
+          .getByRole('button', {name: 'Go to next page'})
+          .first()
+          .click();
+        await expect(paginationInfo).toContainText(
+          `21 - ${ITEM_COUNT} of ${ITEM_COUNT}`,
+        );
+
+        await modal
+          .getByRole('button', {name: 'Go to previous page'})
+          .first()
+          .click();
+        await expect(paginationInfo).toContainText(`1 - 20 of ${ITEM_COUNT}`);
+      });
+
+      test('pagination in "Add to repository" wizard step with >20 repos', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const org = await api.organization('paginaterepo');
+
+        for (let i = 0; i < ITEM_COUNT; i++) {
+          await api.repository(org.name, `repo${String(i).padStart(2, '0')}`);
+        }
+
+        await authenticatedPage.goto(
+          `/organization/${org.name}?tab=Robotaccounts`,
+        );
+
+        await authenticatedPage
+          .getByRole('button', {name: 'Create robot account'})
+          .click();
+        await expect(
+          authenticatedPage.locator('#create-robot-account-modal'),
+        ).toBeVisible();
+
+        await authenticatedPage
+          .getByTestId('robot-wizard-form-name')
+          .fill('paginatebot');
+
+        const wizardNav = authenticatedPage.locator(
+          'nav[aria-label="Wizard steps"]',
+        );
+        await wizardNav.getByText('Add to repository (optional)').click();
+
+        const modal = authenticatedPage.locator('#create-robot-account-modal');
+        const paginationInfo = modal
+          .locator('.pf-v6-c-pagination__total-items')
+          .first();
+        await expect(paginationInfo).toContainText(`1 - 20 of ${ITEM_COUNT}`);
+
+        await modal
+          .getByRole('button', {name: 'Go to next page'})
+          .first()
+          .click();
+        await expect(paginationInfo).toContainText(
+          `21 - ${ITEM_COUNT} of ${ITEM_COUNT}`,
+        );
+
+        await modal
+          .getByRole('button', {name: 'Go to previous page'})
+          .first()
+          .click();
+        await expect(paginationInfo).toContainText(`1 - 20 of ${ITEM_COUNT}`);
+      });
+
+      test('pagination in robot account table with >20 robots', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const org = await api.organization('paginaterobots');
+
+        for (let i = 0; i < ITEM_COUNT; i++) {
+          await api.robot(org.name, `bot${String(i).padStart(2, '0')}`);
+        }
+
+        await authenticatedPage.goto(
+          `/organization/${org.name}?tab=Robotaccounts`,
+        );
+
+        await expect(
+          authenticatedPage.getByTestId('robot-accounts-table'),
+        ).toBeVisible();
+
+        const tabPanel = authenticatedPage.getByRole('tabpanel', {
+          name: 'Robot accounts',
+        });
+        const paginationInfo = tabPanel
+          .locator('.pf-v6-c-pagination__total-items')
+          .first();
+        await expect(paginationInfo).toContainText(`1 - 20 of ${ITEM_COUNT}`);
+
+        await tabPanel
+          .getByRole('button', {name: 'Go to next page'})
+          .first()
+          .click();
+        await expect(paginationInfo).toContainText(
+          `21 - ${ITEM_COUNT} of ${ITEM_COUNT}`,
+        );
+
+        await tabPanel
+          .getByRole('button', {name: 'Go to previous page'})
+          .first()
+          .click();
+        await expect(paginationInfo).toContainText(`1 - 20 of ${ITEM_COUNT}`);
+      });
+    });
+
     test.describe('robot credential execution', {tag: ['@container']}, () => {
       test('robot credentials can authenticate via container login', async ({
         api,


### PR DESCRIPTION
## Summary
- Add 3 Playwright pagination tests for the robot account wizard and table
- Create 21+ teams/repos/robots via API to exceed the default page size of 20
- Verify pagination controls appear and next/prev page navigation works

## Root Cause / Rationale
Existing Playwright tests for the robot wizard never create enough items to trigger pagination. The "Add to team" step, "Add to repository" step, and robot account table all use a default page size of 20, but tests only create 1-3 items. This leaves pagination behavior untested — porting coverage from Cypress tests OCP-67142, OCP-67143, OCP-67144.

## Changes
- Added `pagination with large datasets` describe block to `web/playwright/e2e/organization/robot-accounts.spec.ts`
- Test 1: Creates 21 teams, opens robot wizard "Add to team" step, verifies pagination shows "1 - 20 of 21", navigates next/prev
- Test 2: Creates 21 repos, opens robot wizard "Add to repository" step, verifies pagination shows "1 - 20 of 21", navigates next/prev
- Test 3: Creates 21 robots, navigates to robot accounts tab, verifies pagination shows "1 - 20 of 21", navigates next/prev

## Test Plan
- [ ] Unit tests added/updated
- [ ] Integration/registry tests pass
- [ ] Type checking passes
- [ ] Manual testing performed
- [x] Frontend tests pass
- [ ] Migration tested (upgrade and downgrade)

## JIRA
https://redhat.atlassian.net/browse/PROJQUAY-11628

## Backport
- [ ] Backport required
- [x] No backport needed

## Automation
- **Session ID**: session-ed0366ac-9b67-4310-81ba-b1da96a5ee64