### PR TITLE
PROJQUAY-11598: fix(cve): CVE-2026-44432 - urllib3

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -408,13 +408,8 @@ setuptools-scm==10.0.5 \
     #   pluggy
     #   python-dateutil
     #   setuptools-rust
-    #   zipp
-setuptools-scm==9.2.2 \
-    --hash=sha256:1c674ab4665686a0887d7e24c03ab25f24201c213e82ea689d2f3e169ef7ef57 \
-    --hash=sha256:30e8f84d2ab1ba7cb0e653429b179395d0c33775d54807fc5f1dd6671801aef7
-    # via
-    #   hatch-vcs
     #   urllib3
+    #   zipp
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81

--- a/requirements.txt
+++ b/requirements.txt
@@ -130,7 +130,7 @@ tldextract==2.2.2
 toposort==1.10
 tzlocal==5.0.1
 ua-parser==0.18.0
-urllib3==2.6.3
+urllib3==2.7.0
 webencodings==0.5.1
 WebOb==1.8.8
 websocket-client==1.7.0


### PR DESCRIPTION
## Summary
- Update urllib3 from 2.6.3 to 2.7.0 to fix CVE-2026-44432
- Regenerate requirements-build.txt via pybuild-deps
- Remove setuptools==82 entries (known pybuild-deps bug)

## CVE Details
- **CVE ID**: CVE-2026-44432
- **GHSA**: [GHSA-mf9v-mfxr-j63j](https://github.com/advisories/GHSA-mf9v-mfxr-j63j)
- **Severity**: HIGH (CVSS 7.5)
- **CWE**: CWE-409 (Improper Handling of Highly Compressed Data)
- **Affected versions**: >= 2.6.0, < 2.7.0
- **Fixed version**: 2.7.0

## Description
urllib3 could decompress the whole response instead of the requested portion during the second `HTTPResponse.read(amt=N)` call when using Brotli, or when `HTTPResponse.drain_conn()` was called after partial read. This results in excessive CPU and memory consumption (decompression bomb).

## Changes
- `requirements.txt`: urllib3 2.6.3 → 2.7.0
- `requirements-build.txt`: Regenerated

## Test Results
- **Post-fix scan**: pip-audit confirms CVE resolved with urllib3==2.7.0

## References
- Jira: PROJQUAY-11598
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-44432
- Assessment: [CVE-2026-44432 assessment](artifacts/quay-cvefix/assess/CVE-2026-44432.md)

Resolves: PROJQUAY-11598