### PR TITLE
[redhat-3.17] PROJQUAY-11616: fix(cve): CVE-2026-9277 - shell-quote

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17169,7 +17169,7 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
+      "version": "1.8.4",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17178,8 +17178,8 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       },
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="
     },
     "node_modules/side-channel": {
       "version": "1.1.0",


### PR DESCRIPTION
## Summary

- Fix **CVE-2026-9277** (HIGH, CVSS 8.1) — command injection in `shell-quote` via unescaped line terminators in `quote()`
- Bump `shell-quote` from 1.8.3 to 1.8.4 in `web/package-lock.json` (transitive dependency via `launch-editor`)
- Backport of master fix (PR #6082)
- Advisory: [GHSA-w7jw-789q-3m8p](https://github.com/ljharb/shell-quote/security/advisories/GHSA-w7jw-789q-3m8p)

## CVE Details

| Field | Value |
|-------|-------|
| CVE ID | CVE-2026-9277 |
| Severity | HIGH (CVSS 8.1) |
| CWE | CWE-77 (Command Injection) |
| Package | shell-quote (npm) |
| Affected | <= 1.8.3 |
| Fixed | 1.8.4 |
| NVD | https://nvd.nist.gov/vuln/detail/CVE-2026-9277 |

## Changes

- `web/package-lock.json`: Updated `shell-quote` 1.8.3 → 1.8.4 (version, resolved URL, integrity hash)

## Jira

- PROJQUAY-11616