### PR TITLE
RFE-4378: feat(notifications): add FEATURE_SKIP_EMAIL_CONFIRMATION flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ bin/
 .claude/implementation
 .claude/poll-state/
 .claude/session-state/
+.claude/scheduled_tasks.lock

--- a/config.py
+++ b/config.py
@@ -357,6 +357,12 @@ class DefaultConfig(ImmutableConfig):
     # Feature Flag: Whether emails are enabled.
     FEATURE_MAILING = True
 
+    # Feature Flag: Whether to skip email confirmation requirement for repository notifications.
+    # When False (default), users must confirm email addresses before they can receive repository
+    # notifications. When True, email notifications can be sent to any address without confirmation.
+    # Only enable this in trusted enterprise environments with internal email addresses.
+    FEATURE_SKIP_EMAIL_CONFIRMATION = False
+
     # Feature Flag: Whether users can be created (by non-super users).
     FEATURE_USER_CREATION = True
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -142,6 +142,7 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_RESTRICTED_USERS":                      true,
 	"FEATURE_RESTRICTED_V1_PUSH":                    true,
 	"FEATURE_SECURITY_SCANNER_NOTIFY_ON_NEW_INDEX":  true,
+	"FEATURE_SKIP_EMAIL_CONFIRMATION":               true,
 	"FEATURE_SPARSE_INDEX":                          true,
 	"FEATURE_SUPERUSERS_FULL_ACCESS":                true,
 	"FEATURE_SUPERUSERS_ORG_CREATION_ONLY":          true,

--- a/notifications/notificationmethod.py
+++ b/notifications/notificationmethod.py
@@ -160,6 +160,10 @@ class EmailMethod(NotificationMethod):
         if not email:
             raise CannotValidateNotificationMethodException("Missing e-mail address")
 
+        # When FEATURE_SKIP_EMAIL_CONFIRMATION is enabled, skip the confirmation check
+        if features.SKIP_EMAIL_CONFIRMATION:
+            return
+
         record = model.repository.get_email_authorized_for_repo(namespace_name, repo_name, email)
         if not record or not record.confirmed:
             raise CannotValidateNotificationMethodException(

--- a/notifications/test/test_notificationmethod.py
+++ b/notifications/test/test_notificationmethod.py
@@ -210,3 +210,83 @@ def test_perform_http_call(method, method_config, netloc, initialized_db):
         )
 
     assert url_hit[0]
+
+
+def test_email_requires_confirmation_by_default(initialized_db, monkeypatch):
+    """
+    Verify that email validation requires confirmed authorization when
+    FEATURE_SKIP_EMAIL_CONFIRMATION is False (default).
+    """
+    import features
+
+    # Directly patch the features module attribute to avoid global state pollution
+    monkeypatch.setattr(features, "SKIP_EMAIL_CONFIRMATION", False)
+
+    method = EmailMethod()
+    assert_validated(
+        method,
+        {"email": "test@example.com"},
+        "The specified e-mail address is not authorized to receive notifications for this repository",
+        "devtable",
+        "simple",
+    )
+
+
+def test_email_skips_confirmation_when_feature_enabled(initialized_db, monkeypatch):
+    """
+    Verify that email validation bypasses confirmation check when
+    FEATURE_SKIP_EMAIL_CONFIRMATION is True.
+    """
+    import features
+
+    # Directly patch the features module attribute to avoid global state pollution
+    monkeypatch.setattr(features, "SKIP_EMAIL_CONFIRMATION", True)
+
+    method = EmailMethod()
+    assert_validated(
+        method,
+        {"email": "test@example.com"},
+        None,
+        "devtable",
+        "simple",
+    )
+
+
+def test_email_confirmation_config_loading_path(initialized_db):
+    """
+    Verify that FEATURE_SKIP_EMAIL_CONFIRMATION is properly wired through the
+    config loading path, ensuring the flag name is correct in config/schema.
+    """
+    import features
+
+    # Test that the feature flag loads through config (not just direct patching)
+    # This ensures FEATURE_SKIP_EMAIL_CONFIRMATION is correctly named in config
+    features.import_features({"FEATURE_SKIP_EMAIL_CONFIRMATION": True})
+
+    # Verify the feature flag was loaded into the features module
+    assert hasattr(features, "SKIP_EMAIL_CONFIRMATION")
+    assert features.SKIP_EMAIL_CONFIRMATION is True
+
+    method = EmailMethod()
+    # Should succeed without confirmation when loaded through config
+    assert_validated(
+        method,
+        {"email": "test@example.com"},
+        None,
+        "devtable",
+        "simple",
+    )
+
+    # Test with flag disabled through config
+    features.import_features({"FEATURE_SKIP_EMAIL_CONFIRMATION": False})
+    assert features.SKIP_EMAIL_CONFIRMATION is False
+
+    method = EmailMethod()
+    # Should require confirmation when loaded through config
+    assert_validated(
+        method,
+        {"email": "test@example.com"},
+        "The specified e-mail address is not authorized to receive notifications for this repository",
+        "devtable",
+        "simple",
+    )

--- a/notifications/test/test_notificationmethod.py
+++ b/notifications/test/test_notificationmethod.py
@@ -1,5 +1,3 @@
-from test.fixtures import *
-
 import pytest
 from httmock import HTTMock, urlmatch
 from mock import Mock, patch
@@ -16,6 +14,7 @@ from notifications.notificationmethod import (
     SlackMethod,
     WebhookMethod,
 )
+from test.fixtures import *
 
 
 def assert_validated(method, method_config, error_message, namespace_name, repo_name):
@@ -265,7 +264,7 @@ def test_email_confirmation_config_loading_path(initialized_db):
 
     # Verify the feature flag was loaded into the features module
     assert hasattr(features, "SKIP_EMAIL_CONFIRMATION")
-    assert features.SKIP_EMAIL_CONFIRMATION is True
+    assert bool(features.SKIP_EMAIL_CONFIRMATION) is True
 
     method = EmailMethod()
     # Should succeed without confirmation when loaded through config
@@ -279,7 +278,7 @@ def test_email_confirmation_config_loading_path(initialized_db):
 
     # Test with flag disabled through config
     features.import_features({"FEATURE_SKIP_EMAIL_CONFIRMATION": False})
-    assert features.SKIP_EMAIL_CONFIRMATION is False
+    assert bool(features.SKIP_EMAIL_CONFIRMATION) is False
 
     method = EmailMethod()
     # Should require confirmation when loaded through config

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -215,6 +215,17 @@ CONFIG_SCHEMA = {
             "description": "Whether emails are enabled. Defaults to True",
             "x-example": True,
         },
+        "FEATURE_SKIP_EMAIL_CONFIRMATION": {
+            "type": "boolean",
+            "description": (
+                "Whether to skip email confirmation requirement for repository notifications. "
+                "When False (default), users must confirm email addresses before they can receive "
+                "repository notifications. When True, email notifications can be sent to any address "
+                "without confirmation. Only enable this in trusted enterprise environments with "
+                "internal email addresses. Defaults to False for security."
+            ),
+            "x-example": False,
+        },
         "MAIL_SERVER": {
             "type": "string",
             "description": "The SMTP server to use for sending e-mails. Only required if FEATURE_MAILING is set to true.",


### PR DESCRIPTION
Trying to address RFE https://redhat.atlassian.net/browse/RFE-4378

Add configuration flag to allow bypassing email confirmation requirement for repository notifications in trusted enterprise environments.

Changes:
- Add FEATURE_SKIP_EMAIL_CONFIRMATION flag (default: False for security)
- Modify EmailMethod.validate() to skip confirmation check when enabled
- Add configuration schema definition with security warnings
- Add test coverage for both enabled and disabled states

Security:
- Default: False (maintains current secure behavior)
- Explicit opt-in required via config.yaml
- Only recommended for trusted enterprise deployments with internal emails

Use case:
Enterprise customers with 1000+ repositories who need to configure email notifications via API without manual confirmation for trusted internal email addresses.

When FEATURE_SKIP_EMAIL_CONFIRMATION is False (default):
- Email notifications require confirmation (current behavior)
- Users must click confirmation link in email

When FEATURE_SKIP_EMAIL_CONFIRMATION is True:
- Email notifications can be created without confirmation
- Removes protection against email bombing and unauthorized disclosure
- Only use in trusted enterprise environments