### PR TITLE
PROJQUAY-9537: fix(mirroring): enforce signature verification when unsigned images checkbox unchecked

### DIFF
--- a/conf/containers-policy-strict.json
+++ b/conf/containers-policy-strict.json
@@ -1,0 +1,23 @@
+{
+  "default": [
+    {
+      "type": "reject"
+    }
+  ],
+  "transports": {
+    "docker-daemon": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    },
+    "docker": {
+      "": [
+        {
+          "type": "reject"
+        }
+      ]
+    }
+  }
+}

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -23,6 +23,9 @@ SKOPEO_TIMEOUT_SECONDS = 300
 
 _FILESYSTEM_TRANSPORTS = frozenset({"oci-archive", "oci", "dir", "docker-archive"})
 
+# Path to strict policy file that rejects unsigned images
+STRICT_POLICY_PATH = "/conf/containers-policy-strict.json"
+
 
 def _registry_netloc(image: str) -> Optional[str]:
     """Return the registry hostname for an image URI, or None for filesystem transports.
@@ -98,6 +101,21 @@ class SkopeoMirror(object):
 
     # No DB calls here: This will be called from a separate worker that has no connection except
     # to/from the mirror worker
+    def _get_policy_args(self, unsigned_images: bool) -> list:
+        """Return skopeo policy arguments based on unsigned_images flag."""
+        if unsigned_images:
+            # Allow unsigned images - skip signature verification
+            return ["--insecure-policy"]
+        else:
+            # Enforce signature verification using strict policy
+            if not os.path.exists(STRICT_POLICY_PATH):
+                raise FileNotFoundError(
+                    f"Strict policy file not found at {STRICT_POLICY_PATH}. "
+                    f"Cannot enforce signature verification as required by unsigned_images=False. "
+                    f"Verify container deployment and volume mounts."
+                )
+            return ["--policy", STRICT_POLICY_PATH]
+
     def copy(
         self,
         src_image,
@@ -117,8 +135,7 @@ class SkopeoMirror(object):
         args = ["/usr/bin/skopeo"]
         if verbose_logs:
             args = args + ["--debug"]
-        if unsigned_images:
-            args = args + ["--insecure-policy"]
+        args = args + self._get_policy_args(unsigned_images)
 
         args = args + [
             "copy",
@@ -241,8 +258,7 @@ class SkopeoMirror(object):
         args = ["/usr/bin/skopeo"]
         if verbose_logs:
             args = args + ["--debug"]
-        if unsigned_images:
-            args = args + ["--insecure-policy"]
+        args = args + self._get_policy_args(unsigned_images)
         args = args + [
             "copy",
             "--preserve-digests",

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -221,6 +221,71 @@ def test_mirror_unsigned_images(run_skopeo_mock, initialized_db, app):
 
 @disable_existing_mirrors
 @mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
+@mock.patch("util.repomirror.skopeomirror.os.path.exists")
+def test_mirror_signed_images_only(path_exists_mock, run_skopeo_mock, initialized_db, app):
+    """
+    Test that strict policy is enforced when unsigned_images is False (default).
+    This ensures that only signed images are accepted when the checkbox is not selected.
+    """
+
+    # Mock that the strict policy file exists
+    path_exists_mock.return_value = True
+
+    mirror, repo = create_mirror_repo_robot(
+        ["latest"], external_registry_config={"verify_tls": False, "unsigned_images": False}
+    )
+
+    skopeo_calls = [
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "list-tags",
+                "--tls-verify=False",
+                "docker://registry.example.com/namespace/repository",
+            ],
+            "results": SkopeoResults(True, [], '{"Tags": ["latest"]}', ""),
+        },
+        {
+            "args": [
+                "/usr/bin/skopeo",
+                "--policy",
+                "/conf/containers-policy-strict.json",
+                "copy",
+                "--all",
+                "--remove-signatures",
+                "--src-tls-verify=False",
+                "--dest-tls-verify=True",
+                "--dest-creds",
+                "%s:%s"
+                % (mirror.internal_robot.username, retrieve_robot_token(mirror.internal_robot)),
+                "docker://registry.example.com/namespace/repository:latest",
+                "docker://localhost:5000/mirror/repo:latest",
+            ],
+            "results": SkopeoResults(True, [], "stdout", "stderr"),
+        },
+    ]
+
+    def skopeo_test(args, proxy, timeout=300):
+        try:
+            skopeo_call = skopeo_calls.pop(0)
+            _assert_skopeo_args(args, skopeo_call["args"])
+            assert proxy == {}
+
+            return skopeo_call["results"]
+        except Exception as e:
+            skopeo_calls.append(skopeo_call)
+            raise e
+
+    run_skopeo_mock.side_effect = skopeo_test
+
+    worker = RepoMirrorWorker()
+    worker._process_mirrors()
+
+    assert [] == skopeo_calls
+
+
+@disable_existing_mirrors
+@mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
 def test_successful_disabled_sync_now(run_skopeo_mock, initialized_db, app):
     """
     Disabled mirrors still allow "sync now".


### PR DESCRIPTION
Trying to address: https://redhat.atlassian.net/browse/PROJQUAY-9537

Without selecting the 'Accept Unsigned Images' checkbox in the Repository Mirroring tab, Quay was still mirroring images without signature verification.

Root Cause:
Skopeo's default behavior depends on the system policy configuration. When --insecure-policy flag was absent, it would fall back to the system default policy which could be permissive, allowing unsigned images.

Changes:
- Added strict policy configuration (conf/containers-policy-strict.json) that explicitly rejects all images from Docker registries
- Modified skopeo wrapper to use --policy flag when unsigned_images=False
- Raises FileNotFoundError if policy file missing (fail-secure, not fail-open)
- Applied fix to both copy() and copy_by_digest() methods
- Added test coverage with scoped mock (util.repomirror.skopeomirror.os.path.exists)

Security:
- When unsigned_images=False and policy file is missing, mirroring fails immediately rather than falling back to permissive system policy
- This ensures the security contract is enforced: unsigned images are rejected

Expected Behavior:
- Checkbox UNCHECKED: Skopeo uses strict policy, rejects all images from Docker registries (most public registries don't use GPG signatures)
- Checkbox CHECKED: Skopeo uses --insecure-policy, accepts unsigned images
- Policy Missing + Unchecked: Raises FileNotFoundError, mirroring fails

Note: Most container registries (Docker Hub, Quay.io, gcr.io) do not use GPG signatures. Users must check the 'Accept Unsigned Images' box to mirror from these registries. The unchecked state enforces strict verification suitable only for registries that provide GPG-signed images.