### PR TITLE
NO-ISSUE: fix(make): replace unsupported rm with stop + rm for podman-compose compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,8 @@ enable-builds: local-dev-extract-builder
 
 .PHONY: update-testdata
 update-testdata: local-dev-clean node_modules | build-image-quay
-	$(DOCKER_COMPOSE) rm -fsv quay-db quay
+	$(DOCKER_COMPOSE) stop quay-db quay || true
+	$(DOCKER) rm -f quay-quay quay-db || true
 	$(DOCKER) volume rm -f quay_quay-db-data
 	$(DOCKER_COMPOSE) up -d redis quay-db
 	$(DOCKER) exec -it quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
@@ -316,7 +317,8 @@ local-dev-down:
 
 .PHONY: local-dev-reset-db
 local-dev-reset-db:
-	$(DOCKER_COMPOSE) rm -fsv quay-db quay
+	$(DOCKER_COMPOSE) stop quay-db quay || true
+	$(DOCKER) rm -f quay-quay quay-db || true
 	$(DOCKER) volume rm -f quay_quay-db-data
 	$(DOCKER_COMPOSE) up -d quay-db
 	$(DOCKER) exec -it quay-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'


### PR DESCRIPTION
## Summary
- `podman-compose` does not support the `rm` subcommand, breaking `local-dev-reset-db` and `update-testdata` Makefile targets
- Replaces `$(DOCKER_COMPOSE) rm -fsv` with `$(DOCKER_COMPOSE) stop` followed by `$(DOCKER) rm -f`, which works with both `docker compose` and `podman-compose`

## Test plan
- [ ] Run `make local-dev-reset-db` with `podman-compose` and verify it completes without errors
- [ ] Run `make local-dev-reset-db` with `docker compose` and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)