### PR TITLE
PROJQUAY-11626: test(playwright/notifications): add build notification delivery tests

### DIFF
--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -861,18 +861,18 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
         );
 
         // Trigger a build
-        await api.build(org.name, repo.name, 'FROM scratch\n');
+        const build = await api.build(org.name, repo.name, 'FROM scratch\n');
 
         // Wait for webhook delivery and verify payload
         const webhook = await receiver.waitForWebhook(
           (req) =>
-            typeof req.body.build_id === 'string' &&
+            req.body.build_id === build.buildId &&
             req.body.repository === `${org.name}/${repo.name}`,
           120000,
         );
         expect(webhook, 'build_success webhook not received').not.toBeNull();
         expect(webhook!.body.repository).toBe(`${org.name}/${repo.name}`);
-        expect(typeof webhook!.body.build_id).toBe('string');
+        expect(webhook!.body.build_id).toBe(build.buildId);
       } finally {
         await receiver.stop();
       }

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -740,6 +740,8 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
     'build event notifications delivered via email',
     {tag: ['@feature:BUILD_SUPPORT', '@feature:MAILING', '@PROJQUAY-11626']},
     async ({authenticatedPage, api}) => {
+      // Auth flow + build_queued wait (60s) + build_success wait (120s) + overhead
+      test.setTimeout(300_000);
       const org = await api.organization('buildmail');
       const repo = await api.repository(org.name, 'buildmailrepo');
       const testEmail = `${uniqueName('build')}@example.com`;
@@ -843,6 +845,8 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
     'build event notification delivered via webhook',
     {tag: ['@feature:BUILD_SUPPORT', '@PROJQUAY-11626']},
     async ({api}) => {
+      // Build trigger + webhook wait (120s) + overhead
+      test.setTimeout(180_000);
       const org = await api.organization('buildwh');
       const repo = await api.repository(org.name, 'buildwhrepo');
 

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect, mailpit} from '../../fixtures';
+import {test, expect, mailpit, uniqueName, WebhookReceiver} from '../../fixtures';
 
 test.describe('Repository Notifications', {tag: ['@repository']}, () => {
   test('renders and expands notification details', async ({
@@ -729,4 +729,146 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
       ).toContain(skipped);
     }
   });
+
+  test(
+    'build event notifications delivered via email',
+    {tag: ['@feature:BUILD_SUPPORT', '@feature:MAILING', '@PROJQUAY-11626']},
+    async ({authenticatedPage, api}) => {
+      const org = await api.organization('buildmail');
+      const repo = await api.repository(org.name, 'buildmailrepo');
+      const testEmail = `${uniqueName('build')}@example.com`;
+
+      // Navigate to notifications tab and create build_success email notification via UI
+      // to trigger and complete the email authorization flow.
+      await authenticatedPage.goto(
+        `/repository/${org.name}/${repo.name}?tab=settings`,
+      );
+      await authenticatedPage
+        .getByTestId('settings-tab-eventsandnotifications')
+        .click();
+
+      await authenticatedPage
+        .getByRole('button', {name: 'Create notification'})
+        .click();
+      await authenticatedPage
+        .getByTestId('notification-event-dropdown')
+        .click();
+      await authenticatedPage
+        .getByRole('menuitem', {name: 'Image build success'})
+        .click();
+      await authenticatedPage
+        .getByTestId('notification-method-dropdown')
+        .click();
+      await authenticatedPage
+        .getByRole('menuitem', {name: 'Email Notification'})
+        .click();
+      await authenticatedPage
+        .getByTestId('notification-email')
+        .fill(testEmail);
+      await authenticatedPage
+        .getByTestId('notification-title')
+        .fill('Build Success Email');
+      await authenticatedPage.getByTestId('notification-submit-btn').click();
+
+      // Authorization modal — send the confirmation email
+      await expect(
+        authenticatedPage.getByText('Email Authorization'),
+      ).toBeVisible();
+      await authenticatedPage.getByTestId('send-authorized-email-btn').click();
+
+      // Wait for the verification email in Mailpit (filtered by testEmail for parallel safety)
+      const authEmail = await mailpit.waitForEmail(
+        (msg) =>
+          msg.To.some((to) => to.Address === testEmail) &&
+          msg.Subject.toLowerCase().includes('verify'),
+        15000,
+      );
+      expect(authEmail, 'authorization email not received').not.toBeNull();
+
+      // Confirm the email address
+      const confirmLink = await mailpit.extractLink(authEmail!.ID);
+      expect(confirmLink, 'confirmation link not found in email').not.toBeNull();
+      const confirmPage = await authenticatedPage.context().newPage();
+      await confirmPage.goto(confirmLink!);
+      await confirmPage.close();
+
+      // Wait for the notification to appear as confirmed
+      await expect(
+        authenticatedPage.locator('tbody', {hasText: 'Build Success Email'}),
+      ).toBeVisible({timeout: 15000});
+
+      // Create build_queued notification via API — email is now authorized for this repo
+      await api.notification(
+        org.name,
+        repo.name,
+        'build_queued',
+        'email',
+        {email: testEmail},
+        'Build Queued Email',
+      );
+
+      // Trigger a build
+      await api.build(org.name, repo.name, 'FROM scratch\n');
+
+      // Assert build_queued email is delivered
+      const queuedEmail = await mailpit.waitForEmail(
+        (msg) =>
+          msg.To.some((to) => to.Address === testEmail) &&
+          msg.Subject.includes('Build queued') &&
+          msg.Subject.includes(`${org.name}/${repo.name}`),
+        60000,
+      );
+      expect(queuedEmail, 'build_queued email not received').not.toBeNull();
+
+      // Assert build_success email is delivered
+      const successEmail = await mailpit.waitForEmail(
+        (msg) =>
+          msg.To.some((to) => to.Address === testEmail) &&
+          msg.Subject.includes('Build succeeded') &&
+          msg.Subject.includes(`${org.name}/${repo.name}`),
+        120000,
+      );
+      expect(successEmail, 'build_success email not received').not.toBeNull();
+    },
+  );
+
+  test(
+    'build event notification delivered via webhook',
+    {tag: ['@feature:BUILD_SUPPORT', '@PROJQUAY-11626']},
+    async ({api}) => {
+      const org = await api.organization('buildwh');
+      const repo = await api.repository(org.name, 'buildwhrepo');
+
+      const receiver = new WebhookReceiver();
+      await receiver.start();
+
+      try {
+        // Create webhook notification for build_success event
+        await api.notification(
+          org.name,
+          repo.name,
+          'build_success',
+          'webhook',
+          {url: receiver.getUrl()},
+          'Build Success Webhook',
+        );
+
+        // Trigger a build
+        await api.build(org.name, repo.name, 'FROM scratch\n');
+
+        // Wait for webhook delivery and verify payload
+        const webhook = await receiver.waitForWebhook(
+          (req) =>
+            typeof req.body.build_id === 'string' &&
+            req.body.repository === `${org.name}/${repo.name}`,
+          120000,
+        );
+        expect(webhook, 'build_success webhook not received').not.toBeNull();
+        expect(webhook!.body.repository).toBe(`${org.name}/${repo.name}`);
+        expect(typeof webhook!.body.build_id).toBe('string');
+      } finally {
+        await receiver.stop();
+      }
+    },
+  );
 });

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -829,13 +829,13 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
       );
       expect(queuedEmail, 'build_queued email not received').not.toBeNull();
 
-      // Assert build_success email is delivered
+      // Assert build_success email is delivered (240s: build may queue behind concurrent tests)
       const successEmail = await mailpit.waitForEmail(
         (msg) =>
           msg.To.some((to) => to.Address === testEmail) &&
           msg.Subject.includes('Build succeeded') &&
           msg.Subject.includes(`${org.name}/${repo.name}`),
-        120000,
+        240000,
       );
       expect(successEmail, 'build_success email not received').not.toBeNull();
     },
@@ -845,8 +845,8 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
     'build event notification delivered via webhook',
     {tag: ['@feature:BUILD_SUPPORT', '@PROJQUAY-11626']},
     async ({api}) => {
-      // Build trigger + webhook wait (120s) + overhead
-      test.setTimeout(180_000);
+      // Build trigger + webhook wait (240s) + overhead; build may queue behind concurrent tests
+      test.setTimeout(300_000);
       const org = await api.organization('buildwh');
       const repo = await api.repository(org.name, 'buildwhrepo');
 
@@ -872,7 +872,7 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
           (req) =>
             req.body.build_id === build.buildId &&
             req.body.repository === `${org.name}/${repo.name}`,
-          120000,
+          240000,
         );
         expect(webhook, 'build_success webhook not received').not.toBeNull();
         expect(webhook!.body.repository).toBe(`${org.name}/${repo.name}`);

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -816,8 +816,8 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
         'Build Queued Email',
       );
 
-      // Trigger a build
-      await api.build(org.name, repo.name, 'FROM scratch\n');
+      // Trigger a build — LABEL ensures a layer is produced so Quay marks it build_success
+      await api.build(org.name, repo.name, 'FROM scratch\nLABEL build="notification-test"\n');
 
       // Assert build_queued email is delivered
       const queuedEmail = await mailpit.waitForEmail(
@@ -864,8 +864,8 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
           'Build Success Webhook',
         );
 
-        // Trigger a build
-        const build = await api.build(org.name, repo.name, 'FROM scratch\n');
+        // Trigger a build — LABEL ensures a layer is produced so Quay marks it build_success
+        const build = await api.build(org.name, repo.name, 'FROM scratch\nLABEL build="notification-test"\n');
 
         // Wait for webhook delivery and verify payload
         const webhook = await receiver.waitForWebhook(

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -817,7 +817,11 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
       );
 
       // Trigger a build — LABEL ensures a layer is produced so Quay marks it build_success
-      await api.build(org.name, repo.name, 'FROM scratch\nLABEL build="notification-test"\n');
+      await api.build(
+        org.name,
+        repo.name,
+        'FROM scratch\nLABEL build="notification-test"\n',
+      );
 
       // Assert build_queued email is delivered
       const queuedEmail = await mailpit.waitForEmail(
@@ -865,7 +869,11 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
         );
 
         // Trigger a build — LABEL ensures a layer is produced so Quay marks it build_success
-        const build = await api.build(org.name, repo.name, 'FROM scratch\nLABEL build="notification-test"\n');
+        const build = await api.build(
+          org.name,
+          repo.name,
+          'FROM scratch\nLABEL build="notification-test"\n',
+        );
 
         // Wait for webhook delivery and verify payload
         const webhook = await receiver.waitForWebhook(

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -1,4 +1,10 @@
-import {test, expect, mailpit, uniqueName, WebhookReceiver} from '../../fixtures';
+import {
+  test,
+  expect,
+  mailpit,
+  uniqueName,
+  WebhookReceiver,
+} from '../../fixtures';
 
 test.describe('Repository Notifications', {tag: ['@repository']}, () => {
   test('renders and expands notification details', async ({
@@ -762,9 +768,7 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
       await authenticatedPage
         .getByRole('menuitem', {name: 'Email Notification'})
         .click();
-      await authenticatedPage
-        .getByTestId('notification-email')
-        .fill(testEmail);
+      await authenticatedPage.getByTestId('notification-email').fill(testEmail);
       await authenticatedPage
         .getByTestId('notification-title')
         .fill('Build Success Email');
@@ -787,7 +791,10 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
 
       // Confirm the email address
       const confirmLink = await mailpit.extractLink(authEmail!.ID);
-      expect(confirmLink, 'confirmation link not found in email').not.toBeNull();
+      expect(
+        confirmLink,
+        'confirmation link not found in email',
+      ).not.toBeNull();
       const confirmPage = await authenticatedPage.context().newPage();
       await confirmPage.goto(confirmLink!);
       await confirmPage.close();


### PR DESCRIPTION
## Summary
- Adds two Playwright E2E tests to `notifications.spec.ts` covering build-triggered notification delivery — the coverage gap identified in [PROJQUAY-11626](https://redhat.atlassian.net/browse/PROJQUAY-11626)
- Test 1: triggers a build via API and asserts `build_queued` and `build_success` emails arrive in Mailpit (tagged `@feature:BUILD_SUPPORT @feature:MAILING`)
- Test 2: triggers a build via API and asserts the `build_success` webhook payload is received by a local `WebhookReceiver`, verifying the correct `build_id` (tagged `@feature:BUILD_SUPPORT`)

## Root Cause / Rationale
The existing Playwright notification tests covered CRUD operations and the email authorization flow, but did not verify that build events actually *deliver* notifications end-to-end. This left a gap that would not catch a regression in `EmailMethod.perform` or `WebhookMethod.perform`. The Cypress tests OCP-73285 and OCP-73355 covered this scenario; this PR ports the relevant scenarios to Playwright using Mailpit (already in the local-dev stack) and the existing `WebhookReceiver` utility. Tests use a unique email address per run for parallel safety.

## Changes
- `web/playwright/e2e/repository/notifications.spec.ts` — two new tests appended to the `Repository Notifications` describe block

No production code was changed.

## Test Plan
- [x] Playwright tests added — `web/playwright/e2e/repository/notifications.spec.ts`
- [x] TypeScript type-checks clean (0 errors in changed file)
- [x] ESLint clean (0 errors after prettier auto-fix)
- [ ] Manual run: `make local-dev-up` with `FEATURE_BUILD_SUPPORT: true` + `FEATURE_MAILING: true` in `local-dev/stack/config.yaml`, then `cd web && npx playwright test --grep "[PROJQUAY-11626](https://redhat.atlassian.net/browse/PROJQUAY-11626)"`
- [ ] Tests auto-skip when `BUILD_SUPPORT` / `MAILING` features are disabled (enforced via `@feature:` tag auto-fixture)

## JIRA
https://issues.redhat.com/browse/PROJQUAY-11626

## Backport
- [x] No backport needed

## Automation
- **Session ID**: session-980d1e9a-5c9b-455d-884b-5807fa510763