### PR TITLE
PROJQUAY-11576: feat(ldap): add queue-based admin connection pool

### DIFF
--- a/data/users/__init__.py
+++ b/data/users/__init__.py
@@ -79,6 +79,12 @@ def get_users_handler(config, _, override_config_dir, oauth_login):
         enable_caching = config.get("FEATURE_LDAP_CACHING", False)
         cache_ttl = config.get("LDAP_CACHE_TTL", 5)
 
+        # Connection pooling options
+        connection_pooling = config.get("LDAP_CONNECTION_POOLING", True)
+        pool_size = config.get("LDAP_POOL_SIZE", 10)
+        pool_max_wait = config.get("LDAP_POOL_MAX_WAIT", 5.0)
+        pool_connection_lifetime = config.get("LDAP_POOL_CONNECTION_LIFETIME", 300)
+
         allow_tls_fallback = config.get("LDAP_ALLOW_INSECURE_FALLBACK", False)
         return LDAPUsers(
             ldap_uri,
@@ -101,6 +107,10 @@ def get_users_handler(config, _, override_config_dir, oauth_login):
             ldap_referrals=ldap_referrals,
             enable_caching=enable_caching,
             cache_ttl=cache_ttl,
+            connection_pooling=connection_pooling,
+            pool_size=pool_size,
+            pool_max_wait=pool_max_wait,
+            pool_connection_lifetime=pool_connection_lifetime,
         )
 
     if authentication_type == "JWT":

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -688,10 +688,12 @@ class LDAPUsers(FederatedUsers):
         if err is not None:
             return (False, err)
 
-        if not next(it, False):
-            return (False, "Group does not exist or is empty")
-
-        return (True, None)
+        try:
+            if not next(it, False):
+                return (False, "Group does not exist or is empty")
+            return (True, None)
+        finally:
+            it.close()
 
     def iterate_group_members(self, group_lookup_args, page_size=None, disable_pagination=False):
         try:

--- a/data/users/externalldap.py
+++ b/data/users/externalldap.py
@@ -1,10 +1,14 @@
 import hashlib
 import logging
 import os
+import queue
+import random
 import re
 import sys
 import threading
+import time
 from collections import OrderedDict, namedtuple
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, Callable, Optional
 
@@ -140,6 +144,14 @@ class LDAPConnectionBuilder(object):
         self._network_timeout = network_timeout
         self._referrals = int(referrals)
 
+    @property
+    def admin_dn(self) -> str:
+        return self._user_dn
+
+    @property
+    def admin_pw(self) -> str:
+        return self._user_pw
+
     def get_connection(self):
         return LDAPConnection(
             self._ldap_uri,
@@ -150,6 +162,221 @@ class LDAPConnectionBuilder(object):
             self._network_timeout,
             self._referrals,
         )
+
+    def verify_bind(self, user_dn: str, password: str) -> bool:
+        """Verify user credentials via a direct (non-pooled) connection."""
+        try:
+            with LDAPConnection(
+                self._ldap_uri,
+                user_dn,
+                password,
+                self._allow_tls_fallback,
+                self._timeout,
+                self._network_timeout,
+                self._referrals,
+            ):
+                pass
+            return True
+        except ldap.INVALID_CREDENTIALS:
+            return False
+
+
+_POOL_IDLE_THRESHOLD = 30.0
+_POOL_LIFETIME_JITTER = 0.2
+
+
+@dataclass
+class _PoolEntry:
+    conn: Any
+    created_at: float = field(default_factory=time.monotonic)
+    last_used: float = field(default_factory=time.monotonic)
+    is_overflow: bool = False
+    lifetime_jitter: float = field(
+        default_factory=lambda: random.uniform(1.0 - _POOL_LIFETIME_JITTER, 1.0)
+    )
+
+
+class LDAPConnectionPool:
+    """Queue-based admin LDAP connection pool.
+
+    Requires gevent monkey-patching (threading.Lock and queue.Queue must be
+    patched). All Quay gunicorn configs call monkey.patch_all() before imports.
+    Lazy-initialized so it is safe with preload_app=True (connections are
+    created post-fork, per-worker).
+    """
+
+    def __init__(self, builder, pool_size=10, max_wait=5.0, connection_lifetime=300):
+        self._builder = builder
+        self._pool_size = pool_size
+        self._max_wait = max_wait
+        self._connection_lifetime = connection_lifetime
+        self._queue = None
+        self._lock = threading.Lock()
+        self._total_created = 0
+
+    def _ensure_pool(self):
+        if self._queue is not None:
+            return
+        with self._lock:
+            if self._queue is None:
+                self._queue = queue.Queue(maxsize=self._pool_size)
+
+    def _create_raw_connection(self):
+        wrapper = self._builder.get_connection()
+        try:
+            return wrapper.__enter__()
+        except Exception:
+            try:
+                wrapper.__exit__(*sys.exc_info())
+            except Exception:
+                pass
+            raise
+
+    def _create_with_slot(self, **entry_kwargs):
+        """Reserve a capacity slot and create a connection. Rolls back on failure."""
+        with self._lock:
+            self._total_created += 1
+        try:
+            raw = self._create_raw_connection()
+            return _PoolEntry(conn=raw, **entry_kwargs)
+        except Exception:
+            with self._lock:
+                self._total_created -= 1
+            raise
+
+    def _replace(self, old_entry):
+        """Discard an old connection and create a replacement in its slot."""
+        self._discard(old_entry)
+        return self._create_with_slot()
+
+    def _discard(self, entry):
+        with self._lock:
+            self._total_created = max(0, self._total_created - 1)
+        try:
+            entry.conn.unbind_s()
+        except Exception:
+            pass
+
+    def _health_check(self, entry):
+        try:
+            entry.conn.search_s("", ldap.SCOPE_BASE, "(objectClass=*)", ["1.1"])
+            return True
+        except Exception:
+            return False
+
+    def _checkout(self):
+        self._ensure_pool()
+
+        try:
+            entry = self._queue.get(block=False)
+        except queue.Empty:
+            with self._lock:
+                if self._total_created < self._pool_size:
+                    self._total_created += 1
+                    reserved = True
+                else:
+                    reserved = False
+
+            if reserved:
+                try:
+                    raw = self._create_raw_connection()
+                    return _PoolEntry(conn=raw)
+                except Exception:
+                    with self._lock:
+                        self._total_created -= 1
+                    raise
+
+            try:
+                entry = self._queue.get(block=True, timeout=self._max_wait)
+            except queue.Empty:
+                logger.warning(
+                    "LDAP pool exhausted (size=%d, total=%d), creating overflow connection",
+                    self._pool_size,
+                    self._total_created,
+                )
+                return self._create_with_slot(is_overflow=True)
+
+        now = time.monotonic()
+
+        effective_lifetime = self._connection_lifetime * entry.lifetime_jitter
+        if (now - entry.created_at) >= effective_lifetime:
+            logger.debug("LDAP pooled connection exceeded lifetime, rotating")
+            return self._replace(entry)
+
+        if (now - entry.last_used) >= _POOL_IDLE_THRESHOLD:
+            if not self._health_check(entry):
+                logger.debug("LDAP pooled connection failed health check, replacing")
+                return self._replace(entry)
+
+        entry.last_used = now
+        return entry
+
+    def _return(self, entry, error_occurred=False):
+        if error_occurred or entry.is_overflow:
+            self._discard(entry)
+            return
+
+        effective_lifetime = self._connection_lifetime * entry.lifetime_jitter
+        if (time.monotonic() - entry.created_at) >= effective_lifetime:
+            self._discard(entry)
+            return
+
+        try:
+            self._queue.put_nowait(entry)
+        except queue.Full:
+            self._discard(entry)
+
+    def verify_bind(self, user_dn: str, password: str) -> bool:
+        """Verify user credentials via bind-and-revert on a pooled connection.
+
+        Binds as the user to check their password, then immediately rebinds
+        as admin to restore the connection identity. If the admin rebind
+        fails, the connection is discarded (never returned in wrong state).
+        """
+        entry = self._checkout()
+        try:
+            entry.conn.simple_bind_s(user_dn, password)
+        except ldap.INVALID_CREDENTIALS:
+            try:
+                entry.conn.simple_bind_s(self._builder.admin_dn, self._builder.admin_pw)
+                entry.last_used = time.monotonic()
+                self._return(entry)
+            except Exception:
+                self._discard(entry)
+            return False
+        except Exception:
+            self._discard(entry)
+            raise
+
+        try:
+            entry.conn.simple_bind_s(self._builder.admin_dn, self._builder.admin_pw)
+            entry.last_used = time.monotonic()
+            self._return(entry)
+        except Exception:
+            logger.warning(
+                "LDAP admin rebind failed after user verification, discarding connection"
+            )
+            self._discard(entry)
+
+        return True
+
+    def get_connection(self) -> "_PooledConnectionContext":
+        return _PooledConnectionContext(self)
+
+
+class _PooledConnectionContext:
+    def __init__(self, pool: LDAPConnectionPool) -> None:
+        self._pool = pool
+        self._entry: Optional[_PoolEntry] = None
+
+    def __enter__(self):
+        self._entry = self._pool._checkout()
+        return self._entry.conn
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._entry is not None:
+            self._pool._return(self._entry, error_occurred=exc_type is not None)
+            self._entry = None
 
 
 class LDAPConnection(object):
@@ -232,10 +459,14 @@ class LDAPUsers(FederatedUsers):
         ldap_referrals=_DEFAULT_REFERRALS,
         enable_caching=False,
         cache_ttl=_DEFAULT_CACHE_TTL,
+        connection_pooling=True,
+        pool_size=10,
+        pool_max_wait=5.0,
+        pool_connection_lifetime=300,
     ):
         super(LDAPUsers, self).__init__("ldap", requires_email)
 
-        self._ldap = LDAPConnectionBuilder(
+        builder = LDAPConnectionBuilder(
             ldap_uri,
             admin_dn,
             admin_passwd,
@@ -244,6 +475,13 @@ class LDAPUsers(FederatedUsers):
             network_timeout,
             referrals=ldap_referrals,
         )
+
+        if connection_pooling:
+            self._ldap = LDAPConnectionPool(
+                builder, pool_size, pool_max_wait, pool_connection_lifetime
+            )
+        else:
+            self._ldap = builder
         self._ldap_uri = ldap_uri
         self._uid_attr = uid_attr
         self._email_attr = email_attr
@@ -633,6 +871,19 @@ class LDAPUsers(FederatedUsers):
         logger.debug("For query %s found results %s", query, final_results)
         return (final_results, self.federated_service, None)
 
+    def _verify_password(self, found_dn, password):
+        """Verify password via self._ldap.verify_bind (works for both pool and builder)."""
+        try:
+            return self._ldap.verify_bind(found_dn, password)
+        except ldap.REFERRAL as re:
+            referral_dn = self._get_ldap_referral_dn(re)
+            if not referral_dn:
+                return False
+            try:
+                return self._ldap.verify_bind(referral_dn, password)
+            except ldap.INVALID_CREDENTIALS:
+                return False
+
     def verify_credentials(self, username_or_email, password):
         """
         Verify the credentials with LDAP.
@@ -650,24 +901,7 @@ class LDAPUsers(FederatedUsers):
         logger.debug("DN %s found: %s", found_dn, found_response)
 
         # First validate the password by binding as the user
-        try:
-            with LDAPConnection(self._ldap_uri, found_dn, password, self._allow_tls_fallback):
-                pass
-        except ldap.REFERRAL as re:
-            referral_dn = self._get_ldap_referral_dn(re)
-            if not referral_dn:
-                return (None, "Invalid username or password.")
-
-            try:
-                with LDAPConnection(
-                    self._ldap_uri, referral_dn, password, self._allow_tls_fallback
-                ):
-                    pass
-            except ldap.INVALID_CREDENTIALS:
-                logger.debug("Invalid LDAP credentials")
-                return (None, "Invalid username or password.")
-
-        except ldap.INVALID_CREDENTIALS:
+        if not self._verify_password(found_dn, password):
             logger.debug("Invalid LDAP credentials")
             return (None, "Invalid username or password.")
 
@@ -769,7 +1003,9 @@ class LDAPUsers(FederatedUsers):
 
                 # Conduct the initial search for users that are a member of the group.
                 logger.debug(
-                    "Conducting LDAP search of DN: %s and filter %s", user_search_dn, search_flt
+                    "Conducting LDAP search of DN: %s and filter %s",
+                    user_search_dn,
+                    search_flt,
                 )
                 try:
                     if has_pagination:
@@ -782,7 +1018,10 @@ class LDAPUsers(FederatedUsers):
                         )
                     else:
                         msgid = conn.search(
-                            user_search_dn, ldap.SCOPE_SUBTREE, search_flt, attrlist=attributes
+                            user_search_dn,
+                            ldap.SCOPE_SUBTREE,
+                            search_flt,
+                            attrlist=attributes,
                         )
                 except ldap.LDAPError as lde:
                     logger.exception(

--- a/test/test_ldap.py
+++ b/test/test_ldap.py
@@ -692,6 +692,40 @@ class TestLDAP(unittest.TestCase):
             self.assertTrue(result)
             self.assertIsNone(err)
 
+    def test_check_group_lookup_args_closes_generator(self):
+        """Verify generator is explicitly closed to release LDAP connection."""
+        with mock_ldap() as ldap_users:
+            generator_closed = [False]
+            original_iterate = ldap_users.iterate_group_members
+
+            class TrackingGenerator:
+                def __init__(self, gen):
+                    self._gen = gen
+
+                def __iter__(self):
+                    return self
+
+                def __next__(self):
+                    return next(self._gen)
+
+                def close(self):
+                    generator_closed[0] = True
+                    self._gen.close()
+
+            def tracking_iterate(*args, **kwargs):
+                it, err = original_iterate(*args, **kwargs)
+                if it is None:
+                    return (it, err)
+                return (TrackingGenerator(it), err)
+
+            ldap_users.iterate_group_members = tracking_iterate
+
+            (result, err) = ldap_users.check_group_lookup_args(
+                {"group_dn": "cn=AwesomeFolk"}, disable_pagination=True
+            )
+            self.assertTrue(result)
+            self.assertTrue(generator_closed[0], "Generator was not explicitly closed")
+
     def test_metadata(self):
         with mock_ldap() as ldap:
             assert "base_dn" in ldap.service_metadata()

--- a/test/test_ldap.py
+++ b/test/test_ldap.py
@@ -23,6 +23,7 @@ def _create_ldap(
     global_readonly_superuser_filter=None,
     enable_caching=False,
     cache_ttl=60.0,
+    enable_pooling=True,
 ):
     base_dn = ["dc=quay", "dc=io"]
     admin_dn = "uid=testy,ou=employees,dc=quay,dc=io"
@@ -50,6 +51,7 @@ def _create_ldap(
         ldap_global_readonly_superuser_filter=global_readonly_superuser_filter,
         enable_caching=enable_caching,
         cache_ttl=cache_ttl,
+        connection_pooling=enable_pooling,
     )
     return ldap
 
@@ -63,6 +65,7 @@ def mock_ldap(
     global_readonly_superuser_filter=None,
     enable_caching=False,
     cache_ttl=60.0,
+    enable_pooling=True,
 ):
     mock_data = {
         "dc=quay,dc=io": {"dc": ["quay", "io"]},
@@ -355,6 +358,7 @@ def mock_ldap(
                 global_readonly_superuser_filter=global_readonly_superuser_filter,
                 enable_caching=enable_caching,
                 cache_ttl=cache_ttl,
+                enable_pooling=enable_pooling,
             )
     finally:
         mockldap.stop()
@@ -1195,6 +1199,339 @@ class TestLDAPCache(unittest.TestCase):
 
             # Verify cache has the entry
             self.assertEqual(ldap._cache.size(), 1)
+
+
+class TestLDAPConnectionPool(unittest.TestCase):
+    def setUp(self):
+        setup_database_for_testing(self)
+        self.app = app.test_client()
+        self.ctx = app.test_request_context()
+        self.ctx.__enter__()
+
+    def tearDown(self):
+        finished_database_for_testing(self)
+        self.ctx.__exit__(True, None, None)
+
+    def test_pool_lazy_init(self):
+        """Pool queue is not created until first get_connection call."""
+        from data.users.externalldap import LDAPConnectionPool
+
+        builder = MagicMock()
+        pool = LDAPConnectionPool(builder, pool_size=5)
+        self.assertIsNone(pool._queue)
+
+    def test_pool_reuses_connections(self):
+        """Connections are returned to pool and reused on next checkout."""
+        with mock_ldap(enable_pooling=True) as ldap_users:
+            (result1, _) = ldap_users.get_user("someuser")
+            self.assertEqual(result1.username, "someuser")
+            self.assertEqual(ldap_users._ldap._total_created, 1)
+
+            (result2, _) = ldap_users.get_user("someuser")
+            self.assertEqual(result2.username, "someuser")
+            self.assertEqual(ldap_users._ldap._total_created, 1)
+
+    def test_pool_resilient_after_not_found(self):
+        """Pool still functions correctly after a not-found lookup."""
+        with mock_ldap(enable_pooling=True) as ldap_users:
+            ldap_users.get_user("someuser")
+
+            (result, err) = ldap_users.get_user("nonexistentuser")
+            self.assertIsNone(result)
+
+            (result2, _) = ldap_users.get_user("someuser")
+            self.assertEqual(result2.username, "someuser")
+
+    def test_pool_verify_credentials_uses_bind_and_revert(self):
+        """verify_credentials routes through pool.verify_bind when pooling is enabled."""
+        with mock_ldap(enable_pooling=True) as ldap_users:
+            from data.users.externalldap import LDAPConnectionPool
+
+            self.assertIsInstance(ldap_users._ldap, LDAPConnectionPool)
+            with patch.object(
+                ldap_users._ldap, "verify_bind", wraps=ldap_users._ldap.verify_bind
+            ) as mock_vb:
+                (result, _) = ldap_users.verify_and_link_user("someuser", "somepass")
+                self.assertEqual(result.username, "someuser")
+                mock_vb.assert_called_once()
+
+    def test_pool_disabled_fallback(self):
+        """With pooling disabled, behavior is identical to LDAPConnectionBuilder."""
+        with mock_ldap(enable_pooling=False) as ldap_users:
+            from data.users.externalldap import LDAPConnectionBuilder
+
+            self.assertIsInstance(ldap_users._ldap, LDAPConnectionBuilder)
+
+            (result, _) = ldap_users.get_user("someuser")
+            self.assertEqual(result.username, "someuser")
+
+    def test_pool_iterate_group_members(self):
+        """Team sync iteration works through pooled connections."""
+        with mock_ldap(enable_pooling=True) as ldap_users:
+            (it, err) = ldap_users.iterate_group_members(
+                {"group_dn": "cn=AwesomeFolk"}, disable_pagination=True
+            )
+            self.assertIsNone(err)
+            results = list(it)
+            self.assertEqual(5, len(results))
+
+    def test_pool_ping(self):
+        """Ping works through pooled connections."""
+        with mock_ldap(enable_pooling=True) as ldap_users:
+            (ok, err) = ldap_users.ping()
+            self.assertTrue(ok)
+            self.assertIsNone(err)
+
+    def test_pool_bind_and_revert_valid(self):
+        """Bind-and-revert verifies valid credentials through the pool."""
+        with mock_ldap(enable_pooling=True) as ldap_users:
+            (result, _) = ldap_users.verify_and_link_user("someuser", "somepass")
+            self.assertEqual(result.username, "someuser")
+
+    def test_pool_bind_and_revert_invalid(self):
+        """Bind-and-revert rejects invalid credentials."""
+        with mock_ldap(enable_pooling=True) as ldap_users:
+            (result, err) = ldap_users.verify_and_link_user("someuser", "wrongpass")
+            self.assertIsNone(result)
+            self.assertEqual(err, "Invalid username or password.")
+
+    def test_pool_bind_and_revert_empty_password(self):
+        """Empty password is rejected before reaching the pool."""
+        with mock_ldap(enable_pooling=True) as ldap_users:
+            (result, err) = ldap_users.verify_and_link_user("someuser", "")
+            self.assertIsNone(result)
+            self.assertEqual(err, "Anonymous binding not allowed.")
+
+    def test_pool_disabled_uses_direct_connection(self):
+        """With pooling disabled, verify_credentials uses direct LDAPConnection."""
+        with mock_ldap(enable_pooling=False) as ldap_users:
+            (result, _) = ldap_users.verify_and_link_user("someuser", "somepass")
+            self.assertEqual(result.username, "someuser")
+
+            (result, err) = ldap_users.verify_and_link_user("someuser", "wrongpass")
+            self.assertIsNone(result)
+            self.assertEqual(err, "Invalid username or password.")
+
+    def test_pool_bind_and_revert_restores_admin_identity(self):
+        """After bind-and-revert, the pooled connection is rebound as admin
+        and can perform admin searches (not stuck as the user)."""
+        with mock_ldap(enable_pooling=True) as ldap_users:
+            # Login as someuser — this does bind-and-revert internally
+            (result, _) = ldap_users.verify_and_link_user("someuser", "somepass")
+            self.assertEqual(result.username, "someuser")
+
+            # Now do an admin operation that requires the admin bind.
+            # If the connection were still bound as someuser, this would
+            # fail because the admin search uses the pooled connection.
+            (result2, _) = ldap_users.get_user("testy")
+            self.assertEqual(result2.username, "testy")
+
+            # Do it again with a different user to prove the pool isn't
+            # leaking the first user's identity
+            (result3, _) = ldap_users.verify_and_link_user("secondaryuser", "somepass")
+            self.assertEqual(result3.username, "secondaryuser")
+
+            # Admin search still works
+            (result4, _) = ldap_users.get_user("someuser")
+            self.assertEqual(result4.username, "someuser")
+
+
+class TestLDAPConnectionPoolEdgeCases(unittest.TestCase):
+    """Tests for pool edge cases that can't be exercised through mockldap alone."""
+
+    def _make_pool(self, pool_size=2, max_wait=0.1, lifetime=300):
+        from data.users.externalldap import LDAPConnectionPool
+
+        builder = MagicMock()
+
+        def make_wrapper():
+            wrapper = MagicMock()
+            wrapper.__enter__ = MagicMock(return_value=MagicMock())
+            return wrapper
+
+        builder.get_connection.side_effect = lambda: make_wrapper()
+        pool = LDAPConnectionPool(
+            builder, pool_size=pool_size, max_wait=max_wait, connection_lifetime=lifetime
+        )
+        return pool, builder
+
+    def test_overflow_when_pool_exhausted(self):
+        """When all connections are checked out and none return in time,
+        an overflow connection is created with a warning."""
+        import time
+
+        from data.users.externalldap import LDAPConnectionPool, _PoolEntry
+
+        pool, builder = self._make_pool(pool_size=2, max_wait=0.1)
+
+        # Fill pool to capacity
+        conn1 = pool._checkout()
+        conn2 = pool._checkout()
+        self.assertEqual(pool._total_created, 2)
+
+        # Next checkout should wait, timeout, and create overflow
+        overflow = pool._checkout()
+        self.assertTrue(overflow.is_overflow)
+        self.assertEqual(pool._total_created, 3)
+
+        # Return overflow — it should be discarded, not pooled
+        pool._return(overflow)
+        self.assertEqual(pool._total_created, 2)
+
+        # Return the real ones
+        pool._return(conn1)
+        pool._return(conn2)
+
+    def test_lifetime_rotation_on_checkout(self):
+        """Expired connections are discarded and replaced on checkout."""
+        import time
+
+        from data.users.externalldap import _PoolEntry
+
+        pool, builder = self._make_pool(pool_size=2, lifetime=1)
+
+        # Create and return a connection
+        entry = pool._checkout()
+        pool._return(entry)
+
+        # Simulate time passing beyond lifetime
+        queued = pool._queue.get()
+        queued.created_at = time.monotonic() - 100
+        queued.lifetime_jitter = 1.0
+        pool._queue.put(queued)
+
+        # Next checkout should rotate it
+        new_entry = pool._checkout()
+        self.assertIsNot(new_entry.conn, queued.conn)
+
+    def test_lifetime_rotation_on_return(self):
+        """Expired connections are discarded on return, not put back in pool."""
+        import time
+
+        from data.users.externalldap import _PoolEntry
+
+        pool, builder = self._make_pool(pool_size=2, lifetime=1)
+
+        entry = pool._checkout()
+        entry.created_at = time.monotonic() - 100
+        entry.lifetime_jitter = 1.0
+
+        pool._return(entry)
+        self.assertTrue(pool._queue.empty())
+
+    def test_health_check_replaces_dead_connection(self):
+        """Idle connections that fail health check are replaced."""
+        import time
+
+        from data.users.externalldap import _PoolEntry
+
+        pool, builder = self._make_pool(pool_size=2)
+
+        entry = pool._checkout()
+        pool._return(entry)
+
+        # Simulate idle > 30s
+        queued = pool._queue.get()
+        queued.last_used = time.monotonic() - 60
+        queued.conn.search_s.side_effect = Exception("connection dead")
+        pool._queue.put(queued)
+
+        # Checkout should detect dead connection and create new one
+        new_entry = pool._checkout()
+        self.assertIsNot(new_entry.conn, queued.conn)
+
+    def test_verify_bind_admin_rebind_failure_discards_connection(self):
+        """If admin rebind fails after valid user bind, connection is discarded."""
+        pool, builder = self._make_pool(pool_size=2)
+
+        entry = pool._checkout()
+        pool._return(entry)
+
+        conn = pool._queue.get()
+        bind_call_count = [0]
+        original_conn = conn.conn
+
+        def side_effect_bind(dn, pw):
+            bind_call_count[0] += 1
+            if bind_call_count[0] == 2:
+                raise ldap.SERVER_DOWN("connection lost")
+
+        original_conn.simple_bind_s = MagicMock(side_effect=side_effect_bind)
+        pool._queue.put(conn)
+
+        # verify_bind should succeed (user bind works) but discard the connection
+        result = pool.verify_bind("uid=user,dc=test", "pass")
+        self.assertTrue(result)
+        self.assertTrue(pool._queue.empty())
+
+    def test_verify_bind_invalid_creds_rebind_failure_discards(self):
+        """If admin rebind fails after invalid user bind, connection is discarded."""
+        pool, builder = self._make_pool(pool_size=2)
+
+        entry = pool._checkout()
+        pool._return(entry)
+
+        conn = pool._queue.get()
+        original_conn = conn.conn
+        bind_call_count = [0]
+
+        def side_effect_bind(dn, pw):
+            bind_call_count[0] += 1
+            if bind_call_count[0] == 1:
+                raise ldap.INVALID_CREDENTIALS("wrong password")
+            raise ldap.SERVER_DOWN("connection lost during rebind")
+
+        original_conn.simple_bind_s = MagicMock(side_effect=side_effect_bind)
+        pool._queue.put(conn)
+
+        result = pool.verify_bind("uid=user,dc=test", "wrongpass")
+        self.assertFalse(result)
+        self.assertTrue(pool._queue.empty())
+
+    def test_verify_bind_connection_error_discards_and_raises(self):
+        """If user bind raises a connection error, connection is discarded
+        and the error is propagated."""
+        pool, builder = self._make_pool(pool_size=2)
+
+        entry = pool._checkout()
+        pool._return(entry)
+
+        conn = pool._queue.get()
+        conn.conn.simple_bind_s = MagicMock(side_effect=ldap.SERVER_DOWN("gone"))
+        pool._queue.put(conn)
+
+        with self.assertRaises(ldap.SERVER_DOWN):
+            pool.verify_bind("uid=user,dc=test", "pass")
+        self.assertTrue(pool._queue.empty())
+
+    def test_discard_handles_unbind_exception(self):
+        """_discard swallows exceptions from unbind_s."""
+        from data.users.externalldap import _PoolEntry
+
+        pool, builder = self._make_pool()
+        entry = _PoolEntry(conn=MagicMock())
+        entry.conn.unbind_s.side_effect = Exception("already closed")
+
+        pool._total_created = 1
+        pool._discard(entry)
+        self.assertEqual(pool._total_created, 0)
+
+    def test_context_manager_discards_on_exception(self):
+        """Connection is discarded (not returned) when an exception occurs
+        inside the context manager."""
+        pool, builder = self._make_pool(pool_size=2)
+
+        entry = pool._checkout()
+        pool._return(entry)
+        self.assertFalse(pool._queue.empty())
+
+        try:
+            with pool.get_connection():
+                raise ldap.SERVER_DOWN("simulated failure")
+        except ldap.SERVER_DOWN:
+            pass
+
+        self.assertTrue(pool._queue.empty())
 
 
 class TestLDAPPasswordRedaction(unittest.TestCase):

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -2549,6 +2549,33 @@ CONFIG_SCHEMA = {
         "x-example": 10,
         "x-reference": None,
     },
+    "LDAP_CONNECTION_POOLING": {
+        "type": "boolean",
+        "description": "Enable admin LDAP connection pooling to reuse connections across requests. Set false to fall back to per-request connections. Defaults to True.",
+        "x-example": True,
+        "x-reference": None,
+    },
+    "LDAP_POOL_SIZE": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Maximum number of pooled admin LDAP connections per worker process. Defaults to 10.",
+        "x-example": 10,
+        "x-reference": None,
+    },
+    "LDAP_POOL_MAX_WAIT": {
+        "type": "number",
+        "minimum": 0,
+        "description": "Seconds to wait for a pooled LDAP connection before creating an overflow connection. Defaults to 5.0.",
+        "x-example": 5.0,
+        "x-reference": None,
+    },
+    "LDAP_POOL_CONNECTION_LIFETIME": {
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "description": "Maximum age in seconds of a pooled LDAP connection before it is rotated. Defaults to 300.",
+        "x-example": 300,
+        "x-reference": None,
+    },
     "GLOBAL_PROMETHEUS_STATS_FREQUENCY": {
         "type": "number",
         "description": "Frequency to report metrics to Push gateway. Defaults to 3600 seconds",


### PR DESCRIPTION
## Summary

- Fix generator leak in `check_group_lookup_args` — the generator from `iterate_group_members` held an open LDAP connection until GC
- Add `LDAPConnectionPool` with queue-based admin connection reuse — lazy init (safe with Gunicorn `preload_app`), rootDSE health checks on idle connections, soft lifetime rotation with jitter, overflow connections when pool exhausted
- Add bind-and-revert for user password verification — verifies credentials by rebinding on a pooled connection then restoring admin identity (follows the [UnboundID SDK `bindAndRevertAuthentication`](https://docs.ldap.com/ldap-sdk/docs/javadoc/com/unboundid/ldap/sdk/LDAPConnectionPool.html) pattern)
- Polymorphic `verify_bind` on both `LDAPConnectionPool` and `LDAPConnectionBuilder` — no isinstance dispatch

### Configuration

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `LDAP_CONNECTION_POOLING` | bool | `true` | Kill switch — set `false` to fall back to per-request connections |
| `LDAP_POOL_SIZE` | int | `10` | Max pooled connections per worker process |
| `LDAP_POOL_MAX_WAIT` | float | `5.0` | Seconds to wait before creating overflow connection |
| `LDAP_POOL_CONNECTION_LIFETIME` | int | `300` | Max connection age before rotation |

### Benchmark Results (10 concurrent users, 30s, local dev with 389 DS)

| Metric | pool + bind-revert | no pool |
|---|---|---|
| LDAP connections created | **7** | 178 |
| Throughput (req/s) | 2.6 | 2.51 |
| Latency p50 (ms) | 3728 | 3899 |

The key metric is **96% fewer LDAP connections created** — in production with TLS over a network, each saved connection avoids a full TCP handshake + TLS negotiation + SASL bind.

### Security Invariants

- **User credentials never persist in the pool** — bind-and-revert uses the password once, then immediately rebinds as admin
- **If admin rebind fails, connection is discarded** — never returned to pool in wrong identity
- **Anonymous bind rejected before pool** — empty password guard fires first
- **Pool holds only admin credentials** — constructed with `LDAP_ADMIN_DN` / `LDAP_ADMIN_PASSWD`
- **Socket cleanup on connection creation failure** — no FD leak when bind fails

## Test plan

- [x] 69 unit tests pass (`test/test_ldap.py`) including pool mechanics, edge cases, bind-and-revert
- [x] Existing `TestLDAP` suite runs against pooled path by default (pool is default-on)
- [x] Generator close test verifies leak fix
- [x] Bind-and-revert identity restoration test proves admin identity is restored after user verification
- [x] Edge case tests: pool exhaustion/overflow, lifetime rotation, health check failure, admin rebind failure, connection error propagation
- [x] Kill switch test confirms fallback to `LDAPConnectionBuilder`
- [x] Manual validation via local dev (LDAP login, burst test, pool rotation logs confirmed)
- [x] `make types-test` passes (pre-existing unrelated `rsa` stub error only)
- [ ] CI: existing Playwright `@auth:LDAP` tests cover login/team-sync paths through pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)