### PR TITLE
PROJQUAY-11661: gc: Optimize deletion queries

### DIFF
--- a/data/model/gc.py
+++ b/data/model/gc.py
@@ -186,6 +186,21 @@ def _purge_repository_contents(repo):
     """
     logger.debug("Purging repository %s", repo)
 
+    # We need to break manifest child-parent relationship here. Child images contain ids that are lower than
+    # their parents. If only child images are picked up during chunking, they will not be able to be deleted
+    # because their parent's entry in ManifestChild table will continue to exist. This will cause an endless
+    # loop of constantly enqueueing the same manifests over and over.
+    # The operation is safe because the repository is already marked for deletion and cannot be modified in
+    # any way.
+    ManifestChild.delete().where(ManifestChild.repository == repo).execute()
+
+    # We also delete all UploadedBlob references for the deleted repository at once. This stops potential leaks
+    # later on and also speeds up the GC process becuase we're doing one DELETE at a time instead of doing it
+    # for each individual blob. However, we still have the same _is_blob_orphaned check so this change has no impact
+    # on preserving shared blobs.
+    # The operation is safe because we're only deleting entries related to the deleted repository.
+    UploadedBlob.delete().where(UploadedBlob.repository == repo).execute()
+
     # Purge via all the tags.
     while True:
         found = False

--- a/data/model/gc.py
+++ b/data/model/gc.py
@@ -293,13 +293,31 @@ def garbage_collect_repo(repo):
 
 def _run_garbage_collection(context):
     """
-    Runs the garbage collection loop, deleting manifests, images, labels and blobs in an iterative
-    fashion.
+    Runs the garbage collection loop. Unreferenced Manifests, images and blobs are processed in an iterative
+    fashion, while manifest labels are deleted in bulk to speed up the gc process.
     """
+
     has_changes = True
 
     while has_changes:
         has_changes = False
+
+        manifest_id_list = list(context.manifest_ids)
+        if manifest_id_list:
+            for manifest_blob in ManifestBlob.select().where(
+                ManifestBlob.manifest << manifest_id_list
+            ):
+                context.add_blob_id(manifest_blob.blob_id)
+            # Add child manifests to be GCed.
+            for connector in ManifestChild.select().where(
+                ManifestChild.manifest << manifest_id_list
+            ):
+                context.add_manifest_id(connector.child_manifest_id)
+            # Add the labels to be GCed.
+            for manifest_label in ManifestLabel.select().where(
+                ManifestLabel.manifest << manifest_id_list
+            ):
+                context.add_label_id(manifest_label.label_id)
 
         # GC all manifests encountered.
         for manifest_id in list(context.manifest_ids):
@@ -307,9 +325,8 @@ def _run_garbage_collection(context):
                 has_changes = True
 
         # GC all labels encountered.
-        for label_id in list(context.label_ids):
-            if _garbage_collect_label(label_id, context):
-                has_changes = True
+        if _bulk_garbage_collect_labels(context):
+            has_changes = True
 
         # GC any blobs encountered.
         if context.blob_ids:
@@ -437,18 +454,6 @@ def _garbage_collect_manifest(manifest_id, context):
     # Make sure the manifest isn't referenced.
     if _check_manifest_used(manifest_id):
         return False
-
-    # Add the manifest's blobs to the context to be GCed.
-    for manifest_blob in ManifestBlob.select().where(ManifestBlob.manifest == manifest_id):
-        context.add_blob_id(manifest_blob.blob_id)
-
-    # Add child manifests to be GCed.
-    for connector in ManifestChild.select().where(ManifestChild.manifest == manifest_id):
-        context.add_manifest_id(connector.child_manifest_id)
-
-    # Add the labels to be GCed.
-    for manifest_label in ManifestLabel.select().where(ManifestLabel.manifest == manifest_id):
-        context.add_label_id(manifest_label.label_id)
 
     # Delete the manifest.
     with db_transaction():
@@ -579,3 +584,34 @@ def _garbage_collect_label(label_id, context):
         gc_table_rows_deleted.labels(table="Label").inc(result)
 
     return result
+
+
+def _bulk_garbage_collect_labels(context):
+    """
+    Bulk deletes all labels which are part of a specific manifest.
+    """
+    label_ids = set(context.label_ids)
+    if not label_ids:
+        return False
+
+    deleted = 0
+
+    with db_transaction():
+        referenced = set(
+            ManifestLabel.select(ManifestLabel.label)
+            .where(ManifestLabel.label << label_ids)
+            .tuples()
+        )
+        referenced_ids = {r[0] for r in referenced}
+        unreferenced_ids = label_ids - referenced_ids
+
+        if not unreferenced_ids:
+            return False
+
+        deleted = Label.delete().where(Label.id << list(unreferenced_ids)).execute()
+
+    for label_id in unreferenced_ids:
+        context.mark_label_id_removed(label_id)
+    gc_table_rows_deleted.labels(table="Label").inc(deleted)
+
+    return deleted > 0

--- a/data/model/gc.py
+++ b/data/model/gc.py
@@ -293,31 +293,35 @@ def garbage_collect_repo(repo):
 
 def _run_garbage_collection(context):
     """
-    Runs the garbage collection loop. Unreferenced Manifests, images and blobs are processed in an iterative
-    fashion, while manifest labels are deleted in bulk to speed up the gc process.
+    Runs garbage collection in two phases: first discovers all manifests, blobs and labels
+    in the manifest tree via BFS, then deletes them iteratively. Labels are deleted in bulk.
     """
 
+    # Phase 1: Walk the manifest tree level-by-level, collecting blobs and labels.
+    discovered = set()
+    to_discover = set(context.manifest_ids)
+
+    while to_discover:
+        batch = list(to_discover)
+        discovered.update(to_discover)
+
+        for manifest_blob in ManifestBlob.select().where(ManifestBlob.manifest << batch):
+            context.add_blob_id(manifest_blob.blob_id)
+
+        for manifest_label in ManifestLabel.select().where(ManifestLabel.manifest << batch):
+            context.add_label_id(manifest_label.label_id)
+
+        to_discover = set()
+        for connector in ManifestChild.select().where(ManifestChild.manifest << batch):
+            if connector.child_manifest_id not in discovered:
+                context.add_manifest_id(connector.child_manifest_id)
+                to_discover.add(connector.child_manifest_id)
+
+    # Phase 2: Delete manifests, labels and blobs.
     has_changes = True
 
     while has_changes:
         has_changes = False
-
-        manifest_id_list = list(context.manifest_ids)
-        if manifest_id_list:
-            for manifest_blob in ManifestBlob.select().where(
-                ManifestBlob.manifest << manifest_id_list
-            ):
-                context.add_blob_id(manifest_blob.blob_id)
-            # Add child manifests to be GCed.
-            for connector in ManifestChild.select().where(
-                ManifestChild.manifest << manifest_id_list
-            ):
-                context.add_manifest_id(connector.child_manifest_id)
-            # Add the labels to be GCed.
-            for manifest_label in ManifestLabel.select().where(
-                ManifestLabel.manifest << manifest_id_list
-            ):
-                context.add_label_id(manifest_label.label_id)
 
         # GC all manifests encountered.
         for manifest_id in list(context.manifest_ids):
@@ -553,37 +557,6 @@ def _garbage_collect_manifest(manifest_id, context):
     gc_table_rows_deleted.labels(table="Manifest").inc()
 
     return True
-
-
-def _check_label_used(label_id):
-    assert label_id is not None
-
-    with db_transaction():
-        # Check if the label is referenced by another manifest or tag manifest.
-        try:
-            ManifestLabel.select().where(ManifestLabel.label == label_id).get()
-            return True
-        except ManifestLabel.DoesNotExist:
-            pass
-
-    return False
-
-
-def _garbage_collect_label(label_id, context):
-    assert label_id is not None
-
-    # We can now delete the label.
-    with db_transaction():
-        if _check_label_used(label_id):
-            return False
-
-        result = Label.delete().where(Label.id == label_id).execute() == 1
-
-    if result:
-        context.mark_label_id_removed(label_id)
-        gc_table_rows_deleted.labels(table="Label").inc(result)
-
-    return result
 
 
 def _bulk_garbage_collect_labels(context):

--- a/data/model/gc.py
+++ b/data/model/gc.py
@@ -194,13 +194,6 @@ def _purge_repository_contents(repo):
     # any way.
     ManifestChild.delete().where(ManifestChild.repository == repo).execute()
 
-    # We also delete all UploadedBlob references for the deleted repository at once. This stops potential leaks
-    # later on and also speeds up the GC process becuase we're doing one DELETE at a time instead of doing it
-    # for each individual blob. However, we still have the same _is_blob_orphaned check so this change has no impact
-    # on preserving shared blobs.
-    # The operation is safe because we're only deleting entries related to the deleted repository.
-    UploadedBlob.delete().where(UploadedBlob.repository == repo).execute()
-
     # Purge via all the tags.
     while True:
         found = False
@@ -576,7 +569,7 @@ def _garbage_collect_manifest(manifest_id, context):
 
 def _bulk_garbage_collect_labels(context):
     """
-    Bulk deletes all labels which are part of a specific manifest.
+    Bulk deletes all labels which are part of a specific context.
     """
     label_ids = set(context.label_ids)
     if not label_ids:

--- a/data/model/test/test_gc.py
+++ b/data/model/test/test_gc.py
@@ -21,6 +21,7 @@ from data.database import (
     Label,
     Manifest,
     ManifestBlob,
+    ManifestChild,
     ManifestLabel,
     ManifestPullStatistics,
     MediaType,
@@ -38,6 +39,7 @@ from digest.digest_tools import sha256_digest
 from endpoints.api.repositorynotification_models_pre_oci import pre_oci_model
 from image.docker.schema1 import DockerSchema1ManifestBuilder
 from image.oci.config import OCIConfig
+from image.oci.index import OCIIndexBuilder
 from image.oci.manifest import OCIManifestBuilder
 from image.shared.schemas import parse_manifest_from_bytes
 from test.fixtures import *
@@ -585,7 +587,7 @@ def test_purge_repository_storage_blob(default_tag_policy, initialized_db):
         expected_blobs_removed_from_storage = set()
         preferred = storage.preferred_locations[0]
 
-        # Check that existing uploadedblobs has an object in storage
+        # Check that existing uploadedblobs has an object in storage and collect ids
         for repo in database.Repository.select().order_by(database.Repository.id):
             for uploadedblob in UploadedBlob.select().where(UploadedBlob.repository == repo):
                 assert storage.exists(
@@ -608,21 +610,21 @@ def test_purge_repository_storage_blob(default_tag_policy, initialized_db):
                 has_dependent_uploadedblobs = (
                     UploadedBlob.select()
                     .where(
-                        UploadedBlob == uploadedblob,
+                        UploadedBlob.blob == uploadedblob.blob,
                         UploadedBlob.repository != repo,
                     )
                     .count()
                 )
 
-                if not has_depedent_manifestblob and not has_dependent_uploadedblobs:
-                    expected_blobs_removed_from_storage.add(uploadedblob.blob)
+                # if not has_depedent_manifestblob and not has_dependent_uploadedblobs:
+                #    expected_blobs_removed_from_storage.add(uploadedblob.blob)
 
             assert model.gc.purge_repository(repo, force=True)
 
-        for removed_blob_from_storage in expected_blobs_removed_from_storage:
-            assert not storage.exists(
-                {preferred}, storage.blob_path(removed_blob_from_storage.content_checksum)
-            )
+            for removed_blob_from_storage in expected_blobs_removed_from_storage:
+                assert not storage.exists(
+                    {preferred}, storage.blob_path(removed_blob_from_storage.content_checksum)
+                )
 
 
 def test_delete_manifests_with_subject(initialized_db):
@@ -1562,3 +1564,99 @@ def test_get_or_create_blob_with_lock_fallback_creates_new(default_tag_policy, i
         assert ImageStorage.select().where(ImageStorage.content_checksum == blob_digest).exists()
     finally:
         storage_model.GlobalLock = original_lock
+
+
+def test_gc_manifest_list_with_children(default_tag_policy, initialized_db):
+    """
+    Tests that purging of a repository with a manifest list correctly removes all
+    manifests and their children.
+    """
+    repo = model.repository.create_repository("devtable", "newrepo", None)
+
+    # create three child manifests
+    _, build1 = create_manifest_for_testing(repo, differentiation_field="amd64")
+    _, build2 = create_manifest_for_testing(repo, differentiation_field="ppc64le")
+    _, build3 = create_manifest_for_testing(repo, differentiation_field="arm64")
+
+    # create index
+    index_builder = OCIIndexBuilder()
+    index_builder.add_manifest(build1, architecture="amd64", os="Linux")
+    index_builder.add_manifest(build2, architecture="ppc64le", os="Linux")
+    index_builder.add_manifest(build3, architecture="arm64", os="Linux")
+    manifest_list = index_builder.build()
+
+    created = model.oci.manifest.get_or_create_manifest(repo, manifest_list, storage)
+    assert created
+
+    # tag the manifest list
+    model.oci.tag.retarget_tag("latest", created.manifest)
+
+    # verify manifest child rows exist
+    assert ManifestChild.select().where(ManifestChild.repository == repo).count() == 3
+
+    # purge repo
+    assert model.gc.purge_repository(repo, force=True)
+
+    # verify eveything's cleaned up
+    assert Manifest.select().where(Manifest.repository == repo).count() == 0
+    assert ManifestChild.select().where(ManifestChild.repository == repo).count() == 0
+    assert ManifestBlob.select().where(ManifestBlob.repository == repo).count() == 0
+
+
+def test_gc_manifest_with_labels(default_tag_policy, initialized_db):
+    """
+    Tests that purging of a repository correctly GCs all labels associated with the manifests.
+    """
+    repo = model.repository.create_repository("devtable", "newrepo", None)
+    assert repo
+    manifest, _ = create_manifest_for_testing(repo, differentiation_field="labeled")
+
+    # add labels to the manifest
+    model.oci.label.create_manifest_label(
+        manifest.id, "maintainer", "devtable@devtable.com", "manifest"
+    )
+    model.oci.label.create_manifest_label(manifest.id, "tester", "test@devtable.com", "manifest")
+    model.oci.label.create_manifest_label(manifest.id, "version", "0.0.1", "manifest")
+
+    assert ManifestLabel.select().where(ManifestLabel.repository == repo).count() == 3
+    pre_gc_label_count = Label.select().count()
+
+    # Purge repo
+    assert model.gc.purge_repository(repo, force=True)
+
+    assert Manifest.select().where(Manifest.repository == repo).count() == 0
+    assert ManifestLabel.select().where(ManifestLabel.repository == repo).count() == 0
+    assert Label.select().count() < pre_gc_label_count
+
+
+def test_purge_manifest_list_no_infinite_loop(default_tag_policy, initialized_db):
+    """
+    Tests that purging a repository with manifest lists does not end in an infinite lopp when
+    child manifests have lower ID than their parent.
+    """
+    repo = model.repository.create_repository("devtable", "newrepo", None)
+    assert repo
+
+    built_manifests = []
+    child_manifests = []
+    for arch in ["amd64", "arm64", "ppc64le", "s390x"]:
+        child, build = create_manifest_for_testing(repo, differentiation_field=arch)
+        built_manifests.append(build)
+        child_manifests.append(child)
+
+    index_builder = OCIIndexBuilder()
+    for i, build in enumerate(built_manifests):
+        index_builder.add_manifest(build, architecture=f"arch{i}", os="Linux")
+
+    manifest_list = index_builder.build()
+
+    created = model.oci.manifest.get_or_create_manifest(repo, manifest_list, storage)
+    assert created
+    model.oci.tag.retarget_tag("latest", created.manifest)
+
+    # check if children have lower IDs than the parent
+    for child in child_manifests:
+        assert child.id < created.manifest.id
+
+    assert model.gc.purge_repository(repo, force=True)
+    assert Manifest.select().where(Manifest.repository == repo).count() == 0

--- a/data/model/test/test_gc.py
+++ b/data/model/test/test_gc.py
@@ -1660,3 +1660,82 @@ def test_purge_manifest_list_no_infinite_loop(default_tag_policy, initialized_db
 
     assert model.gc.purge_repository(repo, force=True)
     assert Manifest.select().where(Manifest.repository == repo).count() == 0
+
+
+def test_gc_shared_label_survives_partial_gc(default_tag_policy, initialized_db):
+    """
+    Tests that labels shared across multiple images survive the GC process and are not
+    deleted during garbage collection.
+    """
+    repo = model.repository.create_repository("devtable", "newrepo", None)
+
+    manifest1, _ = create_manifest_for_testing(repo, differentiation_field="shared1")
+    manifest2, _ = create_manifest_for_testing(repo, differentiation_field="shared1")
+
+    model.oci.tag.retarget_tag("tag1", manifest1)
+    model.oci.tag.retarget_tag("tag2", manifest1)
+
+    # add same label to both manifests
+    label1 = model.oci.label.create_manifest_label(
+        manifest1.id, "shared-key", "shared-value", "manifest"
+    )
+    label2 = model.oci.label.create_manifest_label(
+        manifest2.id, "shared-key", "shared-value", "manifest"
+    )
+
+    # verify that label exists
+    assert Label.select().where(Label.id == label1.id).exists()
+    assert Label.select().where(Label.id == label2.id).exists()
+
+    # delete tag1, GC manifest1
+    with assert_gc_integrity(expect_storage_removed=True):
+        delete_tag(repo, "tag1", expect_gc=True)
+
+    # verify that label2 survived
+    assert Label.select().where(Label.id == label2.id).exists()
+
+
+def test_gc_manifest_list_partial_gc_child_in_use(default_tag_policy, initialized_db):
+    """
+    Tests that child images still in use by other manifests are not deleted when one of the
+    parent's manifest list gets GCed.
+    """
+    repo = model.repository.create_repository("devtable", "newrepo", None)
+
+    # create child manifests
+    child_shared, build_shared = create_manifest_for_testing(repo, differentiation_field="shared")
+    child_only1, build_only1 = create_manifest_for_testing(repo, differentiation_field="only1")
+    child_only2, build_only2 = create_manifest_for_testing(repo, differentiation_field="only2")
+
+    # create two different manifest lists that share the child image
+    index_builder1 = OCIIndexBuilder()
+    index_builder1.add_manifest(build_shared, architecture="amd64", os="linux")
+    index_builder1.add_manifest(build_only1, architecture="arm64", os="linux")
+    list1 = index_builder1.build()
+
+    index_builder2 = OCIIndexBuilder()
+    index_builder2.add_manifest(build_shared, architecture="amd64", os="linux")
+    index_builder2.add_manifest(build_only2, architecture="s390x", os="linux")
+    list2 = index_builder2.build()
+
+    created1 = model.oci.manifest.get_or_create_manifest(repo, list1, storage)
+    created2 = model.oci.manifest.get_or_create_manifest(repo, list2, storage)
+    assert created1
+    assert created2
+
+    model.oci.tag.retarget_tag("tag1", created1.manifest)
+    model.oci.tag.retarget_tag("tag2", created2.manifest)
+
+    # delete tag 1, GC manifest 1
+    now = datetime.utcnow()
+    with freeze_time(now + timedelta(minutes=5)):
+        delete_tag(repo, "tag1", perform_gc=True, expect_gc=True)
+
+    # shared child must survive
+    assert Manifest.select().where(Manifest.id == child_shared.id).exists()
+
+    # child_only1 should be deleted
+    assert not Manifest.select().where(Manifest.id == child_only1.id).exists()
+
+    # child_only2 must survive
+    assert Manifest.select().where(Manifest.id == child_only2.id).exists()

--- a/data/model/test/test_gc.py
+++ b/data/model/test/test_gc.py
@@ -587,7 +587,7 @@ def test_purge_repository_storage_blob(default_tag_policy, initialized_db):
         expected_blobs_removed_from_storage = set()
         preferred = storage.preferred_locations[0]
 
-        # Check that existing uploadedblobs has an object in storage and collect ids
+        # Check that existing uploadedblobs has an object in storage
         for repo in database.Repository.select().order_by(database.Repository.id):
             for uploadedblob in UploadedBlob.select().where(UploadedBlob.repository == repo):
                 assert storage.exists(
@@ -616,15 +616,15 @@ def test_purge_repository_storage_blob(default_tag_policy, initialized_db):
                     .count()
                 )
 
-                # if not has_depedent_manifestblob and not has_dependent_uploadedblobs:
-                #    expected_blobs_removed_from_storage.add(uploadedblob.blob)
+                if not has_depedent_manifestblob and not has_dependent_uploadedblobs:
+                    expected_blobs_removed_from_storage.add(uploadedblob.blob)
 
             assert model.gc.purge_repository(repo, force=True)
 
-            for removed_blob_from_storage in expected_blobs_removed_from_storage:
-                assert not storage.exists(
-                    {preferred}, storage.blob_path(removed_blob_from_storage.content_checksum)
-                )
+        for removed_blob_from_storage in expected_blobs_removed_from_storage:
+            assert not storage.exists(
+                {preferred}, storage.blob_path(removed_blob_from_storage.content_checksum)
+            )
 
 
 def test_delete_manifests_with_subject(initialized_db):

--- a/data/model/test/test_gc.py
+++ b/data/model/test/test_gc.py
@@ -1631,7 +1631,7 @@ def test_gc_manifest_with_labels(default_tag_policy, initialized_db):
 
 def test_purge_manifest_list_no_infinite_loop(default_tag_policy, initialized_db):
     """
-    Tests that purging a repository with manifest lists does not end in an infinite lopp when
+    Tests that purging a repository with manifest lists does not end in an infinite loop when
     child manifests have lower ID than their parent.
     """
     repo = model.repository.create_repository("devtable", "newrepo", None)
@@ -1639,14 +1639,34 @@ def test_purge_manifest_list_no_infinite_loop(default_tag_policy, initialized_db
 
     built_manifests = []
     child_manifests = []
-    for arch in ["amd64", "arm64", "ppc64le", "s390x"]:
+
+    # create a massive manifest list that contains 15 child image
+    # Quay's batching process uses up to 10 manifests in a batch
+    test_architectures = [
+        "amd64",
+        "386",
+        "arm64",
+        "arm",
+        "ppc64le",
+        "ppc64",
+        "s390x",
+        "mips64le",
+        "mips64",
+        "mipsle",
+        "mips",
+        "riscv64",
+        "loong64",
+        "sparc64",
+        "wasm",
+    ]
+    for arch in test_architectures:
         child, build = create_manifest_for_testing(repo, differentiation_field=arch)
         built_manifests.append(build)
         child_manifests.append(child)
 
     index_builder = OCIIndexBuilder()
     for i, build in enumerate(built_manifests):
-        index_builder.add_manifest(build, architecture=f"arch{i}", os="Linux")
+        index_builder.add_manifest(build, architecture=test_architectures[i], os="Linux")
 
     manifest_list = index_builder.build()
 

--- a/data/model/test/test_gc.py
+++ b/data/model/test/test_gc.py
@@ -1670,29 +1670,30 @@ def test_gc_shared_label_survives_partial_gc(default_tag_policy, initialized_db)
     repo = model.repository.create_repository("devtable", "newrepo", None)
 
     manifest1, _ = create_manifest_for_testing(repo, differentiation_field="shared1")
-    manifest2, _ = create_manifest_for_testing(repo, differentiation_field="shared1")
+    manifest2, _ = create_manifest_for_testing(repo, differentiation_field="shared2")
 
     model.oci.tag.retarget_tag("tag1", manifest1)
-    model.oci.tag.retarget_tag("tag2", manifest1)
+    model.oci.tag.retarget_tag("tag2", manifest2)
 
     # add same label to both manifests
-    label1 = model.oci.label.create_manifest_label(
-        manifest1.id, "shared-key", "shared-value", "manifest"
+    label = Label.create(
+        key="shared-key",
+        value="shared-value",
+        source_type=Label.source_type.get_id("manifest"),
+        media_type=Label.media_type.get_id("text/plain"),
     )
-    label2 = model.oci.label.create_manifest_label(
-        manifest2.id, "shared-key", "shared-value", "manifest"
-    )
-
-    # verify that label exists
-    assert Label.select().where(Label.id == label1.id).exists()
-    assert Label.select().where(Label.id == label2.id).exists()
+    ManifestLabel.create(manifest=manifest1.id, label=label, repository=repo)
+    ManifestLabel.create(manifest=manifest2.id, label=label, repository=repo)
 
     # delete tag1, GC manifest1
-    with assert_gc_integrity(expect_storage_removed=True):
+    now = datetime.utcnow()
+    with freeze_time(now + timedelta(minutes=5)):
         delete_tag(repo, "tag1", expect_gc=True)
 
-    # verify that label2 survived
-    assert Label.select().where(Label.id == label2.id).exists()
+    # verify that label survived
+    assert Label.select().where(Label.id == label.id).exists()
+    assert not ManifestLabel.select().where(ManifestLabel.manifest == manifest1.id).exists()
+    assert ManifestLabel.select().where(ManifestLabel.manifest == manifest2.id).exists()
 
 
 def test_gc_manifest_list_partial_gc_child_in_use(default_tag_policy, initialized_db):


### PR DESCRIPTION
Previously, we were running deletion queries iteratively on manifests, blobs, child manifests and labels. While this is fine for manifests and blobs, iterative deletion of labels doesn't make much sense. It creates one query per each label and for a lot of labels, this takes a while to execute. 

Changing to bulk deletion shrinks the total number of queries down to 2 instead of the previous `2*n` + `n` transactions speeding up the GC process. Additionally, we no longer collect context per provided manifest, we collect it for all manifests at once, further shrinking the amount of queries GC needs to do.

Finally, so far, there was a chance for the GC process to lock itself in an infinite loop for repositories that have a lot of multiarch images caused by the way batching works. In Quay's case, we collect up to 10 manifest rows from the `Manifest` table to delete. If the only thing we collected are child images without their parent, these would be skipped because of the link in `ManifestChild` table between children and parents; parents entry would still remain. But Quay would then enqueue the same batch of 10 manifests for GC and would enter into an infinite loop. To stop that, we explicitly remove all links between parents and their children from the `ManifestChild` table early during GC process. This is a safe operation because we only delete links for the repo that is being deleted. This allows these manifests to be deleted successfully.

Co-authored-by: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)