### PR TITLE
QUAYIO-1805: feat(secscan): lock-free V2 security scanner indexing job

### DIFF
--- a/config.py
+++ b/config.py
@@ -543,6 +543,11 @@ class DefaultConfig(ImmutableConfig):
     # Minimum number of seconds before re-indexing a manifest with the security scanner.
     SECURITY_SCANNER_V4_REINDEX_THRESHOLD = 300
 
+    # Security scanner V2 worker (lock-free, uses FOR UPDATE SKIP LOCKED)
+    FEATURE_SECURITY_SCANNER_V2 = False
+    SECURITY_SCANNER_V2_INDEXING_INTERVAL = 30
+    SECURITY_SCANNER_V2_BATCH_SIZE = 50
+
     # Maximum layer size allowed for indexing.
     SECURITY_SCANNER_V4_INDEX_MAX_LAYER_SIZE = None
 

--- a/data/database.py
+++ b/data/database.py
@@ -2181,6 +2181,7 @@ class IndexStatus(IntEnum):
     MANIFEST_LAYER_TOO_LARGE = -3
     MANIFEST_UNSUPPORTED = -2
     FAILED = -1
+    PENDING = 0
     IN_PROGRESS = 1
     COMPLETED = 2
 

--- a/data/model/autoprune.py
+++ b/data/model/autoprune.py
@@ -516,7 +516,7 @@ def create_autoprune_task(namespace_id):
 def update_autoprune_task(task, task_status):
     try:
         task.status = task_status
-        task.save()
+        task.save(only=[AutoPruneTaskStatus.status])
     except AutoPruneTaskStatus.DoesNotExist:
         return None
     except Exception as err:
@@ -557,7 +557,7 @@ def fetch_autoprune_task(task_run_interval_ms=60 * 60 * 1000):
 
         task.last_ran_ms = get_epoch_timestamp_ms()
         task.status = "running"
-        task.save()
+        task.save(only=[AutoPruneTaskStatus.last_ran_ms, AutoPruneTaskStatus.status])
 
         return task
 

--- a/data/secscan_model/__init__.py
+++ b/data/secscan_model/__init__.py
@@ -11,22 +11,38 @@ from data.secscan_model.interface import (
 from data.secscan_model.secscan_v4_model import NoopV4SecurityScanner
 from data.secscan_model.secscan_v4_model import ScanToken as V4ScanToken
 from data.secscan_model.secscan_v4_model import V4SecurityScanner
+from data.secscan_model.secscan_v4_model_v2 import V4SecurityScannerV2
 
 logger = logging.getLogger(__name__)
 
 
 class SecurityScannerModelProxy(SecurityScannerInterface):
     def configure(self, app, instance_keys, storage):
+        self._model_v2 = None
+
         try:
             self._model = V4SecurityScanner(app, instance_keys, storage)
         except InvalidConfigurationException:
             self._model = NoopV4SecurityScanner()
 
+        if app.config.get("FEATURE_SECURITY_SCANNER_V2", False):
+            self._model_v2 = V4SecurityScannerV2(app, instance_keys, storage)
+
         logger.info("===============================")
         logger.info("Using split secscan model: `%s`", [self._model])
+        if self._model_v2:
+            logger.info("Using V2 secscan indexer: `%s`", self._model_v2)
         logger.info("===============================")
 
         return self
+
+    @property
+    def v2_enabled(self):
+        return self._model_v2 is not None
+
+    def perform_indexing_v2(self, batch_size):
+        if self._model_v2 is not None:
+            self._model_v2.perform_indexing(batch_size)
 
     def perform_indexing(self, next_token=None, batch_size=None):
         if next_token is not None:

--- a/data/secscan_model/__init__.py
+++ b/data/secscan_model/__init__.py
@@ -42,7 +42,7 @@ class SecurityScannerModelProxy(SecurityScannerInterface):
 
     def perform_indexing_v2(self, batch_size):
         if self._model_v2 is not None:
-            self._model_v2.perform_indexing(batch_size)
+            self._model_v2.perform_indexing(batch_size=batch_size)
 
     def perform_indexing(self, next_token=None, batch_size=None):
         if next_token is not None:
@@ -64,13 +64,6 @@ class SecurityScannerModelProxy(SecurityScannerInterface):
             return info
 
         return SecurityInformationLookupResult.with_status(ScanLookupStatus.NOT_YET_INDEXED)
-
-    def register_model_cleanup_callbacks(self, data_model_config):
-        return self._model.register_model_cleanup_callbacks(data_model_config)
-
-    @property
-    def legacy_api_handler(self):
-        raise NotImplementedError
 
     def lookup_notification_page(self, notification_id, page_index=None):
         return self._model.lookup_notification_page(notification_id, page_index)

--- a/data/secscan_model/interface.py
+++ b/data/secscan_model/interface.py
@@ -1,6 +1,5 @@
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 
-from deprecation import deprecated
 from six import add_metaclass
 
 
@@ -11,14 +10,7 @@ class InvalidConfigurationException(Exception):
 
 
 @add_metaclass(ABCMeta)
-class SecurityScannerInterface(object):
-    """
-    Interface for code to work with the security scan data model.
-
-    This model encapsulates all access when speaking to an external security scanner, as well as any
-    data tracking in the database.
-    """
-
+class SecurityScannerReadInterface(object):
     @abstractmethod
     def load_security_information(
         self, manifest_or_legacy_image, include_vulnerabilities=False, model_cache=None
@@ -26,42 +18,6 @@ class SecurityScannerInterface(object):
         """
         Loads the security information for the given manifest or legacy image, returning a
         SecurityInformationLookupResult structure.
-
-        The manifest_or_legacy_image must be a Manifest or LegacyImage datatype from the
-        registry_model.
-        """
-
-    @abstractmethod
-    def perform_indexing(self, start_token=None, batch_size=None):
-        """
-        Performs indexing of the next set of unindexed manifests/images.
-
-        If start_token is given, the indexing should resume from that point. Returns a new start
-        index for the next iteration of indexing. The tokens returned and given are assumed to be
-        opaque outside of this implementation and should not be relied upon by the caller to conform
-        to any particular format.
-        """
-
-    @abstractmethod
-    def perform_indexing_recent_manifests(self, batch_size=None):
-        """
-        Performs indexing of a recent set of unindexed manifests/images.
-        """
-
-    @abstractmethod
-    def register_model_cleanup_callbacks(self, data_model_config):
-        """
-        Registers any cleanup callbacks with the data model.
-
-        Typically, a callback is registered to remove the manifest/image from the security indexer
-        if it has been GCed in the data model.
-        """
-
-    @abstractproperty
-    @deprecated(details="Only exposed for the legacy notification worker")
-    def legacy_api_handler(self):
-        """
-        Exposes the legacy security scan API for legacy workers that need it or None if none.
         """
 
     @abstractmethod
@@ -84,3 +40,33 @@ class SecurityScannerInterface(object):
         """
         Marks that a security notification from the scanner has been handled.
         """
+
+    @abstractmethod
+    def garbage_collect_manifest_report(self, manifest_digest):
+        """
+        Removes the manifest report from the security scanner when the manifest is GC'd.
+        """
+
+
+@add_metaclass(ABCMeta)
+class SecurityScannerIndexerInterface(object):
+    @abstractmethod
+    def perform_indexing(self, start_token=None, batch_size=None):
+        """
+        Performs indexing of the next set of unindexed manifests/images.
+
+        If start_token is given, the indexing should resume from that point. Returns a new start
+        index for the next iteration of indexing. The tokens returned and given are assumed to be
+        opaque outside of this implementation and should not be relied upon by the caller to conform
+        to any particular format.
+        """
+
+    @abstractmethod
+    def perform_indexing_recent_manifests(self, batch_size=None):
+        """
+        Performs indexing of a recent set of unindexed manifests/images.
+        """
+
+
+class SecurityScannerInterface(SecurityScannerReadInterface, SecurityScannerIndexerInterface):
+    pass

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -92,13 +92,6 @@ class NoopV4SecurityScanner(SecurityScannerInterface):
     def perform_indexing_recent_manifests(self, batch_size=None):
         return None
 
-    def register_model_cleanup_callbacks(self, data_model_config):
-        pass
-
-    @property
-    def legacy_api_handler(self):
-        raise NotImplementedError("Unsupported for this security scanner version")
-
     def lookup_notification_page(self, notification_id, page_index=None):
         return None
 
@@ -803,13 +796,6 @@ class V4SecurityScanner(SecurityScannerInterface):
                     Metadata={},
                 ),
             )
-
-    def register_model_cleanup_callbacks(self, data_model_config):
-        pass
-
-    @property
-    def legacy_api_handler(self):
-        raise NotImplementedError("Unsupported for this security scanner version")
 
     def garbage_collect_manifest_report(self, manifest_digest):
         def manifest_digest_exists():

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from datetime import datetime, timedelta
 from math import log10
 
-from peewee import JOIN, IntegrityError, fn
+from peewee import JOIN, IntegrityError, OperationalError, fn
 
 import features
 from data.cache import cache_key
@@ -597,9 +597,11 @@ class V4SecurityScanner(SecurityScannerInterface):
                         metadata_json={},
                     )
                 except IntegrityError:
-                    # Row already exists and is owned by another worker
                     logger.debug("Manifest %d already claimed by another worker", candidate.id)
                     abt.set()
+                    continue
+                except OperationalError:
+                    logger.debug("Manifest %d skipped due to lock conflict", candidate.id)
                     continue
 
             try:

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -179,15 +179,16 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
         now = datetime.utcnow()
         for candidate in candidates:
             try:
-                ManifestSecurityStatus.create(
-                    manifest=candidate.id,
-                    repository=candidate.repository_id,
-                    index_status=IndexStatus.IN_PROGRESS,
-                    indexer_hash="in_progress_v2",
-                    indexer_version=IndexerVersion.V4,
-                    last_indexed=now,
-                    metadata_json={},
-                )
+                with db_transaction():
+                    ManifestSecurityStatus.create(
+                        manifest=candidate.id,
+                        repository=candidate.repository_id,
+                        index_status=IndexStatus.IN_PROGRESS,
+                        indexer_hash="in_progress_v2",
+                        indexer_version=IndexerVersion.V4,
+                        last_indexed=now,
+                        metadata_json={},
+                    )
                 claimed.append(candidate)
                 if len(claimed) >= batch_size:
                     break

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -122,7 +122,8 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             query = (
                 ManifestSecurityStatus.select()
                 .where(
-                    (
+                    (ManifestSecurityStatus.index_status == IndexStatus.PENDING)
+                    | (
                         (ManifestSecurityStatus.index_status == IndexStatus.FAILED)
                         & (ManifestSecurityStatus.last_indexed < reindex_threshold)
                     )

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -1,0 +1,389 @@
+import logging
+import time
+import urllib
+from collections import namedtuple
+from datetime import datetime, timedelta
+
+from peewee import JOIN, IntegrityError, fn
+
+import features
+from data.database import (
+    IndexerVersion,
+    IndexStatus,
+    Manifest,
+    ManifestSecurityStatus,
+    db_for_update,
+    db_transaction,
+    get_epoch_timestamp_ms,
+)
+from data.registry_model import registry_model
+from data.registry_model.datatypes import Manifest as ManifestDataType
+from data.secscan_model.secscan_v4_model import IndexReportState, _has_container_layers
+from image.docker.schema1 import DOCKER_SCHEMA1_CONTENT_TYPES
+from util.metrics.prometheus import (
+    secscan_v2_cycle_duration,
+    secscan_v2_manifests_claimed,
+    secscan_v2_scan_duration,
+    secscan_v2_scan_result,
+)
+from util.secscan import PRIORITY_LEVELS
+from util.secscan.blob import BlobURLRetriever
+from util.secscan.v4.api import (
+    APIRequestFailure,
+    ClairSecurityScannerAPI,
+    InvalidContentSent,
+    LayerTooLargeException,
+)
+from util.secscan.validator import V4SecurityConfigValidator
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REINDEX_THRESHOLD = 86400
+STALE_IN_PROGRESS_HOURS = 6
+TAG_LIMIT = 100
+
+
+class V4SecurityScannerV2:
+    def __init__(self, app, instance_keys, storage):
+        self.app = app
+        self.storage = storage
+
+        if app.config.get("SECURITY_SCANNER_V4_ENDPOINT", None) is None:
+            raise ValueError("Missing SECURITY_SCANNER_V4_ENDPOINT configuration")
+
+        validator = V4SecurityConfigValidator(
+            app.config.get("FEATURE_SECURITY_SCANNER", False),
+            app.config.get("SECURITY_SCANNER_V4_ENDPOINT", None),
+        )
+
+        if not validator.valid():
+            raise ValueError("Failed to validate security scanner V4 configuration")
+
+        self._secscan_api = ClairSecurityScannerAPI(
+            endpoint=app.config.get("SECURITY_SCANNER_V4_ENDPOINT"),
+            client=app.config.get("HTTPCLIENT"),
+            blob_url_retriever=BlobURLRetriever(storage, instance_keys, app),
+            jwt_psk=app.config.get("SECURITY_SCANNER_V4_PSK", None),
+            max_layer_size=app.config.get("SECURITY_SCANNER_V4_INDEX_MAX_LAYER_SIZE", None),
+        )
+
+    def perform_indexing(self, batch_size):
+        cycle_start = time.monotonic()
+
+        try:
+            indexer_state = self._secscan_api.state()
+        except APIRequestFailure:
+            logger.exception("Failed to fetch indexer state from Clair")
+            return
+
+        indexer_hash = indexer_state.get("state", "")
+
+        reindex_threshold = datetime.utcnow() - timedelta(
+            seconds=self.app.config.get(
+                "SECURITY_SCANNER_V4_REINDEX_THRESHOLD", DEFAULT_REINDEX_THRESHOLD
+            )
+        )
+        stale_threshold = datetime.utcnow() - timedelta(hours=STALE_IN_PROGRESS_HOURS)
+
+        claimed_new = self._claim_unindexed_manifests(batch_size)
+
+        remaining = batch_size - len(claimed_new)
+        claimed_mss = []
+        if remaining > 0:
+            claimed_mss = self._find_and_claim_batch(
+                remaining, reindex_threshold, stale_threshold, indexer_hash
+            )
+
+        total_claimed = len(claimed_new) + len(claimed_mss)
+        secscan_v2_manifests_claimed.observe(total_claimed)
+
+        if total_claimed == 0:
+            logger.debug("No manifests to index this cycle")
+            return
+
+        for candidate in claimed_new:
+            self._index_manifest_by_id(candidate.id, candidate.repository_id)
+
+        for mss_row in claimed_mss:
+            self._index_manifest_by_id(mss_row.manifest_id, mss_row.repository_id)
+
+        cycle_duration = time.monotonic() - cycle_start
+        secscan_v2_cycle_duration.observe(cycle_duration)
+        logger.debug(
+            "Indexing cycle complete: %d manifests in %.1fs", total_claimed, cycle_duration
+        )
+
+    def _find_and_claim_batch(self, batch_size, reindex_threshold, stale_threshold, indexer_hash):
+        with db_transaction():
+            query = (
+                ManifestSecurityStatus.select()
+                .where(
+                    (
+                        (ManifestSecurityStatus.index_status == IndexStatus.FAILED)
+                        & (ManifestSecurityStatus.last_indexed < reindex_threshold)
+                    )
+                    | (
+                        (ManifestSecurityStatus.index_status == IndexStatus.IN_PROGRESS)
+                        & (ManifestSecurityStatus.last_indexed < stale_threshold)
+                    )
+                    | (
+                        (
+                            ManifestSecurityStatus.index_status.not_in(
+                                [
+                                    IndexStatus.MANIFEST_UNSUPPORTED,
+                                    IndexStatus.MANIFEST_LAYER_TOO_LARGE,
+                                    IndexStatus.IN_PROGRESS,
+                                ]
+                            )
+                        )
+                        & (ManifestSecurityStatus.indexer_hash != indexer_hash)
+                        & (ManifestSecurityStatus.last_indexed < reindex_threshold)
+                    )
+                )
+                .order_by(ManifestSecurityStatus.last_indexed.asc())
+                .limit(batch_size)
+            )
+
+            rows = list(db_for_update(query, skip_locked=True))
+
+            if not rows:
+                return []
+
+            row_ids = [r.id for r in rows]
+            now = datetime.utcnow()
+            ManifestSecurityStatus.update(
+                index_status=IndexStatus.IN_PROGRESS,
+                indexer_hash="in_progress_v2",
+                last_indexed=now,
+            ).where(ManifestSecurityStatus.id.in_(row_ids)).execute()
+
+            return rows
+
+    def _claim_unindexed_manifests(self, batch_size):
+        candidates = list(
+            Manifest.select(Manifest.id, Manifest.repository, can_use_read_replica=True)
+            .join(ManifestSecurityStatus, JOIN.LEFT_OUTER)
+            .where(ManifestSecurityStatus.id >> None)
+            .order_by(Manifest.id.desc())
+            .limit(batch_size * 2)
+        )
+
+        if not candidates:
+            return []
+
+        claimed = []
+        now = datetime.utcnow()
+        for candidate in candidates:
+            try:
+                ManifestSecurityStatus.create(
+                    manifest=candidate.id,
+                    repository=candidate.repository_id,
+                    index_status=IndexStatus.IN_PROGRESS,
+                    indexer_hash="in_progress_v2",
+                    indexer_version=IndexerVersion.V4,
+                    last_indexed=now,
+                    metadata_json={},
+                )
+                claimed.append(candidate)
+                if len(claimed) >= batch_size:
+                    break
+            except IntegrityError:
+                continue
+
+        return claimed
+
+    def _index_manifest_by_id(self, manifest_id, repository_id):
+        try:
+            candidate = Manifest.get(Manifest.id == manifest_id)
+        except Manifest.DoesNotExist:
+            logger.warning("Manifest %d no longer exists, skipping", manifest_id)
+            self._mark_failed(manifest_id, "manifest_deleted", {"error": "manifest not found"})
+            return
+
+        manifest = ManifestDataType.for_manifest(candidate, None)
+
+        if manifest.is_manifest_list:
+            self._mark_unsupported(manifest)
+            secscan_v2_scan_result.labels(result="unsupported").inc()
+            return
+
+        layers = registry_model.list_manifest_layers(manifest, self.storage, True)
+
+        if layers is None or len(layers) == 0:
+            logger.warning(
+                "Cannot index %s/%s@%s: manifest has no layers",
+                candidate.repository.namespace_user,
+                candidate.repository.name,
+                manifest.digest,
+            )
+            self._mark_unsupported(manifest)
+            secscan_v2_scan_result.labels(result="unsupported").inc()
+            return
+
+        if manifest.media_type not in DOCKER_SCHEMA1_CONTENT_TYPES:
+            if not _has_container_layers(layers):
+                logger.info(
+                    "Cannot index %s/%s@%s: not a container image",
+                    candidate.repository.namespace_user,
+                    candidate.repository.name,
+                    manifest.digest,
+                )
+                self._mark_unsupported(manifest)
+                secscan_v2_scan_result.labels(result="unsupported").inc()
+                return
+
+        scan_start = time.monotonic()
+        try:
+            (report, state) = self._secscan_api.index(manifest, layers)
+        except InvalidContentSent:
+            self._mark_unsupported(manifest)
+            secscan_v2_scan_result.labels(result="unsupported").inc()
+            logger.exception("Failed to index: invalid content sent")
+            return
+        except APIRequestFailure as ex:
+            self._mark_failed(candidate.id, "api_failure", {"error": str(ex)})
+            secscan_v2_scan_result.labels(result="api_error").inc()
+            logger.exception("Failed to index: security scanner API error")
+            return
+        except LayerTooLargeException:
+            self._mark_layer_too_large(manifest)
+            secscan_v2_scan_result.labels(result="layer_too_large").inc()
+            logger.exception("Failed to index: layer too large")
+            return
+
+        scan_duration = time.monotonic() - scan_start
+        secscan_v2_scan_duration.observe(scan_duration)
+
+        if report["state"] == IndexReportState.Index_Finished:
+            index_status = IndexStatus.COMPLETED
+            self._handle_scan_success(manifest, candidate)
+        elif report["state"] == IndexReportState.Index_Error:
+            index_status = IndexStatus.FAILED
+        else:
+            self._mark_failed(
+                candidate.id,
+                "unknown_state",
+                {"error": "unknown_state", "state": report.get("state")},
+            )
+            secscan_v2_scan_result.labels(result="failed").inc()
+            logger.warning(
+                "Unknown index state '%s' for manifest %d",
+                report.get("state"),
+                candidate.id,
+            )
+            return
+
+        with db_transaction():
+            ManifestSecurityStatus.delete().where(
+                ManifestSecurityStatus.manifest == candidate
+            ).execute()
+            ManifestSecurityStatus.create(
+                manifest=candidate,
+                repository=candidate.repository,
+                error_json=report["err"],
+                index_status=index_status,
+                indexer_hash=state,
+                indexer_version=IndexerVersion.V4,
+                metadata_json={},
+            )
+
+        result_label = "completed" if index_status == IndexStatus.COMPLETED else "failed"
+        secscan_v2_scan_result.labels(result=result_label).inc()
+
+    def _handle_scan_success(self, manifest, candidate):
+        if not manifest.has_been_scanned:
+            created_at = manifest.created_at
+            if created_at is not None:
+                dur_ms = get_epoch_timestamp_ms() - created_at
+                dur_sec = dur_ms / 1000
+                from util.metrics.prometheus import secscan_result_duration
+
+                secscan_result_duration.observe(dur_sec)
+
+            if features.SECURITY_SCANNER_NOTIFY_ON_NEW_INDEX:
+                self._send_vulnerability_notifications(manifest, candidate)
+
+    def _send_vulnerability_notifications(self, manifest, candidate):
+        try:
+            vulnerability_report = self._secscan_api.vulnerability_report(manifest.digest)
+        except APIRequestFailure:
+            return
+
+        if vulnerability_report is None:
+            return
+
+        found_vulnerabilities = vulnerability_report.get("vulnerabilities")
+        if found_vulnerabilities is None:
+            return
+
+        level = self.app.config.get("NOTIFICATION_MIN_SEVERITY_ON_NEW_INDEX") or "High"
+        lowest_severity = PRIORITY_LEVELS[level]
+
+        import notifications
+
+        for key in list(found_vulnerabilities):
+            vuln = found_vulnerabilities[key]
+            found_severity = PRIORITY_LEVELS.get(
+                vuln["normalized_severity"], PRIORITY_LEVELS["Unknown"]
+            )
+
+            if found_severity["score"] < lowest_severity["score"]:
+                continue
+
+            tag_names = list(registry_model.tag_names_for_manifest(manifest, TAG_LIMIT))
+            tags = list(tag_names) if tag_names else [manifest.digest]
+
+            event_data = {
+                "tags": tags,
+                "vulnerable_index_report_created": "true",
+                "vulnerability": {
+                    "id": vuln["id"],
+                    "description": vuln["description"],
+                    "link": vuln["links"],
+                    "priority": vuln["severity"],
+                    "has_fix": bool(vuln["fixed_in_version"]),
+                },
+            }
+
+            notifications.spawn_notification(manifest.repository, "vulnerability_found", event_data)
+
+    def _mark_unsupported(self, manifest):
+        with db_transaction():
+            ManifestSecurityStatus.delete().where(
+                ManifestSecurityStatus.manifest == manifest._db_id,
+                ManifestSecurityStatus.repository == manifest.repository._db_id,
+            ).execute()
+            ManifestSecurityStatus.create(
+                manifest=manifest._db_id,
+                repository=manifest.repository._db_id,
+                index_status=IndexStatus.MANIFEST_UNSUPPORTED,
+                indexer_hash="none",
+                indexer_version=IndexerVersion.V4,
+                metadata_json={},
+            )
+
+    def _mark_layer_too_large(self, manifest):
+        with db_transaction():
+            ManifestSecurityStatus.delete().where(
+                ManifestSecurityStatus.manifest == manifest._db_id,
+                ManifestSecurityStatus.repository == manifest.repository._db_id,
+            ).execute()
+            ManifestSecurityStatus.create(
+                manifest=manifest._db_id,
+                repository=manifest.repository._db_id,
+                index_status=IndexStatus.MANIFEST_LAYER_TOO_LARGE,
+                indexer_hash="none",
+                indexer_version=IndexerVersion.V4,
+                metadata_json={},
+            )
+
+    def _mark_failed(self, manifest_id, indexer_hash, error_json):
+        ManifestSecurityStatus.update(
+            index_status=IndexStatus.FAILED,
+            indexer_hash=indexer_hash,
+            error_json=error_json,
+            last_indexed=datetime.utcnow(),
+        ).where(
+            ManifestSecurityStatus.manifest == manifest_id,
+            ManifestSecurityStatus.index_status == IndexStatus.IN_PROGRESS,
+        ).execute()

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -18,6 +18,7 @@ from data.database import (
 )
 from data.registry_model import registry_model
 from data.registry_model.datatypes import Manifest as ManifestDataType
+from data.secscan_model.interface import SecurityScannerIndexerInterface
 from data.secscan_model.secscan_v4_model import IndexReportState, _has_container_layers
 from image.docker.schema1 import DOCKER_SCHEMA1_CONTENT_TYPES
 from util.metrics.prometheus import (
@@ -43,7 +44,7 @@ STALE_IN_PROGRESS_HOURS = 6
 TAG_LIMIT = 100
 
 
-class V4SecurityScannerV2:
+class V4SecurityScannerV2(SecurityScannerIndexerInterface):
     def __init__(self, app, instance_keys, storage):
         self.app = app
         self.storage = storage
@@ -67,7 +68,10 @@ class V4SecurityScannerV2:
             max_layer_size=app.config.get("SECURITY_SCANNER_V4_INDEX_MAX_LAYER_SIZE", None),
         )
 
-    def perform_indexing(self, batch_size):
+    def perform_indexing_recent_manifests(self, batch_size=None):
+        pass
+
+    def perform_indexing(self, start_token=None, batch_size=None):
         cycle_start = time.monotonic()
 
         try:

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -4,7 +4,7 @@ import urllib
 from collections import namedtuple
 from datetime import datetime, timedelta
 
-from peewee import JOIN, IntegrityError, fn
+from peewee import JOIN, IntegrityError, OperationalError, fn
 
 import features
 from data.database import (
@@ -194,6 +194,9 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
                 if len(claimed) >= batch_size:
                     break
             except IntegrityError:
+                continue
+            except OperationalError:
+                logger.debug("Manifest %d skipped due to lock conflict", candidate.id)
                 continue
 
         return claimed

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -100,6 +100,22 @@ class TestFindAndClaimBatch:
                 metadata_json={},
             )
 
+    def test_claims_pending(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        self._create_mss_for_all(IndexStatus.PENDING)
+
+        manifest_count = Manifest.select().count()
+        claimed = scanner._find_and_claim_batch(
+            manifest_count, reindex_threshold, stale_threshold, "abc"
+        )
+        assert len(claimed) == manifest_count
+
+        for mss in ManifestSecurityStatus.select():
+            assert mss.index_status == IndexStatus.IN_PROGRESS
+            assert mss.indexer_hash == "in_progress_v2"
+
     def test_claims_failed_past_threshold(self, initialized_db, scanner):
         reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
         stale_threshold = datetime.utcnow() - timedelta(hours=6)

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -1,0 +1,317 @@
+import logging
+from datetime import datetime, timedelta
+from unittest import mock
+
+import pytest
+from peewee import fn
+
+from app import app as application
+from app import instance_keys, storage
+from data.database import IndexerVersion, IndexStatus, Manifest, ManifestSecurityStatus
+from data.registry_model import registry_model
+from data.secscan_model.secscan_v4_model import IndexReportState
+from data.secscan_model.secscan_v4_model_v2 import V4SecurityScannerV2
+from test.fixtures import *
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def set_secscan_config():
+    application.config["SECURITY_SCANNER_V4_ENDPOINT"] = "http://clairv4:6060"
+
+
+@pytest.fixture()
+def scanner(set_secscan_config):
+    s = V4SecurityScannerV2(application, instance_keys, storage)
+    s._secscan_api = mock.Mock()
+    s._secscan_api.state.return_value = {"state": "abc"}
+    s._secscan_api.index.return_value = (
+        {"err": None, "state": IndexReportState.Index_Finished},
+        "abc",
+    )
+    s._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+    return s
+
+
+class TestClaimUnindexedManifests:
+    def test_claims_manifests_without_mss(self, initialized_db, scanner):
+        manifest_count = Manifest.select().count()
+        assert manifest_count > 0
+
+        claimed = scanner._claim_unindexed_manifests(manifest_count)
+        assert len(claimed) == manifest_count
+
+        for mss in ManifestSecurityStatus.select():
+            assert mss.index_status == IndexStatus.IN_PROGRESS
+            assert mss.indexer_hash == "in_progress_v2"
+
+    def test_skips_manifests_with_existing_mss(self, initialized_db, scanner):
+        manifests = list(Manifest.select().limit(3))
+        for m in manifests:
+            ManifestSecurityStatus.create(
+                manifest=m,
+                repository=m.repository,
+                error_json={},
+                index_status=IndexStatus.COMPLETED,
+                indexer_hash="abc",
+                indexer_version=IndexerVersion.V4,
+                metadata_json={},
+            )
+
+        total = Manifest.select().count()
+        claimed = scanner._claim_unindexed_manifests(total)
+
+        assert len(claimed) == total - 3
+
+    def test_respects_batch_size(self, initialized_db, scanner):
+        claimed = scanner._claim_unindexed_manifests(2)
+        assert len(claimed) == 2
+
+    def test_returns_empty_when_all_indexed(self, initialized_db, scanner):
+        for m in Manifest.select():
+            ManifestSecurityStatus.create(
+                manifest=m,
+                repository=m.repository,
+                error_json={},
+                index_status=IndexStatus.COMPLETED,
+                indexer_hash="abc",
+                indexer_version=IndexerVersion.V4,
+                metadata_json={},
+            )
+
+        claimed = scanner._claim_unindexed_manifests(10)
+        assert len(claimed) == 0
+
+
+class TestFindAndClaimBatch:
+    def _create_mss_for_all(self, status, indexer_hash="abc", last_indexed=None):
+        if last_indexed is None:
+            last_indexed = datetime.utcnow() - timedelta(days=2)
+        for m in Manifest.select():
+            ManifestSecurityStatus.create(
+                manifest=m,
+                repository=m.repository,
+                error_json={},
+                index_status=status,
+                indexer_hash=indexer_hash,
+                indexer_version=IndexerVersion.V4,
+                last_indexed=last_indexed,
+                metadata_json={},
+            )
+
+    def test_claims_failed_past_threshold(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        self._create_mss_for_all(
+            IndexStatus.FAILED,
+            last_indexed=datetime.utcnow() - timedelta(seconds=600),
+        )
+
+        manifest_count = Manifest.select().count()
+        claimed = scanner._find_and_claim_batch(
+            manifest_count, reindex_threshold, stale_threshold, "abc"
+        )
+        assert len(claimed) == manifest_count
+
+        for mss in ManifestSecurityStatus.select():
+            assert mss.index_status == IndexStatus.IN_PROGRESS
+            assert mss.indexer_hash == "in_progress_v2"
+
+    def test_skips_failed_within_threshold(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        self._create_mss_for_all(
+            IndexStatus.FAILED,
+            last_indexed=datetime.utcnow(),
+        )
+
+        claimed = scanner._find_and_claim_batch(50, reindex_threshold, stale_threshold, "abc")
+        assert len(claimed) == 0
+
+    def test_claims_stale_in_progress(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        self._create_mss_for_all(
+            IndexStatus.IN_PROGRESS,
+            last_indexed=datetime.utcnow() - timedelta(hours=7),
+        )
+
+        manifest_count = Manifest.select().count()
+        claimed = scanner._find_and_claim_batch(
+            manifest_count, reindex_threshold, stale_threshold, "abc"
+        )
+        assert len(claimed) == manifest_count
+
+    def test_skips_fresh_in_progress(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        self._create_mss_for_all(
+            IndexStatus.IN_PROGRESS,
+            last_indexed=datetime.utcnow(),
+        )
+
+        claimed = scanner._find_and_claim_batch(50, reindex_threshold, stale_threshold, "abc")
+        assert len(claimed) == 0
+
+    def test_claims_needs_reindexing(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        self._create_mss_for_all(
+            IndexStatus.COMPLETED,
+            indexer_hash="old_hash",
+            last_indexed=datetime.utcnow() - timedelta(seconds=600),
+        )
+
+        manifest_count = Manifest.select().count()
+        claimed = scanner._find_and_claim_batch(
+            manifest_count, reindex_threshold, stale_threshold, "new_hash"
+        )
+        assert len(claimed) == manifest_count
+
+    def test_skips_completed_with_matching_hash(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        self._create_mss_for_all(
+            IndexStatus.COMPLETED,
+            indexer_hash="abc",
+            last_indexed=datetime.utcnow() - timedelta(seconds=600),
+        )
+
+        claimed = scanner._find_and_claim_batch(50, reindex_threshold, stale_threshold, "abc")
+        assert len(claimed) == 0
+
+    @pytest.mark.parametrize(
+        "status",
+        [IndexStatus.MANIFEST_UNSUPPORTED, IndexStatus.MANIFEST_LAYER_TOO_LARGE],
+    )
+    def test_skips_unsupported_and_too_large(self, initialized_db, scanner, status):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        self._create_mss_for_all(
+            status,
+            indexer_hash="old_hash",
+            last_indexed=datetime.utcnow() - timedelta(days=30),
+        )
+
+        claimed = scanner._find_and_claim_batch(50, reindex_threshold, stale_threshold, "new_hash")
+        assert len(claimed) == 0
+
+    def test_respects_batch_size(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        self._create_mss_for_all(
+            IndexStatus.FAILED,
+            last_indexed=datetime.utcnow() - timedelta(seconds=600),
+        )
+
+        claimed = scanner._find_and_claim_batch(2, reindex_threshold, stale_threshold, "abc")
+        assert len(claimed) == 2
+
+
+class TestPerformIndexingCycle:
+    def test_indexes_unindexed_manifests(self, initialized_db, scanner):
+        scanner.perform_indexing(batch_size=100)
+
+        manifest_count = Manifest.select().count()
+        assert ManifestSecurityStatus.select().count() == manifest_count
+        for mss in ManifestSecurityStatus.select():
+            assert mss.index_status in (
+                IndexStatus.COMPLETED,
+                IndexStatus.MANIFEST_UNSUPPORTED,
+            )
+
+    def test_reindexes_failed_manifests(self, initialized_db, scanner):
+        application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"] = 300
+
+        for m in Manifest.select():
+            ManifestSecurityStatus.create(
+                manifest=m,
+                repository=m.repository,
+                error_json={},
+                index_status=IndexStatus.FAILED,
+                indexer_hash="abc",
+                indexer_version=IndexerVersion.V4,
+                last_indexed=datetime.utcnow() - timedelta(seconds=600),
+                metadata_json={},
+            )
+
+        scanner.perform_indexing(batch_size=100)
+
+        for mss in ManifestSecurityStatus.select():
+            assert mss.index_status in (
+                IndexStatus.COMPLETED,
+                IndexStatus.MANIFEST_UNSUPPORTED,
+            )
+
+    def test_skips_failed_within_threshold(self, initialized_db, scanner):
+        application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"] = 300
+
+        for m in Manifest.select():
+            ManifestSecurityStatus.create(
+                manifest=m,
+                repository=m.repository,
+                error_json={},
+                index_status=IndexStatus.FAILED,
+                indexer_hash="abc",
+                indexer_version=IndexerVersion.V4,
+                metadata_json={},
+            )
+
+        scanner.perform_indexing(batch_size=100)
+
+        for mss in ManifestSecurityStatus.select():
+            assert mss.index_status == IndexStatus.FAILED
+
+    def test_handles_api_failure(self, initialized_db, scanner):
+        scanner._secscan_api.state.side_effect = Exception("connection refused")
+
+        with pytest.raises(Exception):
+            scanner.perform_indexing(batch_size=10)
+
+    def test_handles_clair_state_failure(self, initialized_db, scanner):
+        from util.secscan.v4.api import APIRequestFailure
+
+        scanner._secscan_api.state.side_effect = APIRequestFailure("connection refused")
+
+        scanner.perform_indexing(batch_size=10)
+
+        assert ManifestSecurityStatus.select().count() == 0
+
+    def test_handles_index_error_response(self, initialized_db, scanner):
+        scanner._secscan_api.index.return_value = (
+            {"err": "something went wrong", "state": IndexReportState.Index_Error},
+            "abc",
+        )
+
+        scanner.perform_indexing(batch_size=100)
+
+        for mss in ManifestSecurityStatus.select():
+            assert mss.index_status in (
+                IndexStatus.FAILED,
+                IndexStatus.MANIFEST_UNSUPPORTED,
+            )
+
+    def test_noop_when_nothing_to_do(self, initialized_db, scanner):
+        for m in Manifest.select():
+            ManifestSecurityStatus.create(
+                manifest=m,
+                repository=m.repository,
+                error_json={},
+                index_status=IndexStatus.COMPLETED,
+                indexer_hash="abc",
+                indexer_version=IndexerVersion.V4,
+                metadata_json={},
+            )
+
+        scanner.perform_indexing(batch_size=100)
+
+        scanner._secscan_api.index.assert_not_called()

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -97,6 +97,9 @@ var knownUnmapped = map[string]bool{
 	"SECURITY_SCANNER_V4_NAMESPACE_WHITELIST": true,
 	"SECURITY_SCANNER_V4_PSK":                 true,
 	"SECURITY_SCANNER_V4_MANIFEST_CLEANUP":    true,
+	"FEATURE_SECURITY_SCANNER_V2":             true,
+	"SECURITY_SCANNER_V2_BATCH_SIZE":          true,
+	"SECURITY_SCANNER_V2_INDEXING_INTERVAL":   true,
 
 	// Feature flags not yet mapped
 	"FEATURE_ADVERTISE_V2":                          true,

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -826,6 +826,21 @@ CONFIG_SCHEMA = {
             "description": "A base64 encoded string used to sign JWT(s) on Clair V4 requests. If 'None' jwt signing will not occur.",
             "x-example": "PSK",
         },
+        "FEATURE_SECURITY_SCANNER_V2": {
+            "type": "boolean",
+            "description": "Whether to enable the V2 lock-free security scanner indexer using PostgreSQL FOR UPDATE SKIP LOCKED for work distribution. Defaults to False",
+            "x-example": False,
+        },
+        "SECURITY_SCANNER_V2_BATCH_SIZE": {
+            "type": "number",
+            "description": "The number of manifests to claim per indexing cycle in the V2 security scanner. Defaults to 50.",
+            "x-example": 50,
+        },
+        "SECURITY_SCANNER_V2_INDEXING_INTERVAL": {
+            "type": "number",
+            "description": "The number of seconds between indexing cycles in the V2 security scanner. Defaults to 30.",
+            "x-example": 30,
+        },
         # Repository mirroring
         "REPO_MIRROR_INTERVAL": {
             "type": "number",

--- a/util/metrics/prometheus.py
+++ b/util/metrics/prometheus.py
@@ -132,6 +132,30 @@ secscan_result_duration = Histogram(
     buckets=SECSCAN_RESULT_BUCKETS,
 )
 
+secscan_v2_manifests_claimed = Histogram(
+    "quay_secscan_v2_manifests_claimed_per_cycle",
+    "number of manifests claimed per indexing cycle by the V2 security worker",
+    buckets=(0, 1, 5, 10, 25, 50, 100, 250, INF),
+)
+
+secscan_v2_scan_duration = Histogram(
+    "quay_secscan_v2_scan_duration_seconds",
+    "duration of a single manifest scan (Clair API call) by the V2 security worker",
+    buckets=(0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, INF),
+)
+
+secscan_v2_scan_result = Counter(
+    "quay_secscan_v2_scan_result_total",
+    "count of scan results by outcome for the V2 security worker",
+    labelnames=["result"],
+)
+
+secscan_v2_cycle_duration = Histogram(
+    "quay_secscan_v2_cycle_duration_seconds",
+    "duration of a complete V2 security worker indexing cycle",
+    buckets=(1, 5, 10, 30, 60, 120, 300, 600, INF),
+)
+
 
 PROMETHEUS_PUSH_INTERVAL_SECONDS = 30
 ONE_DAY_IN_SECONDS = 60 * 60 * 24

--- a/workers/securityworker/securityworker.py
+++ b/workers/securityworker/securityworker.py
@@ -4,8 +4,9 @@ import threading
 import time
 
 import features
-from app import app
+from app import app, instance_keys, storage
 from data.secscan_model import secscan_model
+from data.secscan_model.secscan_v4_model_v2 import V4SecurityScannerV2
 from endpoints.v2 import v2_bp
 from util.locking import GlobalLock, LockNotAcquiredException
 from util.log import logfile_path
@@ -26,6 +27,13 @@ class SecurityWorker(Worker):
         interval = app.config.get("SECURITY_SCANNER_INDEXING_INTERVAL", DEFAULT_INDEXING_INTERVAL)
         self.add_operation(self._index_in_scanner, interval)
         self.add_operation(self._index_recent_manifests_in_scanner, interval)
+
+        if app.config.get("FEATURE_SECURITY_SCANNER_V2", False):
+            self._scanner_v2 = V4SecurityScannerV2(app, instance_keys, storage)
+            v2_interval = app.config.get(
+                "SECURITY_SCANNER_V2_INDEXING_INTERVAL", DEFAULT_INDEXING_INTERVAL
+            )
+            self.add_operation(self._index_v2, v2_interval)
 
     def _index_in_scanner(self):
         batch_size = app.config.get("SECURITY_SCANNER_V4_BATCH_SIZE", 0)
@@ -56,6 +64,10 @@ class SecurityWorker(Worker):
 
         else:
             self._model.perform_indexing_recent_manifests(batch_size)
+
+    def _index_v2(self):
+        batch_size = app.config.get("SECURITY_SCANNER_V2_BATCH_SIZE", 50)
+        self._scanner_v2.perform_indexing(batch_size)
 
 
 def create_gunicorn_worker():

--- a/workers/securityworker/securityworker.py
+++ b/workers/securityworker/securityworker.py
@@ -4,9 +4,8 @@ import threading
 import time
 
 import features
-from app import app, instance_keys, storage
+from app import app
 from data.secscan_model import secscan_model
-from data.secscan_model.secscan_v4_model_v2 import V4SecurityScannerV2
 from endpoints.v2 import v2_bp
 from util.locking import GlobalLock, LockNotAcquiredException
 from util.log import logfile_path
@@ -28,8 +27,7 @@ class SecurityWorker(Worker):
         self.add_operation(self._index_in_scanner, interval)
         self.add_operation(self._index_recent_manifests_in_scanner, interval)
 
-        if app.config.get("FEATURE_SECURITY_SCANNER_V2", False):
-            self._scanner_v2 = V4SecurityScannerV2(app, instance_keys, storage)
+        if self._model.v2_enabled:
             v2_interval = app.config.get(
                 "SECURITY_SCANNER_V2_INDEXING_INTERVAL", DEFAULT_INDEXING_INTERVAL
             )
@@ -67,7 +65,7 @@ class SecurityWorker(Worker):
 
     def _index_v2(self):
         batch_size = app.config.get("SECURITY_SCANNER_V2_BATCH_SIZE", 50)
-        self._scanner_v2.perform_indexing(batch_size)
+        self._model.perform_indexing_v2(batch_size)
 
 
 def create_gunicorn_worker():


### PR DESCRIPTION
Add a new V2 security scanner indexer that replaces Redis-based global locking with PostgreSQL FOR UPDATE SKIP LOCKED for work distribution. Multiple worker instances claim disjoint batches of manifests without coordination, enabling horizontal scaling without contention or wasted duplicate scans.

Key changes:
- New V4SecurityScannerV2 indexer — two-phase claiming: optimistic INSERT for unindexed manifests, then SKIP LOCKED SELECT for failed/stale/reindex work. Includes per-manifest vulnerability notification on scan success.
- Interface split — SecurityScannerInterface split into SecurityScannerReadInterface (vulnerability lookups, notifications, GC) and SecurityScannerIndexerInterface (indexing). V2 implements only the indexer interface; reads always go through V1.
- Prometheus metrics — four new histograms/counters for V2 cycle duration, manifests claimed, scan duration, and scan results.
- Dead code removal — register_model_cleanup_callbacks and legacy_api_handler (no callers).

The intent is to deprecate V1's indexing code entirely — the interface split makes that a clean removal without touching the read side