### PR TITLE
RFE-4378: feat(notifications): add FEATURE_SKIP_EMAIL_CONFIRMATION flag

### DIFF
--- a/config.py
+++ b/config.py
@@ -364,6 +364,12 @@ class DefaultConfig(ImmutableConfig):
     # Feature Flag: Whether organizations can share email addresses with other users/orgs.
     FEATURE_ORG_SHARED_EMAIL = False
 
+    # Feature Flag: Whether to skip email confirmation requirement for repository notifications.
+    # When False (default), users must confirm email addresses before they can receive repository
+    # notifications. When True, email notifications can be sent to any address without confirmation.
+    # Only enable this in trusted enterprise environments with internal email addresses.
+    FEATURE_SKIP_EMAIL_CONFIRMATION = False
+
     # Feature Flag: Whether users can be created (by non-super users).
     FEATURE_USER_CREATION = True
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -146,6 +146,7 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_RESTRICTED_USERS":                      true,
 	"FEATURE_RESTRICTED_V1_PUSH":                    true,
 	"FEATURE_SECURITY_SCANNER_NOTIFY_ON_NEW_INDEX":  true,
+	"FEATURE_SKIP_EMAIL_CONFIRMATION":               true,
 	"FEATURE_SPARSE_INDEX":                          true,
 	"FEATURE_SUPERUSERS_ORG_CREATION_ONLY":          true,
 	"FEATURE_SUPERUSER_CONFIGDUMP":                  true,

--- a/notifications/notificationmethod.py
+++ b/notifications/notificationmethod.py
@@ -160,6 +160,10 @@ class EmailMethod(NotificationMethod):
         if not email:
             raise CannotValidateNotificationMethodException("Missing e-mail address")
 
+        # When FEATURE_SKIP_EMAIL_CONFIRMATION is enabled, skip the confirmation check
+        if features.SKIP_EMAIL_CONFIRMATION:
+            return
+
         record = model.repository.get_email_authorized_for_repo(namespace_name, repo_name, email)
         if not record or not record.confirmed:
             raise CannotValidateNotificationMethodException(

--- a/notifications/test/test_notificationmethod.py
+++ b/notifications/test/test_notificationmethod.py
@@ -1,5 +1,3 @@
-from test.fixtures import *
-
 import pytest
 from httmock import HTTMock, urlmatch
 from mock import Mock, patch
@@ -16,6 +14,7 @@ from notifications.notificationmethod import (
     SlackMethod,
     WebhookMethod,
 )
+from test.fixtures import *
 
 
 def assert_validated(method, method_config, error_message, namespace_name, repo_name):
@@ -210,3 +209,88 @@ def test_perform_http_call(method, method_config, netloc, initialized_db):
         )
 
     assert url_hit[0]
+
+
+def test_email_requires_confirmation_by_default(initialized_db, monkeypatch):
+    """
+    Verify that email validation requires confirmed authorization when
+    FEATURE_SKIP_EMAIL_CONFIRMATION is False (default).
+    """
+    import features
+
+    # Directly patch the features module attribute to avoid global state pollution
+    monkeypatch.setattr(features, "SKIP_EMAIL_CONFIRMATION", False)
+
+    method = EmailMethod()
+    assert_validated(
+        method,
+        {"email": "test@example.com"},
+        "The specified e-mail address is not authorized to receive notifications for this repository",
+        "devtable",
+        "simple",
+    )
+
+
+def test_email_skips_confirmation_when_feature_enabled(initialized_db, monkeypatch):
+    """
+    Verify that email validation bypasses confirmation check when
+    FEATURE_SKIP_EMAIL_CONFIRMATION is True.
+    """
+    import features
+
+    # Directly patch the features module attribute to avoid global state pollution
+    monkeypatch.setattr(features, "SKIP_EMAIL_CONFIRMATION", True)
+
+    method = EmailMethod()
+    assert_validated(
+        method,
+        {"email": "test@example.com"},
+        None,
+        "devtable",
+        "simple",
+    )
+
+
+def test_email_confirmation_config_loading_path(initialized_db, monkeypatch):
+    """
+    Verify that FEATURE_SKIP_EMAIL_CONFIRMATION is properly wired through the
+    config loading path, ensuring the flag exists in DefaultConfig, CONFIG_SCHEMA,
+    and correctly affects EmailMethod validation behavior.
+    """
+    import features
+    from config import DefaultConfig
+    from util.config.schema import CONFIG_SCHEMA
+
+    assert hasattr(DefaultConfig, "FEATURE_SKIP_EMAIL_CONFIRMATION")
+    assert DefaultConfig.FEATURE_SKIP_EMAIL_CONFIRMATION is False
+
+    assert "FEATURE_SKIP_EMAIL_CONFIRMATION" in CONFIG_SCHEMA["properties"]
+
+    # Record original value so monkeypatch restores it on teardown (even on failure)
+    original = getattr(features, "SKIP_EMAIL_CONFIRMATION", False)
+    monkeypatch.setattr(features, "SKIP_EMAIL_CONFIRMATION", original)
+
+    features.import_features({"FEATURE_SKIP_EMAIL_CONFIRMATION": True})
+    assert hasattr(features, "SKIP_EMAIL_CONFIRMATION")
+    assert bool(features.SKIP_EMAIL_CONFIRMATION) is True
+
+    method = EmailMethod()
+    assert_validated(
+        method,
+        {"email": "test@example.com"},
+        None,
+        "devtable",
+        "simple",
+    )
+
+    features.import_features({"FEATURE_SKIP_EMAIL_CONFIRMATION": False})
+    assert bool(features.SKIP_EMAIL_CONFIRMATION) is False
+
+    method = EmailMethod()
+    assert_validated(
+        method,
+        {"email": "test@example.com"},
+        "The specified e-mail address is not authorized to receive notifications for this repository",
+        "devtable",
+        "simple",
+    )

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -232,6 +232,17 @@ CONFIG_SCHEMA = {
             "description": "Whether organizations can share email addresses with existing user accounts. Defaults to False",
             "x-example": False,
         },
+        "FEATURE_SKIP_EMAIL_CONFIRMATION": {
+            "type": "boolean",
+            "description": (
+                "Whether to skip email confirmation requirement for repository notifications. "
+                "When False (default), users must confirm email addresses before they can receive "
+                "repository notifications. When True, email notifications can be sent to any address "
+                "without confirmation. Only enable this in trusted enterprise environments with "
+                "internal email addresses. Defaults to False for security."
+            ),
+            "x-example": False,
+        },
         "MAIL_SERVER": {
             "type": "string",
             "description": "The SMTP server to use for sending e-mails. Only required if FEATURE_MAILING is set to true.",


### PR DESCRIPTION
Trying to address https://redhat.atlassian.net/browse/RFE-4378

Add configuration flag to bypass email confirmation requirement for repository notifications in trusted enterprise environments.

When FEATURE_SKIP_EMAIL_CONFIRMATION is False (default), users must confirm email addresses before receiving notifications. When True, notifications can be sent to any address without confirmation.

Changes:
- Add FEATURE_SKIP_EMAIL_CONFIRMATION to config.py (default: False)
- Add schema definition in util/config/schema.py with security guidance
- Modify EmailMethod.validate() to check features.SKIP_EMAIL_CONFIRMATION
- Add test coverage for both enabled and disabled states
- Add config loading path test to verify flag wiring
- Add FEATURE_SKIP_EMAIL_CONFIRMATION to Go knownUnmapped (Python-only)

Security: Defaults to False for secure-by-default behavior. Only enable in trusted enterprise environments with internal email addresses.