### PR TITLE
PROJQUAY-10610: fix(web): enable anonymous browsing of public repos in React UI

### DIFF
--- a/web/playwright/e2e/auth/anonymous-access.spec.ts
+++ b/web/playwright/e2e/auth/anonymous-access.spec.ts
@@ -1,0 +1,209 @@
+import {test, expect, uniqueName, skipUnlessFeature} from '../../fixtures';
+
+test.describe(
+  'Anonymous access',
+  {
+    tag: ['@auth', '@critical', '@feature:ANONYMOUS_ACCESS', '@PROJQUAY-10610'],
+  },
+  () => {
+    test('renders public repository page for unauthenticated user', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization(uniqueName('anon'));
+      const repo = await api.repository(
+        org.name,
+        uniqueName('public'),
+        'public',
+      );
+
+      await unauthenticatedPage.goto(`/repository/${repo.fullName}`);
+
+      // Should NOT redirect to /signin
+      await expect(unauthenticatedPage).toHaveURL(
+        new RegExp(`/repository/${repo.fullName}`),
+      );
+
+      // Repo title should be visible on the page
+      await expect(unauthenticatedPage.getByTestId('repo-title')).toContainText(
+        repo.name,
+        {timeout: 10000},
+      );
+
+      // Sign In link should be visible instead of user menu
+      await expect(
+        unauthenticatedPage.getByRole('link', {name: /sign in/i}),
+      ).toBeVisible();
+      await expect(
+        unauthenticatedPage.getByTestId('user-menu-toggle'),
+      ).not.toBeVisible();
+    });
+
+    test('renders organization list page for unauthenticated user', async ({
+      unauthenticatedPage,
+    }) => {
+      await unauthenticatedPage.goto('/organization');
+
+      // Should render without redirecting to /signin
+      await expect(unauthenticatedPage).toHaveURL(/\/organization/);
+      await expect(
+        unauthenticatedPage.getByRole('heading', {name: /organizations/i}),
+      ).toBeVisible({timeout: 10000});
+    });
+
+    test('redirects shorthand URL to repository page for unauthenticated user', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization(uniqueName('anon'));
+      const repo = await api.repository(
+        org.name,
+        uniqueName('public'),
+        'public',
+      );
+
+      // Use shorthand URL (/:org/:repo instead of /repository/:org/:repo)
+      await unauthenticatedPage.goto(`/${org.name}/${repo.name}`);
+
+      // Should redirect to /repository/org/repo (not /signin)
+      await expect(unauthenticatedPage).toHaveURL(
+        new RegExp(`/repository/${repo.fullName}`),
+      );
+    });
+
+    test('lists public repos on /repository page for unauthenticated user', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization(uniqueName('anon'));
+      const repo = await api.repository(
+        org.name,
+        uniqueName('public'),
+        'public',
+      );
+
+      await unauthenticatedPage.goto('/repository');
+
+      // Should NOT redirect to /signin
+      await expect(unauthenticatedPage).toHaveURL(/\/repository/);
+
+      // Public repo should appear in the list
+      await expect(
+        unauthenticatedPage.getByRole('link', {name: repo.fullName}),
+      ).toBeVisible({timeout: 10000});
+    });
+
+    test('navigates to signin page via Sign In link', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization(uniqueName('anon'));
+      const repo = await api.repository(
+        org.name,
+        uniqueName('public'),
+        'public',
+      );
+
+      await unauthenticatedPage.goto(`/repository/${repo.fullName}`);
+
+      await unauthenticatedPage.getByRole('link', {name: /sign in/i}).click();
+
+      await expect(unauthenticatedPage).toHaveURL(/\/signin/);
+    });
+
+    test('redirects to signin for private repository', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization(uniqueName('anon'));
+      // Default visibility is 'private'
+      const repo = await api.repository(org.name, uniqueName('private'));
+
+      await unauthenticatedPage.goto(`/repository/${repo.fullName}`);
+
+      // Private repo should redirect anonymous user to /signin
+      await expect(unauthenticatedPage).toHaveURL(/\/signin/, {
+        timeout: 10000,
+      });
+    });
+
+    test('does not show private repos in repository list', async ({
+      unauthenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization(uniqueName('anon'));
+      const publicRepo = await api.repository(
+        org.name,
+        uniqueName('pub'),
+        'public',
+      );
+      const privateRepo = await api.repository(org.name, uniqueName('priv'));
+
+      await unauthenticatedPage.goto('/repository');
+      await expect(unauthenticatedPage).toHaveURL(/\/repository/);
+
+      // Public repo should be visible
+      await expect(
+        unauthenticatedPage.getByRole('link', {name: publicRepo.fullName}),
+      ).toBeVisible({timeout: 10000});
+
+      // Private repo should NOT be visible
+      await expect(
+        unauthenticatedPage.getByRole('link', {name: privateRepo.fullName}),
+      ).not.toBeVisible();
+    });
+  },
+);
+
+test.describe(
+  'Anonymous access disabled',
+  {
+    tag: ['@auth', '@critical', '@PROJQUAY-10610'],
+  },
+  () => {
+    test('redirects unauthenticated user to signin when ANONYMOUS_ACCESS is disabled', async ({
+      quayConfig,
+      unauthenticatedPage,
+    }) => {
+      // This test only runs when ANONYMOUS_ACCESS is NOT enabled
+      const [skip] = skipUnlessFeature(quayConfig, 'ANONYMOUS_ACCESS');
+      test.skip(
+        !skip,
+        'ANONYMOUS_ACCESS is enabled — skipping disabled-flag test',
+      );
+
+      await unauthenticatedPage.goto('/organization');
+
+      // Should redirect to /signin when anonymous access is disabled
+      await expect(unauthenticatedPage).toHaveURL(/\/signin/, {
+        timeout: 10000,
+      });
+    });
+
+    test('redirects unauthenticated user to signin for public repo when ANONYMOUS_ACCESS is disabled', async ({
+      quayConfig,
+      unauthenticatedPage,
+      api,
+    }) => {
+      const [skip] = skipUnlessFeature(quayConfig, 'ANONYMOUS_ACCESS');
+      test.skip(
+        !skip,
+        'ANONYMOUS_ACCESS is enabled — skipping disabled-flag test',
+      );
+
+      const org = await api.organization(uniqueName('anon'));
+      const repo = await api.repository(
+        org.name,
+        uniqueName('public'),
+        'public',
+      );
+
+      await unauthenticatedPage.goto(`/repository/${repo.fullName}`);
+
+      // Even public repos should redirect when anonymous access is disabled
+      await expect(unauthenticatedPage).toHaveURL(/\/signin/, {
+        timeout: 10000,
+      });
+    });
+  },
+);

--- a/web/playwright/e2e/auth/logout.spec.ts
+++ b/web/playwright/e2e/auth/logout.spec.ts
@@ -126,7 +126,10 @@ test.describe('Logout functionality', {tag: ['@auth', '@critical']}, () => {
   test(
     'clears session and prevents access to protected pages',
     {tag: '@superuser'},
-    async ({logoutPage, logoutUsername}) => {
+    async ({logoutPage, logoutUsername, quayConfig}) => {
+      const anonymousAccessEnabled =
+        quayConfig?.features?.ANONYMOUS_ACCESS === true;
+
       // Navigate to organization page
       await logoutPage.goto('/organization');
       await expect(logoutPage.getByTestId('user-menu-toggle')).toBeVisible();
@@ -145,16 +148,25 @@ test.describe('Logout functionality', {tag: ['@auth', '@critical']}, () => {
         logoutPage.getByRole('textbox', {name: /username/i}),
       ).toBeVisible();
 
-      // Try to navigate to a protected page (use the temp user's namespace)
+      // Try to navigate to a page (use the temp user's namespace)
       await logoutPage.goto(`/organization/${logoutUsername}`);
 
-      // Should redirect back to signin (not authenticated)
-      await expect(logoutPage).toHaveURL(/\/signin/);
-
-      // Verify still on login page
-      await expect(
-        logoutPage.getByRole('textbox', {name: /username/i}),
-      ).toBeVisible();
+      if (anonymousAccessEnabled) {
+        // When ANONYMOUS_ACCESS is enabled, anonymous users stay on the page
+        // and see a Sign In link instead of user menu
+        await expect(
+          logoutPage.getByTestId('user-menu-toggle'),
+        ).not.toBeVisible();
+        await expect(
+          logoutPage.getByRole('link', {name: /sign in/i}),
+        ).toBeVisible();
+      } else {
+        // When ANONYMOUS_ACCESS is disabled, should redirect to signin
+        await expect(logoutPage).toHaveURL(/\/signin/);
+        await expect(
+          logoutPage.getByRole('textbox', {name: /username/i}),
+        ).toBeVisible();
+      }
     },
   );
 

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -911,6 +911,7 @@ export class TestApi {
  * Known Quay feature flags that can be enabled/disabled
  */
 export type QuayFeature =
+  | 'ANONYMOUS_ACCESS'
   | 'BILLING'
   | 'QUOTA_MANAGEMENT'
   | 'EDIT_QUOTA'

--- a/web/src/components/header/HeaderToolbar.test.tsx
+++ b/web/src/components/header/HeaderToolbar.test.tsx
@@ -1,0 +1,67 @@
+import {render, screen} from 'src/test-utils';
+import {HeaderToolbar} from './HeaderToolbar';
+
+const mockUseCurrentUser = vi.hoisted(() =>
+  vi.fn(() => ({user: {username: 'testuser'}})),
+);
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: () => ({
+    features: {},
+    config: {},
+  }),
+}));
+
+vi.mock('src/hooks/useAppNotifications', () => ({
+  useAppNotifications: () => ({
+    notifications: [],
+    unreadCount: 0,
+    loading: false,
+    dismissNotification: vi.fn(),
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('src/resources/AuthResource', () => ({
+  GlobalAuthState: {csrfToken: null, bearerToken: null},
+  logoutUser: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+vi.mock('src/contexts/ThemeContext', () => ({
+  useTheme: () => ({themePreference: 'light', setThemePreference: vi.fn()}),
+  ThemePreference: {LIGHT: 'light', DARK: 'dark'},
+}));
+
+describe('HeaderToolbar', () => {
+  it('shows sign in button for anonymous users', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true},
+    });
+
+    render(<HeaderToolbar toggleDrawer={vi.fn()} />);
+    expect(screen.getByText('Sign In')).toBeInTheDocument();
+    expect(screen.queryByTestId('notification-bell')).not.toBeInTheDocument();
+  });
+
+  it('shows notification badge for authenticated users', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: 'testuser', anonymous: false},
+    });
+
+    render(<HeaderToolbar toggleDrawer={vi.fn()} />);
+    expect(screen.getByTestId('notification-bell')).toBeInTheDocument();
+    expect(screen.queryByText('Sign In')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -385,9 +385,16 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
     ? `Sign in to ${quayConfig.config.REGISTRY_TITLE_SHORT}`
     : 'Sign In';
 
-  const signInButton = <Button>{signInButtonText}</Button>;
+  // Use full page reload instead of React Router navigation to ensure
+  // React Query cache and auth state are properly cleared before signin
+  const signInButton = (
+    <Button component="a" href="/signin">
+      {signInButtonText}
+    </Button>
+  );
 
-  const {unreadCount} = useAppNotifications();
+  const isAuthenticated = !!user?.username;
+  const {unreadCount} = useAppNotifications(isAuthenticated);
 
   return (
     <>
@@ -399,29 +406,31 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
             align={{default: 'alignEnd'}}
             gap={{default: 'gapNone', md: 'gapMd'}}
           >
-            <ToolbarItem
-              gap={{
-                default: 'gapNone',
-                md: 'gapSm',
-                lg: 'gapMd',
-                xl: 'gapLg',
-              }}
-            >
-              <NotificationBadge
-                variant={
-                  unreadCount > 0
-                    ? NotificationBadgeVariant.unread
-                    : NotificationBadgeVariant.read
-                }
-                count={unreadCount}
-                onClick={toggleDrawer}
-                aria-label="Notifications"
-                data-testid="notification-bell"
-              />
-            </ToolbarItem>
+            {isAuthenticated && (
+              <ToolbarItem
+                gap={{
+                  default: 'gapNone',
+                  md: 'gapSm',
+                  lg: 'gapMd',
+                  xl: 'gapLg',
+                }}
+              >
+                <NotificationBadge
+                  variant={
+                    unreadCount > 0
+                      ? NotificationBadgeVariant.unread
+                      : NotificationBadgeVariant.read
+                  }
+                  count={unreadCount}
+                  onClick={toggleDrawer}
+                  aria-label="Notifications"
+                  data-testid="notification-bell"
+                />
+              </ToolbarItem>
+            )}
             <ToolbarItem>{helpDropdown}</ToolbarItem>
             <ToolbarItem>
-              {user.username ? menuContainer : signInButton}
+              {isAuthenticated ? menuContainer : signInButton}
             </ToolbarItem>
           </ToolbarGroup>
         </ToolbarContent>

--- a/web/src/components/notifications/NotificationDrawerList.test.tsx
+++ b/web/src/components/notifications/NotificationDrawerList.test.tsx
@@ -1,0 +1,45 @@
+import {render} from 'src/test-utils';
+import {NotificationDrawerListComponent} from './NotificationDrawerList';
+
+const mockUseCurrentUser = vi.hoisted(() =>
+  vi.fn(() => ({user: {username: 'testuser'}})),
+);
+
+const mockUseAppNotifications = vi.hoisted(() =>
+  vi.fn(() => ({
+    notifications: [],
+    dismissNotification: vi.fn(),
+    loading: false,
+    refetch: vi.fn(),
+  })),
+);
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock('src/hooks/useAppNotifications', () => ({
+  useAppNotifications: mockUseAppNotifications,
+}));
+
+describe('NotificationDrawerListComponent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('passes true to useAppNotifications for authenticated users', () => {
+    mockUseCurrentUser.mockReturnValue({user: {username: 'testuser'}});
+
+    render(<NotificationDrawerListComponent />);
+    expect(mockUseAppNotifications).toHaveBeenCalledWith(true);
+  });
+
+  it('passes false to useAppNotifications for anonymous users', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true},
+    });
+
+    render(<NotificationDrawerListComponent />);
+    expect(mockUseAppNotifications).toHaveBeenCalledWith(false);
+  });
+});

--- a/web/src/components/notifications/NotificationDrawerList.tsx
+++ b/web/src/components/notifications/NotificationDrawerList.tsx
@@ -10,11 +10,15 @@ import {TimesIcon} from '@patternfly/react-icons';
 import {useState} from 'react';
 
 import {useAppNotifications} from 'src/hooks/useAppNotifications';
+import {useCurrentUser} from 'src/hooks/UseCurrentUser';
 import {getNotificationMessage} from './notificationTemplates';
 import {formatDate} from 'src/libs/utils';
 
 export function NotificationDrawerListComponent() {
-  const {notifications, dismissNotification, loading} = useAppNotifications();
+  const {user} = useCurrentUser();
+  const {notifications, dismissNotification, loading} = useAppNotifications(
+    !!user?.username,
+  );
 
   const [readNotifications, setReadNotifications] = useState<string[]>(() => {
     const stored = localStorage.getItem('notification-read-status');

--- a/web/src/hooks/UseRepositories.test.ts
+++ b/web/src/hooks/UseRepositories.test.ts
@@ -1,0 +1,89 @@
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {RecoilRoot} from 'recoil';
+import {createElement} from 'react';
+import {useRepositories} from './UseRepositories';
+
+const mockUseCurrentUser = vi.hoisted(() =>
+  vi.fn(() => ({
+    user: {username: '', anonymous: true, organizations: []},
+    isSuperUser: false,
+  })),
+);
+
+const mockFetchRepositories = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve([])),
+);
+
+vi.mock('./UseCurrentUser', () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock('src/resources/RepositoryResource', () => ({
+  fetchAllRepos: vi.fn(() => Promise.resolve([])),
+  fetchAllReposAsSuperUser: vi.fn(() =>
+    Promise.resolve({repos: [], truncated: false}),
+  ),
+  fetchRepositories: mockFetchRepositories,
+  fetchRepositoriesForNamespace: vi.fn(() => Promise.resolve([])),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false, cacheTime: 0}},
+    logger: {log: vi.fn(), warn: vi.fn(), error: vi.fn()},
+  });
+  function Wrapper({children}: {children: React.ReactNode}) {
+    return createElement(
+      RecoilRoot,
+      null,
+      createElement(QueryClientProvider, {client: queryClient}, children),
+    );
+  }
+  return Wrapper;
+}
+
+describe('useRepositories', () => {
+  it('returns empty namespaces for anonymous users', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true, organizations: []},
+      isSuperUser: false,
+    });
+
+    const {result} = renderHook(() => useRepositories(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.repos).toEqual([]);
+  });
+
+  it('calls fetchRepositories for anonymous users without org', async () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true, organizations: []},
+      isSuperUser: false,
+    });
+    mockFetchRepositories.mockResolvedValue([
+      {namespace: 'pub', name: 'repo1', is_public: true},
+    ]);
+
+    const {result} = renderHook(() => useRepositories(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockFetchRepositories).toHaveBeenCalled();
+  });
+
+  it('uses anonymous query key for anonymous users', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true, organizations: []},
+      isSuperUser: false,
+    });
+
+    const {result} = renderHook(() => useRepositories(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current).toBeDefined();
+  });
+});

--- a/web/src/hooks/UseRepositories.ts
+++ b/web/src/hooks/UseRepositories.ts
@@ -9,13 +9,31 @@ import {OrgSearchState} from 'src/components/toolbar/SearchTypes';
 import {
   fetchAllRepos,
   fetchAllReposAsSuperUser,
+  fetchRepositories,
   fetchRepositoriesForNamespace,
   IRepository,
   SuperUserReposResult,
 } from 'src/resources/RepositoryResource';
 import {useCurrentUser} from './UseCurrentUser';
 
-export function useRepositories(organization?: string) {
+export interface UseRepositoriesReturn {
+  repos: IRepository[];
+  loading: boolean;
+  error: unknown;
+  search: OrgSearchState;
+  setSearch: (search: OrgSearchState) => void;
+  searchFilter: (item: IRepository) => boolean;
+  page: number;
+  setPage: (page: number) => void;
+  perPage: number;
+  setPerPage: (perPage: number) => void;
+  organization: string | undefined;
+  setCurrentOrganization: (org: string | undefined) => void;
+  totalResults: number;
+  truncated: boolean;
+}
+
+export function useRepositories(organization?: string): UseRepositoriesReturn {
   const {user, isSuperUser} = useCurrentUser();
 
   // Keep state of current search in this hook
@@ -29,7 +47,9 @@ export function useRepositories(organization?: string) {
 
   const listOfOrgNames: string[] = currentOrganization
     ? [currentOrganization]
-    : user?.organizations.map((org) => org.name).concat(user.username);
+    : user?.anonymous
+      ? [] // Anonymous users have no namespaces to fetch
+      : user?.organizations?.map((org) => org.name).concat(user.username) || [];
 
   const handlePartialResults = useCallback((newRepos: IRepository[]) => {
     setPartialResults((prev) => [...prev, ...newRepos]);
@@ -45,7 +65,7 @@ export function useRepositories(organization?: string) {
       'organization',
       organization || 'all',
       'repositories',
-      isSuperUser ? 'superuser' : 'user',
+      isSuperUser ? 'superuser' : user?.anonymous ? 'anonymous' : 'user',
     ],
     keepPreviousData: true,
     placeholderData: [],
@@ -53,6 +73,14 @@ export function useRepositories(organization?: string) {
       // Reset partial results at the start of a new query
       setPartialResults([]);
       setTruncated(false);
+
+      // Anonymous users without a specific org: show all public repos
+      if (user?.anonymous && !currentOrganization) {
+        return fetchRepositories({
+          signal,
+          onPartialResult: handlePartialResults,
+        });
+      }
 
       if (currentOrganization) {
         return fetchRepositoriesForNamespace(currentOrganization, {

--- a/web/src/hooks/UseRepository.test.ts
+++ b/web/src/hooks/UseRepository.test.ts
@@ -48,6 +48,11 @@ describe('UseRepository', () => {
       renderHook(() => useRepository('myorg', undefined), {wrapper});
       expect(fetchRepositoryDetails).not.toHaveBeenCalled();
     });
+
+    it('does not fetch when enabled is false', () => {
+      renderHook(() => useRepository('myorg', 'myrepo', false), {wrapper});
+      expect(fetchRepositoryDetails).not.toHaveBeenCalled();
+    });
   });
 
   describe('useTransitivePermissions', () => {

--- a/web/src/hooks/UseRepository.ts
+++ b/web/src/hooks/UseRepository.ts
@@ -5,11 +5,11 @@ import {
   fetchRepositoryDetails,
 } from 'src/resources/RepositoryResource';
 
-export function useRepository(org: string, repo?: string) {
+export function useRepository(org: string, repo?: string, enabled = true) {
   const {data, error, isLoading, isError} = useQuery(
     ['repodetails', org, repo],
     () => fetchRepositoryDetails(org, repo),
-    {enabled: !isNullOrUndefined(repo)},
+    {enabled: !isNullOrUndefined(repo) && enabled},
   );
 
   return {

--- a/web/src/hooks/UseTeams.test.ts
+++ b/web/src/hooks/UseTeams.test.ts
@@ -151,6 +151,11 @@ describe('UseTeams', () => {
       expect(result.current.paginatedTeams).toHaveLength(2);
     });
 
+    it('does not fetch when enabled is false', async () => {
+      renderHook(() => useFetchTeams('myorg', false), {wrapper});
+      expect(fetchTeamsForNamespace).not.toHaveBeenCalled();
+    });
+
     it('filters teams by search query', async () => {
       const mockTeams = [
         {

--- a/web/src/hooks/UseTeams.ts
+++ b/web/src/hooks/UseTeams.ts
@@ -77,7 +77,7 @@ export interface ITeams {
   is_synced: boolean;
 }
 
-export function useFetchTeams(orgName: string) {
+export function useFetchTeams(orgName: string, enabled = true) {
   const {user} = useCurrentUser();
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(20);
@@ -96,7 +96,7 @@ export function useFetchTeams(orgName: string) {
     ({signal}) => fetchTeamsForNamespace(orgName, signal),
     {
       placeholderData: [],
-      enabled: !(user.username === orgName),
+      enabled: enabled && !(user.username === orgName),
     },
   );
 

--- a/web/src/hooks/useAppNotifications.ts
+++ b/web/src/hooks/useAppNotifications.ts
@@ -40,7 +40,15 @@ function mapAngularLevelToPF(
   }
 }
 
-export function useAppNotifications() {
+export interface UseAppNotificationsReturn {
+  notifications: AppNotification[];
+  unreadCount: number;
+  loading: boolean;
+  dismissNotification: (id: string) => void;
+  refetch: () => void;
+}
+
+export function useAppNotifications(enabled = true): UseAppNotificationsReturn {
   const queryClient = useQueryClient();
 
   const {data: notifications = [], isLoading: loading} = useQuery({
@@ -53,6 +61,7 @@ export function useAppNotifications() {
       }));
     },
     refetchInterval: 5 * 60 * 1000, // refetch every 5 minutes
+    enabled,
   });
 
   const dismissMutation = useMutation({

--- a/web/src/libs/axios.test.ts
+++ b/web/src/libs/axios.test.ts
@@ -1,0 +1,19 @@
+import {setAnonymousMode, isRedirecting} from './axios';
+
+describe('axios exports', () => {
+  describe('setAnonymousMode', () => {
+    it('does not throw when enabling anonymous mode', () => {
+      expect(() => setAnonymousMode(true)).not.toThrow();
+    });
+
+    it('does not throw when disabling anonymous mode', () => {
+      expect(() => setAnonymousMode(false)).not.toThrow();
+    });
+  });
+
+  describe('isRedirecting', () => {
+    it('returns false by default', () => {
+      expect(isRedirecting()).toBe(false);
+    });
+  });
+});

--- a/web/src/libs/axios.ts
+++ b/web/src/libs/axios.ts
@@ -6,6 +6,21 @@ if (process.env.MOCK_API === 'true') {
   require('src/tests/fake-db/ApiMock');
 }
 
+// Track whether user is browsing anonymously. When true, 401 responses
+// from other endpoints (e.g. /api/v1/user/notifications) won't trigger
+// a redirect to /signin. Set by fetchUser() in UserResource.ts.
+let _anonymousMode = false;
+
+let _isRedirecting = false;
+
+export function setAnonymousMode(enabled: boolean): void {
+  _anonymousMode = enabled;
+}
+
+export function isRedirecting(): boolean {
+  return _isRedirecting;
+}
+
 axios.defaults.withCredentials = true;
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
@@ -92,20 +107,40 @@ axiosIns.interceptors.response.use(
 
       // Handle regular session expiry
       if (!isFreshLoginRequired) {
+        // Always refresh plugin tokens when available, regardless of
+        // anonymous mode — prevents stale bearer tokens from wedging
+        // the OpenShift plugin session.
         if (window?.insights?.chrome?.auth) {
-          // Refresh token for plugin
           GlobalAuthState.bearerToken =
             await window.insights.chrome.auth.getToken();
         } else {
-          // Redirect to login page for standalone, but only if not already there
-          // This prevents infinite redirect loops when API calls fail on auth pages
-          const currentPath = window.location.pathname;
-          const isOnAuthPage =
-            currentPath === '/signin' ||
-            currentPath === '/createaccount' ||
-            currentPath.startsWith('/oauth');
-          if (!isOnAuthPage) {
-            window.location.href = '/signin';
+          // Standalone deployment: suppress redirect for user endpoint
+          // and anonymous mode so fetchUser() can return ANONYMOUS_USER
+          const requestUrl = error.config?.url || '';
+          const isUserEndpoint =
+            requestUrl === '/api/v1/user/' ||
+            requestUrl.endsWith('/api/v1/user/');
+
+          const isRepositoryEndpoint =
+            requestUrl.includes('/api/v1/repository/') ||
+            requestUrl.includes('/api/v2/');
+
+          const shouldSkipRedirect =
+            (isUserEndpoint || _anonymousMode) && !isRepositoryEndpoint;
+
+          if (!shouldSkipRedirect) {
+            const currentPath = window.location.pathname;
+            const isOnAuthPage =
+              currentPath === '/signin' ||
+              currentPath === '/createaccount' ||
+              currentPath.startsWith('/oauth');
+            if (!isOnAuthPage) {
+              _isRedirecting = true;
+              window.location.href = '/signin';
+              return new Promise(() => {
+                /* intentionally empty - prevents rejection during redirect */
+              });
+            }
           }
         }
       }

--- a/web/src/resources/RepositoryResource.test.ts
+++ b/web/src/resources/RepositoryResource.test.ts
@@ -223,6 +223,7 @@ describe('RepositoryResource', () => {
       const result = await fetchRepositories();
       expect(axios.get).toHaveBeenCalledWith(
         '/api/v1/repository?last_modified=true&public=true',
+        {signal: undefined},
       );
       expect(result).toEqual(repos);
     });

--- a/web/src/resources/RepositoryResource.ts
+++ b/web/src/resources/RepositoryResource.ts
@@ -141,13 +141,33 @@ export async function fetchRepositoriesForNamespace(
   return repos as IRepository[];
 }
 
-export async function fetchRepositories() {
-  // TODO: Add return type to AxiosResponse
-  const response: AxiosResponse = await axios.get(
-    `/api/v1/repository?last_modified=true&public=true`,
-  );
+export async function fetchRepositories(
+  options: FetchRepositoriesOptions = {},
+): Promise<IRepository[]> {
+  const {signal, next_page_token = null, onPartialResult} = options;
+
+  const url = next_page_token
+    ? `/api/v1/repository?next_page=${next_page_token}&last_modified=true&public=true`
+    : `/api/v1/repository?last_modified=true&public=true`;
+  const response: AxiosResponse = await axios.get(url, {signal});
   assertHttpCode(response.status, 200);
-  return response.data?.repositories as IRepository[];
+
+  const next_page = response.data?.next_page;
+  const repos = response.data?.repositories as IRepository[];
+
+  if (onPartialResult) {
+    onPartialResult(repos);
+  }
+
+  if (next_page) {
+    const rest = await fetchRepositories({
+      signal,
+      next_page_token: next_page,
+      onPartialResult,
+    });
+    return repos.concat(rest);
+  }
+  return repos;
 }
 
 /**

--- a/web/src/resources/UserResource.test.ts
+++ b/web/src/resources/UserResource.test.ts
@@ -31,6 +31,7 @@ vi.mock('src/libs/axios', () => ({
     put: vi.fn(),
     delete: vi.fn(),
   },
+  setAnonymousMode: vi.fn(),
 }));
 
 /** Creates a mock Axios response with the given data and status. */
@@ -57,6 +58,44 @@ describe('UserResource', () => {
       const result = await fetchUser();
       expect(axios.get).toHaveBeenCalledWith('/api/v1/user/');
       expect(result).toEqual(user);
+    });
+
+    it('calls setAnonymousMode(false) on successful fetch', async () => {
+      const {setAnonymousMode} = await import('src/libs/axios');
+      const user = {username: 'testuser', anonymous: false};
+      vi.mocked(axios.get).mockResolvedValueOnce(mockResponse(user));
+
+      await fetchUser();
+      expect(setAnonymousMode).toHaveBeenCalledWith(false);
+    });
+
+    it('returns ANONYMOUS_USER on 401 error', async () => {
+      const axiosErr = new AxiosError('Unauthorized');
+      (axiosErr as any).response = {status: 401};
+      vi.mocked(axios.get).mockRejectedValueOnce(axiosErr);
+
+      const result = await fetchUser();
+      expect(result.anonymous).toBe(true);
+      expect(result.username).toBe('');
+      expect(result.can_create_repo).toBe(false);
+    });
+
+    it('calls setAnonymousMode(true) on 401 error', async () => {
+      const {setAnonymousMode} = await import('src/libs/axios');
+      const axiosErr = new AxiosError('Unauthorized');
+      (axiosErr as any).response = {status: 401};
+      vi.mocked(axios.get).mockRejectedValueOnce(axiosErr);
+
+      await fetchUser();
+      expect(setAnonymousMode).toHaveBeenCalledWith(true);
+    });
+
+    it('rethrows non-401 errors', async () => {
+      const axiosErr = new AxiosError('Server Error');
+      (axiosErr as any).response = {status: 500};
+      vi.mocked(axios.get).mockRejectedValueOnce(axiosErr);
+
+      await expect(fetchUser()).rejects.toThrow('Server Error');
     });
   });
 

--- a/web/src/resources/UserResource.ts
+++ b/web/src/resources/UserResource.ts
@@ -1,5 +1,5 @@
-import {AxiosResponse, AxiosError} from 'axios';
-import axios from 'src/libs/axios';
+import {AxiosResponse, AxiosError, isAxiosError} from 'axios';
+import axios, {setAnonymousMode} from 'src/libs/axios';
 import {assertHttpCode} from './ErrorHandling';
 import {IAvatar, IOrganization} from './OrganizationResource';
 import {IQuotaReport} from 'src/libs/quotaUtils';
@@ -10,22 +10,20 @@ export interface IUserResource {
   avatar: IAvatar;
   can_create_repo: boolean;
   is_me: boolean;
-  verified: true;
+  verified: boolean;
   email: string;
-  logins: [
-    {
-      service: string;
-      service_identifier: string;
-      metadata: {
-        service_username: string;
-      };
-    },
-  ];
+  logins: Array<{
+    service: string;
+    service_identifier: string;
+    metadata: {
+      service_username: string;
+    };
+  }>;
   invoice_email: boolean;
   invoice_email_address: string;
   preferred_namespace: boolean;
   tag_expiration_s: number;
-  prompts: [];
+  prompts: string[];
   super_user: boolean;
   global_readonly_super_user?: boolean;
   enabled?: boolean; // User enabled/disabled status (for superuser user management)
@@ -39,11 +37,50 @@ export interface IUserResource {
   quota_report?: IQuotaReport; // Quota report for the user's namespace
 }
 
-export async function fetchUser() {
-  const response: AxiosResponse<IUserResource> =
-    await axios.get('/api/v1/user/');
-  assertHttpCode(response.status, 200);
-  return response.data;
+// Sentinel anonymous user object returned when the backend returns 401.
+// Matches the Angular UI pattern from static/js/services/user-service.js.
+const ANONYMOUS_USER: IUserResource = {
+  anonymous: true,
+  username: '',
+  avatar: {name: '', hash: '', color: '', kind: 'user'},
+  can_create_repo: false,
+  is_me: false,
+  verified: false,
+  email: '',
+  logins: [],
+  invoice_email: false,
+  invoice_email_address: '',
+  preferred_namespace: false,
+  tag_expiration_s: 0,
+  prompts: [],
+  super_user: false,
+  company: '',
+  family_name: '',
+  given_name: '',
+  location: '',
+  is_free_account: true,
+  has_password_set: false,
+  organizations: [],
+};
+
+export async function fetchUser(): Promise<IUserResource> {
+  try {
+    const response: AxiosResponse<IUserResource> =
+      await axios.get('/api/v1/user/');
+    assertHttpCode(response.status, 200);
+    setAnonymousMode(false);
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 401) {
+      // Not authenticated — return anonymous user object instead of throwing.
+      // This matches Angular UI behavior and enables anonymous browsing of
+      // public repos when FEATURE_ANONYMOUS_ACCESS is enabled (PROJQUAY-10610).
+      setAnonymousMode(true);
+      return ANONYMOUS_USER;
+    }
+    console.error('Error fetching user:', error);
+    throw error;
+  }
 }
 
 export interface AllUsers {
@@ -126,7 +163,7 @@ export interface CreateUserRequest {
 
 export interface CreateUserResponse {
   awaiting_verification?: boolean;
-  [key: string]: any; // Allow other fields from the API response
+  [key: string]: unknown;
 }
 
 export async function createUser(

--- a/web/src/routes/OrganizationsList/OrganizationToolBar.test.tsx
+++ b/web/src/routes/OrganizationsList/OrganizationToolBar.test.tsx
@@ -1,0 +1,49 @@
+import {render, screen} from 'src/test-utils';
+import {OrganizationToolBar} from './OrganizationToolBar';
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: () => ({
+    canModify: false,
+    isReadOnlySuperUser: false,
+  }),
+}));
+
+vi.mock('./modals/CreateUserModal', () => ({
+  CreateUserModal: () => null,
+}));
+
+const baseProps = {
+  createOrgModal: {},
+  isOrganizationModalOpen: false,
+  setOrganizationModalOpen: vi.fn(),
+  isKebabOpen: false,
+  setKebabOpen: vi.fn(),
+  kebabItems: [],
+  selectedOrganization: [],
+  deleteKebabIsOpen: false,
+  deleteModal: {},
+  organizationsList: [],
+  perPage: 10,
+  page: 1,
+  setPage: vi.fn(),
+  setPerPage: vi.fn(),
+  total: 0,
+  search: {query: '', field: 'name'},
+  setSearch: vi.fn(),
+  setSelectedOrganization: vi.fn(),
+  paginatedOrganizationsList: [],
+  onSelectOrganization: vi.fn(),
+  isExternalAuth: false,
+};
+
+describe('OrganizationToolBar', () => {
+  it('hides create button and checkbox for unauthenticated users', () => {
+    render(<OrganizationToolBar {...baseProps} isAuthenticated={false} />);
+    expect(screen.queryByText('Create Organization')).not.toBeInTheDocument();
+  });
+
+  it('shows create button for authenticated users', () => {
+    render(<OrganizationToolBar {...baseProps} isAuthenticated={true} />);
+    expect(screen.getByText('Create Organization')).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/OrganizationToolBar.tsx
+++ b/web/src/routes/OrganizationsList/OrganizationToolBar.tsx
@@ -13,7 +13,9 @@ import * as React from 'react';
 import {useState} from 'react';
 import {FilterInput} from 'src/components/toolbar/FilterInput';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
+import {OrganizationDetail} from 'src/hooks/UseOrganizations';
 import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
+import {OrganizationsTableItem} from './OrganizationsList';
 import {CreateUserModal} from './modals/CreateUserModal';
 
 export function OrganizationToolBar(props: OrganizationToolBarProps) {
@@ -25,25 +27,29 @@ export function OrganizationToolBar(props: OrganizationToolBarProps) {
     <>
       <Toolbar>
         <ToolbarContent>
-          <DropdownCheckbox
-            selectedItems={props.selectedOrganization}
-            deSelectAll={props.setSelectedOrganization}
-            allItemsList={props.organizationsList}
-            itemsPerPageList={props.paginatedOrganizationsList}
-            onItemSelect={props.onSelectOrganization}
-          />
+          {props.isAuthenticated !== false && (
+            <DropdownCheckbox
+              selectedItems={props.selectedOrganization}
+              deSelectAll={props.setSelectedOrganization}
+              allItemsList={props.organizationsList}
+              itemsPerPageList={props.paginatedOrganizationsList}
+              onItemSelect={props.onSelectOrganization}
+            />
+          )}
           <FilterInput
             id="orgslist-search-input"
             searchState={props.search}
             onChange={props.setSearch}
           />
-          <ToolbarButton
-            id="create-organization-button"
-            buttonValue="Create Organization"
-            Modal={props.createOrgModal}
-            isModalOpen={props.isOrganizationModalOpen}
-            setModalOpen={props.setOrganizationModalOpen}
-          />
+          {props.isAuthenticated !== false && (
+            <ToolbarButton
+              id="create-organization-button"
+              buttonValue="Create Organization"
+              Modal={props.createOrgModal}
+              isModalOpen={props.isOrganizationModalOpen}
+              setModalOpen={props.setOrganizationModalOpen}
+            />
+          )}
           {canModify && !props.isExternalAuth && (
             <ToolbarItem>
               <Button
@@ -99,10 +105,10 @@ type OrganizationToolBarProps = {
   isKebabOpen: boolean;
   setKebabOpen: (open) => void;
   kebabItems: React.ReactElement[];
-  selectedOrganization: any[];
+  selectedOrganization: OrganizationsTableItem[];
   deleteKebabIsOpen: boolean;
   deleteModal: object;
-  organizationsList: any[];
+  organizationsList: OrganizationDetail[];
   perPage: number;
   page: number;
   setPage: (pageNumber) => void;
@@ -111,7 +117,8 @@ type OrganizationToolBarProps = {
   search: SearchState;
   setSearch: (searchState) => void;
   setSelectedOrganization: (selectedOrgList) => void;
-  paginatedOrganizationsList: any[];
+  paginatedOrganizationsList: OrganizationDetail[];
   onSelectOrganization: (Org, rowIndex, isSelecting) => void;
   isExternalAuth: boolean;
+  isAuthenticated?: boolean;
 };

--- a/web/src/routes/OrganizationsList/OrganizationsList.tsx
+++ b/web/src/routes/OrganizationsList/OrganizationsList.tsx
@@ -450,6 +450,8 @@ export default function OrganizationsList() {
     );
   }
 
+  const isAuthenticated = !!user?.username;
+
   // Return component Empty state
   if (!loading && !organizationsTableDetails?.length) {
     return (
@@ -467,15 +469,21 @@ export default function OrganizationsList() {
         <Empty
           icon={CubesIcon}
           title="Collaborate and share projects across teams"
-          body="Create a shared space of public and private repositories for your developers to collaborate in. Organizations make it easy to add and manage people and permissions"
+          body={
+            isAuthenticated
+              ? 'Create a shared space of public and private repositories for your developers to collaborate in. Organizations make it easy to add and manage people and permissions'
+              : 'Sign in to create organizations and manage repositories.'
+          }
           button={
-            <ToolbarButton
-              id="create-organization-button"
-              buttonValue="Create Organization"
-              Modal={createOrgModal}
-              isModalOpen={isOrganizationModalOpen}
-              setModalOpen={setOrganizationModalOpen}
-            />
+            isAuthenticated ? (
+              <ToolbarButton
+                id="create-organization-button"
+                buttonValue="Create Organization"
+                Modal={createOrgModal}
+                isModalOpen={isOrganizationModalOpen}
+                setModalOpen={setOrganizationModalOpen}
+              />
+            ) : null
           }
         />
       </>
@@ -520,7 +528,7 @@ export default function OrganizationsList() {
           isKebabOpen={isKebabOpen}
           setKebabOpen={setKebabOpen}
           kebabItems={kebabItems}
-          selectedOrganization={selectedOrganization}
+          selectedOrganization={isAuthenticated ? selectedOrganization : []}
           deleteKebabIsOpen={deleteModalIsOpen}
           deleteModal={deleteModal}
           organizationsList={sortedOrgs}
@@ -532,11 +540,12 @@ export default function OrganizationsList() {
           paginatedOrganizationsList={paginatedOrganizationsList}
           onSelectOrganization={onSelectOrganization}
           isExternalAuth={!!isExternalAuth}
+          isAuthenticated={isAuthenticated}
         />
         <Table aria-label="Selectable table" variant="compact">
           <Thead>
             <Tr>
-              <Th />
+              {isAuthenticated && <Th />}
               <Th sort={getSortableSort(1)} modifier="wrap">
                 {ColumnNames.name}
               </Th>
@@ -558,18 +567,19 @@ export default function OrganizationsList() {
           <Tbody>
             {paginatedOrganizationsList?.map((org, rowIndex) => (
               <Tr key={org.name}>
-                {isOrgSelectable(org) ? (
-                  <Td
-                    select={{
-                      rowIndex,
-                      onSelect: (_event, isSelecting) =>
-                        onSelectOrganization(org, rowIndex, isSelecting),
-                      isSelected: isOrganizationSelected(org),
-                    }}
-                  />
-                ) : (
-                  <Td />
-                )}
+                {isAuthenticated &&
+                  (isOrgSelectable(org) ? (
+                    <Td
+                      select={{
+                        rowIndex,
+                        onSelect: (_event, isSelecting) =>
+                          onSelectOrganization(org, rowIndex, isSelecting),
+                        isSelected: isOrganizationSelected(org),
+                      }}
+                    />
+                  ) : (
+                    <Td />
+                  ))}
                 <OrgTableData
                   name={org.name}
                   isUser={org.isUser}

--- a/web/src/routes/ProtectedRepositoryRoute.test.tsx
+++ b/web/src/routes/ProtectedRepositoryRoute.test.tsx
@@ -1,0 +1,167 @@
+import {render, screen} from 'src/test-utils';
+import ProtectedRepositoryRoute from './ProtectedRepositoryRoute';
+
+const mockUseCurrentUser = vi.hoisted(() =>
+  vi.fn(() => ({user: null, loading: true})),
+);
+
+const mockUseRepository = vi.hoisted(() =>
+  vi.fn(() => ({
+    repoDetails: null,
+    isLoading: false,
+    isError: false,
+    errorLoadingRepoDetails: null,
+  })),
+);
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock('src/hooks/UseRepository', () => ({
+  useRepository: mockUseRepository,
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: () => ({
+      pathname: '/repository/testorg/testrepo',
+      search: '',
+      hash: '',
+    }),
+  };
+});
+
+vi.mock('src/libs/utils', async () => {
+  const actual = await vi.importActual('src/libs/utils');
+  return {
+    ...actual,
+    parseOrgNameFromUrl: () => 'testorg',
+    parseRepoNameFromUrl: () => 'testrepo',
+  };
+});
+
+vi.mock('./RepositoryTagRouter', () => ({
+  default: () => <div data-testid="repo-tag-router">RepositoryTagRouter</div>,
+}));
+
+vi.mock('src/components/header/QuayHeader', () => ({
+  QuayHeader: () => <div data-testid="quay-header">Header</div>,
+}));
+
+vi.mock('src/components/sidebar/QuaySidebar', () => ({
+  QuaySidebar: () => <div data-testid="quay-sidebar">Sidebar</div>,
+}));
+
+describe('ProtectedRepositoryRoute', () => {
+  it('returns null while user is loading', () => {
+    mockUseCurrentUser.mockReturnValue({user: null, loading: true});
+
+    const {container} = render(<ProtectedRepositoryRoute />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders content without Page wrapper for authenticated users', async () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: 'testuser', anonymous: false},
+      loading: false,
+    });
+
+    render(<ProtectedRepositoryRoute />);
+    expect(await screen.findByTestId('repo-tag-router')).toBeInTheDocument();
+    expect(screen.queryByTestId('quay-header')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quay-sidebar')).not.toBeInTheDocument();
+  });
+
+  it('shows error for anonymous user when repo not found', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true},
+      loading: false,
+    });
+    mockUseRepository.mockReturnValue({
+      repoDetails: null,
+      isLoading: false,
+      isError: false,
+      errorLoadingRepoDetails: null,
+    });
+
+    render(<ProtectedRepositoryRoute />);
+    expect(screen.getByText('Repository not found')).toBeInTheDocument();
+  });
+
+  it('shows loading spinner for anonymous user while repo is loading', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true},
+      loading: false,
+    });
+    mockUseRepository.mockReturnValue({
+      repoDetails: null,
+      isLoading: true,
+      isError: false,
+      errorLoadingRepoDetails: null,
+    });
+
+    const {container} = render(<ProtectedRepositoryRoute />);
+    expect(container.querySelector('.pf-v6-c-spinner')).toBeInTheDocument();
+  });
+
+  it('shows error UI for anonymous user on API error', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true},
+      loading: false,
+    });
+    mockUseRepository.mockReturnValue({
+      repoDetails: null,
+      isLoading: false,
+      isError: true,
+      errorLoadingRepoDetails: {response: {status: 500}},
+    });
+
+    render(<ProtectedRepositoryRoute />);
+    expect(screen.getByText('Unable to load repository')).toBeInTheDocument();
+  });
+
+  it('renders content without Page wrapper for anonymous user with repo details', async () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true},
+      loading: false,
+    });
+    mockUseRepository.mockReturnValue({
+      repoDetails: {name: 'testrepo', namespace: 'testorg'},
+      isLoading: false,
+      isError: false,
+      errorLoadingRepoDetails: null,
+    });
+
+    render(<ProtectedRepositoryRoute />);
+    expect(await screen.findByTestId('repo-tag-router')).toBeInTheDocument();
+    expect(screen.queryByTestId('quay-header')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('quay-sidebar')).not.toBeInTheDocument();
+  });
+
+  it('passes correct args to useRepository for anonymous users', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true},
+      loading: false,
+    });
+
+    render(<ProtectedRepositoryRoute />);
+    expect(mockUseRepository).toHaveBeenCalledWith('testorg', 'testrepo', true);
+  });
+
+  it('does not fetch repo for authenticated users', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: 'testuser', anonymous: false},
+      loading: false,
+    });
+
+    render(<ProtectedRepositoryRoute />);
+    expect(mockUseRepository).toHaveBeenCalledWith(
+      'testorg',
+      'testrepo',
+      false,
+    );
+  });
+});

--- a/web/src/routes/ProtectedRepositoryRoute.tsx
+++ b/web/src/routes/ProtectedRepositoryRoute.tsx
@@ -1,0 +1,60 @@
+import {AxiosError} from 'axios';
+import {lazy, Suspense} from 'react';
+import {useLocation} from 'react-router-dom';
+import {useCurrentUser} from 'src/hooks/UseCurrentUser';
+import {useRepository} from 'src/hooks/UseRepository';
+import {LoadingPage} from 'src/components/LoadingPage';
+import RequestError from 'src/components/errors/RequestError';
+import {parseOrgNameFromUrl, parseRepoNameFromUrl} from 'src/libs/utils';
+
+const RepositoryTagRouter = lazy(() => import('./RepositoryTagRouter'));
+
+/**
+ * Protected route wrapper for repository pages.
+ *
+ * For authenticated users: Renders immediately
+ * For anonymous users: Pre-checks repo accessibility before rendering
+ *
+ * This prevents FOUC (Flash of Unauthenticated Content) by ensuring
+ * anonymous users NEVER see the layout for private repos.
+ */
+export default function ProtectedRepositoryRoute(): JSX.Element | null {
+  const {user, loading: userLoading} = useCurrentUser();
+  const location = useLocation();
+
+  const organization = parseOrgNameFromUrl(location.pathname);
+  const repository = parseRepoNameFromUrl(location.pathname);
+
+  const shouldFetchRepo = !userLoading && user?.anonymous;
+  const {repoDetails, isLoading, isError, errorLoadingRepoDetails} =
+    useRepository(organization, repository, shouldFetchRepo);
+
+  if (userLoading) {
+    return null;
+  }
+
+  if (user?.anonymous) {
+    if (isLoading) {
+      return <LoadingPage />;
+    }
+
+    if (isError) {
+      const status = (errorLoadingRepoDetails as AxiosError)?.response?.status;
+      if (status === 401 || status === 403) {
+        window.location.href = '/signin';
+        return null;
+      }
+      return <RequestError message="Unable to load repository" />;
+    }
+
+    if (!repoDetails) {
+      return <RequestError message="Repository not found" />;
+    }
+  }
+
+  return (
+    <Suspense fallback={<LoadingPage />}>
+      <RepositoryTagRouter />
+    </Suspense>
+  );
+}

--- a/web/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/web/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -301,6 +301,8 @@ export default function RepositoriesList(props: RepositoriesListProps) {
     );
   }
 
+  const isAuthenticated = !!user?.username;
+
   // Return component Empty state - only if there are truly no repositories
   // If filtered results are empty but repos exist, show the table with toolbar
   if (!loading && !repos?.length) {
@@ -308,9 +310,13 @@ export default function RepositoriesList(props: RepositoriesListProps) {
       <Empty
         icon={CubesIcon}
         title="There are no viewable repositories"
-        body="Either no repositories exist yet or you may not have permission to view any. If you have permission, try creating a new repository."
+        body={
+          isAuthenticated
+            ? 'Either no repositories exist yet or you may not have permission to view any. If you have permission, try creating a new repository.'
+            : 'No public repositories found. Sign in to view your private repositories.'
+        }
         button={
-          !isReadOnlySuperUser ? (
+          isAuthenticated && !isReadOnlySuperUser ? (
             <ToolbarButton
               id=""
               buttonValue="Create Repository"
@@ -318,7 +324,7 @@ export default function RepositoriesList(props: RepositoriesListProps) {
               isModalOpen={isCreateRepoModalOpen}
               setModalOpen={setCreateRepoModalOpen}
             />
-          ) : undefined
+          ) : null
         }
       />
     );
@@ -353,15 +359,19 @@ export default function RepositoriesList(props: RepositoriesListProps) {
           setSearch={setSearch}
           total={paginationProps.total}
           currentOrg={currentOrg}
-          pageModal={createRepoModal}
-          showPageButton={!isReadOnlySuperUser}
+          pageModal={
+            isAuthenticated && !isReadOnlySuperUser ? createRepoModal : null
+          }
+          showPageButton={isAuthenticated && !isReadOnlySuperUser}
           buttonText="Create Repository"
           isModalOpen={isCreateRepoModalOpen}
           setModalOpen={setCreateRepoModalOpen}
           isKebabOpen={isKebabOpen}
           setKebabOpen={setKebabOpen}
-          kebabItems={!isReadOnlySuperUser ? kebabItems : []}
-          selectedRepoNames={!isReadOnlySuperUser ? selectedRepoNames : []}
+          kebabItems={isAuthenticated && !isReadOnlySuperUser ? kebabItems : []}
+          selectedRepoNames={
+            isAuthenticated && !isReadOnlySuperUser ? selectedRepoNames : []
+          }
           deleteModal={deleteRepositoryModal}
           deleteKebabIsOpen={isDeleteModalOpen}
           makePublicModalOpen={makePublicModalOpen}
@@ -381,7 +391,7 @@ export default function RepositoriesList(props: RepositoriesListProps) {
         <Table aria-label="Selectable table" variant="compact">
           <Thead>
             <Tr>
-              {!isReadOnlySuperUser && <Th />}
+              {isAuthenticated && !isReadOnlySuperUser && <Th />}
               <Th modifier="wrap" sort={getSortableSort(0)}>
                 {RepositoryListColumnNames.name}
               </Th>
@@ -416,7 +426,7 @@ export default function RepositoriesList(props: RepositoriesListProps) {
             ) : (
               paginatedRepositoryList.map((repo, rowIndex) => (
                 <Tr key={rowIndex}>
-                  {!isReadOnlySuperUser && (
+                  {isAuthenticated && !isReadOnlySuperUser && (
                     <Td
                       select={{
                         rowIndex,

--- a/web/src/routes/RepositoryDetails/RepositoryDetails.test.tsx
+++ b/web/src/routes/RepositoryDetails/RepositoryDetails.test.tsx
@@ -1,0 +1,171 @@
+import {render, screen} from 'src/test-utils';
+import RepositoryDetails from './RepositoryDetails';
+
+const mockUseCurrentUser = vi.hoisted(() =>
+  vi.fn(() => ({user: {username: 'testuser'}, loading: false})),
+);
+
+const mockUseRepository = vi.hoisted(() =>
+  vi.fn(() => ({
+    repoDetails: {name: 'testrepo', namespace: 'testorg', can_admin: true},
+    errorLoadingRepoDetails: null,
+  })),
+);
+
+const mockIsRedirecting = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock('src/hooks/UseRepository', () => ({
+  useRepository: mockUseRepository,
+}));
+
+vi.mock('src/libs/axios', () => ({
+  default: {get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn()},
+  isRedirecting: mockIsRedirecting,
+}));
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: () => ({features: {}, config: {}}),
+}));
+
+vi.mock('src/hooks/UseTeams', () => ({
+  useFetchTeams: () => ({teams: []}),
+}));
+
+vi.mock('src/components/breadcrumb/Breadcrumb', () => ({
+  QuayBreadcrumb: () => null,
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: () => ({
+      pathname: '/repository/testorg/testrepo',
+      search: '',
+      hash: '',
+    }),
+    useNavigate: () => vi.fn(),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+    Link: ({children, to}: {children: React.ReactNode; to: string}) => (
+      <a href={to}>{children}</a>
+    ),
+  };
+});
+
+vi.mock('src/libs/utils', async () => {
+  const actual = await vi.importActual('src/libs/utils');
+  return {
+    ...actual,
+    parseOrgNameFromUrl: () => 'testorg',
+    parseRepoNameFromUrl: () => 'testrepo',
+  };
+});
+
+vi.mock('./Tags/TagsList', () => ({default: () => <div>Tags</div>}));
+vi.mock('./TagHistory/TagHistory', () => ({default: () => <div>History</div>}));
+vi.mock('./Builds/Builds', () => ({default: () => <div>Builds</div>}));
+vi.mock('./Settings/Settings', () => ({default: () => <div>Settings</div>}));
+vi.mock('./Settings/NotificationsCreateNotification', () => ({
+  default: () => null,
+}));
+vi.mock('./Settings/PermissionsAddPermission', () => ({
+  default: () => null,
+}));
+vi.mock('./Information/Information', () => ({
+  default: () => <div>Information</div>,
+}));
+vi.mock('../UsageLogs/UsageLogs', () => ({default: () => <div>Logs</div>}));
+vi.mock('./Mirroring/Mirroring', () => ({Mirroring: () => null}));
+vi.mock('src/components/modals/CreateRobotAccountModal', () => ({
+  default: () => null,
+}));
+vi.mock(
+  '../OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreateTeamModal',
+  () => ({CreateTeamModal: () => null}),
+);
+vi.mock('../RepositoriesList/RobotAccountsList', () => ({
+  RepoPermissionDropdownItems: [],
+}));
+
+describe('RepositoryDetails', () => {
+  it('returns null when isRedirecting is true', () => {
+    mockIsRedirecting.mockReturnValue(true);
+
+    const {container} = render(<RepositoryDetails />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns null for anonymous user when repo details not loaded', () => {
+    mockIsRedirecting.mockReturnValue(false);
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true},
+      loading: false,
+    });
+    mockUseRepository.mockReturnValue({
+      repoDetails: null,
+      errorLoadingRepoDetails: null,
+    });
+
+    const {container} = render(<RepositoryDetails />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders repo title for authenticated user', () => {
+    mockIsRedirecting.mockReturnValue(false);
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: 'testuser', anonymous: false},
+      loading: false,
+    });
+    mockUseRepository.mockReturnValue({
+      repoDetails: {
+        name: 'testrepo',
+        namespace: 'testorg',
+        can_admin: true,
+        can_write: true,
+      },
+      errorLoadingRepoDetails: null,
+    });
+
+    render(<RepositoryDetails />);
+    expect(screen.getByTestId('repo-title')).toHaveTextContent('testrepo');
+  });
+
+  it('passes shouldFetchRepo based on userLoading state', () => {
+    mockIsRedirecting.mockReturnValue(false);
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      loading: true,
+    });
+
+    render(<RepositoryDetails />);
+    expect(mockUseRepository).toHaveBeenCalledWith(
+      'testorg',
+      'testrepo',
+      false,
+    );
+  });
+
+  it('renders for anonymous user when repo details are available', () => {
+    mockIsRedirecting.mockReturnValue(false);
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true},
+      loading: false,
+    });
+    mockUseRepository.mockReturnValue({
+      repoDetails: {
+        name: 'testrepo',
+        namespace: 'testorg',
+        can_admin: false,
+        can_write: false,
+      },
+      errorLoadingRepoDetails: null,
+    });
+
+    render(<RepositoryDetails />);
+    expect(screen.getByTestId('repo-title')).toHaveTextContent('testrepo');
+  });
+});

--- a/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
+++ b/web/src/routes/RepositoryDetails/RepositoryDetails.tsx
@@ -28,11 +28,13 @@ import CreateRobotAccountModal from 'src/components/modals/CreateRobotAccountMod
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {useRepository} from 'src/hooks/UseRepository';
 import {useFetchTeams} from 'src/hooks/UseTeams';
+import {useCurrentUser} from 'src/hooks/UseCurrentUser';
 import {
   parseOrgNameFromUrl,
   parseRepoNameFromUrl,
   validateTeamName,
 } from 'src/libs/utils';
+import {isRedirecting} from 'src/libs/axios';
 import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
 import {Entity} from 'src/resources/UserResource';
 import {CreateTeamModal} from '../OrganizationsList/Organization/Tabs/DefaultPermissions/createPermissionDrawer/CreateTeamModal';
@@ -67,6 +69,7 @@ function getTabIndex(tab: string) {
 
 export default function RepositoryDetails() {
   const config = useQuayConfig();
+  const {user, loading: userLoading} = useCurrentUser();
   const [activeTabKey, setActiveTabKey] = useState(TabIndex.Information);
   const navigate = useNavigate();
   const location = useLocation();
@@ -78,23 +81,46 @@ export default function RepositoryDetails() {
   const [selectedEntity, setSelectedEntity] = useState<Entity>(null);
   const {addAlert} = useUI();
   const [err, setErr] = useState<string>();
-
   const drawerRef = useRef<HTMLDivElement>();
 
   const organization = parseOrgNameFromUrl(location.pathname);
   const repository = parseRepoNameFromUrl(location.pathname);
+
+  // Only fetch repository AFTER user state is known
+  // This prevents API calls from firing for anonymous users before we can block them
+  const shouldFetchRepo = !userLoading;
   const {repoDetails, errorLoadingRepoDetails} = useRepository(
     organization,
     repository,
+    shouldFetchRepo,
   );
 
-  // state variables for Create Team
   const [teamName, setTeamName] = useState('');
   const [teamDescription, setTeamDescription] = useState('');
   const [isTeamModalOpen, setIsTeamModalOpen] = useState<boolean>(false);
 
-  const {teams} = useFetchTeams(organization);
+  // Only fetch teams AFTER user state is known (same as repo)
+  const {teams} = useFetchTeams(organization, shouldFetchRepo);
   const setupBuildTriggerUuid = searchParams.get('setupTrigger');
+
+  useEffect(() => {
+    if (errorLoadingRepoDetails) {
+      setErr(
+        addDisplayError(
+          'Unable to get repository',
+          errorLoadingRepoDetails as Error,
+        ),
+      );
+    }
+  }, [errorLoadingRepoDetails]);
+
+  if (isRedirecting()) {
+    return null;
+  }
+
+  if (user?.anonymous && !repoDetails) {
+    return null;
+  }
 
   const createRobotModal = (
     <CreateRobotAccountModal
@@ -177,17 +203,6 @@ export default function RepositoryDetails() {
       />
     ),
   };
-
-  useEffect(() => {
-    if (errorLoadingRepoDetails) {
-      setErr(
-        addDisplayError(
-          'Unable to get repository',
-          errorLoadingRepoDetails as Error,
-        ),
-      );
-    }
-  }, [errorLoadingRepoDetails]);
 
   return (
     <>
@@ -274,6 +289,9 @@ export default function RepositoryDetails() {
                   <Tab
                     eventKey={TabIndex.Logs}
                     title={<TabTitleText>Logs</TabTitleText>}
+                    isHidden={
+                      !repoDetails?.can_write && !repoDetails?.can_admin
+                    }
                     {...({} as any)}
                   >
                     <UsageLogs

--- a/web/src/routes/StandaloneMain.test.tsx
+++ b/web/src/routes/StandaloneMain.test.tsx
@@ -1,0 +1,203 @@
+import {render} from 'src/test-utils';
+import {StandaloneMain} from './StandaloneMain';
+
+const mockUseQuayConfigWithLoading = vi.hoisted(() =>
+  vi.fn(() => ({
+    config: {features: {}, config: {}},
+    isLoading: false,
+    error: null,
+  })),
+);
+
+const mockUseCurrentUser = vi.hoisted(() =>
+  vi.fn(() => ({
+    user: {username: 'testuser', anonymous: false, organizations: []},
+    loading: false,
+    error: null,
+  })),
+);
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: () => mockUseQuayConfigWithLoading().config,
+  useQuayConfigWithLoading: mockUseQuayConfigWithLoading,
+}));
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: mockUseCurrentUser,
+}));
+
+vi.mock('src/hooks/UseExternalScripts', () => ({
+  useExternalScripts: vi.fn(),
+}));
+
+vi.mock('src/components/header/QuayHeader', () => ({
+  QuayHeader: () => <div data-testid="quay-header">Header</div>,
+}));
+
+vi.mock('src/components/sidebar/QuaySidebar', () => ({
+  QuaySidebar: () => <div>Sidebar</div>,
+}));
+
+vi.mock('src/components/footer/QuayFooter', () => ({
+  QuayFooter: () => <div>Footer</div>,
+}));
+
+vi.mock('src/components/notifications/NotificationDrawerList', () => ({
+  NotificationDrawerListComponent: () => <div>Notifications</div>,
+}));
+
+vi.mock('src/components/SystemStatusBanner', () => ({
+  default: () => null,
+}));
+
+vi.mock('src/components/GlobalMessages', () => ({
+  GlobalMessages: () => null,
+}));
+
+vi.mock('src/components/LoadingPage', () => ({
+  LoadingPage: () => <div>Loading...</div>,
+}));
+
+vi.mock('src/routes/RegistryStatus', () => ({
+  default: () => null,
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: () => ({pathname: '/', search: '', hash: ''}),
+    Navigate: ({to}: {to: string}) => <div data-testid="navigate">{to}</div>,
+    Outlet: () => null,
+    Routes: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+    Route: () => null,
+    useParams: () => ({}),
+  };
+});
+
+vi.mock('./Alerts', () => ({default: () => null}));
+
+describe('StandaloneMain', () => {
+  const originalHref = window.location.href;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {href: originalHref},
+    });
+  });
+
+  it('returns null while config is loading', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: null,
+      isLoading: true,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      loading: false,
+      error: null,
+    });
+
+    const {container} = render(<StandaloneMain />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns null while user is loading', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: {features: {}, config: {}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      loading: true,
+      error: null,
+    });
+
+    const {container} = render(<StandaloneMain />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('redirects anonymous user to signin when ANONYMOUS_ACCESS is disabled', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: {features: {ANONYMOUS_ACCESS: false}, config: {}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true, organizations: []},
+      loading: false,
+      error: null,
+    });
+
+    const {container} = render(<StandaloneMain />);
+    expect(window.location.href).toBe('/signin');
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders page for anonymous user when ANONYMOUS_ACCESS is enabled', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: {features: {ANONYMOUS_ACCESS: true}, config: {}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: '', anonymous: true, organizations: []},
+      loading: false,
+      error: null,
+    });
+
+    const {getByTestId} = render(<StandaloneMain />);
+    expect(getByTestId('quay-header')).toBeTruthy();
+  });
+
+  it('renders page for authenticated user', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: {features: {}, config: {}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: 'testuser', anonymous: false, organizations: []},
+      loading: false,
+      error: null,
+    });
+
+    const {getByTestId} = render(<StandaloneMain />);
+    expect(getByTestId('quay-header')).toBeTruthy();
+  });
+
+  it('shows error fallback when config has error', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: null,
+      isLoading: false,
+      error: new Error('config failed'),
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: 'testuser', anonymous: false, organizations: []},
+      loading: false,
+      error: null,
+    });
+
+    const {container} = render(<StandaloneMain />);
+    expect(container.textContent).toContain('unavailable');
+  });
+
+  it('shows error fallback when user fetch has error', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: {features: {}, config: {}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      loading: false,
+      error: new Error('user fetch failed'),
+    });
+
+    const {container} = render(<StandaloneMain />);
+    expect(container.textContent).toContain('unavailable');
+  });
+});

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -25,7 +25,7 @@ import {NavigationPath} from './NavigationPath';
 
 import {useEffect, useState, lazy, Suspense} from 'react';
 import ErrorBoundary from 'src/components/errors/ErrorBoundary';
-import {useQuayConfig} from 'src/hooks/UseQuayConfig';
+import {useQuayConfigWithLoading} from 'src/hooks/UseQuayConfig';
 import SiteUnavailableError from 'src/components/errors/SiteUnavailableError';
 import NotFound from 'src/components/errors/404';
 import {useCurrentUser} from 'src/hooks/UseCurrentUser';
@@ -40,7 +40,6 @@ import {GlobalMessages} from 'src/components/GlobalMessages';
 import {LoadingPage} from 'src/components/LoadingPage';
 import {useUI} from 'src/contexts/UIContext';
 import {useExternalScripts} from 'src/hooks/UseExternalScripts';
-import {AxiosError} from 'axios';
 
 // Lazy load route components for better performance
 const OrganizationsList = lazy(
@@ -52,7 +51,7 @@ const Organization = lazy(
 const RepositoriesList = lazy(
   () => import('./RepositoriesList/RepositoriesList'),
 );
-const RepositoryTagRouter = lazy(() => import('./RepositoryTagRouter'));
+import ProtectedRepositoryRoute from './ProtectedRepositoryRoute';
 const OverviewList = lazy(() => import('./OverviewList/OverviewList'));
 const SetupBuildTriggerRedirect = lazy(
   () => import('./SetupBuildtrigger/SetupBuildTriggerRedirect'),
@@ -183,7 +182,7 @@ const NavigationRoutes = [
   },
   {
     path: NavigationPath.repositoryDetail,
-    Component: <RepositoryTagRouter />,
+    Component: <ProtectedRepositoryRoute />,
   },
   // Static pages
   {
@@ -218,8 +217,12 @@ const NavigationRoutes = [
 ];
 
 export function StandaloneMain() {
-  const quayConfig = useQuayConfig();
-  const {loading, error} = useCurrentUser();
+  const {
+    config: quayConfig,
+    isLoading: configLoading,
+    error: configError,
+  } = useQuayConfigWithLoading();
+  const {user, loading: userLoading, error: userError} = useCurrentUser();
   const location = useLocation();
   const {clearAllAlerts} = useUI();
 
@@ -252,17 +255,23 @@ export function StandaloneMain() {
     }
   }, [quayConfig]);
 
-  // Don't render anything while loading, or if there's a 401 error
-  // (401 errors trigger a redirect to /signin via axios interceptor, so we shouldn't
-  // flash the SiteUnavailableError during the redirect - fixes PROJQUAY-10089)
-  const is401Error = error && (error as AxiosError)?.response?.status === 401;
-  if (loading || is401Error) {
+  // Wait for both user data and config to load before rendering
+  if (userLoading || configLoading) {
     return null;
   }
 
-  // Only show SiteUnavailableError for non-401 errors (real server errors)
+  // If user is anonymous and ANONYMOUS_ACCESS is not enabled, redirect to
+  // signin (preserves existing behavior when anonymous access is disabled).
+  // When ANONYMOUS_ACCESS is enabled, let anonymous users browse public repos
+  if (user?.anonymous && quayConfig?.features?.ANONYMOUS_ACCESS !== true) {
+    window.location.href = '/signin';
+    return null;
+  }
+
+  // Surface config or user fetch errors via the ErrorBoundary
+  const hasError = !!configError || !!userError;
   return (
-    <ErrorBoundary hasError={!!error} fallback={<SiteUnavailableError />}>
+    <ErrorBoundary hasError={hasError} fallback={<SiteUnavailableError />}>
       <Page
         masthead={<QuayHeader toggleDrawer={toggleDrawer} />}
         sidebar={<QuaySidebar />}


### PR DESCRIPTION
## Summary
This PR enables anonymous browsing of public repositories in the React UI  when the ANONYMOUS_ACCESS feature flag is enabled. Anonymous users can view public repos without authentication, while private repos trigger a redirect to /signin. The implementation includes a critical security fix (FOUC prevention) via a protected route wrapper. 

This takes over the work started in PR #5174 by @jbpratt.

## Changes
  - Updated `StandaloneMain.tsx` to allow anonymous users when `ANONYMOUS_ACCESS` is enabled
  - Modified `UseRepositories.ts` to fetch public repos for anonymous users
  - Updated `HeaderToolbar.tsx` to handle anonymous user state
  - Updated API client in `axios.ts` to handle unauthenticated requests
  - Added Playwright tests for anonymous access (`anonymous-access.spec.ts`)
  - Fixed merge conflicts from master branch

## Test Plan
### Manual Testing
  - Anonymous users can browse public repositories
  - Anonymous users get "Requires authentication" error when accessing private repositories
  - Signed-in users can access both public and private repositories

  ### Automated Tests
  - Added `web/playwright/e2e/auth/anonymous-access.spec.ts` with comprehensive test coverage
  - Updated logout tests in `web/playwright/e2e/auth/logout.spec.ts`
