### PR TITLE
NO-ISSUE: ci: move vpc sg rule cleanup to dedicated workflow job

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -26,6 +26,7 @@ jobs:
     runs-on: quay-001-large-ubuntu-24-x64
     outputs:
       digest: ${{ steps.docker_build.outputs.digest }}
+      sg_rule_id: ${{ steps.sg-rule-id.outputs.rule_id }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -52,7 +53,7 @@ jobs:
           echo $cidr
           SGRID=$(ibmcloud is security-group-rule-add --sg ${{ secrets.SG_ID }} --direction=inbound --protocol=tcp --port-min=22 --port-max=22 --remote=$cidr --output JSON | jq -r '.id')
           echo $SGRID
-          echo "RID=${SGRID}" >> $GITHUB_ENV
+          echo "rule_id=${SGRID}" >> $GITHUB_OUTPUT
 
       - name: Setup SSH config for builders
         env:
@@ -120,10 +121,23 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPO_NAME }}:${{ github.event.inputs.tag || env.TAG }}-amd64-ppc64le-s390x
 
-      - name: Clean up
-        if: success() || failure()
+  cleanup-sg-rule:
+    name: Remove VPC SSH rule
+    needs: build-amd64-ppc64le-s390x
+    if: always() && needs.build-amd64-ppc64le-s390x.outputs.sg_rule_id != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install ibmcli and login
         run: |
-          ibmcloud is security-group-rule-delete ${{ secrets.SG_ID }} $RID -f
+          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+          ibmcloud login -q --apikey ${{ secrets.IBMCLOUD_API_KEY }} -r eu-gb
+          ibmcloud plugin install vpc-infrastructure
+
+      - name: Delete VPC security group rule
+        run: |
+          ibmcloud is security-group-rule-delete \
+            ${{ secrets.SG_ID }} \
+            ${{ needs.build-amd64-ppc64le-s390x.outputs.sg_rule_id }} -f
 
   build-arm64:
     name: Build ARM64 image

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -134,10 +134,11 @@ jobs:
           ibmcloud plugin install vpc-infrastructure
 
       - name: Delete VPC security group rule
+        env:
+          SG_ID: ${{ secrets.SG_ID }}
+          SG_RULE_ID: ${{ needs.build-amd64-ppc64le-s390x.outputs.sg_rule_id }}
         run: |
-          ibmcloud is security-group-rule-delete \
-            ${{ secrets.SG_ID }} \
-            ${{ needs.build-amd64-ppc64le-s390x.outputs.sg_rule_id }} -f
+          ibmcloud is security-group-rule-delete "$SG_ID" "$SG_RULE_ID" -f
 
   build-arm64:
     name: Build ARM64 image


### PR DESCRIPTION
Moves VPC security group (SG) cleanup out of the build-and-publish job into a dedicated follow-up job.

Changes:
Export security group rule ID as a job output
Move VPC rule cleanup into a dedicated job that runs on workflow completion