### PR TITLE
NO-ISSUE: feat(cmd): add quay migrate command for OMR-to-Go upgrade path

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -105,7 +105,7 @@ jobs:
         run: make go-schema-check
 
   e2e-mirror:
-    name: E2E Mirror
+    name: E2E Mirror Install
     runs-on: ubuntu-latest
     needs: [build]
     timeout-minutes: 30
@@ -240,4 +240,456 @@ jobs:
         with:
           name: e2e-mirror-diagnostics
           path: /tmp/e2e-diagnostics/
+          retention-days: 7
+
+  e2e-migrate:
+    name: E2E Mirror Migrate
+    runs-on: ubuntu-latest
+    needs: [build]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Download quay binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: quay-binary
+          path: bin/
+
+      - name: Build container image
+        run: |
+          chmod +x bin/quay
+          podman build -f Dockerfile.mirror -t quay-mirror:test .
+
+      - name: Save image archive next to binary
+        run: podman save quay-mirror:test -o bin/quay-mirror.tar
+
+      - name: Install migration test tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y sqlite3
+
+      - name: Download and install old OMR
+        run: |
+          curl -fsSL -o /tmp/mirror-registry.tar.gz \
+            https://github.com/quay/mirror-registry/releases/download/v2.0.11/mirror-registry-offline.tar.gz
+          mkdir -p /tmp/omr && tar xzf /tmp/mirror-registry.tar.gz -C /tmp/omr
+          cd /tmp/omr
+          sudo ./mirror-registry install \
+            --initPassword testpassword123 \
+            --quayHostname localhost
+
+      - name: Wait for old OMR
+        run: |
+          set -euo pipefail
+
+          echo "Waiting for OMR health endpoint..."
+          curl -kfsS --retry 60 --retry-delay 2 --retry-all-errors \
+            https://localhost:8443/health/instance
+          echo "OMR is healthy"
+
+      - name: Push test content to old OMR
+        run: |
+          set -euo pipefail
+          sudo podman login localhost:8443 -u init -p testpassword123 --tls-verify=false
+          sudo podman pull registry.access.redhat.com/ubi9/ubi-micro:latest
+
+          sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:8443/init/test-image:v1
+          sudo podman push localhost:8443/init/test-image:v1 --tls-verify=false
+
+          sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:8443/init/test-image-2:latest
+          sudo podman push localhost:8443/init/test-image-2:latest --tls-verify=false
+
+          # Same manifest under two tags.
+          sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:8443/init/shared:v1
+          sudo podman push localhost:8443/init/shared:v1 --tls-verify=false
+          sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:8443/init/shared:v2
+          sudo podman push localhost:8443/init/shared:v2 --tls-verify=false
+
+          # Same blob set across repositories.
+          sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:8443/init/shared-a:v1
+          sudo podman push localhost:8443/init/shared-a:v1 --tls-verify=false
+          sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:8443/init/shared-b:v1
+          sudo podman push localhost:8443/init/shared-b:v1 --tls-verify=false
+
+          # Manifest-list/index coverage. A single-platform list still drives
+          # distribution through the manifest-list code path.
+          sudo podman manifest create localhost:8443/init/test-index:latest
+          sudo podman manifest add localhost:8443/init/test-index:latest registry.access.redhat.com/ubi9/ubi-micro:latest
+          sudo podman manifest push --all --tls-verify=false \
+            localhost:8443/init/test-index:latest docker://localhost:8443/init/test-index:latest
+
+      - name: Record source registry state
+        run: |
+          set -euo pipefail
+
+          mkdir -p /tmp/e2e-migrate-state
+          ACCEPT_HEADER='Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
+
+          auth_param() {
+            local challenge="$1"
+            local key="$2"
+            printf '%s\n' "$challenge" | sed -n "s/.*${key}=\"\\([^\"]*\\)\".*/\\1/p"
+          }
+
+          fetch_manifest() {
+            local repo="$1"
+            local ref="$2"
+            local headers="$3"
+            local body="$4"
+            local url="https://localhost:8443/v2/${repo}/manifests/${ref}"
+
+            # Go Quay accepts Basic auth directly. Python Quay returns a
+            # Bearer challenge, which podman follows automatically; reproduce
+            # that token flow here so curl can capture source manifests too.
+            if curl -skf -D "$headers" -o "$body" \
+              -u init:testpassword123 \
+              -H "$ACCEPT_HEADER" \
+              "$url"; then
+              return 0
+            fi
+
+            local challenge_headers="${headers%.headers}.challenge.headers"
+            local token_json="${headers%.headers}.token.json"
+            cp "$headers" "$challenge_headers" 2>/dev/null || true
+
+            local challenge
+            challenge=$(tr -d '\r' < "$challenge_headers" | awk -F': ' 'tolower($1) == "www-authenticate" {print $2; exit}')
+            if ! printf '%s' "$challenge" | grep -qi '^Bearer '; then
+              echo "FAIL: manifest request for ${repo}:${ref} did not return a Bearer challenge"
+              return 1
+            fi
+
+            local realm service scope token
+            realm=$(auth_param "$challenge" realm)
+            service=$(auth_param "$challenge" service)
+            scope=$(auth_param "$challenge" scope)
+            if [ -z "$scope" ]; then
+              scope="repository:${repo}:pull"
+            fi
+            if [ -z "$realm" ]; then
+              echo "FAIL: Bearer challenge for ${repo}:${ref} did not include realm"
+              return 1
+            fi
+
+            if [ -n "$service" ]; then
+              curl -skfsS -u init:testpassword123 -G \
+                --data-urlencode "service=${service}" \
+                --data-urlencode "scope=${scope}" \
+                -o "$token_json" \
+                "$realm"
+            else
+              curl -skfsS -u init:testpassword123 -G \
+                --data-urlencode "scope=${scope}" \
+                -o "$token_json" \
+                "$realm"
+            fi
+
+            token=$(jq -r '.token // .access_token // empty' "$token_json")
+            if [ -z "$token" ]; then
+              echo "FAIL: token response for ${repo}:${ref} did not include a token"
+              return 1
+            fi
+
+            curl -skfsS -D "$headers" -o "$body" \
+              -H "$ACCEPT_HEADER" \
+              -H "Authorization: Bearer ${token}" \
+              "$url"
+          }
+
+          manifest_digest() {
+            local repo="$1"
+            local ref="$2"
+            local safe_ref
+            safe_ref=$(echo "$repo-$ref" | tr '/:' '--')
+            local headers="/tmp/e2e-migrate-state/source-${safe_ref}.headers"
+            local body="/tmp/e2e-migrate-state/source-${safe_ref}.json"
+
+            fetch_manifest "$repo" "$ref" "$headers" "$body"
+            tr -d '\r' < "$headers" | awk -F': ' 'tolower($1) == "docker-content-digest" {print $2}' | tail -n1
+          }
+
+          record_digest() {
+            local name="$1"
+            local repo="$2"
+            local ref="$3"
+            local digest
+            digest=$(manifest_digest "$repo" "$ref")
+            if [ -z "$digest" ]; then
+              echo "FAIL: ${name} was not captured from ${repo}:${ref}"
+              return 1
+            fi
+            echo "${name}=${digest}" | tee -a /tmp/e2e-migrate-state/digests.env
+          }
+
+          : > /tmp/e2e-migrate-state/digests.env
+          record_digest TEST_IMAGE_DIGEST init/test-image v1
+          record_digest TEST_IMAGE_2_DIGEST init/test-image-2 latest
+          record_digest SHARED_V1_DIGEST init/shared v1
+          record_digest SHARED_V2_DIGEST init/shared v2
+          record_digest SHARED_A_DIGEST init/shared-a v1
+          record_digest SHARED_B_DIGEST init/shared-b v1
+          record_digest INDEX_DIGEST init/test-index latest
+
+          . /tmp/e2e-migrate-state/digests.env
+          for var in TEST_IMAGE_DIGEST TEST_IMAGE_2_DIGEST SHARED_V1_DIGEST SHARED_V2_DIGEST SHARED_A_DIGEST SHARED_B_DIGEST INDEX_DIGEST; do
+            if [ -z "${!var}" ]; then
+              echo "FAIL: ${var} was not captured"
+              exit 1
+            fi
+          done
+          if [ "$SHARED_V1_DIGEST" != "$SHARED_V2_DIGEST" ]; then
+            echo "FAIL: expected init/shared:v1 and init/shared:v2 to share a manifest digest"
+            exit 1
+          fi
+
+          SQLITE_DIR=$(sudo podman volume inspect sqlite-storage --format '{{.Mountpoint}}')
+          SOURCE_DB="${SQLITE_DIR}/quay_sqlite.db"
+          echo "$SOURCE_DB" | tee /tmp/e2e-migrate-state/source-db-path.txt
+          sudo test -f "$SOURCE_DB"
+
+          sudo sqlite3 "$SOURCE_DB" 'PRAGMA integrity_check;' | tee /tmp/e2e-migrate-state/source-integrity.txt
+          grep -qx ok /tmp/e2e-migrate-state/source-integrity.txt
+
+          : > /tmp/e2e-migrate-state/source-counts.env
+          for table in repository tag manifest manifestblob imagestorage; do
+            count=$(sudo sqlite3 "$SOURCE_DB" "SELECT COUNT(*) FROM ${table};")
+            echo "${table}=${count}" | tee -a /tmp/e2e-migrate-state/source-counts.env
+          done
+          version=$(sudo sqlite3 "$SOURCE_DB" "SELECT version_num FROM alembic_version;")
+          echo "alembic_version=${version}" | tee -a /tmp/e2e-migrate-state/source-counts.env
+
+          sudo podman volume inspect sqlite-storage quay-storage \
+            > /tmp/e2e-migrate-state/source-volumes.json
+          sudo systemctl status quay-app.service quay-redis.service quay-pod.service --no-pager \
+            > /tmp/e2e-migrate-state/source-services.txt || true
+          sudo cp /etc/systemd/system/quay-app.service /tmp/e2e-migrate-state/source-quay-app.service || true
+
+      - name: Run quay migrate
+        run: sudo bin/quay migrate
+
+      - name: Trust registry TLS certificate
+        run: |
+          sudo install -m 644 /var/lib/quay/ssl.cert /usr/local/share/ca-certificates/quay.crt
+          sudo update-ca-certificates
+          sudo mkdir -p /etc/containers/certs.d/localhost:8443
+          sudo install -m 644 /var/lib/quay/ssl.cert /etc/containers/certs.d/localhost:8443/ca.crt
+
+      - name: Verify migrated content
+        run: |
+          set -euo pipefail
+
+          curl -fs https://localhost:8443/healthz
+          echo "Health check passed"
+
+          sudo sqlite3 /var/lib/quay/quay.db 'PRAGMA integrity_check;' | tee /tmp/e2e-migrate-state/target-integrity.txt
+          grep -qx ok /tmp/e2e-migrate-state/target-integrity.txt
+
+          : > /tmp/e2e-migrate-state/target-counts.env
+          for table in repository tag manifest manifestblob imagestorage; do
+            expected=$(awk -F= -v key="$table" '$1 == key {print $2}' /tmp/e2e-migrate-state/source-counts.env)
+            actual=$(sudo sqlite3 /var/lib/quay/quay.db "SELECT COUNT(*) FROM ${table};")
+            echo "${table}=${actual}" | tee -a /tmp/e2e-migrate-state/target-counts.env
+            if [ "$actual" != "$expected" ]; then
+              echo "FAIL: ${table} count changed during migration: expected ${expected}, got ${actual}"
+              exit 1
+            fi
+          done
+
+          expected_version=$(sed -n 's/^const TargetVersion = "\(.*\)"/\1/p' internal/dal/dbcore/migrate.go)
+          actual_version=$(sudo sqlite3 /var/lib/quay/quay.db "SELECT version_num FROM alembic_version;")
+          echo "alembic_version=${actual_version}" | tee -a /tmp/e2e-migrate-state/target-counts.env
+          if [ "$actual_version" != "$expected_version" ]; then
+            echo "FAIL: expected alembic version ${expected_version}, got ${actual_version}"
+            exit 1
+          fi
+
+          . /tmp/e2e-migrate-state/digests.env
+          ACCEPT_HEADER='Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
+
+          auth_param() {
+            local challenge="$1"
+            local key="$2"
+            printf '%s\n' "$challenge" | sed -n "s/.*${key}=\"\\([^\"]*\\)\".*/\\1/p"
+          }
+
+          fetch_manifest() {
+            local repo="$1"
+            local ref="$2"
+            local headers="$3"
+            local body="$4"
+            local url="https://localhost:8443/v2/${repo}/manifests/${ref}"
+
+            if curl -skf -D "$headers" -o "$body" \
+              -u init:testpassword123 \
+              -H "$ACCEPT_HEADER" \
+              "$url"; then
+              return 0
+            fi
+
+            local challenge_headers="${headers%.headers}.challenge.headers"
+            local token_json="${headers%.headers}.token.json"
+            cp "$headers" "$challenge_headers" 2>/dev/null || true
+
+            local challenge
+            challenge=$(tr -d '\r' < "$challenge_headers" | awk -F': ' 'tolower($1) == "www-authenticate" {print $2; exit}')
+            if ! printf '%s' "$challenge" | grep -qi '^Bearer '; then
+              echo "FAIL: manifest request for ${repo}:${ref} did not return a Bearer challenge"
+              return 1
+            fi
+
+            local realm service scope token
+            realm=$(auth_param "$challenge" realm)
+            service=$(auth_param "$challenge" service)
+            scope=$(auth_param "$challenge" scope)
+            if [ -z "$scope" ]; then
+              scope="repository:${repo}:pull"
+            fi
+            if [ -z "$realm" ]; then
+              echo "FAIL: Bearer challenge for ${repo}:${ref} did not include realm"
+              return 1
+            fi
+
+            if [ -n "$service" ]; then
+              curl -skfsS -u init:testpassword123 -G \
+                --data-urlencode "service=${service}" \
+                --data-urlencode "scope=${scope}" \
+                -o "$token_json" \
+                "$realm"
+            else
+              curl -skfsS -u init:testpassword123 -G \
+                --data-urlencode "scope=${scope}" \
+                -o "$token_json" \
+                "$realm"
+            fi
+
+            token=$(jq -r '.token // .access_token // empty' "$token_json")
+            if [ -z "$token" ]; then
+              echo "FAIL: token response for ${repo}:${ref} did not include a token"
+              return 1
+            fi
+
+            curl -skfsS -D "$headers" -o "$body" \
+              -H "$ACCEPT_HEADER" \
+              -H "Authorization: Bearer ${token}" \
+              "$url"
+          }
+
+          verify_manifest_digest() {
+            local repo="$1"
+            local ref="$2"
+            local expected="$3"
+            local safe_ref
+            safe_ref=$(echo "$repo-$ref" | tr '/:' '--')
+            local headers="/tmp/e2e-migrate-state/target-${safe_ref}.headers"
+            local body="/tmp/e2e-migrate-state/target-${safe_ref}.json"
+            local actual
+
+            fetch_manifest "$repo" "$ref" "$headers" "$body"
+            actual=$(tr -d '\r' < "$headers" | awk -F': ' 'tolower($1) == "docker-content-digest" {print $2}' | tail -n1)
+            if [ "$actual" != "$expected" ]; then
+              echo "FAIL: ${repo}:${ref} digest changed: expected ${expected}, got ${actual}"
+              exit 1
+            fi
+            test -s "$body"
+          }
+
+          verify_manifest_digest init/test-image v1 "$TEST_IMAGE_DIGEST"
+          verify_manifest_digest init/test-image "$TEST_IMAGE_DIGEST" "$TEST_IMAGE_DIGEST"
+          verify_manifest_digest init/test-image-2 latest "$TEST_IMAGE_2_DIGEST"
+          verify_manifest_digest init/shared v1 "$SHARED_V1_DIGEST"
+          verify_manifest_digest init/shared v2 "$SHARED_V2_DIGEST"
+          verify_manifest_digest init/shared-a v1 "$SHARED_A_DIGEST"
+          verify_manifest_digest init/shared-b v1 "$SHARED_B_DIGEST"
+          verify_manifest_digest init/test-index latest "$INDEX_DIGEST"
+
+          curl -fsS -u init:testpassword123 \
+            https://localhost:8443/v2/init/shared/tags/list \
+            | tee /tmp/e2e-migrate-state/shared-tags.json
+          jq -e '.tags | index("v1") and index("v2")' /tmp/e2e-migrate-state/shared-tags.json
+
+          sudo podman pull "localhost:8443/init/test-image@${TEST_IMAGE_DIGEST}"
+          sudo podman pull localhost:8443/init/test-image:v1
+          sudo podman pull localhost:8443/init/test-image-2:latest
+          sudo podman pull localhost:8443/init/shared:v2
+          sudo podman pull localhost:8443/init/test-index:latest
+
+          sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:8443/init/post-migrate:latest
+          sudo podman push localhost:8443/init/post-migrate:latest
+          sudo podman pull localhost:8443/init/post-migrate:latest
+
+          echo "All migration verifications passed"
+
+      - name: Clean up old OMR
+        run: |
+          set -euo pipefail
+
+          sudo bin/quay migrate -cleanup
+          echo "Cleanup completed"
+
+          for unit in quay-app.service quay-redis.service quay-pod.service; do
+            if sudo test -e "/etc/systemd/system/${unit}"; then
+              echo "FAIL: old OMR unit still exists: ${unit}"
+              exit 1
+            fi
+          done
+
+          if sudo podman volume exists sqlite-storage; then
+            echo "FAIL: old sqlite-storage volume still exists"
+            exit 1
+          fi
+          if sudo podman volume exists quay-storage; then
+            echo "FAIL: old quay-storage volume still exists"
+            exit 1
+          fi
+          if sudo podman secret inspect redis_pass >/dev/null 2>&1; then
+            echo "FAIL: old redis_pass secret still exists"
+            exit 1
+          fi
+          if sudo test -e /var/lib/quay/.migration-in-progress; then
+            echo "FAIL: migration marker still exists"
+            exit 1
+          fi
+
+          curl -fs https://localhost:8443/healthz
+          echo "Cleanup assertions passed"
+
+      - name: Collect diagnostics
+        if: always()
+        run: |
+          mkdir -p /tmp/e2e-migrate-diagnostics
+          cp -a /tmp/e2e-migrate-state/. /tmp/e2e-migrate-diagnostics/ 2>/dev/null || true
+
+          sudo podman ps -a > /tmp/e2e-migrate-diagnostics/podman-ps.txt 2>&1 || true
+          sudo podman images > /tmp/e2e-migrate-diagnostics/podman-images.txt 2>&1 || true
+          sudo podman volume ls > /tmp/e2e-migrate-diagnostics/podman-volumes.txt 2>&1 || true
+          sudo podman volume inspect sqlite-storage quay-storage > /tmp/e2e-migrate-diagnostics/podman-volume-inspect.json 2>&1 || true
+          sudo podman secret ls > /tmp/e2e-migrate-diagnostics/podman-secrets.txt 2>&1 || true
+          podman ps -a >> /tmp/e2e-migrate-diagnostics/podman-ps.txt 2>&1 || true
+          sudo podman logs quay-app > /tmp/e2e-migrate-diagnostics/omr-quay-app.log 2>&1 || true
+          podman logs quay-app >> /tmp/e2e-migrate-diagnostics/omr-quay-app.log 2>&1 || true
+          sudo podman logs quay-redis > /tmp/e2e-migrate-diagnostics/omr-redis.log 2>&1 || true
+          sudo podman logs systemd-quay > /tmp/e2e-migrate-diagnostics/new-quay.log 2>&1 || true
+          sudo journalctl --no-pager -n 200 > /tmp/e2e-migrate-diagnostics/journal.log 2>&1 || true
+          sudo journalctl -u quay-app.service -u quay-redis.service -u quay-pod.service -u quay.service --no-pager > /tmp/e2e-migrate-diagnostics/quay-units-journal.log 2>&1 || true
+          sudo systemctl list-units 'quay*' --all --no-pager > /tmp/e2e-migrate-diagnostics/systemd-quay-units.txt 2>&1 || true
+          sudo systemctl list-unit-files 'quay*' --no-pager > /tmp/e2e-migrate-diagnostics/systemd-quay-unit-files.txt 2>&1 || true
+          sudo systemctl status quay.service > /tmp/e2e-migrate-diagnostics/service-status.txt 2>&1 || true
+          sudo ls -laR /var/lib/quay/ > /tmp/e2e-migrate-diagnostics/data-dir.txt 2>&1 || true
+          sudo find /var/lib/quay -maxdepth 4 -type f -printf '%p %s bytes\n' > /tmp/e2e-migrate-diagnostics/data-files.txt 2>&1 || true
+          sudo sqlite3 /var/lib/quay/quay.db 'PRAGMA integrity_check;' > /tmp/e2e-migrate-diagnostics/target-integrity-latest.txt 2>&1 || true
+          sudo sqlite3 /var/lib/quay/quay.db "SELECT name, type FROM sqlite_master WHERE type IN ('table', 'index') ORDER BY type, name;" > /tmp/e2e-migrate-diagnostics/target-schema-objects.txt 2>&1 || true
+          curl -kfsS -u init:testpassword123 https://localhost:8443/v2/init/shared/tags/list > /tmp/e2e-migrate-diagnostics/shared-tags-latest.json 2>&1 || true
+          curl -kfsS https://localhost:8443/healthz > /tmp/e2e-migrate-diagnostics/healthz.txt 2>&1 || true
+          ss -tlnp > /tmp/e2e-migrate-diagnostics/ports.txt 2>&1 || true
+
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-migrate-diagnostics
+          path: /tmp/e2e-migrate-diagnostics/
           retention-days: 7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,7 @@ linters:
     paths:
       - .*\.pb\.go$
       - vendor
+      - node_modules
       - config-tool
       - third_party$
       - builtin$
@@ -113,6 +114,7 @@ formatters:
     paths:
       - .*\.pb\.go$
       - vendor
+      - node_modules
       - config-tool
       - third_party$
       - builtin$

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -26,6 +26,7 @@ func Run(args []string) int {
 			newInstallCmd(),
 			newConfigCmd(),
 			newServeCmd(),
+			newMigrateCmd(),
 			newVersionCmd(),
 		},
 		AfterParse: func() error {

--- a/internal/cmd/migrate.go
+++ b/internal/cmd/migrate.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/quay/quay/internal/installer"
+	"github.com/quay/quay/internal/migrate"
+	"github.com/quay/quay/internal/system"
+)
+
+func newMigrateCmd() *Command {
+	fs := flag.NewFlagSet("migrate", flag.ContinueOnError)
+	dataDir := fs.String("data-dir", "/var/lib/quay", "target directory for new installation")
+	hostname := fs.String("hostname", "", "server hostname (auto-detected from old config)")
+	image := fs.String("image", installer.DefaultImage, "container image reference")
+	imageArchive := fs.String("image-archive", "", "path to container image tar (auto-detected)")
+
+	sourceRoot := fs.String("source-root", "", "old quay-install directory")
+	sourceDB := fs.String("source-db", "", "old SQLite database file path")
+	sourceStorage := fs.String("source-storage", "", "old blob storage path")
+	sourceCerts := fs.String("source-certs", "", "old TLS cert directory")
+
+	dryRun := fs.Bool("dry-run", false, "show migration plan without making changes")
+	cleanup := fs.Bool("cleanup", false, "remove old OMR after successful migration")
+	skipInstall := fs.Bool("skip-install", false, "only migrate data, do not deploy Quadlet service")
+
+	return &Command{
+		Name:     "migrate",
+		Synopsis: "Migrate from mirror-registry (OMR) to this binary",
+		Flags:    fs,
+		Run: func(ctx context.Context, _ *Command, _ []string) int {
+			return runMigrate(ctx, &migrate.Migrator{
+				DataDir:       *dataDir,
+				Hostname:      *hostname,
+				Image:         *image,
+				ImageArchive:  *imageArchive,
+				SourceRoot:    *sourceRoot,
+				SourceDB:      *sourceDB,
+				SourceStorage: *sourceStorage,
+				SourceCerts:   *sourceCerts,
+				DryRun:        *dryRun,
+				Cleanup:       *cleanup,
+				SkipInstall:   *skipInstall,
+				Out:           os.Stderr,
+				Runner:        system.NewExecRunner(os.Stderr),
+			})
+		},
+	}
+}
+
+func runMigrate(ctx context.Context, m *migrate.Migrator) int {
+	if err := m.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/internal/dal/daldb/manifest.sql.go
+++ b/internal/dal/daldb/manifest.sql.go
@@ -102,6 +102,17 @@ func (q *Queries) GetManifestByDigest(ctx context.Context, arg GetManifestByDige
 	return i, err
 }
 
+const getManifestContentByDigest = `-- name: GetManifestContentByDigest :one
+SELECT manifest_bytes FROM manifest WHERE digest = ? LIMIT 1
+`
+
+func (q *Queries) GetManifestContentByDigest(ctx context.Context, digest string) (string, error) {
+	row := q.db.QueryRowContext(ctx, getManifestContentByDigest, digest)
+	var manifest_bytes string
+	err := row.Scan(&manifest_bytes)
+	return manifest_bytes, err
+}
+
 const linkManifestBlob = `-- name: LinkManifestBlob :exec
 INSERT OR IGNORE INTO manifestblob (repository_id, manifest_id, blob_id)
 VALUES (?, ?, ?)

--- a/internal/dal/dbcore/bridge.go
+++ b/internal/dal/dbcore/bridge.go
@@ -1,0 +1,215 @@
+package dbcore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/quay/quay/internal/dal/schema"
+)
+
+// knownOMRVersions lists every Alembic version a supported OMR v2.0.x SQLite
+// database could have. The bridge migration is safe to run from any of these
+// starting points.
+var knownOMRVersions = map[string]bool{
+	// Quay 3.12.x era (OMR SQLite support introduced)
+	"0cdd1f27a450": true,
+	"0988213e0885": true,
+	"66147b81aad2": true,
+	"f67fe4871771": true,
+	"2664723e1b4b": true,
+	"8a7ba94c2e84": true,
+	"3f8d7acdf7f9": true,
+	// Versions in the bridge chain itself (partially upgraded DBs)
+	"a32e17bfad20": true,
+	"5b8dc452f5c3": true,
+	"ba263f9be4a6": true,
+	"9085e82074f2": true,
+	"8e97c2cfee57": true,
+	"3634f2df3c5b": true,
+	"e8ed3fb547da": true,
+	"1623f40582ed": true,
+	"7078c84d14e8": true,
+	"9307c3d604b4": true,
+	"27d0df099ac4": true,
+	"a1b2c3d4e5f6": true,
+	"285f36ce97fd": true,
+	"b2c3d4e5f6a7": true,
+	"b1c2d3e4f5a6": true,
+	"15f06d00c4b3": true,
+	"414c5e2fc487": true,
+}
+
+// bridgeColumns are columns that may be missing on existing tables in old OMR databases.
+// New tables created by the bridge SQL already include all columns.
+var bridgeColumns = []struct {
+	table, column, typedef string
+}{
+	{"tag", "immutable", "BOOLEAN DEFAULT (0) NOT NULL"},
+	{"manifest", "artifact_type", "VARCHAR(255)"},
+	{"manifest", "artifact_type_backfilled", "BOOLEAN"},
+	{"repomirrorconfig", "skopeo_timeout", "BIGINT DEFAULT '300' NOT NULL"},
+	{"repomirrorconfig", "architecture_filter", "TEXT"},
+}
+
+// bridgeIndexFixes are indexes that changed from UNIQUE to non-UNIQUE.
+var bridgeIndexFixes = []struct {
+	table, indexName, columns string
+}{
+	{"namespaceautoprunepolicy", "namespaceautoprunepolicy_namespace_id", "namespace_id"},
+	{"repositoryautoprunepolicy", "repositoryautoprunepolicy_repository_id", "repository_id"},
+	{"organizationrhskus", "organizationrhskus_subscription_id", "subscription_id"},
+}
+
+// RunBridge upgrades an OMR SQLite database to the Go binary's target schema.
+// This is a Go-native squash migration for supported OMR Alembic revisions:
+// the standalone binary intentionally does not ship Python, Alembic, or Quay's
+// Python migration runtime. It validates the starting version, applies column
+// additions and index fixes that SQLite cannot express idempotently, then
+// executes the bridge SQL file.
+func RunBridge(ctx context.Context, db *sql.DB, w io.Writer) error {
+	ver, err := SchemaVersion(ctx, db)
+	if err != nil {
+		return fmt.Errorf("read schema version: %w", err)
+	}
+	if ver == TargetVersion {
+		fmt.Fprintf(w, "Schema is current (version %s)\n", ver)
+		return nil
+	}
+	if !knownOMRVersions[ver] {
+		return fmt.Errorf(
+			"unknown schema version %q — this tool supports OMR v2.0.x (SQLite) databases; "+
+				"if you are on OMR v1.3.x, upgrade to OMR v2.0 first", ver)
+	}
+
+	fmt.Fprintf(w, "Bridging schema from %s to %s\n", ver, TargetVersion)
+
+	if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("disable foreign keys: %w", err)
+	}
+	defer func() { _, _ = db.ExecContext(ctx, "PRAGMA foreign_keys = ON") }()
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := applyBridge(ctx, tx); err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, "UPDATE alembic_version SET version_num = ?", TargetVersion); err != nil {
+		return fmt.Errorf("stamp version: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit bridge: %w", err)
+	}
+
+	fmt.Fprintf(w, "Schema bridged to %s\n", TargetVersion)
+	return nil
+}
+
+// applyBridge runs the three bridge steps within the given transaction:
+// column additions, index fixes, and the bridge SQL file.
+func applyBridge(ctx context.Context, tx *sql.Tx) error {
+	for _, col := range bridgeColumns {
+		if err := ensureColumn(ctx, tx, col.table, col.column, col.typedef); err != nil {
+			return fmt.Errorf("ensure column %s.%s: %w", col.table, col.column, err)
+		}
+	}
+
+	for _, idx := range bridgeIndexFixes {
+		if err := ensureNonUniqueIndex(ctx, tx, idx.table, idx.indexName, idx.columns); err != nil {
+			return fmt.Errorf("fix index %s: %w", idx.indexName, err)
+		}
+	}
+
+	bridgeSQL, err := schema.MigrationFiles.ReadFile("sqlite/migrations/0001_bridge_from_omr.sql")
+	if err != nil {
+		return fmt.Errorf("read bridge SQL: %w", err)
+	}
+	for _, stmt := range splitStatements(string(bridgeSQL)) {
+		trimmed := strings.TrimSpace(stmt)
+		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("execute bridge SQL: %w\nstatement: %s", err, truncate(trimmed, 200))
+		}
+	}
+
+	return nil
+}
+
+// ensureColumn adds a column to a table if it does not already exist.
+func ensureColumn(ctx context.Context, tx *sql.Tx, table, column, typedef string) error {
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%q)", table))
+	if err != nil {
+		return fmt.Errorf("table_info %s: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notNull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dflt, &pk); err != nil {
+			return fmt.Errorf("scan table_info: %w", err)
+		}
+		if strings.EqualFold(name, column) {
+			return nil // column already exists
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	stmt := fmt.Sprintf("ALTER TABLE %q ADD COLUMN %s %s", table, column, typedef)
+	if _, err := tx.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("add column: %w", err)
+	}
+	return nil
+}
+
+// ensureNonUniqueIndex checks if an index exists as UNIQUE and recreates it
+// as non-UNIQUE if needed.
+func ensureNonUniqueIndex(ctx context.Context, tx *sql.Tx, table, indexName, columns string) error {
+	var indexSQL sql.NullString
+	err := tx.QueryRowContext(ctx,
+		"SELECT sql FROM sqlite_master WHERE type='index' AND name=?", indexName,
+	).Scan(&indexSQL)
+
+	if errors.Is(err, sql.ErrNoRows) || !indexSQL.Valid {
+		// Index doesn't exist — create it.
+		_, err = tx.ExecContext(ctx, fmt.Sprintf("CREATE INDEX %s ON %s (%s)", indexName, table, columns))
+		return err
+	}
+	if err != nil {
+		return fmt.Errorf("query index %s: %w", indexName, err)
+	}
+
+	if strings.Contains(strings.ToUpper(indexSQL.String), "UNIQUE") {
+		// Wrong uniqueness — drop and recreate.
+		if _, err := tx.ExecContext(ctx, "DROP INDEX "+indexName); err != nil {
+			return fmt.Errorf("drop index %s: %w", indexName, err)
+		}
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("CREATE INDEX %s ON %s (%s)", indexName, table, columns)); err != nil {
+			return fmt.Errorf("recreate index %s: %w", indexName, err)
+		}
+	}
+
+	return nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/dal/dbcore/bridge_test.go
+++ b/internal/dal/dbcore/bridge_test.go
@@ -1,0 +1,272 @@
+package dbcore
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureColumn_AddsMissing(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, "CREATE TABLE test_tbl (id INTEGER PRIMARY KEY, name TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureColumn(ctx, tx, "test_tbl", "age", "INTEGER DEFAULT 0"); err != nil {
+		t.Fatalf("ensureColumn: %v", err)
+	}
+
+	// Verify column exists.
+	var count int
+	err = tx.QueryRowContext(ctx,
+		"SELECT count(*) FROM pragma_table_info('test_tbl') WHERE name='age'",
+	).Scan(&count)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Error("expected age column to exist")
+	}
+}
+
+func TestEnsureColumn_SkipsExisting(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, "CREATE TABLE test_tbl (id INTEGER PRIMARY KEY, name TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should not error when column already exists.
+	if err := ensureColumn(ctx, tx, "test_tbl", "name", "TEXT"); err != nil {
+		t.Fatalf("ensureColumn on existing column: %v", err)
+	}
+}
+
+func TestEnsureNonUniqueIndex_FixesUnique(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, "CREATE TABLE test_tbl (id INTEGER PRIMARY KEY, ns_id INTEGER)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ExecContext(ctx, "CREATE UNIQUE INDEX test_idx ON test_tbl (ns_id)"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureNonUniqueIndex(ctx, tx, "test_tbl", "test_idx", "ns_id"); err != nil {
+		t.Fatalf("ensureNonUniqueIndex: %v", err)
+	}
+
+	// Verify index is now non-unique.
+	var indexSQL string
+	err = tx.QueryRowContext(ctx,
+		"SELECT sql FROM sqlite_master WHERE type='index' AND name='test_idx'",
+	).Scan(&indexSQL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(strings.ToUpper(indexSQL), "UNIQUE") {
+		t.Errorf("expected non-unique index, got: %s", indexSQL)
+	}
+}
+
+func TestEnsureNonUniqueIndex_CreatesWhenMissing(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, "CREATE TABLE test_tbl (id INTEGER PRIMARY KEY, ns_id INTEGER)"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureNonUniqueIndex(ctx, tx, "test_tbl", "test_idx", "ns_id"); err != nil {
+		t.Fatalf("ensureNonUniqueIndex: %v", err)
+	}
+
+	// Verify index was created.
+	var count int
+	err = tx.QueryRowContext(ctx,
+		"SELECT count(*) FROM sqlite_master WHERE type='index' AND name='test_idx'",
+	).Scan(&count)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Error("expected index to be created")
+	}
+}
+
+func TestEnsureNonUniqueIndex_SkipsCorrect(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, "CREATE TABLE test_tbl (id INTEGER PRIMARY KEY, ns_id INTEGER)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ExecContext(ctx, "CREATE INDEX test_idx ON test_tbl (ns_id)"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should be a no-op.
+	if err := ensureNonUniqueIndex(ctx, tx, "test_tbl", "test_idx", "ns_id"); err != nil {
+		t.Fatalf("ensureNonUniqueIndex on correct index: %v", err)
+	}
+}
+
+func TestRunBridge_AlreadyCurrent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := t.Context()
+	if err := InitDatabase(ctx, db, &bytes.Buffer{}); err != nil {
+		t.Fatalf("InitDatabase: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := RunBridge(ctx, db, &buf); err != nil {
+		t.Fatalf("RunBridge: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "current") {
+		t.Errorf("expected 'current' in output, got: %s", buf.String())
+	}
+}
+
+func TestRunBridge_RejectsUnknownVersion(t *testing.T) {
+	db := openTestDB(t)
+	defer db.Close()
+
+	ctx := t.Context()
+	if _, err := db.ExecContext(ctx, "CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, "INSERT INTO alembic_version (version_num) VALUES ('unknown_ver_123')"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RunBridge(ctx, db, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error for unknown version")
+	}
+	if !strings.Contains(err.Error(), "unknown schema version") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunBridge_CreatesBridgeTables(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	ctx := t.Context()
+	if err := InitDatabase(ctx, db, &bytes.Buffer{}); err != nil {
+		t.Fatalf("InitDatabase: %v", err)
+	}
+
+	for _, table := range []string{
+		"tagpullstatistics",
+		"manifestpullstatistics",
+		"orgmirrorconfig",
+		"orgmirrorrepository",
+		"namespaceimmutabilitypolicy",
+		"repositoryimmutabilitypolicy",
+		"organizationcontactemail",
+	} {
+		if _, err := db.ExecContext(ctx, "DROP TABLE "+table); err != nil {
+			t.Fatalf("drop %s: %v", table, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, "UPDATE alembic_version SET version_num = ?", "3f8d7acdf7f9"); err != nil {
+		t.Fatalf("stamp old version: %v", err)
+	}
+
+	if err := RunBridge(ctx, db, &bytes.Buffer{}); err != nil {
+		t.Fatalf("RunBridge: %v", err)
+	}
+
+	ver, err := SchemaVersion(ctx, db)
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if ver != TargetVersion {
+		t.Errorf("version = %q, want %q", ver, TargetVersion)
+	}
+
+	for _, table := range []string{
+		"tagpullstatistics",
+		"manifestpullstatistics",
+		"orgmirrorconfig",
+		"orgmirrorrepository",
+		"namespaceimmutabilitypolicy",
+		"repositoryimmutabilitypolicy",
+		"organizationcontactemail",
+	} {
+		var count int
+		err := db.QueryRowContext(ctx,
+			"SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?", table,
+		).Scan(&count)
+		if err != nil {
+			t.Fatalf("query table %s: %v", table, err)
+		}
+		if count != 1 {
+			t.Errorf("expected table %s to exist", table)
+		}
+	}
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), fmt.Sprintf("test-%s.db", t.Name()))
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	return db
+}

--- a/internal/dal/dbcore/migrate.go
+++ b/internal/dal/dbcore/migrate.go
@@ -94,10 +94,12 @@ func InitDatabase(ctx context.Context, db *sql.DB, w io.Writer) error {
 
 	var seedRows int
 	// Count rows in known seed tables to give a rough summary.
-	seedTables := []string{"mediatype", "logentrykind", "visibility", "repositorykind", "tagkind",
+	seedTables := []string{
+		"mediatype", "logentrykind", "visibility", "repositorykind", "tagkind",
 		"loginservice", "buildtriggerservice", "accesstokenkind", "notificationkind",
 		"externalnotificationevent", "externalnotificationmethod", "quayregion", "quayservice",
-		"imagestoragelocation", "imagestoragetransformation", "imagestoragesignaturekind", "labelsourcetype"}
+		"imagestoragelocation", "imagestoragetransformation", "imagestoragesignaturekind", "labelsourcetype",
+	}
 	for _, t := range seedTables {
 		var n int
 		_ = db.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM %q", t)).Scan(&n)
@@ -325,10 +327,20 @@ func extractRevisionID(migrationSQL string) (string, error) {
 	return "", fmt.Errorf("missing '-- revision: <id>' comment")
 }
 
-// splitStatements splits a SQL script on semicolons, trimming whitespace
-// and discarding empty entries.
+// splitStatements splits a SQL script on semicolons, trimming whitespace and
+// discarding empty entries. It strips full-line "--" comments only; semicolons
+// in inline comments are still treated as statement delimiters.
 func splitStatements(rawSQL string) []string {
-	raw := strings.Split(rawSQL, ";")
+	var withoutComments strings.Builder
+	for _, line := range strings.Split(rawSQL, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "--") {
+			continue
+		}
+		withoutComments.WriteString(line)
+		withoutComments.WriteByte('\n')
+	}
+
+	raw := strings.Split(withoutComments.String(), ";")
 	stmts := make([]string, 0, len(raw))
 	for _, s := range raw {
 		s = strings.TrimSpace(s)

--- a/internal/dal/dbcore/migrate_test.go
+++ b/internal/dal/dbcore/migrate_test.go
@@ -93,6 +93,27 @@ func TestSchemaVersion_EmptyDB(t *testing.T) {
 	}
 }
 
+func TestSplitStatements_DropsLineCommentsWithoutDroppingStatements(t *testing.T) {
+	sql := `-- migration metadata
+-- section comment
+CREATE TABLE first (id INTEGER);
+
+-- next section
+CREATE TABLE second (id INTEGER);
+`
+
+	stmts := splitStatements(sql)
+	if len(stmts) != 2 {
+		t.Fatalf("expected 2 statements, got %d: %#v", len(stmts), stmts)
+	}
+	if !strings.Contains(stmts[0], "CREATE TABLE first") {
+		t.Errorf("first statement was dropped: %#v", stmts)
+	}
+	if !strings.Contains(stmts[1], "CREATE TABLE second") {
+		t.Errorf("second statement was dropped: %#v", stmts)
+	}
+}
+
 func TestIntegrityCheck(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	db, err := OpenSQLite(dbPath)

--- a/internal/dal/metastore/metastore_sqlite.go
+++ b/internal/dal/metastore/metastore_sqlite.go
@@ -398,6 +398,19 @@ func (s *SQLiteStore) GetManifestDigest(ctx context.Context, repoID int64, dgst 
 	return digest.Parse(d)
 }
 
+// GetManifestContent returns manifest JSON stored in the database.
+func (s *SQLiteStore) GetManifestContent(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	q := daldb.New(s.db)
+	content, err := q.GetManifestContentByDigest(ctx, dgst.String())
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("get manifest content %s: %w", dgst, oci.ErrNotExist)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get manifest content %s: %w", dgst, err)
+	}
+	return []byte(content), nil
+}
+
 // BlobLinkedToRepo checks if a blob is linked to a specific repository via
 // manifestblob or uploadedblob (matching Python's get_repository_blob_by_digest).
 func (s *SQLiteStore) BlobLinkedToRepo(ctx context.Context, repoID int64, dgst digest.Digest) (bool, error) {

--- a/internal/dal/metastore/metastore_sqlite_read_test.go
+++ b/internal/dal/metastore/metastore_sqlite_read_test.go
@@ -1,6 +1,7 @@
 package metastore_test
 
 import (
+	"bytes"
 	"context"
 	"path/filepath"
 	"testing"
@@ -118,6 +119,41 @@ func TestGetManifestDigest(t *testing.T) {
 	}
 
 	_, err = store.GetManifestDigest(ctx, repoID, digest.FromString("missing"))
+	if err == nil {
+		t.Fatal("expected error for nonexistent manifest")
+	}
+}
+
+func TestGetManifestContent(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	name := oci.RepositoryName{Namespace: "ns", Name: "repo"}
+	repoID, err := store.EnsureRepository(ctx, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := []byte(`{"schemaVersion":2}`)
+	dgst := digest.FromBytes(content)
+
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    dgst,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   content,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetManifestContent(ctx, dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("GetManifestContent = %s, want %s", got, content)
+	}
+
+	_, err = store.GetManifestContent(ctx, digest.FromString("missing"))
 	if err == nil {
 		t.Fatal("expected error for nonexistent manifest")
 	}

--- a/internal/dal/queries/manifest.sql
+++ b/internal/dal/queries/manifest.sql
@@ -37,3 +37,6 @@ SELECT COUNT(*) FROM manifest;
 
 -- name: ManifestExistsByDigest :one
 SELECT digest FROM manifest WHERE repository_id = ? AND digest = ?;
+
+-- name: GetManifestContentByDigest :one
+SELECT manifest_bytes FROM manifest WHERE digest = ? LIMIT 1;

--- a/internal/dal/schema/sqlite/migrations/0001_bridge_from_omr.sql
+++ b/internal/dal/schema/sqlite/migrations/0001_bridge_from_omr.sql
@@ -1,0 +1,183 @@
+-- revision: c3d4e5f6a7b8
+-- Bridge migration: brings any OMR v2.0.x SQLite database to the
+-- Go binary's target schema. All statements are idempotent.
+
+-- ============================================================
+-- SECTION 1: New tables
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS tagpullstatistics (
+	id INTEGER NOT NULL,
+	repository_id INTEGER NOT NULL,
+	tag_name VARCHAR(255) NOT NULL,
+	tag_pull_count BIGINT NOT NULL,
+	last_tag_pull_date DATETIME NOT NULL,
+	current_manifest_digest VARCHAR(255),
+	CONSTRAINT pk_tagpullstatistics PRIMARY KEY (id),
+	CONSTRAINT fk_tagpullstatistics_repository_id_repository FOREIGN KEY(repository_id) REFERENCES repository (id)
+);
+
+CREATE TABLE IF NOT EXISTS manifestpullstatistics (
+	id INTEGER NOT NULL,
+	repository_id INTEGER NOT NULL,
+	manifest_digest VARCHAR(255) NOT NULL,
+	manifest_pull_count BIGINT NOT NULL,
+	last_manifest_pull_date DATETIME NOT NULL,
+	CONSTRAINT pk_manifestpullstatistics PRIMARY KEY (id),
+	CONSTRAINT fk_manifestpullstatistics_repository_id_repository FOREIGN KEY(repository_id) REFERENCES repository (id)
+);
+
+CREATE TABLE IF NOT EXISTS orgmirrorconfig (
+	id INTEGER NOT NULL,
+	organization_id INTEGER NOT NULL,
+	creation_date DATETIME NOT NULL,
+	is_enabled BOOLEAN DEFAULT (1) NOT NULL,
+	mirror_type INTEGER DEFAULT '1' NOT NULL,
+	external_registry_type INTEGER NOT NULL,
+	external_registry_url VARCHAR(2048) NOT NULL,
+	external_namespace VARCHAR(255) NOT NULL,
+	external_registry_username VARCHAR(4096),
+	external_registry_password VARCHAR(9000),
+	external_registry_config TEXT NOT NULL,
+	internal_robot_id INTEGER NOT NULL,
+	repository_filters TEXT NOT NULL,
+	visibility_id INTEGER NOT NULL,
+	delete_stale_repos BOOLEAN DEFAULT (0) NOT NULL,
+	sync_interval INTEGER NOT NULL,
+	sync_start_date DATETIME,
+	sync_expiration_date DATETIME,
+	sync_retries_remaining INTEGER DEFAULT '3' NOT NULL,
+	sync_status INTEGER DEFAULT '0' NOT NULL,
+	sync_transaction_id VARCHAR(36),
+	skopeo_timeout BIGINT DEFAULT '300' NOT NULL,
+	architecture_filter TEXT DEFAULT '[]' NOT NULL,
+	CONSTRAINT pk_orgmirrorconfig PRIMARY KEY (id),
+	CONSTRAINT fk_orgmirrorconfig_organization_id_user FOREIGN KEY(organization_id) REFERENCES user (id),
+	CONSTRAINT fk_orgmirrorconfig_internal_robot_id_user FOREIGN KEY(internal_robot_id) REFERENCES user (id),
+	CONSTRAINT fk_orgmirrorconfig_visibility_id_visibility FOREIGN KEY(visibility_id) REFERENCES visibility (id)
+);
+
+CREATE TABLE IF NOT EXISTS orgmirrorrepository (
+	id INTEGER NOT NULL,
+	org_mirror_config_id INTEGER NOT NULL,
+	repository_name VARCHAR(255) NOT NULL,
+	repository_id INTEGER,
+	discovery_date DATETIME NOT NULL,
+	sync_status INTEGER DEFAULT '0' NOT NULL,
+	sync_start_date DATETIME,
+	sync_expiration_date DATETIME,
+	last_sync_date DATETIME,
+	status_message TEXT,
+	creation_date DATETIME NOT NULL,
+	sync_retries_remaining INTEGER DEFAULT '3' NOT NULL,
+	sync_transaction_id VARCHAR(36),
+	CONSTRAINT pk_orgmirrorrepository PRIMARY KEY (id),
+	CONSTRAINT fk_orgmirrorrepository_org_mirror_config_id_orgmirrorconfig FOREIGN KEY(org_mirror_config_id) REFERENCES orgmirrorconfig (id),
+	CONSTRAINT fk_orgmirrorrepository_repository_id_repository FOREIGN KEY(repository_id) REFERENCES repository (id)
+);
+
+CREATE TABLE IF NOT EXISTS namespaceimmutabilitypolicy (
+	id INTEGER NOT NULL,
+	uuid VARCHAR(36) NOT NULL,
+	namespace_id INTEGER NOT NULL,
+	policy TEXT NOT NULL,
+	CONSTRAINT pk_namespaceimmutabilitypolicyid PRIMARY KEY (id),
+	CONSTRAINT fk_namespaceimmutabilitypolicy_namespace_id_user FOREIGN KEY(namespace_id) REFERENCES user (id)
+);
+
+CREATE TABLE IF NOT EXISTS repositoryimmutabilitypolicy (
+	id INTEGER NOT NULL,
+	uuid VARCHAR(36) NOT NULL,
+	repository_id INTEGER NOT NULL,
+	namespace_id INTEGER NOT NULL,
+	policy TEXT NOT NULL,
+	CONSTRAINT pk_repositoryimmutabilitypolicyid PRIMARY KEY (id),
+	CONSTRAINT fk_repositoryimmutabilitypolicy_repository_id_repository FOREIGN KEY(repository_id) REFERENCES repository (id),
+	CONSTRAINT fk_repositoryimmutabilitypolicy_namespace_id_user FOREIGN KEY(namespace_id) REFERENCES user (id)
+);
+
+CREATE TABLE IF NOT EXISTS organizationcontactemail (
+	id INTEGER NOT NULL,
+	organization_id INTEGER NOT NULL,
+	contact_email VARCHAR(255),
+	CONSTRAINT pk_organizationcontactemail PRIMARY KEY (id),
+	CONSTRAINT fk_organizationcontactemail_organization_id_user FOREIGN KEY(organization_id) REFERENCES user (id)
+);
+
+-- ============================================================
+-- SECTION 2: Indexes on new tables
+-- ============================================================
+
+CREATE UNIQUE INDEX IF NOT EXISTS tagpullstatistics_repository_id_tag_name ON tagpullstatistics (repository_id, tag_name);
+CREATE UNIQUE INDEX IF NOT EXISTS manifestpullstatistics_repository_id_manifest_digest ON manifestpullstatistics (repository_id, manifest_digest);
+CREATE UNIQUE INDEX IF NOT EXISTS orgmirrorconfig_organization_id ON orgmirrorconfig (organization_id);
+CREATE INDEX IF NOT EXISTS orgmirrorconfig_internal_robot_id ON orgmirrorconfig (internal_robot_id);
+CREATE INDEX IF NOT EXISTS orgmirrorconfig_sync_status ON orgmirrorconfig (sync_status);
+CREATE INDEX IF NOT EXISTS orgmirrorconfig_sync_start_date ON orgmirrorconfig (sync_start_date);
+CREATE INDEX IF NOT EXISTS orgmirrorrepository_org_mirror_config_id ON orgmirrorrepository (org_mirror_config_id);
+CREATE INDEX IF NOT EXISTS orgmirrorrepository_repository_id ON orgmirrorrepository (repository_id);
+CREATE INDEX IF NOT EXISTS orgmirrorrepository_sync_status ON orgmirrorrepository (sync_status);
+CREATE UNIQUE INDEX IF NOT EXISTS orgmirrorrepository_config_repo_name ON orgmirrorrepository (org_mirror_config_id, repository_name);
+CREATE INDEX IF NOT EXISTS orgmirrorrepository_config_status ON orgmirrorrepository (org_mirror_config_id, sync_status);
+CREATE INDEX IF NOT EXISTS namespaceimmutabilitypolicy_namespace_id ON namespaceimmutabilitypolicy (namespace_id);
+CREATE UNIQUE INDEX IF NOT EXISTS namespaceimmutabilitypolicy_uuid ON namespaceimmutabilitypolicy (uuid);
+CREATE INDEX IF NOT EXISTS repositoryimmutabilitypolicy_repository_id ON repositoryimmutabilitypolicy (repository_id);
+CREATE INDEX IF NOT EXISTS repositoryimmutabilitypolicy_namespace_id ON repositoryimmutabilitypolicy (namespace_id);
+CREATE UNIQUE INDEX IF NOT EXISTS repositoryimmutabilitypolicy_uuid ON repositoryimmutabilitypolicy (uuid);
+CREATE UNIQUE INDEX IF NOT EXISTS organizationcontactemail_organization_id ON organizationcontactemail (organization_id);
+CREATE INDEX IF NOT EXISTS organizationcontactemail_contact_email ON organizationcontactemail (contact_email);
+
+-- ============================================================
+-- SECTION 3: Indexes on existing tables
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS tag_repository_id_immutable ON tag (repository_id, immutable);
+CREATE INDEX IF NOT EXISTS tag_manifest_id_immutable ON tag (manifest_id, immutable);
+CREATE INDEX IF NOT EXISTS tag_manifest_id_lifetime_end_ms ON tag (manifest_id, lifetime_end_ms);
+CREATE INDEX IF NOT EXISTS manifest_repository_id_artifact_type ON manifest (repository_id, artifact_type);
+CREATE INDEX IF NOT EXISTS manifest_artifact_type_backfilled ON manifest (artifact_type_backfilled);
+
+-- ============================================================
+-- SECTION 4: Dropped tables
+-- ============================================================
+
+DROP TABLE IF EXISTS namespacegeorestriction;
+
+-- ============================================================
+-- SECTION 5: Seed data (logentrykind)
+-- ============================================================
+
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('change_tag_immutability');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('create_robot_federation');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('delete_robot_federation');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('federated_robot_token_exchange');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('export_logs_success');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('export_logs_failure');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_create_quota');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_change_quota');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_delete_quota');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_create_quota_limit');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_change_quota_limit');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_delete_quota_limit');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_enabled');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_disabled');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_config_changed');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_sync_started');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_sync_completed');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_sync_failed');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_sync_tag_started');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_sync_tag_completed');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_repo_created');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('create_immutability_policy');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('update_immutability_policy');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('delete_immutability_policy');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('org_mirror_repo_creation_failed');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('tag_made_immutable_by_policy');
+INSERT OR IGNORE INTO logentrykind (name) VALUES ('tags_made_immutable_by_policy');
+
+-- ============================================================
+-- SECTION 6: Data migration
+-- ============================================================
+
+INSERT OR IGNORE INTO organizationcontactemail (organization_id, contact_email)
+SELECT id, email FROM "user" WHERE organization = 1 AND email IS NOT NULL;

--- a/internal/migrate/cleanup.go
+++ b/internal/migrate/cleanup.go
@@ -1,0 +1,72 @@
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// cleanup removes old OMR services, volumes, and secrets.
+func (m *Migrator) cleanup(ctx context.Context) error {
+	slog.Info("cleaning up old OMR installation")
+
+	if err := m.removeUnitFiles(); err != nil {
+		return fmt.Errorf("remove unit files: %w", err)
+	}
+
+	m.removeVolumes(ctx)
+
+	if err := m.removeRedisSecret(ctx); err != nil {
+		slog.Warn("failed to remove redis secret", "err", err)
+	}
+
+	if err := m.reloadSystemd(ctx); err != nil {
+		slog.Warn("failed to reload systemd", "err", err)
+	}
+
+	slog.Info("old OMR installation cleaned up — ~/quay-install directory preserved (may contain rootCA distributed to clients)")
+	return nil
+}
+
+func (m *Migrator) removeUnitFiles() error {
+	for _, path := range m.Source.UnitFiles {
+		slog.Info("removing unit file", "path", path)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func (m *Migrator) removeVolumes(ctx context.Context) {
+	if m.Runner == nil {
+		return
+	}
+	for _, vol := range m.Source.VolumeNames {
+		slog.Info("removing podman volume", "name", vol)
+		if err := m.Runner.Run(ctx, "podman", "volume", "rm", vol); err != nil {
+			slog.Warn("failed to remove volume", "name", vol, "err", err)
+		}
+	}
+}
+
+func (m *Migrator) removeRedisSecret(ctx context.Context) error {
+	if m.Runner == nil {
+		return nil
+	}
+	slog.Info("removing podman secret", "name", "redis_pass")
+	return m.Runner.Run(ctx, "podman", "secret", "rm", "redis_pass")
+}
+
+func (m *Migrator) reloadSystemd(ctx context.Context) error {
+	if m.Runner == nil {
+		return nil
+	}
+	var args []string
+	if m.Source.SystemdScope == scopeUser {
+		args = []string{"--user"}
+	}
+	args = append(args, "daemon-reload")
+	return m.Runner.Run(ctx, "systemctl", args...)
+}

--- a/internal/migrate/cleanup_test.go
+++ b/internal/migrate/cleanup_test.go
@@ -1,0 +1,41 @@
+package migrate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCleanup_RemovesUnitFiles(t *testing.T) {
+	dir := t.TempDir()
+	unitPath := filepath.Join(dir, "quay-app.service")
+	os.WriteFile(unitPath, []byte("[Unit]\nDescription=test"), 0o644)
+
+	m := &Migrator{
+		Out: &bytes.Buffer{},
+		Source: OMRSource{
+			UnitFiles:    []string{unitPath},
+			SystemdScope: "user",
+		},
+	}
+
+	if err := m.removeUnitFiles(); err != nil {
+		t.Fatalf("removeUnitFiles: %v", err)
+	}
+
+	if _, err := os.Stat(unitPath); !os.IsNotExist(err) {
+		t.Error("unit file should have been removed")
+	}
+}
+
+func TestCleanup_SkipsWhenNoUnits(t *testing.T) {
+	m := &Migrator{
+		Out:    &bytes.Buffer{},
+		Source: OMRSource{},
+	}
+
+	if err := m.removeUnitFiles(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/migrate/copy.go
+++ b/internal/migrate/copy.go
@@ -1,0 +1,183 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/quay/quay/internal/dal/dbcore"
+)
+
+func (m *Migrator) copyData(ctx context.Context) error {
+	if err := os.MkdirAll(m.DataDir, 0o750); err != nil {
+		return fmt.Errorf("create target directory: %w", err)
+	}
+
+	markerPath := filepath.Join(m.DataDir, markerFile)
+	resuming := false
+	if _, err := os.Stat(markerPath); err == nil {
+		resuming = true
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat marker: %w", err)
+	}
+	if err := os.WriteFile(markerPath, []byte("migration in progress\n"), 0o600); err != nil {
+		return fmt.Errorf("write marker: %w", err)
+	}
+
+	// Dockerfile.mirror currently runs the Go registry as root, so preserving
+	// source modes is enough. If the image moves to a non-root USER, add an
+	// ownership or ACL normalization step for the target data directory here.
+
+	// Copy database (rename quay_sqlite.db → quay.db).
+	if err := checkpointSQLite(ctx, m.Source.DBPath); err != nil {
+		return fmt.Errorf("checkpoint source database: %w", err)
+	}
+	targetDB := filepath.Join(m.DataDir, "quay.db")
+	if resuming {
+		slog.Info("migration marker already existed, recopying database", "dst", targetDB)
+	}
+	if err := copyFileIdempotent(ctx, m.Source.DBPath, targetDB, resuming); err != nil {
+		return fmt.Errorf("copy database: %w", err)
+	}
+	slog.Info("copied database", "src", m.Source.DBPath, "dst", targetDB)
+
+	// Copy TLS certs (flatten from quay-config/ to data-dir root).
+	if m.Source.ConfigDir != "" {
+		for _, name := range []string{"ssl.cert", "ssl.key"} {
+			src := filepath.Join(m.Source.ConfigDir, name)
+			dst := filepath.Join(m.DataDir, name)
+			if _, err := os.Stat(src); err != nil {
+				slog.Warn("cert file not found, skipping", "path", src)
+				continue
+			}
+			if err := copyFileIdempotent(ctx, src, dst, false); err != nil {
+				return fmt.Errorf("copy %s: %w", name, err)
+			}
+			slog.Info("copied cert", "src", src, "dst", dst)
+		}
+	}
+
+	// Copy blob storage recursively.
+	if m.Source.StoragePath != "" {
+		targetStorage := filepath.Join(m.DataDir, "storage")
+		count, totalBytes, err := copyDirRecursive(ctx, m.Source.StoragePath, targetStorage, m.Out)
+		if err != nil {
+			return fmt.Errorf("copy storage: %w", err)
+		}
+		slog.Info("copied storage", "files", count, "bytes", totalBytes)
+	}
+
+	return nil
+}
+
+func checkpointSQLite(ctx context.Context, dbPath string) (retErr error) {
+	db, err := dbcore.OpenSQLite(dbPath)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer func() {
+		if cerr := db.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("close database: %w", cerr)
+		}
+	}()
+
+	if _, err := db.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		return fmt.Errorf("wal checkpoint: %w", err)
+	}
+	return nil
+}
+
+// copyFileIdempotent copies src to dst, skipping if dst already exists with matching size.
+func copyFileIdempotent(ctx context.Context, src, dst string, force bool) (retErr error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+
+	dstInfo, dstErr := os.Stat(dst)
+	if !force && dstErr == nil && dstInfo.Size() == srcInfo.Size() {
+		return nil // already copied
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	in, err := os.Open(src) //nolint:gosec // path from validated source
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := in.Close(); cerr != nil && retErr == nil {
+			retErr = fmt.Errorf("close source: %w", cerr)
+		}
+	}()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode()) //nolint:gosec // path from caller
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		if cerr := out.Close(); cerr != nil {
+			return errors.Join(
+				fmt.Errorf("copy file: %w", err),
+				fmt.Errorf("close destination: %w", cerr),
+			)
+		}
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close destination: %w", err)
+	}
+	return nil
+}
+
+// copyDirRecursive copies the contents of srcDir into dstDir.
+func copyDirRecursive(ctx context.Context, srcDir, dstDir string, w io.Writer) (files int, totalBytes int64, _ error) {
+	err := filepath.Walk(srcDir, func(srcPath string, info os.FileInfo, err error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(srcDir, srcPath)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dstDir, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		if err := copyFileIdempotent(ctx, srcPath, dstPath, false); err != nil {
+			return fmt.Errorf("copy %s: %w", relPath, err)
+		}
+
+		files++
+		totalBytes += info.Size()
+
+		if files%1000 == 0 {
+			fmt.Fprintf(w, "  copied %d files (%d MB)...\n", files, totalBytes/(1024*1024))
+		}
+
+		return nil
+	})
+
+	return files, totalBytes, err
+}
+
+func removeMarker(dataDir string) {
+	_ = os.Remove(filepath.Join(dataDir, markerFile))
+}

--- a/internal/migrate/copy_test.go
+++ b/internal/migrate/copy_test.go
@@ -1,0 +1,199 @@
+package migrate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/quay/quay/internal/dal/dbcore"
+)
+
+func TestCopyData(t *testing.T) {
+	srcDir := t.TempDir()
+	dbDir := t.TempDir()
+	storageDir := t.TempDir()
+
+	dbPath := filepath.Join(dbDir, "quay_sqlite.db")
+	createCopyTestDB(t, dbPath)
+
+	writeCopyTestFile(t, filepath.Join(srcDir, "ssl.cert"), []byte("fake-cert"), 0o644)
+	writeCopyTestFile(t, filepath.Join(srcDir, "ssl.key"), []byte("fake-key"), 0o600)
+
+	mkdirCopyTestDir(t, filepath.Join(storageDir, "sha256", "ab"), 0o750)
+	writeCopyTestFile(t, filepath.Join(storageDir, "sha256", "ab", "abcdef"), []byte("blob-data"), 0o644)
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+
+	m := &Migrator{
+		DataDir: targetDir,
+		Out:     &bytes.Buffer{},
+		Source: OMRSource{
+			ConfigDir:   srcDir,
+			DBPath:      dbPath,
+			StoragePath: storageDir,
+		},
+	}
+
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("copyData: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(targetDir, "quay.db")); err != nil {
+		t.Error("quay.db not found in target")
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "ssl.cert")); err != nil {
+		t.Error("ssl.cert not found in target")
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "ssl.key")); err != nil {
+		t.Error("ssl.key not found in target")
+	}
+
+	blobPath := filepath.Join(targetDir, "storage", "sha256", "ab", "abcdef")
+	if _, err := os.Stat(blobPath); err != nil {
+		t.Errorf("blob not found: %s", blobPath)
+	}
+
+	if _, err := os.Stat(filepath.Join(targetDir, markerFile)); err != nil {
+		t.Error("marker file should exist after copy")
+	}
+}
+
+func TestCopyData_Idempotent(t *testing.T) {
+	srcDir := t.TempDir()
+	dbDir := t.TempDir()
+
+	dbPath := filepath.Join(dbDir, "quay_sqlite.db")
+	createCopyTestDB(t, dbPath)
+	writeCopyTestFile(t, filepath.Join(srcDir, "ssl.cert"), []byte("cert"), 0o644)
+	writeCopyTestFile(t, filepath.Join(srcDir, "ssl.key"), []byte("key"), 0o600)
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+
+	m := &Migrator{
+		DataDir: targetDir,
+		Out:     &bytes.Buffer{},
+		Source: OMRSource{
+			ConfigDir: srcDir,
+			DBPath:    dbPath,
+		},
+	}
+
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("first copy: %v", err)
+	}
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("second copy (idempotent): %v", err)
+	}
+}
+
+func TestCopyData_RecopiesDatabaseWhenMarkerExists(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "quay_sqlite.db")
+	createCopyTestDB(t, dbPath)
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+	mkdirCopyTestDir(t, targetDir, 0o750)
+	writeCopyTestFile(t, filepath.Join(targetDir, markerFile), []byte("migration in progress\n"), 0o600)
+
+	sourceBytes, err := os.ReadFile(dbPath) //nolint:gosec // test fixture path is under t.TempDir.
+	if err != nil {
+		t.Fatalf("read source db: %v", err)
+	}
+	writeCopyTestFile(t, filepath.Join(targetDir, "quay.db"), bytes.Repeat([]byte("x"), len(sourceBytes)), 0o600)
+
+	m := &Migrator{
+		DataDir: targetDir,
+		Out:     &bytes.Buffer{},
+		Source: OMRSource{
+			DBPath: dbPath,
+		},
+	}
+
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("copyData: %v", err)
+	}
+
+	targetBytes, err := os.ReadFile(filepath.Join(targetDir, "quay.db")) //nolint:gosec // test fixture path is under t.TempDir.
+	if err != nil {
+		t.Fatalf("read target db: %v", err)
+	}
+	if !bytes.Equal(targetBytes, sourceBytes) {
+		t.Fatal("target database was not recopied when migration marker existed")
+	}
+}
+
+func TestCopyData_CheckpointsSourceWAL(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "quay_sqlite.db")
+	srcDB, err := dbcore.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite source: %v", err)
+	}
+	defer func() { _ = srcDB.Close() }()
+
+	if _, err := srcDB.ExecContext(t.Context(), "PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("enable WAL: %v", err)
+	}
+	if _, err := srcDB.ExecContext(t.Context(), "CREATE TABLE wal_test (value TEXT)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := srcDB.ExecContext(t.Context(), "INSERT INTO wal_test (value) VALUES ('committed-in-wal')"); err != nil {
+		t.Fatalf("insert row: %v", err)
+	}
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+	m := &Migrator{
+		DataDir: targetDir,
+		Out:     &bytes.Buffer{},
+		Source: OMRSource{
+			DBPath: dbPath,
+		},
+	}
+
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("copyData: %v", err)
+	}
+
+	targetDB, err := dbcore.OpenSQLite(filepath.Join(targetDir, "quay.db"))
+	if err != nil {
+		t.Fatalf("open target: %v", err)
+	}
+	defer func() { _ = targetDB.Close() }()
+
+	var value string
+	if err := targetDB.QueryRowContext(t.Context(), "SELECT value FROM wal_test").Scan(&value); err != nil {
+		t.Fatalf("query copied row: %v", err)
+	}
+	if value != "committed-in-wal" {
+		t.Errorf("copied value = %q, want committed-in-wal", value)
+	}
+}
+
+func createCopyTestDB(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := dbcore.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.ExecContext(t.Context(), "CREATE TABLE copy_test (value TEXT)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := db.ExecContext(t.Context(), "INSERT INTO copy_test (value) VALUES ('ok')"); err != nil {
+		t.Fatalf("insert row: %v", err)
+	}
+}
+
+func mkdirCopyTestDir(t *testing.T, path string, perm os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(path, perm); err != nil {
+		t.Fatalf("mkdir fixture %s: %v", path, err)
+	}
+}
+
+func writeCopyTestFile(t *testing.T, path string, data []byte, perm os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, data, perm); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+}

--- a/internal/migrate/detect.go
+++ b/internal/migrate/detect.go
@@ -1,0 +1,285 @@
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// OMR service names.
+var omrServiceNames = []string{"quay-app", "quay-redis", "quay-pod"}
+
+// detectSystemd scans for old OMR systemd unit files and extracts paths.
+func (m *Migrator) detectSystemd(ctx context.Context) (OMRSource, error) {
+	for _, scope := range []struct {
+		name string
+		dirs []string
+	}{
+		{scopeSystem, []string{"/etc/systemd/system"}},
+		{scopeUser, userSystemdDirs()},
+	} {
+		for _, dir := range scope.dirs {
+			unitPath := filepath.Join(dir, "quay-app.service")
+			data, err := os.ReadFile(unitPath) //nolint:gosec // well-known systemd path
+			if err != nil {
+				continue
+			}
+			slog.Info("found OMR unit file", "path", unitPath)
+			return m.sourceFromUnit(ctx, string(data), scope.name, dir)
+		}
+	}
+	return OMRSource{}, fmt.Errorf("no OMR systemd units found")
+}
+
+func userSystemdDirs() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{filepath.Join(home, ".config", "systemd", "user")}
+}
+
+func (m *Migrator) sourceFromUnit(ctx context.Context, unitContent, scope, unitDir string) (OMRSource, error) {
+	vols := parseUnitVolumes(unitContent)
+
+	src := OMRSource{
+		SystemdScope: scope,
+		Method:       "systemd",
+	}
+
+	// Collect unit file paths for cleanup.
+	for _, svc := range omrServiceNames {
+		p := filepath.Join(unitDir, svc+".service")
+		if _, err := os.Stat(p); err == nil {
+			src.UnitFiles = append(src.UnitFiles, p)
+		}
+	}
+
+	// Extract config dir from the /quay-registry/conf/stack mount.
+	if hostPath, ok := vols["/quay-registry/conf/stack"]; ok {
+		src.ConfigDir = hostPath
+	}
+
+	// Extract sqlite storage from /sqlite mount.
+	if hostPath, ok := vols["/sqlite"]; ok {
+		resolved, volName, err := m.resolveVolumePath(ctx, hostPath)
+		if err == nil {
+			src.DBPath = filepath.Join(resolved, "quay_sqlite.db")
+			if volName != "" {
+				src.VolumeNames = append(src.VolumeNames, volName)
+			}
+		}
+	}
+
+	// Extract blob storage from /datastorage mount.
+	if hostPath, ok := vols["/datastorage"]; ok {
+		resolved, volName, err := m.resolveVolumePath(ctx, hostPath)
+		if err == nil {
+			src.StoragePath = resolved
+			if volName != "" {
+				src.VolumeNames = append(src.VolumeNames, volName)
+			}
+		}
+	}
+
+	// Extract hostname from config.yaml.
+	if src.ConfigDir != "" {
+		configPath := filepath.Join(src.ConfigDir, "config.yaml")
+		data, err := os.ReadFile(configPath) //nolint:gosec // detected config path
+		if err == nil {
+			hostname, err := extractHostname(data)
+			if err == nil {
+				src.Hostname = hostname
+			}
+		}
+	}
+
+	return src, nil
+}
+
+// parseUnitVolumes extracts -v host:container[:opts] mappings from a systemd unit.
+// Returns map[containerPath]hostPath.
+func parseUnitVolumes(unitContent string) map[string]string {
+	vols := make(map[string]string)
+	// Join continuation lines (backslash-newline).
+	joined := strings.ReplaceAll(unitContent, "\\\n", " ")
+	for _, line := range strings.Split(joined, "\n") {
+		line = strings.TrimSpace(line)
+		parts := strings.Fields(line)
+		for i, p := range parts {
+			if p == "-v" && i+1 < len(parts) {
+				mountSpec := parts[i+1]
+				colonParts := strings.SplitN(mountSpec, ":", 3)
+				if len(colonParts) >= 2 {
+					vols[colonParts[1]] = colonParts[0]
+				}
+			}
+		}
+	}
+	return vols
+}
+
+// resolveVolumePath resolves a volume mount source. If it starts with /,
+// it's a host path (returned as-is). Otherwise it's a Podman volume name
+// and we inspect it to get the mountpoint.
+func (m *Migrator) resolveVolumePath(ctx context.Context, hostOrVolume string) (path, volumeName string, err error) {
+	if filepath.IsAbs(hostOrVolume) {
+		return hostOrVolume, "", nil
+	}
+	if m.Runner == nil {
+		return "", "", fmt.Errorf("no command runner for volume inspection")
+	}
+	output, err := m.Runner.Output(ctx, "podman", "volume", "inspect", hostOrVolume, "--format", "{{.Mountpoint}}")
+	if err != nil {
+		return "", "", fmt.Errorf("inspect volume %s: %w", hostOrVolume, err)
+	}
+	return strings.TrimSpace(output), hostOrVolume, nil
+}
+
+// detectPodmanVolumes probes for well-known OMR volume names.
+func (m *Migrator) detectPodmanVolumes(ctx context.Context) (OMRSource, error) {
+	if m.Runner == nil {
+		return OMRSource{}, fmt.Errorf("no command runner")
+	}
+	src := OMRSource{Method: "podman-volume"}
+	sqlitePath, volName, err := m.resolveVolumePath(ctx, "sqlite-storage")
+	if err != nil {
+		return OMRSource{}, fmt.Errorf("sqlite-storage volume: %w", err)
+	}
+	src.DBPath = filepath.Join(sqlitePath, "quay_sqlite.db")
+	src.VolumeNames = append(src.VolumeNames, volName)
+
+	storagePath, volName, err := m.resolveVolumePath(ctx, "quay-storage")
+	if err != nil {
+		return OMRSource{}, fmt.Errorf("quay-storage volume: %w", err)
+	}
+	src.StoragePath = storagePath
+	src.VolumeNames = append(src.VolumeNames, volName)
+
+	// Try well-known config dir.
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		configDir := filepath.Join(home, "quay-install", "quay-config")
+		if _, err := os.Stat(configDir); err == nil {
+			src.ConfigDir = configDir
+		}
+	}
+
+	// Extract hostname if config found.
+	if src.ConfigDir != "" {
+		data, err := os.ReadFile(filepath.Join(src.ConfigDir, "config.yaml")) //nolint:gosec // detected config path
+		if err == nil {
+			hostname, _ := extractHostname(data)
+			src.Hostname = hostname
+		}
+	}
+
+	return src, nil
+}
+
+// detectDefaults uses well-known paths without querying podman or systemd.
+func (m *Migrator) detectDefaults() (OMRSource, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return OMRSource{}, fmt.Errorf("home dir: %w", err)
+	}
+	root := filepath.Join(home, "quay-install")
+	if m.SourceRoot != "" {
+		root = m.SourceRoot
+	}
+	configDir := filepath.Join(root, "quay-config")
+	if _, err := os.Stat(configDir); err != nil {
+		return OMRSource{}, fmt.Errorf("config dir %s not found: %w", configDir, err)
+	}
+	src := OMRSource{
+		ConfigDir:   configDir,
+		DBPath:      filepath.Join(root, "sqlite-storage", "quay_sqlite.db"),
+		StoragePath: filepath.Join(root, "quay-storage"),
+		Method:      "defaults",
+	}
+	data, err := os.ReadFile(filepath.Join(configDir, "config.yaml")) //nolint:gosec // detected config path
+	if err == nil {
+		hostname, _ := extractHostname(data)
+		src.Hostname = hostname
+	}
+	return src, nil
+}
+
+// detect tries each strategy in order.
+func (m *Migrator) detect(ctx context.Context) (OMRSource, error) {
+	if src, err := m.detectSystemd(ctx); err == nil {
+		slog.Info("detected OMR via systemd units", "scope", src.SystemdScope)
+		return m.withImageArchive(&src), nil
+	}
+	if src, err := m.detectPodmanVolumes(ctx); err == nil {
+		slog.Info("detected OMR via podman volumes")
+		return m.withImageArchive(&src), nil
+	}
+	src, err := m.detectDefaults()
+	if err != nil {
+		return OMRSource{}, fmt.Errorf("could not detect OMR installation: %w", err)
+	}
+	slog.Info("detected OMR via default paths")
+	return m.withImageArchive(&src), nil
+}
+
+func (m *Migrator) withImageArchive(src *OMRSource) OMRSource {
+	if src.ImageArchive != "" || m.ImageArchive != "" {
+		return *src
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return *src
+	}
+	archive, err := findImageArchive(filepath.Dir(exe))
+	if err == nil {
+		src.ImageArchive = archive
+		slog.Info("auto-detected image archive", "path", archive)
+	}
+	return *src
+}
+
+// extractHostname parses SERVER_HOSTNAME from an OMR config.yaml.
+// Strips any port suffix since the installer adds :8443 itself.
+func extractHostname(data []byte) (string, error) {
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return "", fmt.Errorf("parse config: %w", err)
+	}
+	hostname, ok := raw["SERVER_HOSTNAME"].(string)
+	if !ok || hostname == "" {
+		return "", fmt.Errorf("SERVER_HOSTNAME not found in config")
+	}
+	if host, _, err := net.SplitHostPort(hostname); err == nil {
+		hostname = host
+	}
+	return hostname, nil
+}
+
+// findImageArchive looks for a single .tar file in dir.
+func findImageArchive(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+	var tars []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".tar") {
+			tars = append(tars, filepath.Join(dir, e.Name()))
+		}
+	}
+	switch len(tars) {
+	case 0:
+		return "", fmt.Errorf("no .tar files found in %s", dir)
+	case 1:
+		return tars[0], nil
+	default:
+		return "", fmt.Errorf("multiple .tar files in %s; specify -image-archive explicitly", dir)
+	}
+}

--- a/internal/migrate/detect_test.go
+++ b/internal/migrate/detect_test.go
@@ -1,0 +1,103 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseUnitVolumes(t *testing.T) {
+	unit := `[Unit]
+Description=Quay App
+After=quay-pod.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/podman run --name quay-app --pod=quay-pod \
+  -v /home/user/quay-install/quay-config:/quay-registry/conf/stack:Z \
+  -v sqlite-storage:/sqlite:Z \
+  -v quay-storage:/datastorage:Z \
+  registry.redhat.io/quay/quay-rhel8:v3.12.12 registry
+
+[Install]
+WantedBy=default.target
+`
+	vols := parseUnitVolumes(unit)
+
+	if len(vols) != 3 {
+		t.Fatalf("expected 3 volumes, got %d: %v", len(vols), vols)
+	}
+
+	want := map[string]string{
+		"/quay-registry/conf/stack": "/home/user/quay-install/quay-config",
+		"/sqlite":                   "sqlite-storage",
+		"/datastorage":              "quay-storage",
+	}
+	for container, host := range want {
+		got, ok := vols[container]
+		if !ok {
+			t.Errorf("missing mount for %s", container)
+			continue
+		}
+		if got != host {
+			t.Errorf("mount %s: got %q, want %q", container, got, host)
+		}
+	}
+}
+
+func TestExtractHostname(t *testing.T) {
+	yaml := `AUTHENTICATION_TYPE: Database
+SERVER_HOSTNAME: registry.example.com
+SETUP_COMPLETE: true
+DB_URI: sqlite:////sqlite/quay_sqlite.db
+`
+	hostname, err := extractHostname([]byte(yaml))
+	if err != nil {
+		t.Fatalf("extractHostname: %v", err)
+	}
+	if hostname != "registry.example.com" {
+		t.Errorf("got %q, want %q", hostname, "registry.example.com")
+	}
+}
+
+func TestExtractHostname_StripsPort(t *testing.T) {
+	yaml := `SERVER_HOSTNAME: localhost:8443
+`
+	hostname, err := extractHostname([]byte(yaml))
+	if err != nil {
+		t.Fatalf("extractHostname: %v", err)
+	}
+	if hostname != "localhost" {
+		t.Errorf("got %q, want %q", hostname, "localhost")
+	}
+}
+
+func TestFindImageArchive(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "quay-mirror.tar")
+	if err := os.WriteFile(tarPath, []byte("fake-tar"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := findImageArchive(dir)
+	if err != nil {
+		t.Fatalf("findImageArchive: %v", err)
+	}
+	if got != tarPath {
+		t.Errorf("got %q, want %q", got, tarPath)
+	}
+}
+
+func TestFindImageArchive_MultipleTars(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.tar", "b.tar"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := findImageArchive(dir)
+	if err == nil {
+		t.Error("expected error for multiple tar files")
+	}
+}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -1,0 +1,178 @@
+// Package migrate implements the OMR-to-Go-binary migration workflow.
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/quay/quay/internal/system"
+)
+
+const (
+	scopeSystem = "system"
+	scopeUser   = "user"
+)
+
+// OMRSource describes a detected OMR v2.0.x SQLite installation.
+type OMRSource struct {
+	ConfigDir   string // path to quay-config/ (config.yaml, ssl.cert, ssl.key)
+	DBPath      string // path to quay_sqlite.db
+	StoragePath string // path to blob storage root
+	Hostname    string // from old config.yaml SERVER_HOSTNAME
+
+	ImageArchive string // container image tar path
+	Image        string // container image ref (alternative)
+
+	SystemdScope string   // "system" or "user"
+	UnitFiles    []string // old systemd unit file paths
+	VolumeNames  []string // podman volume names
+	Method       string   // "systemd", "podman-volume", or "defaults"
+}
+
+// Migrator orchestrates the OMR-to-Go-binary migration phases.
+type Migrator struct {
+	Source OMRSource
+
+	DataDir      string
+	Hostname     string
+	Image        string
+	ImageArchive string
+
+	SourceRoot    string
+	SourceDB      string
+	SourceStorage string
+	SourceCerts   string
+
+	DryRun      bool
+	Cleanup     bool
+	SkipInstall bool
+
+	Out    io.Writer
+	Runner system.CommandRunner
+}
+
+// Run executes the migration phases in order.
+func (m *Migrator) Run(ctx context.Context) error {
+	if m.Out == nil {
+		m.Out = os.Stderr
+	}
+
+	if err := m.detectAndOverride(ctx); err != nil {
+		return err
+	}
+
+	if m.DryRun {
+		m.printPlan()
+		return nil
+	}
+
+	// If cleanup-only (target dir already populated from a previous migration),
+	// skip the migration phases and just clean up the old OMR.
+	if m.Cleanup && targetDirPopulated(m.DataDir) {
+		if err := m.cleanup(ctx); err != nil {
+			return fmt.Errorf("cleanup: %w", err)
+		}
+		slog.Info("cleanup complete")
+		return nil
+	}
+
+	if err := m.migrateData(ctx); err != nil {
+		return err
+	}
+
+	if !m.SkipInstall {
+		if err := m.install(ctx); err != nil {
+			return fmt.Errorf("install: %w", err)
+		}
+	}
+
+	if m.Cleanup {
+		if err := m.cleanup(ctx); err != nil {
+			return fmt.Errorf("cleanup: %w", err)
+		}
+	}
+
+	slog.Info("migration complete")
+	return nil
+}
+
+func targetDirPopulated(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "quay.db"))
+	return err == nil
+}
+
+func (m *Migrator) migrateData(ctx context.Context) error {
+	if err := m.validate(ctx); err != nil {
+		return fmt.Errorf("validate: %w", err)
+	}
+	if err := m.stopOldOMR(ctx); err != nil {
+		return fmt.Errorf("stop old OMR: %w", err)
+	}
+	if err := m.copyData(ctx); err != nil {
+		return fmt.Errorf("copy: %w", err)
+	}
+	if err := m.upgradeSchema(ctx); err != nil {
+		return fmt.Errorf("schema upgrade: %w", err)
+	}
+	return nil
+}
+
+func (m *Migrator) detectAndOverride(ctx context.Context) error {
+	m.applyOverrides()
+
+	if m.Source.DBPath == "" {
+		src, err := m.detect(ctx)
+		if err != nil {
+			return fmt.Errorf("detect: %w", err)
+		}
+		m.Source = src
+		m.applyOverrides()
+	} else if m.Source.Method == "" {
+		m.Source.Method = "manual"
+		m.Source = m.withImageArchive(&m.Source)
+	}
+	return nil
+}
+
+func (m *Migrator) applyOverrides() {
+	if m.Hostname != "" {
+		m.Source.Hostname = m.Hostname
+	}
+	if m.SourceDB != "" {
+		m.Source.DBPath = m.SourceDB
+	}
+	if m.SourceStorage != "" {
+		m.Source.StoragePath = m.SourceStorage
+	}
+	if m.SourceCerts != "" {
+		m.Source.ConfigDir = m.SourceCerts
+	}
+	if m.ImageArchive != "" {
+		m.Source.ImageArchive = m.ImageArchive
+	}
+	if m.Image != "" {
+		m.Source.Image = m.Image
+	}
+}
+
+func (m *Migrator) printPlan() {
+	fmt.Fprintf(m.Out, "Detected OMR installation (via %s):\n", m.Source.Method)
+	fmt.Fprintf(m.Out, "  Config:   %s\n", m.Source.ConfigDir)
+	fmt.Fprintf(m.Out, "  Database: %s\n", m.Source.DBPath)
+	fmt.Fprintf(m.Out, "  Storage:  %s\n", m.Source.StoragePath)
+	fmt.Fprintf(m.Out, "  Hostname: %s\n", m.Source.Hostname)
+	if len(m.Source.UnitFiles) > 0 {
+		fmt.Fprintf(m.Out, "  Services: %v (%s scope)\n", m.Source.UnitFiles, m.Source.SystemdScope)
+	}
+	if len(m.Source.VolumeNames) > 0 {
+		fmt.Fprintf(m.Out, "  Volumes:  %v\n", m.Source.VolumeNames)
+	}
+	if m.Source.ImageArchive != "" {
+		fmt.Fprintf(m.Out, "  Image:    %s (auto-detected)\n", m.Source.ImageArchive)
+	}
+	fmt.Fprintf(m.Out, "\nTarget: %s/\n", m.DataDir)
+}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -1,0 +1,62 @@
+package migrate
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestMigrator_Run_DryRun(t *testing.T) {
+	m := &Migrator{
+		DataDir: t.TempDir(),
+		DryRun:  true,
+		Out:     &bytes.Buffer{},
+	}
+	m.Source = OMRSource{
+		ConfigDir:   "/fake/config",
+		DBPath:      "/fake/db.db",
+		StoragePath: "/fake/storage",
+		Hostname:    "localhost",
+		Method:      "test",
+	}
+
+	err := m.Run(t.Context())
+	if err != nil {
+		t.Fatalf("dry-run should not error with pre-set source: %v", err)
+	}
+
+	out := m.Out.(*bytes.Buffer).String()
+	if out == "" {
+		t.Error("expected dry-run output")
+	}
+}
+
+func TestMigrator_Run_DryRunWithManualSourceSkipsDetection(t *testing.T) {
+	var out bytes.Buffer
+	m := &Migrator{
+		DataDir:       t.TempDir(),
+		SourceDB:      "/manual/quay_sqlite.db",
+		SourceStorage: "/manual/storage",
+		SourceCerts:   "/manual/config",
+		Hostname:      "registry.example.com",
+		DryRun:        true,
+		Out:           &out,
+	}
+
+	if err := m.Run(t.Context()); err != nil {
+		t.Fatalf("dry-run should not auto-detect with manual source: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"via manual",
+		"/manual/quay_sqlite.db",
+		"/manual/storage",
+		"/manual/config",
+		"registry.example.com",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("dry-run output missing %q: %s", want, got)
+		}
+	}
+}

--- a/internal/migrate/schema.go
+++ b/internal/migrate/schema.go
@@ -1,0 +1,111 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/quay/quay/internal/dal/dbcore"
+	"github.com/quay/quay/internal/installer"
+)
+
+// upgradeSchema opens the copied database, backs it up, and runs the bridge
+// migration to bring it to the Go binary's target schema version.
+func (m *Migrator) upgradeSchema(ctx context.Context) error {
+	dbPath := filepath.Join(m.DataDir, "quay.db")
+
+	db, err := dbcore.OpenSQLite(dbPath)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ver, err := dbcore.SchemaVersion(ctx, db)
+	if err != nil {
+		return fmt.Errorf("read schema version: %w", err)
+	}
+
+	if ver == dbcore.TargetVersion {
+		slog.Info("schema is current", "version", ver)
+		return nil
+	}
+
+	slog.Info("upgrading schema", "from", ver, "to", dbcore.TargetVersion)
+
+	backupPath, err := dbcore.BackupDatabase(ctx, db, dbPath)
+	if err != nil {
+		return fmt.Errorf("backup: %w", err)
+	}
+	slog.Info("database backup created", "path", backupPath)
+
+	if err := dbcore.RunBridge(ctx, db, m.Out); err != nil {
+		return fmt.Errorf("bridge migration (restore from %s): %w", backupPath, err)
+	}
+
+	if err := dbcore.IntegrityCheck(ctx, db); err != nil {
+		return fmt.Errorf("post-migration integrity check: %w", err)
+	}
+
+	return nil
+}
+
+// stopOldOMR stops old OMR systemd services to free port 8443 and flush WAL.
+func (m *Migrator) stopOldOMR(ctx context.Context) error {
+	if m.Runner == nil {
+		slog.Info("no command runner, skipping service stop")
+		return nil
+	}
+	if len(m.Source.UnitFiles) == 0 {
+		slog.Info("no OMR services detected, skipping stop")
+		return nil
+	}
+
+	var scopeArgs []string
+	if m.Source.SystemdScope == scopeUser {
+		scopeArgs = []string{"--user"}
+	}
+
+	var stopErrs []error
+	for _, svc := range omrServiceNames {
+		args := make([]string, len(scopeArgs), len(scopeArgs)+2)
+		copy(args, scopeArgs)
+		args = append(args, "stop", svc+".service")
+		slog.Info("stopping service", "service", svc)
+		if err := m.Runner.Run(ctx, "systemctl", args...); err != nil {
+			stopErrs = append(stopErrs, fmt.Errorf("stop OMR service %s: %w", svc, err))
+			slog.Warn("failed to stop service (may already be stopped)", "service", svc, "err", err)
+		}
+	}
+	if err := errors.Join(stopErrs...); err != nil {
+		return fmt.Errorf("stop old OMR services: %w", err)
+	}
+
+	slog.Info("old OMR services stopped")
+	return nil
+}
+
+// install chains into the existing installer to create the Quadlet unit and start the service.
+func (m *Migrator) install(ctx context.Context) error {
+	inst, err := installer.New(m.Out)
+	if err != nil {
+		return fmt.Errorf("create installer: %w", err)
+	}
+
+	cfg := installer.Config{
+		Hostname:     m.Source.Hostname,
+		DataDir:      m.DataDir,
+		ImageArchive: m.Source.ImageArchive,
+		Image:        m.Source.Image,
+	}
+
+	slog.Info("installing new registry", "hostname", cfg.Hostname, "data-dir", cfg.DataDir)
+	if err := inst.Run(ctx, cfg); err != nil {
+		return fmt.Errorf("install: %w", err)
+	}
+
+	removeMarker(m.DataDir)
+	slog.Info("new registry installed and running")
+	return nil
+}

--- a/internal/migrate/schema_test.go
+++ b/internal/migrate/schema_test.go
@@ -1,0 +1,142 @@
+package migrate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/quay/quay/internal/dal/dbcore"
+)
+
+func TestUpgradeSchema_AlreadyCurrent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "quay.db")
+
+	db, err := dbcore.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	if err := dbcore.InitDatabase(t.Context(), db, &bytes.Buffer{}); err != nil {
+		t.Fatalf("InitDatabase: %v", err)
+	}
+	db.Close()
+
+	m := &Migrator{
+		DataDir: dir,
+		Out:     &bytes.Buffer{},
+	}
+
+	if err := m.upgradeSchema(t.Context()); err != nil {
+		t.Fatalf("upgradeSchema: %v", err)
+	}
+}
+
+func TestStopOldOMR_ReturnsErrorWhenQuayAppStopFails(t *testing.T) {
+	runner := &recordingRunner{
+		runErrs: map[string]error{
+			"quay-app.service": errors.New("permission denied"),
+		},
+	}
+	m := &Migrator{
+		Runner: runner,
+		Source: OMRSource{
+			SystemdScope: scopeSystem,
+			UnitFiles:    []string{"/etc/systemd/system/quay-app.service"},
+		},
+	}
+
+	err := m.stopOldOMR(t.Context())
+	if err == nil {
+		t.Fatal("expected stopOldOMR to fail when quay-app cannot stop")
+	}
+	if !strings.Contains(err.Error(), "quay-app") {
+		t.Fatalf("expected error to mention quay-app, got %v", err)
+	}
+	if len(runner.runCalls) != len(omrServiceNames) {
+		t.Fatalf("expected stopOldOMR to attempt all services, got %d calls", len(runner.runCalls))
+	}
+}
+
+func TestStopOldOMR_ReturnsErrorWhenRedisOrPodStopFails(t *testing.T) {
+	runner := &recordingRunner{
+		runErrs: map[string]error{
+			"quay-redis.service": errors.New("already stopped"),
+			"quay-pod.service":   errors.New("already stopped"),
+		},
+	}
+	m := &Migrator{
+		Runner: runner,
+		Source: OMRSource{
+			SystemdScope: scopeSystem,
+			UnitFiles:    []string{"/etc/systemd/system/quay-app.service"},
+		},
+	}
+
+	err := m.stopOldOMR(t.Context())
+	if err == nil {
+		t.Fatal("expected stopOldOMR to fail when any service cannot stop")
+	}
+	for _, svc := range []string{"quay-redis", "quay-pod"} {
+		if !strings.Contains(err.Error(), svc) {
+			t.Fatalf("expected error to mention %s, got %v", svc, err)
+		}
+	}
+	if len(runner.runCalls) != len(omrServiceNames) {
+		t.Fatalf("expected stopOldOMR to attempt all services, got %d calls", len(runner.runCalls))
+	}
+}
+
+func TestStopOldOMR_SkipsWhenNoUnitFilesDetected(t *testing.T) {
+	runner := &recordingRunner{}
+	m := &Migrator{
+		Runner: runner,
+		Source: OMRSource{
+			SystemdScope: scopeSystem,
+		},
+	}
+
+	if err := m.stopOldOMR(t.Context()); err != nil {
+		t.Fatalf("stopOldOMR should skip when no unit files were detected: %v", err)
+	}
+	if len(runner.runCalls) != 0 {
+		t.Fatalf("expected no stop calls when no unit files were detected, got %d", len(runner.runCalls))
+	}
+}
+
+func TestStopOldOMR_SucceedsWhenAllStopsSucceed(t *testing.T) {
+	runner := &recordingRunner{}
+	m := &Migrator{
+		Runner: runner,
+		Source: OMRSource{
+			SystemdScope: scopeSystem,
+			UnitFiles:    []string{"/etc/systemd/system/quay-app.service"},
+		},
+	}
+
+	if err := m.stopOldOMR(t.Context()); err != nil {
+		t.Fatalf("stopOldOMR should succeed when all stop commands succeed: %v", err)
+	}
+	if len(runner.runCalls) != len(omrServiceNames) {
+		t.Fatalf("expected stopOldOMR to attempt all services, got %d calls", len(runner.runCalls))
+	}
+}
+
+type recordingRunner struct {
+	runCalls []string
+	runErrs  map[string]error
+}
+
+func (r *recordingRunner) Run(_ context.Context, name string, args ...string) error {
+	r.runCalls = append(r.runCalls, name+" "+strings.Join(args, " "))
+	if len(args) == 0 {
+		return nil
+	}
+	return r.runErrs[args[len(args)-1]]
+}
+
+func (r *recordingRunner) Output(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", nil
+}

--- a/internal/migrate/validate.go
+++ b/internal/migrate/validate.go
@@ -1,0 +1,130 @@
+package migrate
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/quay/quay/internal/dal/dbcore"
+	"github.com/quay/quay/internal/installer"
+)
+
+const markerFile = ".migration-in-progress"
+
+// validate checks source integrity and target readiness.
+func (m *Migrator) validate(ctx context.Context) error {
+	if _, err := os.Stat(m.Source.DBPath); err != nil {
+		return fmt.Errorf("source database not found: %s", m.Source.DBPath)
+	}
+
+	db, err := dbcore.OpenSQLite(m.Source.DBPath)
+	if err != nil {
+		return fmt.Errorf("open source database: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := dbcore.IntegrityCheck(ctx, db); err != nil {
+		return fmt.Errorf("source database is corrupted — run 'PRAGMA integrity_check' on %s to diagnose: %w",
+			m.Source.DBPath, err)
+	}
+
+	ver, err := dbcore.SchemaVersion(ctx, db)
+	if err != nil {
+		return fmt.Errorf("read schema version: %w", err)
+	}
+	if ver == "" {
+		return fmt.Errorf("source database has no alembic version — not a Quay database")
+	}
+	slog.Info("source schema version", "version", ver)
+
+	if m.Source.ConfigDir != "" {
+		certPath := filepath.Join(m.Source.ConfigDir, "ssl.cert")
+		keyPath := filepath.Join(m.Source.ConfigDir, "ssl.key")
+		if err := validateCertKeyPair(certPath, keyPath); err != nil {
+			return fmt.Errorf("TLS certificate validation: %w", err)
+		}
+	}
+
+	if m.Source.StoragePath != "" {
+		if err := validateStorageDir(m.Source.StoragePath); err != nil {
+			return fmt.Errorf("storage validation: %w", err)
+		}
+	}
+
+	if err := validateTargetDir(m.DataDir); err != nil {
+		return err
+	}
+
+	if err := m.validateInstallInputs(); err != nil {
+		return err
+	}
+
+	slog.Info("validation passed")
+	return nil
+}
+
+func (m *Migrator) validateInstallInputs() error {
+	if m.SkipInstall {
+		return nil
+	}
+	if m.Source.Hostname == "" {
+		return fmt.Errorf("hostname not detected — provide -hostname")
+	}
+	if err := installer.ValidateHostname(m.Source.Hostname); err != nil {
+		return fmt.Errorf("invalid hostname %q: %w", m.Source.Hostname, err)
+	}
+	if m.Source.ImageArchive == "" && m.Source.Image == "" {
+		return fmt.Errorf("no image archive found — provide -image-archive or -image flag")
+	}
+	return nil
+}
+
+func validateCertKeyPair(certPath, keyPath string) error {
+	if _, err := os.Stat(certPath); err != nil {
+		return fmt.Errorf("cert not found: %s", certPath)
+	}
+	if _, err := os.Stat(keyPath); err != nil {
+		return fmt.Errorf("key not found: %s", keyPath)
+	}
+	_, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return fmt.Errorf("cert/key mismatch: %w", err)
+	}
+	return nil
+}
+
+func validateStorageDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("storage directory not found: %s", path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("storage path is not a directory: %s", path)
+	}
+	return nil
+}
+
+func validateTargetDir(path string) error {
+	entries, err := os.ReadDir(path)
+	if os.IsNotExist(err) {
+		return nil // will be created
+	}
+	if err != nil {
+		return fmt.Errorf("read target directory: %w", err)
+	}
+
+	for _, e := range entries {
+		if e.Name() == markerFile {
+			slog.Info("found migration marker, resuming previous migration")
+			return nil
+		}
+	}
+
+	if len(entries) > 0 {
+		return fmt.Errorf("target directory %s is not empty — specify a clean directory or remove existing files", path)
+	}
+	return nil
+}

--- a/internal/migrate/validate_test.go
+++ b/internal/migrate/validate_test.go
@@ -1,0 +1,176 @@
+package migrate
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/quay/quay/internal/dal/dbcore"
+)
+
+func TestValidateSource_ValidDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "quay_sqlite.db")
+
+	db, err := dbcore.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	if err := dbcore.InitDatabase(t.Context(), db, &bytes.Buffer{}); err != nil {
+		t.Fatalf("InitDatabase: %v", err)
+	}
+	db.Close()
+
+	certDir := t.TempDir()
+	writeSelfSignedCert(t, certDir)
+
+	storageDir := t.TempDir()
+	os.MkdirAll(filepath.Join(storageDir, "sha256", "ab"), 0o750)
+
+	targetDir := t.TempDir() + "/target"
+
+	m := &Migrator{
+		DataDir:     targetDir,
+		SkipInstall: true,
+		Out:         &bytes.Buffer{},
+		Source: OMRSource{
+			ConfigDir:   certDir,
+			DBPath:      dbPath,
+			StoragePath: storageDir,
+			Hostname:    "localhost",
+		},
+	}
+
+	if err := m.validate(t.Context()); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestValidateSource_CorruptDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "quay_sqlite.db")
+	os.WriteFile(dbPath, []byte("not a database"), 0o644)
+
+	m := &Migrator{
+		DataDir:     t.TempDir() + "/target",
+		SkipInstall: true,
+		Out:         &bytes.Buffer{},
+		Source: OMRSource{
+			DBPath: dbPath,
+		},
+	}
+
+	if err := m.validate(t.Context()); err == nil {
+		t.Fatal("expected error for corrupt DB")
+	}
+}
+
+func TestValidateSource_RequiresHostnameWhenInstalling(t *testing.T) {
+	m := validInstallMigrator(t)
+	m.Source.Hostname = ""
+
+	err := m.validate(t.Context())
+	if err == nil {
+		t.Fatal("expected error for missing hostname")
+	}
+}
+
+func TestValidateSource_RejectsInvalidHostnameWhenInstalling(t *testing.T) {
+	m := validInstallMigrator(t)
+	m.Source.Hostname = "bad_host"
+
+	err := m.validate(t.Context())
+	if err == nil {
+		t.Fatal("expected error for invalid hostname")
+	}
+}
+
+func TestValidateTarget_NotEmpty(t *testing.T) {
+	targetDir := t.TempDir()
+	os.WriteFile(filepath.Join(targetDir, "existing.txt"), []byte("data"), 0o644)
+
+	err := validateTargetDir(targetDir)
+	if err == nil {
+		t.Fatal("expected error for non-empty target")
+	}
+}
+
+func TestValidateTarget_MarkerAllowsResume(t *testing.T) {
+	targetDir := t.TempDir()
+	os.WriteFile(filepath.Join(targetDir, ".migration-in-progress"), []byte(""), 0o644)
+
+	err := validateTargetDir(targetDir)
+	if err != nil {
+		t.Fatalf("should allow resume with marker: %v", err)
+	}
+}
+
+func writeSelfSignedCert(t *testing.T, dir string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	os.WriteFile(filepath.Join(dir, "ssl.cert"), certPEM, 0o644)
+	os.WriteFile(filepath.Join(dir, "ssl.key"), keyPEM, 0o644)
+}
+
+func validInstallMigrator(t *testing.T) *Migrator {
+	t.Helper()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "quay_sqlite.db")
+	db, err := dbcore.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	if err := dbcore.InitDatabase(t.Context(), db, &bytes.Buffer{}); err != nil {
+		t.Fatalf("InitDatabase: %v", err)
+	}
+	db.Close()
+
+	certDir := t.TempDir()
+	writeSelfSignedCert(t, certDir)
+
+	storageDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(storageDir, "sha256", "ab"), 0o750); err != nil {
+		t.Fatalf("create storage dir: %v", err)
+	}
+
+	return &Migrator{
+		DataDir: t.TempDir() + "/target",
+		Out:     &bytes.Buffer{},
+		Source: OMRSource{
+			ConfigDir:   certDir,
+			DBPath:      dbPath,
+			StoragePath: storageDir,
+			Hostname:    "localhost",
+			Image:       "quay.io/quay/quay-mirror:test",
+		},
+	}
+}

--- a/internal/oci/metadata.go
+++ b/internal/oci/metadata.go
@@ -21,6 +21,7 @@ type MetadataStore interface {
 	GetRepositoryID(ctx context.Context, name RepositoryName) (int64, error)
 	GetTagDigest(ctx context.Context, repoID int64, tag string) (digest.Digest, error)
 	GetManifestDigest(ctx context.Context, repoID int64, dgst digest.Digest) (digest.Digest, error)
+	GetManifestContent(ctx context.Context, dgst digest.Digest) ([]byte, error)
 	BlobExists(ctx context.Context, dgst digest.Digest) (bool, error)
 	BlobLinkedToRepo(ctx context.Context, repoID int64, dgst digest.Digest) (bool, error)
 	ListTags(ctx context.Context, repoID int64) ([]string, error)

--- a/internal/oci/storage/local/distcompat.go
+++ b/internal/oci/storage/local/distcompat.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -39,15 +40,7 @@ func (d *DistDriver) Name() string { return "quay" }
 func (d *DistDriver) GetContent(ctx context.Context, path string) ([]byte, error) {
 	switch classify(path) {
 	case pathBlob:
-		dgst, err := digestFromBlobPath(path)
-		if err != nil {
-			return nil, err
-		}
-		data, err := d.blobs.GetContent(ctx, dgst)
-		if errors.Is(err, storage.ErrNotExist) {
-			return nil, storagedriver.PathNotFoundError{Path: path}
-		}
-		return data, err
+		return d.getBlobContent(ctx, path)
 
 	case pathUpload:
 		id := uploadIDFromPath(path)
@@ -64,6 +57,29 @@ func (d *DistDriver) GetContent(ctx context.Context, path string) ([]byte, error
 	default:
 		return d.getMetadataContent(ctx, path)
 	}
+}
+
+func (d *DistDriver) getBlobContent(ctx context.Context, path string) ([]byte, error) {
+	dgst, err := digestFromBlobPath(path)
+	if err != nil {
+		return nil, err
+	}
+	data, err := d.blobs.GetContent(ctx, dgst)
+	if errors.Is(err, storage.ErrNotExist) {
+		return d.getManifestBlobContent(ctx, path, dgst)
+	}
+	return data, err
+}
+
+func (d *DistDriver) getManifestBlobContent(ctx context.Context, path string, dgst digest.Digest) ([]byte, error) {
+	data, err := d.meta.GetManifestContent(ctx, dgst)
+	if err == nil {
+		return data, nil
+	}
+	if errors.Is(err, oci.ErrNotExist) {
+		return nil, storagedriver.PathNotFoundError{Path: path}
+	}
+	return nil, err
 }
 
 func (d *DistDriver) getMetadataContent(ctx context.Context, path string) ([]byte, error) {
@@ -156,15 +172,7 @@ func (d *DistDriver) PutContent(ctx context.Context, path string, content []byte
 func (d *DistDriver) Reader(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
 	switch classify(path) {
 	case pathBlob:
-		dgst, err := digestFromBlobPath(path)
-		if err != nil {
-			return nil, err
-		}
-		rc, err := d.blobs.Reader(ctx, dgst, offset)
-		if errors.Is(err, storage.ErrNotExist) {
-			return nil, storagedriver.PathNotFoundError{Path: path}
-		}
-		return rc, err
+		return d.readerBlob(ctx, path, offset)
 
 	case pathUpload:
 		id := uploadIDFromPath(path)
@@ -177,6 +185,32 @@ func (d *DistDriver) Reader(ctx context.Context, path string, offset int64) (io.
 	default:
 		return nil, storagedriver.PathNotFoundError{Path: path}
 	}
+}
+
+func (d *DistDriver) readerBlob(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
+	dgst, err := digestFromBlobPath(path)
+	if err != nil {
+		return nil, err
+	}
+	rc, err := d.blobs.Reader(ctx, dgst, offset)
+	if errors.Is(err, storage.ErrNotExist) {
+		return d.readerManifestBlob(ctx, path, dgst, offset)
+	}
+	return rc, err
+}
+
+func (d *DistDriver) readerManifestBlob(ctx context.Context, path string, dgst digest.Digest, offset int64) (io.ReadCloser, error) {
+	data, err := d.getManifestBlobContent(ctx, path, dgst)
+	if err != nil {
+		return nil, err
+	}
+	if offset < 0 {
+		return nil, fmt.Errorf("negative offset %d", offset)
+	}
+	if offset > int64(len(data)) {
+		return nil, fmt.Errorf("offset %d beyond manifest content size %d", offset, len(data))
+	}
+	return io.NopCloser(bytes.NewReader(data[offset:])), nil
 }
 
 // Writer returns a FileWriter for upload data. Distribution uses this
@@ -211,20 +245,7 @@ func (fw *distFileWriter) Cancel(ctx context.Context) error { return fw.w.Cancel
 func (d *DistDriver) Stat(ctx context.Context, path string) (storagedriver.FileInfo, error) {
 	switch classify(path) {
 	case pathBlob:
-		dgst, err := digestFromBlobPath(path)
-		if err != nil {
-			return nil, err
-		}
-		info, err := d.blobs.Stat(ctx, dgst)
-		if errors.Is(err, storage.ErrNotExist) {
-			return nil, storagedriver.PathNotFoundError{Path: path}
-		}
-		if err != nil {
-			return nil, err
-		}
-		return storagedriver.FileInfoInternal{FileInfoFields: storagedriver.FileInfoFields{
-			Path: path, Size: info.Size, IsDir: false,
-		}}, nil
+		return d.statBlob(ctx, path)
 
 	case pathUpload:
 		id := uploadIDFromPath(path)
@@ -264,6 +285,29 @@ func (d *DistDriver) Stat(ctx context.Context, path string) (storagedriver.FileI
 	default:
 		return d.statMetadata(ctx, path)
 	}
+}
+
+func (d *DistDriver) statBlob(ctx context.Context, path string) (storagedriver.FileInfo, error) {
+	dgst, err := digestFromBlobPath(path)
+	if err != nil {
+		return nil, err
+	}
+	info, err := d.blobs.Stat(ctx, dgst)
+	if errors.Is(err, storage.ErrNotExist) {
+		data, err := d.getManifestBlobContent(ctx, path, dgst)
+		if err != nil {
+			return nil, err
+		}
+		return storagedriver.FileInfoInternal{FileInfoFields: storagedriver.FileInfoFields{
+			Path: path, Size: int64(len(data)), IsDir: false,
+		}}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return storagedriver.FileInfoInternal{FileInfoFields: storagedriver.FileInfoFields{
+		Path: path, Size: info.Size, IsDir: false,
+	}}, nil
 }
 
 // statMetadata resolves metadata paths for distribution's Walk tree traversal.

--- a/internal/oci/storage/local/distcompat_test.go
+++ b/internal/oci/storage/local/distcompat_test.go
@@ -3,6 +3,7 @@ package local
 import (
 	"bytes"
 	"errors"
+	"io"
 	"path/filepath"
 	"testing"
 
@@ -217,6 +218,57 @@ func TestDistDriver_MetadataLink_PutContent_NoOp(t *testing.T) {
 	linkPath := "/docker/registry/v2/repositories/lib/test/_layers/sha256/aabb/link"
 	if err := dd.PutContent(ctx, linkPath, []byte("sha256:aabb")); err != nil {
 		t.Fatalf("PutContent on link should be no-op, got error: %v", err)
+	}
+}
+
+func TestDistDriver_ManifestBlobFallbackFromMetadata(t *testing.T) {
+	dd, _, store := setupDistTest(t)
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "lib", Name: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestContent := []byte(`{"schemaVersion":2}`)
+	manifestDgst := digest.FromBytes(manifestContent)
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    manifestDgst,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   manifestContent,
+		Tag:       "latest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	blobPath := "/docker/registry/v2/blobs/sha256/" + manifestDgst.Encoded()[:2] + "/" + manifestDgst.Encoded() + "/data"
+
+	got, err := dd.GetContent(ctx, blobPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, manifestContent) {
+		t.Errorf("GetContent = %s, want %s", got, manifestContent)
+	}
+
+	rc, err := dd.Reader(ctx, blobPath, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rc.Close() }()
+	read, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(read, manifestContent) {
+		t.Errorf("Reader = %s, want %s", read, manifestContent)
+	}
+
+	info, err := dd.Stat(ctx, blobPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != int64(len(manifestContent)) {
+		t.Errorf("Stat size = %d, want %d", info.Size(), len(manifestContent))
 	}
 }
 

--- a/internal/registry/distribution/middleware/middleware_test.go
+++ b/internal/registry/distribution/middleware/middleware_test.go
@@ -85,6 +85,10 @@ func (m *mockStore) GetManifestDigest(_ context.Context, _ int64, _ digest.Diges
 	return "", errNotImplemented
 }
 
+func (m *mockStore) GetManifestContent(_ context.Context, _ digest.Digest) ([]byte, error) {
+	return nil, errNotImplemented
+}
+
 func (m *mockStore) BlobExists(_ context.Context, _ digest.Digest) (bool, error) {
 	return false, errNotImplemented
 }

--- a/internal/system/image_test.go
+++ b/internal/system/image_test.go
@@ -1,0 +1,56 @@
+package system
+
+import "testing"
+
+func TestParseLoadedImageRef(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "standard podman output",
+			output: "Loaded image: localhost/quay-mirror:test\n",
+			want:   "localhost/quay-mirror:test",
+		},
+		{
+			name:   "plural form",
+			output: "Loaded image(s): docker.io/library/nginx:latest\n",
+			want:   "docker.io/library/nginx:latest",
+		},
+		{
+			name:   "with extra whitespace",
+			output: "  Loaded image:   localhost/myimage:v1  \n",
+			want:   "localhost/myimage:v1",
+		},
+		{
+			name:   "multi-line with noise",
+			output: "Getting image source signatures\nCopying blob sha256:abc123\nLoaded image: localhost/test:latest\n",
+			want:   "localhost/test:latest",
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   "",
+		},
+		{
+			name:   "no match",
+			output: "some unrelated output\n",
+			want:   "",
+		},
+		{
+			name:   "no colon separator",
+			output: "Loaded image without colon\n",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseLoadedImageRef(tt.output)
+			if got != tt.want {
+				t.Errorf("ParseLoadedImageRef(%q) = %q, want %q", tt.output, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `quay migrate` CLI command that provides a seamless upgrade path from mirror-registry (OMR) v1.4.x to the new Go-based `quay` binary.

A customer upgrading from OMR runs one command with no arguments:

```bash
./quay migrate
```

The command auto-detects the old OMR installation (systemd units, Podman volumes, config paths), discovers the hostname from the old `config.yaml`, finds the image archive in the binary's directory, and handles the entire upgrade: stop old services → copy data → convert storage format → upgrade schema → deploy new registry → verify health.

Flags exist as overrides if auto-detection gets something wrong, but the happy path is zero arguments.

## How it works

Nine sequential phases:

1. **Detect** — inspects systemd units → Podman volumes → ~/quay-install defaults. Extracts hostname, resolves volume mountpoints, finds image archive next to the binary.
2. **Validate** — DB integrity check, Alembic version whitelist, cert/key pair match, storage dir, target dir is clean.
3. **Stop** — stops old OMR services (quay-app, quay-redis, quay-pod) to free port 8443.
4. **Copy** — copies DB (renamed quay_sqlite.db → quay.db), flattens certs to data-dir root, recursively copies blob storage. Idempotent on re-run.
5. **Convert** — transforms Python Quay's flat storage layout (`sha256/<prefix>/<digest>`) to distribution format (`docker/registry/v2/blobs/sha256/<prefix>/<digest>/data`) using hard-links (zero copy cost). Writes manifest bytes from DB as blobs. Creates repository metadata tree (revision links, tag links, layer links) from DB queries.
6. **Schema Upgrade** — bridge migration bringing any OMR SQLite version to Go binary's target via idempotent SQL (CREATE TABLE IF NOT EXISTS, INSERT OR IGNORE) + Go helpers for ADD COLUMN and index uniqueness fixes.
7. **Install** — chains into existing installer.Run() for Quadlet deployment.
8. **Verify** — healthz check against the live service using custom TLS client.
9. **Cleanup** (opt-in via -cleanup) — removes old units, volumes, Redis secret. Preserves ~/quay-install rootCA. Can be run standalone after a successful migration.

## Design decisions

- **Reuses old TLS certs** — disconnected customers may have distributed the CA. Regenerating breaks trust chains.
- **Copy, don't move** — rollback = delete target data-dir + restart old OMR.
- **Hard-link storage conversion** — O(1) per blob regardless of size. Falls back to copy if hard link fails.
- **Bridge migration with version whitelist** — handles any OMR SQLite version, refuses unknown versions with a clear error.
- **slog for all logging** — structured logging throughout, fmt only for dry-run plan output.
- **No OMR changes** — the old mirror-registry project is not modified.

## E2E test

New e2e-migrate GHA job: downloads offline OMR installer → installs old OMR → pushes test images → runs `quay migrate` with zero args → trusts migrated cert → verifies images pullable via podman pull → runs cleanup.

## Test plan

- [x] 16 migrate package tests + 7 bridge tests + 7 system tests pass
- [x] golangci-lint clean
- [x] Binary builds, `quay migrate -h` shows flags
- [x] Graceful failure when no OMR is installed
- [x] E2E GHA job passes