### PR TITLE
PROJQUAY-11432: fix(api): fix BuildTrigger.to_dict() None check and add superuser build tests

### DIFF
--- a/endpoints/api/superuser_models_interface.py
+++ b/endpoints/api/superuser_models_interface.py
@@ -55,7 +55,7 @@ class BuildTrigger(
     """
 
     def to_dict(self):
-        if not self.trigger and not self.trigger.uuid:
+        if not self.trigger:
             return None
 
         build_trigger = BuildTriggerHandler.get_handler(self.trigger)

--- a/endpoints/api/test/test_superuser.py
+++ b/endpoints/api/test/test_superuser.py
@@ -1,11 +1,13 @@
 import pytest
 
+from data import model
 from data.database import DeletedNamespace, User
 from endpoints.api.superuser import (
     SuperUserDumpConfig,
     SuperUserList,
     SuperUserManagement,
     SuperUserOrganizationList,
+    SuperUserRepositoryBuildResource,
 )
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
@@ -106,3 +108,48 @@ def test_get_superuserdumpconfig(app):
             result.get("schema", {})["description"]
             result.get("schema", {})["required"]
             raise AttributeError()
+
+
+def test_get_repository_build_no_trigger(app):
+    """Superuser build endpoint must not crash when a build has no associated trigger."""
+    repo = model.repository.get_repository("devtable", "simple")
+    access_token = model.token.create_access_token(repo, "read")
+    build = model.build.create_repository_build(
+        repo, access_token, {}, "someresourcekey", "manual build", trigger=None
+    )
+
+    with client_with_identity("devtable", app) as cl:
+        result = conduct_api_call(
+            cl,
+            SuperUserRepositoryBuildResource,
+            "GET",
+            {"build_uuid": build.uuid},
+            None,
+            200,
+        )
+
+    assert result.json["trigger"] is None
+
+
+def test_get_repository_build_with_trigger(app):
+    """Superuser build endpoint returns trigger info for trigger-based builds."""
+    repo = model.repository.get_repository("devtable", "simple")
+    access_token = model.token.create_access_token(repo, "read")
+    user = model.user.get_user("devtable")
+    trigger = model.build.create_build_trigger(repo, "custom-git", "someauthtoken", user)
+    build = model.build.create_repository_build(
+        repo, access_token, {}, "someresourcekey2", "triggered build", trigger=trigger
+    )
+
+    with client_with_identity("devtable", app) as cl:
+        result = conduct_api_call(
+            cl,
+            SuperUserRepositoryBuildResource,
+            "GET",
+            {"build_uuid": build.uuid},
+            None,
+            200,
+        )
+
+    assert result.json["trigger"] is not None
+    assert result.json["trigger"]["service"] == "custom-git"

--- a/web/playwright/e2e/superuser/build-logs.spec.ts
+++ b/web/playwright/e2e/superuser/build-logs.spec.ts
@@ -117,21 +117,32 @@ test.describe(
       );
     });
 
-    test('superuser build API returns trigger:null for triggerless builds @superuser @feature:BUILD_SUPPORT', async ({
+    test('loads a triggerless build without crashing', async ({
+      superuserPage,
       superuserRequest,
       api,
     }) => {
       const org = await api.organization('sunotrigger');
-      const repo = await api.repository(org.name, 'notrigger-repo');
+      const repo = await api.repository(org.name, 'notrigger');
       const build = await api.build(org.name, repo.name);
 
+      // API layer: verify trigger is null (the fix under test)
       const response = await superuserRequest.get(
         `${API_URL}/api/v1/superuser/${build.buildId}/build`,
       );
       expect(response.status()).toBe(200);
-
       const body = await response.json();
       expect(body).toHaveProperty('trigger', null);
+
+      // UI layer: verify the page renders the build without crashing
+      await superuserPage.goto('/build-logs');
+      await superuserPage.getByTestId('build-uuid-input').fill(build.buildId);
+      await superuserPage.getByTestId('load-build-button').click();
+
+      await expect(superuserPage.getByText('Build Information')).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(superuserPage.getByText(build.buildId)).toBeVisible();
     });
 
     test('navigates to Build Logs via sidebar', async ({superuserPage}) => {

--- a/web/playwright/e2e/superuser/build-logs.spec.ts
+++ b/web/playwright/e2e/superuser/build-logs.spec.ts
@@ -1,4 +1,5 @@
 import {test, expect} from '../../fixtures';
+import {API_URL} from '../../utils/config';
 
 test.describe(
   'Superuser Build Logs',
@@ -114,6 +115,23 @@ test.describe(
       await expect(superuserPage.getByTestId('build-logs-display')).toBeVisible(
         {timeout: 15_000},
       );
+    });
+
+    test('superuser build API returns trigger:null for triggerless builds @superuser @feature:BUILD_SUPPORT', async ({
+      superuserRequest,
+      api,
+    }) => {
+      const org = await api.organization('sunotrigger');
+      const repo = await api.repository(org.name, 'notrigger-repo');
+      const build = await api.build(org.name, repo.name);
+
+      const response = await superuserRequest.get(
+        `${API_URL}/api/v1/superuser/${build.buildId}/build`,
+      );
+      expect(response.status()).toBe(200);
+
+      const body = await response.json();
+      expect(body).toHaveProperty('trigger', null);
     });
 
     test('navigates to Build Logs via sidebar', async ({superuserPage}) => {


### PR DESCRIPTION
## Summary

- Fix `BuildTrigger.to_dict()` dead-code logic bug: the original `if not self.trigger and not self.trigger.uuid:` condition would raise `AttributeError` when `self.trigger is None` because `and` doesn't short-circuit on a truthy left operand — it evaluates both sides. Simplified to `if not self.trigger:`.
- Add integration tests verifying superuser build endpoints handle both trigger=None and trigger-present cases correctly.

Note: the primary `superuser_models_pre_oci.py` guard and `RepositoryBuild.to_dict()` trigger guard were already applied to master independently. This PR completes the fix with the remaining logic correction and test coverage.

## Root Cause / Rationale

`RepositoryBuild.trigger` is a nullable FK. `BuildTrigger.to_dict()` contained a broken guard:

```python
# broken: if trigger is None, `not self.trigger` is True, so Python evaluates
# `not self.trigger.uuid` → AttributeError: 'NoneType' has no attribute 'uuid'
if not self.trigger and not self.trigger.uuid:
    return None
```

While the upstream callers now guard before calling `to_dict()`, the defensive fix is still correct and removes confusing dead code.

## Changes

- `endpoints/api/superuser_models_interface.py`: Fix `BuildTrigger.to_dict()` None guard
- `endpoints/api/test/test_superuser.py`: Add integration tests for superuser build endpoints with and without triggers

## Test Plan

- [x] `pytest endpoints/api/test/test_superuser.py::test_get_repository_build_no_trigger -v` — passes
- [x] `pytest endpoints/api/test/test_superuser.py::test_get_repository_build_with_trigger -v` — passes
- [x] All CI checks passing

## JIRA

https://redhat.atlassian.net/browse/PROJQUAY-11432

## Automation
- **Session ID**: session-72226051-2da7-4585-8fce-9bf398c9371b