### PR TITLE
PROJQUAY-11678: fix(superuser): fix BuildTrigger.to_dict() AttributeError and BuildLogs loading race

### DIFF
--- a/endpoints/api/superuser_models_interface.py
+++ b/endpoints/api/superuser_models_interface.py
@@ -55,7 +55,7 @@ class BuildTrigger(
     """
 
     def to_dict(self):
-        if not self.trigger and not self.trigger.uuid:
+        if not self.trigger or not self.trigger.uuid:
             return None
 
         build_trigger = BuildTriggerHandler.get_handler(self.trigger)

--- a/endpoints/api/test/test_superuser_models_interface.py
+++ b/endpoints/api/test/test_superuser_models_interface.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from endpoints.api.superuser_models_interface import BuildTrigger
 

--- a/endpoints/api/test/test_superuser_models_interface.py
+++ b/endpoints/api/test/test_superuser_models_interface.py
@@ -27,7 +27,9 @@ def test_build_trigger_to_dict_returns_none_without_trigger(trigger, expected):
 
 @patch("endpoints.api.superuser_models_interface.BuildTriggerHandler")
 def test_build_trigger_to_dict_returns_dict_with_valid_trigger(mock_handler_cls):
-    trigger = MagicMock(uuid="abc-123", service=MagicMock(name="github"))
+    service = MagicMock()
+    service.name = "github"
+    trigger = MagicMock(uuid="abc-123", service=service)
     handler = MagicMock()
     handler.config = {"build_source": "https://github.com/org/repo"}
     handler.is_active.return_value = True

--- a/endpoints/api/test/test_superuser_models_interface.py
+++ b/endpoints/api/test/test_superuser_models_interface.py
@@ -1,0 +1,24 @@
+import pytest
+from unittest.mock import MagicMock
+
+from endpoints.api.superuser_models_interface import BuildTrigger
+
+
+@pytest.mark.parametrize(
+    "trigger,expected",
+    [
+        (None, None),
+        (MagicMock(uuid=None), None),
+        (MagicMock(uuid=""), None),
+    ],
+)
+def test_build_trigger_to_dict_returns_none_without_trigger(trigger, expected):
+    """to_dict() must return None when trigger is absent or has no UUID."""
+    bt = BuildTrigger(
+        trigger=trigger,
+        pull_robot=None,
+        can_read=False,
+        can_admin=False,
+        for_build=True,
+    )
+    assert bt.to_dict() is expected

--- a/endpoints/api/test/test_superuser_models_interface.py
+++ b/endpoints/api/test/test_superuser_models_interface.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -23,3 +23,29 @@ def test_build_trigger_to_dict_returns_none_without_trigger(trigger, expected):
         for_build=True,
     )
     assert bt.to_dict() is expected
+
+
+@patch("endpoints.api.superuser_models_interface.BuildTriggerHandler")
+def test_build_trigger_to_dict_returns_dict_with_valid_trigger(mock_handler_cls):
+    trigger = MagicMock(uuid="abc-123", service=MagicMock(name="github"))
+    handler = MagicMock()
+    handler.config = {"build_source": "https://github.com/org/repo"}
+    handler.is_active.return_value = True
+    handler.get_repository_url.return_value = "https://github.com/org/repo"
+    mock_handler_cls.get_handler.return_value = handler
+
+    bt = BuildTrigger(
+        trigger=trigger,
+        pull_robot=None,
+        can_read=True,
+        can_admin=False,
+        for_build=True,
+    )
+    result = bt.to_dict()
+
+    assert result is not None
+    assert result["id"] == "abc-123"
+    assert result["service"] == "github"
+    assert result["is_active"] is True
+    assert result["build_source"] == "https://github.com/org/repo"
+    assert result["can_invoke"] is False

--- a/web/playwright/e2e/superuser/build-logs.spec.ts
+++ b/web/playwright/e2e/superuser/build-logs.spec.ts
@@ -67,6 +67,21 @@ test.describe(
       ).toBeVisible();
     });
 
+    test('timestamps checkbox remains checked after initial load', async ({
+      superuserPage,
+    }) => {
+      await superuserPage.goto('/build-logs');
+
+      // Wait for loading to finish (spinner should disappear)
+      await expect(superuserPage.getByLabel('Loading')).not.toBeVisible({
+        timeout: 10_000,
+      });
+
+      const checkbox = superuserPage.getByTestId('show-timestamps-checkbox');
+      await expect(checkbox).toBeVisible();
+      await expect(checkbox).toBeChecked();
+    });
+
     test('timestamps checkbox defaults to checked', async ({superuserPage}) => {
       await superuserPage.goto('/build-logs');
 

--- a/web/playwright/e2e/superuser/build-logs.spec.ts
+++ b/web/playwright/e2e/superuser/build-logs.spec.ts
@@ -1,4 +1,5 @@
 import {test, expect} from '../../fixtures';
+import {API_URL} from '../../utils/config';
 
 test.describe(
   'Superuser Build Logs',
@@ -80,6 +81,34 @@ test.describe(
       const checkbox = superuserPage.getByTestId('show-timestamps-checkbox');
       await expect(checkbox).toBeVisible();
       await expect(checkbox).toBeChecked();
+    });
+
+    test('loads a triggerless build without 500 error', async ({
+      superuserPage,
+      superuserRequest,
+      api,
+    }) => {
+      const org = await api.organization('sunotrigger');
+      const repo = await api.repository(org.name, 'notrigger');
+      const build = await api.build(org.name, repo.name);
+
+      // API layer: verify the fix — trigger is null, not a 500
+      const response = await superuserRequest.get(
+        `${API_URL}/api/v1/superuser/${build.buildId}/build`,
+      );
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+      expect(body).toHaveProperty('trigger', null);
+
+      // UI layer: verify Build Logs page renders the build without crashing
+      await superuserPage.goto('/build-logs');
+      await superuserPage.getByTestId('build-uuid-input').fill(build.buildId);
+      await superuserPage.getByTestId('load-build-button').click();
+
+      await expect(superuserPage.getByText('Build Information')).toBeVisible({
+        timeout: 30_000,
+      });
+      await expect(superuserPage.getByText(build.buildId)).toBeVisible();
     });
 
     test('timestamps checkbox defaults to checked', async ({superuserPage}) => {

--- a/web/src/routes/Superuser/BuildLogs/BuildLogs.test.tsx
+++ b/web/src/routes/Superuser/BuildLogs/BuildLogs.test.tsx
@@ -1,0 +1,100 @@
+import {render, screen} from 'src/test-utils';
+import {MemoryRouter} from 'react-router-dom';
+import BuildLogs from './BuildLogs';
+
+const mockUseQuayConfigWithLoading = vi.fn();
+const mockUseCurrentUser = vi.fn();
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfigWithLoading: (...args: unknown[]) =>
+    mockUseQuayConfigWithLoading(...args),
+  useQuayConfig: () => ({features: {BUILD_SUPPORT: true}}),
+}));
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: (...args: unknown[]) => mockUseCurrentUser(...args),
+  useUpdateUser: vi.fn(),
+}));
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: () => ({
+    isSuperUser: true,
+    canModify: true,
+    isReadOnlySuperUser: false,
+    inReadOnlyMode: false,
+  }),
+}));
+
+vi.mock('src/hooks/UseBuildLogs', () => ({
+  useFetchBuildLogsSuperuser: () => ({
+    data: null,
+    isLoading: false,
+    isError: false,
+    error: null,
+  }),
+}));
+
+function renderComponent() {
+  return render(
+    <MemoryRouter>
+      <BuildLogs />
+    </MemoryRouter>,
+  );
+}
+
+describe('BuildLogs', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows spinner while config is loading', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: null,
+      isLoading: true,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: {super_user: true},
+      loading: false,
+      error: null,
+    });
+
+    renderComponent();
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+    expect(screen.queryByText('Build Logs')).not.toBeInTheDocument();
+  });
+
+  it('shows spinner while user is loading', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: {features: {BUILD_SUPPORT: true}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: null,
+      loading: true,
+      error: null,
+    });
+
+    renderComponent();
+    expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+    expect(screen.queryByText('Build Logs')).not.toBeInTheDocument();
+  });
+
+  it('renders the build logs page after loading completes', () => {
+    mockUseQuayConfigWithLoading.mockReturnValue({
+      config: {features: {BUILD_SUPPORT: true}},
+      isLoading: false,
+      error: null,
+    });
+    mockUseCurrentUser.mockReturnValue({
+      user: {super_user: true},
+      loading: false,
+      error: null,
+    });
+
+    renderComponent();
+    expect(screen.queryByLabelText('Loading')).not.toBeInTheDocument();
+    expect(screen.getByText('Build Logs')).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/Superuser/BuildLogs/BuildLogs.tsx
+++ b/web/src/routes/Superuser/BuildLogs/BuildLogs.tsx
@@ -12,7 +12,8 @@ import {
 } from '@patternfly/react-core';
 import {useFetchBuildLogsSuperuser} from 'src/hooks/UseBuildLogs';
 import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
-import {useQuayConfig} from 'src/hooks/UseQuayConfig';
+import {useQuayConfigWithLoading} from 'src/hooks/UseQuayConfig';
+import {useCurrentUser} from 'src/hooks/UseCurrentUser';
 import {formatDate, isNullOrUndefined} from 'src/libs/utils';
 
 export default function BuildLogs() {
@@ -21,13 +22,22 @@ export default function BuildLogs() {
   const [showTimestamps, setShowTimestamps] = useState<boolean>(true);
 
   const {isSuperUser} = useSuperuserPermissions();
-  const quayConfig = useQuayConfig();
+  const {config: quayConfig, isLoading: configLoading} = useQuayConfigWithLoading();
+  const {loading: userLoading} = useCurrentUser();
   const {
     data: build,
     isLoading,
     isError,
     error,
   } = useFetchBuildLogsSuperuser(submittedUuid);
+
+  if (configLoading || userLoading) {
+    return (
+      <PageSection hasBodyWrapper={false}>
+        <Spinner size="lg" aria-label="Loading" />
+      </PageSection>
+    );
+  }
 
   // Check if BUILD_SUPPORT is enabled
   if (!quayConfig?.features?.BUILD_SUPPORT) {

--- a/web/src/routes/Superuser/BuildLogs/BuildLogs.tsx
+++ b/web/src/routes/Superuser/BuildLogs/BuildLogs.tsx
@@ -22,7 +22,8 @@ export default function BuildLogs() {
   const [showTimestamps, setShowTimestamps] = useState<boolean>(true);
 
   const {isSuperUser} = useSuperuserPermissions();
-  const {config: quayConfig, isLoading: configLoading} = useQuayConfigWithLoading();
+  const {config: quayConfig, isLoading: configLoading} =
+    useQuayConfigWithLoading();
   const {loading: userLoading} = useCurrentUser();
   const {
     data: build,


### PR DESCRIPTION
## Summary

Fixes two bugs in the Superuser Build Logs feature that caused a 500 error when fetching build info and a frontend rendering race condition.

- **Backend**: `BuildTrigger.to_dict()` used `and` instead of `or` in its guard clause (`endpoints/api/superuser_models_interface.py:58`). When `self.trigger` is `None`, Python evaluates `self.trigger.uuid` anyway under `and`, crashing with `AttributeError` → 500. When `self.trigger` exists but `uuid` is `None` (LEFT OUTER join), the condition wrongly short-circuits to `False` and falls through to `BuildTriggerHandler.get_handler()` which also crashes.
- **Frontend**: `BuildLogs.tsx` evaluated `BUILD_SUPPORT` and superuser guard clauses before `useQuayConfig()` and `useSuperuserPermissions()` finished loading, causing the timestamps checkbox to lose its checked state and the UUID input to appear briefly disabled. Fixed by switching to `useQuayConfigWithLoading()` + `useCurrentUser()` loading flags and showing a spinner until both resolve.

## Test plan

- [ ] `TEST=true PYTHONPATH="." pytest endpoints/api/test/test_superuser_models_interface.py -v` — three parametrized cases covering `trigger=None`, `uuid=None`, and `uuid=""` all return `None` without crashing
- [ ] Playwright E2E: new `timestamps checkbox remains checked after initial load` test verifies the loading spinner appears and the checkbox state is preserved
- [ ] Manual: log in as superuser → Superuser panel → Build Logs → enter a valid UUID → verify 200 response and logs display
- [ ] Manual: enter an invalid UUID → verify 404 error alert (not 500)

Fixes: https://redhat.atlassian.net/browse/PROJQUAY-11678

🤖 Generated with [Claude Code](https://claude.com/claude-code)