### PR TITLE
PROJQUAY-11691: fix(permissions): Optimize loading of permissions on UI login

### DIFF
--- a/auth/permissions.py
+++ b/auth/permissions.py
@@ -282,7 +282,7 @@ class QuayDeferredPermissionUser(Identity):
 
             self._superuser_checked = True
 
-        # Super users can do anything on the repositories so we can simply return here if
+        # Super users can do anything on the registry so we can simply return here if
         # full access is enabled
         if self._superuser_loaded and features.SUPERUSERS_FULL_ACCESS:
             if permission.namespace or permission.repo_name:
@@ -338,7 +338,11 @@ class QuayDeferredPermissionUser(Identity):
                 return super(QuayDeferredPermissionUser, self).can(permission)
 
         # Lazy-load the namespace-wide-only permissions.
-        if perm_namespace and perm_namespace not in self._namespace_wide_loaded:
+        if (
+            perm_namespace
+            and perm_namespace not in self._namespace_wide_loaded
+            and not self._all_namespaces_loaded
+        ):
             self._populate_namespace_wide_provides(user_object, perm_namespace)
             self._namespace_wide_loaded.add(perm_namespace)
 

--- a/auth/permissions.py
+++ b/auth/permissions.py
@@ -5,6 +5,7 @@ from typing import DefaultDict, Optional
 
 from flask_principal import Identity, Permission, identity_changed, identity_loaded
 
+import features
 from app import app, model_cache, usermanager
 from auth import scopes
 from data import model
@@ -86,6 +87,13 @@ class QuayDeferredPermissionUser(Identity):
         self._repositories_loaded = set()
         self._repositories_loaded_from_primary = set()
         self._personal_loaded = False
+
+        self._superuser_loaded = False
+        self._readonly_superuser_loaded = False
+
+        self._superuser_checked = False
+
+        self._all_namespaces_loaded = False
 
         self._scope_set = auth_scopes
         self._user_object = user
@@ -174,6 +182,8 @@ class QuayDeferredPermissionUser(Identity):
             )
             logger.debug("Team added permission: {0}".format(team_grant))
             self.provides.add(team_grant)
+            if namespace_filter is None:
+                self._namespace_wide_loaded.add(team.organization.username)
 
     def _populate_repository_provides(
         self, user_object, namespace_filter, repository_name, for_write=False
@@ -249,28 +259,44 @@ class QuayDeferredPermissionUser(Identity):
             logger.debug("User added permission: {0}".format(repo_grant))
             self.provides.add(repo_grant)
 
-    def _populate_superuser_provides(self, user_object):
-        # Global readonly superusers and regular superusers are mutually exclusive.
-        # If a user is in both lists (misconfiguration), readonly takes precedence.
-        if usermanager.is_global_readonly_superuser(user_object.username):
-            logger.debug("Adding global readonly superuser to user: %s", user_object.username)
-            self.provides.add(_GlobalReadOnlySuperUserNeed())
-        elif (
-            scopes.SUPERUSER in self._scope_set or scopes.DIRECT_LOGIN in self._scope_set
-        ) and usermanager.is_superuser(user_object.username):
-            logger.debug("Adding superuser to user: %s", user_object.username)
-            self.provides.add(_SuperUserNeed())
-
     def can(self, permission):
         logger.debug("Loading user permissions after deferring for: %s", self.id)
         user_object = self._user_object or model.user.get_user_by_uuid(self.id)
         if user_object is None:
             return super(QuayDeferredPermissionUser, self).can(permission)
 
+        # determine if this user is a super user or a normal user
+        # Global readonly superusers and regular superusers are mutually exclusive.
+        # If a user is in both lists (misconfiguration), readonly takes precedence.
+        if not self._superuser_checked:
+            if usermanager.is_global_readonly_superuser(user_object.username):
+                logger.debug("Adding global readonly superuser to user: %s", user_object.username)
+                self.provides.add(_GlobalReadOnlySuperUserNeed())
+                self._readonly_superuser_loaded = True
+            elif (
+                scopes.SUPERUSER in self._scope_set or scopes.DIRECT_LOGIN in self._scope_set
+            ) and usermanager.is_superuser(user_object.username):
+                logger.debug("Adding superuser to user: %s", user_object.username)
+                self.provides.add(_SuperUserNeed())
+                self._superuser_loaded = True
+
+            self._superuser_checked = True
+
+        # Super users can do anything on the repositories so we can simply return here if
+        # full access is enabled
+        if self._superuser_loaded and features.SUPERUSERS_FULL_ACCESS:
+            if permission.namespace or permission.repo_name:
+                return True
+
         # Add the user-specific provides.
         if not self._personal_loaded:
             self._populate_user_provides(user_object)
             self._personal_loaded = True
+
+        # Add all permissions for all namespaces but only if we have direct login (UI)
+        if not self._all_namespaces_loaded and scopes.DIRECT_LOGIN in self._scope_set:
+            self._populate_namespace_wide_provides(user_object, namespace_filter=None)
+            self._all_namespaces_loaded = True
 
         # If we now have permission, no need to load any more permissions.
         if super(QuayDeferredPermissionUser, self).can(permission):
@@ -285,8 +311,6 @@ class QuayDeferredPermissionUser(Identity):
             perm_repository = "%s/%s" % (perm_namespace, perm_repo_name)
 
         if not perm_namespace and not perm_repo_name:
-            self._populate_superuser_provides(user_object)
-
             # Nothing more to load, so just check directly.
             return super(QuayDeferredPermissionUser, self).can(permission)
 
@@ -317,9 +341,6 @@ class QuayDeferredPermissionUser(Identity):
         if perm_namespace and perm_namespace not in self._namespace_wide_loaded:
             self._populate_namespace_wide_provides(user_object, perm_namespace)
             self._namespace_wide_loaded.add(perm_namespace)
-
-        # Lazy-load superuser permissions
-        self._populate_superuser_provides(user_object)
 
         return super(QuayDeferredPermissionUser, self).can(permission)
 

--- a/auth/permissions.py
+++ b/auth/permissions.py
@@ -89,6 +89,9 @@ class QuayDeferredPermissionUser(Identity):
         self._personal_loaded = False
 
         self._superuser_loaded = False
+
+        # TODO (ibazulic): In a future fix, we should think about adding the global read only super user
+        # short circuit, like we did for the real super user. This flag is intended for that future use.
         self._readonly_superuser_loaded = False
 
         self._superuser_checked = False

--- a/auth/test/test_permissions.py
+++ b/auth/test/test_permissions.py
@@ -1,10 +1,16 @@
-from test.fixtures import *
+from unittest.mock import patch
 
 import pytest
 
+import features
 from auth import scopes
-from auth.permissions import QuayDeferredPermissionUser, SuperUserPermission
+from auth.permissions import (
+    QuayDeferredPermissionUser,
+    ReadRepositoryPermission,
+    SuperUserPermission,
+)
 from data import model
+from test.fixtures import *
 
 SUPER_USERNAME = "devtable"
 UNSUPER_USERNAME = "freshuser"
@@ -26,6 +32,7 @@ def test_superuser_matrix(superuser, normie):
         (superuser, {scopes.DIRECT_LOGIN}, True),
         (superuser, {scopes.READ_USER, scopes.SUPERUSER}, True),
         (superuser, {scopes.READ_USER}, False),
+        (superuser, {scopes.SUPERUSER, scopes.DIRECT_LOGIN}, True),
         (normie, {scopes.SUPERUSER}, False),
         (normie, {scopes.DIRECT_LOGIN}, False),
         (normie, {scopes.READ_USER, scopes.SUPERUSER}, False),
@@ -36,3 +43,78 @@ def test_superuser_matrix(superuser, normie):
         perm_user = QuayDeferredPermissionUser.for_user(user_obj, scope_set)
         has_su = perm_user.can(SuperUserPermission())
         assert has_su == expected
+
+
+def test_docker_lazyload_permissions(superuser, normie, initialized_db):
+    """
+    Verifies that we load one repository permission at a time when calls are scoped, like during Docker v2 API access.
+    """
+    orgs = [f"org{i}" for i in range(1, 5)]
+    for org in orgs:
+        org_obj = model.organization.create_organization(
+            name=org, email=f"test-{org}@test.com", creating_user=superuser
+        )
+        model.repository.create_repository(org, "testrepo", creating_user=superuser)
+        owners_team = model.team.get_organization_team(org, "owners")
+        model.team.add_user_to_team(normie, owners_team)
+
+    perm_normaluser = QuayDeferredPermissionUser.for_user(normie, auth_scopes={scopes.READ_REPO})
+
+    with patch(
+        "auth.permissions.model.permission.get_org_wide_permissions",
+        wraps=model.permission.get_org_wide_permissions,
+    ) as mock_perms:
+        for org in orgs:
+            perm_normaluser.can(ReadRepositoryPermission(org, "testrepo"))
+        assert mock_perms.call_count == len(orgs)
+
+
+def test_direct_login_load_all_permissions(superuser, normie, initialized_db):
+    """
+    Verifies that we call loading of permissions only once when we login via UI.
+    """
+    orgs = [f"org{i}" for i in range(1, 5)]
+    for org in orgs:
+        org_obj = model.organization.create_organization(
+            name=org, email=f"test-{org}@test.com", creating_user=superuser
+        )
+        model.repository.create_repository(org, "testrepo", creating_user=superuser)
+        owners_team = model.team.get_organization_team(org, "owners")
+        model.team.add_user_to_team(normie, owners_team)
+
+    perm_normaluser = QuayDeferredPermissionUser.for_user(
+        normie, auth_scopes={scopes.READ_REPO, scopes.DIRECT_LOGIN}
+    )
+
+    with patch(
+        "auth.permissions.model.permission.get_org_wide_permissions",
+        wraps=model.permission.get_org_wide_permissions,
+    ) as mock_perms:
+        for org in orgs:
+            perm_normaluser.can(ReadRepositoryPermission(org, "testrepo"))
+        mock_perms.assert_called_once()
+
+
+def test_superuser_never_calls_get_org_wide_permissions(superuser, initialized_db):
+    """
+    Verifies that for super users we never call get_org_wide_permissions.
+    """
+    features.import_features({"FEATURE_SUPERUSERS_FULL_ACCESS": True, "FEATURE_SUPER_USERS": True})
+    orgs = [f"org{i}" for i in range(1, 5)]
+    for org in orgs:
+        org_obj = model.organization.create_organization(
+            name=org, email=f"test-{org}@test.com", creating_user=superuser
+        )
+        model.repository.create_repository(org, "testrepo", creating_user=superuser)
+
+    perm_superuser = QuayDeferredPermissionUser.for_user(
+        superuser, auth_scopes={scopes.SUPERUSER, scopes.DIRECT_LOGIN}
+    )
+
+    with patch(
+        "auth.permissions.model.permission.get_org_wide_permissions",
+        wraps=model.permission.get_org_wide_permissions,
+    ) as mock_perms:
+        for org in orgs:
+            perm_superuser.can(ReadRepositoryPermission(org, "testrepo"))
+        mock_perms.assert_not_called()

--- a/endpoints/api/test/test_global_readonly_superuser.py
+++ b/endpoints/api/test/test_global_readonly_superuser.py
@@ -1002,19 +1002,22 @@ class TestUserAPIGlobalReadOnlySuperuserField:
             "endpoints.api.user.features.SUPER_USERS", FeatureNameValue("SUPER_USERS", True)
         ):
             with patch("endpoints.api.user.SuperUserPermission") as mock_super_perm:
-                # Mock the permission to return True for regular superuser
-                mock_super_perm.return_value.can.return_value = True
+                with patch(
+                    "auth.permissions.usermanager.is_global_readonly_superuser", return_value=False
+                ):
+                    # Mock the permission to return True for regular superuser
+                    mock_super_perm.return_value.can.return_value = True
 
-                with client_with_identity("devtable", app) as cl:
-                    resp = conduct_api_call(cl, User, "GET", None, None, 200)
-                    assert resp.status_code == 200
+                    with client_with_identity("devtable", app) as cl:
+                        resp = conduct_api_call(cl, User, "GET", None, None, 200)
+                        assert resp.status_code == 200
 
-                    # Regular superuser should see super_user field
-                    assert "super_user" in resp.json
-                    assert resp.json["super_user"] is True
+                        # Regular superuser should see super_user field
+                        assert "super_user" in resp.json
+                        assert resp.json["super_user"] is True
 
-                    # But should NOT see global_readonly_super_user field since they're not one
-                    assert "global_readonly_super_user" not in resp.json
+                        # But should NOT see global_readonly_super_user field since they're not one
+                        assert "global_readonly_super_user" not in resp.json
 
     def test_regular_user_does_not_see_global_readonly_field(self, app):
         """

--- a/endpoints/api/test/test_repository.py
+++ b/endpoints/api/test/test_repository.py
@@ -84,7 +84,8 @@ def test_list_starred_repos(app):
         response = conduct_api_call(cl, RepositoryList, "GET", params).json
         repos = {r["namespace"] + "/" + r["name"] for r in response["repositories"]}
         assert "devtable/simple" in repos
-        assert "public/publicrepo" not in repos
+        # super users can see all content, including private repos
+        assert "public/publicrepo" in repos
 
         # testing starred pagination with static rules
         # since this is a list and not a database result we need to start with 0

--- a/endpoints/api/test/test_tag.py
+++ b/endpoints/api/test/test_tag.py
@@ -98,8 +98,8 @@ def test_move_tag(manifest_exists, test_tag, expected_status, app):
         ("devtable", "history", 5),  # +2 for converting object to and from json
         ("devtable", "complex", 5),  # +2 for converting object to and from json
         ("devtable", "gargantuan", 5),  # +2 for converting object to and from json
-        ("buynlarge", "orgrepo", 7),  # +2 for permissions checks (uses UNION).
-        ("buynlarge", "anotherorgrepo", 7),  # +2 for permissions checks (uses UNION).
+        ("buynlarge", "orgrepo", 5),  # +2 for permissions checks (uses UNION).
+        ("buynlarge", "anotherorgrepo", 5),  # +2 for permissions checks (uses UNION).
     ],
 )
 def test_list_repo_tags(repo_namespace, repo_name, query_count, app):

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -374,7 +374,7 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
                 if (
                     CreateRepositoryPermission(namespace).can()
                     and user is not None
-                    and model.user.get_namespace_user(namespace) is not None
+                    and namespace_exists is not None
                 ):
                     if (
                         features.RESTRICTED_USERS

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -368,13 +368,14 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
                                 user,
                                 email_required=features.MAILING,
                             )
+                            namespace_exists = True
                         except model.DataModelException as ex:
                             raise Unsupported(message="Cannot create organization")
 
                 if (
                     CreateRepositoryPermission(namespace).can()
                     and user is not None
-                    and namespace_exists is not None
+                    and namespace_exists
                 ):
                     if (
                         features.RESTRICTED_USERS

--- a/endpoints/v2/v2auth.py
+++ b/endpoints/v2/v2auth.py
@@ -257,6 +257,19 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
     if repository_ref is not None and repository_ref.state == RepositoryState.MARKED_FOR_DELETION:
         raise Unknown(message="Unknown repository")
 
+    # Ensure that the namespace where we want to push the repo exists,
+    # If the namespace doesn't exist and we dont have namespace creation enabled,
+    # exit immediately with empty scopes.
+    namespace_exists = model.user.get_namespace_user(namespace) is not None
+    if not namespace_exists and not app.config.get("CREATE_NAMESPACE_ON_PUSH", False):
+        return scopeResult(
+            actions=[],
+            namespace=namespace,
+            repository=reponame,
+            registry_and_repo=registry_and_repo,
+            tuf_root=_get_tuf_root(repository_ref, namespace, reponame),
+        )
+
     if "push" in requested_actions:
         # Check if there is a valid user or token, as otherwise the repository cannot be
         # accessed.
@@ -358,7 +371,11 @@ def _authorize_or_downscope_request(scope_param, has_valid_auth_context):
                         except model.DataModelException as ex:
                             raise Unsupported(message="Cannot create organization")
 
-                if CreateRepositoryPermission(namespace).can() and user is not None:
+                if (
+                    CreateRepositoryPermission(namespace).can()
+                    and user is not None
+                    and model.user.get_namespace_user(namespace) is not None
+                ):
                     if (
                         features.RESTRICTED_USERS
                         and usermanager.is_restricted_user(user.username)

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -1702,7 +1702,7 @@ def test_tags_disabled_namespace(
         ("devtable", "buynlarge", "baserepo", "buynlarge/baserepo", None),
         # Unsuccessful mount, unknown repo.
         ("devtable", "devtable", "baserepo", "unknown/repohere", Failures.UNAUTHORIZED_FOR_MOUNT),
-        # Successful mount, super user has access to everything if FEATURE_SUPERUSERS_FULl_ACCESS is set
+        # Successful mount, super user has access to everything if FEATURE_SUPERUSERS_FULL_ACCESS is set
         ("public", "public", "baserepo", "public/baserepo", None),
     ],
 )

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -1702,8 +1702,8 @@ def test_tags_disabled_namespace(
         ("devtable", "buynlarge", "baserepo", "buynlarge/baserepo", None),
         # Unsuccessful mount, unknown repo.
         ("devtable", "devtable", "baserepo", "unknown/repohere", Failures.UNAUTHORIZED_FOR_MOUNT),
-        # Unsuccessful mount, no access.
-        ("public", "public", "baserepo", "public/baserepo", Failures.UNAUTHORIZED_FOR_MOUNT),
+        # Successful mount, super user has access to everything if FEATURE_SUPERUSERS_FULl_ACCESS is set
+        ("public", "public", "baserepo", "public/baserepo", None),
     ],
 )
 def test_blob_mounting(
@@ -1760,6 +1760,50 @@ def test_blob_mounting(
             "latest",
             basic_images,
             credentials=("devtable", "password"),
+        )
+
+
+def test_blob_mounting_when_superuser_full_access_disabled(
+    manifest_protocol,
+    pusher,
+    basic_images,
+    liveserver_session,
+    app_reloader,
+    registry_server_executor,
+    liveserver,
+):
+    # push as a public user
+    pusher.push(
+        liveserver_session,
+        "public",
+        "baserepo",
+        "latest",
+        basic_images,
+        credentials=("public", "password"),
+    )
+
+    # disable SUPERUSERS_FULL_ACCESS
+    with FeatureFlagValue("SUPERUSERS_FULL_ACCESS", False, registry_server_executor.on(liveserver)):
+        options = ProtocolOptions()
+        options.scopes = [
+            "repository:devtable/newrepo:push,pull",
+            "repository:public/baserepo:pull",
+        ]
+        options.mount_blobs = {
+            "sha256:" + hashlib.sha256(image.bytes).hexdigest(): "public/baserepo"
+            for image in basic_images
+        }
+
+        # Super user without full access should fail to mount
+        manifest_protocol.push(
+            liveserver_session,
+            "devtable",
+            "newrepo",
+            "latest",
+            basic_images,
+            credentials=("devtable", "password"),
+            options=options,
+            expected_failure=Failures.UNAUTHORIZED_FOR_MOUNT,
         )
 
 

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -2264,7 +2264,7 @@ def test_login_scopes_when_superuser_full_access_enabled_create_repositories_on_
 ):
     """
     Tests that super users have access to a non-existent namespace/repo if SUPERUSERS_FULL_ACCESS
-    is enabled and CREATE_NAMESPACE_ON_PUSH is .
+    is enabled and CREATE_NAMESPACE_ON_PUSH is enabled.
     """
     with ConfigChange(
         "CREATE_NAMESPACE_ON_PUSH", True, registry_server_executor.on(liveserver), liveserver

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -2135,37 +2135,156 @@ def test_login_scopes(
     assert payload["access"] == expected_access
 
 
-def test_login_scopes_when_superuser_full_access_disabled(
-    v2_protocol, liveserver_session, app_reloader, registry_server_executor, liveserver
+@pytest.mark.parametrize(
+    "username, password, scopes, expected_access, expect_success",
+    [
+        # only pull in scopes
+        (
+            "devtable",
+            "password",
+            "repository:somerepo/that/doesnt/exist:pull",
+            [
+                {"type": "repository", "name": "somerepo/that/doesnt/exist", "actions": []},
+            ],
+            True,
+        ),
+        # push-pull in scopes
+        (
+            "devtable",
+            "password",
+            "repository:somerepo/that/doesnt/exist:push,pull",
+            [
+                {"type": "repository", "name": "somerepo/that/doesnt/exist", "actions": []},
+            ],
+            True,
+        ),
+        # star in scope
+        (
+            "devtable",
+            "password",
+            "repository:somerepo/that/doesnt/exist:push,pull,*",
+            [
+                {"type": "repository", "name": "somerepo/that/doesnt/exist", "actions": []},
+            ],
+            True,
+        ),
+    ],
+)
+def test_login_scopes_when_superuser_full_access_disabled_create_repository_on_push_disabled(
+    username,
+    password,
+    scopes,
+    expected_access,
+    expect_success,
+    v2_protocol,
+    liveserver_session,
+    app_reloader,
+    registry_server_executor,
+    liveserver,
 ):
     """
     Tests that super users do not have access to a non-existent namespace/repo if SUPERUSERS_FULL_ACCESS
-    is disabled.
+    is disabled and CREATE_NAMESPACE_ON_PUSH is false.
     """
-    username = "devtable"
-    password = "password"
-    scopes = ["repository:somerepo/that/doesnt/exist:pull"]
-    expect_success = True
-    expected_access = [
-        {
-            "type": "repository",
-            "name": "somerepo/that/doesnt/exist",
-            "actions": [],
-        }
-    ]
+    with ConfigChange(
+        "CREATE_NAMESPACE_ON_PUSH", False, registry_server_executor.on(liveserver), liveserver
+    ):
+        with FeatureFlagValue(
+            "SUPERUSERS_FULL_ACCESS", False, registry_server_executor.on(liveserver)
+        ):
+            response = v2_protocol.login(
+                liveserver_session, username, password, scopes, expect_success
+            )
+            if not expect_success:
+                return
 
-    with FeatureFlagValue("SUPERUSERS_FULL_ACCESS", False, registry_server_executor.on(liveserver)):
-        response = v2_protocol.login(liveserver_session, username, password, scopes, expect_success)
-        if not expect_success:
-            return
+            # Validate the returned token
+            encoded = response.json()["token"]
+            payload = decode_bearer_header(
+                "Bearer " + encoded, instance_keys, {"SERVER_HOSTNAME": "localhost:5000"}
+            )
+            assert payload is not None
+            assert payload["access"] == expected_access
 
-        # Validate the returned token
-        encoded = response.json()["token"]
-        payload = decode_bearer_header(
-            "Bearer " + encoded, instance_keys, {"SERVER_HOSTNAME": "localhost:5000"}
-        )
-        assert payload is not None
-        assert payload["access"] == expected_access
+
+@pytest.mark.parametrize(
+    "username, password, scopes, expected_access, expect_success",
+    [
+        # only pull in scopes
+        (
+            "devtable",
+            "password",
+            "repository:somerepo/that/doesnt/exist:pull",
+            [
+                {"type": "repository", "name": "somerepo/that/doesnt/exist", "actions": ["pull"]},
+            ],
+            True,
+        ),
+        # push-pull in scopes
+        (
+            "devtable",
+            "password",
+            "repository:somerepo/that/doesnt/exist:push,pull",
+            [
+                {
+                    "type": "repository",
+                    "name": "somerepo/that/doesnt/exist",
+                    "actions": ["push", "pull"],
+                },
+            ],
+            True,
+        ),
+        # star in scope
+        (
+            "devtable",
+            "password",
+            "repository:somerepo/that/doesnt/exist:push,pull,*",
+            [
+                {
+                    "type": "repository",
+                    "name": "somerepo/that/doesnt/exist",
+                    "actions": ["push", "pull", "*"],
+                },
+            ],
+            True,
+        ),
+    ],
+)
+def test_login_scopes_when_superuser_full_access_enabled_create_repositories_on_push_enabled(
+    username,
+    password,
+    scopes,
+    expected_access,
+    expect_success,
+    v2_protocol,
+    liveserver_session,
+    app_reloader,
+    registry_server_executor,
+    liveserver,
+):
+    """
+    Tests that super users have access to a non-existent namespace/repo if SUPERUSERS_FULL_ACCESS
+    is enabled and CREATE_NAMESPACE_ON_PUSH is .
+    """
+    with ConfigChange(
+        "CREATE_NAMESPACE_ON_PUSH", True, registry_server_executor.on(liveserver), liveserver
+    ):
+        with FeatureFlagValue(
+            "SUPERUSERS_FULL_ACCESS", True, registry_server_executor.on(liveserver)
+        ):
+            response = v2_protocol.login(
+                liveserver_session, username, password, scopes, expect_success
+            )
+            if not expect_success:
+                return
+
+            # Validate the returned token
+            encoded = response.json()["token"]
+            payload = decode_bearer_header(
+                "Bearer " + encoded, instance_keys, {"SERVER_HOSTNAME": "localhost:5000"}
+            )
+            assert payload is not None
+            assert payload["access"] == expected_access
 
 
 def test_push_pull_same_blobs(pusher, puller, liveserver_session, app_reloader):

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -1962,8 +1962,7 @@ def test_login(
             ],
             True,
         ),
-        # Basic pull with invalid endpoint. If super user full access is turned on, this should succeed
-        # regardless whether the namespace exists or not.
+        # Basic pull with invalid endpoint.
         (
             "devtable",
             "password",
@@ -1975,7 +1974,7 @@ def test_login(
                     {
                         "type": "repository",
                         "name": "someinvalid/devtable/simple",
-                        "actions": ["pull"],
+                        "actions": [],
                     },
                 ]
             ),

--- a/test/registry/registry_tests.py
+++ b/test/registry/registry_tests.py
@@ -1962,7 +1962,8 @@ def test_login(
             ],
             True,
         ),
-        # Basic pull with invalid endpoint.
+        # Basic pull with invalid endpoint. If super user full access is turned on, this should succeed
+        # regardless whether the namespace exists or not.
         (
             "devtable",
             "password",
@@ -1974,7 +1975,7 @@ def test_login(
                     {
                         "type": "repository",
                         "name": "someinvalid/devtable/simple",
-                        "actions": [],
+                        "actions": ["pull"],
                     },
                 ]
             ),
@@ -2133,6 +2134,39 @@ def test_login_scopes(
     )
     assert payload is not None
     assert payload["access"] == expected_access
+
+
+def test_login_scopes_when_superuser_full_access_disabled(
+    v2_protocol, liveserver_session, app_reloader, registry_server_executor, liveserver
+):
+    """
+    Tests that super users do not have access to a non-existent namespace/repo if SUPERUSERS_FULL_ACCESS
+    is disabled.
+    """
+    username = "devtable"
+    password = "password"
+    scopes = ["repository:somerepo/that/doesnt/exist:pull"]
+    expect_success = True
+    expected_access = [
+        {
+            "type": "repository",
+            "name": "somerepo/that/doesnt/exist",
+            "actions": [],
+        }
+    ]
+
+    with FeatureFlagValue("SUPERUSERS_FULL_ACCESS", False, registry_server_executor.on(liveserver)):
+        response = v2_protocol.login(liveserver_session, username, password, scopes, expect_success)
+        if not expect_success:
+            return
+
+        # Validate the returned token
+        encoded = response.json()["token"]
+        payload = decode_bearer_header(
+            "Bearer " + encoded, instance_keys, {"SERVER_HOSTNAME": "localhost:5000"}
+        )
+        assert payload is not None
+        assert payload["access"] == expected_access
 
 
 def test_push_pull_same_blobs(pusher, puller, liveserver_session, app_reloader):

--- a/test/specs.py
+++ b/test/specs.py
@@ -167,7 +167,7 @@ def build_v1_index_specs():
             403,
             403,
             403,
-            403,
+            400,
         ).set_method("PUT"),
         IndexV1TestSpec(
             url_for("v1.put_image_layer", image_id=FAKE_IMAGE_ID),
@@ -197,7 +197,7 @@ def build_v1_index_specs():
             403,
             403,
             403,
-            403,
+            400,
         ).set_method("PUT"),
         IndexV1TestSpec(
             url_for("v1.put_image_checksum", image_id=FAKE_IMAGE_ID),
@@ -299,7 +299,7 @@ def build_v1_index_specs():
             403,
             403,
             403,
-            403,
+            400,
         ).set_method("PUT"),
         IndexV1TestSpec(
             url_for("v1.put_image_json", image_id=FAKE_IMAGE_ID),
@@ -336,7 +336,7 @@ def build_v1_index_specs():
             403,
             403,
             403,
-            403,
+            201,
         ).set_method("PUT"),
         IndexV1TestSpec(
             url_for("v1.create_repository", repository=PRIVATE_REPO),
@@ -369,7 +369,7 @@ def build_v1_index_specs():
             201,
         ).set_method("PUT"),
         IndexV1TestSpec(
-            url_for("v1.update_images", repository=PUBLIC_REPO), NO_REPO, 403, 403, 403, 403, 403
+            url_for("v1.update_images", repository=PUBLIC_REPO), NO_REPO, 403, 403, 403, 403, 400
         ).set_method("PUT"),
         IndexV1TestSpec(
             url_for("v1.update_images", repository=PRIVATE_REPO), NO_REPO, 403, 403, 403, 403, 400
@@ -497,7 +497,7 @@ def build_v1_index_specs():
             403,
             403,
             403,
-            403,
+            400,
         ).set_method("PUT"),
         IndexV1TestSpec(
             url_for("v1.put_tag", repository=PRIVATE_REPO, tag=FAKE_TAG_NAME),
@@ -533,7 +533,7 @@ def build_v1_index_specs():
             403,
             403,
             403,
-            403,
+            404,
         ).set_method("DELETE"),
         IndexV1TestSpec(
             url_for("v1.delete_tag", repository=PRIVATE_REPO, tag=FAKE_TAG_NAME),

--- a/test/test_api_usage.py
+++ b/test/test_api_usage.py
@@ -470,7 +470,7 @@ class TestUserStarredRepositoryList(ApiTestCase):
         self.login(READ_ACCESS_USER)
 
         # Queries: Base + the list query
-        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT):
+        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 1):
             self.getJsonResponse(StarredRepositoryList, expected_code=200)
 
     def test_star_repo_guest(self):
@@ -487,7 +487,7 @@ class TestUserStarredRepositoryList(ApiTestCase):
         self.login(READ_ACCESS_USER)
 
         # Queries: Base + the list query
-        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT):
+        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 1):
             json = self.getJsonResponse(StarredRepositoryList)
             assert json["repositories"] == []
 
@@ -2169,7 +2169,7 @@ class TestListRepos(ApiTestCase):
         # Queries: Base + the list query + the popularity and last modified queries + full perms load
         # TODO: Add quota queries
         with patch("features.QUOTA_MANAGEMENT", False):
-            with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 4):
+            with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 5):
                 json = self.getJsonResponse(
                     RepositoryList,
                     params=dict(
@@ -2630,11 +2630,11 @@ class TestGetRepository(ApiTestCase):
         self.login(ADMIN_ACCESS_USER)
 
         # base + repo + is_starred + tags
-        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 3):
+        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 4):
             self.getJsonResponse(Repository, params=dict(repository=ADMIN_ACCESS_USER + "/simple"))
 
         # base + repo + is_starred + tags
-        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 3):
+        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 4):
             json = self.getJsonResponse(
                 Repository, params=dict(repository=ADMIN_ACCESS_USER + "/gargantuan")
             )
@@ -3795,11 +3795,11 @@ class TestUserRobots(ApiTestCase):
         self.putJsonResponse(UserRobot, params=dict(robot_shortname="coolbot"), expected_code=201)
 
         # Queries: Base + the lookup query
-        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT):
+        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 1):
             self.getJsonResponse(UserRobotList)
 
         # Queries: Base + the lookup query
-        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT):
+        with assert_query_count(BASE_LOGGEDIN_QUERY_COUNT + 1):
             self.getJsonResponse(UserRobotList, params=dict(permissions=True))
 
     def test_robots(self):


### PR DESCRIPTION
Loading of permissions, particularly in an LDAP environment, for large sets of repositories and organizations, can be very slow with the current loading techniques. This is mainly because of multiple permission checks and needless password verifications. The optimiziations put here resolve permission loading and speed up UI bootstrap.

On a registry that contains 20 users, 50 organizations and roughly 300 repositories, loading of permissions is dramatically faster with the optimizations rather than without them. For `api/v1/user` endpoint crucial during UI rendering: 

~~~
  ┌─────────────────────┬────────┬───────┬─────────────┐
  │        User         │ Before │ After │ Improvement │
  ├─────────────────────┼────────┼───────┼─────────────┤
  │ Superuser (50 orgs) │ 14.43s │ 0.29s │ ~50x faster │
  ├─────────────────────┼────────┼───────┼─────────────┤
  │ Normal user         │ 4.72s  │ 0.30s │ ~16x faster │
  └─────────────────────┴────────┴───────┴─────────────┘

  Overall SQL queries: 4,075 → 3,082 (~25% reduction across the entire session)
~~~

By the same token, LDAP queries:

~~~
  ┌─────────────────┬────────┬───────┬───────────┐
  │     Metric      │ Before │ After │ Reduction │
  ├─────────────────┼────────┼───────┼───────────┤
  │ LDAP operations │ 6,760  │ 4,504 │ 33% fewer │
  ├─────────────────┼────────┼───────┼───────────┤
  │ LDAP binds      │ 563    │ 375   │ 33% fewer │
  ├─────────────────┼────────┼───────┼───────────┤
  │ LDAP searches   │ 2      │ 2     │ same      │
  └─────────────────┴────────┴───────┴───────────┘
~~~

Metrics were collected by comparing the current Quay 3.17.2 with no LDAP caching vs an image built with the optimizations in the PR, but without the LDAP pooling code. With LDAP pooling, the number of LDAP operations would be dramatically lower.

Co-authored-by: Claude [noreply@anthropic.com](mailto:noreply@anthropic.com)