### PR TITLE
QUAYIO-1796: ci(konflux): use ECR as a staging repo

### DIFF
--- a/.tekton/quay-py3-pull-request.yaml
+++ b/.tekton/quay-py3-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: use-ecr
     value: "true"
   - name: output-image
-    value: 'quay-py3-backup-staging:on-pr-{{revision}}'
+    value: 'quayio-py3-backup-staging:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/quay-py3-pull-request.yaml
+++ b/.tekton/quay-py3-pull-request.yaml
@@ -25,8 +25,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: use-ecr
+    value: "true"
   - name: output-image
-    value: '{{ ecr_registry_url }}/quay-py3-backup-staging:on-pr-{{revision}}'
+    value: 'quay-py3-backup-staging:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/quay-py3-pull-request.yaml
+++ b/.tekton/quay-py3-pull-request.yaml
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/quayio-tenant/quay-py3/quay-py3:on-pr-{{revision}}
+    value: '{{ ecr_registry_url }}/quay-py3-backup-staging:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/quay-py3-push.yaml
+++ b/.tekton/quay-py3-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: use-ecr
     value: 'true'
   - name: output-image
-    value:  'quay-py3-backup-staging:on-pr-{{revision}}'
+    value:  'quay-py3-backup-staging:{{revision}}'
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/quay-py3-push.yaml
+++ b/.tekton/quay-py3-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/quayio-tenant/quay-py3/quay-py3:{{revision}}
+    value: '{{ ecr_registry_url }}/quay-py3-backup-staging:on-pr-{{revision}}'
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/quay-py3-push.yaml
+++ b/.tekton/quay-py3-push.yaml
@@ -24,8 +24,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: use-ecr
+    value: 'true'
   - name: output-image
-    value: '{{ ecr_registry_url }}/quay-py3-backup-staging:on-pr-{{revision}}'
+    value:  'quay-py3-backup-staging:on-pr-{{revision}}'
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/quay-py3-push.yaml
+++ b/.tekton/quay-py3-push.yaml
@@ -27,7 +27,7 @@ spec:
   - name: use-ecr
     value: 'true'
   - name: output-image
-    value:  'quay-py3-backup-staging:{{revision}}'
+    value:  'quayio-py3-backup-staging:{{revision}}'
   - name: dockerfile
     value: Dockerfile
   - name: path-context


### PR DESCRIPTION
Updates our Konflux pipeline so that it will use AWS ECR as an intermediary repo for staging changes. The ECR repo change was made in https://github.com/quay/quay-konflux-configs/pull/218 (private repo).

https://redhat.atlassian.net/browse/QUAYIO-1796