### PR TITLE
NO-ISSUE: fix(ci): use --dist loadfile for PG integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -120,4 +120,4 @@ commands =
     python --version
     /bin/sh -c "docker exec $(docker ps -q -n 1) psql -U quay -d quay_ci -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'"
     /bin/sh -c "TEST_DATABASE_URI=postgresql://quay:quay@127.0.0.1:$POSTGRES_5432_TCP_PORT/quay_ci alembic upgrade head"
-    /bin/sh -c 'TEST_DATABASE_URI=postgresql://quay:quay@127.0.0.1:$POSTGRES_5432_TCP_PORT/quay_ci pytest --timeout=3600 -n auto -m {env:MARKERS} --exitfirst --ignore=buildman/test/test_buildman.py -vv {env:FILE:} {posargs}'
+    /bin/sh -c 'TEST_DATABASE_URI=postgresql://quay:quay@127.0.0.1:$POSTGRES_5432_TCP_PORT/quay_ci pytest --timeout=3600 -n auto --dist loadfile -m {env:MARKERS} --exitfirst --ignore=buildman/test/test_buildman.py -vv {env:FILE:} {posargs}'


### PR DESCRIPTION
## Summary
- Switch pytest-xdist from `--dist load` (round-robin) to `--dist loadfile` for `py312-psql`
- Ensures tests from the same file run on the same xdist worker, preventing cross-file PostgreSQL deadlocks
- Matches the strategy already used by `py312-sqlite`

## Problem
The PostgreSQL Integration Test CI job fails ~20% of the time on master due to deadlocks between tests in different files (e.g., `test_gc.py` and `test_secscan_v4_model.py`) that write to shared tables while running on different xdist workers.

## Test plan
- [ ] CI PostgreSQL Integration Test passes on this PR
- [ ] Monitor 10+ subsequent CI runs for flake rate reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)