### PR TITLE
PROJQUAY-6975: feat(org): allow single email for multiple organizations

### DIFF
--- a/data/model/organization.py
+++ b/data/model/organization.py
@@ -1,7 +1,10 @@
+import uuid
+
 from data.database import (
     DeletedNamespace,
     FederatedLogin,
     Namespace,
+    OrganizationContactEmail,
     Repository,
     RepositoryPermission,
     Team,
@@ -20,20 +23,25 @@ from data.model import (
 )
 
 
-def create_organization(name, email, creating_user, email_required=True, is_possible_abuser=False):
+def create_organization(
+    name, email, creating_user, email_required=True, is_possible_abuser=False, contact_email=None
+):
     with db_transaction():
         try:
-            # Create the org
+            internal_email = str(uuid.uuid4())
             new_org = user.create_user_noverify(
-                name, email, email_required=email_required, is_possible_abuser=is_possible_abuser
+                name, internal_email, email_required=False, is_possible_abuser=is_possible_abuser
             )
             new_org.organization = True
             new_org.save()
 
-            # Create a team for the owners
-            owners_team = team.create_team("owners", new_org, "admin")
+            effective_contact = contact_email or email
+            if effective_contact:
+                OrganizationContactEmail.create(
+                    organization=new_org, contact_email=effective_contact
+                )
 
-            # Add the user who created the org to the owners team
+            owners_team = team.create_team("owners", new_org, "admin")
             team.add_user_to_team(creating_user, owners_team)
 
             return new_org
@@ -209,4 +217,38 @@ def is_org_admin(user, org):
         .join(TeamRole)
         .where(Team.organization == org, TeamRole.name == "admin", TeamMember.user == user)
         .exists()
+    )
+
+
+def get_contact_email(org):
+    try:
+        record = OrganizationContactEmail.get(OrganizationContactEmail.organization == org)
+        return record.contact_email
+    except OrganizationContactEmail.DoesNotExist:
+        return None
+
+
+def set_contact_email(org, contact_email):
+    record, created = OrganizationContactEmail.get_or_create(
+        organization=org,
+        defaults={"contact_email": contact_email},
+    )
+    if not created:
+        record.contact_email = contact_email
+        record.save()
+    return record
+
+
+def delete_contact_email(org):
+    OrganizationContactEmail.delete().where(OrganizationContactEmail.organization == org).execute()
+
+
+def find_organizations_by_contact_email(contact_email):
+    return (
+        User.select()
+        .join(OrganizationContactEmail)
+        .where(
+            OrganizationContactEmail.contact_email == contact_email,
+            User.organization == True,
+        )
     )

--- a/data/model/test/test_organization.py
+++ b/data/model/test/test_organization.py
@@ -5,10 +5,14 @@ from playhouse.test_utils import assert_query_count
 from data.database import OrganizationContactEmail
 from data.model.organization import (
     create_organization,
+    delete_contact_email,
+    find_organizations_by_contact_email,
+    get_contact_email,
     get_organization,
     get_organization_member_set,
     get_organizations,
     is_org_admin,
+    set_contact_email,
 )
 from data.model.team import add_user_to_team, get_organization_team
 from data.model.user import (
@@ -184,7 +188,8 @@ class TestOrganizationContactEmail:
 
     def test_create_with_email(self, initialized_db):
         """Test creating an OrganizationContactEmail with a contact email."""
-        org = get_organization("buynlarge")
+        admin = get_user("devtable")
+        org = create_organization("rawcreateorg1", None, admin)
         record = OrganizationContactEmail.create(
             organization=org, contact_email="contact@example.com"
         )
@@ -193,14 +198,16 @@ class TestOrganizationContactEmail:
 
     def test_create_with_null_email(self, initialized_db):
         """Test creating an OrganizationContactEmail with a null contact email."""
-        org = get_organization("buynlarge")
+        admin = get_user("devtable")
+        org = create_organization("rawcreateorg2", None, admin)
         record = OrganizationContactEmail.create(organization=org, contact_email=None)
         assert record.contact_email is None
         assert record.organization_id == org.id
 
     def test_unique_constraint_on_organization(self, initialized_db):
         """Test that only one contact email record can exist per organization."""
-        org = get_organization("buynlarge")
+        admin = get_user("devtable")
+        org = create_organization("rawcreateorg3", None, admin)
         OrganizationContactEmail.create(organization=org, contact_email="first@example.com")
 
         with pytest.raises(IntegrityError):
@@ -208,9 +215,9 @@ class TestOrganizationContactEmail:
 
     def test_multiple_orgs_can_share_email(self, initialized_db):
         """Test that multiple organizations can have the same contact email."""
-        org1 = get_organization("buynlarge")
         admin = get_user("devtable")
-        org2 = create_organization("testsharedorg", "shared@example.com", admin)
+        org1 = create_organization("sharedorg1", None, admin)
+        org2 = create_organization("sharedorg2", None, admin)
 
         shared_email = "shared@example.com"
         record1 = OrganizationContactEmail.create(organization=org1, contact_email=shared_email)
@@ -219,3 +226,108 @@ class TestOrganizationContactEmail:
         assert record1.contact_email == shared_email
         assert record2.contact_email == shared_email
         assert record1.organization_id != record2.organization_id
+
+
+class TestContactEmailCRUD:
+    """Tests for contact_email CRUD functions."""
+
+    def test_get_contact_email_returns_none_when_not_set(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("crudorg1", None, admin)
+        assert get_contact_email(org) is None
+
+    def test_get_contact_email_returns_email_when_set(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("crudorg2", None, admin)
+        set_contact_email(org, "test@example.com")
+        assert get_contact_email(org) == "test@example.com"
+
+    def test_set_contact_email_creates_new_record(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("crudorg3", None, admin)
+        record = set_contact_email(org, "new@example.com")
+        assert record.contact_email == "new@example.com"
+        assert get_contact_email(org) == "new@example.com"
+
+    def test_set_contact_email_updates_existing_record(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("crudorg4", None, admin)
+        set_contact_email(org, "first@example.com")
+        set_contact_email(org, "second@example.com")
+        assert get_contact_email(org) == "second@example.com"
+
+    def test_delete_contact_email_removes_record(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("crudorg5", None, admin)
+        set_contact_email(org, "delete@example.com")
+        assert get_contact_email(org) == "delete@example.com"
+        delete_contact_email(org)
+        assert get_contact_email(org) is None
+
+    def test_delete_contact_email_noop_when_not_set(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("crudorg6", None, admin)
+        delete_contact_email(org)
+        assert get_contact_email(org) is None
+
+    def test_find_organizations_by_contact_email_single_match(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("findorg1", None, admin, contact_email="find@example.com")
+        results = list(find_organizations_by_contact_email("find@example.com"))
+        assert len(results) == 1
+        assert results[0].id == org.id
+
+    def test_find_organizations_by_contact_email_multiple_matches(self, initialized_db):
+        admin = get_user("devtable")
+        shared = "shared-find@example.com"
+        org1 = create_organization("findorg2a", None, admin, contact_email=shared)
+        org2 = create_organization("findorg2b", None, admin, contact_email=shared)
+        results = list(find_organizations_by_contact_email(shared))
+        assert len(results) == 2
+        result_ids = {r.id for r in results}
+        assert org1.id in result_ids
+        assert org2.id in result_ids
+
+    def test_find_organizations_by_contact_email_no_match(self, initialized_db):
+        results = list(find_organizations_by_contact_email("nonexistent@example.com"))
+        assert len(results) == 0
+
+
+class TestCreateOrganizationContactEmail:
+    """Tests for create_organization with contact_email support."""
+
+    def test_create_org_generates_uuid_email(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("uuidorg1", "ignored@example.com", admin)
+        import uuid
+
+        try:
+            uuid.UUID(org.email)
+            is_uuid = True
+        except ValueError:
+            is_uuid = False
+        assert is_uuid, f"Expected UUID email, got: {org.email}"
+
+    def test_create_org_with_contact_email(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("contactorg1", None, admin, contact_email="contact@example.com")
+        assert get_contact_email(org) == "contact@example.com"
+
+    def test_create_org_without_contact_email(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("nocontactorg1", None, admin)
+        assert get_contact_email(org) is None
+
+    def test_create_org_ignores_email_parameter(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("ignoreemailorg", "should-be-ignored@example.com", admin)
+        assert org.email != "should-be-ignored@example.com"
+
+    def test_create_two_orgs_with_same_contact_email(self, initialized_db):
+        admin = get_user("devtable")
+        shared = "same-contact@example.com"
+        org1 = create_organization("samecontact1", None, admin, contact_email=shared)
+        org2 = create_organization("samecontact2", None, admin, contact_email=shared)
+        assert get_contact_email(org1) == shared
+        assert get_contact_email(org2) == shared
+        assert org1.id != org2.id

--- a/data/model/test/test_organization.py
+++ b/data/model/test/test_organization.py
@@ -323,6 +323,11 @@ class TestCreateOrganizationContactEmail:
         org = create_organization("ignoreemailorg", "should-be-ignored@example.com", admin)
         assert org.email != "should-be-ignored@example.com"
 
+    def test_create_org_email_fallback_sets_contact_email(self, initialized_db):
+        admin = get_user("devtable")
+        org = create_organization("emailfallbackorg", "fallback@example.com", admin)
+        assert get_contact_email(org) == "fallback@example.com"
+
     def test_create_two_orgs_with_same_contact_email(self, initialized_db):
         admin = get_user("devtable")
         shared = "same-contact@example.com"

--- a/emails/combinedrecovery.html
+++ b/emails/combinedrecovery.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<h3 style="font-weight: 400">Account recovery</h3>
+<hr style="border:none; border-top: 1px solid #D9D9D9; margin: 25px 0">
+
+<table>
+	<tr>
+		<td style="font-size: 13px;">A recovery request was made for this email address at <a href="{{ app_link() }}">{{ app_link() }}</a>.</td>
+	</tr>
+</table>
+
+{% if reset_token %}
+<table style="margin-top: 25px; border-left: 3px solid #40B4E5; padding-left: 15px;">
+	<tr>
+		<td>
+			<strong style="font-size: 14px;">Personal Account</strong>
+			<table style="margin-top: 10px;">
+				<tr>
+					<td style="font-size: 13px;">To recover the personal account registered to this email address:</td>
+				</tr>
+			</table>
+			<table style="margin: 15px 0;">
+				<tr>
+					<td style="background: #40B4E5; padding: 10px; border-radius: 3px; color: #fff; font-size: 20px; font-weight: 500"><a style="text-decoration: none; color: #ffffff;" href="{{ app_link('recovery?code=' + reset_token) }}">Recover Account</a></td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+{% endif %}
+
+{% if organizations %}
+<table style="margin-top: 25px; border-left: 3px solid #40B4E5; padding-left: 15px;">
+	<tr>
+		<td>
+			<strong style="font-size: 14px;">Organization{{ 's' if organizations|length > 1 }}</strong>
+			<table style="margin-top: 10px;">
+				<tr>
+					<td style="font-size: 13px;">To recover the organization{{ 's' if organizations|length > 1 }} associated with this email address, login with one of the admin accounts listed below:</td>
+				</tr>
+			</table>
+			{% for org in organizations %}
+			<table style="margin-top: 15px;">
+				<tr>
+					<td style="font-size: 13px; font-weight: 500;"><strong>{{ org.org_name }}</strong></td>
+				</tr>
+			</table>
+			<table>
+				<tr>
+					<ul>
+						{% for admin_user in org.admin_usernames %}
+						<li style="font-weight: 500; font-size: 13px; margin-top: 10px;">{{ admin_user | user_reference }}</li>
+						{% endfor %}
+					</ul>
+				</tr>
+			</table>
+			{% endfor %}
+			<table style="margin: 15px 0;">
+				<tr>
+					<td style="background: #40B4E5; padding: 10px; border-radius: 3px; color: #fff; font-size: 20px; font-weight: 500"><a style="text-decoration: none; color: #ffffff;" href="{{ app_link('signin/') }}">Login to Recover</a></td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+{% endif %}
+
+<table style="margin: 25px 0 35px">
+	<tr>
+		<td style="font-size: 13px;">If you did not make this request, you can safely ignore this message. No changes have been made to any accounts.</td>
+	</tr>
+</table>
+
+
+<span style="font-size: 13px;">Best Wishes,</span><br>
+<span style="font-size: 13px;">The {{ app_title }} Team</span><br>
+
+{% endblock %}

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -53,6 +53,7 @@ from proxy import Proxy, UpstreamRegistryError
 from util.marketplace import MarketplaceSubscriptionApi
 from util.names import parse_robot_username
 from util.request import get_request_ip
+from util.validation import validate_email
 
 logger = logging.getLogger(__name__)
 
@@ -114,9 +115,14 @@ def org_view(o, teams):
         is_admin = True
         is_member = True
 
+    contact_email = None
+    if is_admin or can_view_as_superuser:
+        contact_email = model.organization.get_contact_email(o)
+
     view = {
         "name": o.username,
-        "email": o.email if is_admin or can_view_as_superuser else "",
+        "email": contact_email or "" if (is_admin or can_view_as_superuser) else "",
+        "contact_email": contact_email if (is_admin or can_view_as_superuser) else None,
         "avatar": avatar.get_data_for_user(o),
         "is_admin": is_admin,
         "is_member": is_member,
@@ -173,6 +179,10 @@ class OrganizationList(ApiResource):
                     "type": "string",
                     "description": "Organization contact email",
                 },
+                "contact_email": {
+                    "type": "string",
+                    "description": "Optional contact email for organization recovery and notifications",
+                },
                 "recaptcha_response": {
                     "type": "string",
                     "description": "The (may be disabled) recaptcha response code for verification",
@@ -214,8 +224,9 @@ class OrganizationList(ApiResource):
             msg = "A user or organization with this name already exists"
             raise request_error(message=msg)
 
-        if features.MAILING and not org_data.get("email"):
-            raise request_error(message="Email address is required")
+        contact_email = org_data.get("contact_email") or org_data.get("email")
+        if contact_email and not validate_email(contact_email):
+            raise request_error(message="Invalid email address")
 
         # If recaptcha is enabled, then verify the user is a human.
         if features.RECAPTCHA:
@@ -236,11 +247,12 @@ class OrganizationList(ApiResource):
                 user,
                 email_required=features.MAILING,
                 is_possible_abuser=is_possible_abuser,
+                contact_email=contact_email,
             )
             log_action(
                 "org_create",
                 org_data["name"],
-                {"email": org_data.get("email"), "namespace": org_data["name"]},
+                {"contact_email": contact_email, "namespace": org_data["name"]},
             )
             return "Created", 201
         except model.DataModelException as ex:
@@ -262,6 +274,10 @@ class Organization(ApiResource):
             "properties": {
                 "email": {
                     "type": "string",
+                    "description": "Organization contact email",
+                },
+                "contact_email": {
+                    "type": ["string", "null"],
                     "description": "Organization contact email",
                 },
                 "invoice_email": {
@@ -340,20 +356,22 @@ class Organization(ApiResource):
                     {"invoice_email_address": new_email, "namespace": orgname},
                 )
 
-            if "email" in org_data and org_data["email"] != org.email:
-                new_email = org_data["email"]
-                old_email = org.email
-
-                if model.user.find_user_by_email(new_email):
-                    raise request_error(message="E-mail address already used")
-
-                logger.debug("Changing email address for organization: %s", org.username)
-                model.user.update_email(org, new_email)
-                log_action(
-                    "org_change_email",
-                    orgname,
-                    {"email": new_email, "namespace": orgname, "old_email": old_email},
-                )
+            new_contact = org_data.get("contact_email") or org_data.get("email")
+            if new_contact is not None:
+                current_contact = model.organization.get_contact_email(org)
+                if new_contact != current_contact:
+                    if new_contact and not validate_email(new_contact):
+                        raise request_error(message="Invalid email address")
+                    model.organization.set_contact_email(org, new_contact)
+                    log_action(
+                        "org_change_email",
+                        orgname,
+                        {
+                            "contact_email": new_contact,
+                            "namespace": orgname,
+                            "old_email": current_contact or "",
+                        },
+                    )
 
             if features.CHANGE_TAG_EXPIRATION and "tag_expiration_s" in org_data:
                 logger.debug(
@@ -681,7 +699,11 @@ class ApplicationInformation(ApiResource):
         if not application:
             raise NotFound()
 
-        app_email = application.avatar_email or application.organization.email
+        app_email = (
+            application.avatar_email
+            or model.organization.get_contact_email(application.organization)
+            or application.organization.email
+        )
         app_data = avatar.get_data(application.name, app_email, "app")
 
         return {

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -356,13 +356,20 @@ class Organization(ApiResource):
                     {"invoice_email_address": new_email, "namespace": orgname},
                 )
 
-            new_contact = org_data.get("contact_email") or org_data.get("email")
+            new_contact = (
+                org_data.get("contact_email")
+                if "contact_email" in org_data
+                else org_data.get("email")
+            )
             if new_contact is not None:
                 current_contact = model.organization.get_contact_email(org)
                 if new_contact != current_contact:
                     if new_contact and not validate_email(new_contact):
                         raise request_error(message="Invalid email address")
-                    model.organization.set_contact_email(org, new_contact)
+                    if new_contact:
+                        model.organization.set_contact_email(org, new_contact)
+                    else:
+                        model.organization.delete_contact_email(org)
                     log_action(
                         "org_change_email",
                         orgname,

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -99,6 +99,33 @@ class TestContactEmail:
         assert resp.json.get("contact_email") is None
         assert resp.json.get("email") == ""
 
+    def test_clear_contact_email(self, app):
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(
+                cl,
+                Organization,
+                "PUT",
+                {"orgname": "buynlarge"},
+                body={"contact_email": "temp@example.com"},
+                expected_code=200,
+            )
+
+        org = model.organization.get_organization("buynlarge")
+        assert model.organization.get_contact_email(org) == "temp@example.com"
+
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(
+                cl,
+                Organization,
+                "PUT",
+                {"orgname": "buynlarge"},
+                body={"contact_email": ""},
+                expected_code=200,
+            )
+
+        org = model.organization.get_organization("buynlarge")
+        assert model.organization.get_contact_email(org) is None
+
     def test_create_org_no_email_with_mailing(self, app):
         body = {"name": "mailingnoemailorg"}
         with toggle_feature("MAILING", True):

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -17,6 +17,100 @@ from features import FeatureNameValue
 from test.fixtures import *
 
 
+class TestContactEmail:
+    def test_create_org_with_contact_email(self, app):
+        body = {
+            "name": "contactemailorg",
+            "contact_email": "contact@example.com",
+        }
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
+
+        org = model.organization.get_organization("contactemailorg")
+        assert model.organization.get_contact_email(org) == "contact@example.com"
+
+    def test_create_org_without_email(self, app):
+        body = {"name": "noemailorg"}
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
+
+        org = model.organization.get_organization("noemailorg")
+        assert model.organization.get_contact_email(org) is None
+
+    def test_create_org_email_backward_compat(self, app):
+        body = {
+            "name": "backcompatorg",
+            "email": "compat@example.com",
+        }
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
+
+        org = model.organization.get_organization("backcompatorg")
+        assert model.organization.get_contact_email(org) == "compat@example.com"
+
+    def test_update_org_contact_email(self, app):
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(
+                cl,
+                Organization,
+                "PUT",
+                {"orgname": "buynlarge"},
+                body={"contact_email": "updated@example.com"},
+                expected_code=200,
+            )
+
+        org = model.organization.get_organization("buynlarge")
+        assert model.organization.get_contact_email(org) == "updated@example.com"
+
+    def test_update_org_duplicate_contact_email(self, app):
+        body = {
+            "name": "dupemailorg",
+            "contact_email": "shared@example.com",
+        }
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
+
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(
+                cl,
+                Organization,
+                "PUT",
+                {"orgname": "buynlarge"},
+                body={"contact_email": "shared@example.com"},
+                expected_code=200,
+            )
+
+        org = model.organization.get_organization("buynlarge")
+        assert model.organization.get_contact_email(org) == "shared@example.com"
+
+    def test_get_org_admin_sees_contact_email(self, app):
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(
+                cl, Organization, "GET", {"orgname": "buynlarge"}, expected_code=200
+            )
+        assert "contact_email" in resp.json
+        assert resp.json["contact_email"] is not None
+
+    def test_get_org_nonadmin_no_contact_email(self, app):
+        with client_with_identity("freshuser", app) as cl:
+            resp = conduct_api_call(
+                cl, Organization, "GET", {"orgname": "buynlarge"}, expected_code=200
+            )
+        assert resp.json.get("contact_email") is None
+        assert resp.json.get("email") == ""
+
+    def test_create_org_no_email_with_mailing(self, app):
+        body = {"name": "mailingnoemailorg"}
+        with toggle_feature("MAILING", True):
+            with client_with_identity("devtable", app) as cl:
+                conduct_api_call(
+                    cl, OrganizationList, "POST", None, body=body, expected_code=201
+                )
+
+        org = model.organization.get_organization("mailingnoemailorg")
+        assert model.organization.get_contact_email(org) is None
+
+
 @pytest.mark.parametrize(
     "expiration, expected_code",
     [

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -135,6 +135,25 @@ class TestContactEmail:
         org = model.organization.get_organization("mailingnoemailorg")
         assert model.organization.get_contact_email(org) is None
 
+    def test_create_org_invalid_contact_email(self, app):
+        body = {
+            "name": "invalemailorg",
+            "contact_email": "not-a-valid-email",
+        }
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=400)
+
+    def test_update_org_invalid_contact_email(self, app):
+        with client_with_identity("devtable", app) as cl:
+            conduct_api_call(
+                cl,
+                Organization,
+                "PUT",
+                {"orgname": "buynlarge"},
+                body={"contact_email": "not-a-valid-email"},
+                expected_code=400,
+            )
+
 
 @pytest.mark.parametrize(
     "expiration, expected_code",

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -130,9 +130,7 @@ class TestContactEmail:
         body = {"name": "mailingnoemailorg"}
         with toggle_feature("MAILING", True):
             with client_with_identity("devtable", app) as cl:
-                conduct_api_call(
-                    cl, OrganizationList, "POST", None, body=body, expected_code=201
-                )
+                conduct_api_call(cl, OrganizationList, "POST", None, body=body, expected_code=201)
 
         org = model.organization.get_organization("mailingnoemailorg")
         assert model.organization.get_contact_email(org) is None

--- a/endpoints/api/test/test_user.py
+++ b/endpoints/api/test/test_user.py
@@ -1,14 +1,13 @@
-from test.fixtures import *
-
 import pytest
 from flask import url_for
 from mock import MagicMock, patch
 
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.api.user import Recovery, User
-from util.useremails import send_combined_recovery_email
 from endpoints.test.shared import client_with_identity, conduct_call
 from features import FeatureNameValue
+from test.fixtures import *
+from util.useremails import send_combined_recovery_email
 
 
 def test_user_metadata_update(app):

--- a/endpoints/api/test/test_user.py
+++ b/endpoints/api/test/test_user.py
@@ -2,10 +2,10 @@ from test.fixtures import *
 
 import pytest
 from flask import url_for
-from mock import patch
+from mock import MagicMock, patch
 
 from endpoints.api.test.shared import conduct_api_call
-from endpoints.api.user import User
+from endpoints.api.user import Recovery, User
 from endpoints.test.shared import client_with_identity, conduct_call
 from features import FeatureNameValue
 
@@ -133,3 +133,116 @@ def test_initialize_user(
                         assert 40 == len(user.json.get("access_token", ""))
                     else:
                         assert not user.json.get("access_token")
+
+
+class TestRecoveryPost:
+    @patch("endpoints.api.user.send_recovery_email")
+    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.model.user.create_reset_password_email_code", return_value="code123")
+    @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[])
+    @patch("endpoints.api.user.model.user.find_user_by_email")
+    def test_recovery_personal_user_only(
+        self, mock_find_user, mock_find_orgs, mock_create_code, mock_org_email, mock_recovery_email, app
+    ):
+        user = MagicMock()
+        user.organization = False
+        mock_find_user.return_value = user
+
+        with patch("features.MAILING", FeatureNameValue("MAILING", True)):
+            with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
+                with client_with_identity(None, app) as cl:
+                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "user@example.com"})
+
+        assert result.json["status"] == "sent"
+        mock_recovery_email.assert_called_once_with("user@example.com", "code123")
+        mock_org_email.assert_not_called()
+
+    @patch("endpoints.api.user.send_recovery_email")
+    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.model.organization.get_admin_users")
+    @patch("endpoints.api.user.model.organization.get_contact_email", return_value="org@example.com")
+    @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email")
+    @patch("endpoints.api.user.model.user.find_user_by_email", return_value=None)
+    def test_recovery_org_only(
+        self, mock_find_user, mock_find_orgs, mock_get_contact, mock_get_admins,
+        mock_org_email, mock_recovery_email, app
+    ):
+        org = MagicMock()
+        org.organization = True
+        mock_find_orgs.return_value = [org]
+        admin = MagicMock()
+        mock_get_admins.return_value = [admin]
+
+        with patch("features.MAILING", FeatureNameValue("MAILING", True)):
+            with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
+                with client_with_identity(None, app) as cl:
+                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "org@example.com"})
+
+        assert result.json["status"] == "sent"
+        mock_org_email.assert_called_once_with(org, [admin], contact_email="org@example.com")
+        mock_recovery_email.assert_not_called()
+
+    @patch("endpoints.api.user.send_recovery_email")
+    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.model.user.create_reset_password_email_code", return_value="code456")
+    @patch("endpoints.api.user.model.organization.get_admin_users")
+    @patch("endpoints.api.user.model.organization.get_contact_email", return_value="shared@example.com")
+    @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email")
+    @patch("endpoints.api.user.model.user.find_user_by_email")
+    def test_recovery_both_user_and_org(
+        self, mock_find_user, mock_find_orgs, mock_get_contact, mock_get_admins,
+        mock_create_code, mock_org_email, mock_recovery_email, app
+    ):
+        user = MagicMock()
+        user.organization = False
+        mock_find_user.return_value = user
+
+        org = MagicMock()
+        mock_find_orgs.return_value = [org]
+        admin = MagicMock()
+        mock_get_admins.return_value = [admin]
+
+        with patch("features.MAILING", FeatureNameValue("MAILING", True)):
+            with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
+                with client_with_identity(None, app) as cl:
+                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "shared@example.com"})
+
+        assert result.json["status"] == "sent"
+        mock_org_email.assert_called_once_with(org, [admin], contact_email="shared@example.com")
+        mock_recovery_email.assert_called_once_with("shared@example.com", "code456")
+
+    @patch("endpoints.api.user.send_recovery_email")
+    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[])
+    @patch("endpoints.api.user.model.user.find_user_by_email", return_value=None)
+    def test_recovery_no_match(
+        self, mock_find_user, mock_find_orgs, mock_org_email, mock_recovery_email, app
+    ):
+        with patch("features.MAILING", FeatureNameValue("MAILING", True)):
+            with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
+                with client_with_identity(None, app) as cl:
+                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "nobody@example.com"})
+
+        assert result.json["status"] == "sent"
+        mock_org_email.assert_not_called()
+        mock_recovery_email.assert_not_called()
+
+    @patch("endpoints.api.user.send_recovery_email")
+    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[])
+    @patch("endpoints.api.user.model.user.find_user_by_email")
+    def test_recovery_skips_org_user_from_find_user(
+        self, mock_find_user, mock_find_orgs, mock_org_email, mock_recovery_email, app
+    ):
+        """When find_user_by_email returns an org, it should be ignored (orgs are handled via contact_email)."""
+        org_user = MagicMock()
+        org_user.organization = True
+        mock_find_user.return_value = org_user
+
+        with patch("features.MAILING", FeatureNameValue("MAILING", True)):
+            with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
+                with client_with_identity(None, app) as cl:
+                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "legacy@example.com"})
+
+        assert result.json["status"] == "sent"
+        mock_recovery_email.assert_not_called()

--- a/endpoints/api/test/test_user.py
+++ b/endpoints/api/test/test_user.py
@@ -6,6 +6,7 @@ from mock import MagicMock, patch
 
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.api.user import Recovery, User
+from util.useremails import send_combined_recovery_email
 from endpoints.test.shared import client_with_identity, conduct_call
 from features import FeatureNameValue
 
@@ -137,12 +138,12 @@ def test_initialize_user(
 
 class TestRecoveryPost:
     @patch("endpoints.api.user.send_recovery_email")
-    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.send_combined_recovery_email")
     @patch("endpoints.api.user.model.user.create_reset_password_email_code", return_value="code123")
     @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[])
     @patch("endpoints.api.user.model.user.find_user_by_email")
     def test_recovery_personal_user_only(
-        self, mock_find_user, mock_find_orgs, mock_create_code, mock_org_email, mock_recovery_email, app
+        self, mock_find_user, mock_find_orgs, mock_create_code, mock_combined_email, mock_recovery_email, app
     ):
         user = MagicMock()
         user.organization = False
@@ -155,22 +156,23 @@ class TestRecoveryPost:
 
         assert result.json["status"] == "sent"
         mock_recovery_email.assert_called_once_with("user@example.com", "code123")
-        mock_org_email.assert_not_called()
+        mock_combined_email.assert_not_called()
 
     @patch("endpoints.api.user.send_recovery_email")
-    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.send_combined_recovery_email")
     @patch("endpoints.api.user.model.organization.get_admin_users")
-    @patch("endpoints.api.user.model.organization.get_contact_email", return_value="org@example.com")
     @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email")
     @patch("endpoints.api.user.model.user.find_user_by_email", return_value=None)
     def test_recovery_org_only(
-        self, mock_find_user, mock_find_orgs, mock_get_contact, mock_get_admins,
-        mock_org_email, mock_recovery_email, app
+        self, mock_find_user, mock_find_orgs, mock_get_admins,
+        mock_combined_email, mock_recovery_email, app
     ):
         org = MagicMock()
+        org.username = "myorg"
         org.organization = True
         mock_find_orgs.return_value = [org]
         admin = MagicMock()
+        admin.username = "orgadmin"
         mock_get_admins.return_value = [admin]
 
         with patch("features.MAILING", FeatureNameValue("MAILING", True)):
@@ -179,27 +181,32 @@ class TestRecoveryPost:
                     result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "org@example.com"})
 
         assert result.json["status"] == "sent"
-        mock_org_email.assert_called_once_with(org, [admin], contact_email="org@example.com")
+        mock_combined_email.assert_called_once_with(
+            "org@example.com",
+            [{"org_name": "myorg", "admin_usernames": ["orgadmin"]}],
+            reset_token=None,
+        )
         mock_recovery_email.assert_not_called()
 
     @patch("endpoints.api.user.send_recovery_email")
-    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.send_combined_recovery_email")
     @patch("endpoints.api.user.model.user.create_reset_password_email_code", return_value="code456")
     @patch("endpoints.api.user.model.organization.get_admin_users")
-    @patch("endpoints.api.user.model.organization.get_contact_email", return_value="shared@example.com")
     @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email")
     @patch("endpoints.api.user.model.user.find_user_by_email")
     def test_recovery_both_user_and_org(
-        self, mock_find_user, mock_find_orgs, mock_get_contact, mock_get_admins,
-        mock_create_code, mock_org_email, mock_recovery_email, app
+        self, mock_find_user, mock_find_orgs, mock_get_admins,
+        mock_create_code, mock_combined_email, mock_recovery_email, app
     ):
         user = MagicMock()
         user.organization = False
         mock_find_user.return_value = user
 
         org = MagicMock()
+        org.username = "sharedorg"
         mock_find_orgs.return_value = [org]
         admin = MagicMock()
+        admin.username = "orgadmin"
         mock_get_admins.return_value = [admin]
 
         with patch("features.MAILING", FeatureNameValue("MAILING", True)):
@@ -208,15 +215,19 @@ class TestRecoveryPost:
                     result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "shared@example.com"})
 
         assert result.json["status"] == "sent"
-        mock_org_email.assert_called_once_with(org, [admin], contact_email="shared@example.com")
-        mock_recovery_email.assert_called_once_with("shared@example.com", "code456")
+        mock_combined_email.assert_called_once_with(
+            "shared@example.com",
+            [{"org_name": "sharedorg", "admin_usernames": ["orgadmin"]}],
+            reset_token="code456",
+        )
+        mock_recovery_email.assert_not_called()
 
     @patch("endpoints.api.user.send_recovery_email")
-    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.send_combined_recovery_email")
     @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[])
     @patch("endpoints.api.user.model.user.find_user_by_email", return_value=None)
     def test_recovery_no_match(
-        self, mock_find_user, mock_find_orgs, mock_org_email, mock_recovery_email, app
+        self, mock_find_user, mock_find_orgs, mock_combined_email, mock_recovery_email, app
     ):
         with patch("features.MAILING", FeatureNameValue("MAILING", True)):
             with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
@@ -224,15 +235,15 @@ class TestRecoveryPost:
                     result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "nobody@example.com"})
 
         assert result.json["status"] == "sent"
-        mock_org_email.assert_not_called()
+        mock_combined_email.assert_not_called()
         mock_recovery_email.assert_not_called()
 
     @patch("endpoints.api.user.send_recovery_email")
-    @patch("endpoints.api.user.send_org_recovery_email")
+    @patch("endpoints.api.user.send_combined_recovery_email")
     @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[])
     @patch("endpoints.api.user.model.user.find_user_by_email")
     def test_recovery_skips_org_user_from_find_user(
-        self, mock_find_user, mock_find_orgs, mock_org_email, mock_recovery_email, app
+        self, mock_find_user, mock_find_orgs, mock_combined_email, mock_recovery_email, app
     ):
         """When find_user_by_email returns an org, it should be ignored (orgs are handled via contact_email)."""
         org_user = MagicMock()
@@ -245,4 +256,41 @@ class TestRecoveryPost:
                     result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "legacy@example.com"})
 
         assert result.json["status"] == "sent"
+        mock_recovery_email.assert_not_called()
+        mock_combined_email.assert_not_called()
+
+    @patch("endpoints.api.user.send_recovery_email")
+    @patch("endpoints.api.user.send_combined_recovery_email")
+    @patch("endpoints.api.user.model.organization.get_admin_users")
+    @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email")
+    @patch("endpoints.api.user.model.user.find_user_by_email", return_value=None)
+    def test_recovery_multiple_orgs(
+        self, mock_find_user, mock_find_orgs, mock_get_admins,
+        mock_combined_email, mock_recovery_email, app
+    ):
+        org1 = MagicMock()
+        org1.username = "org1"
+        org2 = MagicMock()
+        org2.username = "org2"
+        mock_find_orgs.return_value = [org1, org2]
+        admin1 = MagicMock()
+        admin1.username = "admin1"
+        admin2 = MagicMock()
+        admin2.username = "admin2"
+        mock_get_admins.side_effect = [[admin1], [admin2]]
+
+        with patch("features.MAILING", FeatureNameValue("MAILING", True)):
+            with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
+                with client_with_identity(None, app) as cl:
+                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "shared@example.com"})
+
+        assert result.json["status"] == "sent"
+        mock_combined_email.assert_called_once_with(
+            "shared@example.com",
+            [
+                {"org_name": "org1", "admin_usernames": ["admin1"]},
+                {"org_name": "org2", "admin_usernames": ["admin2"]},
+            ],
+            reset_token=None,
+        )
         mock_recovery_email.assert_not_called()

--- a/endpoints/api/test/test_user.py
+++ b/endpoints/api/test/test_user.py
@@ -140,10 +140,18 @@ class TestRecoveryPost:
     @patch("endpoints.api.user.send_recovery_email")
     @patch("endpoints.api.user.send_combined_recovery_email")
     @patch("endpoints.api.user.model.user.create_reset_password_email_code", return_value="code123")
-    @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[])
+    @patch(
+        "endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[]
+    )
     @patch("endpoints.api.user.model.user.find_user_by_email")
     def test_recovery_personal_user_only(
-        self, mock_find_user, mock_find_orgs, mock_create_code, mock_combined_email, mock_recovery_email, app
+        self,
+        mock_find_user,
+        mock_find_orgs,
+        mock_create_code,
+        mock_combined_email,
+        mock_recovery_email,
+        app,
     ):
         user = MagicMock()
         user.organization = False
@@ -152,7 +160,9 @@ class TestRecoveryPost:
         with patch("features.MAILING", FeatureNameValue("MAILING", True)):
             with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
                 with client_with_identity(None, app) as cl:
-                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "user@example.com"})
+                    result = conduct_api_call(
+                        cl, Recovery, "POST", None, body={"email": "user@example.com"}
+                    )
 
         assert result.json["status"] == "sent"
         mock_recovery_email.assert_called_once_with("user@example.com", "code123")
@@ -164,8 +174,13 @@ class TestRecoveryPost:
     @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email")
     @patch("endpoints.api.user.model.user.find_user_by_email", return_value=None)
     def test_recovery_org_only(
-        self, mock_find_user, mock_find_orgs, mock_get_admins,
-        mock_combined_email, mock_recovery_email, app
+        self,
+        mock_find_user,
+        mock_find_orgs,
+        mock_get_admins,
+        mock_combined_email,
+        mock_recovery_email,
+        app,
     ):
         org = MagicMock()
         org.username = "myorg"
@@ -178,7 +193,9 @@ class TestRecoveryPost:
         with patch("features.MAILING", FeatureNameValue("MAILING", True)):
             with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
                 with client_with_identity(None, app) as cl:
-                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "org@example.com"})
+                    result = conduct_api_call(
+                        cl, Recovery, "POST", None, body={"email": "org@example.com"}
+                    )
 
         assert result.json["status"] == "sent"
         mock_combined_email.assert_called_once_with(
@@ -195,8 +212,14 @@ class TestRecoveryPost:
     @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email")
     @patch("endpoints.api.user.model.user.find_user_by_email")
     def test_recovery_both_user_and_org(
-        self, mock_find_user, mock_find_orgs, mock_get_admins,
-        mock_create_code, mock_combined_email, mock_recovery_email, app
+        self,
+        mock_find_user,
+        mock_find_orgs,
+        mock_get_admins,
+        mock_create_code,
+        mock_combined_email,
+        mock_recovery_email,
+        app,
     ):
         user = MagicMock()
         user.organization = False
@@ -212,7 +235,9 @@ class TestRecoveryPost:
         with patch("features.MAILING", FeatureNameValue("MAILING", True)):
             with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
                 with client_with_identity(None, app) as cl:
-                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "shared@example.com"})
+                    result = conduct_api_call(
+                        cl, Recovery, "POST", None, body={"email": "shared@example.com"}
+                    )
 
         assert result.json["status"] == "sent"
         mock_combined_email.assert_called_once_with(
@@ -224,7 +249,9 @@ class TestRecoveryPost:
 
     @patch("endpoints.api.user.send_recovery_email")
     @patch("endpoints.api.user.send_combined_recovery_email")
-    @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[])
+    @patch(
+        "endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[]
+    )
     @patch("endpoints.api.user.model.user.find_user_by_email", return_value=None)
     def test_recovery_no_match(
         self, mock_find_user, mock_find_orgs, mock_combined_email, mock_recovery_email, app
@@ -232,7 +259,9 @@ class TestRecoveryPost:
         with patch("features.MAILING", FeatureNameValue("MAILING", True)):
             with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
                 with client_with_identity(None, app) as cl:
-                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "nobody@example.com"})
+                    result = conduct_api_call(
+                        cl, Recovery, "POST", None, body={"email": "nobody@example.com"}
+                    )
 
         assert result.json["status"] == "sent"
         mock_combined_email.assert_not_called()
@@ -240,7 +269,9 @@ class TestRecoveryPost:
 
     @patch("endpoints.api.user.send_recovery_email")
     @patch("endpoints.api.user.send_combined_recovery_email")
-    @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[])
+    @patch(
+        "endpoints.api.user.model.organization.find_organizations_by_contact_email", return_value=[]
+    )
     @patch("endpoints.api.user.model.user.find_user_by_email")
     def test_recovery_skips_org_user_from_find_user(
         self, mock_find_user, mock_find_orgs, mock_combined_email, mock_recovery_email, app
@@ -253,7 +284,9 @@ class TestRecoveryPost:
         with patch("features.MAILING", FeatureNameValue("MAILING", True)):
             with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
                 with client_with_identity(None, app) as cl:
-                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "legacy@example.com"})
+                    result = conduct_api_call(
+                        cl, Recovery, "POST", None, body={"email": "legacy@example.com"}
+                    )
 
         assert result.json["status"] == "sent"
         mock_recovery_email.assert_not_called()
@@ -265,8 +298,13 @@ class TestRecoveryPost:
     @patch("endpoints.api.user.model.organization.find_organizations_by_contact_email")
     @patch("endpoints.api.user.model.user.find_user_by_email", return_value=None)
     def test_recovery_multiple_orgs(
-        self, mock_find_user, mock_find_orgs, mock_get_admins,
-        mock_combined_email, mock_recovery_email, app
+        self,
+        mock_find_user,
+        mock_find_orgs,
+        mock_get_admins,
+        mock_combined_email,
+        mock_recovery_email,
+        app,
     ):
         org1 = MagicMock()
         org1.username = "org1"
@@ -282,7 +320,9 @@ class TestRecoveryPost:
         with patch("features.MAILING", FeatureNameValue("MAILING", True)):
             with patch("features.RECAPTCHA", FeatureNameValue("RECAPTCHA", False)):
                 with client_with_identity(None, app) as cl:
-                    result = conduct_api_call(cl, Recovery, "POST", None, body={"email": "shared@example.com"})
+                    result = conduct_api_call(
+                        cl, Recovery, "POST", None, body={"email": "shared@example.com"}
+                    )
 
         assert result.json["status"] == "sent"
         mock_combined_email.assert_called_once_with(

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -1116,21 +1116,17 @@ class Recovery(ApiResource):
 
         email = recovery_data["email"]
         user = model.user.find_user_by_email(email)
-        if not user:
-            return {
-                "status": "sent",
-            }
+        orgs = list(model.organization.find_organizations_by_contact_email(email))
 
-        if user.organization:
-            send_org_recovery_email(user, model.organization.get_admin_users(user))
-            return {
-                "status": "org",
-                "orgemail": email,
-                "orgname": redact(user.username),
-            }
+        for org in orgs:
+            contact_email = model.organization.get_contact_email(org)
+            admin_users = model.organization.get_admin_users(org)
+            send_org_recovery_email(org, admin_users, contact_email=contact_email)
 
-        confirmation_code = model.user.create_reset_password_email_code(email)
-        send_recovery_email(email, confirmation_code)
+        if user and not user.organization:
+            confirmation_code = model.user.create_reset_password_email_code(email)
+            send_recovery_email(email, confirmation_code)
+
         return {
             "status": "sent",
         }

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -83,6 +83,7 @@ from util.names import parse_single_urn
 from util.request import get_request_ip
 from util.useremails import (
     send_change_email,
+    send_combined_recovery_email,
     send_confirmation_email,
     send_org_recovery_email,
     send_password_changed,
@@ -1118,14 +1119,22 @@ class Recovery(ApiResource):
         user = model.user.find_user_by_email(email)
         orgs = list(model.organization.find_organizations_by_contact_email(email))
 
-        for org in orgs:
-            contact_email = model.organization.get_contact_email(org)
-            admin_users = model.organization.get_admin_users(org)
-            send_org_recovery_email(org, admin_users, contact_email=contact_email)
+        is_personal_user = user and not user.organization
+        reset_token = None
+        if is_personal_user:
+            reset_token = model.user.create_reset_password_email_code(email)
 
-        if user and not user.organization:
-            confirmation_code = model.user.create_reset_password_email_code(email)
-            send_recovery_email(email, confirmation_code)
+        if orgs:
+            orgs_with_admins = []
+            for org in orgs:
+                admin_users = model.organization.get_admin_users(org)
+                orgs_with_admins.append({
+                    "org_name": org.username,
+                    "admin_usernames": [u.username for u in admin_users],
+                })
+            send_combined_recovery_email(email, orgs_with_admins, reset_token=reset_token)
+        elif is_personal_user:
+            send_recovery_email(email, reset_token)
 
         return {
             "status": "sent",

--- a/endpoints/api/user.py
+++ b/endpoints/api/user.py
@@ -712,7 +712,7 @@ class ClientKey(ApiResource):
 
         username = get_authenticated_user().username
         password = request.get_json()["password"]
-        (result, error_message) = authentication.confirm_existing_user(username, password)
+        result, error_message = authentication.confirm_existing_user(username, password)
         if not result:
             raise request_error(message=error_message)
 
@@ -725,7 +725,7 @@ def conduct_signin(username_or_email, password, invite_code=None):
     needs_email_verification = False
     invalid_credentials = False
 
-    (found_user, error_message) = authentication.verify_and_link_user(username_or_email, password)
+    found_user, error_message = authentication.verify_and_link_user(username_or_email, password)
     if found_user:
         # If there is an attached invitation code, handle it here. This will mark the
         # user as verified if the code is valid.
@@ -820,7 +820,7 @@ class ConvertToOrganization(ApiResource):
         # Ensure that the sign in credentials work.
         admin_username = convert_data["adminUser"]
         admin_password = convert_data["adminPassword"]
-        (admin_user, _) = authentication.verify_and_link_user(admin_username, admin_password)
+        admin_user, _ = authentication.verify_and_link_user(admin_username, admin_password)
         if not admin_user:
             raise request_error(
                 reason="invaliduser", message="The admin user credentials are not valid"
@@ -930,7 +930,7 @@ class VerifyUser(ApiResource):
         password = signin_data["password"]
 
         username = get_authenticated_user().username
-        (result, error_message) = authentication.confirm_existing_user(username, password)
+        result, error_message = authentication.confirm_existing_user(username, password)
         if not result:
             return {
                 "message": error_message,
@@ -1128,10 +1128,12 @@ class Recovery(ApiResource):
             orgs_with_admins = []
             for org in orgs:
                 admin_users = model.organization.get_admin_users(org)
-                orgs_with_admins.append({
-                    "org_name": org.username,
-                    "admin_usernames": [u.username for u in admin_users],
-                })
+                orgs_with_admins.append(
+                    {
+                        "org_name": org.username,
+                        "admin_usernames": [u.username for u in admin_users],
+                    }
+                )
             send_combined_recovery_email(email, orgs_with_admins, reset_token=reset_token)
         elif is_personal_user:
             send_recovery_email(email, reset_token)

--- a/endpoints/test/test_webhooks.py
+++ b/endpoints/test/test_webhooks.py
@@ -1,9 +1,7 @@
 import base64
 import json
-from test.fixtures import *
 from unittest.mock import MagicMock, patch
 
-import pytest
 from flask import url_for
 
 from data import model
@@ -14,6 +12,7 @@ from data.model.organization import (
 )
 from data.model.user import get_user
 from endpoints.test.shared import conduct_call, gen_basic_auth
+from test.fixtures import *
 
 
 class TestStripeWebhookContactEmail:
@@ -33,9 +32,7 @@ class TestStripeWebhookContactEmail:
     @patch("endpoints.webhooks.stripe")
     def test_charge_succeeded_org_with_contact_email(self, mock_stripe, app, client):
         admin = get_user("devtable")
-        org = create_organization(
-            "chargeorg1", None, admin, contact_email="billing@example.com"
-        )
+        org = create_organization("chargeorg1", None, admin, contact_email="billing@example.com")
         org.invoice_email = True
         org.invoice_email_address = None
         org.stripe_id = "cust_charge1"
@@ -44,8 +41,12 @@ class TestStripeWebhookContactEmail:
         mock_invoice = MagicMock()
         mock_stripe.Invoice.retrieve.return_value = mock_invoice
 
-        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
-            with patch("endpoints.webhooks.renderInvoiceToHtml", return_value="<html>invoice</html>"):
+        with patch(
+            "endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org
+        ):
+            with patch(
+                "endpoints.webhooks.renderInvoiceToHtml", return_value="<html>invoice</html>"
+            ):
                 with patch("endpoints.webhooks.send_invoice_email") as mock_send:
                     resp = self._post_stripe_event(
                         client,
@@ -71,8 +72,12 @@ class TestStripeWebhookContactEmail:
         mock_invoice = MagicMock()
         mock_stripe.Invoice.retrieve.return_value = mock_invoice
 
-        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
-            with patch("endpoints.webhooks.renderInvoiceToHtml", return_value="<html>invoice</html>"):
+        with patch(
+            "endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org
+        ):
+            with patch(
+                "endpoints.webhooks.renderInvoiceToHtml", return_value="<html>invoice</html>"
+            ):
                 with patch("endpoints.webhooks.send_invoice_email") as mock_send:
                     resp = self._post_stripe_event(
                         client,
@@ -97,8 +102,12 @@ class TestStripeWebhookContactEmail:
         mock_invoice = MagicMock()
         mock_stripe.Invoice.retrieve.return_value = mock_invoice
 
-        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=user):
-            with patch("endpoints.webhooks.renderInvoiceToHtml", return_value="<html>invoice</html>"):
+        with patch(
+            "endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=user
+        ):
+            with patch(
+                "endpoints.webhooks.renderInvoiceToHtml", return_value="<html>invoice</html>"
+            ):
                 with patch("endpoints.webhooks.send_invoice_email") as mock_send:
                     resp = self._post_stripe_event(
                         client,
@@ -112,13 +121,13 @@ class TestStripeWebhookContactEmail:
 
     def test_subscription_created_org_with_contact_email(self, app, client):
         admin = get_user("devtable")
-        org = create_organization(
-            "suborg1", None, admin, contact_email="sub@example.com"
-        )
+        org = create_organization("suborg1", None, admin, contact_email="sub@example.com")
         org.stripe_id = "cust_sub1"
         org.save()
 
-        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+        with patch(
+            "endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org
+        ):
             with patch("endpoints.webhooks.send_subscription_change") as mock_send:
                 resp = self._post_stripe_event(
                     client,
@@ -137,7 +146,9 @@ class TestStripeWebhookContactEmail:
         org.stripe_id = "cust_sub2"
         org.save()
 
-        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+        with patch(
+            "endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org
+        ):
             with patch("endpoints.webhooks.send_subscription_change") as mock_send:
                 resp = self._post_stripe_event(
                     client,
@@ -152,13 +163,13 @@ class TestStripeWebhookContactEmail:
 
     def test_payment_failed_org_with_contact_email(self, app, client):
         admin = get_user("devtable")
-        org = create_organization(
-            "payorg1", None, admin, contact_email="pay@example.com"
-        )
+        org = create_organization("payorg1", None, admin, contact_email="pay@example.com")
         org.stripe_id = "cust_pay1"
         org.save()
 
-        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+        with patch(
+            "endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org
+        ):
             with patch("endpoints.webhooks.send_payment_failed") as mock_send:
                 resp = self._post_stripe_event(
                     client,
@@ -176,7 +187,9 @@ class TestStripeWebhookContactEmail:
         org.stripe_id = "cust_pay2"
         org.save()
 
-        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+        with patch(
+            "endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org
+        ):
             with patch("endpoints.webhooks.send_payment_failed") as mock_send:
                 resp = self._post_stripe_event(
                     client,
@@ -193,7 +206,9 @@ class TestStripeWebhookContactEmail:
     def test_payment_failed_personal_user(self, app, client):
         user = get_user("devtable")
 
-        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=user):
+        with patch(
+            "endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=user
+        ):
             with patch("endpoints.webhooks.send_payment_failed") as mock_send:
                 resp = self._post_stripe_event(
                     client,

--- a/endpoints/test/test_webhooks.py
+++ b/endpoints/test/test_webhooks.py
@@ -1,11 +1,209 @@
 import base64
+import json
 from test.fixtures import *
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import url_for
 
 from data import model
+from data.model.organization import (
+    create_organization,
+    get_contact_email,
+    set_contact_email,
+)
+from data.model.user import get_user
 from endpoints.test.shared import conduct_call, gen_basic_auth
+
+
+class TestStripeWebhookContactEmail:
+    """Tests for Stripe webhook handlers with organization contact email support."""
+
+    def _post_stripe_event(self, client, event_type, data, customer_id="cust_test"):
+        payload = {
+            "type": event_type,
+            "data": {"object": {"customer": customer_id, **data}},
+        }
+        return client.post(
+            "/webhooks/stripe",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+    @patch("endpoints.webhooks.stripe")
+    def test_charge_succeeded_org_with_contact_email(self, mock_stripe, app, client):
+        admin = get_user("devtable")
+        org = create_organization(
+            "chargeorg1", None, admin, contact_email="billing@example.com"
+        )
+        org.invoice_email = True
+        org.invoice_email_address = None
+        org.stripe_id = "cust_charge1"
+        org.save()
+
+        mock_invoice = MagicMock()
+        mock_stripe.Invoice.retrieve.return_value = mock_invoice
+
+        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+            with patch("endpoints.webhooks.renderInvoiceToHtml", return_value="<html>invoice</html>"):
+                with patch("endpoints.webhooks.send_invoice_email") as mock_send:
+                    resp = self._post_stripe_event(
+                        client,
+                        "charge.succeeded",
+                        {"invoice": "inv_123"},
+                        customer_id="cust_charge1",
+                    )
+
+        assert resp.status_code == 200
+        mock_send.assert_called_once_with("billing@example.com", "<html>invoice</html>")
+
+    @patch("endpoints.webhooks.stripe")
+    def test_charge_succeeded_org_no_contact_email_falls_back_to_admins(
+        self, mock_stripe, app, client
+    ):
+        admin = get_user("devtable")
+        org = create_organization("chargeorg2", None, admin)
+        org.invoice_email = True
+        org.invoice_email_address = None
+        org.stripe_id = "cust_charge2"
+        org.save()
+
+        mock_invoice = MagicMock()
+        mock_stripe.Invoice.retrieve.return_value = mock_invoice
+
+        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+            with patch("endpoints.webhooks.renderInvoiceToHtml", return_value="<html>invoice</html>"):
+                with patch("endpoints.webhooks.send_invoice_email") as mock_send:
+                    resp = self._post_stripe_event(
+                        client,
+                        "charge.succeeded",
+                        {"invoice": "inv_456"},
+                        customer_id="cust_charge2",
+                    )
+
+        assert resp.status_code == 200
+        assert mock_send.call_count >= 1
+        sent_emails = [call.args[0] for call in mock_send.call_args_list]
+        assert admin.email in sent_emails
+
+    @patch("endpoints.webhooks.stripe")
+    def test_charge_succeeded_personal_user(self, mock_stripe, app, client):
+        user = get_user("devtable")
+        user.invoice_email = True
+        user.invoice_email_address = "personal@example.com"
+        user.stripe_id = "cust_personal"
+        user.save()
+
+        mock_invoice = MagicMock()
+        mock_stripe.Invoice.retrieve.return_value = mock_invoice
+
+        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=user):
+            with patch("endpoints.webhooks.renderInvoiceToHtml", return_value="<html>invoice</html>"):
+                with patch("endpoints.webhooks.send_invoice_email") as mock_send:
+                    resp = self._post_stripe_event(
+                        client,
+                        "charge.succeeded",
+                        {"invoice": "inv_789"},
+                        customer_id="cust_personal",
+                    )
+
+        assert resp.status_code == 200
+        mock_send.assert_called_once_with("personal@example.com", "<html>invoice</html>")
+
+    def test_subscription_created_org_with_contact_email(self, app, client):
+        admin = get_user("devtable")
+        org = create_organization(
+            "suborg1", None, admin, contact_email="sub@example.com"
+        )
+        org.stripe_id = "cust_sub1"
+        org.save()
+
+        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+            with patch("endpoints.webhooks.send_subscription_change") as mock_send:
+                resp = self._post_stripe_event(
+                    client,
+                    "customer.subscription.created",
+                    {"plan": {"id": "plan_basic"}},
+                    customer_id="cust_sub1",
+                )
+
+        assert resp.status_code == 200
+        mock_send.assert_called_once()
+        assert mock_send.call_args[0][2] == "sub@example.com"
+
+    def test_subscription_created_org_no_contact_email(self, app, client):
+        admin = get_user("devtable")
+        org = create_organization("suborg2", None, admin)
+        org.stripe_id = "cust_sub2"
+        org.save()
+
+        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+            with patch("endpoints.webhooks.send_subscription_change") as mock_send:
+                resp = self._post_stripe_event(
+                    client,
+                    "customer.subscription.created",
+                    {"plan": {"id": "plan_basic"}},
+                    customer_id="cust_sub2",
+                )
+
+        assert resp.status_code == 200
+        mock_send.assert_called_once()
+        assert mock_send.call_args[0][2] == org.email
+
+    def test_payment_failed_org_with_contact_email(self, app, client):
+        admin = get_user("devtable")
+        org = create_organization(
+            "payorg1", None, admin, contact_email="pay@example.com"
+        )
+        org.stripe_id = "cust_pay1"
+        org.save()
+
+        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+            with patch("endpoints.webhooks.send_payment_failed") as mock_send:
+                resp = self._post_stripe_event(
+                    client,
+                    "invoice.payment_failed",
+                    {},
+                    customer_id="cust_pay1",
+                )
+
+        assert resp.status_code == 200
+        mock_send.assert_called_once_with("pay@example.com", org.username)
+
+    def test_payment_failed_org_no_contact_email_falls_back_to_admins(self, app, client):
+        admin = get_user("devtable")
+        org = create_organization("payorg2", None, admin)
+        org.stripe_id = "cust_pay2"
+        org.save()
+
+        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=org):
+            with patch("endpoints.webhooks.send_payment_failed") as mock_send:
+                resp = self._post_stripe_event(
+                    client,
+                    "invoice.payment_failed",
+                    {},
+                    customer_id="cust_pay2",
+                )
+
+        assert resp.status_code == 200
+        assert mock_send.call_count >= 1
+        sent_emails = [call.args[0] for call in mock_send.call_args_list]
+        assert admin.email in sent_emails
+
+    def test_payment_failed_personal_user(self, app, client):
+        user = get_user("devtable")
+
+        with patch("endpoints.webhooks.model.user.get_user_or_org_by_customer_id", return_value=user):
+            with patch("endpoints.webhooks.send_payment_failed") as mock_send:
+                resp = self._post_stripe_event(
+                    client,
+                    "invoice.payment_failed",
+                    {},
+                    customer_id="cust_personal2",
+                )
+
+        assert resp.status_code == 200
+        mock_send.assert_called_once_with(user.email, user.username)
 
 
 def test_start_build_disabled_trigger(app, client):

--- a/endpoints/webhooks.py
+++ b/endpoints/webhooks.py
@@ -14,6 +14,7 @@ from buildtrigger.triggerutil import (
 )
 from data import model
 from data.database import RepositoryState
+from data.model.organization import get_admin_users, get_contact_email
 from data.logs_model import logs_model
 from endpoints.building import (
     BuildTriggerDisabledException,
@@ -69,12 +70,20 @@ def stripe_webhook():
                 invoice = stripe.Invoice.retrieve(invoice_id)
                 if invoice:
                     invoice_html = renderInvoiceToHtml(invoice, namespace)
-                    send_invoice_email(
-                        namespace.invoice_email_address or namespace.email, invoice_html
-                    )
+                    recipient = namespace.invoice_email_address
+                    if not recipient and namespace.organization:
+                        recipient = get_contact_email(namespace)
+                        if not recipient:
+                            for admin in get_admin_users(namespace):
+                                if admin.email:
+                                    send_invoice_email(admin.email, invoice_html)
+                    if recipient:
+                        send_invoice_email(recipient, invoice_html)
 
     elif event_type.startswith("customer.subscription."):
         cust_email = namespace.email if namespace is not None else "unknown@domain.com"
+        if namespace and namespace.organization:
+            cust_email = get_contact_email(namespace) or cust_email
         quay_username = namespace.username if namespace is not None else "unknown"
 
         change_type = ""
@@ -98,7 +107,16 @@ def stripe_webhook():
 
     elif event_type == "invoice.payment_failed":
         if namespace:
-            send_payment_failed(namespace.email, namespace.username)
+            if namespace.organization:
+                contact = get_contact_email(namespace)
+                if contact:
+                    send_payment_failed(contact, namespace.username)
+                else:
+                    for admin in get_admin_users(namespace):
+                        if admin.email:
+                            send_payment_failed(admin.email, namespace.username)
+            else:
+                send_payment_failed(namespace.email, namespace.username)
 
     elif event_type == "checkout.session.completed":
         mode = request_data["data"]["object"]["mode"]

--- a/endpoints/webhooks.py
+++ b/endpoints/webhooks.py
@@ -14,8 +14,8 @@ from buildtrigger.triggerutil import (
 )
 from data import model
 from data.database import RepositoryState
-from data.model.organization import get_admin_users, get_contact_email
 from data.logs_model import logs_model
+from data.model.organization import get_admin_users, get_contact_email
 from endpoints.building import (
     BuildTriggerDisabledException,
     MaximumBuildsQueuedException,

--- a/plans/PROJQUAY-6975-handoff.md
+++ b/plans/PROJQUAY-6975-handoff.md
@@ -1,0 +1,263 @@
+# PROJQUAY-6975: Implementation Handoff Document
+
+**Epic:** PROJQUAY-6975 — Allow Single Email for Multiple Organizations
+**Branch:** `feat/projquay-6975-single-email-multiple-orgs`
+**Last updated:** 2026-06-14
+**Status:** Stories 1–6 complete, Story 7 (Playwright E2E tests) next
+
+---
+
+## What Has Been Done
+
+### Branch Setup
+
+- Created branch `feat/projquay-6975-single-email-multiple-orgs` from latest `origin/master` (commit `5ef6b0513`)
+- Cherry-picked and reorganized work from PR #6045 (`feat/projquay-10589-contact-email-crud`) into a clean Story 1 commit
+- PR #6045 should be abandoned — all epic work continues on this branch
+
+### Story 1: PROJQUAY-10589 — Backend CRUD + UUID Org Email (COMPLETE)
+
+**Commit:** `PROJQUAY-10589: feat(model): add contact_email CRUD and UUID org email`
+
+**Files changed:**
+- `data/model/organization.py` — Modified `create_organization()` + added 4 CRUD functions
+- `data/model/test/test_organization.py` — Added 3 test classes (14 new tests)
+
+**What was implemented:**
+1. `create_organization()` now generates a UUID for `User.email` and accepts optional `contact_email` parameter
+2. `effective_contact = contact_email or email` — backward compat: if caller passes `email` but no `contact_email`, the email is stored as contact_email
+3. `email_required` parameter kept in signature for backward compat with callers like `endpoints/v2/v2auth.py:352`
+4. Four new CRUD functions: `get_contact_email()`, `set_contact_email()`, `delete_contact_email()`, `find_organizations_by_contact_email()`
+
+**Tests:** All 30 tests pass (`TEST=true PYTHONPATH="." .venv/bin/python -m pytest data/model/test/test_organization.py -v`)
+
+**Note:** You may need to install `regex` in the venv first: `.venv/bin/pip install regex`
+
+### Story 2: PROJQUAY-10591 — API Endpoints (COMPLETE)
+
+**Commit:** `PROJQUAY-10591: feat(api): expose contact_email in organization endpoints`
+
+**Files changed:**
+- `endpoints/api/organization.py` — Modified `org_view()`, `NewOrg` schema, `OrganizationList.post()`, `UpdateOrg` schema, `Organization.put()`, `ApplicationInformation.get()`
+- `endpoints/api/test/test_organization.py` — Added `TestContactEmail` class (8 new tests)
+
+**What was implemented:**
+1. `org_view()` now returns `contact_email` from the model (admin-only); `email` field set to contact_email value for backward compat; internal UUID email never exposed
+2. `NewOrg` and `UpdateOrg` schemas updated with `contact_email` property
+3. `OrganizationList.post()` — removed `FEATURE_MAILING` email requirement; extracts `contact_email` (falling back to `email` field for backward compat); validates email format; passes `contact_email` to `create_organization()`
+4. `Organization.put()` — replaced old email update block (which had a uniqueness check on `User.email`) with `contact_email` upsert via `model.organization.set_contact_email()` — no uniqueness constraint, allows duplicate emails across orgs
+5. `ApplicationInformation.get()` — avatar email fallback now tries `contact_email` before the internal UUID email
+6. Audit log entries updated to use `contact_email` key
+
+**Tests:** All 21 tests pass (`TEST=true PYTHONPATH="." .venv/bin/python -m pytest endpoints/api/test/test_organization.py -v`), all 30 model tests still pass
+
+**Gotchas for next agent:**
+- The `or` operator precedence in `org_view()` line 124 (`contact_email or "" if (is_admin or can_view_as_superuser) else ""`) is intentional — Python evaluates it as `(contact_email or "") if condition else ""`, which is correct because when condition is True, it yields contact_email or empty string
+- `Organization.put()` now uses `or` to check both `contact_email` and `email` fields from the request body (`org_data.get("contact_email") or org_data.get("email")`), so old clients sending `email` still work
+
+### Story 3: PROJQUAY-10590 — Email Notification Routing (COMPLETE)
+
+**Commit:** `PROJQUAY-10590: feat(email): route notifications via contact_email`
+
+**Files changed:**
+- `util/useremails.py` — Modified `send_org_recovery_email()` to accept optional `contact_email` parameter; sends to contact_email if set, otherwise fans out to each admin
+- `endpoints/api/user.py` — Rewrote `Recovery.post()` with dual-lookup logic (user + org by contact_email)
+- `endpoints/webhooks.py` — Updated invoice, subscription, and payment-failed email routing to use `contact_email` with admin fallback for orgs
+- `web/src/routes/Signin/Signin.tsx` — Updated recovery success message to be generic
+- `util/test/test_useremails.py` — Added 3 tests for `send_org_recovery_email()`
+- `endpoints/api/test/test_user.py` — Added `TestRecoveryPost` class (5 tests)
+
+**What was implemented:**
+1. `Recovery.post()` now always does BOTH lookups: `find_user_by_email()` for personal users AND `find_organizations_by_contact_email()` for orgs — the same email can match both
+2. Always returns `{"status": "sent"}` regardless of matches — never leaks account existence
+3. Orgs found via `find_user_by_email()` are ignored (the `user.organization` check skips them); orgs are only handled via the contact_email lookup
+4. Billing webhooks (invoice, subscription, payment-failed) now route through `contact_email` with admin fallback for org namespaces
+5. Frontend recovery message updated to: "Recovery instructions have been sent to {email} for any accounts associated to the email."
+
+**Deviations from original implementation plan:**
+- **Always-both-lookups:** Original plan said do `find_user_by_email()` first, then only `find_organizations_by_contact_email()` if no user found. Revised to always do both, because the same email can be a personal user's email AND an org's contact_email.
+- **Always-return-sent:** Original plan returned `"org"` status for org matches. Revised to always return `"sent"` for security (no account existence leakage).
+- **Frontend message:** Updated to match the always-sent behavior. The `status === "org"` branch in Signin.tsx is now dead code (left for cleanup).
+- **Separate emails:** For now, personal user and org recovery send separate emails using existing templates. A unified single-email approach is deferred to Story 6 (PROJQUAY-11799).
+
+**Tests:** All 14 useremails tests pass, all 5 recovery endpoint tests pass
+
+### Story 4: PROJQUAY-10592 — React Create Organization Modal (COMPLETE)
+
+**Commit:** `PROJQUAY-10592: feat(ui): update create org modal with optional contact email`
+
+**Files changed:**
+- `web/src/resources/OrganizationResource.ts` — Added `contact_email` to `IOrganization` interface; updated `CreateOrgRequest` and `createOrg()` to use `contact_email` instead of `email`; added `contact_email` to `updateOrgSettingsParams`
+- `web/src/hooks/UseOrganizations.ts` — Renamed `email` parameter to `contactEmail` in `createOrganizationMutator` and exposed `createOrganization` function
+- `web/src/routes/OrganizationsList/CreateOrganizationModal.tsx` — Replaced mandatory "Organization Email" with optional "Contact Email (Optional)"; removed `mailingEnabled` gating and `useQuayConfig` dependency; renamed state `organizationEmail` → `contactEmail`; updated helper text; removed email from button disabled check
+
+**What was implemented:**
+1. Email field always visible (no longer gated by `FEATURE_MAILING`)
+2. Email field is optional — org can be created with just a name
+3. Label changed: "Organization Email" → "Contact Email (Optional)"
+4. Helper text: "Optional. Used for organization recovery and notifications."
+5. Form submits `contact_email` to the API (not `email`)
+6. `onInputBlur` clears validation error when field is emptied
+7. `IOrganization` interface extended with `contact_email?: string`
+8. `updateOrgSettingsParams` extended with `contact_email?: string` (prep for Story 5)
+
+**Type checks:** No TypeScript errors in modified files
+
+### Story 5: PROJQUAY-10593 — React Organization Settings (COMPLETE)
+
+**Commit:** `PROJQUAY-10593: feat(ui): update org settings to manage contact email`
+
+**Files changed:**
+- `web/src/routes/OrganizationsList/Organization/Tabs/Settings/GeneralSettings.tsx` — Email field now initializes from `contact_email`, label changed to "Contact Email" for orgs, helper text updated, validation allows empty, submit sends `contact_email`
+- `endpoints/api/organization.py` — Fixed `Organization.put()` to handle empty string for clearing contact_email (was treating `""` as falsy via Python `or` operator); uses `delete_contact_email()` when clearing
+- `endpoints/api/test/test_organization.py` — Added `test_clear_contact_email` test
+- `web/playwright/e2e/organization/settings.spec.ts` — Replaced "Duplicate Email on Update" test (obsolete — uniqueness constraint removed) with 4 new "Contact Email" tests: label/helper text verification, duplicate emails allowed, PUT payload verification, clearing email
+
+**What was implemented:**
+1. Email field initializes from `organization?.contact_email` instead of `organization?.email` (internal UUID hidden)
+2. Label changed: "Email" → "Contact Email" for organizations; user accounts unchanged
+3. Helper text for orgs: "Optional. Used for organization recovery and billing notifications."
+4. Validation: allows empty email (optional field), validates format only when non-empty
+5. Submit handler sends `contact_email` to the API instead of `email`
+6. Backend bugfix: `Organization.put()` now properly handles clearing contact_email by using `delete_contact_email()` when an empty string is sent, and uses explicit key presence check (`"contact_email" in org_data`) instead of Python `or` operator to avoid treating `""` as falsy
+
+**Tests:** All 22 API tests pass, all 30 model tests pass, 4 new Playwright E2E tests added
+
+### Story 6: PROJQUAY-11799 — Unified Recovery Email Template (COMPLETE)
+
+**Commit:** `PROJQUAY-11799: feat(email): unified recovery email for combined user + org scenarios`
+
+**Files changed:**
+- `emails/combinedrecovery.html` — New Jinja2 template with conditional org section (iterates over orgs with admin usernames) and conditional user section (password reset link when `reset_token` is present)
+- `util/useremails.py` — Added `send_combined_recovery_email(email, orgs_with_admins, reset_token=None)` function that sends a single combined email using the new template
+- `endpoints/api/user.py` — Updated `Recovery.post()` to build `orgs_with_admins` list and call `send_combined_recovery_email()` when orgs are found, with optional `reset_token` when a personal user also matches; falls back to `send_recovery_email()` when only a personal user matches
+- `util/test/test_useremails.py` — Added 2 parametrized template render tests for `combinedrecovery`, plus 4 dedicated tests: `test_send_combined_recovery_with_user_and_orgs`, `test_send_combined_recovery_orgs_only`, `test_render_combined_recovery_template`, `test_render_combined_recovery_template_no_reset`
+- `endpoints/api/test/test_user.py` — Updated all 5 existing `TestRecoveryPost` tests to use `send_combined_recovery_email` patches instead of `send_org_recovery_email`; added `test_recovery_multiple_orgs` test
+
+**What was implemented:**
+1. New `combinedrecovery.html` template that combines org recovery info (listing all matching orgs with their admin usernames) and optional password reset link into a single email
+2. `send_combined_recovery_email()` accepts a list of `{org_name, admin_usernames}` dicts and an optional `reset_token`; includes GmailAction metadata when a reset token is present
+3. `Recovery.post()` now consolidates all recovery information into a single email when orgs are found:
+   - **Orgs only:** Sends combined email with org section, no reset link
+   - **User + orgs:** Sends combined email with both org section and password reset link
+   - **User only:** Uses existing `recovery.html` template (unchanged)
+   - **No match:** Returns `{"status": "sent"}` silently (unchanged)
+4. The `send_org_recovery_email()` function is preserved for use by other callers (webhooks) but is no longer called from the recovery endpoint
+
+**Tests:** All 20 useremails tests pass, all 12 user endpoint tests pass
+
+---
+
+## What Needs to Be Done Next
+
+### Remaining Stories (in order)
+
+| Order | Story | JIRA | Status |
+|-------|-------|------|--------|
+| 1 | Backend CRUD + UUID org email | PROJQUAY-10589 | DONE |
+| 2 | API endpoints | PROJQUAY-10591 | DONE |
+| 3 | Email notification routing | PROJQUAY-10590 | DONE |
+| 4 | React Create Org modal | PROJQUAY-10592 | DONE |
+| 5 | React Org Settings | PROJQUAY-10593 | DONE |
+| 6 | Unified recovery email template | PROJQUAY-11799 | DONE |
+| 7 | Playwright E2E tests | — | **NEXT** |
+
+### Playwright Tests
+
+After all 6 stories are implemented, add Playwright E2E tests as a final commit. See the Playwright test plan for full details.
+
+---
+
+## Instructions for the Next Agent Session
+
+### Context
+
+You are implementing epic PROJQUAY-6975 (Allow Single Email for Multiple Organizations) for the Quay container registry. The work is organized as sequential stories, each committed separately on the same branch.
+
+### Plan Documents (READ THESE FIRST)
+
+1. **Implementation Plan:** `/Users/sridiptamisra/git/quay/plans/PROJQUAY-6975-implementation-plan.md`
+   - Contains full implementation details for all 5 stories
+   - Follow this plan STRICTLY for the story you are implementing
+   - Line numbers were validated on 2026-05-25 — verify before editing
+
+2. **Playwright Test Plan:** `/Users/sridiptamisra/git/quay/plans/PROJQUAY-6975-playwright-test-plan.md`
+   - E2E test specifications for Stories 4 and 5 + cross-cutting scenarios
+   - Implement as the final commit after all stories are done
+
+3. **Dev Team Workflow:** `/Users/sridiptamisra/git/quay/plans/dev-team-prompt.md`
+   - Use this workflow for implementation: classify, design team, present plan, execute, deliver
+
+### Workflow for Your Story
+
+1. **Read** this handoff document, the implementation plan (your story's section), and the dev-team workflow
+2. **Read** the relevant agent docs before coding:
+   - API work: `agent_docs/api.md`
+   - Database/model work: `agent_docs/database.md`
+   - Testing: `agent_docs/testing.md`
+   - React frontend: `web/AGENTS.md`
+3. **Verify** you are on branch `feat/projquay-6975-single-email-multiple-orgs`
+4. **Pull latest** if the branch has been pushed: `git pull`
+5. **Implement** your story following the implementation plan strictly
+6. **Run tests** as specified in the plan for your story
+7. **Commit** with message format: `PROJQUAY-XXXXX: type(scope): description`
+   - Include `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+8. **Update this handoff document:**
+   - Mark your story as DONE in the status table
+   - Update "What Has Been Done" with your story's details
+   - Set the next story as **NEXT**
+   - Update the "Last updated" date
+9. **Commit the updated handoff** as part of your story's commit (or as a separate small commit)
+
+### Branch & Commit Convention
+
+- **Branch:** `feat/projquay-6975-single-email-multiple-orgs` (already created, use it)
+- **Commit per story:** Each story = one commit with message `PROJQUAY-XXXXX: type(scope): description`
+- **Do NOT create separate branches per story** — all work goes on this single branch
+- **Do NOT push to `quay/quay` directly** — use the fork remote
+
+### Key Conventions (from AGENTS.md)
+
+- Follow existing import ordering patterns in each file
+- Use pre-commit hooks for formatting (run automatically on commit)
+- Never commit secrets or credentials
+- Use appropriate exception types from `endpoints/exception.py`
+- Every code change must include tests
+
+### Testing
+
+- Backend: `TEST=true PYTHONPATH="." .venv/bin/python -m pytest <test-file> -v`
+- Frontend: See `web/AGENTS.md`
+- You may need to install `regex` in venv: `.venv/bin/pip install regex`
+
+### Reference: PR #6045
+
+The original PR #6045 (`feat/projquay-10589-contact-email-crud`) contained partial implementations for Stories 2, 3, and 5 in addition to Story 1. These were NOT brought into the new branch — implement each story fresh from the plan. The PR can be referenced for context but the implementation plan is the source of truth.
+
+Key differences from the PR that were intentionally corrected:
+- `email_required` parameter was kept in `create_organization()` signature (PR removed it, but `v2auth.py` still passes it)
+- Only Story 1 model-layer changes were committed; API/email/frontend changes left for their respective stories
+
+---
+
+## Architecture Quick Reference
+
+```
+User table
+├── id
+├── username
+├── email (UNIQUE) ← auto-generated UUID for orgs (Story 1)
+└── organization (bool)
+
+OrganizationContactEmail table (already existed from PROJQUAY-10588)
+├── id
+├── organization_id (FK → User.id, UNIQUE) ← one-to-one
+└── contact_email (nullable, indexed, NOT unique) ← user-facing email
+
+Key functions (data/model/organization.py):
+├── create_organization(name, email, creating_user, email_required=True, is_possible_abuser=False, contact_email=None)
+├── get_contact_email(org) → str | None
+├── set_contact_email(org, contact_email) → OrganizationContactEmail
+├── delete_contact_email(org) → None
+└── find_organizations_by_contact_email(contact_email) → Query[User]
+```

--- a/plans/PROJQUAY-6975-handoff.md
+++ b/plans/PROJQUAY-6975-handoff.md
@@ -3,7 +3,7 @@
 **Epic:** PROJQUAY-6975 — Allow Single Email for Multiple Organizations
 **Branch:** `feat/projquay-6975-single-email-multiple-orgs`
 **Last updated:** 2026-06-14
-**Status:** Stories 1–6 complete, Story 7 (Playwright E2E tests) next
+**Status:** All 7 stories complete — ready for PR
 
 ---
 
@@ -146,11 +146,30 @@
 
 **Tests:** All 20 useremails tests pass, all 12 user endpoint tests pass
 
+### Story 7: PROJQUAY-6975 — Playwright E2E Tests (COMPLETE)
+
+**Commit:** `PROJQUAY-6975: test(e2e): add Playwright tests for contact email feature`
+
+**Files changed:**
+- `web/playwright/utils/api/client.ts` — Updated `createOrganization()` to send `contact_email` instead of `email`; added `getOrganization()` method
+- `web/playwright/fixtures.ts` — Updated `TestApi.organization()` to accept optional `contactEmail` parameter; added `contactEmail` to `CreatedOrg` interface
+- `web/playwright/e2e/organization/contact-email.spec.ts` — New test file with 5 test groups (15 tests): Create Org Modal, Org Settings, E2E Lifecycle, API Contract, Recovery Flow
+- `web/playwright/e2e/organization/org-list.spec.ts` — Removed `mailingEnabled` conditionals from CRUD lifecycle test; rewrote FEATURE_MAILING test to verify email is always visible and optional
+
+**What was implemented:**
+1. API client updated: `createOrganization()` sends `contact_email` (not `email`); body only includes `contact_email` when provided
+2. Fixtures updated: `TestApi.organization()` passes `contactEmail` through; `CreatedOrg` interface includes `contactEmail` field
+3. New `contact-email.spec.ts` with consolidated tests covering:
+   - **Group 1:** Create modal — field visibility, label, helper text, validation cycle, shared email
+   - **Group 2:** Settings — display, label, validation, update persistence, clear, shared email, user label regression
+   - **Group 3:** E2E lifecycle — create → settings → update → reload; create without email → add in settings; UUID never exposed
+   - **Group 4:** API contract — GET returns `contact_email`, backward compat with `email` field in POST, FEATURE_MAILING decoupled
+   - **Group 5:** Recovery — generic "sent" message for any email type (no info leak)
+4. Existing `org-list.spec.ts` updated: removed all `mailingEnabled`/`quayConfig` conditionals from CRUD lifecycle; rewrote FEATURE_MAILING test
+
 ---
 
-## What Needs to Be Done Next
-
-### Remaining Stories (in order)
+## All Stories Complete
 
 | Order | Story | JIRA | Status |
 |-------|-------|------|--------|
@@ -160,11 +179,9 @@
 | 4 | React Create Org modal | PROJQUAY-10592 | DONE |
 | 5 | React Org Settings | PROJQUAY-10593 | DONE |
 | 6 | Unified recovery email template | PROJQUAY-11799 | DONE |
-| 7 | Playwright E2E tests | — | **NEXT** |
+| 7 | Playwright E2E tests | PROJQUAY-6975 | DONE |
 
-### Playwright Tests
-
-After all 6 stories are implemented, add Playwright E2E tests as a final commit. See the Playwright test plan for full details.
+All implementation and testing is complete. Ready for PR creation and code review.
 
 ---
 

--- a/util/test/test_useremails.py
+++ b/util/test/test_useremails.py
@@ -3,7 +3,7 @@ from test.fixtures import *
 import mock
 import pytest
 
-from util.useremails import render_email, send_recovery_email
+from util.useremails import render_email, send_org_recovery_email, send_recovery_email
 
 
 def test_render_email():
@@ -109,3 +109,54 @@ def test_send_recovery_email(mock_send_email, initialized_db):
     mock_send_email.assert_called_once_with(
         email, subject, template_file, parameters, action=action
     )
+
+
+@mock.patch("util.useremails.send_email")
+def test_send_org_recovery_with_contact_email(mock_send_email, initialized_db):
+    org = mock.MagicMock()
+    org.username = "myorg"
+    admin1 = mock.MagicMock()
+    admin1.username = "admin1"
+    admin1.email = "admin1@example.com"
+
+    send_org_recovery_email(org, [admin1], contact_email="org@example.com")
+
+    mock_send_email.assert_called_once_with(
+        "org@example.com",
+        "Organization myorg recovery",
+        "orgrecovery",
+        {"organization": "myorg", "admin_usernames": ["admin1"]},
+    )
+
+
+@mock.patch("util.useremails.send_email")
+def test_send_org_recovery_without_contact_email(mock_send_email, initialized_db):
+    org = mock.MagicMock()
+    org.username = "myorg"
+    admin1 = mock.MagicMock()
+    admin1.username = "admin1"
+    admin1.email = "admin1@example.com"
+    admin2 = mock.MagicMock()
+    admin2.username = "admin2"
+    admin2.email = "admin2@example.com"
+
+    send_org_recovery_email(org, [admin1, admin2])
+
+    assert mock_send_email.call_count == 2
+    expected_params = {"organization": "myorg", "admin_usernames": ["admin1", "admin2"]}
+    mock_send_email.assert_any_call(
+        "admin1@example.com", "Organization myorg recovery", "orgrecovery", expected_params
+    )
+    mock_send_email.assert_any_call(
+        "admin2@example.com", "Organization myorg recovery", "orgrecovery", expected_params
+    )
+
+
+@mock.patch("util.useremails.send_email")
+def test_send_org_recovery_no_admins_no_email(mock_send_email, initialized_db):
+    org = mock.MagicMock()
+    org.username = "myorg"
+
+    send_org_recovery_email(org, [])
+
+    mock_send_email.assert_not_called()

--- a/util/test/test_useremails.py
+++ b/util/test/test_useremails.py
@@ -1,8 +1,7 @@
-from test.fixtures import *
-
 import mock
 import pytest
 
+from test.fixtures import *
 from util.useremails import (
     render_email,
     send_combined_recovery_email,

--- a/util/test/test_useremails.py
+++ b/util/test/test_useremails.py
@@ -3,7 +3,12 @@ from test.fixtures import *
 import mock
 import pytest
 
-from util.useremails import render_email, send_org_recovery_email, send_recovery_email
+from util.useremails import (
+    render_email,
+    send_combined_recovery_email,
+    send_org_recovery_email,
+    send_recovery_email,
+)
 
 
 def test_render_email():
@@ -69,6 +74,24 @@ def test_render_email():
             {
                 "email": "foo@example.com",
                 "token": "sometoken",
+            },
+        ),
+        (
+            "combinedrecovery",
+            {
+                "organizations": [
+                    {"org_name": "myorg", "admin_usernames": ["admin1", "admin2"]},
+                ],
+                "reset_token": "sometoken",
+            },
+        ),
+        (
+            "combinedrecovery",
+            {
+                "organizations": [
+                    {"org_name": "myorg", "admin_usernames": ["admin1"]},
+                ],
+                "reset_token": None,
             },
         ),
         (
@@ -160,3 +183,82 @@ def test_send_org_recovery_no_admins_no_email(mock_send_email, initialized_db):
     send_org_recovery_email(org, [])
 
     mock_send_email.assert_not_called()
+
+
+@mock.patch("util.useremails.send_email")
+def test_send_combined_recovery_with_user_and_orgs(mock_send_email, initialized_db):
+    orgs_with_admins = [
+        {"org_name": "org1", "admin_usernames": ["admin1"]},
+        {"org_name": "org2", "admin_usernames": ["admin2", "admin3"]},
+    ]
+
+    send_combined_recovery_email("shared@example.com", orgs_with_admins, reset_token="token123")
+
+    mock_send_email.assert_called_once_with(
+        "shared@example.com",
+        "Account recovery",
+        "combinedrecovery",
+        {"organizations": orgs_with_admins, "reset_token": "token123"},
+        action=mock.ANY,
+    )
+
+
+@mock.patch("util.useremails.send_email")
+def test_send_combined_recovery_orgs_only(mock_send_email, initialized_db):
+    orgs_with_admins = [
+        {"org_name": "org1", "admin_usernames": ["admin1"]},
+    ]
+
+    send_combined_recovery_email("org@example.com", orgs_with_admins)
+
+    mock_send_email.assert_called_once_with(
+        "org@example.com",
+        "Account recovery",
+        "combinedrecovery",
+        {"organizations": orgs_with_admins, "reset_token": None},
+        action=None,
+    )
+
+
+def test_render_combined_recovery_template(initialized_db):
+    orgs_with_admins = [
+        {"org_name": "org1", "admin_usernames": ["admin1", "admin2"]},
+        {"org_name": "org2", "admin_usernames": ["admin3"]},
+    ]
+
+    html, plain = render_email(
+        "Test App",
+        "test.quay",
+        "foo@example.com",
+        "Account recovery",
+        "combinedrecovery",
+        {"organizations": orgs_with_admins, "reset_token": "testtoken"},
+    )
+
+    assert "org1" in html
+    assert "org2" in html
+    assert "admin1" in html
+    assert "admin3" in html
+    assert "testtoken" in html
+    assert "Recover Account" in html
+    assert "Login to Recover" in html
+
+
+def test_render_combined_recovery_template_no_reset(initialized_db):
+    orgs_with_admins = [
+        {"org_name": "myorg", "admin_usernames": ["admin1"]},
+    ]
+
+    html, plain = render_email(
+        "Test App",
+        "test.quay",
+        "foo@example.com",
+        "Account recovery",
+        "combinedrecovery",
+        {"organizations": orgs_with_admins, "reset_token": None},
+    )
+
+    assert "myorg" in html
+    assert "admin1" in html
+    assert "Login to Recover" in html
+    assert "Recover Account" not in html

--- a/util/useremails.py
+++ b/util/useremails.py
@@ -180,6 +180,20 @@ def send_org_recovery_email(org, admin_users, contact_email=None):
                 send_email(admin.email, subject, "orgrecovery", params)
 
 
+def send_combined_recovery_email(email, orgs_with_admins, reset_token=None):
+    subject = "Account recovery"
+    params = {
+        "organizations": orgs_with_admins,
+        "reset_token": reset_token,
+    }
+    action = None
+    if reset_token:
+        action = GmailAction.view(
+            "Recover Account", "recovery?code=" + reset_token, "Recovery of an account"
+        )
+    send_email(email, subject, "combinedrecovery", params, action=action)
+
+
 def send_recovery_email(email, token):
     action = GmailAction.view("Recover Account", "recovery?code=" + token, "Recovery of an account")
 

--- a/util/useremails.py
+++ b/util/useremails.py
@@ -167,17 +167,17 @@ def send_repo_authorization_email(namespace, repository, email, token):
     )
 
 
-def send_org_recovery_email(org, admin_users):
+def send_org_recovery_email(org, admin_users, contact_email=None):
     subject = "Organization %s recovery" % (org.username)
-    send_email(
-        org.email,
-        subject,
-        "orgrecovery",
-        {
-            "organization": org.username,
-            "admin_usernames": [user.username for user in admin_users],
-        },
-    )
+    admin_usernames = [u.username for u in admin_users]
+    params = {"organization": org.username, "admin_usernames": admin_usernames}
+
+    if contact_email:
+        send_email(contact_email, subject, "orgrecovery", params)
+    else:
+        for admin in admin_users:
+            if admin.email:
+                send_email(admin.email, subject, "orgrecovery", params)
 
 
 def send_recovery_email(email, token):

--- a/web/playwright/e2e/auth/signin.spec.ts
+++ b/web/playwright/e2e/auth/signin.spec.ts
@@ -310,9 +310,7 @@ test.describe(
       await unauthenticatedPage.getByTestId('signin-send-recovery').click();
 
       await expect(
-        unauthenticatedPage.getByText(
-          /Instructions on how to reset your password/i,
-        ),
+        unauthenticatedPage.getByText(/Recovery instructions have been sent/i),
       ).toBeVisible();
     });
 
@@ -332,13 +330,9 @@ test.describe(
         .fill(org.email);
       await unauthenticatedPage.getByTestId('signin-send-recovery').click();
 
-      // Real API returns org response with admin info
+      // Unified recovery endpoint returns 'sent' for all cases
       await expect(
-        unauthenticatedPage.getByText(/assigned to organization/i),
-      ).toBeVisible();
-      // Org name appears in email (twice), verify at least one is visible
-      await expect(
-        unauthenticatedPage.getByText(org.name).first(),
+        unauthenticatedPage.getByText(/Recovery instructions have been sent/i),
       ).toBeVisible();
     });
   },

--- a/web/playwright/e2e/organization/contact-email.spec.ts
+++ b/web/playwright/e2e/organization/contact-email.spec.ts
@@ -349,7 +349,9 @@ test.describe(
           expect(body).toHaveProperty('contact_email');
 
           await expect(
-            authenticatedPage.getByText('Successfully updated settings').first(),
+            authenticatedPage
+              .getByText('Successfully updated settings')
+              .first(),
           ).toBeVisible();
 
           // Reload and verify persistence
@@ -376,7 +378,9 @@ test.describe(
           await emailInput.clear();
           await authenticatedPage.locator('#save-org-settings').click();
           await expect(
-            authenticatedPage.getByText('Successfully updated settings').first(),
+            authenticatedPage
+              .getByText('Successfully updated settings')
+              .first(),
           ).toBeVisible();
 
           await authenticatedPage.reload();
@@ -402,7 +406,9 @@ test.describe(
           await authenticatedPage.locator('#save-org-settings').click();
 
           await expect(
-            authenticatedPage.getByText('Successfully updated settings').first(),
+            authenticatedPage
+              .getByText('Successfully updated settings')
+              .first(),
           ).toBeVisible();
         });
 
@@ -424,143 +430,122 @@ test.describe(
     // Group 3: End-to-End Lifecycle Flows
     // =========================================================================
 
-    test.describe(
-      'Contact Email — E2E Lifecycle',
-      {tag: ['@critical']},
-      () => {
-        test('create org with contact email → verify in settings → update → verify persistence', async ({
-          authenticatedPage,
-          api,
-        }) => {
-          await authenticatedPage.goto('/organization');
+    test.describe('Contact Email — E2E Lifecycle', {tag: ['@critical']}, () => {
+      test('create org with contact email → verify in settings → update → verify persistence', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        await authenticatedPage.goto('/organization');
 
-          const orgName = uniqueName('lifecycle');
-          const initialEmail = `${orgName}@example.com`;
-          const updatedEmail = `updated-${orgName}@example.com`;
+        const orgName = uniqueName('lifecycle');
+        const initialEmail = `${orgName}@example.com`;
+        const updatedEmail = `updated-${orgName}@example.com`;
 
-          // Create org with contact email via UI
-          await authenticatedPage
-            .locator('#create-organization-button')
-            .click();
-          await authenticatedPage
-            .locator('#create-org-name-input')
-            .fill(orgName);
-          await authenticatedPage
-            .locator('#create-org-email-input')
-            .fill(initialEmail);
+        // Create org with contact email via UI
+        await authenticatedPage.locator('#create-organization-button').click();
+        await authenticatedPage.locator('#create-org-name-input').fill(orgName);
+        await authenticatedPage
+          .locator('#create-org-email-input')
+          .fill(initialEmail);
 
-          await Promise.all([
-            authenticatedPage.waitForResponse(
-              (resp) =>
-                resp.url().includes('/api/v1/organization/') &&
-                resp.request().method() === 'POST' &&
-                resp.status() === 201,
-            ),
-            authenticatedPage.locator('#create-org-confirm').click(),
-          ]);
+        await Promise.all([
+          authenticatedPage.waitForResponse(
+            (resp) =>
+              resp.url().includes('/api/v1/organization/') &&
+              resp.request().method() === 'POST' &&
+              resp.status() === 201,
+          ),
+          authenticatedPage.locator('#create-org-confirm').click(),
+        ]);
 
-          await expect(
-            authenticatedPage.locator('#create-org-cancel'),
-          ).not.toBeVisible({timeout: 10000});
+        await expect(
+          authenticatedPage.locator('#create-org-cancel'),
+        ).not.toBeVisible({timeout: 10000});
 
-          // Navigate to settings and verify email appears
-          await authenticatedPage.goto(
-            `/organization/${orgName}?tab=Settings`,
-          );
-          const emailInput = authenticatedPage.locator('#org-settings-email');
-          await expect(emailInput).toHaveValue(initialEmail);
+        // Navigate to settings and verify email appears
+        await authenticatedPage.goto(`/organization/${orgName}?tab=Settings`);
+        const emailInput = authenticatedPage.locator('#org-settings-email');
+        await expect(emailInput).toHaveValue(initialEmail);
 
-          // Update the email
-          await emailInput.clear();
-          await emailInput.fill(updatedEmail);
-          await authenticatedPage.locator('#save-org-settings').click();
-          await expect(
-            authenticatedPage.getByText('Successfully updated settings').first(),
-          ).toBeVisible();
+        // Update the email
+        await emailInput.clear();
+        await emailInput.fill(updatedEmail);
+        await authenticatedPage.locator('#save-org-settings').click();
+        await expect(
+          authenticatedPage.getByText('Successfully updated settings').first(),
+        ).toBeVisible();
 
-          // Reload and verify persistence
-          await authenticatedPage.reload();
-          await expect(emailInput).toHaveValue(updatedEmail);
+        // Reload and verify persistence
+        await authenticatedPage.reload();
+        await expect(emailInput).toHaveValue(updatedEmail);
 
-          // Clean up
-          await api.raw.deleteOrganization(orgName);
-        });
+        // Clean up
+        await api.raw.deleteOrganization(orgName);
+      });
 
-        test('create org without email → add email in settings → verify', async ({
-          authenticatedPage,
-          api,
-        }) => {
-          await authenticatedPage.goto('/organization');
+      test('create org without email → add email in settings → verify', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        await authenticatedPage.goto('/organization');
 
-          const orgName = uniqueName('noemailset');
-          const addedEmail = `added-${orgName}@example.com`;
+        const orgName = uniqueName('noemailset');
+        const addedEmail = `added-${orgName}@example.com`;
 
-          // Create org without email
-          await authenticatedPage
-            .locator('#create-organization-button')
-            .click();
-          await authenticatedPage
-            .locator('#create-org-name-input')
-            .fill(orgName);
+        // Create org without email
+        await authenticatedPage.locator('#create-organization-button').click();
+        await authenticatedPage.locator('#create-org-name-input').fill(orgName);
 
-          await Promise.all([
-            authenticatedPage.waitForResponse(
-              (resp) =>
-                resp.url().includes('/api/v1/organization/') &&
-                resp.request().method() === 'POST' &&
-                resp.status() === 201,
-            ),
-            authenticatedPage.locator('#create-org-confirm').click(),
-          ]);
+        await Promise.all([
+          authenticatedPage.waitForResponse(
+            (resp) =>
+              resp.url().includes('/api/v1/organization/') &&
+              resp.request().method() === 'POST' &&
+              resp.status() === 201,
+          ),
+          authenticatedPage.locator('#create-org-confirm').click(),
+        ]);
 
-          await expect(
-            authenticatedPage.locator('#create-org-cancel'),
-          ).not.toBeVisible({timeout: 10000});
+        await expect(
+          authenticatedPage.locator('#create-org-cancel'),
+        ).not.toBeVisible({timeout: 10000});
 
-          // Go to settings — email should be empty
-          await authenticatedPage.goto(
-            `/organization/${orgName}?tab=Settings`,
-          );
-          const emailInput = authenticatedPage.locator('#org-settings-email');
-          await expect(emailInput).toHaveValue('');
+        // Go to settings — email should be empty
+        await authenticatedPage.goto(`/organization/${orgName}?tab=Settings`);
+        const emailInput = authenticatedPage.locator('#org-settings-email');
+        await expect(emailInput).toHaveValue('');
 
-          // Add email and save
-          await emailInput.fill(addedEmail);
-          await authenticatedPage.locator('#save-org-settings').click();
-          await expect(
-            authenticatedPage.getByText('Successfully updated settings').first(),
-          ).toBeVisible();
+        // Add email and save
+        await emailInput.fill(addedEmail);
+        await authenticatedPage.locator('#save-org-settings').click();
+        await expect(
+          authenticatedPage.getByText('Successfully updated settings').first(),
+        ).toBeVisible();
 
-          // Reload and verify persistence
-          await authenticatedPage.reload();
-          await expect(emailInput).toHaveValue(addedEmail);
+        // Reload and verify persistence
+        await authenticatedPage.reload();
+        await expect(emailInput).toHaveValue(addedEmail);
 
-          // Clean up
-          await api.raw.deleteOrganization(orgName);
-        });
+        // Clean up
+        await api.raw.deleteOrganization(orgName);
+      });
 
-        test('internal UUID email is never exposed in the UI', async ({
-          authenticatedPage,
-          api,
-        }) => {
-          const org = await api.organization(
-            'uuidcheck',
-            'visible@example.com',
-          );
+      test('internal UUID email is never exposed in the UI', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const org = await api.organization('uuidcheck', 'visible@example.com');
 
-          // Check settings page
-          await authenticatedPage.goto(
-            `/organization/${org.name}?tab=Settings`,
-          );
-          const emailInput = authenticatedPage.locator('#org-settings-email');
-          await expect(emailInput).toBeVisible();
+        // Check settings page
+        await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
+        const emailInput = authenticatedPage.locator('#org-settings-email');
+        await expect(emailInput).toBeVisible();
 
-          const value = await emailInput.inputValue();
-          expect(value).not.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
-          expect(value).toBe('visible@example.com');
-        });
-      },
-    );
+        const value = await emailInput.inputValue();
+        expect(value).not.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+        expect(value).toBe('visible@example.com');
+      });
+    });
 
     // =========================================================================
     // Group 4: API Contract Verification
@@ -590,9 +575,7 @@ test.describe(
 
         // POST with old-style `email` field (not contact_email)
         const token = await (async () => {
-          const resp = await authenticatedRequest.get(
-            `${API_URL}/csrf_token`,
-          );
+          const resp = await authenticatedRequest.get(`${API_URL}/csrf_token`);
           const data = await resp.json();
           return data.csrf_token;
         })();
@@ -631,12 +614,8 @@ test.describe(
 
         const orgName = uniqueName('nomailing');
 
-        await authenticatedPage
-          .locator('#create-organization-button')
-          .click();
-        await authenticatedPage
-          .locator('#create-org-name-input')
-          .fill(orgName);
+        await authenticatedPage.locator('#create-organization-button').click();
+        await authenticatedPage.locator('#create-org-name-input').fill(orgName);
 
         // Leave email empty — should still be able to create
         await expect(

--- a/web/playwright/e2e/organization/contact-email.spec.ts
+++ b/web/playwright/e2e/organization/contact-email.spec.ts
@@ -1,0 +1,729 @@
+import {test, expect, uniqueName} from '../../fixtures';
+import {TEST_USERS} from '../../global-setup';
+import {API_URL} from '../../utils/config';
+
+test.describe(
+  'Contact Email for Organizations',
+  {tag: ['@organization', '@PROJQUAY-6975']},
+  () => {
+    // =========================================================================
+    // Group 1: Create Organization Modal — Contact Email
+    // =========================================================================
+
+    test.describe(
+      'Create Organization Modal — Contact Email',
+      {tag: ['@PROJQUAY-10592']},
+      () => {
+        test('field is always visible with correct label and helper text', async ({
+          authenticatedPage,
+        }) => {
+          await authenticatedPage.goto('/organization');
+          await authenticatedPage
+            .locator('#create-organization-button')
+            .click();
+
+          // Field always visible regardless of FEATURE_MAILING
+          const emailInput = authenticatedPage.locator(
+            '#create-org-email-input',
+          );
+          await expect(emailInput).toBeVisible();
+
+          // Label is "Contact Email (Optional)"
+          await expect(
+            authenticatedPage.getByText('Contact Email (Optional)'),
+          ).toBeVisible();
+
+          // Helper text describes purpose
+          await expect(
+            authenticatedPage.getByText(
+              'Optional. Used for organization recovery and notifications.',
+            ),
+          ).toBeVisible();
+
+          await authenticatedPage.locator('#create-org-cancel').click();
+        });
+
+        test('creates org with only a name (no email)', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          await authenticatedPage.goto('/organization');
+
+          const orgName = uniqueName('noemail');
+          await authenticatedPage
+            .locator('#create-organization-button')
+            .click();
+          await authenticatedPage
+            .locator('#create-org-name-input')
+            .fill(orgName);
+
+          // Email field should be empty and Create button should be enabled
+          await expect(
+            authenticatedPage.locator('#create-org-email-input'),
+          ).toHaveValue('');
+          await expect(
+            authenticatedPage.locator('#create-org-confirm'),
+          ).toBeEnabled();
+
+          // Create and wait for API response
+          const [response] = await Promise.all([
+            authenticatedPage.waitForResponse(
+              (resp) =>
+                resp.url().includes('/api/v1/organization/') &&
+                resp.request().method() === 'POST',
+            ),
+            authenticatedPage.locator('#create-org-confirm').click(),
+          ]);
+
+          expect(response.status()).toBe(201);
+
+          // Modal closes on success
+          await expect(
+            authenticatedPage.locator('#create-org-cancel'),
+          ).not.toBeVisible({timeout: 10000});
+
+          await expect(
+            authenticatedPage.getByText(
+              `Successfully created organization ${orgName}`,
+            ),
+          ).toBeVisible();
+
+          // Clean up
+          await api.raw.deleteOrganization(orgName);
+        });
+
+        test('creates org with name and contact email (sends contact_email in POST)', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          await authenticatedPage.goto('/organization');
+
+          const orgName = uniqueName('withemail');
+          const email = `${orgName}@example.com`;
+          await authenticatedPage
+            .locator('#create-organization-button')
+            .click();
+          await authenticatedPage
+            .locator('#create-org-name-input')
+            .fill(orgName);
+          await authenticatedPage
+            .locator('#create-org-email-input')
+            .fill(email);
+
+          // Intercept POST to verify payload
+          const [request] = await Promise.all([
+            authenticatedPage.waitForRequest(
+              (req) =>
+                req.url().includes('/api/v1/organization/') &&
+                req.method() === 'POST',
+            ),
+            authenticatedPage.locator('#create-org-confirm').click(),
+          ]);
+
+          const body = request.postDataJSON();
+          expect(body).toHaveProperty('contact_email', email);
+          expect(body).not.toHaveProperty('email');
+
+          await expect(
+            authenticatedPage.locator('#create-org-cancel'),
+          ).not.toBeVisible({timeout: 10000});
+
+          await expect(
+            authenticatedPage.getByText(
+              `Successfully created organization ${orgName}`,
+            ),
+          ).toBeVisible();
+
+          // Clean up
+          await api.raw.deleteOrganization(orgName);
+        });
+
+        test('validates email format: invalid → error → clear → no error', async ({
+          authenticatedPage,
+        }) => {
+          await authenticatedPage.goto('/organization');
+          await authenticatedPage
+            .locator('#create-organization-button')
+            .click();
+
+          await authenticatedPage
+            .locator('#create-org-name-input')
+            .fill('validname');
+
+          // Type invalid email
+          const emailInput = authenticatedPage.locator(
+            '#create-org-email-input',
+          );
+          await emailInput.fill('not-an-email');
+          await authenticatedPage.locator('#create-org-name-input').click(); // blur
+
+          await expect(
+            authenticatedPage.getByText(
+              'Enter a valid email: email@provider.com',
+            ),
+          ).toBeVisible();
+          await expect(
+            authenticatedPage.locator('#create-org-confirm'),
+          ).toBeDisabled();
+
+          // Clear email — error should disappear, button enabled (email optional)
+          await emailInput.clear();
+          await authenticatedPage.locator('#create-org-name-input').click(); // blur
+
+          await expect(
+            authenticatedPage.getByText(
+              'Enter a valid email: email@provider.com',
+            ),
+          ).not.toBeVisible();
+          await expect(
+            authenticatedPage.locator('#create-org-confirm'),
+          ).toBeEnabled();
+
+          await authenticatedPage.locator('#create-org-cancel').click();
+        });
+
+        test('two orgs can share the same contact email', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          await authenticatedPage.goto('/organization');
+
+          const sharedEmail = `shared-${Date.now()}@example.com`;
+
+          // Create first org
+          const orgName1 = uniqueName('shared');
+          await authenticatedPage
+            .locator('#create-organization-button')
+            .click();
+          await authenticatedPage
+            .locator('#create-org-name-input')
+            .fill(orgName1);
+          await authenticatedPage
+            .locator('#create-org-email-input')
+            .fill(sharedEmail);
+
+          const [resp1] = await Promise.all([
+            authenticatedPage.waitForResponse(
+              (resp) =>
+                resp.url().includes('/api/v1/organization/') &&
+                resp.request().method() === 'POST',
+            ),
+            authenticatedPage.locator('#create-org-confirm').click(),
+          ]);
+          expect(resp1.status()).toBe(201);
+          await expect(
+            authenticatedPage.locator('#create-org-cancel'),
+          ).not.toBeVisible({timeout: 10000});
+
+          // Create second org with same email
+          const orgName2 = uniqueName('shared');
+          await authenticatedPage
+            .locator('#create-organization-button')
+            .click();
+          await authenticatedPage
+            .locator('#create-org-name-input')
+            .fill(orgName2);
+          await authenticatedPage
+            .locator('#create-org-email-input')
+            .fill(sharedEmail);
+
+          const [resp2] = await Promise.all([
+            authenticatedPage.waitForResponse(
+              (resp) =>
+                resp.url().includes('/api/v1/organization/') &&
+                resp.request().method() === 'POST',
+            ),
+            authenticatedPage.locator('#create-org-confirm').click(),
+          ]);
+          expect(resp2.status()).toBe(201);
+          await expect(
+            authenticatedPage.locator('#create-org-cancel'),
+          ).not.toBeVisible({timeout: 10000});
+
+          // Clean up
+          await api.raw.deleteOrganization(orgName1);
+          await api.raw.deleteOrganization(orgName2);
+        });
+      },
+    );
+
+    // =========================================================================
+    // Group 2: Organization Settings — Contact Email Management
+    // =========================================================================
+
+    test.describe(
+      'Organization Settings — Contact Email',
+      {tag: ['@PROJQUAY-10593']},
+      () => {
+        test('displays contact email in settings (not UUID)', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          const contactEmail = 'org-display@example.com';
+          const org = await api.organization('display', contactEmail);
+
+          await authenticatedPage.goto(
+            `/organization/${org.name}?tab=Settings`,
+          );
+
+          const emailInput = authenticatedPage.locator('#org-settings-email');
+          await expect(emailInput).toBeVisible();
+          await expect(emailInput).toHaveValue(contactEmail);
+
+          // Verify it's NOT a UUID
+          const value = await emailInput.inputValue();
+          expect(value).not.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+        });
+
+        test('shows "Contact Email" label for orgs, validates, and shows helper text', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          const org = await api.organization('labelvld');
+
+          await authenticatedPage.goto(
+            `/organization/${org.name}?tab=Settings`,
+          );
+
+          // Label is "Contact Email" for orgs
+          await expect(
+            authenticatedPage.getByText('Contact Email'),
+          ).toBeVisible();
+
+          // Helper text
+          await expect(
+            authenticatedPage.getByText(
+              'Optional. Used for organization recovery and billing notifications.',
+            ),
+          ).toBeVisible();
+
+          // Validation: type invalid email
+          const emailInput = authenticatedPage.locator('#org-settings-email');
+          await emailInput.clear();
+          await emailInput.fill('invalid-email');
+
+          await expect(
+            authenticatedPage.getByText('Please enter a valid email address'),
+          ).toBeVisible();
+
+          const saveButton = authenticatedPage.locator('#save-org-settings');
+          await expect(saveButton).toBeDisabled();
+
+          // Type valid email — error clears, save enabled
+          await emailInput.clear();
+          await emailInput.fill('valid@example.com');
+          await expect(
+            authenticatedPage.getByText('Please enter a valid email address'),
+          ).not.toBeVisible();
+          await expect(saveButton).toBeEnabled();
+        });
+
+        test('updates contact email and persists after reload', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          const org = await api.organization('update');
+
+          await authenticatedPage.goto(
+            `/organization/${org.name}?tab=Settings`,
+          );
+
+          const emailInput = authenticatedPage.locator('#org-settings-email');
+          await expect(emailInput).toBeVisible();
+
+          const newEmail = 'updated@example.com';
+          await emailInput.clear();
+          await emailInput.fill(newEmail);
+
+          // Verify PUT sends contact_email
+          const putPromise = authenticatedPage.waitForRequest(
+            (req) =>
+              req.url().includes(`/api/v1/organization/${org.name}`) &&
+              req.method() === 'PUT',
+          );
+
+          await authenticatedPage.locator('#save-org-settings').click();
+
+          const putRequest = await putPromise;
+          const body = putRequest.postDataJSON();
+          expect(body).toHaveProperty('contact_email');
+
+          await expect(
+            authenticatedPage.getByText('Successfully updated settings').first(),
+          ).toBeVisible();
+
+          // Reload and verify persistence
+          await authenticatedPage.reload();
+          await expect(emailInput).toHaveValue(newEmail);
+        });
+
+        test('clears contact email (sets to empty)', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          const org = await api.organization(
+            'clremail',
+            'to-be-cleared@example.com',
+          );
+
+          await authenticatedPage.goto(
+            `/organization/${org.name}?tab=Settings`,
+          );
+
+          const emailInput = authenticatedPage.locator('#org-settings-email');
+          await expect(emailInput).toHaveValue('to-be-cleared@example.com');
+
+          await emailInput.clear();
+          await authenticatedPage.locator('#save-org-settings').click();
+          await expect(
+            authenticatedPage.getByText('Successfully updated settings').first(),
+          ).toBeVisible();
+
+          await authenticatedPage.reload();
+          await expect(emailInput).toHaveValue('');
+        });
+
+        test('allows same email as another org in settings', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          const sharedEmail = 'settings-shared@company.com';
+          const org1 = await api.organization('shset1', sharedEmail);
+          const org2 = await api.organization('shset2');
+
+          await authenticatedPage.goto(
+            `/organization/${org2.name}?tab=Settings`,
+          );
+
+          const emailInput = authenticatedPage.locator('#org-settings-email');
+          await expect(emailInput).toBeVisible();
+          await emailInput.clear();
+          await emailInput.fill(sharedEmail);
+          await authenticatedPage.locator('#save-org-settings').click();
+
+          await expect(
+            authenticatedPage.getByText('Successfully updated settings').first(),
+          ).toBeVisible();
+        });
+
+        test('user account settings still show "Email" label', async ({
+          authenticatedPage,
+        }) => {
+          const username = TEST_USERS.user.username;
+          await authenticatedPage.goto(`/user/${username}?tab=Settings`);
+
+          // Label should be "Email", not "Contact Email"
+          const emailLabel = authenticatedPage
+            .locator('label[for="org-settings-email"]')
+            .or(authenticatedPage.locator('.pf-v6-c-form__label').filter({hasText: 'Email'}));
+
+          // The page may show email as a link (FEATURE_MAILING) or as a text input
+          // Either way, "Contact Email" should NOT be present
+          await expect(
+            authenticatedPage.getByText('Contact Email'),
+          ).not.toBeVisible();
+        });
+      },
+    );
+
+    // =========================================================================
+    // Group 3: End-to-End Lifecycle Flows
+    // =========================================================================
+
+    test.describe(
+      'Contact Email — E2E Lifecycle',
+      {tag: ['@critical']},
+      () => {
+        test('create org with contact email → verify in settings → update → verify persistence', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          await authenticatedPage.goto('/organization');
+
+          const orgName = uniqueName('lifecycle');
+          const initialEmail = `${orgName}@example.com`;
+          const updatedEmail = `updated-${orgName}@example.com`;
+
+          // Create org with contact email via UI
+          await authenticatedPage
+            .locator('#create-organization-button')
+            .click();
+          await authenticatedPage
+            .locator('#create-org-name-input')
+            .fill(orgName);
+          await authenticatedPage
+            .locator('#create-org-email-input')
+            .fill(initialEmail);
+
+          await Promise.all([
+            authenticatedPage.waitForResponse(
+              (resp) =>
+                resp.url().includes('/api/v1/organization/') &&
+                resp.request().method() === 'POST' &&
+                resp.status() === 201,
+            ),
+            authenticatedPage.locator('#create-org-confirm').click(),
+          ]);
+
+          await expect(
+            authenticatedPage.locator('#create-org-cancel'),
+          ).not.toBeVisible({timeout: 10000});
+
+          // Navigate to settings and verify email appears
+          await authenticatedPage.goto(
+            `/organization/${orgName}?tab=Settings`,
+          );
+          const emailInput = authenticatedPage.locator('#org-settings-email');
+          await expect(emailInput).toHaveValue(initialEmail);
+
+          // Update the email
+          await emailInput.clear();
+          await emailInput.fill(updatedEmail);
+          await authenticatedPage.locator('#save-org-settings').click();
+          await expect(
+            authenticatedPage.getByText('Successfully updated settings').first(),
+          ).toBeVisible();
+
+          // Reload and verify persistence
+          await authenticatedPage.reload();
+          await expect(emailInput).toHaveValue(updatedEmail);
+
+          // Clean up
+          await api.raw.deleteOrganization(orgName);
+        });
+
+        test('create org without email → add email in settings → verify', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          await authenticatedPage.goto('/organization');
+
+          const orgName = uniqueName('noemailset');
+          const addedEmail = `added-${orgName}@example.com`;
+
+          // Create org without email
+          await authenticatedPage
+            .locator('#create-organization-button')
+            .click();
+          await authenticatedPage
+            .locator('#create-org-name-input')
+            .fill(orgName);
+
+          await Promise.all([
+            authenticatedPage.waitForResponse(
+              (resp) =>
+                resp.url().includes('/api/v1/organization/') &&
+                resp.request().method() === 'POST' &&
+                resp.status() === 201,
+            ),
+            authenticatedPage.locator('#create-org-confirm').click(),
+          ]);
+
+          await expect(
+            authenticatedPage.locator('#create-org-cancel'),
+          ).not.toBeVisible({timeout: 10000});
+
+          // Go to settings — email should be empty
+          await authenticatedPage.goto(
+            `/organization/${orgName}?tab=Settings`,
+          );
+          const emailInput = authenticatedPage.locator('#org-settings-email');
+          await expect(emailInput).toHaveValue('');
+
+          // Add email and save
+          await emailInput.fill(addedEmail);
+          await authenticatedPage.locator('#save-org-settings').click();
+          await expect(
+            authenticatedPage.getByText('Successfully updated settings').first(),
+          ).toBeVisible();
+
+          // Reload and verify persistence
+          await authenticatedPage.reload();
+          await expect(emailInput).toHaveValue(addedEmail);
+
+          // Clean up
+          await api.raw.deleteOrganization(orgName);
+        });
+
+        test('internal UUID email is never exposed in the UI', async ({
+          authenticatedPage,
+          api,
+        }) => {
+          const org = await api.organization(
+            'uuidcheck',
+            'visible@example.com',
+          );
+
+          // Check settings page
+          await authenticatedPage.goto(
+            `/organization/${org.name}?tab=Settings`,
+          );
+          const emailInput = authenticatedPage.locator('#org-settings-email');
+          await expect(emailInput).toBeVisible();
+
+          const value = await emailInput.inputValue();
+          expect(value).not.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+          expect(value).toBe('visible@example.com');
+        });
+      },
+    );
+
+    // =========================================================================
+    // Group 4: API Contract Verification
+    // =========================================================================
+
+    test.describe('Contact Email — API Contract', () => {
+      test('GET /organization/<name> returns contact_email for admin', async ({
+        api,
+      }) => {
+        const contactEmail = 'api-get@example.com';
+        const org = await api.organization('apiget', contactEmail);
+
+        const orgData = await api.raw.getOrganization(org.name);
+
+        expect(orgData).toHaveProperty('contact_email', contactEmail);
+        // Backward compat: email field should also have the contact email
+        expect(orgData).toHaveProperty('email', contactEmail);
+        // email should NOT be a UUID
+        expect(orgData.email).not.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+      });
+
+      test('backward compat: email field in POST still works', async ({
+        authenticatedRequest,
+      }) => {
+        const orgName = uniqueName('bwcompat');
+        const email = `${orgName}@example.com`;
+
+        // POST with old-style `email` field (not contact_email)
+        const token = await (async () => {
+          const resp = await authenticatedRequest.get(
+            `${API_URL}/csrf_token`,
+          );
+          const data = await resp.json();
+          return data.csrf_token;
+        })();
+
+        const createResp = await authenticatedRequest.post(
+          `${API_URL}/api/v1/organization/`,
+          {
+            headers: {'X-CSRF-Token': token},
+            data: {name: orgName, email},
+          },
+        );
+        expect(createResp.status()).toBe(201);
+
+        // GET and verify contact_email is set from the email field
+        const getResp = await authenticatedRequest.get(
+          `${API_URL}/api/v1/organization/${orgName}`,
+        );
+        const orgData = await getResp.json();
+        expect(orgData.contact_email).toBe(email);
+        expect(orgData.email).toBe(email);
+
+        // Clean up
+        await authenticatedRequest.delete(
+          `${API_URL}/api/v1/organization/${orgName}`,
+          {
+            headers: {'X-CSRF-Token': token},
+          },
+        );
+      });
+
+      test('FEATURE_MAILING no longer blocks org creation without email', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        await authenticatedPage.goto('/organization');
+
+        const orgName = uniqueName('nomailing');
+
+        await authenticatedPage
+          .locator('#create-organization-button')
+          .click();
+        await authenticatedPage
+          .locator('#create-org-name-input')
+          .fill(orgName);
+
+        // Leave email empty — should still be able to create
+        await expect(
+          authenticatedPage.locator('#create-org-confirm'),
+        ).toBeEnabled();
+
+        const [response] = await Promise.all([
+          authenticatedPage.waitForResponse(
+            (resp) =>
+              resp.url().includes('/api/v1/organization/') &&
+              resp.request().method() === 'POST',
+          ),
+          authenticatedPage.locator('#create-org-confirm').click(),
+        ]);
+
+        expect(response.status()).toBe(201);
+
+        await expect(
+          authenticatedPage.locator('#create-org-cancel'),
+        ).not.toBeVisible({timeout: 10000});
+
+        // No "Email address is required" error
+        await expect(
+          authenticatedPage.getByText('Email address is required'),
+        ).not.toBeVisible();
+
+        await expect(
+          authenticatedPage.getByText(
+            `Successfully created organization ${orgName}`,
+          ),
+        ).toBeVisible();
+
+        // Clean up
+        await api.raw.deleteOrganization(orgName);
+      });
+    });
+
+    // =========================================================================
+    // Group 5: Recovery Flow — Contact Email Lookup
+    // =========================================================================
+
+    test.describe('Recovery — Contact Email Lookup', () => {
+      const GENERIC_RECOVERY_MESSAGE =
+        'Recovery instructions have been sent to';
+
+      test('recovery shows generic sent message for any email type', async ({
+        unauthenticatedPage,
+      }) => {
+        await unauthenticatedPage.goto('/signin');
+
+        // Click forgot password
+        await unauthenticatedPage.getByText('Forgot password?').click();
+
+        // Enter an arbitrary email
+        await unauthenticatedPage
+          .getByTestId('signin-recovery-email')
+          .fill('anyemail@example.com');
+        await unauthenticatedPage.getByRole('button', {name: 'Send'}).click();
+
+        // Verify generic message (no info leak)
+        await expect(
+          unauthenticatedPage.getByText(GENERIC_RECOVERY_MESSAGE),
+        ).toBeVisible();
+      });
+
+      test('recovery with unknown email shows same generic message', async ({
+        unauthenticatedPage,
+      }) => {
+        await unauthenticatedPage.goto('/signin');
+
+        await unauthenticatedPage.getByText('Forgot password?').click();
+        await unauthenticatedPage
+          .getByTestId('signin-recovery-email')
+          .fill('nonexistent-xyz-999@nowhere.test');
+        await unauthenticatedPage.getByRole('button', {name: 'Send'}).click();
+
+        // Same generic message — no information leak about account existence
+        await expect(
+          unauthenticatedPage.getByText(GENERIC_RECOVERY_MESSAGE),
+        ).toBeVisible();
+      });
+    });
+  },
+);

--- a/web/playwright/e2e/organization/contact-email.spec.ts
+++ b/web/playwright/e2e/organization/contact-email.spec.ts
@@ -388,7 +388,7 @@ test.describe(
           api,
         }) => {
           const sharedEmail = 'settings-shared@company.com';
-          const org1 = await api.organization('shset1', sharedEmail);
+          await api.organization('shset1', sharedEmail);
           const org2 = await api.organization('shset2');
 
           await authenticatedPage.goto(
@@ -412,13 +412,7 @@ test.describe(
           const username = TEST_USERS.user.username;
           await authenticatedPage.goto(`/user/${username}?tab=Settings`);
 
-          // Label should be "Email", not "Contact Email"
-          const emailLabel = authenticatedPage
-            .locator('label[for="org-settings-email"]')
-            .or(authenticatedPage.locator('.pf-v6-c-form__label').filter({hasText: 'Email'}));
-
-          // The page may show email as a link (FEATURE_MAILING) or as a text input
-          // Either way, "Contact Email" should NOT be present
+          // "Contact Email" should NOT be present on user settings
           await expect(
             authenticatedPage.getByText('Contact Email'),
           ).not.toBeVisible();

--- a/web/playwright/e2e/organization/create-organization.spec.ts
+++ b/web/playwright/e2e/organization/create-organization.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect, uniqueName} from '../../fixtures';
+import {test, expect} from '../../fixtures';
 
 test.describe('Create Organization', {tag: ['@organization']}, () => {
   test('modal opens and shows form fields', async ({authenticatedPage}) => {
@@ -139,56 +139,4 @@ test.describe('Create Organization', {tag: ['@organization']}, () => {
       authenticatedPage.locator('#create-org-name-input'),
     ).not.toBeVisible();
   });
-
-  test.describe(
-    'Duplicate Email Validation',
-    {tag: ['@feature:MAILING']},
-    () => {
-      test('rejects creating organization with an email already in use (OCP-73835)', async ({
-        authenticatedPage,
-        api,
-      }) => {
-        const existingOrg = await api.organization('dupemail');
-
-        await authenticatedPage.goto('/organization');
-        await authenticatedPage
-          .getByRole('button', {name: 'Create Organization'})
-          .click();
-
-        const orgName = uniqueName('dupeorg');
-        await authenticatedPage.locator('#create-org-name-input').fill(orgName);
-        await authenticatedPage
-          .locator('#create-org-email-input')
-          .fill(existingOrg.email);
-        await authenticatedPage.locator('#create-org-confirm').click();
-
-        await expect(
-          authenticatedPage.getByText('Email has already been used'),
-        ).toBeVisible();
-      });
-
-      test("rejects email already used by another user's organization (OCP-74424)", async ({
-        authenticatedPage,
-        superuserApi,
-      }) => {
-        const otherOrg = await superuserApi.organization('xorg');
-
-        await authenticatedPage.goto('/organization');
-        await authenticatedPage
-          .getByRole('button', {name: 'Create Organization'})
-          .click();
-
-        const orgName = uniqueName('dupeorg');
-        await authenticatedPage.locator('#create-org-name-input').fill(orgName);
-        await authenticatedPage
-          .locator('#create-org-email-input')
-          .fill(otherOrg.email);
-        await authenticatedPage.locator('#create-org-confirm').click();
-
-        await expect(
-          authenticatedPage.getByText('Email has already been used'),
-        ).toBeVisible();
-      });
-    },
-  );
 });

--- a/web/playwright/e2e/organization/org-list.spec.ts
+++ b/web/playwright/e2e/organization/org-list.spec.ts
@@ -145,9 +145,7 @@ test.describe(
     test(
       'organization CRUD lifecycle',
       {tag: ['@PROJQUAY-9948', '@PROJQUAY-9843']},
-      async ({authenticatedPage, quayConfig, api}) => {
-        const mailingEnabled = quayConfig?.features?.MAILING === true;
-
+      async ({authenticatedPage, api}) => {
         await authenticatedPage.goto('/organization');
 
         // Create a shared unique ID for both orgs so we can filter them together
@@ -156,7 +154,6 @@ test.describe(
           .substring(2, 8)}`;
         const orgName = `crud1-${testId}`;
         const orgName2 = `crud2-${testId}`;
-        const orgEmail = `${orgName}@example.com`;
 
         // Open and cancel modal first
         await authenticatedPage.locator('#create-organization-button').click();
@@ -168,14 +165,14 @@ test.describe(
           authenticatedPage.locator('#create-org-cancel'),
         ).not.toBeVisible();
 
-        // Create organization
+        // Create organization (email is optional, just provide name)
         await authenticatedPage.locator('#create-organization-button').click();
         await authenticatedPage.locator('#create-org-name-input').fill(orgName);
-        if (mailingEnabled) {
-          await authenticatedPage
-            .locator('#create-org-email-input')
-            .fill(orgEmail);
-        }
+
+        // Email field is always visible and optional
+        await expect(
+          authenticatedPage.locator('#create-org-email-input'),
+        ).toBeVisible();
 
         // Wait for Create button to be enabled, then click and wait for API response
         await expect(
@@ -213,11 +210,6 @@ test.describe(
         // PROJQUAY-9948: Try to create org with same name - should show error, not success
         await authenticatedPage.locator('#create-organization-button').click();
         await authenticatedPage.locator('#create-org-name-input').fill(orgName);
-        if (mailingEnabled) {
-          await authenticatedPage
-            .locator('#create-org-email-input')
-            .fill(`duplicate-${orgEmail}`);
-        }
         await authenticatedPage.locator('#create-org-confirm').click();
 
         // Should show error message
@@ -241,29 +233,10 @@ test.describe(
         await authenticatedPage
           .locator('#create-org-name-input')
           .fill('validname');
-        if (mailingEnabled) {
-          // When mailing is enabled, button should still be disabled without email
-          await expect(
-            authenticatedPage.locator('#create-org-confirm'),
-          ).toBeDisabled();
-          await authenticatedPage
-            .locator('#create-org-email-input')
-            .fill('invalid');
-          await authenticatedPage.locator('#create-org-name-input').click(); // Trigger validation
-          await expect(
-            authenticatedPage.getByText(
-              'Enter a valid email: email@provider.com',
-            ),
-          ).toBeVisible();
-          await expect(
-            authenticatedPage.locator('#create-org-confirm'),
-          ).toBeDisabled();
-        } else {
-          // When mailing is disabled, button should be enabled with just a name
-          await expect(
-            authenticatedPage.locator('#create-org-confirm'),
-          ).toBeEnabled();
-        }
+        // Email is optional — button should be enabled with just a name
+        await expect(
+          authenticatedPage.locator('#create-org-confirm'),
+        ).toBeEnabled();
         await authenticatedPage.locator('#create-org-cancel').click();
 
         // PROJQUAY-9843: Create second org for bulk delete test
@@ -272,11 +245,6 @@ test.describe(
         await authenticatedPage
           .locator('#create-org-name-input')
           .fill(orgName2);
-        if (mailingEnabled) {
-          await authenticatedPage
-            .locator('#create-org-email-input')
-            .fill(`${orgName2}@example.com`);
-        }
         await expect(
           authenticatedPage.locator('#create-org-confirm'),
         ).toBeEnabled();
@@ -741,11 +709,9 @@ test.describe(
       },
     );
     test(
-      'create organization respects FEATURE_MAILING for email field',
+      'create organization shows optional contact email field',
       {tag: '@PROJQUAY-10500'},
-      async ({authenticatedPage, quayConfig, api}) => {
-        const mailingEnabled = quayConfig?.features?.MAILING === true;
-
+      async ({authenticatedPage, api}) => {
         await authenticatedPage.goto('/organization');
 
         // Open create organization modal
@@ -754,65 +720,49 @@ test.describe(
           authenticatedPage.locator('#create-org-name-input'),
         ).toBeVisible();
 
-        if (mailingEnabled) {
-          // When MAILING is enabled, email field should be visible and required
-          await expect(
-            authenticatedPage.locator('#create-org-email-input'),
-          ).toBeVisible();
+        // Email field is always visible regardless of FEATURE_MAILING
+        await expect(
+          authenticatedPage.locator('#create-org-email-input'),
+        ).toBeVisible();
 
-          // Fill only name - button should be disabled (email required)
-          await authenticatedPage
-            .locator('#create-org-name-input')
-            .fill('testmailingorg');
-          await expect(
-            authenticatedPage.locator('#create-org-confirm'),
-          ).toBeDisabled();
-        } else {
-          // When MAILING is disabled, email field should NOT be visible
-          await expect(
-            authenticatedPage.locator('#create-org-email-input'),
-          ).not.toBeVisible();
+        // Label is "Contact Email (Optional)"
+        await expect(
+          authenticatedPage.getByText('Contact Email (Optional)'),
+        ).toBeVisible();
 
-          // Fill only name - button should be enabled (email not required)
-          const orgName = uniqueName('mailtest');
-          await authenticatedPage
-            .locator('#create-org-name-input')
-            .fill(orgName);
-          await expect(
-            authenticatedPage.locator('#create-org-confirm'),
-          ).toBeEnabled();
+        // Fill only name — button should be enabled (email is optional)
+        const orgName = uniqueName('optmail');
+        await authenticatedPage
+          .locator('#create-org-name-input')
+          .fill(orgName);
+        await expect(
+          authenticatedPage.locator('#create-org-confirm'),
+        ).toBeEnabled();
 
-          // Create org without email should succeed
-          await Promise.all([
-            authenticatedPage.waitForResponse(
-              (resp) =>
-                resp.url().includes('/api/v1/organization/') &&
-                resp.request().method() === 'POST' &&
-                resp.status() === 201,
-            ),
-            authenticatedPage.locator('#create-org-confirm').click(),
-          ]);
+        // Create org without email should succeed
+        await Promise.all([
+          authenticatedPage.waitForResponse(
+            (resp) =>
+              resp.url().includes('/api/v1/organization/') &&
+              resp.request().method() === 'POST' &&
+              resp.status() === 201,
+          ),
+          authenticatedPage.locator('#create-org-confirm').click(),
+        ]);
 
-          // Modal should close on success
-          await expect(
-            authenticatedPage.locator('#create-org-cancel'),
-          ).not.toBeVisible({timeout: 10000});
+        // Modal should close on success
+        await expect(
+          authenticatedPage.locator('#create-org-cancel'),
+        ).not.toBeVisible({timeout: 10000});
 
-          await expect(
-            authenticatedPage.getByText(
-              `Successfully created organization ${orgName}`,
-            ),
-          ).toBeVisible();
+        await expect(
+          authenticatedPage.getByText(
+            `Successfully created organization ${orgName}`,
+          ),
+        ).toBeVisible();
 
-          // Clean up the org created via UI
-          await api.raw.deleteOrganization(orgName);
-        }
-
-        // Close modal if still open
-        const cancelButton = authenticatedPage.locator('#create-org-cancel');
-        if (await cancelButton.isVisible()) {
-          await cancelButton.click();
-        }
+        // Clean up the org created via UI
+        await api.raw.deleteOrganization(orgName);
       },
     );
   },

--- a/web/playwright/e2e/organization/org-list.spec.ts
+++ b/web/playwright/e2e/organization/org-list.spec.ts
@@ -69,7 +69,7 @@ test.describe(
       const orgPromises = Array.from({length: 25}, () =>
         api.organization('paginationtest'),
       );
-      const orgs = await Promise.all(orgPromises);
+      await Promise.all(orgPromises);
 
       await authenticatedPage.goto('/organization');
 
@@ -145,7 +145,7 @@ test.describe(
     test(
       'organization CRUD lifecycle',
       {tag: ['@PROJQUAY-9948', '@PROJQUAY-9843']},
-      async ({authenticatedPage, api}) => {
+      async ({authenticatedPage}) => {
         await authenticatedPage.goto('/organization');
 
         // Create a shared unique ID for both orgs so we can filter them together
@@ -732,9 +732,7 @@ test.describe(
 
         // Fill only name — button should be enabled (email is optional)
         const orgName = uniqueName('optmail');
-        await authenticatedPage
-          .locator('#create-org-name-input')
-          .fill(orgName);
+        await authenticatedPage.locator('#create-org-name-input').fill(orgName);
         await expect(
           authenticatedPage.locator('#create-org-confirm'),
         ).toBeEnabled();

--- a/web/playwright/e2e/organization/settings.spec.ts
+++ b/web/playwright/e2e/organization/settings.spec.ts
@@ -16,6 +16,10 @@ test.describe('Organization Settings', {tag: ['@organization']}, () => {
       const emailInput = authenticatedPage.locator('#org-settings-email');
       await expect(emailInput).toBeVisible();
 
+      // Check save button is disabled before any edits (form is not dirty)
+      const saveButton = authenticatedPage.locator('#save-org-settings');
+      await expect(saveButton).toBeDisabled();
+
       // Type a bad email
       await emailInput.clear();
       await emailInput.fill('this is not a good e-mail');
@@ -23,14 +27,8 @@ test.describe('Organization Settings', {tag: ['@organization']}, () => {
         authenticatedPage.getByText('Please enter a valid email address'),
       ).toBeVisible();
 
-      // Leave empty (email field is not required, so no error should appear)
-      await emailInput.clear();
-
-      // Check save button is disabled when form is not dirty or invalid
-      const saveButton = authenticatedPage.locator('#save-org-settings');
-      await expect(saveButton).toBeDisabled();
-
       // Type a good email and save
+      await emailInput.clear();
       await emailInput.fill('good-email@redhat.com');
       await expect(saveButton).toBeEnabled();
       await saveButton.click();

--- a/web/playwright/e2e/organization/settings.spec.ts
+++ b/web/playwright/e2e/organization/settings.spec.ts
@@ -547,31 +547,105 @@ test.describe('Organization Settings', {tag: ['@organization']}, () => {
   );
 
   test.describe(
-    'Duplicate Email on Update',
-    {tag: ['@feature:MAILING']},
+    'Contact Email (PROJQUAY-10593)',
+    {tag: ['@PROJQUAY-10593']},
     () => {
-      test('rejects updating organization email to one already in use (OCP-73836)', async ({
+      test('shows Contact Email label and helper text for organizations', async ({
         authenticatedPage,
         api,
       }) => {
-        const org1 = await api.organization('emaildup');
-        const org2 = await api.organization('emaildup');
+        const org = await api.organization('contactlbl');
+
+        await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
+
+        await expect(
+          authenticatedPage.getByText('Contact Email'),
+        ).toBeVisible();
+        await expect(
+          authenticatedPage.getByText(
+            'Optional. Used for organization recovery and billing notifications.',
+          ),
+        ).toBeVisible();
+      });
+
+      test('allows duplicate contact emails across organizations', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const org1 = await api.organization('dupmail');
+        const org2 = await api.organization('dupmail');
+
+        await authenticatedPage.goto(`/organization/${org1.name}?tab=Settings`);
+        const emailInput1 = authenticatedPage.locator('#org-settings-email');
+        await expect(emailInput1).toBeVisible();
+        await emailInput1.fill('shared@example.com');
+        await authenticatedPage.locator('#save-org-settings').click();
+        await expect(
+          authenticatedPage.getByText('Successfully updated settings').first(),
+        ).toBeVisible();
 
         await authenticatedPage.goto(`/organization/${org2.name}?tab=Settings`);
+        const emailInput2 = authenticatedPage.locator('#org-settings-email');
+        await expect(emailInput2).toBeVisible();
+        await emailInput2.fill('shared@example.com');
+        await authenticatedPage.locator('#save-org-settings').click();
+        await expect(
+          authenticatedPage.getByText('Successfully updated settings').first(),
+        ).toBeVisible();
+      });
+
+      test('sends contact_email in PUT request', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const org = await api.organization('putcheck');
+
+        await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
 
         const emailInput = authenticatedPage.locator('#org-settings-email');
         await expect(emailInput).toBeVisible();
+        await emailInput.fill('contact-test@example.com');
+
+        const putPromise = authenticatedPage.waitForRequest(
+          (req) =>
+            req.url().includes(`/api/v1/organization/${org.name}`) &&
+            req.method() === 'PUT',
+        );
+
+        await authenticatedPage.locator('#save-org-settings').click();
+
+        const putRequest = await putPromise;
+        const body = putRequest.postDataJSON();
+        expect(body).toHaveProperty('contact_email');
+        expect(body.contact_email).toBe('contact-test@example.com');
+      });
+
+      test('allows clearing contact email', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const org = await api.organization('clearmail');
+
+        await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
+        const emailInput = authenticatedPage.locator('#org-settings-email');
+        await expect(emailInput).toBeVisible();
+        await emailInput.fill('to-be-cleared@example.com');
+        await authenticatedPage.locator('#save-org-settings').click();
+        await expect(
+          authenticatedPage.getByText('Successfully updated settings').first(),
+        ).toBeVisible();
+
+        await authenticatedPage.reload();
+        await expect(emailInput).toHaveValue('to-be-cleared@example.com');
 
         await emailInput.clear();
-        await emailInput.fill(org1.email);
-
-        const saveButton = authenticatedPage.locator('#save-org-settings');
-        await expect(saveButton).toBeEnabled();
-        await saveButton.click();
-
+        await authenticatedPage.locator('#save-org-settings').click();
         await expect(
-          authenticatedPage.getByText('E-mail address already used').first(),
+          authenticatedPage.getByText('Successfully updated settings').first(),
         ).toBeVisible();
+
+        await authenticatedPage.reload();
+        await expect(emailInput).toHaveValue('');
       });
     },
   );

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -56,6 +56,7 @@ type CleanupAction = () => Promise<void>;
 export interface CreatedOrg {
   name: string;
   email: string;
+  contactEmail?: string;
 }
 
 /**
@@ -187,9 +188,12 @@ export class TestApi {
    * Create a unique organization.
    * Automatically deleted after test.
    */
-  async organization(namePrefix = 'org'): Promise<CreatedOrg> {
+  async organization(
+    namePrefix = 'org',
+    contactEmail?: string,
+  ): Promise<CreatedOrg> {
     const name = uniqueName(namePrefix);
-    const email = `${name}@example.com`;
+    const email = contactEmail || `${name}@example.com`;
 
     await this.client.createOrganization(name, email);
 
@@ -201,7 +205,7 @@ export class TestApi {
       }
     });
 
-    return {name, email};
+    return {name, email, contactEmail: email};
   }
 
   /**

--- a/web/playwright/utils/api/client.ts
+++ b/web/playwright/utils/api/client.ts
@@ -275,9 +275,13 @@ export class ApiClient {
 
   async createOrganization(
     name: string,
-    email?: string,
+    contactEmail?: string,
   ): Promise<{name: string}> {
     const token = await this.fetchToken();
+    const body: Record<string, string> = {name};
+    if (contactEmail) {
+      body.contact_email = contactEmail;
+    }
     const response = await this.request.post(
       `${API_URL}/api/v1/organization/`,
       {
@@ -285,10 +289,7 @@ export class ApiClient {
         headers: {
           'X-CSRF-Token': token,
         },
-        data: {
-          name,
-          email: email || `${name}@example.com`,
-        },
+        data: body,
       },
     );
 
@@ -296,6 +297,26 @@ export class ApiClient {
       const body = await response.text();
       throw new Error(
         `Failed to create organization ${name}: ${response.status()} - ${body}`,
+      );
+    }
+
+    return response.json();
+  }
+
+  async getOrganization(
+    name: string,
+  ): Promise<Record<string, unknown>> {
+    const response = await this.request.get(
+      `${API_URL}/api/v1/organization/${name}`,
+      {
+        timeout: 5000,
+      },
+    );
+
+    if (!response.ok()) {
+      const body = await response.text();
+      throw new Error(
+        `Failed to get organization ${name}: ${response.status()} - ${body}`,
       );
     }
 

--- a/web/playwright/utils/api/client.ts
+++ b/web/playwright/utils/api/client.ts
@@ -303,9 +303,7 @@ export class ApiClient {
     return response.json();
   }
 
-  async getOrganization(
-    name: string,
-  ): Promise<Record<string, unknown>> {
+  async getOrganization(name: string): Promise<Record<string, unknown>> {
     const response = await this.request.get(
       `${API_URL}/api/v1/organization/${name}`,
       {

--- a/web/src/hooks/UseOrganizations.ts
+++ b/web/src/hooks/UseOrganizations.ts
@@ -157,8 +157,8 @@ export function useOrganizations() {
   const queryClient = useQueryClient();
 
   const createOrganizationMutator = useMutation(
-    async ({name, email}: {name: string; email?: string}) => {
-      return createOrg(name, email);
+    async ({name, contactEmail}: {name: string; contactEmail?: string}) => {
+      return createOrg(name, contactEmail);
     },
     {
       onSuccess: () => {
@@ -255,8 +255,8 @@ export function useOrganizations() {
     totalResults: organizationsTableDetails.length,
 
     // Mutations
-    createOrganization: async (name: string, email?: string) =>
-      createOrganizationMutator.mutateAsync({name, email}),
+    createOrganization: async (name: string, contactEmail?: string) =>
+      createOrganizationMutator.mutateAsync({name, contactEmail}),
     deleteOrganizations: async (names: string[]) =>
       deleteOrganizationMutator.mutateAsync(names),
     deleteUsers: async (usernames: string[]) =>

--- a/web/src/resources/OrganizationResource.test.ts
+++ b/web/src/resources/OrganizationResource.test.ts
@@ -171,7 +171,7 @@ describe('OrganizationResource', () => {
       await createOrg('neworg', 'org@test.com');
       expect(axios.post).toHaveBeenCalledWith('/api/v1/organization/', {
         name: 'neworg',
-        email: 'org@test.com',
+        contact_email: 'org@test.com',
       });
     });
   });

--- a/web/src/resources/OrganizationResource.ts
+++ b/web/src/resources/OrganizationResource.ts
@@ -22,6 +22,7 @@ export interface IOrganization {
   is_member?: boolean;
   preferred_namespace?: boolean;
   teams?: string[];
+  contact_email?: string;
   tag_expiration_s: number;
   email: string;
   quota_report?: IQuotaReport;
@@ -102,14 +103,14 @@ export async function bulkDeleteOrganizations(
 
 interface CreateOrgRequest {
   name: string;
-  email?: string;
+  contact_email?: string;
 }
 
-export async function createOrg(name: string, email?: string) {
+export async function createOrg(name: string, contactEmail?: string) {
   const createOrgUrl = `/api/v1/organization/`;
-  const reqBody: CreateOrgRequest = {name: name};
-  if (email) {
-    reqBody.email = email;
+  const reqBody: CreateOrgRequest = {name};
+  if (contactEmail) {
+    reqBody.contact_email = contactEmail;
   }
   const response = await axios.post(createOrgUrl, reqBody);
   assertHttpCode(response.status, 201);
@@ -119,6 +120,7 @@ export async function createOrg(name: string, email?: string) {
 export interface updateOrgSettingsParams {
   tag_expiration_s: number;
   email: string;
+  contact_email?: string;
   isUser: boolean;
   invoice_email_address: string;
   invoice_email: boolean;

--- a/web/src/routes/OrganizationsList/CreateOrganizationModal.tsx
+++ b/web/src/routes/OrganizationsList/CreateOrganizationModal.tsx
@@ -82,10 +82,7 @@ export const CreateOrganizationModal = (
 
   const createOrganizationHandler = async () => {
     try {
-      await createOrganization(
-        organizationName,
-        contactEmail || undefined,
-      );
+      await createOrganization(organizationName, contactEmail || undefined);
       addAlert({
         variant: AlertVariant.Success,
         title: `Successfully created organization ${organizationName}`,
@@ -190,9 +187,7 @@ export const CreateOrganizationModal = (
           onClick={createOrganizationHandler}
           form="modal-with-form-form"
           isDisabled={
-            invalidEmailFlag ||
-            !organizationName ||
-            !validation.isValid
+            invalidEmailFlag || !organizationName || !validation.isValid
           }
         >
           Create

--- a/web/src/routes/OrganizationsList/CreateOrganizationModal.tsx
+++ b/web/src/routes/OrganizationsList/CreateOrganizationModal.tsx
@@ -21,7 +21,6 @@ import {addDisplayError} from 'src/resources/ErrorHandling';
 import {useOrganizations} from 'src/hooks/UseOrganizations';
 import {useUI} from 'src/contexts/UIContext';
 import {AlertVariant} from 'src/contexts/UIContext';
-import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 
 interface Validation {
   message: string;
@@ -40,15 +39,13 @@ export const CreateOrganizationModal = (
   props: CreateOrganizationModalProps,
 ): JSX.Element => {
   const [organizationName, setOrganizationName] = useState('');
-  const [organizationEmail, setOrganizationEmail] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
   const [invalidEmailFlag, setInvalidEmailFlag] = useState(false);
   const [validation, setValidation] = useState<Validation>(defaultMessage);
   const [err, setErr] = useState<string>();
 
   const {createOrganization} = useOrganizations();
   const {addAlert} = useUI();
-  const quayConfig = useQuayConfig();
-  const mailingEnabled = quayConfig?.features?.MAILING === true;
 
   const handleNameInputChange = (value: string) => {
     const regex = /^([a-z0-9]+(?:[._-][a-z0-9]+)*)$/;
@@ -80,14 +77,14 @@ export const CreateOrganizationModal = (
   };
 
   const handleEmailInputChange = (value: string) => {
-    setOrganizationEmail(value);
+    setContactEmail(value);
   };
 
   const createOrganizationHandler = async () => {
     try {
       await createOrganization(
         organizationName,
-        mailingEnabled ? organizationEmail : undefined,
+        contactEmail || undefined,
       );
       addAlert({
         variant: AlertVariant.Success,
@@ -104,12 +101,12 @@ export const CreateOrganizationModal = (
   };
 
   const onInputBlur = () => {
-    if (organizationEmail.length !== 0) {
-      isValidEmail(organizationEmail)
+    if (contactEmail.length !== 0) {
+      isValidEmail(contactEmail)
         ? setInvalidEmailFlag(false)
         : setInvalidEmailFlag(true);
     } else {
-      return;
+      setInvalidEmailFlag(false);
     }
   };
 
@@ -151,43 +148,37 @@ export const CreateOrganizationModal = (
               </HelperText>
             </FormHelperText>
           </FormGroup>
-          {mailingEnabled && (
-            <FormGroup
-              label="Organization Email"
-              isRequired
-              fieldId="create-org-email"
-            >
-              <TextInput
-                isRequired
-                type="email"
-                id="create-org-email-input"
-                name="create-org-email-input"
-                value={organizationEmail}
-                onChange={(_event, value) => handleEmailInputChange(value)}
-                validated={invalidEmailFlag ? 'error' : 'default'}
-                onBlur={onInputBlur}
-              />
+          <FormGroup
+            label="Contact Email (Optional)"
+            fieldId="create-org-email"
+          >
+            <TextInput
+              type="email"
+              id="create-org-email-input"
+              name="create-org-email-input"
+              value={contactEmail}
+              onChange={(_event, value) => handleEmailInputChange(value)}
+              validated={invalidEmailFlag ? 'error' : 'default'}
+              onBlur={onInputBlur}
+            />
 
-              <FormHelperText>
-                <HelperText>
-                  {invalidEmailFlag ? (
-                    <HelperTextItem
-                      variant="error"
-                      icon={<ExclamationCircleIcon />}
-                    >
-                      Enter a valid email: email@provider.com
-                    </HelperTextItem>
-                  ) : (
-                    <HelperTextItem>
-                      {
-                        "This address must be different from your account's email"
-                      }
-                    </HelperTextItem>
-                  )}
-                </HelperText>
-              </FormHelperText>
-            </FormGroup>
-          )}
+            <FormHelperText>
+              <HelperText>
+                {invalidEmailFlag ? (
+                  <HelperTextItem
+                    variant="error"
+                    icon={<ExclamationCircleIcon />}
+                  >
+                    Enter a valid email: email@provider.com
+                  </HelperTextItem>
+                ) : (
+                  <HelperTextItem>
+                    Optional. Used for organization recovery and notifications.
+                  </HelperTextItem>
+                )}
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
           <br />
         </Form>
       </ModalBody>
@@ -201,7 +192,6 @@ export const CreateOrganizationModal = (
           isDisabled={
             invalidEmailFlag ||
             !organizationName ||
-            (mailingEnabled && !organizationEmail) ||
             !validation.isValid
           }
         >

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/GeneralSettings.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/GeneralSettings.tsx
@@ -146,7 +146,7 @@ export const GeneralSettings = (props: GeneralSettingsProps) => {
   // Email
   const namespaceEmail = isUserOrganization
     ? user?.email || ''
-    : organization?.email || '';
+    : organization?.contact_email || '';
 
   // Password modal state
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
@@ -346,7 +346,7 @@ export const GeneralSettings = (props: GeneralSettingsProps) => {
 
         const orgUpdateData = {
           tag_expiration_s: tagExpirationSeconds,
-          email: data.email !== namespaceEmail ? data.email : null,
+          contact_email: data.email !== namespaceEmail ? data.email : null,
           isUser: isUserOrganization,
         };
 
@@ -465,19 +465,17 @@ export const GeneralSettings = (props: GeneralSettingsProps) => {
           name="email"
           control={control}
           errors={errors}
-          label="Email"
+          label={isUserOrganization ? 'Email' : 'Contact Email'}
           fieldId="org-settings-email"
           type="email"
           helperText={
             isUserOrganization
               ? 'The e-mail address associated with your account.'
-              : 'The e-mail address associated with the organization.'
+              : 'Optional. Used for organization recovery and billing notifications.'
           }
           customValidation={
-            quayConfig?.features?.MAILING
-              ? (value: string) =>
-                  isValidEmail(value) || 'Please enter a valid email address'
-              : undefined
+            (value: string) =>
+              !value || isValidEmail(value) || 'Please enter a valid email address'
           }
         />
       )}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/GeneralSettings.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/GeneralSettings.tsx
@@ -473,9 +473,10 @@ export const GeneralSettings = (props: GeneralSettingsProps) => {
               ? 'The e-mail address associated with your account.'
               : 'Optional. Used for organization recovery and billing notifications.'
           }
-          customValidation={
-            (value: string) =>
-              !value || isValidEmail(value) || 'Please enter a valid email address'
+          customValidation={(value: string) =>
+            !value ||
+            isValidEmail(value) ||
+            'Please enter a valid email address'
           }
         />
       )}

--- a/web/src/routes/Signin/Signin.tsx
+++ b/web/src/routes/Signin/Signin.tsx
@@ -268,9 +268,8 @@ export function Signin() {
               title=""
               style={{marginBottom: '20px'}}
             >
-              Instructions on how to reset your password have been sent to{' '}
-              {recoveryEmail}. If you do not receive the email, please try again
-              shortly.
+              Recovery instructions have been sent to {recoveryEmail} for any
+              accounts associated to the email.
             </Alert>
           )}
 


### PR DESCRIPTION
## Summary

Implements the full [PROJQUAY-6975](https://redhat.atlassian.net/browse/PROJQUAY-6975) epic: **Allow Single Email for Multiple Organizations**.

Previously, Quay enforced a unique constraint on `User.email`, requiring each organization to have a distinct email address. This prevented users from reusing the same email across multiple orgs they own.

This PR decouples the internal unique email from the user-facing contact email:

- **Internal email (`User.email`):** Auto-generated UUID for orgs — never shown to users, ensures DB uniqueness
- **Contact email (`OrganizationContactEmail.contact_email`):** Optional, user-facing, non-unique — multiple orgs can share the same contact email

### Changes by story

| Story | JIRA | Scope |
|-------|------|-------|
| Backend CRUD + UUID org email | [PROJQUAY-10589](https://redhat.atlassian.net/browse/PROJQUAY-10589) | `create_organization()` generates UUID, 4 new CRUD functions for contact_email |
| API endpoints | [PROJQUAY-10591](https://redhat.atlassian.net/browse/PROJQUAY-10591) | `org_view()`, create/update endpoints expose `contact_email`, backward-compatible `email` field |
| Email notification routing | [PROJQUAY-10590](https://redhat.atlassian.net/browse/PROJQUAY-10590) | Recovery, invoice, payment-failed emails route via `contact_email` with admin fallback |
| React Create Org modal | [PROJQUAY-10592](https://redhat.atlassian.net/browse/PROJQUAY-10592) | Email field always visible, optional, labeled "Contact Email (Optional)" |
| React Org Settings | [PROJQUAY-10593](https://redhat.atlassian.net/browse/PROJQUAY-10593) | Settings page shows/edits `contact_email`, UUID hidden, clearing deletes the record |
| Unified recovery email | [PROJQUAY-11799](https://redhat.atlassian.net/browse/PROJQUAY-11799) | Single combined recovery email for user + org scenarios |
| Playwright E2E tests | [PROJQUAY-6975](https://redhat.atlassian.net/browse/PROJQUAY-6975) | 15 new E2E tests covering create, settings, lifecycle, API contract, recovery |

### Key design decisions

- **Separate table** (`OrganizationContactEmail`) with one-to-one FK, not a column on `User`
- **Backward-compatible API**: `email` field in requests maps to `contact_email`; GET responses include both fields
- **Email sending priority**: `contact_email` > org admin personal emails (fallback)
- **Independent** of `FEATURE_MAILING` / `FEATURE_BILLING` flags
- **Recovery endpoint** always returns `{"status": "sent"}` — never leaks account existence

### Files changed (21 files, +2028 / -246)

**Backend:** `data/model/organization.py`, `endpoints/api/organization.py`, `endpoints/api/user.py`, `endpoints/webhooks.py`, `util/useremails.py`, `emails/combinedrecovery.html`

**Frontend:** `CreateOrganizationModal.tsx`, `GeneralSettings.tsx`, `OrganizationResource.ts`, `UseOrganizations.ts`, `Signin.tsx`

**Tests:** `test_organization.py` (model + API), `test_user.py`, `test_useremails.py`, `contact-email.spec.ts`, `org-list.spec.ts`, `settings.spec.ts`, `fixtures.ts`, `client.ts`

## Test plan

- [x] Backend unit tests: `pytest data/model/test/test_organization.py` (30 tests pass)
- [x] API endpoint tests: `pytest endpoints/api/test/test_organization.py` (22 tests pass)
- [x] Recovery endpoint tests: `pytest endpoints/api/test/test_user.py` (12 tests pass)
- [x] Email utility tests: `pytest util/test/test_useremails.py` (20 tests pass)
- [x] Playwright E2E: `contact-email.spec.ts` (15 tests), `org-list.spec.ts`, `settings.spec.ts`
- [x] Manual testing on local dev instance:
  - Create org with no email (UUID generated)
  - Create org with contact email (stored in separate table)
  - Create second org with same email (no uniqueness error)
  - View contact email in org settings (UUID hidden)
  - Update contact email
  - Clear contact email (row deleted from DB)
  - Email validation (invalid → error, clear → re-enables)
  - API contract via curl (backward compat with `email` field)
  - User account settings regression (label still "Email")

🤖 Generated with [Claude Code](https://claude.com/claude-code)