### PR TITLE
PROJQUAY-11665: fix(cve): CVE-2026-6322 - FastUri

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7187,7 +7187,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -134,7 +134,8 @@
     "node-forge": "1.4.0",
     "minimatch": "3.1.5",
     "svgo": "4.0.1",
-    "immutable": "^5.1.5"
+    "immutable": "^5.1.5",
+    "fast-uri": "^3.1.2"
   },
   "pnpm": {
     "overrides": {
@@ -150,7 +151,8 @@
       "node-forge": "1.4.0",
       "minimatch": "3.1.5",
       "svgo": "4.0.1",
-      "immutable": "^5.1.5"
+      "immutable": "^5.1.5",
+      "fast-uri": "^3.1.2"
     }
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   minimatch: 3.1.5
   svgo: 4.0.1
   immutable: ^5.1.5
+  fast-uri: ^3.1.2
 
 importers:
 


### PR DESCRIPTION
## CVE Details
- **CVE ID**: CVE-2026-6322 
- **Severity**: HIGH (CVSS 7.5)
- **Package**: fast-uri
- **Affected versions**: <= 3.1.1
- **Fixed version**: 3.1.2
- **Advisory**: https://www.cve.org/CVERecord?id=CVE-2026-6322

## Fix Summary
Overided Fast-URI from 3.1.2 in  `package.json` and regenerated `package-lock.json`.

## Jira References
- Resolves: [PROJQUAY-11665](https://issues.redhat.com/browse/PROJQUAY-11665)