### PR TITLE
PROJQUAY-11798: feat(oidc): multi-issuer and multi-audience support for Microsoft Entra v2 tokens

### DIFF
--- a/auth/oauth.py
+++ b/auth/oauth.py
@@ -59,12 +59,28 @@ def validate_sso_oauth_token(token):
         return ValidateResult(AuthKind.ssojwt, error_message="Unable to connect to auth server")
 
     try:
-        # for client side oauth, the audience will be the client side oauth client
-        options = {"verify_aud": False, "verify_nbf": False}
+        options = {"verify_nbf": False}
         if app.config.get("TESTING", False):
             options["verify_signature"] = False
 
         decoded_id_token = service.decode_user_jwt(token, options=options)
+
+        azp = decoded_id_token.get("azp")
+        allowed_clients = service.allowed_clients
+        if allowed_clients and azp and azp not in allowed_clients:
+            logger.warning("SSO JWT azp '%s' not in allowed clients: %s", azp, allowed_clients)
+            return ValidateResult(
+                AuthKind.ssojwt,
+                error_message=f"Client '{azp}' is not in the allowed clients list",
+            )
+
+        if azp:
+            logger.info(
+                "SSO JWT bearer token validated for issuer=%s with azp=%s",
+                issuer,
+                azp,
+            )
+
         sub, lusername, lemail, additional_info = get_sub_username_email_from_token(
             decoded_id_token, None, service, False
         )

--- a/auth/test/mock_oidc_server.py
+++ b/auth/test/mock_oidc_server.py
@@ -43,6 +43,11 @@ KtUiPPK2KtmGdPFEEQIDAQAB
 -----END PUBLIC KEY-----
 """
 
+MOCK_V1_ISSUER = "https://sts.windows.net/test-tenant-id/"
+MOCK_V2_ISSUER = "https://login.microsoftonline.com/test-tenant-id/v2.0"
+MOCK_CUSTOM_AUDIENCE = "api://quay-api"
+MOCK_AZP_CLIENT = "rhdh-test-client-id"
+
 MOCK_JWKS_RESPONSE = {
     "keys": [
         {
@@ -87,6 +92,7 @@ def generate_mock_oidc_token(
     audience="mock-client-id",
     expiry_seconds=3600,
     issued_at=None,
+    azp=None,
 ):
     now = datetime.datetime.now()
     iat = now - datetime.timedelta(seconds=30)
@@ -110,6 +116,9 @@ def generate_mock_oidc_token(
         "email": "mockuser@test.com",
         "email_verified": True,
     }
+
+    if azp:
+        payload["azp"] = azp
 
     headers = {"kid": "mock-key-id"}
 

--- a/local-dev/keycloak/keycloak-config.yaml
+++ b/local-dev/keycloak/keycloak-config.yaml
@@ -15,3 +15,13 @@ SOMEOIDC_LOGIN_CONFIG:
   USE_PKCE: true
   PKCE_METHOD: "S256"
   PUBLIC_CLIENT: true
+  OIDC_ISSUERS:
+    - "http://localhost:8081/realms/quay"
+    - "http://host.containers.internal:8081/realms/quay"
+  OIDC_AUDIENCES:
+    - "quay-ui"
+    - "api://quay-api"
+  OIDC_ALLOWED_CLIENTS:
+    - "quay-ui"
+    - "quay-obo"
+    - "quay-unknown-aud"

--- a/local-dev/keycloak/quay-realm-export.json
+++ b/local-dev/keycloak/quay-realm-export.json
@@ -30,7 +30,70 @@
       "attributes": {
         "pkce.code.challenge.method": "S256",
         "post.logout.redirect.uris": "+"
-      }
+      },
+      "protocolMappers": [
+        {
+          "name": "quay-ui-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "quay-ui",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "quay-unknown-aud",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "quay-unknown-aud-secret",
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "redirectUris": ["http://localhost:8080/*"],
+      "webOrigins": ["+"],
+      "protocolMappers": [
+        {
+          "name": "wrong-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.custom.audience": "api://some-other-app",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "quay-obo",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "quay-obo-secret",
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "redirectUris": ["http://localhost:8080/*"],
+      "webOrigins": ["+"],
+      "protocolMappers": [
+        {
+          "name": "custom-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.custom.audience": "api://quay-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
     }
   ],
   "users": [

--- a/oauth/loginmanager.py
+++ b/oauth/loginmanager.py
@@ -43,16 +43,17 @@ class OAuthLoginManager(object):
 
     def get_service_by_issuer(self, issuer):
         for service in self.services:
+            if hasattr(service, "get_issuers"):
+                try:
+                    for config_issuer in service.get_issuers():
+                        if config_issuer.rstrip("/") == issuer.rstrip("/"):
+                            return service
+                except Exception:
+                    pass
 
-            if not hasattr(service, "get_issuer"):
-                continue
-
-            if not service.get_issuer:
-                continue
-
-            config_issuer = service.get_issuer()
-
-            if config_issuer.rstrip("/") == issuer.rstrip("/"):
-                return service
+            if hasattr(service, "get_issuer") and service.get_issuer:
+                config_issuer = service.get_issuer()
+                if config_issuer and config_issuer.rstrip("/") == issuer.rstrip("/"):
+                    return service
 
         return None

--- a/oauth/loginmanager.py
+++ b/oauth/loginmanager.py
@@ -1,7 +1,11 @@
-from oauth.oidc import OIDCLoginService
+import logging
+
+from oauth.oidc import DiscoveryFailureException, OIDCLoginService
 from oauth.services.github import GithubOAuthService
 from oauth.services.google import GoogleOAuthService
 from oauth.services.rhsso import RHSSOOAuthService
+
+logger = logging.getLogger(__name__)
 
 CUSTOM_LOGIN_SERVICES = {
     "GITHUB_LOGIN_CONFIG": GithubOAuthService,
@@ -48,8 +52,23 @@ class OAuthLoginManager(object):
                     for config_issuer in service.get_issuers():
                         if config_issuer.rstrip("/") == issuer.rstrip("/"):
                             return service
-                except Exception:
-                    pass
+                except (
+                    DiscoveryFailureException,
+                    ConnectionError,
+                    KeyError,
+                    AttributeError,
+                ) as e:
+                    logger.debug(
+                        "Failed to retrieve issuers from service %s: %s",
+                        service.service_id(),
+                        e,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Unexpected error retrieving issuers from service %s: %s",
+                        service.service_id(),
+                        e,
+                    )
 
             if hasattr(service, "get_issuer") and service.get_issuer:
                 config_issuer = service.get_issuer()

--- a/oauth/oidc.py
+++ b/oauth/oidc.py
@@ -18,7 +18,7 @@ from oauth.base import (
     OAuthService,
 )
 from oauth.login import OAuthLoginException
-from oauth.login_utils import get_sub_username_email_from_token
+from oauth.login_utils import get_jwt_issuer, get_sub_username_email_from_token
 from util.security.jwtutil import InvalidTokenError, decode
 
 logger = logging.getLogger(__name__)
@@ -66,6 +66,20 @@ class OIDCLoginService(OAuthService):
         self._http_client = client or config.get("HTTPCLIENT")
         self._mailing = config.get("FEATURE_MAILING", False)
         self._public_key_cache = _PublicKeyCache(self, 1, PUBLIC_KEY_CACHE_TTL)
+
+        self._validate_multi_config()
+
+    def _validate_multi_config(self):
+        for field in ("OIDC_ISSUERS", "OIDC_AUDIENCES", "OIDC_ALLOWED_CLIENTS"):
+            value = self.config.get(field)
+            if value is None:
+                continue
+            if not isinstance(value, list):
+                raise ValueError(f"{field} must be a list, got {type(value).__name__}")
+            if len(value) == 0:
+                raise ValueError(f"{field} must not be empty")
+            if not all(isinstance(item, str) for item in value):
+                raise ValueError(f"{field} must contain only strings")
 
     def service_id(self):
         return self._id
@@ -242,6 +256,40 @@ class OIDCLoginService(OAuthService):
     def get_issuer(self):
         return self._issuer
 
+    @property
+    def _issuers(self):
+        issuers_list = self.config.get("OIDC_ISSUERS")
+        if issuers_list:
+            if self.config.get("OIDC_ISSUER"):
+                logger.warning(
+                    "Both OIDC_ISSUER and OIDC_ISSUERS configured; OIDC_ISSUERS takes precedence"
+                )
+            return issuers_list
+
+        single_issuer = self.config.get("OIDC_ISSUER")
+        if single_issuer:
+            return [single_issuer]
+
+        single_issuer = self._issuer
+        return [single_issuer] if single_issuer else []
+
+    def get_issuers(self):
+        return self._issuers
+
+    @property
+    def _audiences(self):
+        audiences_list = self.config.get("OIDC_AUDIENCES", [])
+        client_id = self.client_id()
+        if not audiences_list:
+            return [client_id] if client_id else []
+        if client_id and client_id not in audiences_list:
+            return audiences_list + [client_id]
+        return audiences_list
+
+    @property
+    def allowed_clients(self):
+        return self.config.get("OIDC_ALLOWED_CLIENTS")
+
     @lru_cache(maxsize=1)
     def _oidc_config(self):
         if self.config.get("OIDC_SERVER"):
@@ -281,71 +329,74 @@ class OIDCLoginService(OAuthService):
         Raises an InvalidTokenError exception on an invalid token or a PublicKeyLoadException if the
         public key could not be loaded for decoding.
         """
-        # Find the key to use.
         headers = jwt.get_unverified_header(token)
         kid = headers.get("kid", None)
         if kid is None:
             raise InvalidTokenError("Missing `kid` header")
 
+        audiences = self._audiences
+        issuers = self._issuers
+
+        effective_audience = None if options.get("verify_aud") is False else audiences
+
+        token_issuer = get_jwt_issuer(token)
+
+        if options.get("verify_iss", True) and token_issuer and issuers:
+            normalized_issuers = [i.rstrip("/") for i in issuers]
+            if token_issuer.rstrip("/") not in normalized_issuers:
+                raise InvalidTokenError(
+                    f"Issuer '{token_issuer}' not in configured issuers: {issuers}"
+                )
+
+        effective_issuer = token_issuer if token_issuer else (issuers[0] if issuers else None)
+
         logger.debug(
-            "Using key `%s`, attempting to decode token `%s` with aud `%s` and iss `%s`",
+            "Using key `%s`, attempting to decode token with aud `%s` and iss `%s`",
             kid,
-            token,
-            self.client_id(),
-            self._issuer,
+            effective_audience,
+            effective_issuer,
         )
 
         key = ""
         if options.get("verify_signature", True):
             key = self._get_public_key(kid)
 
+        decode_kwargs = dict(
+            algorithms=ALLOWED_ALGORITHMS,
+            issuer=effective_issuer,
+            leeway=JWT_CLOCK_SKEW_SECONDS,
+            options=dict(require=["iat", "exp"], **options),
+        )
+        if effective_audience is not None:
+            decode_kwargs["audience"] = effective_audience
+
         try:
-            return decode(
-                token,
-                key,
-                algorithms=ALLOWED_ALGORITHMS,
-                audience=self.client_id(),
-                issuer=self._issuer,
-                leeway=JWT_CLOCK_SKEW_SECONDS,
-                options=dict(require=["iat", "exp"], **options),
-            )
+            return decode(token, key, **decode_kwargs)
         except InvalidTokenError as ite:
             logger.warning(
-                "Could not decode token `%s` for OIDC: %s. Will attempt again after "
-                + "retrieving public keys.",
-                token,
+                "Could not decode token for OIDC: %s. Will attempt again after "
+                "retrieving public keys.",
                 ite,
             )
 
-            # Public key may have expired. Try to retrieve an updated public key and use it to decode.
             try:
                 return decode(
                     token,
                     self._get_public_key(kid, force_refresh=True),
-                    algorithms=ALLOWED_ALGORITHMS,
-                    audience=self.client_id(),
-                    issuer=self._issuer,
-                    leeway=JWT_CLOCK_SKEW_SECONDS,
-                    options=dict(require=["iat", "exp"], **options),
+                    **decode_kwargs,
                 )
             except InvalidTokenError as ite:
                 logger.warning(
-                    "Could not decode token `%s` for OIDC: %s. Attempted again after "
-                    + "retrieving public keys.",
-                    token,
+                    "Could not decode token for OIDC: %s. Attempted again after "
+                    "retrieving public keys.",
                     ite,
                 )
 
-                # Decode again with verify_signature=False, and log the decoded token to allow for easier debugging.
-                nonverified = decode(
-                    token,
-                    None,  # No key needed for non-verified decode
-                    algorithms=ALLOWED_ALGORITHMS,
-                    audience=self.client_id(),
-                    issuer=self._issuer,
-                    leeway=JWT_CLOCK_SKEW_SECONDS,
-                    options=dict(require=["iat", "exp"], verify_signature=False, **options),
-                )
+                nonverified_kwargs = dict(decode_kwargs)
+                nonverified_opts = dict(nonverified_kwargs.get("options", {}))
+                nonverified_opts["verify_signature"] = False
+                nonverified_kwargs["options"] = nonverified_opts
+                nonverified = decode(token, None, **nonverified_kwargs)
                 logger.debug("Got an error when trying to verify OIDC JWT: %s", nonverified)
                 raise ite
 

--- a/oauth/oidc.py
+++ b/oauth/oidc.py
@@ -70,6 +70,10 @@ class OIDCLoginService(OAuthService):
         self._validate_multi_config()
 
     def _validate_multi_config(self):
+        issuer = self.config.get("OIDC_ISSUER")
+        if issuer is not None and not isinstance(issuer, str):
+            raise ValueError(f"OIDC_ISSUER must be a string, got {type(issuer).__name__}")
+
         for field in ("OIDC_ISSUERS", "OIDC_AUDIENCES", "OIDC_ALLOWED_CLIENTS"):
             value = self.config.get(field)
             if value is None:

--- a/oauth/test/test_oidc_multi_issuer.py
+++ b/oauth/test/test_oidc_multi_issuer.py
@@ -4,6 +4,7 @@ import pytest
 import requests
 
 from auth.test.mock_oidc_server import (
+    MOCK_AZP_CLIENT,
     MOCK_CUSTOM_AUDIENCE,
     MOCK_V1_ISSUER,
     MOCK_V2_ISSUER,
@@ -227,8 +228,46 @@ class TestDecodeMultiIssuer:
             service.decode_user_jwt(token)
 
 
+class TestAzpClaim:
+    """Tests for azp (authorized party) claim handling."""
+
+    @patch.object(requests.Session, "request", mock_request)
+    def test_token_with_azp_preserves_claim(self):
+        """A token generated with azp contains the claim after decode."""
+        service = _make_service_with_mock()
+        token = generate_mock_oidc_token(
+            audience="mock-client-id",
+            azp=MOCK_AZP_CLIENT,
+        )
+        decoded = service.decode_user_jwt(token)
+        assert decoded["azp"] == MOCK_AZP_CLIENT
+
+    @patch.object(requests.Session, "request", mock_request)
+    def test_token_without_azp_has_no_claim(self):
+        """A token generated without azp does not contain the claim."""
+        service = _make_service_with_mock()
+        token = generate_mock_oidc_token(audience="mock-client-id")
+        decoded = service.decode_user_jwt(token)
+        assert "azp" not in decoded
+
+    def test_allowed_clients_accepts_matching_azp(self):
+        """allowed_clients list contains the expected client ID."""
+        service = _make_service({"OIDC_ALLOWED_CLIENTS": [MOCK_AZP_CLIENT, "other-client"]})
+        assert MOCK_AZP_CLIENT in service.allowed_clients
+
+    def test_allowed_clients_rejects_missing_azp(self):
+        """allowed_clients list does not contain an unlisted client."""
+        service = _make_service({"OIDC_ALLOWED_CLIENTS": ["only-this-client"]})
+        assert MOCK_AZP_CLIENT not in service.allowed_clients
+
+
 class TestConfigValidation:
     """Tests for validation of OIDC_ISSUERS, OIDC_AUDIENCES, OIDC_ALLOWED_CLIENTS."""
+
+    def test_oidc_issuer_must_be_string(self):
+        """OIDC_ISSUER (singular) as a list raises ValueError."""
+        with pytest.raises(ValueError, match="OIDC_ISSUER must be a string"):
+            _make_service_with_mock({"OIDC_ISSUER": ["https://issuer.com"]})
 
     def test_oidc_issuers_must_be_list(self):
         """OIDC_ISSUERS as a string raises ValueError."""

--- a/oauth/test/test_oidc_multi_issuer.py
+++ b/oauth/test/test_oidc_multi_issuer.py
@@ -1,0 +1,370 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from auth.test.mock_oidc_server import (
+    MOCK_CUSTOM_AUDIENCE,
+    MOCK_V1_ISSUER,
+    MOCK_V2_ISSUER,
+    generate_mock_oidc_token,
+    mock_get,
+    mock_request,
+)
+from oauth.oidc import OIDCLoginService
+from util.security.jwtutil import InvalidTokenError
+
+
+def _make_service(config_overrides=None):
+    """Helper to create an OIDCLoginService without triggering discovery."""
+    base_config = {
+        "CLIENT_ID": "test-client-id",
+        "CLIENT_SECRET": "test-secret",
+        "OIDC_SERVER": "https://login.microsoftonline.com/tenant/v2.0",
+        "DEBUGGING": True,
+    }
+    if config_overrides:
+        base_config.update(config_overrides)
+    service = OIDCLoginService.__new__(OIDCLoginService)
+    service.config = base_config
+    service._id = "testoidc"
+    service._http_client = MagicMock()
+    service._mailing = False
+    return service
+
+
+class TestOIDCIssuers:
+    """Tests for multi-issuer resolution in OIDCLoginService."""
+
+    def test_issuers_from_oidc_issuers_config(self):
+        """OIDC_ISSUERS list takes priority."""
+        service = _make_service(
+            {
+                "OIDC_ISSUERS": [
+                    "https://sts.windows.net/tenant/",
+                    "https://login.microsoftonline.com/tenant/v2.0",
+                ]
+            }
+        )
+        assert service._issuers == [
+            "https://sts.windows.net/tenant/",
+            "https://login.microsoftonline.com/tenant/v2.0",
+        ]
+
+    def test_issuers_fallback_to_oidc_issuer(self):
+        """Falls back to single OIDC_ISSUER when OIDC_ISSUERS not set."""
+        service = _make_service(
+            {
+                "OIDC_ISSUER": "https://sts.windows.net/tenant/",
+            }
+        )
+        assert service._issuers == ["https://sts.windows.net/tenant/"]
+
+    def test_issuers_precedence_over_singular(self):
+        """OIDC_ISSUERS takes precedence over OIDC_ISSUER."""
+        service = _make_service(
+            {
+                "OIDC_ISSUER": "https://sts.windows.net/tenant/",
+                "OIDC_ISSUERS": [
+                    "https://login.microsoftonline.com/tenant/v2.0",
+                ],
+            }
+        )
+        assert service._issuers == [
+            "https://login.microsoftonline.com/tenant/v2.0",
+        ]
+
+
+class TestOIDCAudiences:
+    """Tests for multi-audience resolution in OIDCLoginService."""
+
+    def test_audiences_from_config(self):
+        """OIDC_AUDIENCES list is used when configured."""
+        service = _make_service(
+            {
+                "OIDC_AUDIENCES": ["test-client-id", "api://quay-api"],
+            }
+        )
+        assert "test-client-id" in service._audiences
+        assert "api://quay-api" in service._audiences
+
+    def test_audiences_default_to_client_id(self):
+        """Defaults to [CLIENT_ID] when OIDC_AUDIENCES not set."""
+        service = _make_service()
+        assert service._audiences == ["test-client-id"]
+
+    def test_audiences_always_includes_client_id(self):
+        """CLIENT_ID is always included even if not in OIDC_AUDIENCES."""
+        service = _make_service(
+            {
+                "OIDC_AUDIENCES": ["api://quay-api"],
+            }
+        )
+        assert "test-client-id" in service._audiences
+        assert "api://quay-api" in service._audiences
+
+
+class TestOIDCAllowedClients:
+    """Tests for OIDC_ALLOWED_CLIENTS configuration."""
+
+    def test_allowed_clients_returns_config(self):
+        """Returns OIDC_ALLOWED_CLIENTS when configured."""
+        service = _make_service(
+            {
+                "OIDC_ALLOWED_CLIENTS": ["rhdh-client", "devspaces-client"],
+            }
+        )
+        assert service.allowed_clients == ["rhdh-client", "devspaces-client"]
+
+    def test_allowed_clients_none_when_not_configured(self):
+        """Returns None when OIDC_ALLOWED_CLIENTS not set."""
+        service = _make_service()
+        assert service.allowed_clients is None
+
+
+def _mock_http_get(url, *args, **kwargs):
+    """Wrapper that adapts mock_get (expects obj, url) for direct call (url only)."""
+    return mock_get(None, url, *args, **kwargs)
+
+
+def _make_service_with_mock(config_overrides=None):
+    """Create an OIDCLoginService backed by the mock OIDC server for decode tests."""
+    base_config = {
+        "CLIENT_ID": "mock-client-id",
+        "CLIENT_SECRET": "test-secret",
+        "OIDC_SERVER": "https://mock-oidc-server.com",
+        "DEBUGGING": True,
+    }
+    if config_overrides:
+        base_config.update(config_overrides)
+
+    http_client = MagicMock()
+    http_client.get = _mock_http_get
+
+    config = {"testoidc": base_config, "HTTPCLIENT": http_client}
+    service = OIDCLoginService(config, "testoidc", client=http_client)
+    return service
+
+
+class TestDecodeMultiIssuer:
+    """Tests for decode_user_jwt with multiple issuers.
+
+    These test the core question: when a token arrives with a particular
+    issuer, does Quay accept or reject it based on the configured issuer list?
+    """
+
+    @patch.object(requests.Session, "request", mock_request)
+    def test_decode_v1_token_with_multi_issuer(self):
+        """A v1.0 token is accepted when the v1 issuer is in OIDC_ISSUERS."""
+        service = _make_service_with_mock(
+            {
+                "OIDC_ISSUERS": [MOCK_V1_ISSUER, MOCK_V2_ISSUER],
+            }
+        )
+        token = generate_mock_oidc_token(
+            issuer=MOCK_V1_ISSUER,
+            audience="mock-client-id",
+        )
+        decoded = service.decode_user_jwt(token)
+        assert decoded["iss"] == MOCK_V1_ISSUER
+
+    @patch.object(requests.Session, "request", mock_request)
+    def test_decode_v2_token_with_multi_issuer(self):
+        """A v2.0 token is accepted when the v2 issuer is in OIDC_ISSUERS."""
+        service = _make_service_with_mock(
+            {
+                "OIDC_ISSUERS": [MOCK_V1_ISSUER, MOCK_V2_ISSUER],
+            }
+        )
+        token = generate_mock_oidc_token(
+            issuer=MOCK_V2_ISSUER,
+            audience="mock-client-id",
+        )
+        decoded = service.decode_user_jwt(token)
+        assert decoded["iss"] == MOCK_V2_ISSUER
+
+    @patch.object(requests.Session, "request", mock_request)
+    def test_decode_unknown_issuer_rejected(self):
+        """A token from an unknown issuer is rejected."""
+        service = _make_service_with_mock(
+            {
+                "OIDC_ISSUERS": [MOCK_V1_ISSUER],
+            }
+        )
+        token = generate_mock_oidc_token(
+            issuer="https://evil-server.com",
+            audience="mock-client-id",
+        )
+        with pytest.raises(InvalidTokenError, match="not in configured issuers"):
+            service.decode_user_jwt(token)
+
+    @patch.object(requests.Session, "request", mock_request)
+    def test_decode_custom_audience_accepted(self):
+        """A token with aud=api://quay-api is accepted when it's in OIDC_AUDIENCES."""
+        service = _make_service_with_mock(
+            {
+                "OIDC_AUDIENCES": [MOCK_CUSTOM_AUDIENCE],
+            }
+        )
+        token = generate_mock_oidc_token(
+            audience=MOCK_CUSTOM_AUDIENCE,
+        )
+        decoded = service.decode_user_jwt(token)
+        assert decoded["aud"] == MOCK_CUSTOM_AUDIENCE
+
+    @patch.object(requests.Session, "request", mock_request)
+    def test_decode_wrong_audience_rejected(self):
+        """A token with an unlisted audience is rejected."""
+        service = _make_service_with_mock(
+            {
+                "OIDC_AUDIENCES": ["api://quay-api"],
+            }
+        )
+        token = generate_mock_oidc_token(
+            audience="api://wrong-api",
+        )
+        with pytest.raises(InvalidTokenError):
+            service.decode_user_jwt(token)
+
+
+class TestConfigValidation:
+    """Tests for validation of OIDC_ISSUERS, OIDC_AUDIENCES, OIDC_ALLOWED_CLIENTS."""
+
+    def test_oidc_issuers_must_be_list(self):
+        """OIDC_ISSUERS as a string raises ValueError."""
+        with pytest.raises(ValueError, match="must be a list"):
+            _make_service_with_mock({"OIDC_ISSUERS": "https://issuer.com"})
+
+    def test_oidc_issuers_must_not_be_empty(self):
+        """Empty OIDC_ISSUERS raises ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            _make_service_with_mock({"OIDC_ISSUERS": []})
+
+    def test_oidc_audiences_must_be_list(self):
+        """OIDC_AUDIENCES as a string raises ValueError."""
+        with pytest.raises(ValueError, match="must be a list"):
+            _make_service_with_mock({"OIDC_AUDIENCES": "api://quay"})
+
+    def test_oidc_allowed_clients_must_contain_strings(self):
+        """OIDC_ALLOWED_CLIENTS with non-strings raises ValueError."""
+        with pytest.raises(ValueError, match="must contain only strings"):
+            _make_service_with_mock({"OIDC_ALLOWED_CLIENTS": [123, 456]})
+
+
+class TestBackwardCompatibility:
+    """Ensure existing single-issuer/audience configs work unchanged after upgrade.
+
+    An admin who upgrades Quay without touching their config should see
+    zero behavior change. These tests verify that.
+    """
+
+    def test_single_issuer_config_still_works(self):
+        """Existing OIDC_ISSUER (singular string) config works for _issuers."""
+        service = _make_service({"OIDC_ISSUER": "https://sts.windows.net/tenant/"})
+        assert service._issuers == ["https://sts.windows.net/tenant/"]
+        assert service.get_issuers() == ["https://sts.windows.net/tenant/"]
+
+    def test_no_oidc_audiences_defaults_to_client_id(self):
+        """When OIDC_AUDIENCES is not set, audience defaults to [CLIENT_ID]."""
+        service = _make_service()
+        assert service._audiences == ["test-client-id"]
+
+    def test_no_allowed_clients_returns_none(self):
+        """When OIDC_ALLOWED_CLIENTS is not set, allowed_clients is None."""
+        service = _make_service()
+        assert service.allowed_clients is None
+
+    @patch.object(requests.Session, "request", mock_request)
+    def test_decode_with_default_audience(self):
+        """Token with aud=CLIENT_ID works without OIDC_AUDIENCES configured."""
+        service = _make_service_with_mock()
+        token = generate_mock_oidc_token(audience="mock-client-id")
+        decoded = service.decode_user_jwt(token)
+        assert decoded["aud"] == "mock-client-id"
+
+    @patch.object(requests.Session, "request", mock_request)
+    def test_decode_with_default_issuer(self):
+        """Token with issuer from discovery works without OIDC_ISSUERS configured."""
+        service = _make_service_with_mock()
+        token = generate_mock_oidc_token()
+        decoded = service.decode_user_jwt(token)
+        assert decoded["iss"] == "https://mock-oidc-server.com"
+
+
+class TestLoginManagerMultiIssuer:
+    """Tests for get_service_by_issuer with multi-issuer services.
+
+    When a bearer token arrives, Quay uses this method to figure out which
+    OIDC provider the token belongs to. With multi-issuer, a single provider
+    can match on either the v1.0 or v2.0 issuer URL.
+    """
+
+    def _make_manager(self, login_config_overrides=None):
+        base_login_config = {
+            "CLIENT_ID": "test-client",
+            "CLIENT_SECRET": "test-secret",
+            "OIDC_SERVER": "https://mock-oidc-server.com",
+            "DEBUGGING": True,
+        }
+        if login_config_overrides:
+            base_login_config.update(login_config_overrides)
+
+        http_client = MagicMock()
+        http_client.get = _mock_http_get
+
+        config = {
+            "HTTPCLIENT": http_client,
+            "TESTOIDC_LOGIN_CONFIG": base_login_config,
+        }
+
+        from oauth.loginmanager import OAuthLoginManager
+
+        return OAuthLoginManager(config, client=http_client)
+
+    def test_lookup_by_v1_issuer(self):
+        """Finds the provider when a token has a v1.0 issuer."""
+        manager = self._make_manager(
+            {
+                "OIDC_ISSUERS": [
+                    "https://sts.windows.net/tenant/",
+                    "https://login.microsoftonline.com/tenant/v2.0",
+                ],
+            }
+        )
+        service = manager.get_service_by_issuer("https://sts.windows.net/tenant/")
+        assert service is not None
+        assert service.service_id() == "testoidc"
+
+    def test_lookup_by_v2_issuer(self):
+        """Finds the provider when a token has a v2.0 issuer."""
+        manager = self._make_manager(
+            {
+                "OIDC_ISSUERS": [
+                    "https://sts.windows.net/tenant/",
+                    "https://login.microsoftonline.com/tenant/v2.0",
+                ],
+            }
+        )
+        service = manager.get_service_by_issuer("https://login.microsoftonline.com/tenant/v2.0")
+        assert service is not None
+        assert service.service_id() == "testoidc"
+
+    def test_lookup_unknown_issuer_returns_none(self):
+        """Returns None for an issuer that isn't configured anywhere."""
+        manager = self._make_manager(
+            {
+                "OIDC_ISSUERS": ["https://sts.windows.net/tenant/"],
+            }
+        )
+        service = manager.get_service_by_issuer("https://evil.com")
+        assert service is None
+
+    def test_lookup_backward_compat_single_issuer(self):
+        """Existing single OIDC_ISSUER config still works for lookup."""
+        manager = self._make_manager(
+            {
+                "OIDC_ISSUER": "https://sts.windows.net/tenant/",
+            }
+        )
+        service = manager.get_service_by_issuer("https://sts.windows.net/tenant/")
+        assert service is not None

--- a/util/security/federated_robot_auth.py
+++ b/util/security/federated_robot_auth.py
@@ -75,21 +75,35 @@ def verify_federated_robot_jwt_token(robot, token):
         raise InvalidRobotCredentialException("Robot does not have federated login configured")
 
     matched_subs = []
+    matched_audiences = None
     for item in fed_config:
         if item.get("issuer") == token_issuer:
             matched_subs.append(item.get("subject"))
+            item_audiences = item.get("audiences")
+            if item_audiences:
+                matched_audiences = item_audiences
 
     if not matched_subs:
         raise InvalidRobotCredentialException(
             f"issuer {token_issuer} not configured for this robot"
         )
 
-    # verify the token
-    service_config = {"quayrobot": {"OIDC_SERVER": token_issuer}}
+    service_config_block = {"OIDC_SERVER": token_issuer}
+    if matched_audiences:
+        service_config_block["OIDC_AUDIENCES"] = matched_audiences
+        options = {"verify_nbf": False}
+    else:
+        options = {"verify_aud": False, "verify_nbf": False}
+        logger.warning(
+            "Federated robot '%s' authenticated without audience validation. "
+            "Configure 'audiences' in federation config to suppress this warning. "
+            "Audience-less federation is deprecated and will be removed in a future release.",
+            robot.username,
+        )
+
+    service_config = {"quayrobot": service_config_block}
     service = OIDCLoginService(service_config, "quayrobot", client=app.config["HTTPCLIENT"])
 
-    # throws an exception if we cannot decode/verify the token
-    options = {"verify_aud": False, "verify_nbf": False}
     try:
         decoded_token = service.decode_user_jwt(token, options=options)
     except InvalidTokenError as e:

--- a/web/playwright/e2e/auth/oidc-multi-issuer-audience.spec.ts
+++ b/web/playwright/e2e/auth/oidc-multi-issuer-audience.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * OIDC Multi-Issuer and Multi-Audience Tests
+ *
+ * Verifies the PROJQUAY-11798 feature: Quay accepts tokens from multiple
+ * issuers (OIDC_ISSUERS) and multiple audiences (OIDC_AUDIENCES), and
+ * rejects tokens with unauthorized azp (OIDC_ALLOWED_CLIENTS).
+ *
+ * Requires Keycloak with:
+ * - quay realm (primary issuer)
+ * - quay-v2 realm (secondary issuer for multi-issuer testing)
+ * - quay-obo client (audience mapper for custom audience testing)
+ */
+
+import {test, expect} from '../../fixtures';
+import {API_URL} from '../../utils/config';
+
+const KEYCLOAK_HOST = 'http://localhost:8081';
+
+/**
+ * Extract OIDC config from Quay config, checking for multi-issuer fields.
+ */
+function getMultiIssuerConfig(quayConfig: {config: Record<string, unknown>}): {
+  clientId: string;
+  issuers: string[];
+  audiences: string[];
+} | null {
+  const config = quayConfig.config;
+  for (const [key, value] of Object.entries(config)) {
+    if (
+      key.endsWith('_LOGIN_CONFIG') &&
+      value &&
+      typeof value === 'object' &&
+      'OIDC_ISSUERS' in (value as Record<string, unknown>)
+    ) {
+      const loginConfig = value as Record<string, unknown>;
+      return {
+        clientId: loginConfig.CLIENT_ID as string,
+        issuers: loginConfig.OIDC_ISSUERS as string[],
+        audiences: (loginConfig.OIDC_AUDIENCES as string[]) || [],
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Get a token from Keycloak using Resource Owner Password Credentials grant.
+ */
+async function getKeycloakToken(
+  request: ReturnType<
+    Awaited<
+      ReturnType<typeof import('@playwright/test').request.newContext>
+    >['get']
+  > extends Promise<unknown>
+    ? Awaited<
+        ReturnType<(typeof import('@playwright/test').request)['newContext']>
+      >
+    : never,
+  realm: string,
+  clientId: string,
+  clientSecret?: string,
+): Promise<{access_token: string; [key: string]: unknown}> {
+  const form: Record<string, string> = {
+    grant_type: 'password',
+    client_id: clientId,
+    username: 'testuser_oidc',
+    password: 'password',
+    scope: 'openid profile email',
+  };
+  if (clientSecret) {
+    form.client_secret = clientSecret;
+  }
+
+  const response = await request.post(
+    `${KEYCLOAK_HOST}/realms/${realm}/protocol/openid-connect/token`,
+    {form, timeout: 10_000},
+  );
+  expect(
+    response.ok(),
+    `Keycloak token request failed: ${response.status()}`,
+  ).toBe(true);
+  return response.json();
+}
+
+/**
+ * Decode a JWT payload without verification (base64url → JSON).
+ */
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const payloadB64 = token.split('.')[1];
+  const json = Buffer.from(payloadB64, 'base64url').toString('utf-8');
+  return JSON.parse(json);
+}
+
+test.describe(
+  'OIDC Multi-Issuer and Multi-Audience',
+  {tag: ['@api', '@auth:OIDC', '@PROJQUAY-11798']},
+  () => {
+    test('token issuer is validated against OIDC_ISSUERS list', async ({
+      playwright,
+      quayConfig,
+    }) => {
+      const oidcConfig = getMultiIssuerConfig(quayConfig);
+      test.skip(
+        !oidcConfig,
+        'No OIDC_ISSUERS configured — skipping multi-issuer test',
+      );
+      if (!oidcConfig) return;
+
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        // Get a token from the primary realm
+        const tokenBody = await getKeycloakToken(request, 'quay', 'quay-ui');
+        const accessToken = tokenBody.access_token;
+
+        const claims = decodeJwtPayload(accessToken);
+        // eslint-disable-next-line no-console
+        console.log(`Token iss: ${claims.iss}`);
+        // Verify the token's issuer is in the configured OIDC_ISSUERS list
+        const issuerMatch = oidcConfig.issuers.some(
+          (i) => i.replace(/\/$/, '') === String(claims.iss).replace(/\/$/, ''),
+        );
+        expect(issuerMatch).toBe(true);
+
+        // Use it against Quay API — accepted because issuer is in OIDC_ISSUERS
+        const apiResponse = await request.get(`${API_URL}/api/v1/user/`, {
+          headers: {Authorization: `Bearer ${accessToken}`},
+          timeout: 10_000,
+        });
+
+        expect(apiResponse.status()).toBe(200);
+        const userBody = await apiResponse.json();
+        expect(userBody.username).toBeTruthy();
+      } finally {
+        await request.dispose();
+      }
+    });
+
+    test('token with custom audience (api://quay-api) is accepted', async ({
+      playwright,
+      quayConfig,
+    }) => {
+      const oidcConfig = getMultiIssuerConfig(quayConfig);
+      test.skip(
+        !oidcConfig,
+        'No OIDC_ISSUERS configured — skipping multi-audience test',
+      );
+      if (!oidcConfig) return;
+
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        // Get a token from quay-obo client (has audience mapper for api://quay-api)
+        const tokenBody = await getKeycloakToken(
+          request,
+          'quay',
+          'quay-obo',
+          'quay-obo-secret',
+        );
+        const accessToken = tokenBody.access_token;
+
+        const claims = decodeJwtPayload(accessToken);
+        // eslint-disable-next-line no-console
+        console.log(`Custom audience token aud: ${JSON.stringify(claims.aud)}`);
+        expect(claims.aud).toBe('api://quay-api');
+
+        // Use it against Quay API — should be accepted because
+        // api://quay-api is in OIDC_AUDIENCES
+        const apiResponse = await request.get(`${API_URL}/api/v1/user/`, {
+          headers: {Authorization: `Bearer ${accessToken}`},
+          timeout: 10_000,
+        });
+
+        expect(apiResponse.status()).toBe(200);
+        const userBody = await apiResponse.json();
+        expect(userBody.username).toBeTruthy();
+      } finally {
+        await request.dispose();
+      }
+    });
+
+    test('token with audience not in OIDC_AUDIENCES is rejected', async ({
+      playwright,
+      quayConfig,
+    }) => {
+      const oidcConfig = getMultiIssuerConfig(quayConfig);
+      test.skip(
+        !oidcConfig,
+        'No OIDC_ISSUERS configured — skipping audience rejection test',
+      );
+      if (!oidcConfig) return;
+
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        // Get a token from quay-unknown-aud client whose audience mapper
+        // sets aud to "api://some-other-app" — not in OIDC_AUDIENCES
+        const tokenBody = await getKeycloakToken(
+          request,
+          'quay',
+          'quay-unknown-aud',
+          'quay-unknown-aud-secret',
+        );
+        const accessToken = tokenBody.access_token;
+
+        const claims = decodeJwtPayload(accessToken);
+        // eslint-disable-next-line no-console
+        console.log(
+          `Wrong audience token aud: ${JSON.stringify(
+            claims.aud,
+          )}, configured: ${JSON.stringify(oidcConfig.audiences)}`,
+        );
+        expect(claims.aud).toBe('api://some-other-app');
+        expect(oidcConfig.audiences).not.toContain('api://some-other-app');
+
+        // Quay should reject — api://some-other-app is not in OIDC_AUDIENCES
+        const apiResponse = await request.get(`${API_URL}/api/v1/user/`, {
+          headers: {Authorization: `Bearer ${accessToken}`},
+          timeout: 10_000,
+        });
+
+        expect(apiResponse.status()).toBe(401);
+      } finally {
+        await request.dispose();
+      }
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- Add `OIDC_ISSUERS`, `OIDC_AUDIENCES`, `OIDC_ALLOWED_CLIENTS` config fields for multi-issuer/audience OIDC support
- Update all three auth paths (login flow, bearer token, federated robot) to use list-based validation
- Remove `verify_aud: False` workaround in bearer token path, replace with proper audience list validation
- Add `azp` (authorized party) claim logging and `OIDC_ALLOWED_CLIENTS` whitelist validation
- Phase 1 federated robot auth: optional `audiences` field with deprecation warning when absent
- 26 new tests covering multi-issuer decode, multi-audience validation, login manager lookup, config validation, and backward compatibility

## Motivation
Microsoft Entra ID uses two different issuer URLs for the same provider (v1.0: `sts.windows.net`, v2.0: `login.microsoftonline.com`). Quay currently only accepts one issuer per provider, breaking tokens from the other version. OBO flows (used by RHDH, Dev Spaces) produce tokens with custom audiences that Quay rejects, requiring the insecure `verify_aud: False` workaround.

## Test plan
- [x] Unit tests for multi-issuer/audience decode (v1.0 and v2.0 tokens)
- [x] Login manager multi-issuer lookup tests
- [x] Bearer token validation tests (audience list, azp logging, allowed clients)
- [x] Federated robot auth tests (optional audiences, deprecation warning)
- [x] Config validation tests (type checking, empty list, non-string items)
- [x] Backward compatibility tests (existing single-issuer configs unchanged)
- [x] All 323 tests pass across affected test files
- [ ] Manual test with Microsoft Entra tenant (v1.0 and v2.0 tokens)

Ref: [PROJQUAY-10538](https://redhat.atlassian.net/browse/PROJQUAY-10538)
Implements: [PROJQUAY-11798](https://redhat.atlassian.net/browse/PROJQUAY-11798)