### PR TITLE
PROJQUAY-11764: chore(web): bump axios to 1.16.1 [master]

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,7 +18,7 @@
         "@tanstack/react-query": "^4.13.5",
         "@types/node": "^20.6.5",
         "@types/react": "^18.2.0",
-        "axios": "^1.15.2",
+        "axios": "^1.16.1",
         "https-proxy-agent": "^5.0.1",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.7.6",

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-query": "^4.13.5",
     "@types/node": "^20.6.5",
     "@types/react": "^18.2.0",
-    "axios": "^1.15.2",
+    "axios": "^1.16.1",
     "https-proxy-agent": "^5.0.1",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.7.6",
@@ -122,7 +122,7 @@
     "webpack-merge": "^5.10.0"
   },
   "overrides": {
-    "axios": "^1.15.2",
+    "axios": "^1.16.1",
     "cross-spawn": "^7.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -139,7 +139,7 @@
   },
   "pnpm": {
     "overrides": {
-      "axios": "^1.15.2",
+      "axios": "^1.16.1",
       "cross-spawn": "^7.0.6",
       "react": "^18.2.0",
       "react-dom": "^18.2.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios: ^1.15.2
+  axios: ^1.16.1
   cross-spawn: ^7.0.6
   react: ^18.2.0
   react-dom: ^18.2.0
@@ -55,8 +55,8 @@ importers:
         specifier: ^18.2.0
         version: 18.3.28
       axios:
-        specifier: ^1.15.2
-        version: 1.16.0
+        specifier: ^1.16.1
+        version: 1.16.1
       https-proxy-agent:
         specifier: ^5.0.1
         version: 5.0.1
@@ -159,7 +159,7 @@ importers:
         version: 4.1.6(vitest@4.1.6)
       axios-mock-adapter:
         specifier: ^1.22.0
-        version: 1.22.0(axios@1.16.0)
+        version: 1.22.0(axios@1.16.1)
       copy-webpack-plugin:
         specifier: ^10.2.4
         version: 10.2.4(webpack@5.106.2)
@@ -2113,8 +2113,8 @@ packages:
     peerDependencies:
       axios: ^1.15.2
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -7207,7 +7207,7 @@ snapshots:
       '@redhat-cloud-services/types': 2.0.3
       '@sentry/browser': 7.120.4
       awesome-debounce-promise: 2.1.0
-      axios: 1.16.0
+      axios: 1.16.1
       commander: 2.20.3
       mkdirp: 1.0.4
       p-map: 7.0.4
@@ -7245,7 +7245,7 @@ snapshots:
 
   '@redhat-cloud-services/javascript-clients-shared@1.2.7':
     dependencies:
-      axios: 1.16.0
+      axios: 1.16.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - debug
@@ -7253,7 +7253,7 @@ snapshots:
   '@redhat-cloud-services/rbac-client@2.2.11':
     dependencies:
       '@redhat-cloud-services/javascript-clients-shared': 1.2.7
-      axios: 1.16.0
+      axios: 1.16.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - debug
@@ -8111,16 +8111,17 @@ snapshots:
 
   axe-core@4.11.4: {}
 
-  axios-mock-adapter@1.22.0(axios@1.16.0):
+  axios-mock-adapter@1.22.0(axios@1.16.1):
     dependencies:
-      axios: 1.16.0
+      axios: 1.16.1
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
 
-  axios@1.16.0:
+  axios@1.16.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
Bumping axios version to 1.16.1, which is a patch for CVE-2026-44496 on master branch

Files modified: web/package.json, web/package-lock.json, web/pnpm-lock.yaml (17 insertions, 16 deletions) 
Changes:

web/package.json: "axios": "^1.15.2" → "^1.16.1" in dependencies, overrides, and pnpm.overrides
web/package-lock.json: updated specifier from ^1.15.2 to ^1.16.1
web/pnpm-lock.yaml: updated overrides, specifier, version resolution (1.16.0 → 1.16.1), integrity hash, added https-proxy-agent: 5.0.1 dependency, updated all transitive axios references
