### PR TITLE
[redhat-3.16] PROJQUAY-11779: chore(web): bump axios to 1.16.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^20.6.5",
         "@types/react": "^18.2.0",
         "@types/react-google-recaptcha": "^2.1.9",
-        "axios": "^1.15.2",
+        "axios": "^1.16.1",
         "https-proxy-agent": "^5.0.1",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.7.6",
@@ -5060,13 +5060,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^20.6.5",
     "@types/react": "^18.2.0",
     "@types/react-google-recaptcha": "^2.1.9",
-    "axios": "^1.15.2",
+    "axios": "^1.16.1",
     "https-proxy-agent": "^5.0.1",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.7.6",


### PR DESCRIPTION
Bumping axios version to 1.16.1, which is a patch for CVE-2026-44496 on redhat-3.16 branch
Files modified: web/package.json, web/package-lock.json (7 insertions, 6 deletions) 
Changes:

web/package.json: "axios": "^1.15.2" → "^1.16.1" in dependencies
web/package-lock.json: updated specifier, version (1.15.2 → 1.16.1), resolved URL, integrity hash, added https-proxy-agent dependency