### PR TITLE
[redhat-3.12] PROJQUAY-11762: chore(web): bump axios to 1.16.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@types/jest": "^29.5.3",
         "@types/node": "^20.6.5",
         "@types/react": "^17.0.2",
-        "axios": "^1.15.2",
+        "axios": "^1.16.1",
         "buffer": "^4.9.2",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.7.6",
@@ -6964,13 +6964,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -30224,7 +30225,7 @@
         "@redhat-cloud-services/types": "^0.0.24",
         "@sentry/browser": "^5.30.0",
         "awesome-debounce-promise": "^2.1.0",
-        "axios": "^1.15.2",
+        "axios": "^1.16.1",
         "commander": "^2.20.3",
         "mkdirp": "^1.0.4",
         "react-content-loader": "^6.2.0"
@@ -30248,7 +30249,7 @@
       "integrity": "sha512-zFTumiNZdgxAuihm53JwUM37nF5yMyMsDxlJ9EMD11SXLKh1LkNZVScie3y7JT7VQ6D8C8y74TAn/n5B25Vq4w==",
       "peer": true,
       "requires": {
-        "axios": "^1.15.2"
+        "axios": "^1.16.1"
       }
     },
     "@redhat-cloud-services/types": {
@@ -32056,12 +32057,13 @@
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g=="
     },
     "axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "requires": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       },
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^29.5.3",
     "@types/node": "^20.6.5",
     "@types/react": "^17.0.2",
-    "axios": "^1.15.2",
+    "axios": "^1.16.1",
     "buffer": "^4.9.2",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.7.6",
@@ -117,7 +117,7 @@
     "@patternfly/react-icons": "^5.1.0",
     "@patternfly/react-table": "^5.1.0",
     "node-forge": "^1.4.0",
-    "axios": "^1.15.2",
+    "axios": "^1.16.1",
     "minimatch": "^3.1.5",
     "filelist": {
       "minimatch": "^5.0.1"


### PR DESCRIPTION
Bumping axios version to 1.16.1, which is a patch for CVE-2026-44496 on redhat-3.12 branch
Files modified: web/package.json, web/package-lock.json (15 insertions, 13 deletions) 
Changes:

web/package.json: "axios": "^1.15.2" → "^1.16.1" in both dependencies and overrides
web/package-lock.json: updated specifier (3 places), node_modules/axios entry (version, resolved, integrity, deps), and v2-format dependencies.axios entry
