### PR TITLE
[redhat-3.9] PROJQUAY-11785: chore(web): bump axios to 1.16.1

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@types/jest": "^27.4.1",
         "@types/node": "^16.11.26",
         "@types/react": "^17.0.2",
-        "axios": "^1.15.2",
+        "axios": "^1.16.1",
         "buffer": "^4.9.2",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.6.1",
@@ -6500,13 +6500,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@types/jest": "^27.4.1",
     "@types/node": "^16.11.26",
     "@types/react": "^17.0.2",
-    "axios": "^1.15.2",
+    "axios": "^1.16.1",
     "buffer": "^4.9.2",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.6.1",
@@ -115,7 +115,7 @@
       "minimatch": "^9.0.4"
     },
     "node-forge": "^1.4.0",
-    "axios": "^1.15.2",
+    "axios": "^1.16.1",
     "immutable": "^5.1.5",
     "svgo": "4.0.1"
   },


### PR DESCRIPTION
Bumping axios version to 1.16.1, which is a patch for CVE-2026-44496 on redhat-3.9 branch
Files modified: web/package.json, web/package-lock.json (8 insertions, 7 deletions) 
Changes:

web/package.json: "axios": "^1.15.2" → "^1.16.1" in both dependencies and overrides
web/package-lock.json: updated specifier, node_modules/axios entry (version, resolved, integrity, deps)