### PR TITLE
NO-ISSUE: fix(workers): fix scheduling race and lock TTL in reconciliation worker

### DIFF
--- a/workers/reconciliationworker.py
+++ b/workers/reconciliationworker.py
@@ -9,14 +9,14 @@ from app import app
 from app import billing as stripe
 from app import marketplace_subscriptions, marketplace_users
 from data import model
-from data.billing import RH_SKUS, get_plan
+from data.billing import get_plan
 from util.locking import GlobalLock, LockNotAcquiredException
 from util.marketplace import MarketplaceApiException
 from workers.gunicorn_worker import GunicornWorker
-from workers.namespacegcworker import LOCK_TIMEOUT_PADDING
 from workers.worker import Worker
 
 logger = logging.getLogger(__name__)
+
 
 RECONCILIATION_TIMEOUT = 5 * 60  # 5min
 RECONCILIATION_FREQUENCY = 5 * 60  # run reconciliation every 5 min
@@ -141,9 +141,7 @@ class ReconciliationWorker(Worker):
         else:
             try:
                 with GlobalLock(
-                    "RECONCILIATION_WORKER",
-                    lock_ttl=app.config.get("RECONCILIATION_FREQUENCY", RECONCILIATION_FREQUENCY)
-                    + LOCK_TIMEOUT_PADDING,
+                    "RECONCILIATION_WORKER", lock_ttl=RECONCILIATION_TIMEOUT, auto_renewal=True
                 ):
                     self._perform_reconciliation(
                         user_api=marketplace_users, marketplace_api=marketplace_subscriptions

--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -7,7 +7,9 @@ from app import billing as stripe
 from app import marketplace_subscriptions, marketplace_users
 from data import model
 from test.fixtures import *
+from util.locking import LockNotAcquiredException
 from workers.reconciliationworker import (
+    RECONCILIATION_TIMEOUT,
     ReconciliationWorker,
     reconciliation_api_call_duration,
     reconciliation_api_call_errors,
@@ -439,3 +441,45 @@ def test_reconciliation_duration_recorded():
     # Check that duration was recorded (gauge will have a value greater than 0)
     final_duration = reconciliation_duration_seconds._value.get()
     assert final_duration > 0
+
+
+def test_reconcile_acquires_lock_with_auto_renewal():
+    with (
+        patch("workers.reconciliationworker.GlobalLock") as mock_lock_cls,
+        patch.object(worker, "_perform_reconciliation") as mock_perform,
+    ):
+        mock_lock_cls.return_value.__enter__ = MagicMock(return_value=None)
+        mock_lock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        worker._reconcile_entitlements()
+
+        mock_lock_cls.assert_called_once_with(
+            "RECONCILIATION_WORKER",
+            lock_ttl=RECONCILIATION_TIMEOUT,
+            auto_renewal=True,
+        )
+        mock_perform.assert_called_once()
+
+
+def test_reconcile_skips_on_lock_not_acquired():
+    with (
+        patch("workers.reconciliationworker.GlobalLock") as mock_lock_cls,
+        patch.object(worker, "_perform_reconciliation") as mock_perform,
+    ):
+        mock_lock_cls.return_value.__enter__ = MagicMock(side_effect=LockNotAcquiredException)
+        mock_lock_cls.return_value.__exit__ = MagicMock(return_value=True)
+
+        worker._reconcile_entitlements()
+
+        mock_perform.assert_not_called()
+
+
+def test_reconcile_skip_lock_for_testing():
+    with (
+        patch("workers.reconciliationworker.GlobalLock") as mock_lock_cls,
+        patch.object(worker, "_perform_reconciliation") as mock_perform,
+    ):
+        worker._reconcile_entitlements(skip_lock_for_testing=True)
+
+        mock_lock_cls.assert_not_called()
+        mock_perform.assert_called_once()

--- a/workers/test/test_worker.py
+++ b/workers/test/test_worker.py
@@ -220,7 +220,8 @@ def test_start_schedules_job_with_5s_buffer():
         assert start_date is not None
         assert start_date >= before + timedelta(seconds=4)
         assert start_date <= after + timedelta(seconds=6)
-        assert call_kwargs.kwargs.get("seconds") or call_kwargs[1].get("seconds") == 86400
+        seconds = call_kwargs.kwargs.get("seconds") or call_kwargs[1].get("seconds")
+        assert seconds == 86400
 
 
 def test_start_stagger_workers_adds_random_delay():

--- a/workers/test/test_worker.py
+++ b/workers/test/test_worker.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from workers.worker import (
@@ -184,3 +185,74 @@ def test_default_sentry_config_values():
 
         # Verify the SDK was called exactly once
         assert mock_sentry_sdk.init.call_count == 1
+
+
+def test_start_schedules_job_with_5s_buffer():
+    with (
+        patch("workers.worker.app") as mock_app,
+        patch("workers.worker.signal"),
+    ):
+        mock_app.config.get.side_effect = lambda key, default=None: {
+            "SETUP_COMPLETE": True,
+            "REGISTRY_STATE": "normal",
+        }.get(key, default)
+
+        worker = Worker()
+        worker.add_operation(lambda: None, 86400)
+
+        mock_sched = MagicMock()
+        worker._sched = mock_sched
+
+        stop_event = MagicMock()
+        stop_event.wait.return_value = True
+        worker._stop = stop_event
+
+        before = datetime.now()
+        worker.start()
+        after = datetime.now()
+
+        mock_sched.add_job.assert_called_once()
+        call_kwargs = mock_sched.add_job.call_args
+        start_date = call_kwargs.kwargs.get("start_date") or call_kwargs[1].get("start_date")
+        if start_date is None:
+            start_date = call_kwargs[0][2] if len(call_kwargs[0]) > 2 else None
+
+        assert start_date is not None
+        assert start_date >= before + timedelta(seconds=4)
+        assert start_date <= after + timedelta(seconds=6)
+        assert call_kwargs.kwargs.get("seconds") or call_kwargs[1].get("seconds") == 86400
+
+
+def test_start_stagger_workers_adds_random_delay():
+    with (
+        patch("workers.worker.app") as mock_app,
+        patch("workers.worker.signal"),
+        patch("workers.worker.randint", return_value=100) as mock_randint,
+    ):
+        mock_app.config.get.side_effect = lambda key, default=None: {
+            "SETUP_COMPLETE": True,
+            "REGISTRY_STATE": "normal",
+            "STAGGER_WORKERS": True,
+        }.get(key, default)
+
+        worker = Worker()
+        worker.add_operation(lambda: None, 86400)
+
+        mock_sched = MagicMock()
+        worker._sched = mock_sched
+
+        stop_event = MagicMock()
+        stop_event.wait.return_value = True
+        worker._stop = stop_event
+
+        before = datetime.now()
+        worker.start()
+
+        mock_randint.assert_called_once_with(1, 86400)
+
+        call_kwargs = mock_sched.add_job.call_args
+        start_date = call_kwargs.kwargs.get("start_date") or call_kwargs[1].get("start_date")
+        if start_date is None:
+            start_date = call_kwargs[0][2] if len(call_kwargs[0]) > 2 else None
+
+        assert start_date >= before + timedelta(seconds=104)

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -201,7 +201,7 @@ class Worker(object):
 
         self._sched.start()
         for operation_func, operation_sec in self._operations:
-            start_date = datetime.now() + timedelta(seconds=0.001)
+            start_date = datetime.now() + timedelta(seconds=5)
             if app.config.get("STAGGER_WORKERS"):
                 start_date += timedelta(seconds=randint(1, operation_sec))
             logger.debug("First run scheduled for %s", start_date)

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -201,6 +201,7 @@ class Worker(object):
 
         self._sched.start()
         for operation_func, operation_sec in self._operations:
+            # Allow time for app initialization before the first job run
             start_date = datetime.now() + timedelta(seconds=5)
             if app.config.get("STAGGER_WORKERS"):
                 start_date += timedelta(seconds=randint(1, operation_sec))


### PR DESCRIPTION
## Summary

- **Fix first-run delay:** The `Worker` base class scheduled the first job execution with a 0.001s buffer (`start_date = now + 1ms`). APScheduler's `IntervalTrigger.get_next_fire_time()` races this — if the 1ms elapses before evaluation, `start_date` is in the past and the trigger skips to `start_date + interval`. At `RECONCILIATION_FREQUENCY=86400`, this delays the first run by a full day. Increased the buffer to 5 seconds.

- **Fix lock TTL on crash:** The `GlobalLock` TTL was set to `RECONCILIATION_FREQUENCY + LOCK_TIMEOUT_PADDING` (86460s). If the lock-holding process crashes, no other process can acquire the lock for ~24 hours. Decoupled by using `RECONCILIATION_TIMEOUT` (300s) with `auto_renewal=True` — the lock auto-extends while the process is alive via a background thread, but expires within 5 minutes on crash. This pattern is already used by `SecurityWorker`.

- Removed unused `RH_SKUS` and `LOCK_TIMEOUT_PADDING` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)