### PR TITLE
NO-ISSUE: fix(mirror): resolve tag expiration UNIQUE constraint race

### DIFF
--- a/internal/dal/daldb/tag.sql.go
+++ b/internal/dal/daldb/tag.sql.go
@@ -89,7 +89,8 @@ func (q *Queries) GetTagsByRepository(ctx context.Context, arg GetTagsByReposito
 const upsertTag = `-- name: UpsertTag :one
 INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, tag_kind_id)
 VALUES (?, ?, ?, ?, ?)
-ON CONFLICT (repository_id, name, lifetime_end_ms) DO UPDATE SET manifest_id = excluded.manifest_id
+ON CONFLICT (repository_id, name) WHERE lifetime_end_ms IS NULL
+DO UPDATE SET manifest_id = excluded.manifest_id
 RETURNING id
 `
 
@@ -101,11 +102,6 @@ type UpsertTagParams struct {
 	TagKindID       int64         `json:"tag_kind_id"`
 }
 
-// KNOWN LIMITATION: ON CONFLICT uses lifetime_end_ms which is nullable.
-// NULL != NULL in SQL, so active tags (lifetime_end_ms IS NULL) never conflict.
-// This inserts duplicates instead of updating. Proper fix requires a partial
-// unique index: CREATE UNIQUE INDEX ON tag (repository_id, name) WHERE lifetime_end_ms IS NULL.
-// Until then, callers should expire the old tag before inserting a new one.
 func (q *Queries) UpsertTag(ctx context.Context, arg UpsertTagParams) (int64, error) {
 	row := q.db.QueryRowContext(ctx, upsertTag,
 		arg.Name,

--- a/internal/dal/dbcore/bootstrap.go
+++ b/internal/dal/dbcore/bootstrap.go
@@ -38,7 +38,6 @@ func ensureSchema(ctx context.Context, db *sql.DB, dbPath string) error {
 		if err := InitDatabase(ctx, db, io.Discard); err != nil {
 			return fmt.Errorf("init database: %w", err)
 		}
-		return nil
 	}
 
 	ver, err := SchemaVersion(ctx, db)

--- a/internal/dal/dbcore/migrate.go
+++ b/internal/dal/dbcore/migrate.go
@@ -17,7 +17,7 @@ import (
 
 // TargetVersion is the alembic HEAD revision this binary was built against.
 // Updated by make go-schema when schema changes.
-const TargetVersion = "c3d4e5f6a7b8"
+const TargetVersion = "d4e5f6a7b8c9"
 
 // InitDatabase creates a fresh SQLite database by executing the embedded DDL
 // and seed data. It returns an error if the database file already contains
@@ -291,10 +291,6 @@ func applyMigrationTx(ctx context.Context, db *sql.DB, migrationSQL, revisionID 
 	defer tx.Rollback() //nolint:errcheck // no-op after commit
 
 	for _, stmt := range splitStatements(migrationSQL) {
-		trimmed := strings.TrimSpace(stmt)
-		if trimmed == "" || strings.HasPrefix(trimmed, "--") {
-			continue
-		}
 		if _, err := tx.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("execute SQL: %w", err)
 		}
@@ -325,10 +321,16 @@ func extractRevisionID(migrationSQL string) (string, error) {
 	return "", fmt.Errorf("missing '-- revision: <id>' comment")
 }
 
-// splitStatements splits a SQL script on semicolons, trimming whitespace
-// and discarding empty entries.
+// splitStatements strips SQL comment lines, then splits on semicolons,
+// trimming whitespace and discarding empty entries.
 func splitStatements(rawSQL string) []string {
-	raw := strings.Split(rawSQL, ";")
+	var filtered []string
+	for _, line := range strings.Split(rawSQL, "\n") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "--") {
+			filtered = append(filtered, line)
+		}
+	}
+	raw := strings.Split(strings.Join(filtered, "\n"), ";")
 	stmts := make([]string, 0, len(raw))
 	for _, s := range raw {
 		s = strings.TrimSpace(s)

--- a/internal/dal/metastore/metastore_sqlite_test.go
+++ b/internal/dal/metastore/metastore_sqlite_test.go
@@ -367,6 +367,72 @@ func TestDeleteTag(t *testing.T) {
 	}
 }
 
+func TestPutTag_RapidReplace(t *testing.T) {
+	store := setupStore(t)
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "pokemon", Name: "encounter-service"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dgst := digest.FromString("manifest-v1")
+	_, err = store.PutManifest(ctx, repoID, metastore.ManifestRecord{
+		Digest:    dgst,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{}`),
+		Tag:       "v1.0.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rapid sequential PutTag calls for the same tag can land in the same
+	// millisecond, causing ExpireActiveTag to collide with a previously-
+	// expired row's lifetime_end_ms. This must not fail.
+	for i := range 20 {
+		id, err := store.PutTag(ctx, repoID, metastore.TagRecord{
+			Name:   "v1.0.0",
+			Digest: dgst,
+		})
+		if err != nil {
+			t.Fatalf("iteration %d: %v", i, err)
+		}
+		if id == 0 {
+			t.Fatalf("iteration %d: expected non-zero tag ID", i)
+		}
+	}
+}
+
+func TestDeleteTag_RapidExpire(t *testing.T) {
+	store := setupStore(t)
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "pokemon", Name: "encounter-service"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dgst := digest.FromString("manifest-v1")
+
+	// Rapidly create-then-delete the same tag. Expiration timestamps may
+	// collide with previously-expired rows.
+	for i := range 20 {
+		_, err := store.PutManifest(ctx, repoID, metastore.ManifestRecord{
+			Digest:    dgst,
+			MediaType: "application/vnd.oci.image.manifest.v1+json",
+			Content:   []byte(`{}`),
+			Tag:       "latest",
+		})
+		if err != nil {
+			t.Fatalf("iteration %d put: %v", i, err)
+		}
+		if err := store.DeleteTag(ctx, repoID, "latest"); err != nil {
+			t.Fatalf("iteration %d delete: %v", i, err)
+		}
+	}
+}
+
 // --- test helpers ---
 
 func assertActiveTag(t *testing.T, s *metastore.SQLiteStore, repoID int64, tag string) {

--- a/internal/dal/queries/tag.sql
+++ b/internal/dal/queries/tag.sql
@@ -1,12 +1,8 @@
 -- name: UpsertTag :one
--- KNOWN LIMITATION: ON CONFLICT uses lifetime_end_ms which is nullable.
--- NULL != NULL in SQL, so active tags (lifetime_end_ms IS NULL) never conflict.
--- This inserts duplicates instead of updating. Proper fix requires a partial
--- unique index: CREATE UNIQUE INDEX ON tag (repository_id, name) WHERE lifetime_end_ms IS NULL.
--- Until then, callers should expire the old tag before inserting a new one.
 INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, tag_kind_id)
 VALUES (?, ?, ?, ?, ?)
-ON CONFLICT (repository_id, name, lifetime_end_ms) DO UPDATE SET manifest_id = excluded.manifest_id
+ON CONFLICT (repository_id, name) WHERE lifetime_end_ms IS NULL
+DO UPDATE SET manifest_id = excluded.manifest_id
 RETURNING id;
 
 -- name: ExpireActiveTag :execresult

--- a/internal/dal/schema/sqlite/migrations/0002_partial_tag_index.sql
+++ b/internal/dal/schema/sqlite/migrations/0002_partial_tag_index.sql
@@ -1,0 +1,4 @@
+-- revision: d4e5f6a7b8c9
+DROP INDEX IF EXISTS tag_repository_id_name_lifetime_end_ms;
+CREATE UNIQUE INDEX tag_repository_id_name_active ON tag (repository_id, name) WHERE lifetime_end_ms IS NULL;
+CREATE INDEX tag_repository_id_name_lifetime_end_ms ON tag (repository_id, name, lifetime_end_ms);


### PR DESCRIPTION
## Summary

- Add a SQLite-specific migration that replaces the UNIQUE index on `(repository_id, name, lifetime_end_ms)` with a partial unique index on `(repository_id, name) WHERE lifetime_end_ms IS NULL`
- Fix `ensureSchema` to apply pending migrations after fresh DB init, keeping the base schema in sync with PG
- Fix `splitStatements` to strip SQL comments before splitting on semicolons

## Root Cause

Two sequential transactions completing within the same millisecond both try to expire a tag to the same `lifetime_end_ms` timestamp. The old UNIQUE index treats this as a constraint violation — even though duplicate expired timestamps are semantically meaningless.

PostgreSQL avoids this via advisory locks in `retarget_tag()` (`data/model/oci/tag.py:471`), which fully serialize tag mutations per repository. SQLite has no advisory locks, and `MaxOpenConns=1` serialization is fast enough that back-to-back transactions land in the same millisecond.

The partial unique index enforces the real invariant (one active tag per name) while letting expired rows pile up freely. This also resolves the documented `KNOWN LIMITATION` in `UpsertTag` where `NULL != NULL` prevented the `ON CONFLICT` clause from deduplicating active tags.

## Architecture

```
Fresh DB:  quay_schema.sql (PG baseline) → migrations/ (SQLite-specific) → ready
Existing:  check version → migrations/ → ready
```

The base schema (`quay_schema.sql`) stays in sync with PG via `make go-schema`. SQLite-specific changes live in `internal/dal/schema/sqlite/migrations/` and are applied after the baseline — for both fresh and existing databases.

## Changes

| File | Change |
|------|--------|
| `migrations/0002_partial_tag_index.sql` | New migration: swap UNIQUE → partial unique index |
| `queries/tag.sql` | `ON CONFLICT` targets partial index; removed KNOWN LIMITATION comment |
| `daldb/tag.sql.go` | Regenerated by sqlc |
| `dbcore/bootstrap.go` | `ensureSchema` falls through to apply migrations after fresh init |
| `dbcore/migrate.go` | `TargetVersion` bumped; `splitStatements` strips comments before splitting |
| `metastore_sqlite_test.go` | Two regression tests (20 rapid iterations each) |

## Reproducer

```bash
# prewarm with concurrent pushes — triggers same-millisecond tag expiration
for x in list_of_images; do skopeo copy src dst; done
```

```json
{"level":"ERROR","msg":"metadata write failed","operation":"tag",
 "err":"expire tag \"v1.0.0\": constraint failed: UNIQUE constraint failed: tag.repository_id, tag.name, tag.lifetime_end_ms (2067)"}
```

## Test Plan

- [x] `TestPutTag_RapidReplace` — 20 rapid sequential PutTag calls for the same tag
- [x] `TestDeleteTag_RapidExpire` — 20 rapid create-then-delete cycles
- [x] `TestSetup_FreshDB` — fresh DB applies baseline + migration
- [x] `TestSetup_ExistingDB` — idempotent on restart (migration not re-applied)
- [x] All 135 `internal/...` tests pass with `-race`
- [x] sqlc regenerated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)