### PR TITLE
NO-ISSUE: fix(test): isolate autoprune user-namespace tests with freshUser fixture

### DIFF
--- a/web/playwright/e2e/organization/autoprune-policies.spec.ts
+++ b/web/playwright/e2e/organization/autoprune-policies.spec.ts
@@ -274,53 +274,57 @@ test.describe(
     });
 
     test('user namespace tag-count pruning removes excess tags', async ({
-      api,
+      freshUser,
     }) => {
       test.slow();
-      const username = user.username;
-      const repoName = `pruneusr${Date.now()}`;
+      const {user, api} = freshUser;
+      const repo = await api.repository(user.username, 'prunetest');
 
-      await api.raw.deleteAllUserAutoPrunePolicies();
-      await api.raw.createRepository(username, repoName, 'private');
+      await pushImage(
+        user.username,
+        repo.name,
+        'v1',
+        user.username,
+        user.password,
+      );
+      await pushImage(
+        user.username,
+        repo.name,
+        'v2',
+        user.username,
+        user.password,
+      );
 
-      try {
-        await pushImage(username, repoName, 'v1', user.username, user.password);
-        await pushImage(username, repoName, 'v2', user.username, user.password);
+      await api.userAutoPrunePolicy({method: 'number_of_tags', value: 1});
 
-        await api.userAutoPrunePolicy({method: 'number_of_tags', value: 1});
-
-        await expect(async () => {
-          const tags = await api.raw.getTags(username, repoName);
-          expect(tags.tags).toHaveLength(1);
-          expect(tags.tags[0].name).toBe('v2');
-        }).toPass({timeout: 120_000, intervals: [5_000]});
-      } finally {
-        await api.raw.deleteRepository(username, repoName);
-      }
+      await expect(async () => {
+        const tags = await api.raw.getTags(user.username, repo.name);
+        expect(tags.tags).toHaveLength(1);
+        expect(tags.tags[0].name).toBe('v2');
+      }).toPass({timeout: 120_000, intervals: [5_000]});
     });
 
     test('user namespace time-based pruning removes old tags', async ({
-      api,
+      freshUser,
     }) => {
       test.slow();
-      const username = user.username;
-      const repoName = `pruneusrage${Date.now()}`;
+      const {user, api} = freshUser;
+      const repo = await api.repository(user.username, 'prunetest');
 
-      await api.raw.deleteAllUserAutoPrunePolicies();
-      await api.raw.createRepository(username, repoName, 'private');
+      await pushImage(
+        user.username,
+        repo.name,
+        'v1',
+        user.username,
+        user.password,
+      );
 
-      try {
-        await pushImage(username, repoName, 'v1', user.username, user.password);
+      await api.userAutoPrunePolicy({method: 'creation_date', value: '10s'});
 
-        await api.userAutoPrunePolicy({method: 'creation_date', value: '10s'});
-
-        await expect(async () => {
-          const tags = await api.raw.getTags(username, repoName);
-          expect(tags.tags).toHaveLength(0);
-        }).toPass({timeout: 180_000, intervals: [10_000]});
-      } finally {
-        await api.raw.deleteRepository(username, repoName);
-      }
+      await expect(async () => {
+        const tags = await api.raw.getTags(user.username, repo.name);
+        expect(tags.tags).toHaveLength(0);
+      }).toPass({timeout: 180_000, intervals: [10_000]});
     });
 
     test('combined org + repo policies coexist without interference', async ({
@@ -348,37 +352,44 @@ test.describe(
       }).toPass({timeout: 120_000, intervals: [5_000]});
     });
 
-    test('multiple user-namespace policies both take effect', async ({api}) => {
+    test('multiple user-namespace policies both take effect', async ({
+      freshUser,
+    }) => {
       test.slow();
-      const username = user.username;
-      const repoName = `prunemulti${Date.now()}`;
+      const {user, api} = freshUser;
+      const repo = await api.repository(user.username, 'prunetest');
 
-      await api.raw.deleteAllUserAutoPrunePolicies();
-      await api.raw.createRepository(username, repoName, 'private');
+      await pushImage(
+        user.username,
+        repo.name,
+        'v1',
+        user.username,
+        user.password,
+      );
+      await pushImage(
+        user.username,
+        repo.name,
+        'v2',
+        user.username,
+        user.password,
+      );
 
-      try {
-        await pushImage(username, repoName, 'v1', user.username, user.password);
-        await pushImage(username, repoName, 'v2', user.username, user.password);
+      // Create tag-count policy first and verify it prunes
+      await api.userAutoPrunePolicy({method: 'number_of_tags', value: 1});
 
-        // Create tag-count policy first and verify it prunes
-        await api.userAutoPrunePolicy({method: 'number_of_tags', value: 1});
+      await expect(async () => {
+        const tags = await api.raw.getTags(user.username, repo.name);
+        expect(tags.tags).toHaveLength(1);
+        expect(tags.tags[0].name).toBe('v2');
+      }).toPass({timeout: 120_000, intervals: [5_000]});
 
-        await expect(async () => {
-          const tags = await api.raw.getTags(username, repoName);
-          expect(tags.tags).toHaveLength(1);
-          expect(tags.tags[0].name).toBe('v2');
-        }).toPass({timeout: 120_000, intervals: [5_000]});
+      // Add time-based policy — remaining tag is already >10s old
+      await api.userAutoPrunePolicy({method: 'creation_date', value: '10s'});
 
-        // Add time-based policy — remaining tag is already >10s old
-        await api.userAutoPrunePolicy({method: 'creation_date', value: '10s'});
-
-        await expect(async () => {
-          const tags = await api.raw.getTags(username, repoName);
-          expect(tags.tags).toHaveLength(0);
-        }).toPass({timeout: 120_000, intervals: [5_000]});
-      } finally {
-        await api.raw.deleteRepository(username, repoName);
-      }
+      await expect(async () => {
+        const tags = await api.raw.getTags(user.username, repo.name);
+        expect(tags.tags).toHaveLength(0);
+      }).toPass({timeout: 120_000, intervals: [5_000]});
     });
   },
 );

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -1039,6 +1039,9 @@ type TestFixtures = {
   // Unauthenticated RawApiClient (no browser required)
   anonClient: RawApiClient;
 
+  // Isolated user with its own API client (no shared namespace state)
+  freshUser: {user: CreatedUser; api: TestApi};
+
   // Auto-fixture: skips tests based on @feature: tags (runs automatically)
   _autoSkipByFeature: void;
 
@@ -1219,6 +1222,25 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     const testApi = new TestApi(client);
     await use(testApi);
     await testApi.cleanup();
+  },
+
+  freshUser: async ({superuserApi, playwright}, use) => {
+    const created = await superuserApi.user('iso');
+    await superuserApi.raw.updateUserAsSuperuser(created.username, {
+      email: created.email,
+    });
+    const request = await playwright.request.newContext({
+      ignoreHTTPSErrors: true,
+    });
+    const client = new ApiClient(request);
+    await client.signIn(created.username, created.password);
+    client.setCredentials(created.username, created.password);
+    const testApi = new TestApi(client, created.username);
+
+    await use({user: created, api: testApi});
+
+    await testApi.cleanup();
+    await request.dispose();
   },
 
   // =========================================================================

--- a/web/playwright/utils/api/client.ts
+++ b/web/playwright/utils/api/client.ts
@@ -930,6 +930,29 @@ export class ApiClient {
     };
   }
 
+  async updateUserAsSuperuser(
+    username: string,
+    data: {email?: string; enabled?: boolean; password?: string},
+  ): Promise<void> {
+    const response = await this.withFreshLoginRetry(async () => {
+      const token = await this.fetchToken();
+      return this.request.put(`${API_URL}/api/v1/superuser/users/${username}`, {
+        timeout: 10000,
+        headers: {
+          'X-CSRF-Token': token,
+        },
+        data,
+      });
+    });
+
+    if (!response.ok()) {
+      const body = await response.text();
+      throw new Error(
+        `Failed to update user ${username}: ${response.status()} - ${body}`,
+      );
+    }
+  }
+
   async deleteUser(username: string): Promise<void> {
     const response = await this.withFreshLoginRetry(async () => {
       const token = await this.fetchToken();


### PR DESCRIPTION
## Summary
- Add a `freshUser` Playwright fixture that creates a throwaway user with its own authenticated API client and auto-cleanup via user deletion cascade
- Migrate autoprune user-namespace functional tests to use `freshUser` instead of the shared `testuser` account, eliminating cross-test interference under `fullyParallel: true`
- Remove `deleteAllUserAutoPrunePolicies()` calls that were nuking concurrent tests' state

## Root Cause
User-namespace autoprune policies are global — any policy on `testuser` affects all repos in that namespace. With 4 parallel workers, the UI test creating policies via the browser and functional tests calling `deleteAllUserAutoPrunePolicies()` would race, causing flaky failures (e.g. [run 27711379659](https://github.com/quay/quay/actions/runs/27711379659)).

## Test plan
- [ ] Playwright CI passes with autoprune tests running in parallel
- [ ] `freshUser` fixture creates isolated user, signs in, and cleans up on teardown
- [ ] Org-level tests unchanged and still pass
- [ ] TypeScript type-check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)