### PR TITLE
PROJQUAY-11889: fix(ui): hide sidebar on repository and organization detail pages

### DIFF
--- a/web/playwright/e2e/repository/builds.spec.ts
+++ b/web/playwright/e2e/repository/builds.spec.ts
@@ -186,8 +186,8 @@ test.describe(
       });
       await expect(dateHeader).toHaveAttribute('aria-sort', 'descending');
 
-      // Click to toggle sort direction
-      await dateHeader.click();
+      // Click the sort button inside the column header to toggle direction
+      await dateHeader.getByRole('button').click();
       await expect(dateHeader).toHaveAttribute('aria-sort', 'ascending');
 
       // Both builds should remain visible after sort toggle

--- a/web/playwright/e2e/ui/sidebar-visibility.spec.ts
+++ b/web/playwright/e2e/ui/sidebar-visibility.spec.ts
@@ -39,10 +39,8 @@ test.describe(
         authenticatedPage.getByRole('tab', {name: 'Information'}),
       ).toBeVisible();
 
-      // Sidebar should not be visible
-      await expect(
-        authenticatedPage.locator('.page-sidebar'),
-      ).not.toBeVisible();
+      // Sidebar should be removed from the DOM, not just visually hidden
+      await expect(authenticatedPage.locator('.page-sidebar')).toHaveCount(0);
     });
 
     test('sidebar is hidden on organization detail page', async ({
@@ -55,10 +53,8 @@ test.describe(
       // Org detail content should be visible (proves we're on a detail page)
       await expect(authenticatedPage.locator('h1')).toBeVisible();
 
-      // Sidebar should not be visible
-      await expect(
-        authenticatedPage.locator('.page-sidebar'),
-      ).not.toBeVisible();
+      // Sidebar should be removed from the DOM, not just visually hidden
+      await expect(authenticatedPage.locator('.page-sidebar')).toHaveCount(0);
     });
   },
 );

--- a/web/playwright/e2e/ui/sidebar-visibility.spec.ts
+++ b/web/playwright/e2e/ui/sidebar-visibility.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Sidebar visibility tests
+ *
+ * Verifies the global sidebar is hidden on detail pages (repository, organization)
+ * where tab navigation provides contextual nav, and visible on list pages.
+ *
+ * Ref: PROJQUAY-11889
+ */
+
+import {test, expect} from '../../fixtures';
+
+test.describe(
+  'Sidebar visibility',
+  {tag: ['@ui', '@sidebar', '@PROJQUAY-11889']},
+  () => {
+    test('sidebar is visible on repository list page', async ({
+      authenticatedPage,
+    }) => {
+      await authenticatedPage.goto('/repository');
+      await expect(
+        authenticatedPage.locator('.page-sidebar'),
+      ).toBeVisible();
+    });
+
+    test('sidebar is visible on organization list page', async ({
+      authenticatedPage,
+    }) => {
+      await authenticatedPage.goto('/organization');
+      await expect(
+        authenticatedPage.locator('.page-sidebar'),
+      ).toBeVisible();
+    });
+
+    test('sidebar is hidden on repository detail page', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const repo = await api.repository();
+      await authenticatedPage.goto(`/repository/${repo.fullName}`);
+
+      // Tab navigation should be visible (proves we're on a detail page)
+      await expect(
+        authenticatedPage.getByRole('tab', {name: 'Information'}),
+      ).toBeVisible();
+
+      // Sidebar should not be visible
+      await expect(
+        authenticatedPage.locator('.page-sidebar'),
+      ).not.toBeVisible();
+    });
+
+    test('sidebar is hidden on organization detail page', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('sidebarorg');
+      await authenticatedPage.goto(`/organization/${org.name}`);
+
+      // Org detail content should be visible (proves we're on a detail page)
+      await expect(authenticatedPage.locator('h1')).toBeVisible();
+
+      // Sidebar should not be visible
+      await expect(
+        authenticatedPage.locator('.page-sidebar'),
+      ).not.toBeVisible();
+    });
+  },
+);

--- a/web/playwright/e2e/ui/sidebar-visibility.spec.ts
+++ b/web/playwright/e2e/ui/sidebar-visibility.spec.ts
@@ -17,18 +17,14 @@ test.describe(
       authenticatedPage,
     }) => {
       await authenticatedPage.goto('/repository');
-      await expect(
-        authenticatedPage.locator('.page-sidebar'),
-      ).toBeVisible();
+      await expect(authenticatedPage.locator('.page-sidebar')).toBeVisible();
     });
 
     test('sidebar is visible on organization list page', async ({
       authenticatedPage,
     }) => {
       await authenticatedPage.goto('/organization');
-      await expect(
-        authenticatedPage.locator('.page-sidebar'),
-      ).toBeVisible();
+      await expect(authenticatedPage.locator('.page-sidebar')).toBeVisible();
     });
 
     test('sidebar is hidden on repository detail page', async ({

--- a/web/src/components/sidebar/QuaySidebar.test.ts
+++ b/web/src/components/sidebar/QuaySidebar.test.ts
@@ -18,12 +18,12 @@ describe('isDetailPagePath', () => {
     expect(
       isDetailPagePath('/repository/myorg/myrepo/manifest/sha256:abc'),
     ).toBe(true);
-    expect(
-      isDetailPagePath('/repository/myorg/myrepo/trigger/uuid-123'),
-    ).toBe(true);
-    expect(
-      isDetailPagePath('/repository/myorg/myrepo/build/build-456'),
-    ).toBe(true);
+    expect(isDetailPagePath('/repository/myorg/myrepo/trigger/uuid-123')).toBe(
+      true,
+    );
+    expect(isDetailPagePath('/repository/myorg/myrepo/build/build-456')).toBe(
+      true,
+    );
   });
 
   it('returns true for organization detail page', () => {

--- a/web/src/components/sidebar/QuaySidebar.test.ts
+++ b/web/src/components/sidebar/QuaySidebar.test.ts
@@ -1,0 +1,50 @@
+import {isDetailPagePath} from './QuaySidebar';
+
+describe('isDetailPagePath', () => {
+  it('returns false for repository list page', () => {
+    expect(isDetailPagePath('/repository')).toBe(false);
+  });
+
+  it('returns false for organization list page', () => {
+    expect(isDetailPagePath('/organization')).toBe(false);
+  });
+
+  it('returns true for repository detail page', () => {
+    expect(isDetailPagePath('/repository/myorg/myrepo')).toBe(true);
+  });
+
+  it('returns true for repository detail sub-routes', () => {
+    expect(isDetailPagePath('/repository/myorg/myrepo/tag/latest')).toBe(true);
+    expect(
+      isDetailPagePath('/repository/myorg/myrepo/manifest/sha256:abc'),
+    ).toBe(true);
+    expect(
+      isDetailPagePath('/repository/myorg/myrepo/trigger/uuid-123'),
+    ).toBe(true);
+    expect(
+      isDetailPagePath('/repository/myorg/myrepo/build/build-456'),
+    ).toBe(true);
+  });
+
+  it('returns true for organization detail page', () => {
+    expect(isDetailPagePath('/organization/myorg')).toBe(true);
+  });
+
+  it('returns false for organization team sub-route', () => {
+    expect(isDetailPagePath('/organization/myorg/teams/devs')).toBe(false);
+  });
+
+  it('returns false for superuser pages', () => {
+    expect(isDetailPagePath('/service-keys')).toBe(false);
+    expect(isDetailPagePath('/change-log')).toBe(false);
+    expect(isDetailPagePath('/usage-logs')).toBe(false);
+  });
+
+  it('returns false for overview page', () => {
+    expect(isDetailPagePath('/overview')).toBe(false);
+  });
+
+  it('returns false for root path', () => {
+    expect(isDetailPagePath('/')).toBe(false);
+  });
+});

--- a/web/src/components/sidebar/QuaySidebar.test.tsx
+++ b/web/src/components/sidebar/QuaySidebar.test.tsx
@@ -49,8 +49,21 @@ describe('isDetailPagePath', () => {
     expect(isDetailPagePath('/organization/myorg')).toBe(true);
   });
 
+  it('returns true for user detail page', () => {
+    expect(isDetailPagePath('/user/testuser')).toBe(true);
+  });
+
+  it('returns false for user list page', () => {
+    expect(isDetailPagePath('/user')).toBe(false);
+  });
+
   it('returns false for organization team sub-route', () => {
     expect(isDetailPagePath('/organization/myorg/teams/devs')).toBe(false);
+  });
+
+  it('returns false for trailing-slash paths (React Router normalizes these)', () => {
+    expect(isDetailPagePath('/organization/myorg/')).toBe(false);
+    expect(isDetailPagePath('/user/testuser/')).toBe(false);
   });
 
   it('returns false for superuser pages', () => {
@@ -83,6 +96,12 @@ describe('sidebarPropsForPath', () => {
 
   it('returns null sidebar on organization detail pages', () => {
     const props = sidebarPropsForPath('/organization/myorg');
+    expect(props.sidebar).toBeNull();
+    expect(props.isManagedSidebar).toBe(false);
+  });
+
+  it('returns null sidebar on user detail pages', () => {
+    const props = sidebarPropsForPath('/user/testuser');
     expect(props.sidebar).toBeNull();
     expect(props.isManagedSidebar).toBe(false);
   });

--- a/web/src/components/sidebar/QuaySidebar.test.tsx
+++ b/web/src/components/sidebar/QuaySidebar.test.tsx
@@ -74,21 +74,4 @@ describe('QuaySidebar', () => {
     expect(screen.getByText('Repositories')).toBeInTheDocument();
   });
 
-  it('hides sidebar on repository detail pages', () => {
-    render(
-      <MemoryRouter initialEntries={['/repository/myorg/myrepo']}>
-        <QuaySidebar />
-      </MemoryRouter>,
-    );
-    expect(screen.queryByText('Repositories')).not.toBeInTheDocument();
-  });
-
-  it('hides sidebar on organization detail pages', () => {
-    render(
-      <MemoryRouter initialEntries={['/organization/myorg']}>
-        <QuaySidebar />
-      </MemoryRouter>,
-    );
-    expect(screen.queryByText('Organizations')).not.toBeInTheDocument();
-  });
 });

--- a/web/src/components/sidebar/QuaySidebar.test.tsx
+++ b/web/src/components/sidebar/QuaySidebar.test.tsx
@@ -73,5 +73,4 @@ describe('QuaySidebar', () => {
     );
     expect(screen.getByText('Repositories')).toBeInTheDocument();
   });
-
 });

--- a/web/src/components/sidebar/QuaySidebar.test.tsx
+++ b/web/src/components/sidebar/QuaySidebar.test.tsx
@@ -1,6 +1,10 @@
 import {render, screen} from 'src/test-utils';
 import {MemoryRouter} from 'react-router-dom';
-import {isDetailPagePath, QuaySidebar, sidebarPropsForPath} from './QuaySidebar';
+import {
+  isDetailPagePath,
+  QuaySidebar,
+  sidebarPropsForPath,
+} from './QuaySidebar';
 
 vi.mock('src/hooks/UseQuayConfig', () => ({
   useQuayConfig: vi.fn(() => ({

--- a/web/src/components/sidebar/QuaySidebar.test.tsx
+++ b/web/src/components/sidebar/QuaySidebar.test.tsx
@@ -1,4 +1,19 @@
-import {isDetailPagePath} from './QuaySidebar';
+import {render, screen} from 'src/test-utils';
+import {MemoryRouter} from 'react-router-dom';
+import {isDetailPagePath, QuaySidebar} from './QuaySidebar';
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: vi.fn(() => ({
+    config: {BRANDING: {}},
+    features: {},
+  })),
+}));
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: vi.fn(() => ({
+    isSuperUser: false,
+  })),
+}));
 
 describe('isDetailPagePath', () => {
   it('returns false for repository list page', () => {
@@ -46,5 +61,34 @@ describe('isDetailPagePath', () => {
 
   it('returns false for root path', () => {
     expect(isDetailPagePath('/')).toBe(false);
+  });
+});
+
+describe('QuaySidebar', () => {
+  it('renders sidebar on list pages', () => {
+    render(
+      <MemoryRouter initialEntries={['/repository']}>
+        <QuaySidebar />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Repositories')).toBeInTheDocument();
+  });
+
+  it('hides sidebar on repository detail pages', () => {
+    render(
+      <MemoryRouter initialEntries={['/repository/myorg/myrepo']}>
+        <QuaySidebar />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText('Repositories')).not.toBeInTheDocument();
+  });
+
+  it('hides sidebar on organization detail pages', () => {
+    render(
+      <MemoryRouter initialEntries={['/organization/myorg']}>
+        <QuaySidebar />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText('Organizations')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/sidebar/QuaySidebar.test.tsx
+++ b/web/src/components/sidebar/QuaySidebar.test.tsx
@@ -1,6 +1,6 @@
 import {render, screen} from 'src/test-utils';
 import {MemoryRouter} from 'react-router-dom';
-import {isDetailPagePath, QuaySidebar} from './QuaySidebar';
+import {isDetailPagePath, QuaySidebar, sidebarPropsForPath} from './QuaySidebar';
 
 vi.mock('src/hooks/UseQuayConfig', () => ({
   useQuayConfig: vi.fn(() => ({
@@ -61,6 +61,26 @@ describe('isDetailPagePath', () => {
 
   it('returns false for root path', () => {
     expect(isDetailPagePath('/')).toBe(false);
+  });
+});
+
+describe('sidebarPropsForPath', () => {
+  it('returns sidebar component and managed sidebar on list pages', () => {
+    const props = sidebarPropsForPath('/repository');
+    expect(props.sidebar).not.toBeNull();
+    expect(props.isManagedSidebar).toBe(true);
+  });
+
+  it('returns null sidebar on repository detail pages', () => {
+    const props = sidebarPropsForPath('/repository/myorg/myrepo');
+    expect(props.sidebar).toBeNull();
+    expect(props.isManagedSidebar).toBe(false);
+  });
+
+  it('returns null sidebar on organization detail pages', () => {
+    const props = sidebarPropsForPath('/organization/myorg');
+    expect(props.sidebar).toBeNull();
+    expect(props.isManagedSidebar).toBe(false);
   });
 });
 

--- a/web/src/components/sidebar/QuaySidebar.tsx
+++ b/web/src/components/sidebar/QuaySidebar.tsx
@@ -35,6 +35,17 @@ export function isDetailPagePath(pathname: string): boolean {
   );
 }
 
+export function sidebarPropsForPath(pathname: string): {
+  sidebar: JSX.Element | null;
+  isManagedSidebar: boolean;
+} {
+  const isDetail = isDetailPagePath(pathname);
+  return {
+    sidebar: isDetail ? null : <QuaySidebar />,
+    isManagedSidebar: !isDetail,
+  };
+}
+
 export function QuaySidebar() {
   const location = useLocation();
   const {isSidebarOpen} = useUI();

--- a/web/src/components/sidebar/QuaySidebar.tsx
+++ b/web/src/components/sidebar/QuaySidebar.tsx
@@ -184,9 +184,7 @@ export function QuaySidebar() {
     </Nav>
   );
 
-  const isDetailPage = isDetailPagePath(location.pathname);
-
-  if (isSidebarOpen && !isDetailPage) {
+  if (isSidebarOpen) {
     return (
       <PageSidebar className="page-sidebar">
         <PageSidebarBody>{Navigation}</PageSidebarBody>

--- a/web/src/components/sidebar/QuaySidebar.tsx
+++ b/web/src/components/sidebar/QuaySidebar.tsx
@@ -31,7 +31,8 @@ interface SideNavProps {
 export function isDetailPagePath(pathname: string): boolean {
   return (
     /^\/repository\/[^/]+\/[^/]+/.test(pathname) ||
-    /^\/organization\/[^/]+$/.test(pathname)
+    /^\/organization\/[^/]+$/.test(pathname) ||
+    /^\/user\/[^/]+$/.test(pathname)
   );
 }
 

--- a/web/src/components/sidebar/QuaySidebar.tsx
+++ b/web/src/components/sidebar/QuaySidebar.tsx
@@ -177,7 +177,11 @@ export function QuaySidebar() {
     </Nav>
   );
 
-  if (isSidebarOpen) {
+  const isDetailPage =
+    /^\/repository\/[^/]+\/[^/]+/.test(location.pathname) ||
+    /^\/organization\/[^/]+$/.test(location.pathname);
+
+  if (isSidebarOpen && !isDetailPage) {
     return (
       <PageSidebar className="page-sidebar">
         <PageSidebarBody>{Navigation}</PageSidebarBody>

--- a/web/src/components/sidebar/QuaySidebar.tsx
+++ b/web/src/components/sidebar/QuaySidebar.tsx
@@ -28,6 +28,13 @@ interface SideNavProps {
   component: JSX.Element;
 }
 
+export function isDetailPagePath(pathname: string): boolean {
+  return (
+    /^\/repository\/[^/]+\/[^/]+/.test(pathname) ||
+    /^\/organization\/[^/]+$/.test(pathname)
+  );
+}
+
 export function QuaySidebar() {
   const location = useLocation();
   const {isSidebarOpen} = useUI();
@@ -177,9 +184,7 @@ export function QuaySidebar() {
     </Nav>
   );
 
-  const isDetailPage =
-    /^\/repository\/[^/]+\/[^/]+/.test(location.pathname) ||
-    /^\/organization\/[^/]+$/.test(location.pathname);
+  const isDetailPage = isDetailPagePath(location.pathname);
 
   if (isSidebarOpen && !isDetailPage) {
     return (

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -19,7 +19,10 @@ import {
 } from 'react-router-dom';
 
 import {QuayHeader} from 'src/components/header/QuayHeader';
-import {QuaySidebar, isDetailPagePath} from 'src/components/sidebar/QuaySidebar';
+import {
+  QuaySidebar,
+  isDetailPagePath,
+} from 'src/components/sidebar/QuaySidebar';
 import {QuayFooter} from 'src/components/footer/QuayFooter';
 import {NavigationPath} from './NavigationPath';
 

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -267,7 +267,6 @@ export function StandaloneMain() {
         masthead={<QuayHeader toggleDrawer={toggleDrawer} />}
         sidebar={<QuaySidebar />}
         isManagedSidebar
-        defaultManagedSidebarIsOpen={true}
         notificationDrawer={notificationDrawer}
         isNotificationDrawerExpanded={isDrawerOpen}
         isContentFilled

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -19,7 +19,7 @@ import {
 } from 'react-router-dom';
 
 import {QuayHeader} from 'src/components/header/QuayHeader';
-import {QuaySidebar} from 'src/components/sidebar/QuaySidebar';
+import {QuaySidebar, isDetailPagePath} from 'src/components/sidebar/QuaySidebar';
 import {QuayFooter} from 'src/components/footer/QuayFooter';
 import {NavigationPath} from './NavigationPath';
 
@@ -222,6 +222,7 @@ export function StandaloneMain() {
   const {loading, error} = useCurrentUser();
   const location = useLocation();
   const {clearAllAlerts} = useUI();
+  const isDetailPage = isDetailPagePath(location.pathname);
 
   // Load external scripts (Stripe, StatusPage) only when BILLING feature is enabled (PROJQUAY-9803)
   useExternalScripts();
@@ -265,8 +266,8 @@ export function StandaloneMain() {
     <ErrorBoundary hasError={!!error} fallback={<SiteUnavailableError />}>
       <Page
         masthead={<QuayHeader toggleDrawer={toggleDrawer} />}
-        sidebar={<QuaySidebar />}
-        isManagedSidebar
+        sidebar={isDetailPage ? null : <QuaySidebar />}
+        isManagedSidebar={!isDetailPage}
         notificationDrawer={notificationDrawer}
         isNotificationDrawerExpanded={isDrawerOpen}
         isContentFilled

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -19,10 +19,7 @@ import {
 } from 'react-router-dom';
 
 import {QuayHeader} from 'src/components/header/QuayHeader';
-import {
-  QuaySidebar,
-  isDetailPagePath,
-} from 'src/components/sidebar/QuaySidebar';
+import {sidebarPropsForPath} from 'src/components/sidebar/QuaySidebar';
 import {QuayFooter} from 'src/components/footer/QuayFooter';
 import {NavigationPath} from './NavigationPath';
 
@@ -225,7 +222,7 @@ export function StandaloneMain() {
   const {loading, error} = useCurrentUser();
   const location = useLocation();
   const {clearAllAlerts} = useUI();
-  const isDetailPage = isDetailPagePath(location.pathname);
+  const {sidebar, isManagedSidebar} = sidebarPropsForPath(location.pathname);
 
   // Load external scripts (Stripe, StatusPage) only when BILLING feature is enabled (PROJQUAY-9803)
   useExternalScripts();
@@ -269,8 +266,8 @@ export function StandaloneMain() {
     <ErrorBoundary hasError={!!error} fallback={<SiteUnavailableError />}>
       <Page
         masthead={<QuayHeader toggleDrawer={toggleDrawer} />}
-        sidebar={isDetailPage ? null : <QuaySidebar />}
-        isManagedSidebar={!isDetailPage}
+        sidebar={sidebar}
+        isManagedSidebar={isManagedSidebar}
         notificationDrawer={notificationDrawer}
         isNotificationDrawerExpanded={isDrawerOpen}
         isContentFilled


### PR DESCRIPTION
## Summary
- Hide the global left sidebar (Organizations/Repositories) on repository and organization detail pages
- Add route-awareness to `QuaySidebar` to auto-hide when on detail pages that have their own tab navigation
- Remove `defaultManagedSidebarIsOpen={true}` so PatternFly doesn't force the sidebar container open

## Motivation
The new React UI unconditionally shows the sidebar on all pages, including repository detail pages (Logs, Tags, Settings, etc.) where:
1. The sidebar items are top-level navigation the user has already navigated past
2. The tab bar provides contextual navigation within the detail page
3. Data-heavy views like Logs need horizontal space for the table columns

The old Angular UI hid the sidebar on these pages via a `newLayout: true` route flag (`static/js/pages/repo-view.js:7`). The new React UI never ported this behavior.

## Changes
- **`web/src/components/sidebar/QuaySidebar.tsx`**: Add route check to hide sidebar on `/repository/:org/:repo/*` and `/organization/:org` paths
- **`web/src/routes/StandaloneMain.tsx`**: Remove `defaultManagedSidebarIsOpen={true}` to let QuaySidebar fully control visibility

## Pages affected

| Route | Sidebar |
|---|---|
| `/overview` | Visible |
| `/organization` (list) | Visible |
| `/organization/:org` (detail + tabs) | **Hidden** |
| `/repository` (list) | Visible |
| `/repository/:org/:repo` (detail + tabs) | **Hidden** |
| `/repository/:org/:repo/tag/:tag` | **Hidden** |
| `/repository/:org/:repo/manifest/:digest` | **Hidden** |
| Superuser pages | Visible |

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit` — no new errors)
- [ ] Visual: repository detail page (Logs tab) — sidebar hidden, full-width content
- [ ] Visual: repository list page — sidebar visible
- [ ] Visual: organization detail page — sidebar hidden
- [ ] Visual: organization list page — sidebar visible
- [ ] Visual: superuser pages — sidebar visible

Ref: [PROJQUAY-11889](https://redhat.atlassian.net/browse/PROJQUAY-11889)