### PR TITLE
PROJQUAY-11903: fix(ui): import patternfly-charts.css for dark mode chart support

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1,6 +1,7 @@
 /* Global Styles */
 @import '~@patternfly/patternfly/patternfly.css';
 @import '~@patternfly/patternfly/patternfly-addons.css';
+@import '~@patternfly/patternfly/patternfly-charts.css';
 
 html, body, #root,  .App {
   height: 100%;

--- a/web/src/routes/TagDetails/SecurityReport/SecurityReportChart.css
+++ b/web/src/routes/TagDetails/SecurityReport/SecurityReportChart.css
@@ -1,3 +1,0 @@
-.pf-v6-theme-dark {
-    --pf-v6-chart-donut--label--title--Fill: var(--pf-t--global--text--color--brand--hover);
-}

--- a/web/src/routes/UsageLogs/css/UsageLogs.scss
+++ b/web/src/routes/UsageLogs/css/UsageLogs.scss
@@ -11,7 +11,3 @@
   max-height: 200px;
   width: 1200px;
 }
-
-.pf-v6-theme-dark {
-  --pf-v6-chart-global--label--Fill: var(--pf-t--global--text--color--brand--hover);
-}


### PR DESCRIPTION
## Summary
- Import `patternfly-charts.css` to fix all chart dark mode issues (axis labels, legend text, donut labels)
- Remove manual `.pf-v6-theme-dark` CSS variable overrides from UsageLogs and SecurityReportChart

## Root Cause

The app imports `patternfly.css` and `patternfly-addons.css` but was missing
`patternfly-charts.css`. That stylesheet contains all the dark mode variable
overrides for chart elements — label fill, axis tick colors, grid colors, etc.

Without it, Victory/PatternFly charts rendered with light-mode defaults
(`#1f1f1f` for legend labels, `#383838` for axis tick labels) producing
invisible text on dark backgrounds.

Previous fix attempts manually overrode `--pf-v6-chart-global--label--Fill`
but missed `--pf-v6-chart-axis--tick-label--Fill` and other variables, so
axis labels remained unreadable.

## Changes

- `web/src/App.css` — add `@import '~@patternfly/patternfly/patternfly-charts.css'`
- `web/src/routes/UsageLogs/css/UsageLogs.scss` — remove manual `.pf-v6-theme-dark` override
- `web/src/routes/TagDetails/SecurityReport/SecurityReportChart.css` — remove manual `.pf-v6-theme-dark` override

## Test Plan
- [x] Verified dark mode usage logs chart: axis labels and legend text now white
- [x] Verified via DOM inspection: `--pf-v6-chart-axis--tick-label--Fill` and `--pf-v6-chart-global--label--Fill` both resolve correctly in dark mode
- [ ] Manual: enable dark mode, check usage logs chart + security report donut chart

## JIRA
https://issues.redhat.com/browse/PROJQUAY-11903

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1001" height="612" alt="image" src="https://github.com/user-attachments/assets/9ea90e2b-4131-4537-b7ce-b25f6bd87ccf" />
