### PR TITLE
NO-ISSUE: chore(ci): make e2e test coverage check non-blocking

### DIFF
--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -111,6 +111,7 @@ jobs:
     if: ${{ inputs.is-pr }}
     runs-on: ubuntu-latest
     name: e2e test coverage check
+    continue-on-error: true
     permissions:
       pull-requests: read
     steps:


### PR DESCRIPTION
## Summary
- Adds `continue-on-error: true` to the `e2e-test-check` job in `ci-web.yaml`
- The check still runs and reports pass/fail status on PRs, but no longer blocks the `all-green` gate

## Test plan
- [ ] Verify `all-green` passes even when `e2e-test-check` fails
- [ ] Verify `e2e-test-check` still reports its status on PRs


🤖 Generated with [Claude Code](https://claude.com/claude-code)