### PR TITLE
PROJQUAY-11904: test(e2e): add real export delivery tests for usage logs

### DIFF
--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -200,6 +200,8 @@ jobs:
             FEATURE_SECURITY_NOTIFICATIONS: true
             DEFAULT_UI: react
             AUTOPRUNE_TASK_RUN_MINIMUM_INTERVAL_MINUTES: 0
+            SSRF_ALLOWED_HOSTS:
+              - host.containers.internal
 
       - name: Start LDAP server (pre-initialize for later auth swap)
         run: |

--- a/web/playwright/e2e/usage-logs.spec.ts
+++ b/web/playwright/e2e/usage-logs.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect} from '../fixtures';
+import {test, expect, mailpit} from '../fixtures';
 import type {Page} from '@playwright/test';
 import {pushImage} from '../utils/container';
 import {TEST_USERS} from '../global-setup';
@@ -97,6 +97,79 @@ test.describe('Usage Logs', {tag: ['@logs']}, () => {
     await expect(
       authenticatedPage.getByTestId('usage-logs-export-confirm-button'),
     ).toBeDisabled();
+  });
+
+  test.describe('export delivery', {tag: ['@feature:LOG_EXPORT']}, () => {
+    test('delivers export email for organization logs', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      test.setTimeout(180_000);
+      const org = await api.organization('exportemail');
+      const recipient = `export-${org.name}@example.com`;
+
+      await authenticatedPage.goto(`/organization/${org.name}?tab=Logs`);
+
+      await authenticatedPage.getByTestId('usage-logs-export-button').click();
+      await authenticatedPage
+        .getByTestId('usage-logs-export-email-input')
+        .fill(recipient);
+      await authenticatedPage
+        .getByTestId('usage-logs-export-confirm-button')
+        .click();
+
+      await expect(
+        authenticatedPage.getByText('Logs exported with id'),
+      ).toBeVisible();
+
+      const email = await mailpit.waitForEmail(
+        (msg) =>
+          msg.Subject.includes('Export Action Logs Complete') &&
+          msg.To.some((to) => to.Address === recipient),
+        120_000,
+      );
+      expect(email).not.toBeNull();
+
+      const body = await mailpit.getEmailBody(email!.ID);
+      expect(body).toContain('Usage Logs Export has completed');
+      expect(body).toContain('exported logs information can be found at');
+    });
+
+    test('delivers callback for repository logs export', async ({
+      authenticatedPage,
+      api,
+      webhook,
+    }) => {
+      test.setTimeout(180_000);
+      const repo = await api.repository();
+
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=logs`);
+
+      await authenticatedPage.getByTestId('usage-logs-export-button').click();
+      await authenticatedPage
+        .getByTestId('usage-logs-export-email-input')
+        .fill(webhook.getUrl('/export-callback'));
+      await authenticatedPage
+        .getByTestId('usage-logs-export-confirm-button')
+        .click();
+
+      await expect(
+        authenticatedPage.getByText('Logs exported with id'),
+      ).toBeVisible();
+
+      const received = await webhook.waitForWebhook(
+        (req) => req.url === '/export-callback',
+        120_000,
+      );
+      expect(received).not.toBeNull();
+
+      const body = received!.body;
+      expect(body).toHaveProperty('export_id');
+      expect(body).toHaveProperty('status', 'success');
+      expect(body).toHaveProperty('exported_data_url');
+      expect(body).toHaveProperty('namespace');
+      expect(body).toHaveProperty('repository');
+    });
   });
 
   test('filters logs by text input', async ({authenticatedPage, api}) => {

--- a/web/playwright/e2e/usage-logs.spec.ts
+++ b/web/playwright/e2e/usage-logs.spec.ts
@@ -119,7 +119,7 @@ test.describe('Usage Logs', {tag: ['@logs']}, () => {
         .click();
 
       await expect(
-        authenticatedPage.getByText('Logs exported with id'),
+        authenticatedPage.getByText('Logs exported with id').first(),
       ).toBeVisible();
 
       const email = await mailpit.waitForEmail(
@@ -154,7 +154,7 @@ test.describe('Usage Logs', {tag: ['@logs']}, () => {
         .click();
 
       await expect(
-        authenticatedPage.getByText('Logs exported with id'),
+        authenticatedPage.getByText('Logs exported with id').first(),
       ).toBeVisible();
 
       const received = await webhook.waitForWebhook(

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -40,6 +40,7 @@ import {
   TeamRole,
 } from './utils/api';
 import {isContainerRuntimeAvailable} from './utils/container';
+import {WebhookReceiver} from './utils/webhook';
 
 // ============================================================================
 // TestApi: Auto-cleanup API client for tests
@@ -1053,6 +1054,9 @@ type TestFixtures = {
 
   // Auto-fixture: skips tests based on @container tag (runs automatically)
   _autoSkipByContainer: void;
+
+  // WebhookReceiver that auto-starts and auto-stops per test
+  webhook: WebhookReceiver;
 };
 
 /**
@@ -1399,6 +1403,14 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     },
     {auto: true},
   ],
+
+  // eslint-disable-next-line no-empty-pattern
+  webhook: async ({}, use) => {
+    const receiver = new WebhookReceiver();
+    await receiver.start();
+    await use(receiver);
+    await receiver.stop();
+  },
 });
 
 // Re-export expect for convenience


### PR DESCRIPTION
## Summary
- Adds two e2e Playwright tests that verify the **full export pipeline** — from UI click through the export action logs worker to actual delivery
- **Email export test**: triggers org-level export, verifies the worker delivers the email via mailpit (subject, download link in body)
- **Callback URL export test**: triggers repo-level export with a `WebhookReceiver` callback, verifies the worker POSTs the payload with `export_id`, `status: "success"`, `exported_data_url`, `namespace`, and `repository`
- Adds a `webhook` fixture to `fixtures.ts` for auto-managed `WebhookReceiver` lifecycle (start/stop per test)

## Test plan
- [ ] `delivers export email for organization logs` — verifies mailpit receives email with "Export Action Logs Complete" subject and download link
- [ ] `delivers callback for repository logs export` — verifies WebhookReceiver receives POST with full export payload
- [ ] Existing usage-logs tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)