### PR TITLE
NO-ISSUE: fix(test): click sort button inside column header in builds test

### DIFF
--- a/web/playwright/e2e/repository/builds.spec.ts
+++ b/web/playwright/e2e/repository/builds.spec.ts
@@ -186,8 +186,8 @@ test.describe(
       });
       await expect(dateHeader).toHaveAttribute('aria-sort', 'descending');
 
-      // Click to toggle sort direction
-      await dateHeader.click();
+      // Click the sort button inside the header to toggle direction
+      await dateHeader.getByRole('button').click();
       await expect(dateHeader).toHaveAttribute('aria-sort', 'ascending');
 
       // Both builds should remain visible after sort toggle


### PR DESCRIPTION
## Summary
- The "build list sorts by date started" Playwright test was consistently failing because `dateHeader.click()` targeted the `<th>` element, but PF v6 sortable headers nest the click handler on a `<button>` inside the `<th>`
- Changed to `dateHeader.getByRole('button').click()` to target the sort button directly, matching the pattern used in `security-scan.spec.ts`

## Test plan
- [ ] CI Playwright suite passes — specifically `repository/builds.spec.ts` "build list sorts by date started"

🤖 Generated with [Claude Code](https://claude.com/claude-code)