### PR TITLE
PROJQUAY-11858: fix(web): disable quota fetch when feature is off

### DIFF
--- a/web/src/hooks/UseQuotaManagement.test.tsx
+++ b/web/src/hooks/UseQuotaManagement.test.tsx
@@ -82,6 +82,13 @@ describe('UseQuotaManagement', () => {
       expect(fetchOrganizationQuota).not.toHaveBeenCalled();
     });
 
+    it('does not fetch when disabled, even for viewMode=self', () => {
+      renderHook(() => useFetchOrganizationQuota('', 'self', false), {
+        wrapper,
+      });
+      expect(fetchOrganizationQuota).not.toHaveBeenCalled();
+    });
+
     it('is enabled when viewMode is "self" even with empty orgName', async () => {
       vi.mocked(fetchOrganizationQuota).mockResolvedValueOnce([mockQuota]);
       const {result} = renderHook(() => useFetchOrganizationQuota('', 'self'), {

--- a/web/src/hooks/UseQuotaManagement.ts
+++ b/web/src/hooks/UseQuotaManagement.ts
@@ -20,6 +20,7 @@ import {AxiosError} from 'axios';
 export function useFetchOrganizationQuota(
   orgName: string,
   viewMode?: QuotaViewMode,
+  enabled = true,
 ) {
   const {
     data: organizationQuotas,
@@ -30,7 +31,7 @@ export function useFetchOrganizationQuota(
     ['organizationquota', orgName, viewMode],
     ({signal}) => fetchOrganizationQuota(orgName, signal, viewMode),
     {
-      enabled: !!orgName || viewMode === 'self',
+      enabled: enabled && (!!orgName || viewMode === 'self'),
     },
   );
 

--- a/web/src/routes/RepositoriesList/RepositoriesList.test.tsx
+++ b/web/src/routes/RepositoriesList/RepositoriesList.test.tsx
@@ -1,6 +1,15 @@
 import {render, screen} from 'src/test-utils';
 import RepositoriesList from './RepositoriesList';
 
+const mockUseQuayConfig = vi.hoisted(() =>
+  vi.fn(() => ({
+    features: {QUOTA_MANAGEMENT: false, EDIT_QUOTA: false},
+  })),
+);
+const mockUseFetchOrganizationQuota = vi.hoisted(() =>
+  vi.fn(() => ({organizationQuota: null})),
+);
+
 // Minimal stubs for hooks unrelated to the spinner logic
 // Breaks: RepositoriesList → Breadcrumb → NavigationPath → OrganizationsList → Organizations.scss (Sass compat issue in test env)
 vi.mock('src/components/breadcrumb/Breadcrumb', () => ({
@@ -19,9 +28,7 @@ vi.mock('react-router-dom', async () => {
 });
 
 vi.mock('src/hooks/UseQuayConfig', () => ({
-  useQuayConfig: () => ({
-    features: {QUOTA_MANAGEMENT: false, EDIT_QUOTA: false},
-  }),
+  useQuayConfig: mockUseQuayConfig,
 }));
 
 vi.mock('src/hooks/UseCurrentUser', () => ({
@@ -33,7 +40,7 @@ vi.mock('src/hooks/UseSuperuserPermissions', () => ({
 }));
 
 vi.mock('src/hooks/UseQuotaManagement', () => ({
-  useFetchOrganizationQuota: () => ({organizationQuota: null}),
+  useFetchOrganizationQuota: mockUseFetchOrganizationQuota,
 }));
 
 vi.mock('src/hooks/UseDeleteRepositories', () => ({
@@ -92,6 +99,10 @@ const oneRepo = {
 
 describe('RepositoriesList — search empty state (PROJQUAY-11217)', () => {
   beforeEach(() => {
+    mockUseQuayConfig.mockReturnValue({
+      features: {QUOTA_MANAGEMENT: false, EDIT_QUOTA: false},
+    });
+    mockUseFetchOrganizationQuota.mockReturnValue({organizationQuota: null});
     mockUseRepositories.mockReturnValue(baseReposHook);
     mockPaginatedTable.mockReturnValue(basePaginatedReturn);
   });
@@ -151,5 +162,52 @@ describe('RepositoriesList — search empty state (PROJQUAY-11217)', () => {
     expect(screen.getByText('my-repo')).toBeInTheDocument();
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     expect(screen.queryByText('No repositories found')).not.toBeInTheDocument();
+  });
+
+  it('disables quota fetching when quota features are disabled for user namespaces', () => {
+    mockUseRepositories.mockReturnValue({...baseReposHook, loading: false});
+    mockPaginatedTable.mockReturnValue({
+      ...basePaginatedReturn,
+      filteredData: [oneRepo],
+      paginatedData: [oneRepo],
+    });
+
+    render(
+      <RepositoriesList
+        organizationName="testuser"
+        isUserOrganization={true}
+      />,
+    );
+
+    expect(mockUseFetchOrganizationQuota).toHaveBeenCalledWith(
+      'testuser',
+      'self',
+      false,
+    );
+  });
+
+  it('enables quota fetching when both quota features are enabled', () => {
+    mockUseQuayConfig.mockReturnValue({
+      features: {QUOTA_MANAGEMENT: true, EDIT_QUOTA: true},
+    });
+    mockUseRepositories.mockReturnValue({...baseReposHook, loading: false});
+    mockPaginatedTable.mockReturnValue({
+      ...basePaginatedReturn,
+      filteredData: [oneRepo],
+      paginatedData: [oneRepo],
+    });
+
+    render(
+      <RepositoriesList
+        organizationName="testuser"
+        isUserOrganization={true}
+      />,
+    );
+
+    expect(mockUseFetchOrganizationQuota).toHaveBeenCalledWith(
+      'testuser',
+      'self',
+      true,
+    );
   });
 });

--- a/web/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/web/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -70,10 +70,17 @@ export default function RepositoriesList(props: RepositoriesListProps) {
   const quayConfig = useQuayConfig();
   const {user} = useCurrentUser();
   const {isReadOnlySuperUser} = useSuperuserPermissions();
+  const isQuotaManagementEnabled =
+    quayConfig?.features?.QUOTA_MANAGEMENT === true &&
+    quayConfig?.features?.EDIT_QUOTA === true;
 
   // Fetch quota information - use 'self' viewMode for user namespaces, 'organization' for orgs
   const viewMode = props.isUserOrganization ? 'self' : 'organization';
-  const {organizationQuota} = useFetchOrganizationQuota(currentOrg, viewMode);
+  const {organizationQuota} = useFetchOrganizationQuota(
+    currentOrg,
+    viewMode,
+    isQuotaManagementEnabled,
+  );
   const {repos, loading, error, search, setSearch, searchFilter, truncated} =
     useRepositories(currentOrg);
 
@@ -334,15 +341,13 @@ export default function RepositoriesList(props: RepositoriesListProps) {
             style={{marginBottom: '1em'}}
           />
         )}
-        {quayConfig?.features?.QUOTA_MANAGEMENT &&
-          quayConfig?.features?.EDIT_QUOTA &&
-          currentOrg && (
-            <div style={{marginBottom: '1em'}}>
-              <Title headingLevel="h4" size="md">
-                Total Quota Consumed: <span>{formatQuotaDisplay()}</span>
-              </Title>
-            </div>
-          )}
+        {isQuotaManagementEnabled && currentOrg && (
+          <div style={{marginBottom: '1em'}}>
+            <Title headingLevel="h4" size="md">
+              Total Quota Consumed: <span>{formatQuotaDisplay()}</span>
+            </Title>
+          </div>
+        )}
         <RepositoryToolBar
           search={search}
           setSearch={setSearch}
@@ -383,8 +388,7 @@ export default function RepositoriesList(props: RepositoriesListProps) {
               <Th modifier="wrap" sort={getSortableSort(1)}>
                 {RepositoryListColumnNames.visibility}
               </Th>
-              {quayConfig?.features.QUOTA_MANAGEMENT &&
-              quayConfig?.features.EDIT_QUOTA ? (
+              {isQuotaManagementEnabled ? (
                 <Th modifier="wrap" sort={getSortableSort(2)}>
                   {RepositoryListColumnNames.size}
                 </Th>
@@ -461,8 +465,7 @@ export default function RepositoriesList(props: RepositoriesListProps) {
                   <Td dataLabel={RepositoryListColumnNames.visibility}>
                     {repo.is_public ? 'public' : 'private'}
                   </Td>
-                  {quayConfig?.features.QUOTA_MANAGEMENT &&
-                  quayConfig?.features.EDIT_QUOTA ? (
+                  {isQuotaManagementEnabled ? (
                     <Td dataLabel={RepositoryListColumnNames.size}>
                       {(() => {
                         const sizeDisplay =


### PR DESCRIPTION
## Summary
- Gate quota fetching behind the quota feature flags in the repository list
- Keep the quota fetch hook backward compatible with an optional enabled flag
- Add regression coverage for disabled quota features and user namespace quota fetches

## Testing
- ./node_modules/.bin/vitest run src/hooks/UseQuotaManagement.test.tsx src/routes/RepositoriesList/RepositoriesList.test.tsx
- ./node_modules/.bin/prettier --check src/hooks/UseQuotaManagement.ts src/hooks/UseQuotaManagement.test.tsx src/routes/RepositoriesList/RepositoriesList.tsx src/routes/RepositoriesList/RepositoriesList.test.tsx