### PR TITLE
PROJQUAY-11912: feat(go): support anonymous pulls

### DIFF
--- a/internal/api/v1/api.go
+++ b/internal/api/v1/api.go
@@ -1,0 +1,44 @@
+// Package v1 implements composable Go-backed Quay API v1 surfaces.
+package v1
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/quay/quay/internal/auth"
+)
+
+// Module registers a selectable API surface.
+type Module interface {
+	Register(*Router)
+}
+
+// Config holds dependencies shared by API v1 modules.
+type Config struct {
+	Authenticator Authenticator
+	Realm         string
+}
+
+// Authenticator validates requests for protected API routes.
+type Authenticator interface {
+	Authenticate(*http.Request) auth.Result
+}
+
+// New returns an API v1 HTTP handler with the supplied modules registered.
+func New(cfg Config, modules ...Module) (http.Handler, error) {
+	if cfg.Authenticator == nil {
+		return nil, fmt.Errorf("nil authenticator")
+	}
+	if cfg.Realm == "" {
+		cfg.Realm = "Quay API"
+	}
+
+	router := NewRouter(cfg)
+	for _, module := range modules {
+		if module == nil {
+			continue
+		}
+		module.Register(router)
+	}
+	return router, nil
+}

--- a/internal/api/v1/api_test.go
+++ b/internal/api/v1/api_test.go
@@ -1,0 +1,74 @@
+package v1
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/quay/quay/internal/auth"
+)
+
+type staticAuthenticator struct{}
+
+func (staticAuthenticator) Authenticate(*http.Request) auth.Result {
+	return auth.Result{
+		Principal:     auth.Principal{Username: "user", Kind: auth.PrincipalUser},
+		Username:      "user",
+		Presented:     true,
+		Authenticated: true,
+	}
+}
+
+type testModule struct{}
+
+func (testModule) Register(router *Router) {
+	router.Handle(http.MethodGet, MatchFunc(func(path string) (Params, bool) {
+		if path != "/api/v1/test" {
+			return nil, false
+		}
+		return Params{}, true
+	}), func(w http.ResponseWriter, _ *http.Request, _ Params) {
+		WriteJSON(w, http.StatusOK, map[string]bool{"success": true})
+	})
+}
+
+func TestNewRegistersOnlyProvidedModules(t *testing.T) {
+	emptyHandler, err := New(Config{Authenticator: staticAuthenticator{}})
+	if err != nil {
+		t.Fatalf("new empty api: %v", err)
+	}
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/test", http.NoBody)
+	rec := httptest.NewRecorder()
+	emptyHandler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("empty api status = %d, want 404", rec.Code)
+	}
+
+	moduleHandler, err := New(Config{Authenticator: staticAuthenticator{}}, testModule{})
+	if err != nil {
+		t.Fatalf("new api: %v", err)
+	}
+	rec = httptest.NewRecorder()
+	moduleHandler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("module api status = %d, want 200", rec.Code)
+	}
+}
+
+func TestRouterMethodNotAllowed(t *testing.T) {
+	handler, err := New(Config{Authenticator: staticAuthenticator{}}, testModule{})
+	if err != nil {
+		t.Fatalf("new api: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/test", http.NoBody)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != http.MethodGet {
+		t.Fatalf("Allow = %q, want GET", got)
+	}
+}

--- a/internal/api/v1/auth.go
+++ b/internal/api/v1/auth.go
@@ -1,0 +1,24 @@
+package v1
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// RequireBasic protects a route with HTTP Basic auth.
+func (r *Router) RequireBasic(next AuthHandlerFunc) HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request, params Params) {
+		result := r.authenticator.Authenticate(req)
+		if !result.Authenticated {
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", r.realm))
+			if !result.Presented {
+				WriteError(w, http.StatusUnauthorized, "authentication required")
+				return
+			}
+			WriteError(w, http.StatusUnauthorized, "authentication failed")
+			return
+		}
+
+		next(w, req, params, &result.Principal)
+	}
+}

--- a/internal/api/v1/path.go
+++ b/internal/api/v1/path.go
@@ -1,0 +1,25 @@
+package v1
+
+import "strings"
+
+// RepositoryPath returns a matcher for routes containing Quay's apirepopath
+// semantics: the namespace is the first path segment and the repository name
+// may contain additional slash-separated segments before suffix.
+func RepositoryPath(paramName, prefix, suffix string) Matcher {
+	return MatchFunc(func(path string) (Params, bool) {
+		if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+			return nil, false
+		}
+
+		repositoryPath := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+		namespace, repository, ok := strings.Cut(repositoryPath, "/")
+		if !ok || namespace == "" || repository == "" {
+			return nil, false
+		}
+
+		return Params{
+			"namespace": namespace,
+			paramName:   repository,
+		}, true
+	})
+}

--- a/internal/api/v1/repository/visibility.go
+++ b/internal/api/v1/repository/visibility.go
@@ -1,0 +1,118 @@
+// Package repository registers repository API v1 endpoints.
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	apiv1 "github.com/quay/quay/internal/api/v1"
+	"github.com/quay/quay/internal/auth"
+	repomodel "github.com/quay/quay/internal/repository"
+)
+
+const (
+	changeVisibilityPathPrefix = "/api/v1/repository/"
+	changeVisibilityPathSuffix = "/changevisibility"
+	repositoryParamName        = "repository"
+)
+
+// Service provides repository business operations used by API handlers.
+type Service interface {
+	ChangeVisibility(ctx context.Context, principal *auth.Principal, ref repomodel.Ref, visibility repomodel.Visibility) error
+	Delete(ctx context.Context, principal *auth.Principal, ref repomodel.Ref) error
+}
+
+// Module registers repository API endpoints.
+type Module struct {
+	service Service
+}
+
+// NewModule returns a selectable repository API module.
+func NewModule(service Service) Module {
+	return Module{service: service}
+}
+
+// Register registers repository API routes.
+func (m Module) Register(router *apiv1.Router) {
+	router.Handle(
+		http.MethodPost,
+		apiv1.RepositoryPath(repositoryParamName, changeVisibilityPathPrefix, changeVisibilityPathSuffix),
+		router.RequireBasic(m.changeVisibility),
+	)
+	router.Handle(
+		http.MethodDelete,
+		repositoryPath(),
+		router.RequireBasic(m.deleteRepository),
+	)
+}
+
+func (m Module) changeVisibility(w http.ResponseWriter, r *http.Request, params apiv1.Params, principal *auth.Principal) {
+	namespace := params["namespace"]
+	repositoryName := params[repositoryParamName]
+
+	var req struct {
+		Visibility string `json:"visibility"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		apiv1.WriteError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+
+	err := m.service.ChangeVisibility(
+		r.Context(),
+		principal,
+		repomodel.Ref{Namespace: namespace, Name: repositoryName},
+		repomodel.Visibility(req.Visibility),
+	)
+	if err != nil {
+		switch {
+		case errors.Is(err, repomodel.ErrNotFound):
+			apiv1.WriteError(w, http.StatusNotFound, "repository not found")
+		case errors.Is(err, repomodel.ErrForbidden):
+			apiv1.WriteError(w, http.StatusForbidden, "forbidden")
+		case errors.Is(err, repomodel.ErrInvalidVisibility):
+			apiv1.WriteError(w, http.StatusBadRequest, "visibility must be public or private")
+		default:
+			apiv1.WriteError(w, http.StatusInternalServerError, "visibility update failed")
+		}
+		return
+	}
+
+	apiv1.WriteJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+func (m Module) deleteRepository(w http.ResponseWriter, r *http.Request, params apiv1.Params, principal *auth.Principal) {
+	namespace := params["namespace"]
+	repositoryName := params[repositoryParamName]
+
+	err := m.service.Delete(
+		r.Context(),
+		principal,
+		repomodel.Ref{Namespace: namespace, Name: repositoryName},
+	)
+	if err != nil {
+		switch {
+		case errors.Is(err, repomodel.ErrNotFound):
+			apiv1.WriteError(w, http.StatusNotFound, "repository not found")
+		case errors.Is(err, repomodel.ErrForbidden):
+			apiv1.WriteError(w, http.StatusForbidden, "forbidden")
+		default:
+			apiv1.WriteError(w, http.StatusInternalServerError, "repository delete failed")
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func repositoryPath() apiv1.Matcher {
+	return apiv1.MatchFunc(func(path string) (apiv1.Params, bool) {
+		if strings.HasSuffix(path, changeVisibilityPathSuffix) {
+			return nil, false
+		}
+		return apiv1.RepositoryPath(repositoryParamName, changeVisibilityPathPrefix, "").Match(path)
+	})
+}

--- a/internal/api/v1/repository/visibility_test.go
+++ b/internal/api/v1/repository/visibility_test.go
@@ -1,0 +1,420 @@
+package repository
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+
+	apiv1 "github.com/quay/quay/internal/api/v1"
+	"github.com/quay/quay/internal/auth"
+	"github.com/quay/quay/internal/dal/daldb"
+	repomodel "github.com/quay/quay/internal/repository"
+	repositorydal "github.com/quay/quay/internal/repository/dal"
+	_ "modernc.org/sqlite"
+)
+
+func setupAPITestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+
+	ctx := t.Context()
+	_, err = db.ExecContext(ctx, `CREATE TABLE "user" (
+		id INTEGER PRIMARY KEY,
+		uuid VARCHAR(36),
+		username VARCHAR(255) NOT NULL,
+		password_hash VARCHAR(255),
+		email VARCHAR(255) NOT NULL,
+		verified INTEGER NOT NULL DEFAULT 0,
+		organization INTEGER NOT NULL DEFAULT 0,
+		robot INTEGER NOT NULL DEFAULT 0,
+		enabled INTEGER NOT NULL DEFAULT 1
+	)`)
+	if err != nil {
+		t.Fatalf("create user table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE visibility (
+		id INTEGER PRIMARY KEY,
+		name VARCHAR(255) NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create visibility table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE repository (
+		id INTEGER PRIMARY KEY,
+		namespace_user_id INTEGER,
+		name VARCHAR(255) NOT NULL,
+		visibility_id INTEGER NOT NULL,
+		kind_id INTEGER NOT NULL DEFAULT 1,
+		state INTEGER NOT NULL DEFAULT 0
+	)`)
+	if err != nil {
+		t.Fatalf("create repository table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE deletedrepository (
+		id INTEGER PRIMARY KEY,
+		repository_id INTEGER NOT NULL,
+		marked DATETIME NOT NULL,
+		original_name VARCHAR(255) NOT NULL,
+		queue_id VARCHAR(255)
+	)`)
+	if err != nil {
+		t.Fatalf("create deletedrepository table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE star (
+		id INTEGER PRIMARY KEY,
+		user_id INTEGER NOT NULL,
+		repository_id INTEGER NOT NULL,
+		created DATETIME NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create star table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO visibility (id, name) VALUES (1, 'public'), (2, 'private')`)
+	if err != nil {
+		t.Fatalf("insert visibility: %v", err)
+	}
+
+	insertUser := func(username, password string) {
+		t.Helper()
+		hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+		if err != nil {
+			t.Fatalf("bcrypt: %v", err)
+		}
+		_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+			VALUES (?, ?, ?, ?, 1, 0, 0, 1)`, "u-"+username, username, string(hash), username+"@test.com")
+		if err != nil {
+			t.Fatalf("insert user %s: %v", username, err)
+		}
+	}
+	insertUser("admin", "password")
+	insertUser("devtable", "password")
+	insertUser("reader", "password")
+
+	for _, username := range []string{"public"} {
+		_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+			VALUES (?, ?, NULL, ?, 1, 0, 0, 1)`, "u-"+username, username, username+"@test.com")
+		if err != nil {
+			t.Fatalf("insert namespace %s: %v", username, err)
+		}
+	}
+
+	insertRepo := func(namespace, name, visibility string, state int) {
+		t.Helper()
+		_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+			SELECT u.id, ?, v.id, 1, ? FROM "user" u, visibility v WHERE u.username = ? AND v.name = ?`,
+			name, state, namespace, visibility)
+		if err != nil {
+			t.Fatalf("insert repo %s/%s: %v", namespace, name, err)
+		}
+	}
+	insertRepo("public", "publicrepo", "private", 0)
+	insertRepo("devtable", "repo/withslash", "private", 0)
+	insertRepo("devtable", "deleted", "private", 3)
+	_, err = db.ExecContext(ctx, `INSERT INTO star (user_id, repository_id, created)
+		SELECT u.id, r.id, datetime('now')
+		FROM "user" u, repository r
+		JOIN "user" ns ON r.namespace_user_id = ns.id
+		WHERE u.username = 'reader' AND ns.username = 'public' AND r.name = 'publicrepo'`)
+	if err != nil {
+		t.Fatalf("insert star: %v", err)
+	}
+
+	return db
+}
+
+func newAPITestHandler(t *testing.T, db *sql.DB) http.Handler {
+	t.Helper()
+	repositoryService, err := repomodel.NewService(
+		repositorydal.NewStore(db),
+		repomodel.OwnerOrBootstrapAdminAuthorizer{AdminUsername: "admin"},
+	)
+	if err != nil {
+		t.Fatalf("new repository service: %v", err)
+	}
+
+	handler, err := apiv1.New(apiv1.Config{
+		Authenticator: auth.NewBasicAuthenticator(db),
+		Realm:         "test",
+	},
+		NewModule(repositoryService),
+	)
+	if err != nil {
+		t.Fatalf("new api: %v", err)
+	}
+	return handler
+}
+
+func TestChangeVisibilityAdminSuccess(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/repository/public/publicrepo/changevisibility", strings.NewReader(`{"visibility":"public"}`))
+	setBasicAuth(req, "admin")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := repositoryVisibility(t, db, "public", "publicrepo"); got != "public" {
+		t.Fatalf("visibility = %q, want public", got)
+	}
+}
+
+func TestChangeVisibilityOwnerSuccessWithSlashRepository(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/repository/devtable/repo/withslash/changevisibility", strings.NewReader(`{"visibility":"public"}`))
+	setBasicAuth(req, "devtable")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := repositoryVisibility(t, db, "devtable", "repo/withslash"); got != "public" {
+		t.Fatalf("visibility = %q, want public", got)
+	}
+}
+
+func TestChangeVisibilityRequiresAuth(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/repository/public/publicrepo/changevisibility", strings.NewReader(`{"visibility":"public"}`))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); got == "" {
+		t.Fatal("expected WWW-Authenticate header")
+	}
+}
+
+func TestChangeVisibilityForbidden(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/repository/public/publicrepo/changevisibility", strings.NewReader(`{"visibility":"public"}`))
+	setBasicAuth(req, "reader")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestChangeVisibilityInvalidVisibility(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/repository/public/publicrepo/changevisibility", strings.NewReader(`{"visibility":"internal"}`))
+	setBasicAuth(req, "admin")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestChangeVisibilityMissingRepository(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/repository/public/missing/changevisibility", strings.NewReader(`{"visibility":"public"}`))
+	setBasicAuth(req, "admin")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestChangeVisibilityDeletedRepositoryNotFound(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/repository/devtable/deleted/changevisibility", strings.NewReader(`{"visibility":"public"}`))
+	setBasicAuth(req, "admin")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestDeleteRepositoryAdminSuccess(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/v1/repository/public/publicrepo", http.NoBody)
+	setBasicAuth(req, "admin")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	assertRepositoryDeleted(t, db, "publicrepo")
+	if got := starCount(t, db); got != 0 {
+		t.Fatalf("star count = %d, want 0", got)
+	}
+}
+
+func TestDeleteRepositoryOwnerSuccessWithSlashRepository(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/v1/repository/devtable/repo/withslash", http.NoBody)
+	setBasicAuth(req, "devtable")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	assertRepositoryDeleted(t, db, "repo/withslash")
+}
+
+func TestDeleteRepositoryRequiresAuth(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/v1/repository/public/publicrepo", http.NoBody)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); got == "" {
+		t.Fatal("expected WWW-Authenticate header")
+	}
+}
+
+func TestDeleteRepositoryForbidden(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/v1/repository/public/publicrepo", http.NoBody)
+	setBasicAuth(req, "reader")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestDeleteRepositoryMissingRepository(t *testing.T) {
+	db := setupAPITestDB(t)
+	defer db.Close()
+	handler := newAPITestHandler(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/v1/repository/public/missing", http.NoBody)
+	setBasicAuth(req, "admin")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func setBasicAuth(req *http.Request, username string) {
+	token := base64.StdEncoding.EncodeToString([]byte(username + ":password"))
+	req.Header.Set("Authorization", "Basic "+token)
+}
+
+func repositoryVisibility(t *testing.T, db *sql.DB, namespace, repository string) string {
+	t.Helper()
+	q := daldb.New(db)
+	repo, err := q.GetRepositoryAccessByNamespaceName(t.Context(), daldb.GetRepositoryAccessByNamespaceNameParams{
+		Username: namespace,
+		Name:     repository,
+	})
+	if err != nil {
+		t.Fatalf("lookup repository: %v", err)
+	}
+	return repo.Visibility
+}
+
+func assertRepositoryDeleted(t *testing.T, db *sql.DB, originalName string) {
+	t.Helper()
+
+	var deletedName string
+	var state int
+	var markedOriginalName string
+	err := db.QueryRowContext(t.Context(), `SELECT r.name, r.state, d.original_name
+		FROM deletedrepository d
+		JOIN repository r ON d.repository_id = r.id
+		WHERE d.original_name = ?`, originalName).Scan(&deletedName, &state, &markedOriginalName)
+	if err != nil {
+		t.Fatalf("lookup deleted repository: %v", err)
+	}
+	if markedOriginalName != originalName {
+		t.Fatalf("deletedrepository original_name = %q, want %q", markedOriginalName, originalName)
+	}
+	if state != 3 {
+		t.Fatalf("repository state = %d, want 3", state)
+	}
+	if deletedName == originalName || deletedName == "" {
+		t.Fatalf("deleted repository name = %q, want generated name", deletedName)
+	}
+
+	var activeCount int
+	if err := db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM repository WHERE name = ? AND state != 3`, originalName).Scan(&activeCount); err != nil {
+		t.Fatalf("count active repositories by original name: %v", err)
+	}
+	if activeCount != 0 {
+		t.Fatalf("active repository count for original name = %d, want 0", activeCount)
+	}
+}
+
+func starCount(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var count int
+	if err := db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM star`).Scan(&count); err != nil {
+		t.Fatalf("count stars: %v", err)
+	}
+	return count
+}

--- a/internal/api/v1/response.go
+++ b/internal/api/v1/response.go
@@ -1,0 +1,18 @@
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// WriteJSON writes payload as a JSON response.
+func WriteJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+// WriteError writes a JSON error response.
+func WriteError(w http.ResponseWriter, status int, message string) {
+	WriteJSON(w, status, map[string]string{"error": message})
+}

--- a/internal/api/v1/router.go
+++ b/internal/api/v1/router.go
@@ -1,0 +1,88 @@
+package v1
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/quay/quay/internal/auth"
+)
+
+// Params contains path parameters extracted from a route match.
+type Params map[string]string
+
+// HandlerFunc handles a matched API request.
+type HandlerFunc func(http.ResponseWriter, *http.Request, Params)
+
+// AuthHandlerFunc handles a matched API request after authentication.
+type AuthHandlerFunc func(http.ResponseWriter, *http.Request, Params, *auth.Principal)
+
+// Matcher determines whether a route handles a request path.
+type Matcher interface {
+	Match(path string) (Params, bool)
+}
+
+// MatchFunc adapts a function into a Matcher.
+type MatchFunc func(path string) (Params, bool)
+
+// Match calls f(path).
+func (f MatchFunc) Match(path string) (Params, bool) {
+	return f(path)
+}
+
+type route struct {
+	method  string
+	matcher Matcher
+	handler HandlerFunc
+}
+
+// Router dispatches API v1 routes.
+type Router struct {
+	authenticator Authenticator
+	realm         string
+	routes        []route
+}
+
+// NewRouter returns an empty API v1 router.
+func NewRouter(cfg Config) *Router {
+	return &Router{authenticator: cfg.Authenticator, realm: cfg.Realm}
+}
+
+// Handle registers a route.
+func (r *Router) Handle(method string, matcher Matcher, handler HandlerFunc) {
+	r.routes = append(r.routes, route{method: method, matcher: matcher, handler: handler})
+}
+
+// ServeHTTP dispatches the request to a registered route.
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	allowed := make(map[string]bool)
+	for _, route := range r.routes {
+		params, ok := route.matcher.Match(req.URL.Path)
+		if !ok {
+			continue
+		}
+		if route.method != req.Method {
+			allowed[route.method] = true
+			continue
+		}
+		route.handler(w, req, params)
+		return
+	}
+
+	if len(allowed) > 0 {
+		w.Header().Set("Allow", strings.Join(sortedMethods(allowed), ", "))
+		WriteError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	WriteError(w, http.StatusNotFound, "not found")
+}
+
+func sortedMethods(methods map[string]bool) []string {
+	result := make([]string, 0, len(methods))
+	for method := range methods {
+		result = append(result, method)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/auth/basic.go
+++ b/internal/auth/basic.go
@@ -1,0 +1,112 @@
+// Package auth provides shared authentication helpers for Go services.
+package auth
+
+import (
+	"database/sql"
+	"log/slog"
+	"net/http"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/quay/quay/internal/dal/daldb"
+)
+
+// PrincipalKind identifies the kind of authenticated identity.
+type PrincipalKind string
+
+const (
+	// PrincipalUser is a regular user account.
+	PrincipalUser PrincipalKind = "user"
+	// PrincipalRobot is a robot account.
+	PrincipalRobot PrincipalKind = "robot"
+	// PrincipalAnonymous is an unauthenticated caller.
+	PrincipalAnonymous PrincipalKind = "anonymous"
+)
+
+// Principal is the identity evaluated by API and registry authorization.
+type Principal struct {
+	ID       int64
+	UUID     sql.NullString
+	Username string
+	Email    string
+	Kind     PrincipalKind
+}
+
+// AnonymousPrincipal returns the shared anonymous identity.
+func AnonymousPrincipal() *Principal {
+	return &Principal{Username: "anonymous", Kind: PrincipalAnonymous}
+}
+
+// IsAnonymous reports whether p represents an unauthenticated caller.
+func (p *Principal) IsAnonymous() bool {
+	return p == nil || p.Kind == PrincipalAnonymous
+}
+
+// Result describes the outcome of an authentication attempt.
+type Result struct {
+	// Principal is populated only when authentication succeeds.
+	Principal Principal
+	// Username is populated when credentials were presented, even if they were
+	// invalid. This lets callers distinguish failed credentials from missing
+	// credentials without re-parsing the request.
+	Username string
+	// Presented reports whether the request included credentials for this
+	// authenticator. For Basic auth, this means an Authorization: Basic header
+	// was present; it does not imply the credentials were valid.
+	Presented bool
+	// Authenticated reports whether the presented credentials were valid.
+	Authenticated bool
+}
+
+// BasicAuthenticator validates HTTP Basic credentials against the Quay user table.
+type BasicAuthenticator struct {
+	queries *daldb.Queries
+}
+
+// NewBasicAuthenticator creates a BasicAuthenticator backed by db.
+func NewBasicAuthenticator(db *sql.DB) *BasicAuthenticator {
+	return &BasicAuthenticator{queries: daldb.New(db)}
+}
+
+// dummyHash is a valid bcrypt hash used when the user is not found, so that
+// bcrypt.CompareHashAndPassword always runs and timing is constant regardless
+// of whether the username exists.
+var dummyHash = []byte("$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy")
+
+// Authenticate validates request Basic credentials.
+//
+// Result.Username is set when credentials were presented, even if they did not
+// validate. Callers can distinguish missing credentials from failed credentials
+// while preserving constant-time password comparison.
+func (a *BasicAuthenticator) Authenticate(r *http.Request) Result {
+	username, password, presented := r.BasicAuth()
+	if !presented {
+		return Result{}
+	}
+
+	dbUser, err := a.queries.GetUserByUsername(r.Context(), username)
+
+	hashToCompare := dummyHash
+	if err == nil && dbUser.Enabled && dbUser.PasswordHash.Valid {
+		hashToCompare = []byte(dbUser.PasswordHash.String)
+	}
+
+	if bcrypt.CompareHashAndPassword(hashToCompare, []byte(password)) != nil ||
+		err != nil || !dbUser.Enabled || !dbUser.PasswordHash.Valid {
+		slog.Debug("authentication failed", "username", username)
+		return Result{Username: username, Presented: true}
+	}
+
+	return Result{
+		Principal: Principal{
+			ID:       dbUser.ID,
+			UUID:     dbUser.Uuid,
+			Username: dbUser.Username,
+			Email:    dbUser.Email,
+			Kind:     PrincipalUser,
+		},
+		Username:      username,
+		Presented:     true,
+		Authenticated: true,
+	}
+}

--- a/internal/auth/basic_test.go
+++ b/internal/auth/basic_test.go
@@ -1,0 +1,106 @@
+package auth
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+	_ "modernc.org/sqlite"
+)
+
+func setupAuthTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE "user" (
+		id INTEGER PRIMARY KEY,
+		uuid VARCHAR(36),
+		username VARCHAR(255) NOT NULL,
+		password_hash VARCHAR(255),
+		email VARCHAR(255) NOT NULL,
+		verified INTEGER NOT NULL DEFAULT 0,
+		organization INTEGER NOT NULL DEFAULT 0,
+		robot INTEGER NOT NULL DEFAULT 0,
+		enabled INTEGER NOT NULL DEFAULT 1
+	)`)
+	if err != nil {
+		t.Fatalf("create user table: %v", err)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	_, err = db.ExecContext(t.Context(), `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+		VALUES ('u1', 'admin', ?, 'admin@test.com', 1, 0, 0, 1)`, string(hash))
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	return db
+}
+
+func TestBasicAuthenticatorResult(t *testing.T) {
+	db := setupAuthTestDB(t)
+	defer db.Close()
+	authenticator := NewBasicAuthenticator(db)
+
+	t.Run("missing credentials", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+
+		result := authenticator.Authenticate(req)
+
+		if result.Presented {
+			t.Fatal("presented = true, want false")
+		}
+		if result.Authenticated {
+			t.Fatal("authenticated = true, want false")
+		}
+	})
+
+	t.Run("valid credentials", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+		req.SetBasicAuth("admin", "correct-password")
+
+		result := authenticator.Authenticate(req)
+
+		if !result.Presented {
+			t.Fatal("presented = false, want true")
+		}
+		if !result.Authenticated {
+			t.Fatal("authenticated = false, want true")
+		}
+		if result.Username != "admin" {
+			t.Fatalf("username = %q, want admin", result.Username)
+		}
+		if result.Principal.Username != "admin" {
+			t.Fatalf("principal username = %q, want admin", result.Principal.Username)
+		}
+		if result.Principal.Kind != PrincipalUser {
+			t.Fatalf("principal kind = %q, want user", result.Principal.Kind)
+		}
+	})
+
+	t.Run("invalid credentials", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+		req.SetBasicAuth("admin", "wrong-password")
+
+		result := authenticator.Authenticate(req)
+
+		if !result.Presented {
+			t.Fatal("presented = false, want true")
+		}
+		if result.Authenticated {
+			t.Fatal("authenticated = true, want false")
+		}
+		if result.Username != "admin" {
+			t.Fatalf("username = %q, want admin", result.Username)
+		}
+	})
+}

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -12,11 +12,16 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	apiv1 "github.com/quay/quay/internal/api/v1"
+	repositoryapi "github.com/quay/quay/internal/api/v1/repository"
+	"github.com/quay/quay/internal/auth"
 	"github.com/quay/quay/internal/bootstrap"
 	"github.com/quay/quay/internal/config"
 	"github.com/quay/quay/internal/dal/dbcore"
 	"github.com/quay/quay/internal/dal/metastore"
 	"github.com/quay/quay/internal/registry/distribution"
+	"github.com/quay/quay/internal/repository"
+	repositorydal "github.com/quay/quay/internal/repository/dal"
 	"github.com/quay/quay/internal/server"
 )
 
@@ -71,6 +76,7 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUse
 		DB:               db,
 		Store:            store,
 		LibraryNamespace: resolved.Config.LibraryNamespace,
+		AnonymousAccess:  resolved.Config.FeatureAnonymousAccess,
 	})
 	if err != nil {
 		slog.Error("registry setup error", "err", err)
@@ -78,9 +84,30 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUse
 	}
 	defer func() { _ = reg.Close() }()
 
+	repositoryService, err := repository.NewService(
+		repositorydal.NewStore(db),
+		repository.OwnerOrBootstrapAdminAuthorizer{AdminUsername: adminUsername},
+	)
+	if err != nil {
+		slog.Error("repository service setup error", "err", err)
+		return 1
+	}
+
+	api, err := apiv1.New(apiv1.Config{
+		Authenticator: auth.NewBasicAuthenticator(db),
+		Realm:         resolved.Config.ServerHostname,
+	},
+		repositoryapi.NewModule(repositoryService),
+	)
+	if err != nil {
+		slog.Error("api setup error", "err", err)
+		return 1
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/healthz", healthHandler(db))
 	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/api/", api)
 	mux.Handle("/", reg.Handler())
 
 	srv, err := server.New(ctx, mux, &server.Config{

--- a/internal/dal/daldb/repository.sql.go
+++ b/internal/dal/daldb/repository.sql.go
@@ -21,6 +21,15 @@ func (q *Queries) CountRepositories(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const deleteStarsByRepository = `-- name: DeleteStarsByRepository :exec
+DELETE FROM star WHERE repository_id = ?
+`
+
+func (q *Queries) DeleteStarsByRepository(ctx context.Context, repositoryID int64) error {
+	_, err := q.db.ExecContext(ctx, deleteStarsByRepository, repositoryID)
+	return err
+}
+
 const getOrCreateRepository = `-- name: GetOrCreateRepository :one
 INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, badge_token, state)
 VALUES (?, ?, ?, ?, ?, 0)
@@ -47,6 +56,44 @@ func (q *Queries) GetOrCreateRepository(ctx context.Context, arg GetOrCreateRepo
 	var id int64
 	err := row.Scan(&id)
 	return id, err
+}
+
+const getRepositoryAccessByNamespaceName = `-- name: GetRepositoryAccessByNamespaceName :one
+SELECT r.id, u.id AS namespace_user_id, u.username AS namespace, r.name, r.visibility_id, v.name AS visibility, r.state
+FROM repository r
+JOIN "user" u ON r.namespace_user_id = u.id
+JOIN visibility v ON r.visibility_id = v.id
+WHERE u.username = ? AND r.name = ? AND r.state != 3
+`
+
+type GetRepositoryAccessByNamespaceNameParams struct {
+	Username string `json:"username"`
+	Name     string `json:"name"`
+}
+
+type GetRepositoryAccessByNamespaceNameRow struct {
+	ID              int64  `json:"id"`
+	NamespaceUserID int64  `json:"namespace_user_id"`
+	Namespace       string `json:"namespace"`
+	Name            string `json:"name"`
+	VisibilityID    int64  `json:"visibility_id"`
+	Visibility      string `json:"visibility"`
+	State           int64  `json:"state"`
+}
+
+func (q *Queries) GetRepositoryAccessByNamespaceName(ctx context.Context, arg GetRepositoryAccessByNamespaceNameParams) (GetRepositoryAccessByNamespaceNameRow, error) {
+	row := q.db.QueryRowContext(ctx, getRepositoryAccessByNamespaceName, arg.Username, arg.Name)
+	var i GetRepositoryAccessByNamespaceNameRow
+	err := row.Scan(
+		&i.ID,
+		&i.NamespaceUserID,
+		&i.Namespace,
+		&i.Name,
+		&i.VisibilityID,
+		&i.Visibility,
+		&i.State,
+	)
+	return i, err
 }
 
 const getRepositoryByName = `-- name: GetRepositoryByName :one
@@ -101,6 +148,24 @@ func (q *Queries) GetRepositoryByNamespaceName(ctx context.Context, arg GetRepos
 	return id, err
 }
 
+const insertDeletedRepository = `-- name: InsertDeletedRepository :one
+INSERT INTO deletedrepository (repository_id, marked, original_name)
+VALUES (?1, datetime('now'), ?2)
+RETURNING id
+`
+
+type InsertDeletedRepositoryParams struct {
+	RepositoryID int64  `json:"repository_id"`
+	OriginalName string `json:"original_name"`
+}
+
+func (q *Queries) InsertDeletedRepository(ctx context.Context, arg InsertDeletedRepositoryParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, insertDeletedRepository, arg.RepositoryID, arg.OriginalName)
+	var id int64
+	err := row.Scan(&id)
+	return id, err
+}
+
 const listAllRepositories = `-- name: ListAllRepositories :many
 SELECT u.username AS namespace, r.name
 FROM repository r
@@ -134,4 +199,61 @@ func (q *Queries) ListAllRepositories(ctx context.Context) ([]ListAllRepositorie
 		return nil, err
 	}
 	return items, nil
+}
+
+const markRepositoryDeleted = `-- name: MarkRepositoryDeleted :execresult
+UPDATE repository
+SET name = ?1, state = 3
+WHERE repository.id = ?2
+  AND state != 3
+`
+
+type MarkRepositoryDeletedParams struct {
+	DeletedName  string `json:"deleted_name"`
+	RepositoryID int64  `json:"repository_id"`
+}
+
+func (q *Queries) MarkRepositoryDeleted(ctx context.Context, arg MarkRepositoryDeletedParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, markRepositoryDeleted, arg.DeletedName, arg.RepositoryID)
+}
+
+const repositoryIsPublicByNamespaceName = `-- name: RepositoryIsPublicByNamespaceName :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repository r
+  JOIN "user" u ON r.namespace_user_id = u.id
+  JOIN visibility v ON r.visibility_id = v.id
+  WHERE u.username = ?
+    AND r.name = ?
+    AND v.name = 'public'
+    AND r.state != 3
+)
+`
+
+type RepositoryIsPublicByNamespaceNameParams struct {
+	Username string `json:"username"`
+	Name     string `json:"name"`
+}
+
+func (q *Queries) RepositoryIsPublicByNamespaceName(ctx context.Context, arg RepositoryIsPublicByNamespaceNameParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, repositoryIsPublicByNamespaceName, arg.Username, arg.Name)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const updateRepositoryVisibility = `-- name: UpdateRepositoryVisibility :execresult
+UPDATE repository
+SET visibility_id = (SELECT id FROM visibility WHERE visibility.name = ?1)
+WHERE repository.id = ?2
+  AND state != 3
+`
+
+type UpdateRepositoryVisibilityParams struct {
+	Visibility   string `json:"visibility"`
+	RepositoryID int64  `json:"repository_id"`
+}
+
+func (q *Queries) UpdateRepositoryVisibility(ctx context.Context, arg UpdateRepositoryVisibilityParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, updateRepositoryVisibility, arg.Visibility, arg.RepositoryID)
 }

--- a/internal/dal/queries/repository.sql
+++ b/internal/dal/queries/repository.sql
@@ -17,6 +17,45 @@ SELECT r.id FROM repository r
 JOIN "user" u ON r.namespace_user_id = u.id
 WHERE u.username = ? AND r.name = ?;
 
+-- name: GetRepositoryAccessByNamespaceName :one
+SELECT r.id, u.id AS namespace_user_id, u.username AS namespace, r.name, r.visibility_id, v.name AS visibility, r.state
+FROM repository r
+JOIN "user" u ON r.namespace_user_id = u.id
+JOIN visibility v ON r.visibility_id = v.id
+WHERE u.username = ? AND r.name = ? AND r.state != 3;
+
+-- name: RepositoryIsPublicByNamespaceName :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repository r
+  JOIN "user" u ON r.namespace_user_id = u.id
+  JOIN visibility v ON r.visibility_id = v.id
+  WHERE u.username = ?
+    AND r.name = ?
+    AND v.name = 'public'
+    AND r.state != 3
+);
+
+-- name: UpdateRepositoryVisibility :execresult
+UPDATE repository
+SET visibility_id = (SELECT id FROM visibility WHERE visibility.name = @visibility)
+WHERE repository.id = @repository_id
+  AND state != 3;
+
+-- name: MarkRepositoryDeleted :execresult
+UPDATE repository
+SET name = @deleted_name, state = 3
+WHERE repository.id = @repository_id
+  AND state != 3;
+
+-- name: InsertDeletedRepository :one
+INSERT INTO deletedrepository (repository_id, marked, original_name)
+VALUES (@repository_id, datetime('now'), @original_name)
+RETURNING id;
+
+-- name: DeleteStarsByRepository :exec
+DELETE FROM star WHERE repository_id = ?;
+
 -- name: ListAllRepositories :many
 SELECT u.username AS namespace, r.name
 FROM repository r

--- a/internal/registry/distribution/app.go
+++ b/internal/registry/distribution/app.go
@@ -23,6 +23,7 @@ type Config struct {
 	DB               *sql.DB
 	Store            oci.MetadataStore
 	LibraryNamespace string
+	AnonymousAccess  *bool
 }
 
 // Registry wraps the distribution registry handler.
@@ -45,7 +46,7 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 
 	libraryNamespace := cfg.LibraryNamespace
 	if libraryNamespace == "" {
-		libraryNamespace = "library"
+		libraryNamespace = defaultLibraryNamespace
 	}
 
 	local.RegisterMetadataStore(cfg.Store)
@@ -66,13 +67,15 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 		},
 		Auth: configuration.Auth{
 			"quaydb": configuration.Parameters{
-				"realm": cfg.Hostname,
-				"db":    cfg.DB,
+				"realm":            cfg.Hostname,
+				"db":               cfg.DB,
+				"libraryNamespace": libraryNamespace,
+				"anonymousAccess":  anonymousAccessEnabled(cfg.AnonymousAccess),
 			},
 		},
 	}
 	distCfg.Middleware = map[string][]configuration.Middleware{
-		"repository": {{Name: registrymw.Name()}},
+		repositoryResourceType: {{Name: registrymw.Name()}},
 	}
 
 	distCfg.HTTP.Addr = cfg.ListenAddr
@@ -90,4 +93,11 @@ func (a *Registry) Handler() http.Handler {
 // Close releases resources held by the registry.
 func (a *Registry) Close() error {
 	return nil
+}
+
+func anonymousAccessEnabled(configured *bool) bool {
+	if configured == nil {
+		return true
+	}
+	return *configured
 }

--- a/internal/registry/distribution/auth.go
+++ b/internal/registry/distribution/auth.go
@@ -5,29 +5,34 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
-	"golang.org/x/crypto/bcrypt"
-
-	"github.com/distribution/distribution/v3/registry/auth"
+	distauth "github.com/distribution/distribution/v3/registry/auth"
+	"github.com/quay/quay/internal/auth"
 	"github.com/quay/quay/internal/dal/daldb"
 	"github.com/quay/quay/internal/oci"
 )
 
 func init() {
-	if err := auth.Register("quaydb", auth.InitFunc(newAccessController)); err != nil {
+	if err := distauth.Register("quaydb", distauth.InitFunc(newAccessController)); err != nil {
 		slog.Error("failed to register quaydb auth", "err", err)
 	}
 }
 
 type accessController struct {
-	queries *daldb.Queries
-	realm   string
+	authenticator    *auth.BasicAuthenticator
+	queries          *daldb.Queries
+	realm            string
+	libraryNamespace string
+	anonymousAccess  bool
 }
 
-var _ auth.AccessController = &accessController{}
-var _ oci.Authenticator = &accessController{}
+var (
+	_ distauth.AccessController = &accessController{}
+	_ oci.Authenticator         = &accessController{}
+)
 
-func newAccessController(options map[string]interface{}) (auth.AccessController, error) {
+func newAccessController(options map[string]interface{}) (distauth.AccessController, error) {
 	realm, ok := options["realm"].(string)
 	if !ok || realm == "" {
 		return nil, fmt.Errorf(`"realm" must be set for quaydb access controller`)
@@ -38,69 +43,128 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 		return nil, fmt.Errorf(`"db" must be set to *sql.DB for quaydb access controller`)
 	}
 
+	libraryNamespace, _ := options["libraryNamespace"].(string)
+	if libraryNamespace == "" {
+		libraryNamespace = defaultLibraryNamespace
+	}
+
+	anonymousAccess, ok := options["anonymousAccess"].(bool)
+	if !ok {
+		anonymousAccess = true
+	}
+
 	return &accessController{
-		queries: daldb.New(db),
-		realm:   realm,
+		authenticator:    auth.NewBasicAuthenticator(db),
+		queries:          daldb.New(db),
+		realm:            realm,
+		libraryNamespace: libraryNamespace,
+		anonymousAccess:  anonymousAccess,
 	}, nil
 }
 
-// dummyHash is a valid bcrypt hash used when the user is not found, so that
-// bcrypt.CompareHashAndPassword always runs and timing is constant regardless
-// of whether the username exists.
-var dummyHash = []byte("$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy")
-
-func (ac *accessController) authenticateUser(r *http.Request) (string, bool) {
-	username, password, ok := r.BasicAuth()
-	if !ok {
-		return "", false
+func (ac *accessController) Authorized(req *http.Request, access ...distauth.Access) (*distauth.Grant, error) {
+	result := ac.authenticator.Authenticate(req)
+	// Only missing credentials may fall back to anonymous public pulls. Invalid
+	// credentials must fail instead of silently becoming anonymous.
+	if !result.Authenticated && !result.Presented && ac.canAnonymousPull(req, access) {
+		return &distauth.Grant{User: distauth.UserInfo{Name: auth.AnonymousPrincipal().Username}}, nil
 	}
 
-	var hashToCompare []byte
-
-	user, err := ac.queries.GetUserByUsername(r.Context(), username)
-	if err != nil || !user.Enabled || !user.PasswordHash.Valid {
-		hashToCompare = dummyHash
-	} else {
-		hashToCompare = []byte(user.PasswordHash.String)
-	}
-
-	if bcrypt.CompareHashAndPassword(hashToCompare, []byte(password)) != nil ||
-		err != nil || !user.Enabled || !user.PasswordHash.Valid {
-		slog.Debug("authentication failed", "username", username)
-		return username, false
-	}
-
-	return username, true
-}
-
-func (ac *accessController) Authorized(req *http.Request, access ...auth.Access) (*auth.Grant, error) {
-	username, ok := ac.authenticateUser(req)
-	if !ok && username == "" {
+	if !result.Authenticated && !result.Presented {
 		return nil, &challenge{
 			realm: ac.realm,
-			err:   auth.ErrInvalidCredential,
+			err:   distauth.ErrInvalidCredential,
 		}
 	}
-	if !ok {
+	if !result.Authenticated {
 		return nil, &challenge{
 			realm: ac.realm,
-			err:   auth.ErrAuthenticationFailure,
+			err:   distauth.ErrAuthenticationFailure,
 		}
 	}
 
-	return &auth.Grant{User: auth.UserInfo{Name: username}}, nil
+	return &distauth.Grant{User: distauth.UserInfo{Name: result.Principal.Username}}, nil
 }
 
-func (ac *accessController) Authenticate(r *http.Request, _ ...oci.Access) (*oci.Grant, error) {
-	username, ok := ac.authenticateUser(r)
-	if !ok {
+func (ac *accessController) Authenticate(r *http.Request, access ...oci.Access) (*oci.Grant, error) {
+	result := ac.authenticator.Authenticate(r)
+	// Only missing credentials may fall back to anonymous public pulls. Invalid
+	// credentials must fail instead of silently becoming anonymous.
+	if !result.Authenticated && !result.Presented && ac.canAnonymousOCIPull(r, access) {
+		return &oci.Grant{User: oci.User{Name: auth.AnonymousPrincipal().Username}}, nil
+	}
+
+	if !result.Authenticated {
 		return nil, &challenge{
 			realm: ac.realm,
 			err:   oci.ErrUnauthorized,
 		}
 	}
 
-	return &oci.Grant{User: oci.User{Name: username}}, nil
+	return &oci.Grant{User: oci.User{Name: result.Principal.Username}}, nil
+}
+
+func (ac *accessController) canAnonymousPull(req *http.Request, access []distauth.Access) bool {
+	if !ac.anonymousAccess || len(access) == 0 {
+		return false
+	}
+
+	for _, item := range access {
+		if item.Type != repositoryResourceType || item.Action != repositoryPullAction {
+			return false
+		}
+		if !ac.repositoryIsPublic(req, item.Name) {
+			return false
+		}
+	}
+	return true
+}
+
+func (ac *accessController) canAnonymousOCIPull(req *http.Request, access []oci.Access) bool {
+	if !ac.anonymousAccess || len(access) == 0 {
+		return false
+	}
+
+	for _, item := range access {
+		resourceType, resourceName, ok := strings.Cut(item.Resource, ":")
+		if !ok || resourceType != repositoryResourceType || item.Action != repositoryPullAction {
+			return false
+		}
+		if !ac.repositoryIsPublic(req, resourceName) {
+			return false
+		}
+	}
+	return true
+}
+
+func (ac *accessController) repositoryIsPublic(req *http.Request, name string) bool {
+	namespace, repository, ok := ac.repositoryParts(name)
+	if !ok {
+		return false
+	}
+
+	isPublic, err := ac.queries.RepositoryIsPublicByNamespaceName(req.Context(), daldb.RepositoryIsPublicByNamespaceNameParams{
+		Username: namespace,
+		Name:     repository,
+	})
+	if err != nil {
+		slog.Debug("anonymous repository visibility lookup failed", "repository", name, "err", err)
+		return false
+	}
+
+	return isPublic == 1
+}
+
+func (ac *accessController) repositoryParts(name string) (namespace, repository string, ok bool) {
+	namespace, repository, ok = strings.Cut(name, "/")
+	if !ok {
+		namespace = ac.libraryNamespace
+		repository = name
+	}
+	if namespace == "" || repository == "" {
+		return "", "", false
+	}
+	return namespace, repository, true
 }
 
 // challenge implements auth.Challenge for Basic auth 401 responses.
@@ -109,7 +173,7 @@ type challenge struct {
 	err   error
 }
 
-var _ auth.Challenge = challenge{}
+var _ distauth.Challenge = challenge{}
 
 func (ch challenge) SetHeaders(_ *http.Request, w http.ResponseWriter) {
 	w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", ch.realm))

--- a/internal/registry/distribution/auth_test.go
+++ b/internal/registry/distribution/auth_test.go
@@ -39,6 +39,29 @@ func setupTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("create table: %v", err)
 	}
 
+	_, err = db.ExecContext(ctx, `CREATE TABLE visibility (
+		id INTEGER PRIMARY KEY,
+		name VARCHAR(255) NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create visibility table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE repository (
+		id INTEGER PRIMARY KEY,
+		namespace_user_id INTEGER,
+		name VARCHAR(255) NOT NULL,
+		visibility_id INTEGER NOT NULL,
+		kind_id INTEGER NOT NULL DEFAULT 1,
+		state INTEGER NOT NULL DEFAULT 0
+	)`)
+	if err != nil {
+		t.Fatalf("create repository table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO visibility (id, name) VALUES (1, 'public'), (2, 'private')`)
+	if err != nil {
+		t.Fatalf("insert visibility: %v", err)
+	}
+
 	hash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
 	if err != nil {
 		t.Fatalf("bcrypt: %v", err)
@@ -58,14 +81,49 @@ func setupTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("insert disabled: %v", err)
 	}
 
+	for _, username := range []string{"public", "devtable", "library"} {
+		_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+			VALUES (?, ?, NULL, ?, 1, 0, 0, 1)`, "u-"+username, username, username+"@test.com")
+		if err != nil {
+			t.Fatalf("insert namespace %s: %v", username, err)
+		}
+	}
+
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'publicrepo', 1, 1, 0 FROM "user" WHERE username = 'public'`)
+	if err != nil {
+		t.Fatalf("insert public repo: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'simple', 2, 1, 0 FROM "user" WHERE username = 'devtable'`)
+	if err != nil {
+		t.Fatalf("insert private repo: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'deleted', 1, 1, 3 FROM "user" WHERE username = 'public'`)
+	if err != nil {
+		t.Fatalf("insert deleted repo: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'nginx', 1, 1, 0 FROM "user" WHERE username = 'library'`)
+	if err != nil {
+		t.Fatalf("insert library repo: %v", err)
+	}
+
 	return db
 }
 
 func newTestController(t *testing.T, db *sql.DB) auth.AccessController {
 	t.Helper()
+	return newTestControllerWithAnonymousAccess(t, db, true)
+}
+
+func newTestControllerWithAnonymousAccess(t *testing.T, db *sql.DB, anonymousAccess bool) auth.AccessController {
+	t.Helper()
 	ac, err := newAccessController(map[string]interface{}{
-		"realm": "test-realm",
-		"db":    db,
+		"realm":           "test-realm",
+		"db":              db,
+		"anonymousAccess": anonymousAccess,
 	})
 	if err != nil {
 		t.Fatalf("new access controller: %v", err)
@@ -159,10 +217,127 @@ func TestAuthorized_NoAuthHeader(t *testing.T) {
 	}
 }
 
+func TestAuthorized_AnonymousPullPublicRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+
+	grant, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
+	if err != nil {
+		t.Fatalf("expected anonymous pull to public repo to succeed, got: %v", err)
+	}
+	if grant.User.Name != "anonymous" {
+		t.Errorf("expected anonymous user, got %q", grant.User.Name)
+	}
+}
+
+func TestAuthorized_AnonymousPullDisabledByFeatureFlag(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestControllerWithAnonymousAccess(t, db, false)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+
+	_, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
+	if err == nil {
+		t.Fatal("expected missing auth challenge when anonymous access is disabled")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_AnonymousPullPrivateRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/devtable/simple/manifests/latest", http.NoBody)
+
+	_, err := ac.Authorized(req, repositoryAccess("devtable/simple", "pull"))
+	if err == nil {
+		t.Fatal("expected missing auth challenge for private repo")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_AnonymousPullDeletedPublicRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/deleted/manifests/latest", http.NoBody)
+
+	_, err := ac.Authorized(req, repositoryAccess("public/deleted", "pull"))
+	if err == nil {
+		t.Fatal("expected missing auth challenge for deleted public repo")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_AnonymousPushPublicRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+
+	_, err := ac.Authorized(
+		req,
+		repositoryAccess("public/publicrepo", "pull"),
+		repositoryAccess("public/publicrepo", "push"),
+	)
+	if err == nil {
+		t.Fatal("expected missing auth challenge for anonymous push")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_InvalidBasicAuthDoesNotFallBackToAnonymous(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+	req.SetBasicAuth("admin", "wrong-password")
+
+	_, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
+	if err == nil {
+		t.Fatal("expected auth failure for invalid basic credentials")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_AnonymousPullLibraryRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/nginx/manifests/latest", http.NoBody)
+
+	grant, err := ac.Authorized(req, repositoryAccess("nginx", "pull"))
+	if err != nil {
+		t.Fatalf("expected anonymous pull to library repo to succeed, got: %v", err)
+	}
+	if grant.User.Name != "anonymous" {
+		t.Errorf("expected anonymous user, got %q", grant.User.Name)
+	}
+}
+
 func assertChallenge(t *testing.T, err error) {
 	t.Helper()
 	var ch auth.Challenge
 	if !errors.As(err, &ch) {
 		t.Errorf("expected Challenge error, got %T: %v", err, err)
+	}
+}
+
+func repositoryAccess(name, action string) auth.Access {
+	return auth.Access{
+		Resource: auth.Resource{
+			Type: "repository",
+			Name: name,
+		},
+		Action: action,
 	}
 }

--- a/internal/registry/distribution/constants.go
+++ b/internal/registry/distribution/constants.go
@@ -1,0 +1,8 @@
+// Package distribution implements the OCI registry using go-distribution.
+package distribution
+
+const (
+	defaultLibraryNamespace = "library"
+	repositoryResourceType  = "repository"
+	repositoryPullAction    = "pull"
+)

--- a/internal/repository/authz.go
+++ b/internal/repository/authz.go
@@ -1,0 +1,25 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/quay/quay/internal/auth"
+)
+
+// OwnerOrBootstrapAdminAuthorizer grants repository admin to the namespace
+// owner and the standalone registry bootstrap admin.
+//
+// Full Quay permission-table authorization can replace this implementation
+// without changing repository service callers.
+type OwnerOrBootstrapAdminAuthorizer struct {
+	AdminUsername string
+}
+
+// CanAdminRepository reports whether actor can administer repo.
+func (a OwnerOrBootstrapAdminAuthorizer) CanAdminRepository(_ context.Context, principal *auth.Principal, repo Repository) (bool, error) {
+	if principal.IsAnonymous() {
+		return false, nil
+	}
+	return principal.Username == repo.Ref.Namespace ||
+		(a.AdminUsername != "" && principal.Username == a.AdminUsername), nil
+}

--- a/internal/repository/dal/store.go
+++ b/internal/repository/dal/store.go
@@ -1,0 +1,100 @@
+// Package dal adapts repository business storage to sqlc database queries.
+package dal
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/quay/quay/internal/dal/daldb"
+	"github.com/quay/quay/internal/repository"
+)
+
+// Store implements repository.Store with the Quay database.
+type Store struct {
+	db      *sql.DB
+	queries *daldb.Queries
+}
+
+var _ repository.Store = (*Store)(nil)
+
+// NewStore returns a SQL-backed repository store.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db, queries: daldb.New(db)}
+}
+
+// Get returns repository details for business operations.
+func (s *Store) Get(ctx context.Context, ref repository.Ref) (repository.Repository, error) {
+	row, err := s.queries.GetRepositoryAccessByNamespaceName(ctx, daldb.GetRepositoryAccessByNamespaceNameParams{
+		Username: ref.Namespace,
+		Name:     ref.Name,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return repository.Repository{}, repository.ErrNotFound
+	}
+	if err != nil {
+		return repository.Repository{}, err
+	}
+
+	return repository.Repository{
+		ID: row.ID,
+		Ref: repository.Ref{
+			Namespace: row.Namespace,
+			Name:      row.Name,
+		},
+		Visibility: repository.Visibility(row.Visibility),
+	}, nil
+}
+
+// SetVisibility changes a repository visibility value.
+func (s *Store) SetVisibility(ctx context.Context, id int64, visibility repository.Visibility) error {
+	result, err := s.queries.UpdateRepositoryVisibility(ctx, daldb.UpdateRepositoryVisibilityParams{
+		Visibility:   string(visibility),
+		RepositoryID: id,
+	})
+	if err != nil {
+		return err
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
+		return repository.ErrNotFound
+	}
+	return nil
+}
+
+// MarkDeleted renames and marks a repository deleted with its deletedrepository marker.
+func (s *Store) MarkDeleted(ctx context.Context, repo repository.Repository, deletedName string) (retErr error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if retErr != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	q := s.queries.WithTx(tx)
+	if err := q.DeleteStarsByRepository(ctx, repo.ID); err != nil {
+		return err
+	}
+
+	result, err := q.MarkRepositoryDeleted(ctx, daldb.MarkRepositoryDeletedParams{
+		DeletedName:  deletedName,
+		RepositoryID: repo.ID,
+	})
+	if err != nil {
+		return err
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
+		return repository.ErrNotFound
+	}
+
+	if _, err := q.InsertDeletedRepository(ctx, daldb.InsertDeletedRepositoryParams{
+		RepositoryID: repo.ID,
+		OriginalName: repo.Ref.Name,
+	}); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}

--- a/internal/repository/errors.go
+++ b/internal/repository/errors.go
@@ -1,0 +1,12 @@
+package repository
+
+import "errors"
+
+var (
+	// ErrNotFound indicates the repository does not exist for this operation.
+	ErrNotFound = errors.New("repository not found")
+	// ErrForbidden indicates the actor cannot perform the operation.
+	ErrForbidden = errors.New("forbidden")
+	// ErrInvalidVisibility indicates the requested visibility is unsupported.
+	ErrInvalidVisibility = errors.New("invalid visibility")
+)

--- a/internal/repository/service.go
+++ b/internal/repository/service.go
@@ -1,0 +1,83 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/quay/quay/internal/auth"
+)
+
+// Store persists repository state.
+type Store interface {
+	Get(ctx context.Context, ref Ref) (Repository, error)
+	SetVisibility(ctx context.Context, id int64, visibility Visibility) error
+	MarkDeleted(ctx context.Context, repo Repository, deletedName string) error
+}
+
+// Authorizer decides whether an actor can perform repository operations.
+type Authorizer interface {
+	CanAdminRepository(ctx context.Context, principal *auth.Principal, repo Repository) (bool, error)
+}
+
+// Service implements repository business operations.
+type Service struct {
+	store      Store
+	authorizer Authorizer
+}
+
+// NewService returns a repository service.
+func NewService(store Store, authorizer Authorizer) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("nil repository store")
+	}
+	if authorizer == nil {
+		return nil, fmt.Errorf("nil repository authorizer")
+	}
+	return &Service{store: store, authorizer: authorizer}, nil
+}
+
+// ChangeVisibility changes a repository visibility after validation and authorization.
+func (s *Service) ChangeVisibility(ctx context.Context, principal *auth.Principal, ref Ref, visibility Visibility) error {
+	if !visibility.Valid() {
+		return ErrInvalidVisibility
+	}
+
+	repo, err := s.store.Get(ctx, ref)
+	if err != nil {
+		return err
+	}
+
+	allowed, err := s.authorizer.CanAdminRepository(ctx, principal, repo)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return ErrForbidden
+	}
+
+	return s.store.SetVisibility(ctx, repo.ID, visibility)
+}
+
+// Delete marks a repository for deletion after authorization.
+//
+// This is the minimal standalone Go equivalent of Python's repository delete:
+// it frees the original name by renaming the repository, marks it deleted, and
+// records a deletedrepository marker. GC queueing and downstream cleanup are
+// intentionally left for later worker migration.
+func (s *Service) Delete(ctx context.Context, principal *auth.Principal, ref Ref) error {
+	repo, err := s.store.Get(ctx, ref)
+	if err != nil {
+		return err
+	}
+
+	allowed, err := s.authorizer.CanAdminRepository(ctx, principal, repo)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return ErrForbidden
+	}
+
+	return s.store.MarkDeleted(ctx, repo, uuid.NewString())
+}

--- a/internal/repository/service_test.go
+++ b/internal/repository/service_test.go
@@ -1,0 +1,209 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/quay/quay/internal/auth"
+)
+
+type fakeStore struct {
+	repo          Repository
+	getErr        error
+	setID         int64
+	setVisibility Visibility
+	setErr        error
+	setCalled     bool
+	deletedRepo   Repository
+	deletedName   string
+	deleteErr     error
+	deleteCalled  bool
+}
+
+func (s *fakeStore) Get(context.Context, Ref) (Repository, error) {
+	if s.getErr != nil {
+		return Repository{}, s.getErr
+	}
+	return s.repo, nil
+}
+
+func (s *fakeStore) SetVisibility(_ context.Context, id int64, visibility Visibility) error {
+	s.setCalled = true
+	s.setID = id
+	s.setVisibility = visibility
+	return s.setErr
+}
+
+func (s *fakeStore) MarkDeleted(_ context.Context, repo Repository, deletedName string) error {
+	s.deleteCalled = true
+	s.deletedRepo = repo
+	s.deletedName = deletedName
+	return s.deleteErr
+}
+
+type fakeAuthorizer struct {
+	allowed bool
+	err     error
+}
+
+func (a fakeAuthorizer) CanAdminRepository(context.Context, *auth.Principal, Repository) (bool, error) {
+	return a.allowed, a.err
+}
+
+func TestServiceChangeVisibility(t *testing.T) {
+	store := &fakeStore{
+		repo: Repository{
+			ID: 7,
+			Ref: Ref{
+				Namespace: "devtable",
+				Name:      "repo",
+			},
+			Visibility: VisibilityPrivate,
+		},
+	}
+	service, err := NewService(store, fakeAuthorizer{allowed: true})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+
+	err = service.ChangeVisibility(
+		t.Context(),
+		&auth.Principal{Username: "devtable", Kind: auth.PrincipalUser},
+		Ref{Namespace: "devtable", Name: "repo"},
+		VisibilityPublic,
+	)
+	if err != nil {
+		t.Fatalf("change visibility: %v", err)
+	}
+	if !store.setCalled {
+		t.Fatal("expected SetVisibility call")
+	}
+	if store.setID != 7 {
+		t.Fatalf("set ID = %d, want 7", store.setID)
+	}
+	if store.setVisibility != VisibilityPublic {
+		t.Fatalf("set visibility = %q, want public", store.setVisibility)
+	}
+}
+
+func TestServiceChangeVisibilityInvalidVisibility(t *testing.T) {
+	store := &fakeStore{}
+	service, err := NewService(store, fakeAuthorizer{allowed: true})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+
+	err = service.ChangeVisibility(t.Context(), &auth.Principal{Username: "devtable", Kind: auth.PrincipalUser}, Ref{Namespace: "devtable", Name: "repo"}, Visibility("internal"))
+	if !errors.Is(err, ErrInvalidVisibility) {
+		t.Fatalf("err = %v, want ErrInvalidVisibility", err)
+	}
+	if store.setCalled {
+		t.Fatal("SetVisibility should not be called")
+	}
+}
+
+func TestServiceChangeVisibilityForbidden(t *testing.T) {
+	store := &fakeStore{
+		repo: Repository{
+			ID: 7,
+			Ref: Ref{
+				Namespace: "devtable",
+				Name:      "repo",
+			},
+		},
+	}
+	service, err := NewService(store, fakeAuthorizer{allowed: false})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+
+	err = service.ChangeVisibility(t.Context(), &auth.Principal{Username: "reader", Kind: auth.PrincipalUser}, Ref{Namespace: "devtable", Name: "repo"}, VisibilityPublic)
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+	if store.setCalled {
+		t.Fatal("SetVisibility should not be called")
+	}
+}
+
+func TestServiceDelete(t *testing.T) {
+	store := &fakeStore{
+		repo: Repository{
+			ID: 7,
+			Ref: Ref{
+				Namespace: "devtable",
+				Name:      "repo",
+			},
+		},
+	}
+	service, err := NewService(store, fakeAuthorizer{allowed: true})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+
+	err = service.Delete(t.Context(), &auth.Principal{Username: "devtable", Kind: auth.PrincipalUser}, Ref{Namespace: "devtable", Name: "repo"})
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !store.deleteCalled {
+		t.Fatal("expected MarkDeleted call")
+	}
+	if store.deletedRepo.ID != 7 {
+		t.Fatalf("deleted repo ID = %d, want 7", store.deletedRepo.ID)
+	}
+	if store.deletedName == "" || store.deletedName == "repo" {
+		t.Fatalf("deleted name = %q, want generated name", store.deletedName)
+	}
+}
+
+func TestServiceDeleteForbidden(t *testing.T) {
+	store := &fakeStore{
+		repo: Repository{
+			ID: 7,
+			Ref: Ref{
+				Namespace: "devtable",
+				Name:      "repo",
+			},
+		},
+	}
+	service, err := NewService(store, fakeAuthorizer{allowed: false})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+
+	err = service.Delete(t.Context(), &auth.Principal{Username: "reader", Kind: auth.PrincipalUser}, Ref{Namespace: "devtable", Name: "repo"})
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("err = %v, want ErrForbidden", err)
+	}
+	if store.deleteCalled {
+		t.Fatal("MarkDeleted should not be called")
+	}
+}
+
+func TestOwnerOrBootstrapAdminAuthorizer(t *testing.T) {
+	authz := OwnerOrBootstrapAdminAuthorizer{AdminUsername: "admin"}
+	repo := Repository{Ref: Ref{Namespace: "devtable", Name: "repo"}}
+
+	for _, tc := range []struct {
+		name    string
+		actor   *auth.Principal
+		allowed bool
+	}{
+		{name: "owner", actor: &auth.Principal{Username: "devtable", Kind: auth.PrincipalUser}, allowed: true},
+		{name: "admin", actor: &auth.Principal{Username: "admin", Kind: auth.PrincipalUser}, allowed: true},
+		{name: "other", actor: &auth.Principal{Username: "reader", Kind: auth.PrincipalUser}, allowed: false},
+		{name: "anonymous", actor: auth.AnonymousPrincipal(), allowed: false},
+		{name: "nil", actor: nil, allowed: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			allowed, err := authz.CanAdminRepository(t.Context(), tc.actor, repo)
+			if err != nil {
+				t.Fatalf("authorize: %v", err)
+			}
+			if allowed != tc.allowed {
+				t.Fatalf("allowed = %v, want %v", allowed, tc.allowed)
+			}
+		})
+	}
+}

--- a/internal/repository/types.go
+++ b/internal/repository/types.go
@@ -1,0 +1,30 @@
+// Package repository contains repository business operations.
+package repository
+
+// Ref identifies a repository by namespace and name.
+type Ref struct {
+	Namespace string
+	Name      string
+}
+
+// Visibility is a repository visibility value.
+type Visibility string
+
+const (
+	// VisibilityPublic makes a repository pullable by anonymous users when enabled.
+	VisibilityPublic Visibility = "public"
+	// VisibilityPrivate requires authentication and permission to pull.
+	VisibilityPrivate Visibility = "private"
+)
+
+// Valid reports whether v is a supported repository visibility.
+func (v Visibility) Valid() bool {
+	return v == VisibilityPublic || v == VisibilityPrivate
+}
+
+// Repository contains repository fields needed by business operations.
+type Repository struct {
+	ID         int64
+	Ref        Ref
+	Visibility Visibility
+}


### PR DESCRIPTION
## Summary

- Honor `FEATURE_ANONYMOUS_ACCESS` in the Go registry auth path by allowing anonymous pulls only for public, non-deleted repositories when the feature is enabled.
- Add a shared Basic auth principal/result model so API and registry code can distinguish missing credentials from invalid credentials without falling back to anonymous access.
- Split Go API v1 into composable module registration with shared routing, Basic auth middleware, path parsing, and JSON response helpers.
- Add repository visibility and minimal soft-delete endpoints backed by a repository service and sqlc-backed DAL.

## Notes

- Mirror mode remains intentionally slim: this introduces the seams for selectable API modules and swappable repository authorization without trying to port full Quay RBAC in this patch.
- The minimal delete endpoint mirrors Python's soft-delete shape by renaming the repository, marking it deleted, inserting a `deletedrepository` marker, and clearing stars in one transaction.
- Downstream delete work such as GC queueing, worker cleanup, cache invalidation, and action logging is intentionally left for later migration.

## Validation

- `GOCACHE=/tmp/quay-go-build-cache go test ./internal/auth ./internal/api/v1/... ./internal/repository/... ./internal/registry/distribution ./internal/cmd ./internal/dal/...`
- `GOCACHE=/tmp/quay-go-build-cache go build -o /tmp/quay-go-smoke/quay ./cmd/quay`
- Smoke ran `/tmp/quay-go-smoke/quay serve --data-dir /tmp/quay-go-smoke/data-pr --addr :18444 --hostname localhost --admin-username admin`; `GET /healthz` returned `HTTP 200 {"status":"ok"}`.
