### PR TITLE
[redhat-3.16] NO-ISSUE: chore(config-tool): update Go base image to 1…

### DIFF
--- a/config-tool/Dockerfile
+++ b/config-tool/Dockerfile
@@ -6,7 +6,7 @@ RUN yum install -y nodejs && \
     npm install --ignore-engines && \
     npm run build
 
-FROM golang:1.24.8-alpine3.22
+FROM golang:1.25.11-alpine3.24
 
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/* && mkdir /usr/local/share/ca-certificates/extra
 WORKDIR /go/src/config-tool


### PR DESCRIPTION
## Summary

The `config-tool/go.mod` requires Go 1.25.0, but the `config-tool/Dockerfile` was using `golang:1.24.8-alpine3.22`. This updates the base image to `golang:1.25.11-alpine3.24` to match the Go module requirement.

## Changes

- Updated `config-tool/Dockerfile` FROM line: `golang:1.24.8-alpine3.22` → `golang:1.25.11-alpine3.24`

No other files modified.