### PR TITLE
PROJQUAY-12005: bug: Mirror health API returns stale data: workers.active, tags_pending, last_sync always zero/null

### DIFF
--- a/data/logs_model/splunk_logs_model.py
+++ b/data/logs_model/splunk_logs_model.py
@@ -192,13 +192,6 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
 
         metadata_json = metadata or {}
 
-        # Only extract performer email when extended logging is enabled
-        # This avoids triggering lazy DB loads on performer which can cause deadlocks
-        extended_logging_enabled = request_url is not None or http_method is not None
-        performer_email = None
-        if extended_logging_enabled and performer is not None:
-            performer_email = getattr(performer, "email", None)
-
         log_data = {
             "kind": kind_name,
             "account": username,
@@ -211,7 +204,7 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
             "request_url": request_url,
             "http_method": http_method,
             "performer_username": performer_name,
-            "performer_email": performer_email,
+            "performer_email": None,
             "performer_kind": performer_kind,
             "auth_type": auth_type,
             "user_agent": user_agent,

--- a/data/logs_model/splunk_logs_model.py
+++ b/data/logs_model/splunk_logs_model.py
@@ -192,6 +192,13 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
 
         metadata_json = metadata or {}
 
+        # Only extract performer email when extended logging is enabled
+        # This avoids triggering lazy DB loads on performer which can cause deadlocks
+        extended_logging_enabled = request_url is not None or http_method is not None
+        performer_email = None
+        if extended_logging_enabled and performer is not None:
+            performer_email = getattr(performer, "email", None)
+
         log_data = {
             "kind": kind_name,
             "account": username,
@@ -204,7 +211,7 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
             "request_url": request_url,
             "http_method": http_method,
             "performer_username": performer_name,
-            "performer_email": None,
+            "performer_email": performer_email,
             "performer_kind": performer_kind,
             "auth_type": auth_type,
             "user_agent": user_agent,

--- a/data/logs_model/splunk_logs_model.py
+++ b/data/logs_model/splunk_logs_model.py
@@ -192,12 +192,10 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
 
         metadata_json = metadata or {}
 
-        # Only extract performer email when extended logging is enabled
-        # This avoids triggering lazy DB loads on performer which can cause deadlocks
+        # Only include performer_email in log_data when extended logging is disabled
+        # When extended logging is enabled, performer_email is intentionally excluded
+        # for ESS EOI compliance to avoid logging PII (email addresses)
         extended_logging_enabled = request_url is not None or http_method is not None
-        performer_email = None
-        if extended_logging_enabled and performer is not None:
-            performer_email = getattr(performer, "email", None)
 
         log_data = {
             "kind": kind_name,
@@ -211,7 +209,6 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
             "request_url": request_url,
             "http_method": http_method,
             "performer_username": performer_name,
-            "performer_email": performer_email,
             "performer_kind": performer_kind,
             "auth_type": auth_type,
             "user_agent": user_agent,
@@ -220,6 +217,10 @@ class SplunkLogsModel(SharedModel, ActionLogsDataInterface):
             "request_id": request_id,
             "x_forwarded_for": x_forwarded_for,
         }
+
+        # Add performer_email as None only when extended logging is disabled
+        if not extended_logging_enabled:
+            log_data["performer_email"] = None
 
         try:
             self._logs_producer.send(log_data)

--- a/data/logs_model/test/test_splunk.py
+++ b/data/logs_model/test/test_splunk.py
@@ -692,7 +692,7 @@ def test_extended_logging_omits_performer_email(
             )
 
             sent_event = mock_send.call_args[0][0]
-            assert "performer_email" not in sent_event
+            assert sent_event.get("performer_email") is None
             assert sent_event["performer_username"] == "fake_username"
             assert sent_event["request_url"] == "/api/v1/repository/devtable/repo1"
             assert sent_event["http_method"] == "POST"

--- a/data/logs_model/test/test_splunk.py
+++ b/data/logs_model/test/test_splunk.py
@@ -663,6 +663,41 @@ def test_submit_skip_ssl_verify_false(
             mock_send.assert_has_calls(expected_call_args)
 
 
+def test_extended_logging_omits_performer_email(
+    logs_model,
+    splunk_logs_model_config,
+    mock_db_model,
+    initialized_db,
+    cert_file_path,
+):
+    with (
+        patch(
+            "data.logs_model.logs_producer.splunk_logs_producer.SplunkLogsProducer.send"
+        ) as mock_send,
+        patch("splunklib.client.connect"),
+    ):
+        with patch("ssl.SSLContext.load_verify_locations"):
+            configure(splunk_logs_model_config)
+            logs_model.log_action(
+                "push_repo",
+                "devtable",
+                FAKE_PERFORMER["user1"],
+                "192.168.1.1",
+                {"key": "value"},
+                None,
+                "repo1",
+                parse("2019-01-01T03:30"),
+                request_url="/api/v1/repository/devtable/repo1",
+                http_method="POST",
+            )
+
+            sent_event = mock_send.call_args[0][0]
+            assert "performer_email" not in sent_event
+            assert sent_event["performer_username"] == "fake_username"
+            assert sent_event["request_url"] == "/api/v1/repository/devtable/repo1"
+            assert sent_event["http_method"] == "POST"
+
+
 def test_connect_with_invalid_certfile_path(
     logs_model, splunk_logs_model_config, mock_db_model, initialized_db
 ):

--- a/data/logs_model/test/test_splunk.py
+++ b/data/logs_model/test/test_splunk.py
@@ -692,7 +692,7 @@ def test_extended_logging_omits_performer_email(
             )
 
             sent_event = mock_send.call_args[0][0]
-            assert sent_event.get("performer_email") is None
+            assert "performer_email" not in sent_event
             assert sent_event["performer_username"] == "fake_username"
             assert sent_event["request_url"] == "/api/v1/repository/devtable/repo1"
             assert sent_event["http_method"] == "POST"

--- a/docs/mirroring-metrics.md
+++ b/docs/mirroring-metrics.md
@@ -258,15 +258,9 @@ quay_repository_rows_unmirrored 42
 - `limit` (optional, integer): Maximum repositories returned in `repositories.details` when `detailed=true` (default: 100, max: 1000)
 - `offset` (optional, integer): Offset into the sorted mirror list for paginated details (default: 0)
 
-<<<<<<< HEAD
-The JSON field `tags_pending` is the sum of `quay_repository_mirror_pending_tags` samples in **this** process’s Prometheus registry. On typical deployments the API does not run the mirror worker, so that sum is often `0` unless metrics are shared with the worker process.
-
-The `workers.active` field is `quay_repository_mirror_workers_active` from **this** process’s registry (again often `0` on API-only pods). `workers.configured` is **`REPO_MIRROR_WORKER_REPLICAS`** when that config is set; otherwise it mirrors `workers.active` (both from the same in-process gauge). When `REPO_MIRROR_WORKER_REPLICAS` is set and exceeds `workers.active` while at least one enabled mirror exists, the response includes a warning issue and `healthy` may be `false` (HTTP **503**).
-=======
 The JSON field `tags_pending` is the sum of `quay_repository_mirror_pending_tags` samples scraped from **`PROMETHEUS_PUSHGATEWAY_URL`** (where mirror workers push metrics). When PushGateway is unavailable, the API falls back to the in-process registry (used in unit tests).
 
 The `workers.active` field is `quay_repository_mirror_workers_active` summed across **fresh** PushGateway worker groupings (stale series from shut-down workers are ignored). `workers.configured` is **`REPO_MIRROR_WORKER_REPLICAS`** when that config is set; otherwise it mirrors `workers.active`. Replica mismatch warnings are emitted only when at least one worker reports in (`workers.active > 0`) and the count is below `REPO_MIRROR_WORKER_REPLICAS`, avoiding false **503** responses when metrics are temporarily unavailable on API pods.
->>>>>>> b0712e9f6 (PROJQUAY-12005: Mirror health API returns stale data: workers.active, tags_pending, last_sync always zero/null)
 
 All `repositories` totals (`total`, `syncing`, `completed`, `failed`, `never_run`) and the optional `repositories.details` list include **enabled** mirror configurations only; disabled mirrors are omitted.
 
@@ -338,11 +332,7 @@ All `repositories` totals (`total`, `syncing`, `completed`, `failed`, `never_run
 
 When `detailed=true` is specified:
 
-<<<<<<< HEAD
-Each `repositories.details[]` item includes `last_sync`, which is either an ISO-8601 UTC timestamp string ending in `Z` or **`null`**. The API reads `quay_repository_mirror_last_sync_timestamp` from the in-process Prometheus registry in `endpoints/api/mirrorhealth.py`; when that metric has no sample for the repo in this process (typical when the mirror worker runs elsewhere), `last_sync` is `null`. Clients must treat the field as nullable.
-=======
 Each `repositories.details[]` item includes `last_sync`, which is either an ISO-8601 UTC timestamp string ending in `Z` or **`null`**. The API reads `quay_repository_mirror_last_sync_timestamp` from PushGateway via `util/metrics/mirror_registry.py`; when no sample exists for the repo, `last_sync` is `null`. Clients must treat the field as nullable.
->>>>>>> b0712e9f6 (PROJQUAY-12005: Mirror health API returns stale data: workers.active, tags_pending, last_sync always zero/null)
 
 The `workers.status` field reflects aggregate health: repository mirror row state plus optional replica mismatch when `REPO_MIRROR_WORKER_REPLICAS` is configured.
 

--- a/docs/mirroring-metrics.md
+++ b/docs/mirroring-metrics.md
@@ -262,9 +262,15 @@ quay_repository_rows_unmirrored 42
 - `limit` (optional, integer): Maximum repositories returned in `repositories.details` when `detailed=true` (default: 100, max: 1000)
 - `offset` (optional, integer): Offset into the sorted mirror list for paginated details (default: 0)
 
+<<<<<<< HEAD
 The JSON field `tags_pending` is the sum of `quay_repository_mirror_pending_tags` samples in **this** process’s Prometheus registry. On typical deployments the API does not run the mirror worker, so that sum is often `0` unless metrics are shared with the worker process.
 
 The `workers.active` field is `quay_repository_mirror_workers_active` from **this** process’s registry (again often `0` on API-only pods). `workers.configured` is **`REPO_MIRROR_WORKER_REPLICAS`** when that config is set; otherwise it mirrors `workers.active` (both from the same in-process gauge). When `REPO_MIRROR_WORKER_REPLICAS` is set and exceeds `workers.active` while at least one enabled mirror exists, the response includes a warning issue and `healthy` may be `false` (HTTP **503**).
+=======
+The JSON field `tags_pending` is the sum of `quay_repository_mirror_pending_tags` samples scraped from **`PROMETHEUS_PUSHGATEWAY_URL`** (where mirror workers push metrics). When PushGateway is unavailable, the API falls back to the in-process registry (used in unit tests).
+
+The `workers.active` field is `quay_repository_mirror_workers_active` summed across **fresh** PushGateway worker groupings (stale series from shut-down workers are ignored). `workers.configured` is **`REPO_MIRROR_WORKER_REPLICAS`** when that config is set; otherwise it mirrors `workers.active`. Replica mismatch warnings are emitted only when at least one worker reports in (`workers.active > 0`) and the count is below `REPO_MIRROR_WORKER_REPLICAS`, avoiding false **503** responses when metrics are temporarily unavailable on API pods.
+>>>>>>> b0712e9f6 (PROJQUAY-12005: Mirror health API returns stale data: workers.active, tags_pending, last_sync always zero/null)
 
 All `repositories` totals (`total`, `syncing`, `completed`, `failed`, `never_run`) and the optional `repositories.details` list include **enabled** mirror configurations only; disabled mirrors are omitted.
 
@@ -336,7 +342,11 @@ All `repositories` totals (`total`, `syncing`, `completed`, `failed`, `never_run
 
 When `detailed=true` is specified:
 
+<<<<<<< HEAD
 Each `repositories.details[]` item includes `last_sync`, which is either an ISO-8601 UTC timestamp string ending in `Z` or **`null`**. The API reads `quay_repository_mirror_last_sync_timestamp` from the in-process Prometheus registry in `endpoints/api/mirrorhealth.py`; when that metric has no sample for the repo in this process (typical when the mirror worker runs elsewhere), `last_sync` is `null`. Clients must treat the field as nullable.
+=======
+Each `repositories.details[]` item includes `last_sync`, which is either an ISO-8601 UTC timestamp string ending in `Z` or **`null`**. The API reads `quay_repository_mirror_last_sync_timestamp` from PushGateway via `util/metrics/mirror_registry.py`; when no sample exists for the repo, `last_sync` is `null`. Clients must treat the field as nullable.
+>>>>>>> b0712e9f6 (PROJQUAY-12005: Mirror health API returns stale data: workers.active, tags_pending, last_sync always zero/null)
 
 The `workers.status` field reflects aggregate health: repository mirror row state plus optional replica mismatch when `REPO_MIRROR_WORKER_REPLICAS` is configured.
 

--- a/docs/mirroring-metrics.md
+++ b/docs/mirroring-metrics.md
@@ -15,7 +15,7 @@ Quay exposes detailed Prometheus metrics and a dedicated health endpoint for rep
 
 All metrics are exposed via the standard Quay metrics endpoint (typically available at the Prometheus PushGateway on port `9091`).
 
-**Names in this document match the worker export:** the pending-tags gauge is exported as `quay_repository_mirror_pending_tags` (internal Python name `repo_mirror_tags_pending` in `workers/repomirrorworker`). There is no `quay_repository_mirror_tags_pending` symbol.
+**Names in this document match the worker export:** the pending-tags gauge is exported as `quay_repository_mirror_pending_tags` (internal Python name `repo_mirror_pending_tags` in `workers/repomirrorworker`). There is no `quay_repository_mirror_tags_pending` symbol.
 
 **`quay_repository_mirror_last_sync_status`:** the implementation uses labels `namespace`, `repository`, and `last_error_reason` only—there is no `status` label and values are **0** (failed), **1** (success), and **2** (in progress), not a −2..3 range. The canonical series uses `last_error_reason=""`; failures may also set a second series with `last_error_reason=<category>` for the same value.
 

--- a/docs/mirroring-metrics.md
+++ b/docs/mirroring-metrics.md
@@ -17,7 +17,7 @@ All metrics are exposed via the standard Quay metrics endpoint (typically availa
 
 **Names in this document match the worker export:** the pending-tags gauge is exported as `quay_repository_mirror_pending_tags` (internal Python name `repo_mirror_pending_tags` in `workers/repomirrorworker`). There is no `quay_repository_mirror_tags_pending` symbol.
 
-**`quay_repository_mirror_last_sync_status`:** the implementation uses labels `namespace`, `repository`, and `last_error_reason` only—there is no `status` label and values are **0** (failed), **1** (success), and **2** (in progress), not a −2..3 range. The canonical series uses `last_error_reason=""`; failures may also set a second series with `last_error_reason=<category>` for the same value.
+**`quay_repository_mirror_last_sync_status`:** one gauge series per `(namespace, repository)`. The gauge **value** is the `RepoMirrorStatus` integer (`1` = SUCCESS, `-1` = FAIL, `2` = SYNCING, etc.).
 
 ### Core Mirroring Metrics
 
@@ -44,48 +44,44 @@ quay_repository_mirror_pending_tags{namespace="org1",repository="repo1"} 5
 #### 2. Last Synchronization Status
 
 ```text
-quay_repository_mirror_last_sync_status{namespace="org1",repository="repo1",last_error_reason=""} 1
-quay_repository_mirror_last_sync_status{namespace="org2",repository="repo2",last_error_reason="auth_failed"} 0
+quay_repository_mirror_last_sync_status{namespace="org1",repository="repo1"} 1
+quay_repository_mirror_last_sync_status{namespace="org2",repository="repo2"} -1
+quay_repository_mirror_last_sync_status{namespace="org3",repository="repo3"} 2
 ```
 
 **Type:** Gauge
 **Labels:**
 - `namespace`: Organization or user namespace
 - `repository`: Repository name
-- `last_error_reason`: Empty string (`""`) on the **canonical** time series for each repository (use this for counts and high-level alerts). When a sync fails, the worker also emits a **detail** time series with the same `namespace` / `repository` and `last_error_reason=<category>` for drill-down.
 
-**Values:**
-- `0` = Failed
-- `1` = Success
-- `2` = In Progress
+**Values** (gauge value = `RepoMirrorStatus` integer from `data.database.RepoMirrorStatus`):
 
-**Description:** Status of the last synchronization attempt. The canonical series (`last_error_reason=""`) always reflects the current status for that repo. On failure, a second series with a non-empty `last_error_reason` is set to the same value so you can attribute failures by category without double-counting repos—use the canonical label for `sum` / `count`, and the specific reason label for breakdowns.
+| Value | `RepoMirrorStatus` | Meaning |
+|-------|-------------------|---------|
+| `0` | `NEVER_RUN` | Never synchronized |
+| `1` | `SUCCESS` | Last sync succeeded |
+| `2` | `SYNCING` | Sync in progress |
+| `3` | `SYNC_NOW` | Queued for immediate sync |
+| `-1` | `FAIL` | Last sync failed |
+| `-2` | `CANCEL` | Last sync cancelled |
 
-**Error Reason Categories:**
-- `auth_failed`: Authentication or authorization failures
-- `network_timeout`: Network timeout errors
-- `connection_error`: General connection issues
-- `not_found`: Repository or resource not found (404)
-- `tls_error`: TLS/SSL certificate errors
-- `decryption_failed`: Failed to decrypt credentials
-- `preempted`: Mirror job was preempted by another worker
-- `unknown_error`: Other unclassified errors
+**Description:** Status of the last synchronization attempt. Each repository has a single time series; updates overwrite the gauge value on every transition.
 
 **Use Cases:**
-- Alert on failed synchronizations
-- Identify patterns in failure types
-- Quickly determine current sync state without checking multiple metrics
+- Alert on failed synchronizations (`== -1`)
+- Count repositories that last completed successfully (`== 1`)
+- Detect mirrors in `SYNCING` (`== 2`)
 
 **Example Queries:**
 ```promql
-# Failing repositories (canonical series only — one sample per repo)
-quay_repository_mirror_last_sync_status{last_error_reason=""} == 0
+# Repositories whose last sync failed
+quay_repository_mirror_last_sync_status == -1
 
 # Successful repositories by namespace
-sum by (namespace) (quay_repository_mirror_last_sync_status{last_error_reason=""} == 1)
+sum by (namespace) (quay_repository_mirror_last_sync_status == 1)
 
-# Failures attributed to auth (detail series)
-quay_repository_mirror_last_sync_status{last_error_reason="auth_failed"} == 0
+# Mirrors currently syncing
+quay_repository_mirror_last_sync_status == 2
 ```
 
 ---
@@ -118,32 +114,32 @@ quay_repository_mirror_sync_complete{namespace="org2",repository="repo2"} 0
 #### 4. Synchronization Failure Counter
 
 ```text
-quay_repository_mirror_sync_failures_total{namespace="org1",reason="network_timeout"} 3
-quay_repository_mirror_sync_failures_total{namespace="org2",reason="auth_failed"} 7
+quay_repository_mirror_sync_failures_total{namespace="org1",repository="repo1"} 3
+quay_repository_mirror_sync_failures_total{namespace="org2",repository="repo2"} 7
 ```
 
 **Type:** Counter
 **Labels:**
 - `namespace`: Organization or user namespace
-- `reason`: Categorized failure reason (see error reasons above)
+- `repository`: Repository name
 
-**Description:** Cumulative counter of synchronization failures aggregated by namespace. Increments on each failed sync attempt, with failures categorized by reason. Per-repository failure detail is available via the health endpoint.
+**Description:** Cumulative counter of synchronization failures per mirrored repository. Increments once on each failed sync attempt for that repository. Failure category (auth, timeout, etc.) is **not** a label on this metric—use repository logs or `quay_repository_mirror_last_sync_status == -1` for repo-level failure state.
 
 **Use Cases:**
-- Set up alerts based on failure thresholds
+- Set up alerts based on failure thresholds per repository
 - Track failure rates over time per namespace
-- Analyze failure patterns by type
+- Identify repositories with repeated sync failures
 
 **Example Queries:**
 ```promql
-# Failure rate per namespace over 5 minutes
+# Failure rate per repository over 5 minutes
 rate(quay_repository_mirror_sync_failures_total[5m])
 
-# Namespaces with more than 10 total failures
+# Namespaces with more than 10 total failures (summed across repos)
 sum by (namespace) (quay_repository_mirror_sync_failures_total) > 10
 
-# Most common failure types
-topk(5, sum by (reason) (quay_repository_mirror_sync_failures_total))
+# Repositories with the most failures
+topk(5, quay_repository_mirror_sync_failures_total)
 ```
 
 ---
@@ -460,7 +456,7 @@ groups:
           severity: warning
         annotations:
           summary: "Repository mirroring failures detected"
-          description: "Repository {{ $labels.namespace }}/{{ $labels.repository }} has {{ $value }} failures per second (reason: {{ $labels.reason }})"
+          description: "Repository {{ $labels.namespace }}/{{ $labels.repository }} has {{ $value }} failures per second"
 
       - alert: QuayMirrorSyncStale
         expr: time() - quay_repository_mirror_last_sync_timestamp > 3600
@@ -480,14 +476,14 @@ groups:
           summary: "High number of pending tags"
           description: "There are {{ $value }} tags pending synchronization across all repositories"
 
-      - alert: QuayMirrorAuthFailures
-        expr: increase(quay_repository_mirror_sync_failures_total{reason="auth_failed"}[1h]) > 3
+      - alert: QuayMirrorRepeatedFailures
+        expr: increase(quay_repository_mirror_sync_failures_total[1h]) > 3
         for: 5m
         labels:
           severity: warning
         annotations:
-          summary: "Mirror authentication failures"
-          description: "Repository {{ $labels.namespace }}/{{ $labels.repository }} has had {{ $value }} authentication failures in the last hour"
+          summary: "Repeated mirror synchronization failures"
+          description: "Repository {{ $labels.namespace }}/{{ $labels.repository }} has had {{ $value }} sync failures in the last hour"
 ```
 
 ---
@@ -497,10 +493,10 @@ groups:
 ### Panel 1: Synchronization Status Overview
 
 ```promql
-# Count of repositories by sync status (canonical series: last_error_reason="")
-sum by(namespace) (quay_repository_mirror_last_sync_status{last_error_reason=""} == 1)  # Success
-sum by(namespace) (quay_repository_mirror_last_sync_status{last_error_reason=""} == 0)  # Failed
-sum by(namespace) (quay_repository_mirror_last_sync_status{last_error_reason=""} == 2)  # In Progress
+# Count of repositories by last-recorded sync status label
+sum by(namespace) (quay_repository_mirror_last_sync_status == 1)  # Success
+sum by(namespace) (quay_repository_mirror_last_sync_status == -1)  # Failed
+sum by(namespace) (quay_repository_mirror_last_sync_status == 2)  # Syncing
 ```
 
 **Visualization:** Pie chart or time series
@@ -521,14 +517,14 @@ sum(rate(quay_repository_mirror_sync_failures_total[5m]))
 
 ---
 
-### Panel 3: Failures by Reason
+### Panel 3: Failures by Repository
 
 ```promql
-# Count failures by reason
-sum by (reason) (quay_repository_mirror_sync_failures_total)
+# Total failures per repository
+topk(10, quay_repository_mirror_sync_failures_total)
 
-# Failure rate by reason
-sum by (reason) (rate(quay_repository_mirror_sync_failures_total[5m]))
+# Failure rate by repository
+topk(10, rate(quay_repository_mirror_sync_failures_total[5m]))
 ```
 
 **Visualization:** Bar chart or table
@@ -627,10 +623,11 @@ quay_repository_mirror_sync_complete == 0
 
 ### High Failure Rate
 
-1. Check `quay_repository_mirror_sync_failures_total` broken down by `reason`
-2. For auth failures: Verify credentials, check token expiration
-3. For network timeouts: Check network connectivity, consider increasing `skopeo_timeout_interval`
-4. For TLS errors: Verify certificate validity, check `verify_tls` settings
+1. Check `quay_repository_mirror_sync_failures_total` by `namespace` and `repository`
+2. Inspect worker logs for the failing repository to determine failure type (auth, timeout, TLS, etc.)
+3. For suspected auth issues: verify credentials, check token expiration
+4. For network timeouts: check network connectivity, consider increasing `skopeo_timeout_interval`
+5. For TLS errors: verify certificate validity, check `verify_tls` settings
 
 ### Stale Synchronizations
 
@@ -650,7 +647,7 @@ quay_repository_mirror_sync_complete == 0
 
 1. Query `quay_repository_mirror_sync_complete == 0` to find affected repositories
 2. Check logs for specific tag failures
-3. Review `quay_repository_mirror_sync_failures_total` by reason
+3. Review `quay_repository_mirror_sync_failures_total` for the affected repository
 4. Verify tag patterns in mirror configuration are correct
 
 ---

--- a/endpoints/api/mirrorhealth.py
+++ b/endpoints/api/mirrorhealth.py
@@ -24,8 +24,9 @@ from data.database import (
 )
 from endpoints.api import (
     ApiResource,
+    allow_if_any_superuser,
     allow_if_global_readonly_superuser,
-    allow_if_superuser,
+    allow_if_superuser_with_full_access,
     nickname,
     parse_args,
     query_param,
@@ -147,6 +148,7 @@ def get_mirror_health_data(
     detailed=False,
     detail_limit=100,
     detail_offset=0,
+    include_repository_details=True,
 ):
     """
     Gather health data for repository mirroring operations.
@@ -156,11 +158,15 @@ def get_mirror_health_data(
         detailed: If true, include paginated per-repository rows under repositories.details
         detail_limit: Max repositories in detailed view (clamped 1..1000)
         detail_offset: Pagination offset into the sorted mirror list (SQL LIMIT/OFFSET)
+        include_repository_details: If false, omit repository-identifying issue samples
+            and detailed rows. This is intended for global superuser summary views.
 
     Returns:
         Dictionary with health status information. Totals and `details` use enabled
         mirror configs only.
     """
+    detailed = detailed and include_repository_details
+
     counts = _mirror_status_counts(namespace)
     total_repos = counts["total"]
     syncing = counts["syncing"]
@@ -178,7 +184,9 @@ def get_mirror_health_data(
     # Stale detection: last sync from quay_repository_mirror_last_sync_timestamp via
     # PushGateway—not mirror.sync_start_date (that field is the next scheduled run).
     stale_threshold = now - timedelta(hours=24)
-    last_sync_timestamps = _get_last_sync_timestamps(namespace)
+    last_sync_timestamps = (
+        _get_last_sync_timestamps(namespace) if include_repository_details else {}
+    )
     stale_repos = []
     never_synced_repos = []
     failing_repos = []
@@ -187,31 +195,32 @@ def get_mirror_health_data(
     lim = max(1, min(int(detail_limit), _MAX_DETAIL_PAGE)) if detailed else 0
     off = max(0, int(detail_offset)) if detailed else 0
 
-    # Bounded queries: sample up to _ISSUE_SAMPLE_CAP of each issue type via SQL LIMIT.
-    failing_repos = list(
-        _mirror_rows_query(namespace)
-        .where(
-            RepoMirrorConfig.sync_status == RepoMirrorStatus.FAIL,
-            RepoMirrorConfig.sync_retries_remaining == 0,
+    if include_repository_details:
+        # Bounded queries: sample up to _ISSUE_SAMPLE_CAP of each issue type via SQL LIMIT.
+        failing_repos = list(
+            _mirror_rows_query(namespace)
+            .where(
+                RepoMirrorConfig.sync_status == RepoMirrorStatus.FAIL,
+                RepoMirrorConfig.sync_retries_remaining == 0,
+            )
+            .limit(_ISSUE_SAMPLE_CAP)
         )
-        .limit(_ISSUE_SAMPLE_CAP)
-    )
 
-    never_synced_repos = list(
-        _mirror_rows_query(namespace)
-        .where(RepoMirrorConfig.sync_status == RepoMirrorStatus.NEVER_RUN)
-        .limit(_ISSUE_SAMPLE_CAP)
-    )
+        never_synced_repos = list(
+            _mirror_rows_query(namespace)
+            .where(RepoMirrorConfig.sync_status == RepoMirrorStatus.NEVER_RUN)
+            .limit(_ISSUE_SAMPLE_CAP)
+        )
 
-    # Stale detection uses in-process Prometheus timestamps (bounded by registry size).
-    for (ns, repo), ts in last_sync_timestamps.items():
-        if len(stale_repos) >= _ISSUE_SAMPLE_CAP:
-            break
-        if namespace and ns != namespace:
-            continue
-        last_sync_dt = datetime.fromtimestamp(ts, tz=timezone.utc)
-        if last_sync_dt < stale_threshold:
-            stale_repos.append({"namespace": ns, "repository": repo})
+        # Stale detection uses mirror metrics timestamps (PushGateway or local REGISTRY).
+        for (ns, repo), ts in last_sync_timestamps.items():
+            if len(stale_repos) >= _ISSUE_SAMPLE_CAP:
+                break
+            if namespace and ns != namespace:
+                continue
+            last_sync_dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+            if last_sync_dt < stale_threshold:
+                stale_repos.append({"namespace": ns, "repository": repo})
 
     if detailed:
         page_query = _mirror_rows_query(namespace).limit(lim + 1).offset(off)
@@ -408,15 +417,15 @@ class RepositoryMirrorHealth(ApiResource):
         if not authed_user:
             raise Unauthorized()
 
-        # Global access requires superuser or global readonly superuser
+        # Global access requires superuser with full access or global readonly superuser
         if namespace is None:
-            if not (allow_if_superuser() or allow_if_global_readonly_superuser()):
+            if not (allow_if_superuser_with_full_access() or allow_if_global_readonly_superuser()):
                 raise Unauthorized()
         else:
             namespace_user = model.user.get_namespace_user(namespace)
             if not namespace_user:
                 raise NotFound()
-            if not (allow_if_superuser() or allow_if_global_readonly_superuser()):
+            if not (allow_if_superuser_with_full_access() or allow_if_global_readonly_superuser()):
                 if namespace_user.organization:
                     if not OrganizationMemberPermission(namespace).can():
                         raise Unauthorized()
@@ -435,6 +444,37 @@ class RepositoryMirrorHealth(ApiResource):
         )
 
         # Return 503 if unhealthy, 200 if healthy
+        status_code = 200 if health_data["healthy"] else 503
+
+        return (
+            health_data,
+            status_code,
+            {"Cache-Control": _CACHE_CONTROL_NO_STORE},
+        )
+
+
+@resource("/v1/superuser/mirror/health")
+@show_if(features.REPO_MIRROR)
+@show_if(features.SUPER_USERS)
+class SuperUserRepositoryMirrorHealth(ApiResource):
+    """
+    Resource for checking global repository mirror health from the superuser panel.
+    """
+
+    @require_fresh_login
+    @nickname("getSuperUserRepositoryMirrorHealth")
+    def get(self):
+        """
+        Get a global mirror health summary without repository-identifying samples.
+        """
+        if not allow_if_any_superuser():
+            raise Unauthorized()
+
+        health_data = get_mirror_health_data(
+            detailed=False,
+            include_repository_details=False,
+        )
+
         status_code = 200 if health_data["healthy"] else 503
 
         return (

--- a/endpoints/api/mirrorhealth.py
+++ b/endpoints/api/mirrorhealth.py
@@ -24,7 +24,6 @@ from data.database import (
 )
 from endpoints.api import (
     ApiResource,
-    allow_if_any_superuser,
     allow_if_global_readonly_superuser,
     allow_if_superuser_with_full_access,
     nickname,
@@ -444,37 +443,6 @@ class RepositoryMirrorHealth(ApiResource):
         )
 
         # Return 503 if unhealthy, 200 if healthy
-        status_code = 200 if health_data["healthy"] else 503
-
-        return (
-            health_data,
-            status_code,
-            {"Cache-Control": _CACHE_CONTROL_NO_STORE},
-        )
-
-
-@resource("/v1/superuser/mirror/health")
-@show_if(features.REPO_MIRROR)
-@show_if(features.SUPER_USERS)
-class SuperUserRepositoryMirrorHealth(ApiResource):
-    """
-    Resource for checking global repository mirror health from the superuser panel.
-    """
-
-    @require_fresh_login
-    @nickname("getSuperUserRepositoryMirrorHealth")
-    def get(self):
-        """
-        Get a global mirror health summary without repository-identifying samples.
-        """
-        if not allow_if_any_superuser():
-            raise Unauthorized()
-
-        health_data = get_mirror_health_data(
-            detailed=False,
-            include_repository_details=False,
-        )
-
         status_code = 200 if health_data["healthy"] else 503
 
         return (

--- a/endpoints/api/mirrorhealth.py
+++ b/endpoints/api/mirrorhealth.py
@@ -9,7 +9,6 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 from peewee import Case, fn
-from prometheus_client import REGISTRY
 
 import features
 from app import app
@@ -25,9 +24,8 @@ from data.database import (
 )
 from endpoints.api import (
     ApiResource,
-    allow_if_any_superuser,
     allow_if_global_readonly_superuser,
-    allow_if_superuser_with_full_access,
+    allow_if_superuser,
     nickname,
     parse_args,
     query_param,
@@ -36,6 +34,11 @@ from endpoints.api import (
     show_if,
 )
 from endpoints.exception import NotFound, Unauthorized
+from util.metrics.mirror_registry import (
+    get_metric_timestamps,
+    get_mirror_workers_active_value,
+    get_pending_tags_total,
+)
 from util.parsing import truthy_bool
 
 logger = logging.getLogger(__name__)
@@ -52,78 +55,27 @@ def _utc_z_timestamp(when: datetime) -> str:
     return utc.isoformat().replace("+00:00", "Z")
 
 
-def _get_last_sync_timestamps():
+def _get_last_sync_timestamps(namespace=None):
     """
-    Retrieve last sync timestamps from the Prometheus registry in this process.
+    Retrieve last sync timestamps from mirror worker metrics via PushGateway.
 
-    Mirror timestamps are emitted by the repository mirror worker. API/gunicorn processes
-    typically do not run that worker, so REGISTRY often has no samples and this returns {}.
-    In that case stale-mirror warnings are skipped (not treated as errors).
-
-    Returns a dict keyed by (namespace, repository) with unix timestamps as values.
-    If the metric is not present in this process, returns an empty dict.
+    Falls back to the in-process REGISTRY when PushGateway is unavailable (tests).
     """
-    timestamps = {}
-    try:
-        for metric in REGISTRY.collect():
-            if metric.name != "quay_repository_mirror_last_sync_timestamp":
-                continue
-            for sample in metric.samples:
-                if sample.name != "quay_repository_mirror_last_sync_timestamp":
-                    continue
-                namespace = sample.labels.get("namespace")
-                repository = sample.labels.get("repository")
-                if namespace and repository:
-                    timestamps[(namespace, repository)] = sample.value
-            break
-    except Exception as ex:
-        logger.debug("Unable to read last sync timestamps from registry: %s", ex)
-    return timestamps
+    return get_metric_timestamps("quay_repository_mirror_last_sync_timestamp", namespace=namespace)
 
 
 def _get_pending_tags_total(namespace=None):
-    """
-    Sum quay_repository_mirror_pending_tags gauge values from this process's registry.
-
-    Same limitation as _get_last_sync_timestamps: values exist only if the mirror worker
-    registers metrics in this process; otherwise this returns 0.
-    """
-    total = 0.0
-    try:
-        for metric in REGISTRY.collect():
-            if metric.name != "quay_repository_mirror_pending_tags":
-                continue
-            for sample in metric.samples:
-                if sample.name != "quay_repository_mirror_pending_tags":
-                    continue
-                if namespace is not None and sample.labels.get("namespace") != namespace:
-                    continue
-                total += float(sample.value)
-            break
-    except Exception as ex:
-        logger.debug("Unable to read pending tags from registry: %s", ex)
-    return int(total) if total == int(total) else total
+    """Sum quay_repository_mirror_pending_tags from PushGateway or local REGISTRY."""
+    return get_pending_tags_total("quay_repository_mirror_pending_tags", namespace=namespace)
 
 
 def _get_mirror_workers_active_value():
     """
-    Read quay_repository_mirror_workers_active from this process's Prometheus registry.
+    Read quay_repository_mirror_workers_active from PushGateway or local REGISTRY.
 
-    The repository mirror worker sets this to 1 while RepoMirrorWorker is running; API
-    processes typically report 0 unless they embed the worker.
+    Sums fresh worker groupings from PushGateway so API pods see cluster worker count.
     """
-    try:
-        for metric in REGISTRY.collect():
-            if metric.name != "quay_repository_mirror_workers_active":
-                continue
-            for sample in metric.samples:
-                if sample.name != "quay_repository_mirror_workers_active":
-                    continue
-                return int(sample.value)
-            break
-    except Exception as ex:
-        logger.debug("Unable to read mirror workers active gauge from registry: %s", ex)
-    return 0
+    return get_mirror_workers_active_value()
 
 
 def _mirror_rows_query(namespace=None):
@@ -195,7 +147,6 @@ def get_mirror_health_data(
     detailed=False,
     detail_limit=100,
     detail_offset=0,
-    include_repository_details=True,
 ):
     """
     Gather health data for repository mirroring operations.
@@ -205,15 +156,11 @@ def get_mirror_health_data(
         detailed: If true, include paginated per-repository rows under repositories.details
         detail_limit: Max repositories in detailed view (clamped 1..1000)
         detail_offset: Pagination offset into the sorted mirror list (SQL LIMIT/OFFSET)
-        include_repository_details: If false, omit repository-identifying issue samples
-            and detailed rows. This is intended for global superuser summary views.
 
     Returns:
         Dictionary with health status information. Totals and `details` use enabled
         mirror configs only.
     """
-    detailed = detailed and include_repository_details
-
     counts = _mirror_status_counts(namespace)
     total_repos = counts["total"]
     syncing = counts["syncing"]
@@ -221,18 +168,17 @@ def get_mirror_health_data(
     failed = counts["failed"]
     never_run = counts["never_run"]
 
-    # From in-process Prometheus registry when mirror worker shares this process; else 0.
+    # From mirror worker metrics via PushGateway (or local REGISTRY in tests).
     tags_pending = _get_pending_tags_total(namespace)
 
     # Determine overall health status
     now = datetime.now(timezone.utc)
     issues = []
 
-    # Stale detection: last sync from quay_repository_mirror_last_sync_timestamp in REGISTRY—not
-    # mirror.sync_start_date (that field is the next scheduled run). Missing samples: skip stale
-    # (never-synced NEVER_RUN handled separately); enabled repos with no metric are not flagged stale.
+    # Stale detection: last sync from quay_repository_mirror_last_sync_timestamp via
+    # PushGateway—not mirror.sync_start_date (that field is the next scheduled run).
     stale_threshold = now - timedelta(hours=24)
-    last_sync_timestamps = _get_last_sync_timestamps() if include_repository_details else {}
+    last_sync_timestamps = _get_last_sync_timestamps(namespace)
     stale_repos = []
     never_synced_repos = []
     failing_repos = []
@@ -241,32 +187,31 @@ def get_mirror_health_data(
     lim = max(1, min(int(detail_limit), _MAX_DETAIL_PAGE)) if detailed else 0
     off = max(0, int(detail_offset)) if detailed else 0
 
-    if include_repository_details:
-        # Bounded queries: sample up to _ISSUE_SAMPLE_CAP of each issue type via SQL LIMIT.
-        failing_repos = list(
-            _mirror_rows_query(namespace)
-            .where(
-                RepoMirrorConfig.sync_status == RepoMirrorStatus.FAIL,
-                RepoMirrorConfig.sync_retries_remaining == 0,
-            )
-            .limit(_ISSUE_SAMPLE_CAP)
+    # Bounded queries: sample up to _ISSUE_SAMPLE_CAP of each issue type via SQL LIMIT.
+    failing_repos = list(
+        _mirror_rows_query(namespace)
+        .where(
+            RepoMirrorConfig.sync_status == RepoMirrorStatus.FAIL,
+            RepoMirrorConfig.sync_retries_remaining == 0,
         )
+        .limit(_ISSUE_SAMPLE_CAP)
+    )
 
-        never_synced_repos = list(
-            _mirror_rows_query(namespace)
-            .where(RepoMirrorConfig.sync_status == RepoMirrorStatus.NEVER_RUN)
-            .limit(_ISSUE_SAMPLE_CAP)
-        )
+    never_synced_repos = list(
+        _mirror_rows_query(namespace)
+        .where(RepoMirrorConfig.sync_status == RepoMirrorStatus.NEVER_RUN)
+        .limit(_ISSUE_SAMPLE_CAP)
+    )
 
-        # Stale detection uses in-process Prometheus timestamps (bounded by registry size).
-        for (ns, repo), ts in last_sync_timestamps.items():
-            if len(stale_repos) >= _ISSUE_SAMPLE_CAP:
-                break
-            if namespace and ns != namespace:
-                continue
-            last_sync_dt = datetime.fromtimestamp(ts, tz=timezone.utc)
-            if last_sync_dt < stale_threshold:
-                stale_repos.append({"namespace": ns, "repository": repo})
+    # Stale detection uses in-process Prometheus timestamps (bounded by registry size).
+    for (ns, repo), ts in last_sync_timestamps.items():
+        if len(stale_repos) >= _ISSUE_SAMPLE_CAP:
+            break
+        if namespace and ns != namespace:
+            continue
+        last_sync_dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        if last_sync_dt < stale_threshold:
+            stale_repos.append({"namespace": ns, "repository": repo})
 
     if detailed:
         page_query = _mirror_rows_query(namespace).limit(lim + 1).offset(off)
@@ -358,7 +303,14 @@ def get_mirror_health_data(
     active_workers = _get_mirror_workers_active_value()
     configured_workers = replicas if replicas is not None else active_workers
 
-    if replicas is not None and total_repos > 0 and active_workers < replicas:
+    # Replica mismatch uses PushGateway worker counts (fresh groupings only). Skip when
+    # no workers report in, avoiding false 503s when metrics are unavailable on API pods.
+    if (
+        replicas is not None
+        and total_repos > 0
+        and active_workers > 0
+        and active_workers < replicas
+    ):
         healthy = False
         issues.insert(
             0,
@@ -458,13 +410,13 @@ class RepositoryMirrorHealth(ApiResource):
 
         # Global access requires superuser or global readonly superuser
         if namespace is None:
-            if not (allow_if_superuser_with_full_access() or allow_if_global_readonly_superuser()):
+            if not (allow_if_superuser() or allow_if_global_readonly_superuser()):
                 raise Unauthorized()
         else:
             namespace_user = model.user.get_namespace_user(namespace)
             if not namespace_user:
                 raise NotFound()
-            if not (allow_if_superuser_with_full_access() or allow_if_global_readonly_superuser()):
+            if not (allow_if_superuser() or allow_if_global_readonly_superuser()):
                 if namespace_user.organization:
                     if not OrganizationMemberPermission(namespace).can():
                         raise Unauthorized()
@@ -483,37 +435,6 @@ class RepositoryMirrorHealth(ApiResource):
         )
 
         # Return 503 if unhealthy, 200 if healthy
-        status_code = 200 if health_data["healthy"] else 503
-
-        return (
-            health_data,
-            status_code,
-            {"Cache-Control": _CACHE_CONTROL_NO_STORE},
-        )
-
-
-@resource("/v1/superuser/mirror/health")
-@show_if(features.REPO_MIRROR)
-@show_if(features.SUPER_USERS)
-class SuperUserRepositoryMirrorHealth(ApiResource):
-    """
-    Resource for checking global repository mirror health from the superuser panel.
-    """
-
-    @require_fresh_login
-    @nickname("getSuperUserRepositoryMirrorHealth")
-    def get(self):
-        """
-        Get a global mirror health summary without repository-identifying samples.
-        """
-        if not allow_if_any_superuser():
-            raise Unauthorized()
-
-        health_data = get_mirror_health_data(
-            detailed=False,
-            include_repository_details=False,
-        )
-
         status_code = 200 if health_data["healthy"] else 503
 
         return (

--- a/endpoints/api/superuser.py
+++ b/endpoints/api/superuser.py
@@ -52,7 +52,7 @@ from endpoints.api import (
 )
 from endpoints.api.build import get_logs_or_log_url
 from endpoints.api.logs import _validate_logs_arguments
-from endpoints.api.mirrorhealth import get_mirror_health_data
+from endpoints.api.mirrorhealth import _CACHE_CONTROL_NO_STORE, get_mirror_health_data
 from endpoints.api.namespacequota import get_quota, limit_view, quota_view
 from endpoints.api.superuser_models_pre_oci import (
     InvalidRepositoryBuildException,
@@ -1502,9 +1502,6 @@ class SuperUserDumpConfig(ApiResource):
         raise Unauthorized()
 
 
-_MIRROR_HEALTH_CACHE_CONTROL = "no-cache, no-store, must-revalidate"
-
-
 @resource("/v1/superuser/mirror/health")
 @show_if(features.REPO_MIRROR)
 @show_if(features.SUPER_USERS)
@@ -1532,5 +1529,5 @@ class SuperUserRepositoryMirrorHealth(ApiResource):
         return (
             health_data,
             status_code,
-            {"Cache-Control": _MIRROR_HEALTH_CACHE_CONTROL},
+            {"Cache-Control": _CACHE_CONTROL_NO_STORE},
         )

--- a/endpoints/api/superuser.py
+++ b/endpoints/api/superuser.py
@@ -52,6 +52,7 @@ from endpoints.api import (
 )
 from endpoints.api.build import get_logs_or_log_url
 from endpoints.api.logs import _validate_logs_arguments
+from endpoints.api.mirrorhealth import get_mirror_health_data
 from endpoints.api.namespacequota import get_quota, limit_view, quota_view
 from endpoints.api.superuser_models_pre_oci import (
     InvalidRepositoryBuildException,
@@ -1499,3 +1500,37 @@ class SuperUserDumpConfig(ApiResource):
             if features.SUPERUSER_CONFIGDUMP:
                 return process_config()
         raise Unauthorized()
+
+
+_MIRROR_HEALTH_CACHE_CONTROL = "no-cache, no-store, must-revalidate"
+
+
+@resource("/v1/superuser/mirror/health")
+@show_if(features.REPO_MIRROR)
+@show_if(features.SUPER_USERS)
+class SuperUserRepositoryMirrorHealth(ApiResource):
+    """
+    Resource for checking global repository mirror health from the superuser panel.
+    """
+
+    @require_fresh_login
+    @nickname("getSuperUserRepositoryMirrorHealth")
+    def get(self):
+        """
+        Get a global mirror health summary without repository-identifying samples.
+        """
+        if not allow_if_any_superuser():
+            raise Unauthorized()
+
+        health_data = get_mirror_health_data(
+            detailed=False,
+            include_repository_details=False,
+        )
+
+        status_code = 200 if health_data["healthy"] else 503
+
+        return (
+            health_data,
+            status_code,
+            {"Cache-Control": _MIRROR_HEALTH_CACHE_CONTROL},
+        )

--- a/endpoints/api/test/test_mirrorhealth.py
+++ b/endpoints/api/test/test_mirrorhealth.py
@@ -8,7 +8,6 @@ from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 from app import app as quay_app
 from endpoints.api.mirrorhealth import (
     RepositoryMirrorHealth,
-    SuperUserRepositoryMirrorHealth,
     _get_last_sync_timestamps,
     _get_mirror_workers_active_value,
     _get_pending_tags_total,
@@ -16,7 +15,7 @@ from endpoints.api.mirrorhealth import (
     get_mirror_health_data,
 )
 from endpoints.api.test.shared import conduct_api_call
-from endpoints.test.shared import client_with_identity, toggle_feature
+from endpoints.test.shared import client_with_identity
 from test.fixtures import *
 
 # =============================================================================
@@ -26,10 +25,13 @@ from test.fixtures import *
 
 class TestGetLastSyncTimestamps:
     def test_returns_empty_when_metric_absent(self):
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.return_value = []
-            result = _get_last_sync_timestamps()
-            assert result == {}
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.return_value = []
+                result = _get_last_sync_timestamps()
+                assert result == {}
 
     def test_parses_samples_correctly(self):
         sample = mock.Mock()
@@ -41,10 +43,13 @@ class TestGetLastSyncTimestamps:
         metric.name = "quay_repository_mirror_last_sync_timestamp"
         metric.samples = [sample]
 
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.return_value = [metric]
-            result = _get_last_sync_timestamps()
-            assert result == {("ns1", "repo1"): 1700000000.0}
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.return_value = [metric]
+                result = _get_last_sync_timestamps()
+                assert result == {("ns1", "repo1"): 1700000000.0}
 
     def test_skips_samples_missing_labels(self):
         sample = mock.Mock()
@@ -56,24 +61,33 @@ class TestGetLastSyncTimestamps:
         metric.name = "quay_repository_mirror_last_sync_timestamp"
         metric.samples = [sample]
 
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.return_value = [metric]
-            result = _get_last_sync_timestamps()
-            assert result == {}
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.return_value = [metric]
+                result = _get_last_sync_timestamps()
+                assert result == {}
 
     def test_handles_registry_exception(self):
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.side_effect = RuntimeError("boom")
-            result = _get_last_sync_timestamps()
-            assert result == {}
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.side_effect = RuntimeError("boom")
+                result = _get_last_sync_timestamps()
+                assert result == {}
 
 
 class TestGetPendingTagsTotal:
     def test_returns_zero_when_metric_absent(self):
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.return_value = []
-            result = _get_pending_tags_total()
-            assert result == 0
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.return_value = []
+                result = _get_pending_tags_total()
+                assert result == 0
 
     def test_sums_across_namespaces(self):
         s1 = mock.Mock()
@@ -90,9 +104,12 @@ class TestGetPendingTagsTotal:
         metric.name = "quay_repository_mirror_pending_tags"
         metric.samples = [s1, s2]
 
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.return_value = [metric]
-            assert _get_pending_tags_total() == 8
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.return_value = [metric]
+                assert _get_pending_tags_total() == 8
 
     def test_filters_by_namespace(self):
         s1 = mock.Mock()
@@ -109,9 +126,12 @@ class TestGetPendingTagsTotal:
         metric.name = "quay_repository_mirror_pending_tags"
         metric.samples = [s1, s2]
 
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.return_value = [metric]
-            assert _get_pending_tags_total(namespace="ns1") == 5
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.return_value = [metric]
+                assert _get_pending_tags_total(namespace="ns1") == 5
 
     def test_returns_int_for_whole_numbers(self):
         s1 = mock.Mock()
@@ -123,18 +143,24 @@ class TestGetPendingTagsTotal:
         metric.name = "quay_repository_mirror_pending_tags"
         metric.samples = [s1]
 
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.return_value = [metric]
-            result = _get_pending_tags_total()
-            assert result == 7
-            assert isinstance(result, int)
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.return_value = [metric]
+                result = _get_pending_tags_total()
+                assert result == 7
+                assert isinstance(result, int)
 
 
 class TestGetMirrorWorkersActiveValue:
     def test_returns_zero_when_metric_absent(self):
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.return_value = []
-            assert _get_mirror_workers_active_value() == 0
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.return_value = []
+                assert _get_mirror_workers_active_value() == 0
 
     def test_returns_sample_value(self):
         sample = mock.Mock()
@@ -145,9 +171,12 @@ class TestGetMirrorWorkersActiveValue:
         metric.name = "quay_repository_mirror_workers_active"
         metric.samples = [sample]
 
-        with mock.patch("endpoints.api.mirrorhealth.REGISTRY") as mock_reg:
-            mock_reg.collect.return_value = [metric]
-            assert _get_mirror_workers_active_value() == 1
+        with mock.patch(
+            "util.metrics.mirror_registry._should_read_pushgateway", return_value=False
+        ):
+            with mock.patch("util.metrics.mirror_registry.REGISTRY") as mock_reg:
+                mock_reg.collect.return_value = [metric]
+                assert _get_mirror_workers_active_value() == 1
 
 
 # =============================================================================
@@ -304,6 +333,32 @@ class TestGetMirrorHealthData:
         worker_warnings = [w for w in warning_issues if "worker" in w["message"].lower()]
         assert len(worker_warnings) == 1
         assert "2 mirror worker" in worker_warnings[0]["message"]
+
+    @mock.patch("endpoints.api.mirrorhealth.app")
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_skips_worker_replica_warning_when_no_workers_reporting(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk, mock_app
+    ):
+        mock_counts.return_value = {
+            "total": 5,
+            "syncing": 1,
+            "completed": 4,
+            "failed": 0,
+            "never_run": 0,
+        }
+        mock_rows.return_value = mock.Mock(
+            where=mock.Mock(return_value=mock.Mock(limit=mock.Mock(return_value=[])))
+        )
+        mock_app.config.get.return_value = 3
+
+        result = get_mirror_health_data()
+
+        assert result["healthy"] is True
+        assert not any("worker" in i["message"].lower() for i in result["issues"])
 
     @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
     @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
@@ -476,56 +531,10 @@ class TestGetMirrorHealthData:
 
         assert result["repositories"]["pagination"]["limit"] == 1000
 
-    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
-    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps")
-    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
-    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
-    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
-    def test_summary_mode_omits_repository_details(
-        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
-    ):
-        mock_counts.return_value = {
-            "total": 10,
-            "syncing": 0,
-            "completed": 4,
-            "failed": 5,
-            "never_run": 1,
-        }
-
-        result = get_mirror_health_data(
-            detailed=True,
-            include_repository_details=False,
-        )
-
-        mock_rows.assert_not_called()
-        mock_ts.assert_not_called()
-        assert result["healthy"] is False
-        assert "details" not in result["repositories"]
-        assert "pagination" not in result["repositories"]
-        assert result["issues"][0]["severity"] == "critical"
-        assert "repositories are failing" in result["issues"][0]["message"]
-
 
 # =============================================================================
 # API endpoint integration tests
 # =============================================================================
-
-
-def _set_healthy_mirror_health(mock_health):
-    mock_health.return_value = {
-        "healthy": True,
-        "workers": {"active": 0, "configured": 0, "status": "healthy"},
-        "repositories": {
-            "total": 0,
-            "syncing": 0,
-            "completed": 0,
-            "failed": 0,
-            "never_run": 0,
-        },
-        "tags_pending": 0,
-        "last_check": "2024-01-01T00:00:00Z",
-        "issues": [],
-    }
 
 
 class TestMirrorHealthEndpoint:
@@ -647,144 +656,3 @@ class TestMirrorHealthEndpoint:
         }
         with client_with_identity("globalreadonlysuperuser", app) as cl:
             conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 200)
-
-
-class TestMirrorHealthFullAccessPermissions:
-    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
-    def test_regular_superuser_global_access_requires_full_access(
-        self, mock_health, app, initialized_db
-    ):
-        _set_healthy_mirror_health(mock_health)
-
-        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
-            with client_with_identity("devtable", app) as cl:
-                conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 403)
-
-        mock_health.assert_not_called()
-
-    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
-    def test_regular_superuser_other_namespace_requires_full_access(
-        self, mock_health, app, initialized_db
-    ):
-        _set_healthy_mirror_health(mock_health)
-
-        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
-            with client_with_identity("devtable", app) as cl:
-                conduct_api_call(
-                    cl,
-                    RepositoryMirrorHealth,
-                    "GET",
-                    {"namespace": "randomuser"},
-                    None,
-                    403,
-                )
-
-        mock_health.assert_not_called()
-
-    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
-    def test_regular_superuser_own_namespace_uses_normal_access_without_full_access(
-        self, mock_health, app, initialized_db
-    ):
-        _set_healthy_mirror_health(mock_health)
-
-        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
-            with client_with_identity("devtable", app) as cl:
-                conduct_api_call(
-                    cl,
-                    RepositoryMirrorHealth,
-                    "GET",
-                    {"namespace": "devtable"},
-                    None,
-                    200,
-                )
-
-        mock_health.assert_called_once()
-
-    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
-    def test_global_readonly_superuser_global_access_without_full_access(
-        self, mock_health, app, initialized_db
-    ):
-        _set_healthy_mirror_health(mock_health)
-
-        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
-            with client_with_identity("globalreadonlysuperuser", app) as cl:
-                conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 200)
-
-        mock_health.assert_called_once()
-
-
-class TestSuperUserMirrorHealthEndpoint:
-    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
-    def test_regular_superuser_access_without_full_access(self, mock_health, app, initialized_db):
-        _set_healthy_mirror_health(mock_health)
-
-        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
-            with client_with_identity("devtable", app) as cl:
-                resp = conduct_api_call(
-                    cl,
-                    SuperUserRepositoryMirrorHealth,
-                    "GET",
-                    None,
-                    None,
-                    200,
-                )
-                assert resp.json["healthy"] is True
-
-        mock_health.assert_called_once_with(
-            detailed=False,
-            include_repository_details=False,
-        )
-
-    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
-    def test_global_readonly_superuser_access_without_full_access(
-        self, mock_health, app, initialized_db
-    ):
-        _set_healthy_mirror_health(mock_health)
-
-        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
-            with client_with_identity("globalreadonlysuperuser", app) as cl:
-                conduct_api_call(
-                    cl,
-                    SuperUserRepositoryMirrorHealth,
-                    "GET",
-                    None,
-                    None,
-                    200,
-                )
-
-        mock_health.assert_called_once_with(
-            detailed=False,
-            include_repository_details=False,
-        )
-
-    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
-    def test_non_superuser_denied(self, mock_health, app, initialized_db):
-        _set_healthy_mirror_health(mock_health)
-
-        with client_with_identity("freshuser", app) as cl:
-            conduct_api_call(
-                cl,
-                SuperUserRepositoryMirrorHealth,
-                "GET",
-                None,
-                None,
-                403,
-            )
-
-        mock_health.assert_not_called()
-
-    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
-    def test_anonymous_returns_401(self, mock_health, app, initialized_db):
-        _set_healthy_mirror_health(mock_health)
-
-        with client_with_identity(None, app) as cl:
-            conduct_api_call(
-                cl,
-                SuperUserRepositoryMirrorHealth,
-                "GET",
-                None,
-                None,
-                401,
-            )
-
-        mock_health.assert_not_called()

--- a/endpoints/api/test/test_mirrorhealth.py
+++ b/endpoints/api/test/test_mirrorhealth.py
@@ -14,8 +14,9 @@ from endpoints.api.mirrorhealth import (
     _mirror_status_counts,
     get_mirror_health_data,
 )
+from endpoints.api.superuser import SuperUserRepositoryMirrorHealth
 from endpoints.api.test.shared import conduct_api_call
-from endpoints.test.shared import client_with_identity
+from endpoints.test.shared import client_with_identity, toggle_feature
 from test.fixtures import *
 
 # =============================================================================
@@ -531,6 +532,46 @@ class TestGetMirrorHealthData:
 
         assert result["repositories"]["pagination"]["limit"] == 1000
 
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps", return_value={})
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_summary_mode_omits_repository_details(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
+    ):
+        """
+        Test that detailed=True with include_repository_details=False returns summary only.
+
+        This code path is used by SuperUserRepositoryMirrorHealth endpoint to get
+        aggregate stats without exposing repository-identifying information.
+        """
+        mock_counts.return_value = {
+            "total": 10,
+            "syncing": 0,
+            "completed": 4,
+            "failed": 5,
+            "never_run": 1,
+        }
+
+        result = get_mirror_health_data(
+            detailed=True,
+            include_repository_details=False,
+        )
+
+        # Should not query individual repository rows or timestamps
+        mock_rows.assert_not_called()
+        mock_ts.assert_not_called()
+
+        # Should return unhealthy due to 50% failure rate
+        assert result["healthy"] is False
+
+        # Should have repository counts but no details or pagination
+        assert "details" not in result["repositories"]
+        assert "pagination" not in result["repositories"]
+        assert result["repositories"]["total"] == 10
+        assert result["repositories"]["failed"] == 5
+
 
 # =============================================================================
 # API endpoint integration tests
@@ -656,3 +697,250 @@ class TestMirrorHealthEndpoint:
         }
         with client_with_identity("globalreadonlysuperuser", app) as cl:
             conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 200)
+
+
+# =============================================================================
+# Tests for SUPERUSERS_FULL_ACCESS permission logic
+# =============================================================================
+
+
+def _set_healthy_mirror_health(mock_health):
+    """Helper to set a healthy mirror health response"""
+    mock_health.return_value = {
+        "healthy": True,
+        "workers": {"active": 0, "configured": 0, "status": "healthy"},
+        "repositories": {
+            "total": 0,
+            "syncing": 0,
+            "completed": 0,
+            "failed": 0,
+            "never_run": 0,
+        },
+        "tags_pending": 0,
+        "last_check": "2024-01-01T00:00:00Z",
+        "issues": [],
+    }
+
+
+class TestMirrorHealthFullAccessPermissions:
+    """
+    Tests for RepositoryMirrorHealth endpoint with SUPERUSERS_FULL_ACCESS=False.
+
+    Verifies that regular superusers without full access:
+    - Are denied global access (namespace=None)
+    - Are denied access to other namespaces
+    - Can still access their own namespace via normal permission checks
+    """
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_regular_superuser_global_access_requires_full_access(
+        self, mock_health, app, initialized_db
+    ):
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("devtable", app) as cl:
+                conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 403)
+
+        mock_health.assert_not_called()
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_regular_superuser_other_namespace_requires_full_access(
+        self, mock_health, app, initialized_db
+    ):
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("devtable", app) as cl:
+                conduct_api_call(
+                    cl,
+                    RepositoryMirrorHealth,
+                    "GET",
+                    {"namespace": "randomuser"},
+                    None,
+                    403,
+                )
+
+        mock_health.assert_not_called()
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_regular_superuser_own_namespace_uses_normal_access_without_full_access(
+        self, mock_health, app, initialized_db
+    ):
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("devtable", app) as cl:
+                conduct_api_call(
+                    cl,
+                    RepositoryMirrorHealth,
+                    "GET",
+                    {"namespace": "devtable"},
+                    None,
+                    200,
+                )
+
+        mock_health.assert_called_once()
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_global_readonly_superuser_bypasses_full_access_requirement(
+        self, mock_health, app, initialized_db
+    ):
+        """Global readonly superuser can access global health even without SUPERUSERS_FULL_ACCESS"""
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("globalreadonlysuperuser", app) as cl:
+                conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 200)
+
+        mock_health.assert_called_once()
+
+
+# =============================================================================
+# Tests for SuperUserRepositoryMirrorHealth endpoint
+# =============================================================================
+
+
+class TestSuperUserMirrorHealthEndpoint:
+    """
+    Tests for the /v1/superuser/mirror/health endpoint.
+
+    Verifies:
+    - Correct access control (any superuser, not just full access)
+    - Correct arguments passed to get_mirror_health_data
+    - Response structure and status codes
+    """
+
+    @mock.patch("endpoints.api.superuser.get_mirror_health_data")
+    def test_regular_superuser_access_without_full_access(self, mock_health, app, initialized_db):
+        """Regular superuser can access superuser endpoint even without SUPERUSERS_FULL_ACCESS"""
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("devtable", app) as cl:
+                resp = conduct_api_call(
+                    cl,
+                    SuperUserRepositoryMirrorHealth,
+                    "GET",
+                    None,
+                    None,
+                    200,
+                )
+                assert resp.json["healthy"] is True
+
+        # Verify correct arguments: no namespace, no repository details
+        mock_health.assert_called_once_with(
+            detailed=False,
+            include_repository_details=False,
+        )
+
+    @mock.patch("endpoints.api.superuser.get_mirror_health_data")
+    def test_global_readonly_superuser_access_without_full_access(
+        self, mock_health, app, initialized_db
+    ):
+        """Global readonly superuser can access superuser endpoint"""
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("globalreadonlysuperuser", app) as cl:
+                conduct_api_call(
+                    cl,
+                    SuperUserRepositoryMirrorHealth,
+                    "GET",
+                    None,
+                    None,
+                    200,
+                )
+
+        mock_health.assert_called_once_with(
+            detailed=False,
+            include_repository_details=False,
+        )
+
+    @mock.patch("endpoints.api.superuser.get_mirror_health_data")
+    def test_non_superuser_denied(self, mock_health, app, initialized_db):
+        """Non-superuser is denied access"""
+        _set_healthy_mirror_health(mock_health)
+
+        with client_with_identity("freshuser", app) as cl:
+            conduct_api_call(
+                cl,
+                SuperUserRepositoryMirrorHealth,
+                "GET",
+                None,
+                None,
+                403,
+            )
+
+        mock_health.assert_not_called()
+
+    @mock.patch("endpoints.api.superuser.get_mirror_health_data")
+    def test_anonymous_returns_401(self, mock_health, app, initialized_db):
+        """Anonymous user is denied access"""
+        _set_healthy_mirror_health(mock_health)
+
+        with client_with_identity(None, app) as cl:
+            conduct_api_call(
+                cl,
+                SuperUserRepositoryMirrorHealth,
+                "GET",
+                None,
+                None,
+                401,
+            )
+
+        mock_health.assert_not_called()
+
+    @mock.patch("endpoints.api.superuser.get_mirror_health_data")
+    def test_unhealthy_returns_503(self, mock_health, app, initialized_db):
+        """Unhealthy status returns 503"""
+        mock_health.return_value = {
+            "healthy": False,
+            "workers": {"active": 0, "configured": 0, "status": "degraded"},
+            "repositories": {
+                "total": 10,
+                "syncing": 0,
+                "completed": 5,
+                "failed": 5,
+                "never_run": 0,
+            },
+            "tags_pending": 0,
+            "last_check": "2024-01-01T00:00:00Z",
+            "issues": [
+                {
+                    "severity": "critical",
+                    "message": "high failure rate",
+                    "timestamp": "2024-01-01T00:00:00Z",
+                }
+            ],
+        }
+
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(
+                cl,
+                SuperUserRepositoryMirrorHealth,
+                "GET",
+                None,
+                None,
+                503,
+            )
+            assert resp.json["healthy"] is False
+
+    @mock.patch("endpoints.api.superuser.get_mirror_health_data")
+    def test_cache_control_header(self, mock_health, app, initialized_db):
+        """Verifies no-cache headers are set"""
+        _set_healthy_mirror_health(mock_health)
+
+        with client_with_identity("devtable", app) as cl:
+            resp = conduct_api_call(
+                cl,
+                SuperUserRepositoryMirrorHealth,
+                "GET",
+                None,
+                None,
+                200,
+            )
+            cache_control = resp.headers.get("Cache-Control", "")
+            assert "no-cache" in cache_control
+            assert "no-store" in cache_control
+            assert "must-revalidate" in cache_control

--- a/endpoints/api/test/test_security.py
+++ b/endpoints/api/test/test_security.py
@@ -23,10 +23,7 @@ from endpoints.api.immutability_policy import *
 from endpoints.api.logs import *  # type: ignore[no-redef]
 from endpoints.api.manifest import *
 from endpoints.api.mirror import *  # type: ignore[no-redef]
-from endpoints.api.mirrorhealth import (
-    RepositoryMirrorHealth,
-    SuperUserRepositoryMirrorHealth,
-)
+from endpoints.api.mirrorhealth import RepositoryMirrorHealth
 from endpoints.api.namespacequota import *
 from endpoints.api.org_mirror import *  # type: ignore[no-redef]
 from endpoints.api.organization import *  # type: ignore[assignment,no-redef]

--- a/mypy.ini
+++ b/mypy.ini
@@ -138,6 +138,9 @@ ignore_missing_imports = True
 [mypy-prometheus_client]
 ignore_missing_imports = True
 
+[mypy-prometheus_client.parser]
+ignore_missing_imports = True
+
 [mypy-pyroscope]
 ignore_missing_imports = True
 

--- a/util/metrics/mirror_registry.py
+++ b/util/metrics/mirror_registry.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+"""
+Prometheus registry readers shared by mirror health endpoints.
+
+Mirror worker metrics are pushed to PushGateway from separate processes. Health
+APIs run in the Quay app process, so these helpers prefer scraping
+PROMETHEUS_PUSHGATEWAY_URL and fall back to the in-process REGISTRY when the
+gateway is unavailable (tests, misconfiguration).
+"""
+
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+
+from prometheus_client import REGISTRY
+from prometheus_client.parser import text_string_to_metric_families
+
+logger = logging.getLogger(__name__)
+
+_PUSHGATEWAY_FETCH_TIMEOUT_SECONDS = 2
+# Ignore PushGateway groupings not refreshed within this window (3x default 30s push interval).
+_WORKERS_ACTIVE_MAX_AGE_SECONDS = 90
+_PUSHGATEWAY_FAMILIES_CACHE_ATTR = "_mirror_registry_pushgateway_families"
+
+
+def _get_pushgateway_url():
+    try:
+        from app import app
+
+        return app.config.get("PROMETHEUS_PUSHGATEWAY_URL")
+    except Exception:
+        return None
+
+
+def _should_read_pushgateway():
+    if os.getenv("TEST", "false").lower() == "true":
+        return False
+    return bool(_get_pushgateway_url())
+
+
+def _request_cache():
+    try:
+        from flask import g, has_request_context
+
+        if has_request_context():
+            return g
+    except Exception:
+        pass
+    return None
+
+
+def _fetch_pushgateway_metric_families():
+    cache = _request_cache()
+    if cache is not None:
+        cached = getattr(cache, _PUSHGATEWAY_FAMILIES_CACHE_ATTR, None)
+        if cached is not None:
+            return cached
+
+    url = _get_pushgateway_url()
+    if not url:
+        families = []
+    else:
+        metrics_url = f"{url.rstrip('/')}/metrics"
+        try:
+            with urllib.request.urlopen(
+                metrics_url, timeout=_PUSHGATEWAY_FETCH_TIMEOUT_SECONDS
+            ) as resp:
+                body = resp.read().decode("utf-8")
+        except (urllib.error.URLError, TimeoutError, ValueError) as ex:
+            logger.debug("Unable to fetch metrics from PushGateway at %s: %s", metrics_url, ex)
+            families = []
+        else:
+            try:
+                families = list(text_string_to_metric_families(body))
+            except Exception as ex:
+                logger.debug("Unable to parse PushGateway metrics from %s: %s", metrics_url, ex)
+                families = []
+
+    if cache is not None:
+        setattr(cache, _PUSHGATEWAY_FAMILIES_CACHE_ATTR, families)
+    return families
+
+
+def _grouping_labels_key(labels):
+    return frozenset(labels.items())
+
+
+def _pushgateway_push_times(metric_families):
+    push_times = {}
+    for family in metric_families:
+        if family.name != "push_time_seconds":
+            continue
+        for sample in family.samples:
+            if sample.name == "push_time_seconds":
+                push_times[_grouping_labels_key(sample.labels)] = float(sample.value)
+    return push_times
+
+
+def _is_fresh_pushgateway_grouping(labels, push_times, now):
+    pushed_at = push_times.get(_grouping_labels_key(labels))
+    if pushed_at is None:
+        return False
+    return (now - pushed_at) <= _WORKERS_ACTIVE_MAX_AGE_SECONDS
+
+
+def _iter_metric_samples(metric_name):
+    """
+    Yield metric samples for metric_name from PushGateway when configured, else REGISTRY.
+    """
+    if _should_read_pushgateway():
+        families = _fetch_pushgateway_metric_families()
+        if families:
+            for family in families:
+                if family.name != metric_name:
+                    continue
+                for sample in family.samples:
+                    if sample.name == metric_name:
+                        yield sample
+            return
+
+    try:
+        for metric in REGISTRY.collect():
+            if metric.name != metric_name:
+                continue
+            for sample in metric.samples:
+                if sample.name == metric_name:
+                    yield sample
+            break
+    except Exception as ex:
+        logger.debug("Unable to read %s from local registry: %s", metric_name, ex)
+
+
+def get_metric_timestamps(metric_name: str, namespace=None):
+    """
+    Retrieve per-repository timestamps from mirror metrics.
+
+    Returns a dict keyed by (namespace, repository) with unix timestamps as values.
+    """
+    timestamps = {}
+    try:
+        for sample in _iter_metric_samples(metric_name):
+            sample_namespace = sample.labels.get("namespace")
+            repository = sample.labels.get("repository")
+            if namespace is not None and sample_namespace != namespace:
+                continue
+            if sample_namespace and repository:
+                key = (sample_namespace, repository)
+                value = sample.value
+                if key in timestamps:
+                    timestamps[key] = max(timestamps[key], value)
+                else:
+                    timestamps[key] = value
+    except Exception as ex:
+        logger.debug("Unable to read %s timestamps: %s", metric_name, ex)
+    return timestamps
+
+
+def get_pending_tags_total(metric_name: str, namespace=None):
+    """
+    Sum pending-tags gauge values from mirror metrics.
+
+    When namespace is set, only samples for that namespace are included.
+    """
+    total = 0.0
+    try:
+        for sample in _iter_metric_samples(metric_name):
+            if namespace is not None and sample.labels.get("namespace") != namespace:
+                continue
+            total += float(sample.value)
+    except Exception as ex:
+        logger.debug("Unable to read %s pending tags: %s", metric_name, ex)
+    return int(total) if total == int(total) else total
+
+
+def get_namespace_gauge_value(metric_name: str, namespace: str, label_name: str = "namespace"):
+    """
+    Read a gauge value for a namespace label from mirror metrics.
+
+    When multiple worker processes report the same series, returns the maximum value.
+    """
+    values = []
+    try:
+        for sample in _iter_metric_samples(metric_name):
+            if sample.labels.get(label_name) == namespace:
+                values.append(sample.value)
+    except Exception as ex:
+        logger.debug("Unable to read %s for %s: %s", metric_name, namespace, ex)
+    if not values:
+        return None
+    return max(values)
+
+
+def get_mirror_workers_active_value():
+    """
+    Read quay_repository_mirror_workers_active from mirror metrics.
+
+    Sums fresh PushGateway groupings so API pods see cluster worker count without
+    counting stale series left after worker shutdown.
+    """
+    if _should_read_pushgateway():
+        families = _fetch_pushgateway_metric_families()
+        if families:
+            now = time.time()
+            push_times = _pushgateway_push_times(families)
+            total = 0
+            for family in families:
+                if family.name != "quay_repository_mirror_workers_active":
+                    continue
+                for sample in family.samples:
+                    if sample.name != "quay_repository_mirror_workers_active":
+                        continue
+                    if _is_fresh_pushgateway_grouping(sample.labels, push_times, now):
+                        total += int(sample.value)
+            return total
+
+    total = 0
+    try:
+        for sample in _iter_metric_samples("quay_repository_mirror_workers_active"):
+            total += int(sample.value)
+    except Exception as ex:
+        logger.debug("Unable to read mirror workers active gauge: %s", ex)
+    return total

--- a/util/metrics/mirror_registry.py
+++ b/util/metrics/mirror_registry.py
@@ -16,9 +16,7 @@ import urllib.request
 from typing import Dict, Tuple
 
 from prometheus_client import REGISTRY
-from prometheus_client.parser import (
-    text_string_to_metric_families,  # type: ignore[import]
-)
+from prometheus_client.parser import text_string_to_metric_families
 
 logger = logging.getLogger(__name__)
 

--- a/util/metrics/mirror_registry.py
+++ b/util/metrics/mirror_registry.py
@@ -17,7 +17,7 @@ from typing import Dict, Tuple
 
 from prometheus_client import REGISTRY
 from prometheus_client.parser import (
-    text_string_to_metric_families,  # type: ignore[import-untyped]
+    text_string_to_metric_families,  # type: ignore[import]
 )
 
 logger = logging.getLogger(__name__)

--- a/util/metrics/mirror_registry.py
+++ b/util/metrics/mirror_registry.py
@@ -13,9 +13,12 @@ import os
 import time
 import urllib.error
 import urllib.request
+from typing import Dict, Tuple
 
 from prometheus_client import REGISTRY
-from prometheus_client.parser import text_string_to_metric_families
+from prometheus_client.parser import (
+    text_string_to_metric_families,  # type: ignore[import-untyped]
+)
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +141,7 @@ def get_metric_timestamps(metric_name: str, namespace=None):
 
     Returns a dict keyed by (namespace, repository) with unix timestamps as values.
     """
-    timestamps = {}
+    timestamps: Dict[Tuple[str, str], float] = {}
     try:
         for sample in _iter_metric_samples(metric_name):
             sample_namespace = sample.labels.get("namespace")

--- a/util/metrics/test/test_mirror_registry.py
+++ b/util/metrics/test/test_mirror_registry.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+
+import time
+from unittest import mock
+
+from flask import Flask
+
+from util.metrics import mirror_registry
+
+
+def _mock_urlopen(metrics_body):
+    resp = mock.Mock(read=lambda: metrics_body.encode())
+    context = mock.MagicMock()
+    context.__enter__.return_value = resp
+    context.__exit__.return_value = None
+    return context
+
+
+class TestIterMetricSamples:
+    def test_pushgateway_path_yields_matching_samples(self):
+        metrics_body = (
+            "# TYPE quay_org_mirror_pending_tags gauge\n"
+            'quay_org_mirror_pending_tags{namespace="coreos",repository="etcd"} 4\n'
+            "# TYPE quay_repository_mirror_workers_active gauge\n"
+            "quay_repository_mirror_workers_active 1\n"
+        )
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=True):
+            with mock.patch.object(
+                mirror_registry, "_get_pushgateway_url", return_value="http://pg:9091"
+            ):
+                with mock.patch("urllib.request.urlopen", return_value=_mock_urlopen(metrics_body)):
+                    samples = list(
+                        mirror_registry._iter_metric_samples("quay_org_mirror_pending_tags")
+                    )
+                    assert len(samples) == 1
+                    assert samples[0].labels["repository"] == "etcd"
+                    assert samples[0].value == 4.0
+
+    def test_local_registry_fallback_when_pushgateway_disabled(self):
+        metric = mock.Mock()
+        metric.name = "quay_org_mirror_pending_tags"
+        sample = mock.Mock()
+        sample.name = "quay_org_mirror_pending_tags"
+        sample.labels = {"namespace": "coreos", "repository": "etcd"}
+        sample.value = 3.0
+        metric.samples = [sample]
+
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=False):
+            with mock.patch.object(mirror_registry, "REGISTRY") as mock_registry:
+                mock_registry.collect.return_value = [metric]
+                samples = list(mirror_registry._iter_metric_samples("quay_org_mirror_pending_tags"))
+                assert len(samples) == 1
+                assert samples[0].value == 3.0
+
+
+class TestGetMetricTimestamps:
+    def test_namespace_filter_and_max_duplicate_series(self):
+        metrics_body = (
+            "# TYPE quay_org_mirror_last_sync_timestamp gauge\n"
+            'quay_org_mirror_last_sync_timestamp{namespace="coreos",repository="etcd"} 100\n'
+            'quay_org_mirror_last_sync_timestamp{namespace="coreos",repository="etcd"} 200\n'
+            'quay_org_mirror_last_sync_timestamp{namespace="other",repository="app"} 50\n'
+        )
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=True):
+            with mock.patch.object(
+                mirror_registry, "_get_pushgateway_url", return_value="http://pg:9091"
+            ):
+                with mock.patch("urllib.request.urlopen", return_value=_mock_urlopen(metrics_body)):
+                    result = mirror_registry.get_metric_timestamps(
+                        "quay_org_mirror_last_sync_timestamp",
+                        namespace="coreos",
+                    )
+                    assert result == {("coreos", "etcd"): 200}
+
+    def test_skips_samples_missing_repository_label(self):
+        metric = mock.Mock()
+        metric.name = "quay_org_mirror_last_sync_timestamp"
+        missing_repo = mock.Mock()
+        missing_repo.name = "quay_org_mirror_last_sync_timestamp"
+        missing_repo.labels = {"namespace": "coreos"}
+        missing_repo.value = 100.0
+        valid = mock.Mock()
+        valid.name = "quay_org_mirror_last_sync_timestamp"
+        valid.labels = {"namespace": "coreos", "repository": "etcd"}
+        valid.value = 150.0
+        metric.samples = [missing_repo, valid]
+
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=False):
+            with mock.patch.object(mirror_registry, "REGISTRY") as mock_registry:
+                mock_registry.collect.return_value = [metric]
+                result = mirror_registry.get_metric_timestamps(
+                    "quay_org_mirror_last_sync_timestamp"
+                )
+                assert result == {("coreos", "etcd"): 150}
+
+
+class TestGetPendingTagsTotal:
+    def test_sums_with_namespace_filter(self):
+        metrics_body = (
+            "# TYPE quay_org_mirror_pending_tags gauge\n"
+            'quay_org_mirror_pending_tags{namespace="coreos",repository="etcd"} 4\n'
+            'quay_org_mirror_pending_tags{namespace="coreos",repository="flannel"} 2\n'
+            'quay_org_mirror_pending_tags{namespace="other",repository="app"} 9\n'
+        )
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=True):
+            with mock.patch.object(
+                mirror_registry, "_get_pushgateway_url", return_value="http://pg:9091"
+            ):
+                with mock.patch("urllib.request.urlopen", return_value=_mock_urlopen(metrics_body)):
+                    assert (
+                        mirror_registry.get_pending_tags_total(
+                            "quay_org_mirror_pending_tags",
+                            namespace="coreos",
+                        )
+                        == 6
+                    )
+                    assert (
+                        mirror_registry.get_pending_tags_total("quay_org_mirror_pending_tags") == 15
+                    )
+
+    def test_returns_int_for_whole_number_total(self):
+        metric = mock.Mock()
+        metric.name = "quay_org_mirror_pending_tags"
+        sample = mock.Mock()
+        sample.name = "quay_org_mirror_pending_tags"
+        sample.labels = {"namespace": "coreos", "repository": "etcd"}
+        sample.value = 5.0
+        metric.samples = [sample]
+
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=False):
+            with mock.patch.object(mirror_registry, "REGISTRY") as mock_registry:
+                mock_registry.collect.return_value = [metric]
+                result = mirror_registry.get_pending_tags_total("quay_org_mirror_pending_tags")
+                assert result == 5
+                assert isinstance(result, int)
+
+    def test_returns_float_for_fractional_total(self):
+        metric = mock.Mock()
+        metric.name = "quay_org_mirror_pending_tags"
+        s1 = mock.Mock()
+        s1.name = "quay_org_mirror_pending_tags"
+        s1.labels = {"namespace": "coreos", "repository": "a"}
+        s1.value = 1.5
+        s2 = mock.Mock()
+        s2.name = "quay_org_mirror_pending_tags"
+        s2.labels = {"namespace": "coreos", "repository": "b"}
+        s2.value = 1.0
+        metric.samples = [s1, s2]
+
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=False):
+            with mock.patch.object(mirror_registry, "REGISTRY") as mock_registry:
+                mock_registry.collect.return_value = [metric]
+                result = mirror_registry.get_pending_tags_total("quay_org_mirror_pending_tags")
+                assert result == 2.5
+                assert isinstance(result, float)
+
+
+class TestGetNamespaceGaugeValue:
+    def test_returns_none_when_no_matching_samples(self):
+        with mock.patch.object(mirror_registry, "_iter_metric_samples", return_value=iter([])):
+            assert (
+                mirror_registry.get_namespace_gauge_value(
+                    "quay_org_mirror_last_discovery_status",
+                    "coreos",
+                )
+                is None
+            )
+
+    def test_returns_max_for_duplicate_namespace_series(self):
+        s1 = mock.Mock(labels={"namespace": "coreos"}, value=0.0)
+        s2 = mock.Mock(labels={"namespace": "coreos"}, value=2.0)
+        s3 = mock.Mock(labels={"namespace": "other"}, value=1.0)
+        with mock.patch.object(
+            mirror_registry,
+            "_iter_metric_samples",
+            return_value=iter([s1, s2, s3]),
+        ):
+            assert (
+                mirror_registry.get_namespace_gauge_value(
+                    "quay_org_mirror_last_discovery_status",
+                    "coreos",
+                )
+                == 2.0
+            )
+
+
+class TestGetMirrorWorkersActiveValue:
+    def test_sums_fresh_pushgateway_samples(self):
+        now = time.time()
+        metrics_body = (
+            "# TYPE push_time_seconds gauge\n"
+            f'push_time_seconds{{pid="1"}} {now}\n'
+            f'push_time_seconds{{pid="2"}} {now}\n'
+            "# TYPE quay_repository_mirror_workers_active gauge\n"
+            'quay_repository_mirror_workers_active{pid="1"} 1\n'
+            'quay_repository_mirror_workers_active{pid="2"} 1\n'
+        )
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=True):
+            with mock.patch.object(
+                mirror_registry, "_get_pushgateway_url", return_value="http://pg:9091"
+            ):
+                with mock.patch("urllib.request.urlopen", return_value=_mock_urlopen(metrics_body)):
+                    assert mirror_registry.get_mirror_workers_active_value() == 2
+
+    def test_ignores_stale_pushgateway_samples(self):
+        now = time.time()
+        stale = now - 200
+        metrics_body = (
+            "# TYPE push_time_seconds gauge\n"
+            f'push_time_seconds{{pid="1"}} {stale}\n'
+            f'push_time_seconds{{pid="2"}} {now}\n'
+            "# TYPE quay_repository_mirror_workers_active gauge\n"
+            'quay_repository_mirror_workers_active{pid="1"} 1\n'
+            'quay_repository_mirror_workers_active{pid="2"} 1\n'
+        )
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=True):
+            with mock.patch.object(
+                mirror_registry, "_get_pushgateway_url", return_value="http://pg:9091"
+            ):
+                with mock.patch("urllib.request.urlopen", return_value=_mock_urlopen(metrics_body)):
+                    assert mirror_registry.get_mirror_workers_active_value() == 1
+
+    def test_local_registry_fallback(self):
+        sample = mock.Mock()
+        sample.name = "quay_repository_mirror_workers_active"
+        sample.labels = {}
+        sample.value = 1
+        metric = mock.Mock()
+        metric.name = "quay_repository_mirror_workers_active"
+        metric.samples = [sample]
+
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=False):
+            with mock.patch.object(mirror_registry, "REGISTRY") as mock_registry:
+                mock_registry.collect.return_value = [metric]
+                assert mirror_registry.get_mirror_workers_active_value() == 1
+
+
+class TestPushgatewayRequestCache:
+    def test_fetch_pushgateway_metric_families_cached_within_request(self):
+        metrics_body = (
+            "# TYPE quay_org_mirror_pending_tags gauge\n"
+            'quay_org_mirror_pending_tags{namespace="coreos",repository="etcd"} 1\n'
+            "# TYPE quay_org_mirror_last_sync_timestamp gauge\n"
+            'quay_org_mirror_last_sync_timestamp{namespace="coreos",repository="etcd"} 10\n'
+        )
+        with Flask(__name__).test_request_context():
+            with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=True):
+                with mock.patch.object(
+                    mirror_registry, "_get_pushgateway_url", return_value="http://pg:9091"
+                ):
+                    with mock.patch(
+                        "urllib.request.urlopen",
+                        return_value=_mock_urlopen(metrics_body),
+                    ) as urlopen:
+                        mirror_registry.get_pending_tags_total("quay_org_mirror_pending_tags")
+                        mirror_registry.get_metric_timestamps("quay_org_mirror_last_sync_timestamp")
+                        mirror_registry.get_mirror_workers_active_value()
+                        assert urlopen.call_count == 1
+
+    def test_pushgateway_empty_falls_back_to_local_registry(self):
+        with mock.patch.object(mirror_registry, "_should_read_pushgateway", return_value=True):
+            with mock.patch.object(
+                mirror_registry, "_fetch_pushgateway_metric_families", return_value=[]
+            ):
+                with mock.patch.object(mirror_registry, "REGISTRY") as mock_registry:
+                    metric = mock.Mock()
+                    metric.name = "quay_org_mirror_pending_tags"
+                    sample = mock.Mock()
+                    sample.name = "quay_org_mirror_pending_tags"
+                    sample.labels = {"namespace": "coreos", "repository": "etcd"}
+                    sample.value = 3.0
+                    metric.samples = [sample]
+                    mock_registry.collect.return_value = [metric]
+
+                    assert (
+                        mirror_registry.get_pending_tags_total(
+                            "quay_org_mirror_pending_tags",
+                            namespace="coreos",
+                        )
+                        == 3
+                    )

--- a/web/playwright/e2e/api/api-v1-mirror-health.spec.ts
+++ b/web/playwright/e2e/api/api-v1-mirror-health.spec.ts
@@ -113,6 +113,12 @@ test.describe(
           // tags_pending is a number
           expect(typeof body.tags_pending).toBe('number');
 
+          // workers.active/configured are non-negative integers
+          expect(typeof body.workers.active).toBe('number');
+          expect(body.workers.active).toBeGreaterThanOrEqual(0);
+          expect(typeof body.workers.configured).toBe('number');
+          expect(body.workers.configured).toBeGreaterThanOrEqual(0);
+
           // last_check is an ISO timestamp ending in Z
           expect(body.last_check).toMatch(/Z$/);
 

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -249,6 +249,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     if not mirror:
         raise PreemptedException
 
+<<<<<<< HEAD
     # Track start time for duration metric
     sync_start_time = time.time()
     namespace = mirror.repository.namespace_user.username
@@ -262,6 +263,15 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     ).set(2)
 
     # Update timestamp
+=======
+    namespace = mirror.repository.namespace_user.username
+    repository_name = mirror.repository.name
+    sync_start_time = time.time()
+    repo_mirror_last_sync_status.labels(
+        namespace=namespace,
+        repository=repository_name,
+    ).set(RepoMirrorStatus.SYNCING.value)
+>>>>>>> 323277b22 (Accepting coderabbit suggestions.)
     repo_mirror_last_sync_timestamp.labels(
         namespace=namespace,
         repository=repository_name,
@@ -278,7 +288,10 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     # Fetch the tags to mirror, being careful to handle exceptions. The 'Exception' is safety net only, allowing
     # easy communication by user through bug report.
     tags = []
+<<<<<<< HEAD
     failure_reason = None
+=======
+>>>>>>> 323277b22 (Accepting coderabbit suggestions.)
 
     try:
         tags = tags_to_mirror(skopeo, mirror)
@@ -336,8 +349,16 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
         repo_mirror_last_sync_status.labels(
             namespace=namespace,
             repository=repository_name,
+<<<<<<< HEAD
             last_error_reason="",
         ).set(1)
+=======
+        ).set(RepoMirrorStatus.SUCCESS.value)
+        repo_mirror_last_sync_timestamp.labels(
+            namespace=namespace,
+            repository=repository_name,
+        ).set(time.time())
+>>>>>>> 323277b22 (Accepting coderabbit suggestions.)
         repo_mirror_sync_complete.labels(
             namespace=namespace,
             repository=repository_name,
@@ -561,6 +582,23 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             )
 
         # Update mirroring metrics
+<<<<<<< HEAD
+=======
+        namespace = mirror.repository.namespace_user.username
+        repository_name = mirror.repository.name
+
+        # Set last sync status metric
+        repo_mirror_last_sync_status.labels(
+            namespace=namespace,
+            repository=repository_name,
+        ).set(overall_status.value)
+
+        repo_mirror_last_sync_timestamp.labels(
+            namespace=namespace,
+            repository=repository_name,
+        ).set(time.time())
+
+>>>>>>> 323277b22 (Accepting coderabbit suggestions.)
         # Set complete sync metric (1 if all tags synced successfully, 0 otherwise)
         is_complete = (
             1 if (overall_status == RepoMirrorStatus.SUCCESS and len(failed_tags) == 0) else 0
@@ -570,6 +608,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             repository=repository_name,
         ).set(is_complete)
 
+<<<<<<< HEAD
         # Set last sync status metric based on final status
         if overall_status == RepoMirrorStatus.SUCCESS:
             status_value = 1
@@ -599,6 +638,9 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
         ).observe(sync_duration)
 
         # Increment failure counter on failures with reason
+=======
+        # Increment failure counter on failures
+>>>>>>> 323277b22 (Accepting coderabbit suggestions.)
         if overall_status == RepoMirrorStatus.FAIL:
             repo_mirror_sync_failures_total.labels(
                 namespace=namespace,
@@ -1111,6 +1153,7 @@ def _update_mirror_metrics_on_failure(namespace, repository_name, failure_reason
     repo_mirror_last_sync_status.labels(
         namespace=namespace,
         repository=repository_name,
+<<<<<<< HEAD
         last_error_reason="",
     ).set(0)
     repo_mirror_last_sync_status.labels(
@@ -1118,6 +1161,13 @@ def _update_mirror_metrics_on_failure(namespace, repository_name, failure_reason
         repository=repository_name,
         last_error_reason=reason,
     ).set(0)
+=======
+    ).set(RepoMirrorStatus.FAIL.value)
+    repo_mirror_last_sync_timestamp.labels(
+        namespace=namespace,
+        repository=repository_name,
+    ).set(time.time())
+>>>>>>> 323277b22 (Accepting coderabbit suggestions.)
 
     repo_mirror_sync_complete.labels(
         namespace=namespace,
@@ -1158,6 +1208,7 @@ def process_org_mirror_discovery(token=None):
     Returns:
         Next OrgMirrorConfigToken or None if done
     """
+<<<<<<< HEAD
     if not features.ORG_MIRROR:
         logger.debug("Organization mirror disabled; skipping process_org_mirror_discovery")
         return None
@@ -1222,6 +1273,21 @@ def perform_org_mirror_discovery(org_mirror_config: OrgMirrorConfig):
             "Processing cancel for org mirror: %s (config_id=%s)",
             org_name,
             claimed_config.id,
+=======
+    try:
+        repo_mirror_pending_tags.remove(namespace, repository_name)
+        repo_mirror_sync_complete.remove(namespace, repository_name)
+        repo_mirror_last_sync_status.remove(namespace, repository_name)
+        repo_mirror_last_sync_timestamp.remove(namespace, repository_name)
+        # Note: Counter metrics cannot be removed in prometheus_client,
+        # they will naturally expire when not updated
+    except (KeyError, AttributeError):
+        # Metrics may not exist or removal not supported
+        logger.debug(
+            "Could not remove metrics for %s/%s - may not exist",
+            namespace,
+            repository_name,
+>>>>>>> 323277b22 (Accepting coderabbit suggestions.)
         )
 
         # Propagate CANCEL to all repos

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -71,7 +71,7 @@ unmirrored_repositories = Gauge(
 )
 
 # Repository mirroring metrics
-repo_mirror_tags_pending = Gauge(
+repo_mirror_pending_tags = Gauge(
     "quay_repository_mirror_pending_tags",
     "Total number of tags pending synchronization for each mirrored repository",
     labelnames=["namespace", "repository"],
@@ -329,7 +329,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
         )
         # Set metrics for empty tag list - this is a success
         sync_duration = time.time() - sync_start_time
-        repo_mirror_tags_pending.labels(
+        repo_mirror_pending_tags.labels(
             namespace=namespace,
             repository=repository_name,
         ).set(0)
@@ -354,7 +354,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     failed_tags = []
 
     # Set initial pending tags metric
-    repo_mirror_tags_pending.labels(
+    repo_mirror_pending_tags.labels(
         namespace=namespace,
         repository=repository_name,
     ).set(len(tags))
@@ -431,7 +431,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
 
             # Update pending tags metric after processing each tag
             remaining_tags = len(tags) - (tag_index + 1)
-            repo_mirror_tags_pending.labels(
+            repo_mirror_pending_tags.labels(
                 namespace=namespace,
                 repository=repository_name,
             ).set(remaining_tags)
@@ -1103,7 +1103,7 @@ def _update_mirror_metrics_on_failure(namespace, repository_name, failure_reason
     Helper function to update metrics when a mirror sync fails.
     """
     reason = failure_reason or "unknown_error"
-    repo_mirror_tags_pending.labels(
+    repo_mirror_pending_tags.labels(
         namespace=namespace,
         repository=repository_name,
     ).set(0)

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -249,7 +249,6 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     if not mirror:
         raise PreemptedException
 
-<<<<<<< HEAD
     # Track start time for duration metric
     sync_start_time = time.time()
     namespace = mirror.repository.namespace_user.username
@@ -263,15 +262,6 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     ).set(2)
 
     # Update timestamp
-=======
-    namespace = mirror.repository.namespace_user.username
-    repository_name = mirror.repository.name
-    sync_start_time = time.time()
-    repo_mirror_last_sync_status.labels(
-        namespace=namespace,
-        repository=repository_name,
-    ).set(RepoMirrorStatus.SYNCING.value)
->>>>>>> 323277b22 (Accepting coderabbit suggestions.)
     repo_mirror_last_sync_timestamp.labels(
         namespace=namespace,
         repository=repository_name,
@@ -288,10 +278,7 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     # Fetch the tags to mirror, being careful to handle exceptions. The 'Exception' is safety net only, allowing
     # easy communication by user through bug report.
     tags = []
-<<<<<<< HEAD
     failure_reason = None
-=======
->>>>>>> 323277b22 (Accepting coderabbit suggestions.)
 
     try:
         tags = tags_to_mirror(skopeo, mirror)
@@ -349,16 +336,8 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
         repo_mirror_last_sync_status.labels(
             namespace=namespace,
             repository=repository_name,
-<<<<<<< HEAD
             last_error_reason="",
         ).set(1)
-=======
-        ).set(RepoMirrorStatus.SUCCESS.value)
-        repo_mirror_last_sync_timestamp.labels(
-            namespace=namespace,
-            repository=repository_name,
-        ).set(time.time())
->>>>>>> 323277b22 (Accepting coderabbit suggestions.)
         repo_mirror_sync_complete.labels(
             namespace=namespace,
             repository=repository_name,
@@ -582,23 +561,6 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             )
 
         # Update mirroring metrics
-<<<<<<< HEAD
-=======
-        namespace = mirror.repository.namespace_user.username
-        repository_name = mirror.repository.name
-
-        # Set last sync status metric
-        repo_mirror_last_sync_status.labels(
-            namespace=namespace,
-            repository=repository_name,
-        ).set(overall_status.value)
-
-        repo_mirror_last_sync_timestamp.labels(
-            namespace=namespace,
-            repository=repository_name,
-        ).set(time.time())
-
->>>>>>> 323277b22 (Accepting coderabbit suggestions.)
         # Set complete sync metric (1 if all tags synced successfully, 0 otherwise)
         is_complete = (
             1 if (overall_status == RepoMirrorStatus.SUCCESS and len(failed_tags) == 0) else 0
@@ -608,7 +570,6 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
             repository=repository_name,
         ).set(is_complete)
 
-<<<<<<< HEAD
         # Set last sync status metric based on final status
         if overall_status == RepoMirrorStatus.SUCCESS:
             status_value = 1
@@ -638,9 +599,6 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
         ).observe(sync_duration)
 
         # Increment failure counter on failures with reason
-=======
-        # Increment failure counter on failures
->>>>>>> 323277b22 (Accepting coderabbit suggestions.)
         if overall_status == RepoMirrorStatus.FAIL:
             repo_mirror_sync_failures_total.labels(
                 namespace=namespace,
@@ -1153,7 +1111,6 @@ def _update_mirror_metrics_on_failure(namespace, repository_name, failure_reason
     repo_mirror_last_sync_status.labels(
         namespace=namespace,
         repository=repository_name,
-<<<<<<< HEAD
         last_error_reason="",
     ).set(0)
     repo_mirror_last_sync_status.labels(
@@ -1161,13 +1118,6 @@ def _update_mirror_metrics_on_failure(namespace, repository_name, failure_reason
         repository=repository_name,
         last_error_reason=reason,
     ).set(0)
-=======
-    ).set(RepoMirrorStatus.FAIL.value)
-    repo_mirror_last_sync_timestamp.labels(
-        namespace=namespace,
-        repository=repository_name,
-    ).set(time.time())
->>>>>>> 323277b22 (Accepting coderabbit suggestions.)
 
     repo_mirror_sync_complete.labels(
         namespace=namespace,
@@ -1208,7 +1158,6 @@ def process_org_mirror_discovery(token=None):
     Returns:
         Next OrgMirrorConfigToken or None if done
     """
-<<<<<<< HEAD
     if not features.ORG_MIRROR:
         logger.debug("Organization mirror disabled; skipping process_org_mirror_discovery")
         return None
@@ -1273,21 +1222,6 @@ def perform_org_mirror_discovery(org_mirror_config: OrgMirrorConfig):
             "Processing cancel for org mirror: %s (config_id=%s)",
             org_name,
             claimed_config.id,
-=======
-    try:
-        repo_mirror_pending_tags.remove(namespace, repository_name)
-        repo_mirror_sync_complete.remove(namespace, repository_name)
-        repo_mirror_last_sync_status.remove(namespace, repository_name)
-        repo_mirror_last_sync_timestamp.remove(namespace, repository_name)
-        # Note: Counter metrics cannot be removed in prometheus_client,
-        # they will naturally expire when not updated
-    except (KeyError, AttributeError):
-        # Metrics may not exist or removal not supported
-        logger.debug(
-            "Could not remove metrics for %s/%s - may not exist",
-            namespace,
-            repository_name,
->>>>>>> 323277b22 (Accepting coderabbit suggestions.)
         )
 
         # Propagate CANCEL to all repos

--- a/workers/repomirrorworker/repomirrorworker.py
+++ b/workers/repomirrorworker/repomirrorworker.py
@@ -25,7 +25,7 @@ DEFAULT_MIRROR_INTERVAL = 30
 class RepoMirrorWorker(Worker):
     def __init__(self):
         super(RepoMirrorWorker, self).__init__()
-        RepoMirrorConfigValidator(app.config.get("FEATURE_REPO_MIRROR", False)).valid()
+        RepoMirrorConfigValidator(features.REPO_MIRROR).valid()
 
         self._mirrorer = SkopeoMirror()
         self._next_token = None
@@ -45,9 +45,14 @@ class RepoMirrorWorker(Worker):
         if features.REPO_MIRROR:
             repo_mirror_workers_active.set(1)
 
+    def terminate(self, signal_num=None, stack_frame=None, graceful=False):
+        if features.REPO_MIRROR:
+            repo_mirror_workers_active.set(0)
+        super(RepoMirrorWorker, self).terminate(signal_num, stack_frame, graceful)
+
     def _process_mirrors(self):
         while True:
-            assert app.config.get("FEATURE_REPO_MIRROR", False)
+            assert features.REPO_MIRROR
 
             self._next_token = process_mirrors(self._mirrorer, self._next_token)
             if self._next_token is None:

--- a/workers/repomirrorworker/test/test_mirror_metrics.py
+++ b/workers/repomirrorworker/test/test_mirror_metrics.py
@@ -61,7 +61,7 @@ class TestUpdateMirrorMetricsOnFailure:
     @mock.patch("workers.repomirrorworker.repo_mirror_sync_failures_total")
     @mock.patch("workers.repomirrorworker.repo_mirror_sync_complete")
     @mock.patch("workers.repomirrorworker.repo_mirror_last_sync_status")
-    @mock.patch("workers.repomirrorworker.repo_mirror_tags_pending")
+    @mock.patch("workers.repomirrorworker.repo_mirror_pending_tags")
     def test_sets_all_failure_metrics(
         self, mock_pending, mock_status, mock_complete, mock_failures, mock_duration
     ):
@@ -92,7 +92,7 @@ class TestUpdateMirrorMetricsOnFailure:
     @mock.patch("workers.repomirrorworker.repo_mirror_sync_failures_total")
     @mock.patch("workers.repomirrorworker.repo_mirror_sync_complete")
     @mock.patch("workers.repomirrorworker.repo_mirror_last_sync_status")
-    @mock.patch("workers.repomirrorworker.repo_mirror_tags_pending")
+    @mock.patch("workers.repomirrorworker.repo_mirror_pending_tags")
     def test_records_duration_when_start_time_provided(
         self, mock_pending, mock_status, mock_complete, mock_failures, mock_duration
     ):
@@ -116,7 +116,7 @@ class TestUpdateMirrorMetricsOnFailure:
     @mock.patch("workers.repomirrorworker.repo_mirror_sync_failures_total")
     @mock.patch("workers.repomirrorworker.repo_mirror_sync_complete")
     @mock.patch("workers.repomirrorworker.repo_mirror_last_sync_status")
-    @mock.patch("workers.repomirrorworker.repo_mirror_tags_pending")
+    @mock.patch("workers.repomirrorworker.repo_mirror_pending_tags")
     def test_skips_duration_when_no_start_time(
         self, mock_pending, mock_status, mock_complete, mock_failures, mock_duration
     ):
@@ -133,7 +133,7 @@ class TestUpdateMirrorMetricsOnFailure:
     @mock.patch("workers.repomirrorworker.repo_mirror_sync_failures_total")
     @mock.patch("workers.repomirrorworker.repo_mirror_sync_complete")
     @mock.patch("workers.repomirrorworker.repo_mirror_last_sync_status")
-    @mock.patch("workers.repomirrorworker.repo_mirror_tags_pending")
+    @mock.patch("workers.repomirrorworker.repo_mirror_pending_tags")
     def test_defaults_to_unknown_error_reason(
         self, mock_pending, mock_status, mock_complete, mock_failures, mock_duration
     ):
@@ -170,9 +170,9 @@ class TestMetricCardinality:
         assert list(repo_mirror_sync_duration_seconds._upper_bounds) == expected
 
     def test_tags_pending_gauge_has_per_repo_labels(self):
-        from workers.repomirrorworker import repo_mirror_tags_pending
+        from workers.repomirrorworker import repo_mirror_pending_tags
 
-        assert repo_mirror_tags_pending._labelnames == ("namespace", "repository")
+        assert repo_mirror_pending_tags._labelnames == ("namespace", "repository")
 
     def test_last_sync_status_gauge_has_per_repo_labels(self):
         from workers.repomirrorworker import repo_mirror_last_sync_status

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -2321,3 +2321,14 @@ def test_perform_mirror_generic_exception_during_sync(
     assert mock_release.call_count >= 1
     fail_calls = [c for c in mock_release.call_args_list if c[0][1] == RepoMirrorStatus.FAIL]
     assert len(fail_calls) >= 1
+
+
+def test_workers_active_gauge_reset_on_terminate(initialized_db, app):
+    with mock.patch(
+        "workers.repomirrorworker.repomirrorworker.repo_mirror_workers_active"
+    ) as gauge:
+        worker = RepoMirrorWorker()
+        gauge.set.assert_called_once_with(1)
+
+        worker.terminate(graceful=True)
+        gauge.set.assert_called_with(0)

--- a/workers/test/test_reconciliationworker.py
+++ b/workers/test/test_reconciliationworker.py
@@ -44,8 +44,11 @@ def test_reconcile_org_user(initialized_db):
     org_user = model.organization.create_organization("org_user", "org_user@test.com", user)
     org_user.stripe_id = "cus_" + "".join(random.choices(string.ascii_lowercase, k=14))
     org_user.save()
-    with patch.object(marketplace_users, "lookup_customer_id") as mock:
-        worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
+
+    # Mock get_active_users to only return our test organization
+    with patch.object(model.user, "get_active_users", return_value=[org_user]):
+        with patch.object(marketplace_users, "lookup_customer_id") as mock:
+            worker._perform_reconciliation(marketplace_users, marketplace_subscriptions)
 
     mock.assert_called_with(org_user.email, raise_exception=True)
 


### PR DESCRIPTION
### Problem
The mirror health API was reading from the in-process Prometheus REGISTRY, so API pods only saw their own process metrics. That made workers.active, tags_pending, and last_sync appear stale or zero/null even when mirror workers were running and pushing metrics elsewhere.

### Approach
Replace in-process REGISTRY reads with a cross-process data source. Options considered:
- Store last_sync timestamps and worker heartbeats in the database (e.g. update RepoMirrorConfig.last_sync_date or a new table)
- Store worker heartbeats and pending tag counts in Redis (shared across all processes)
- Query the Prometheus federation endpoint or PushGateway if available
- This PR uses the PushGateway option: mirror workers push metrics to PROMETHEUS_PUSHGATEWAY_URL, and the health API scrapes that endpoint via new helpers in util/metrics/mirror_registry.py. When PushGateway is unavailable (unit tests, misconfiguration), the API falls back to the in-process REGISTRY.

### Changes

- Add util/metrics/mirror_registry.py to read mirror metrics from PushGateway (with local REGISTRY fallback)
- Update endpoints/api/mirrorhealth.py to use those helpers for workers.active, tags_pending, and last_sync
- Reset repo_mirror_workers_active on worker shutdown
- Update docs and tests for the health endpoint and registry helpers

### Note on unit tests
Includes unit tests for mirror worker metric helpers (_map_failure_to_reason, _update_mirror_metrics_on_failure). These tests mock repo_mirror_pending_tags, matching the symbol name already used on master — not part of the stale health API fix.