### PR TITLE
NO-ISSUE: fix(nginx): remove deprecated ssl on directive

### DIFF
--- a/conf/nginx/nginx.conf.jnj
+++ b/conf/nginx/nginx.conf.jnj
@@ -51,8 +51,6 @@ http {
         listen [::]:8443 ssl http2 default;
         {% endif %}
 
-        ssl on;
-
         # This header must be set only for HTTPS
         add_header Strict-Transport-Security "max-age=63072000; preload";
 
@@ -80,8 +78,6 @@ http {
         listen [::]:7443 ssl http2 default proxy_protocol;
         {% endif %}
 
-        ssl on;
-
         # This header must be set only for HTTPS
         add_header Strict-Transport-Security "max-age=63072000; preload";
 
@@ -106,7 +102,6 @@ http {
         {% if use_ipv6 %}
         listen [::]:55443 ssl http2 default;
         {% endif %}
-        ssl on;
 
         # Required for gRPC streaming of long running builds
         client_header_timeout 2h;
@@ -145,8 +140,6 @@ http {
         listen [::]:8443 ssl;
         {% endif %}
 
-        ssl on;
-
         # This header must be set only for HTTPS
         add_header Strict-Transport-Security "max-age=63072000; preload";
 
@@ -167,8 +160,6 @@ http {
         {% if use_ipv6 %}
         listen [::]:7443 ssl proxy_protocol;
         {% endif %}
-        ssl on;
-
         # This header must be set only for HTTPS
         add_header Strict-Transport-Security "max-age=63072000; preload";
 


### PR DESCRIPTION
## Summary
- Remove all 5 instances of the deprecated `ssl on;` directive from `conf/nginx/nginx.conf.jnj`
- The directive was deprecated in nginx 1.15.0 and is redundant when `listen ... ssl` is already specified on every server block
- A recent RHEL 9 nginx RPM update (`nginx-1.24.0-7.module+el9.8.0+24379+0344c460.2`) causes this deprecated directive to fail at runtime, resulting in nginx returning 500 for **all** requests — pods fail startup health checks and never become ready

## Impact
All new pods on stage.quay.io using image `216ace1` (latest master) are affected. Nginx silently returns 500 for every request including static responses and health endpoints, causing `QuayIOPodsNotReady` to fire. The previous image (`deb0329`) used the older nginx RPM (`el9.8.0+24289+833e4c02.1`) where the directive was only a warning.

## Test plan
- [ ] Verify `nginx -t` passes without `ssl` deprecation warnings
- [ ] Deploy to stage and confirm `/health/instance` returns 200
- [ ] Confirm pods reach Ready state

🤖 Generated with [Claude Code](https://claude.com/claude-code)