### PR TITLE
NO-ISSUE: fix(nginx): pin nginx RPM to avoid CVE-2026-9256 backport regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN set -ex\
 	; microdnf -y --setopt=tsflags=nodocs install \
 		dnsmasq \
 		memcached \
-		nginx \
+		nginx-1.24.0-7.module+el9.8.0+24289+833e4c02.1 \
 		libpq-devel \
 		libjpeg-turbo \
 		openldap \


### PR DESCRIPTION
Pin nginx to 1.24.0-7.module+el9.8.0+24289+833e4c02.1 because the latest RPM (el9.8.0+24379+0344c460.2) introduces a regression where nginx returns 500 Internal Server Error for all requests, including trivial `return 200` directives. The regression was introduced by the CVE-2026-9256 (ngx_http_rewrite_module heap buffer overflow) backport which breaks basic request processing at generic phase 0.