### PR TITLE
PROJQUAY-11621: docs: add repo context addenda

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,16 @@ ln -sf "$(git -C /path/to/main/repo rev-parse --show-toplevel)/web/node_modules"
 - PostgreSQL: localhost:5432
 - Redis: localhost:6379
 - Clair: localhost:6000 (from Quay container, when enabled)
+
+## Contextification Addendum
+
+Use this low-token routing map before opening broader docs:
+
+- API: `endpoints/api/`, `agent_docs/api.md`
+- Registry protocol: `endpoints/v2/`, `data/registry_model/`
+- Schema/migrations: `data/database.py`, `data/migrations/`, `agent_docs/database.md`
+- Workers: `workers/`
+- Storage: `storage/`
+- React UI: `web/AGENTS.md`
+
+Guardrails: add tests for behavior changes, generate Alembic revisions instead of hand-writing IDs, and keep secrets out of config and fixtures.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,3 +8,29 @@ See the [agent_docs/](agent_docs/) directory for detailed architecture documenta
 - [development.md](agent_docs/development.md) — Local development setup
 - [testing.md](agent_docs/testing.md) — Testing patterns and fixtures
 - [workflow.md](agent_docs/workflow.md) — Dev workflow, JIRA, PRs, CI
+
+## Contextification Addendum
+
+```mermaid
+flowchart LR
+    client[Client]
+    flask[Flask app]
+    api[REST API]
+    v2[OCI registry API]
+    model[Data model]
+    db[(Database)]
+    storage[Object storage]
+    workers[Workers]
+
+    client --> flask
+    flask --> api
+    flask --> v2
+    api --> model
+    v2 --> model
+    model --> db
+    v2 --> storage
+    workers --> model
+    workers --> storage
+```
+
+Quay state is split between database metadata, Redis coordination/cache data, and object storage blobs. Use `data/model/` and `data/registry_model/` rather than direct endpoint-to-database shortcuts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,17 @@
 # Contributing
 
 See [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for contribution guidelines.
+
+## Contextification Addendum
+
+Start local development with:
+
+```bash
+make local-dev-up
+make local-dev-up-with-clair
+TEST=true PYTHONPATH="." pytest path/to/test.py -v
+make unit-test
+make registry-test
+```
+
+For database changes, update `data/database.py`, generate an Alembic revision, and add downgrade logic where possible. For frontend work, read `web/AGENTS.md` first. Every behavior change should include a focused test note in the PR.

--- a/README.md
+++ b/README.md
@@ -76,3 +76,65 @@ High-level features include:
 
 Project Quay is under the Apache 2.0 license.
 See the LICENSE file for details.
+
+## Contextification Addendum
+
+### Repository Map
+
+```mermaid
+flowchart LR
+    clients[Docker, Podman, UI, API clients]
+    app[Flask application]
+    api[endpoints/api]
+    registry[endpoints/v2]
+    data[data/model and data/registry_model]
+    db[(PostgreSQL)]
+    redis[(Redis)]
+    storage[storage backends]
+    workers[workers]
+    ui[web/ and static/]
+
+    clients --> app
+    app --> api
+    app --> registry
+    app --> ui
+    api --> data
+    registry --> data
+    data --> db
+    data --> redis
+    registry --> storage
+    workers --> data
+    workers --> storage
+```
+
+Key paths: `data/database.py` is the schema source of truth, `endpoints/v2/` serves registry protocol traffic, `workers/` runs async jobs, `web/` is the React UI, and `config-tool/` validates config.
+
+### Development Shortcuts
+
+```bash
+make local-dev-up
+make local-dev-up-with-clair
+TEST=true PYTHONPATH="." pytest path/to/test.py -v
+make unit-test
+make registry-test
+make types-test
+```
+
+Local UI notes:
+
+- Legacy Angular UI (`static/`) is started by `make local-dev-up` and is available at `http://localhost:8080`.
+- New React UI (`web/`) runs separately at `http://localhost:9000`; after `make local-dev-up`, run:
+
+  ```bash
+  cd web
+  npm install
+  npm start
+  ```
+
+- If backend code changes are not reflected in the local stack, restart the Quay container:
+
+  ```bash
+  podman restart quay-quay
+  ```
+
+Related repos: [quay-operator](https://github.com/quay/quay-operator), [quay-builder](https://github.com/quay/quay-builder), [quay-tests](https://github.com/quay/quay-tests), [quay-fbcs](https://github.com/quay/quay-fbcs), and [quay-konflux-components](https://github.com/quay/quay-konflux-components).


### PR DESCRIPTION
## Summary
  Adds contextification addenda for the main `quay` repository as part of [PROJQUAY-11621](https://redhat.atlassian.net/browse/PROJQUAY-11621).

## Changes
  - Updates `README.md` with a repo map, development shortcuts, UI port notes, and related Quay repo links.
  - Updates `AGENTS.md` with low-token routing for AI agents.
  - Updates `ARCHITECTURE.md` with a high-level system flow.
  - Updates `CONTRIBUTING.md` with local development and testing guidance.
