### PR TITLE
PROJQUAY-11516: fix(api): restrict mirror health global access

### DIFF
--- a/endpoints/api/mirrorhealth.py
+++ b/endpoints/api/mirrorhealth.py
@@ -25,8 +25,9 @@ from data.database import (
 )
 from endpoints.api import (
     ApiResource,
+    allow_if_any_superuser,
     allow_if_global_readonly_superuser,
-    allow_if_superuser,
+    allow_if_superuser_with_full_access,
     nickname,
     parse_args,
     query_param,
@@ -194,6 +195,7 @@ def get_mirror_health_data(
     detailed=False,
     detail_limit=100,
     detail_offset=0,
+    include_repository_details=True,
 ):
     """
     Gather health data for repository mirroring operations.
@@ -203,11 +205,15 @@ def get_mirror_health_data(
         detailed: If true, include paginated per-repository rows under repositories.details
         detail_limit: Max repositories in detailed view (clamped 1..1000)
         detail_offset: Pagination offset into the sorted mirror list (SQL LIMIT/OFFSET)
+        include_repository_details: If false, omit repository-identifying issue samples
+            and detailed rows. This is intended for global superuser summary views.
 
     Returns:
         Dictionary with health status information. Totals and `details` use enabled
         mirror configs only.
     """
+    detailed = detailed and include_repository_details
+
     counts = _mirror_status_counts(namespace)
     total_repos = counts["total"]
     syncing = counts["syncing"]
@@ -226,7 +232,7 @@ def get_mirror_health_data(
     # mirror.sync_start_date (that field is the next scheduled run). Missing samples: skip stale
     # (never-synced NEVER_RUN handled separately); enabled repos with no metric are not flagged stale.
     stale_threshold = now - timedelta(hours=24)
-    last_sync_timestamps = _get_last_sync_timestamps()
+    last_sync_timestamps = _get_last_sync_timestamps() if include_repository_details else {}
     stale_repos = []
     never_synced_repos = []
     failing_repos = []
@@ -235,31 +241,32 @@ def get_mirror_health_data(
     lim = max(1, min(int(detail_limit), _MAX_DETAIL_PAGE)) if detailed else 0
     off = max(0, int(detail_offset)) if detailed else 0
 
-    # Bounded queries: sample up to _ISSUE_SAMPLE_CAP of each issue type via SQL LIMIT.
-    failing_repos = list(
-        _mirror_rows_query(namespace)
-        .where(
-            RepoMirrorConfig.sync_status == RepoMirrorStatus.FAIL,
-            RepoMirrorConfig.sync_retries_remaining == 0,
+    if include_repository_details:
+        # Bounded queries: sample up to _ISSUE_SAMPLE_CAP of each issue type via SQL LIMIT.
+        failing_repos = list(
+            _mirror_rows_query(namespace)
+            .where(
+                RepoMirrorConfig.sync_status == RepoMirrorStatus.FAIL,
+                RepoMirrorConfig.sync_retries_remaining == 0,
+            )
+            .limit(_ISSUE_SAMPLE_CAP)
         )
-        .limit(_ISSUE_SAMPLE_CAP)
-    )
 
-    never_synced_repos = list(
-        _mirror_rows_query(namespace)
-        .where(RepoMirrorConfig.sync_status == RepoMirrorStatus.NEVER_RUN)
-        .limit(_ISSUE_SAMPLE_CAP)
-    )
+        never_synced_repos = list(
+            _mirror_rows_query(namespace)
+            .where(RepoMirrorConfig.sync_status == RepoMirrorStatus.NEVER_RUN)
+            .limit(_ISSUE_SAMPLE_CAP)
+        )
 
-    # Stale detection uses in-process Prometheus timestamps (bounded by registry size).
-    for (ns, repo), ts in last_sync_timestamps.items():
-        if len(stale_repos) >= _ISSUE_SAMPLE_CAP:
-            break
-        if namespace and ns != namespace:
-            continue
-        last_sync_dt = datetime.fromtimestamp(ts, tz=timezone.utc)
-        if last_sync_dt < stale_threshold:
-            stale_repos.append({"namespace": ns, "repository": repo})
+        # Stale detection uses in-process Prometheus timestamps (bounded by registry size).
+        for (ns, repo), ts in last_sync_timestamps.items():
+            if len(stale_repos) >= _ISSUE_SAMPLE_CAP:
+                break
+            if namespace and ns != namespace:
+                continue
+            last_sync_dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+            if last_sync_dt < stale_threshold:
+                stale_repos.append({"namespace": ns, "repository": repo})
 
     if detailed:
         page_query = _mirror_rows_query(namespace).limit(lim + 1).offset(off)
@@ -451,13 +458,13 @@ class RepositoryMirrorHealth(ApiResource):
 
         # Global access requires superuser or global readonly superuser
         if namespace is None:
-            if not (allow_if_superuser() or allow_if_global_readonly_superuser()):
+            if not (allow_if_superuser_with_full_access() or allow_if_global_readonly_superuser()):
                 raise Unauthorized()
         else:
             namespace_user = model.user.get_namespace_user(namespace)
             if not namespace_user:
                 raise NotFound()
-            if not (allow_if_superuser() or allow_if_global_readonly_superuser()):
+            if not (allow_if_superuser_with_full_access() or allow_if_global_readonly_superuser()):
                 if namespace_user.organization:
                     if not OrganizationMemberPermission(namespace).can():
                         raise Unauthorized()
@@ -476,6 +483,37 @@ class RepositoryMirrorHealth(ApiResource):
         )
 
         # Return 503 if unhealthy, 200 if healthy
+        status_code = 200 if health_data["healthy"] else 503
+
+        return (
+            health_data,
+            status_code,
+            {"Cache-Control": _CACHE_CONTROL_NO_STORE},
+        )
+
+
+@resource("/v1/superuser/mirror/health")
+@show_if(features.REPO_MIRROR)
+@show_if(features.SUPER_USERS)
+class SuperUserRepositoryMirrorHealth(ApiResource):
+    """
+    Resource for checking global repository mirror health from the superuser panel.
+    """
+
+    @require_fresh_login
+    @nickname("getSuperUserRepositoryMirrorHealth")
+    def get(self):
+        """
+        Get a global mirror health summary without repository-identifying samples.
+        """
+        if not allow_if_any_superuser():
+            raise Unauthorized()
+
+        health_data = get_mirror_health_data(
+            detailed=False,
+            include_repository_details=False,
+        )
+
         status_code = 200 if health_data["healthy"] else 503
 
         return (

--- a/endpoints/api/test/test_mirrorhealth.py
+++ b/endpoints/api/test/test_mirrorhealth.py
@@ -8,6 +8,7 @@ from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
 from app import app as quay_app
 from endpoints.api.mirrorhealth import (
     RepositoryMirrorHealth,
+    SuperUserRepositoryMirrorHealth,
     _get_last_sync_timestamps,
     _get_mirror_workers_active_value,
     _get_pending_tags_total,
@@ -15,7 +16,7 @@ from endpoints.api.mirrorhealth import (
     get_mirror_health_data,
 )
 from endpoints.api.test.shared import conduct_api_call
-from endpoints.test.shared import client_with_identity
+from endpoints.test.shared import client_with_identity, toggle_feature
 from test.fixtures import *
 
 # =============================================================================
@@ -475,10 +476,56 @@ class TestGetMirrorHealthData:
 
         assert result["repositories"]["pagination"]["limit"] == 1000
 
+    @mock.patch("endpoints.api.mirrorhealth._get_mirror_workers_active_value", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._get_last_sync_timestamps")
+    @mock.patch("endpoints.api.mirrorhealth._get_pending_tags_total", return_value=0)
+    @mock.patch("endpoints.api.mirrorhealth._mirror_rows_query")
+    @mock.patch("endpoints.api.mirrorhealth._mirror_status_counts")
+    def test_summary_mode_omits_repository_details(
+        self, mock_counts, mock_rows, mock_pending, mock_ts, mock_wk
+    ):
+        mock_counts.return_value = {
+            "total": 10,
+            "syncing": 0,
+            "completed": 4,
+            "failed": 5,
+            "never_run": 1,
+        }
+
+        result = get_mirror_health_data(
+            detailed=True,
+            include_repository_details=False,
+        )
+
+        mock_rows.assert_not_called()
+        mock_ts.assert_not_called()
+        assert result["healthy"] is False
+        assert "details" not in result["repositories"]
+        assert "pagination" not in result["repositories"]
+        assert result["issues"][0]["severity"] == "critical"
+        assert "repositories are failing" in result["issues"][0]["message"]
+
 
 # =============================================================================
 # API endpoint integration tests
 # =============================================================================
+
+
+def _set_healthy_mirror_health(mock_health):
+    mock_health.return_value = {
+        "healthy": True,
+        "workers": {"active": 0, "configured": 0, "status": "healthy"},
+        "repositories": {
+            "total": 0,
+            "syncing": 0,
+            "completed": 0,
+            "failed": 0,
+            "never_run": 0,
+        },
+        "tags_pending": 0,
+        "last_check": "2024-01-01T00:00:00Z",
+        "issues": [],
+    }
 
 
 class TestMirrorHealthEndpoint:
@@ -600,3 +647,144 @@ class TestMirrorHealthEndpoint:
         }
         with client_with_identity("globalreadonlysuperuser", app) as cl:
             conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 200)
+
+
+class TestMirrorHealthFullAccessPermissions:
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_regular_superuser_global_access_requires_full_access(
+        self, mock_health, app, initialized_db
+    ):
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("devtable", app) as cl:
+                conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 403)
+
+        mock_health.assert_not_called()
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_regular_superuser_other_namespace_requires_full_access(
+        self, mock_health, app, initialized_db
+    ):
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("devtable", app) as cl:
+                conduct_api_call(
+                    cl,
+                    RepositoryMirrorHealth,
+                    "GET",
+                    {"namespace": "randomuser"},
+                    None,
+                    403,
+                )
+
+        mock_health.assert_not_called()
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_regular_superuser_own_namespace_uses_normal_access_without_full_access(
+        self, mock_health, app, initialized_db
+    ):
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("devtable", app) as cl:
+                conduct_api_call(
+                    cl,
+                    RepositoryMirrorHealth,
+                    "GET",
+                    {"namespace": "devtable"},
+                    None,
+                    200,
+                )
+
+        mock_health.assert_called_once()
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_global_readonly_superuser_global_access_without_full_access(
+        self, mock_health, app, initialized_db
+    ):
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("globalreadonlysuperuser", app) as cl:
+                conduct_api_call(cl, RepositoryMirrorHealth, "GET", None, None, 200)
+
+        mock_health.assert_called_once()
+
+
+class TestSuperUserMirrorHealthEndpoint:
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_regular_superuser_access_without_full_access(self, mock_health, app, initialized_db):
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("devtable", app) as cl:
+                resp = conduct_api_call(
+                    cl,
+                    SuperUserRepositoryMirrorHealth,
+                    "GET",
+                    None,
+                    None,
+                    200,
+                )
+                assert resp.json["healthy"] is True
+
+        mock_health.assert_called_once_with(
+            detailed=False,
+            include_repository_details=False,
+        )
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_global_readonly_superuser_access_without_full_access(
+        self, mock_health, app, initialized_db
+    ):
+        _set_healthy_mirror_health(mock_health)
+
+        with toggle_feature("SUPERUSERS_FULL_ACCESS", False):
+            with client_with_identity("globalreadonlysuperuser", app) as cl:
+                conduct_api_call(
+                    cl,
+                    SuperUserRepositoryMirrorHealth,
+                    "GET",
+                    None,
+                    None,
+                    200,
+                )
+
+        mock_health.assert_called_once_with(
+            detailed=False,
+            include_repository_details=False,
+        )
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_non_superuser_denied(self, mock_health, app, initialized_db):
+        _set_healthy_mirror_health(mock_health)
+
+        with client_with_identity("freshuser", app) as cl:
+            conduct_api_call(
+                cl,
+                SuperUserRepositoryMirrorHealth,
+                "GET",
+                None,
+                None,
+                403,
+            )
+
+        mock_health.assert_not_called()
+
+    @mock.patch("endpoints.api.mirrorhealth.get_mirror_health_data")
+    def test_anonymous_returns_401(self, mock_health, app, initialized_db):
+        _set_healthy_mirror_health(mock_health)
+
+        with client_with_identity(None, app) as cl:
+            conduct_api_call(
+                cl,
+                SuperUserRepositoryMirrorHealth,
+                "GET",
+                None,
+                None,
+                401,
+            )
+
+        mock_health.assert_not_called()

--- a/endpoints/api/test/test_security.py
+++ b/endpoints/api/test/test_security.py
@@ -22,7 +22,10 @@ from endpoints.api.immutability_policy import *
 from endpoints.api.logs import *  # type: ignore[no-redef]
 from endpoints.api.manifest import *
 from endpoints.api.mirror import *  # type: ignore[no-redef]
-from endpoints.api.mirrorhealth import RepositoryMirrorHealth
+from endpoints.api.mirrorhealth import (
+    RepositoryMirrorHealth,
+    SuperUserRepositoryMirrorHealth,
+)
 from endpoints.api.namespacequota import *
 from endpoints.api.org_mirror import *  # type: ignore[no-redef]
 from endpoints.api.organization import *  # type: ignore[assignment,no-redef]
@@ -5429,6 +5432,11 @@ SECURITY_TESTS: List[
     (SuperUserLogs, "GET", None, None, "globalreadonlysuperuser", 200),
     (SuperUserLogs, "GET", None, None, "freshuser", 403),
     (SuperUserLogs, "GET", None, None, "reader", 403),
+    (SuperUserRepositoryMirrorHealth, "GET", None, None, None, 401),
+    (SuperUserRepositoryMirrorHealth, "GET", None, None, "devtable", 200),
+    (SuperUserRepositoryMirrorHealth, "GET", None, None, "globalreadonlysuperuser", 200),
+    (SuperUserRepositoryMirrorHealth, "GET", None, None, "freshuser", 403),
+    (SuperUserRepositoryMirrorHealth, "GET", None, None, "reader", 403),
     (SuperUserAppTokens, "GET", None, None, None, 401),
     (SuperUserAppTokens, "GET", None, None, "devtable", 200),
     (SuperUserAppTokens, "GET", None, None, "globalreadonlysuperuser", 200),

--- a/web/playwright/e2e/api/api-v1-mirror-health.spec.ts
+++ b/web/playwright/e2e/api/api-v1-mirror-health.spec.ts
@@ -22,6 +22,7 @@ import {API_URL} from '../../utils/config';
 import {TEST_USERS, TEST_USERS_OIDC} from '../../global-setup';
 
 const HEALTH_URL = '/api/v1/repository/mirror/health';
+const SUPERUSER_HEALTH_URL = '/api/v1/superuser/mirror/health';
 
 test.describe(
   'Mirror Health API',
@@ -63,67 +64,106 @@ test.describe(
     // Section 1 -- Superuser access (global)
     // ========================================================================
 
-    test.describe('Superuser global access', () => {
-      test('superuser can GET mirror health globally', async ({
-        adminClient,
-      }) => {
-        const r = await adminClient.get(HEALTH_URL);
-        // 200 (healthy) or 503 (unhealthy) are both valid
-        expect([200, 503]).toContain(r.status());
+    test.describe(
+      'Superuser global access',
+      {tag: '@feature:SUPERUSERS_FULL_ACCESS'},
+      () => {
+        test('superuser can GET mirror health globally', async ({
+          adminClient,
+        }) => {
+          const r = await adminClient.get(HEALTH_URL);
+          // 200 (healthy) or 503 (unhealthy) are both valid
+          expect([200, 503]).toContain(r.status());
 
-        const body = await r.json();
-        expect(body).toHaveProperty('healthy');
-        expect(body).toHaveProperty('workers');
-        expect(body).toHaveProperty('repositories');
-        expect(body).toHaveProperty('tags_pending');
-        expect(body).toHaveProperty('last_check');
-        expect(body).toHaveProperty('issues');
-      });
+          const body = await r.json();
+          expect(body).toHaveProperty('healthy');
+          expect(body).toHaveProperty('workers');
+          expect(body).toHaveProperty('repositories');
+          expect(body).toHaveProperty('tags_pending');
+          expect(body).toHaveProperty('last_check');
+          expect(body).toHaveProperty('issues');
+        });
 
-      test('response has correct structure', async ({adminClient}) => {
-        const r = await adminClient.get(HEALTH_URL);
-        expect([200, 503]).toContain(r.status());
+        test('response has correct structure', async ({adminClient}) => {
+          const r = await adminClient.get(HEALTH_URL);
+          expect([200, 503]).toContain(r.status());
 
-        const body = await r.json();
+          const body = await r.json();
 
-        // workers object
-        expect(body.workers).toHaveProperty('active');
-        expect(body.workers).toHaveProperty('configured');
-        expect(body.workers).toHaveProperty('status');
-        expect(['healthy', 'degraded']).toContain(body.workers.status);
+          // workers object
+          expect(body.workers).toHaveProperty('active');
+          expect(body.workers).toHaveProperty('configured');
+          expect(body.workers).toHaveProperty('status');
+          expect(['healthy', 'degraded']).toContain(body.workers.status);
 
-        // repositories object
-        expect(body.repositories).toHaveProperty('total');
-        expect(body.repositories).toHaveProperty('syncing');
-        expect(body.repositories).toHaveProperty('completed');
-        expect(body.repositories).toHaveProperty('failed');
-        expect(body.repositories).toHaveProperty('never_run');
+          // repositories object
+          expect(body.repositories).toHaveProperty('total');
+          expect(body.repositories).toHaveProperty('syncing');
+          expect(body.repositories).toHaveProperty('completed');
+          expect(body.repositories).toHaveProperty('failed');
+          expect(body.repositories).toHaveProperty('never_run');
 
-        // Counts are non-negative integers
-        expect(body.repositories.total).toBeGreaterThanOrEqual(0);
-        expect(body.repositories.syncing).toBeGreaterThanOrEqual(0);
-        expect(body.repositories.completed).toBeGreaterThanOrEqual(0);
-        expect(body.repositories.failed).toBeGreaterThanOrEqual(0);
-        expect(body.repositories.never_run).toBeGreaterThanOrEqual(0);
+          // Counts are non-negative integers
+          expect(body.repositories.total).toBeGreaterThanOrEqual(0);
+          expect(body.repositories.syncing).toBeGreaterThanOrEqual(0);
+          expect(body.repositories.completed).toBeGreaterThanOrEqual(0);
+          expect(body.repositories.failed).toBeGreaterThanOrEqual(0);
+          expect(body.repositories.never_run).toBeGreaterThanOrEqual(0);
 
-        // tags_pending is a number
-        expect(typeof body.tags_pending).toBe('number');
+          // tags_pending is a number
+          expect(typeof body.tags_pending).toBe('number');
 
-        // last_check is an ISO timestamp ending in Z
-        expect(body.last_check).toMatch(/Z$/);
+          // last_check is an ISO timestamp ending in Z
+          expect(body.last_check).toMatch(/Z$/);
 
-        // issues is an array
-        expect(Array.isArray(body.issues)).toBe(true);
-      });
+          // issues is an array
+          expect(Array.isArray(body.issues)).toBe(true);
+        });
 
-      test('Cache-Control header is no-store', async ({adminClient}) => {
-        const r = await adminClient.get(HEALTH_URL);
-        expect([200, 503]).toContain(r.status());
+        test('Cache-Control header is no-store', async ({adminClient}) => {
+          const r = await adminClient.get(HEALTH_URL);
+          expect([200, 503]).toContain(r.status());
 
-        const cacheControl = r.headers()['cache-control'] || '';
-        expect(cacheControl).toContain('no-cache');
-        expect(cacheControl).toContain('no-store');
-      });
+          const cacheControl = r.headers()['cache-control'] || '';
+          expect(cacheControl).toContain('no-cache');
+          expect(cacheControl).toContain('no-store');
+        });
+      },
+    );
+
+    test.describe('Superuser global access without full access', () => {
+      test(
+        'regular superuser cannot GET mirror health globally when full access is disabled',
+        {tag: '@PROJQUAY-11516'},
+        async ({adminClient, quayConfig}) => {
+          test.skip(
+            quayConfig?.features?.SUPERUSERS_FULL_ACCESS !== false,
+            'Requires FEATURE_SUPERUSERS_FULL_ACCESS disabled',
+          );
+
+          const r = await adminClient.get(HEALTH_URL);
+          expect(r.status()).toBe(403);
+        },
+      );
+
+      test(
+        'regular superuser can GET superuser mirror health summary when full access is disabled',
+        {tag: '@PROJQUAY-11516'},
+        async ({adminClient, quayConfig}) => {
+          test.skip(
+            quayConfig?.features?.SUPERUSERS_FULL_ACCESS !== false,
+            'Requires FEATURE_SUPERUSERS_FULL_ACCESS disabled',
+          );
+
+          const r = await adminClient.get(SUPERUSER_HEALTH_URL);
+          expect([200, 503]).toContain(r.status());
+
+          const body = await r.json();
+          expect(body).toHaveProperty('healthy');
+          expect(body).toHaveProperty('repositories');
+          expect(body.repositories).not.toHaveProperty('details');
+        },
+      );
     });
 
     // ========================================================================
@@ -195,85 +235,93 @@ test.describe(
     // Section 5 -- Query parameters
     // ========================================================================
 
-    test.describe('Query parameters', () => {
-      test('namespace parameter filters results', async ({adminClient}) => {
-        const r = await adminClient.get(
-          `${HEALTH_URL}?namespace=${normalUsername}`,
-        );
-        expect([200, 503]).toContain(r.status());
+    test.describe(
+      'Query parameters',
+      {tag: '@feature:SUPERUSERS_FULL_ACCESS'},
+      () => {
+        test('namespace parameter filters results', async ({adminClient}) => {
+          const r = await adminClient.get(
+            `${HEALTH_URL}?namespace=${normalUsername}`,
+          );
+          expect([200, 503]).toContain(r.status());
 
-        const body = await r.json();
-        expect(body).toHaveProperty('healthy');
-        expect(body).toHaveProperty('repositories');
-      });
+          const body = await r.json();
+          expect(body).toHaveProperty('healthy');
+          expect(body).toHaveProperty('repositories');
+        });
 
-      test('detailed=true includes details and pagination', async ({
-        adminClient,
-      }) => {
-        const r = await adminClient.get(`${HEALTH_URL}?detailed=true`);
-        expect([200, 503]).toContain(r.status());
+        test('detailed=true includes details and pagination', async ({
+          adminClient,
+        }) => {
+          const r = await adminClient.get(`${HEALTH_URL}?detailed=true`);
+          expect([200, 503]).toContain(r.status());
 
-        const body = await r.json();
-        expect(body.repositories).toHaveProperty('details');
-        expect(Array.isArray(body.repositories.details)).toBe(true);
-        expect(body.repositories).toHaveProperty('pagination');
-        expect(body.repositories.pagination).toHaveProperty('limit');
-        expect(body.repositories.pagination).toHaveProperty('offset');
-        expect(body.repositories.pagination).toHaveProperty('has_more');
-      });
+          const body = await r.json();
+          expect(body.repositories).toHaveProperty('details');
+          expect(Array.isArray(body.repositories.details)).toBe(true);
+          expect(body.repositories).toHaveProperty('pagination');
+          expect(body.repositories.pagination).toHaveProperty('limit');
+          expect(body.repositories.pagination).toHaveProperty('offset');
+          expect(body.repositories.pagination).toHaveProperty('has_more');
+        });
 
-      test('detailed=false omits details and pagination', async ({
-        adminClient,
-      }) => {
-        const r = await adminClient.get(`${HEALTH_URL}?detailed=false`);
-        expect([200, 503]).toContain(r.status());
+        test('detailed=false omits details and pagination', async ({
+          adminClient,
+        }) => {
+          const r = await adminClient.get(`${HEALTH_URL}?detailed=false`);
+          expect([200, 503]).toContain(r.status());
 
-        const body = await r.json();
-        expect(body.repositories).not.toHaveProperty('details');
-        expect(body.repositories).not.toHaveProperty('pagination');
-      });
+          const body = await r.json();
+          expect(body.repositories).not.toHaveProperty('details');
+          expect(body.repositories).not.toHaveProperty('pagination');
+        });
 
-      test('limit and offset params accepted in detailed mode', async ({
-        adminClient,
-      }) => {
-        const r = await adminClient.get(
-          `${HEALTH_URL}?detailed=true&limit=5&offset=0`,
-        );
-        expect([200, 503]).toContain(r.status());
+        test('limit and offset params accepted in detailed mode', async ({
+          adminClient,
+        }) => {
+          const r = await adminClient.get(
+            `${HEALTH_URL}?detailed=true&limit=5&offset=0`,
+          );
+          expect([200, 503]).toContain(r.status());
 
-        const body = await r.json();
-        expect(body.repositories.pagination.limit).toBe(5);
-        expect(body.repositories.pagination.offset).toBe(0);
-      });
+          const body = await r.json();
+          expect(body.repositories.pagination.limit).toBe(5);
+          expect(body.repositories.pagination.offset).toBe(0);
+        });
 
-      test('limit is clamped to max 1000', async ({adminClient}) => {
-        const r = await adminClient.get(
-          `${HEALTH_URL}?detailed=true&limit=9999`,
-        );
-        expect([200, 503]).toContain(r.status());
+        test('limit is clamped to max 1000', async ({adminClient}) => {
+          const r = await adminClient.get(
+            `${HEALTH_URL}?detailed=true&limit=9999`,
+          );
+          expect([200, 503]).toContain(r.status());
 
-        const body = await r.json();
-        expect(body.repositories.pagination.limit).toBeLessThanOrEqual(1000);
-      });
-    });
+          const body = await r.json();
+          expect(body.repositories.pagination.limit).toBeLessThanOrEqual(1000);
+        });
+      },
+    );
 
     // ========================================================================
     // Section 6 -- healthy vs unhealthy status codes
     // ========================================================================
 
-    test.describe('Status code semantics', () => {
-      test('healthy=true returns 200, healthy=false returns 503', async ({
-        adminClient,
-      }) => {
-        const r = await adminClient.get(HEALTH_URL);
-        const body = await r.json();
+    test.describe(
+      'Status code semantics',
+      {tag: '@feature:SUPERUSERS_FULL_ACCESS'},
+      () => {
+        test('healthy=true returns 200, healthy=false returns 503', async ({
+          adminClient,
+        }) => {
+          const r = await adminClient.get(HEALTH_URL);
+          const body = await r.json();
 
-        if (body.healthy) {
-          expect(r.status()).toBe(200);
-        } else {
-          expect(r.status()).toBe(503);
-        }
-      });
-    });
+          if (body.healthy) {
+            expect(r.status()).toBe(200);
+          } else {
+            expect(r.status()).toBe(503);
+          }
+        });
+      },
+    );
   },
 );


### PR DESCRIPTION
## Summary
- require full-access superuser permission for global and cross-namespace access to `/api/v1/repository/mirror/health`
- preserve global readonly superuser access and normal namespace-scoped access for users and org members
- add `/api/v1/superuser/mirror/health` for the superuser panel, returning sanitized aggregate mirror-health data without repository-identifying details
- add backend, security-matrix, and conditional Playwright API coverage for disabled full-access deployments

## Testing
- `TEST=true PYTHONPATH=. /var/home/bpratt/git/quay/quay2/.venv/bin/python -m pytest endpoints/api/test/test_mirrorhealth.py -q --tb=short`
- `TEST=true PYTHONPATH=. /var/home/bpratt/git/quay/quay2/.venv/bin/python -m pytest endpoints/api/test/test_security.py::test_api_security -q -k MirrorHealth --tb=short`
- `TEST=true PYTHONPATH=. /var/home/bpratt/git/quay/quay2/.venv/bin/python -m pytest endpoints/api/test/test_security.py::test_all_apis_tested -q --tb=short`
- `web/node_modules/.bin/prettier --check web/playwright/e2e/api/api-v1-mirror-health.spec.ts`
- `node_modules/.bin/playwright test playwright/e2e/api/api-v1-mirror-health.spec.ts --grep @PROJQUAY-11516 --list`
- `git diff --check`
