### PR TITLE
PROJQUAY-11912: feat(go): support anonymous pulls

### DIFF
--- a/internal/auth/basic.go
+++ b/internal/auth/basic.go
@@ -1,0 +1,122 @@
+// Package auth provides shared authentication helpers for Go services.
+package auth
+
+import (
+	"database/sql"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/quay/quay/internal/dal/daldb"
+)
+
+// PrincipalKind identifies the kind of authenticated identity.
+type PrincipalKind string
+
+const (
+	// PrincipalUser is a regular user account.
+	PrincipalUser PrincipalKind = "user"
+	// PrincipalRobot is a robot account.
+	PrincipalRobot PrincipalKind = "robot"
+	// PrincipalAnonymous is an unauthenticated caller.
+	PrincipalAnonymous PrincipalKind = "anonymous"
+)
+
+// Principal is the identity evaluated by API and registry authorization.
+type Principal struct {
+	ID       int64
+	UUID     sql.NullString
+	Username string
+	Email    string
+	Kind     PrincipalKind
+}
+
+// AnonymousPrincipal returns the shared anonymous identity.
+func AnonymousPrincipal() *Principal {
+	return &Principal{Username: "anonymous", Kind: PrincipalAnonymous}
+}
+
+// IsAnonymous reports whether p represents an unauthenticated caller.
+func (p *Principal) IsAnonymous() bool {
+	return p == nil || p.Kind == PrincipalAnonymous
+}
+
+// Result describes the outcome of an authentication attempt.
+type Result struct {
+	// Principal is populated only when authentication succeeds.
+	Principal Principal
+	// Username is populated when credentials were presented, even if they were
+	// invalid. This lets callers distinguish failed credentials from missing
+	// credentials without re-parsing the request.
+	Username string
+	// Presented reports whether the request included credentials for this
+	// authenticator. For Basic auth, this means an Authorization: Basic header
+	// was present; it does not imply the credentials were valid.
+	Presented bool
+	// Authenticated reports whether the presented credentials were valid.
+	Authenticated bool
+}
+
+// BasicAuthenticator validates HTTP Basic credentials against the Quay user table.
+type BasicAuthenticator struct {
+	queries *daldb.Queries
+}
+
+// NewBasicAuthenticator creates a BasicAuthenticator backed by db.
+func NewBasicAuthenticator(db *sql.DB) *BasicAuthenticator {
+	return &BasicAuthenticator{queries: daldb.New(db)}
+}
+
+// dummyHash is a valid bcrypt hash used when the user is not found, so that
+// bcrypt.CompareHashAndPassword always runs and timing is constant regardless
+// of whether the username exists.
+var dummyHash = []byte("$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy")
+
+// Authenticate validates request Basic credentials.
+//
+// Result.Username is set when credentials were presented, even if they did not
+// validate. Callers can distinguish missing credentials from failed credentials
+// while preserving constant-time password comparison.
+func (a *BasicAuthenticator) Authenticate(r *http.Request) Result {
+	basicPresented := hasBasicAuthorizationHeader(r.Header.Get("Authorization"))
+	username, password, presented := r.BasicAuth()
+	if !presented {
+		if basicPresented {
+			return Result{Presented: true}
+		}
+		return Result{}
+	}
+
+	dbUser, err := a.queries.GetUserByUsername(r.Context(), username)
+
+	hashToCompare := dummyHash
+	if err == nil && dbUser.Enabled && dbUser.PasswordHash.Valid {
+		hashToCompare = []byte(dbUser.PasswordHash.String)
+	}
+
+	if bcrypt.CompareHashAndPassword(hashToCompare, []byte(password)) != nil ||
+		err != nil || !dbUser.Enabled || !dbUser.PasswordHash.Valid {
+		slog.Debug("authentication failed", "username", username)
+		return Result{Username: username, Presented: true}
+	}
+
+	return Result{
+		Principal: Principal{
+			ID:       dbUser.ID,
+			UUID:     dbUser.Uuid,
+			Username: dbUser.Username,
+			Email:    dbUser.Email,
+			Kind:     PrincipalUser,
+		},
+		Username:      username,
+		Presented:     true,
+		Authenticated: true,
+	}
+}
+
+func hasBasicAuthorizationHeader(authHeader string) bool {
+	fields := strings.Fields(authHeader)
+	return len(fields) > 0 && strings.EqualFold(fields[0], "Basic")
+}

--- a/internal/auth/basic_test.go
+++ b/internal/auth/basic_test.go
@@ -1,0 +1,123 @@
+package auth
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+	_ "modernc.org/sqlite"
+)
+
+func setupAuthTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE "user" (
+		id INTEGER PRIMARY KEY,
+		uuid VARCHAR(36),
+		username VARCHAR(255) NOT NULL,
+		password_hash VARCHAR(255),
+		email VARCHAR(255) NOT NULL,
+		verified INTEGER NOT NULL DEFAULT 0,
+		organization INTEGER NOT NULL DEFAULT 0,
+		robot INTEGER NOT NULL DEFAULT 0,
+		enabled INTEGER NOT NULL DEFAULT 1
+	)`)
+	if err != nil {
+		t.Fatalf("create user table: %v", err)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	_, err = db.ExecContext(t.Context(), `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+		VALUES ('u1', 'admin', ?, 'admin@test.com', 1, 0, 0, 1)`, string(hash))
+	if err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	return db
+}
+
+func TestBasicAuthenticatorResult(t *testing.T) {
+	db := setupAuthTestDB(t)
+	defer db.Close()
+	authenticator := NewBasicAuthenticator(db)
+
+	t.Run("missing credentials", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+
+		result := authenticator.Authenticate(req)
+
+		if result.Presented {
+			t.Fatal("presented = true, want false")
+		}
+		if result.Authenticated {
+			t.Fatal("authenticated = true, want false")
+		}
+	})
+
+	t.Run("valid credentials", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+		req.SetBasicAuth("admin", "correct-password")
+
+		result := authenticator.Authenticate(req)
+
+		if !result.Presented {
+			t.Fatal("presented = false, want true")
+		}
+		if !result.Authenticated {
+			t.Fatal("authenticated = false, want true")
+		}
+		if result.Username != "admin" {
+			t.Fatalf("username = %q, want admin", result.Username)
+		}
+		if result.Principal.Username != "admin" {
+			t.Fatalf("principal username = %q, want admin", result.Principal.Username)
+		}
+		if result.Principal.Kind != PrincipalUser {
+			t.Fatalf("principal kind = %q, want user", result.Principal.Kind)
+		}
+	})
+
+	t.Run("invalid credentials", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+		req.SetBasicAuth("admin", "wrong-password")
+
+		result := authenticator.Authenticate(req)
+
+		if !result.Presented {
+			t.Fatal("presented = false, want true")
+		}
+		if result.Authenticated {
+			t.Fatal("authenticated = true, want false")
+		}
+		if result.Username != "admin" {
+			t.Fatalf("username = %q, want admin", result.Username)
+		}
+	})
+
+	t.Run("malformed basic credentials", func(t *testing.T) {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+		req.Header.Set("Authorization", "Basic not-base64")
+
+		result := authenticator.Authenticate(req)
+
+		if !result.Presented {
+			t.Fatal("presented = false, want true")
+		}
+		if result.Authenticated {
+			t.Fatal("authenticated = true, want false")
+		}
+		if result.Username != "" {
+			t.Fatalf("username = %q, want empty", result.Username)
+		}
+	})
+}

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -71,6 +71,7 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUse
 		DB:               db,
 		Store:            store,
 		LibraryNamespace: resolved.Config.LibraryNamespace,
+		AnonymousAccess:  resolved.Config.FeatureAnonymousAccess,
 	})
 	if err != nil {
 		slog.Error("registry setup error", "err", err)

--- a/internal/dal/daldb/repository.sql.go
+++ b/internal/dal/daldb/repository.sql.go
@@ -135,3 +135,28 @@ func (q *Queries) ListAllRepositories(ctx context.Context) ([]ListAllRepositorie
 	}
 	return items, nil
 }
+
+const repositoryIsPublicByNamespaceName = `-- name: RepositoryIsPublicByNamespaceName :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repository r
+  JOIN "user" u ON r.namespace_user_id = u.id
+  JOIN visibility v ON r.visibility_id = v.id
+  WHERE u.username = ?
+    AND r.name = ?
+    AND v.name = 'public'
+    AND r.state != 3
+)
+`
+
+type RepositoryIsPublicByNamespaceNameParams struct {
+	Username string `json:"username"`
+	Name     string `json:"name"`
+}
+
+func (q *Queries) RepositoryIsPublicByNamespaceName(ctx context.Context, arg RepositoryIsPublicByNamespaceNameParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, repositoryIsPublicByNamespaceName, arg.Username, arg.Name)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}

--- a/internal/dal/queries/repository.sql
+++ b/internal/dal/queries/repository.sql
@@ -17,6 +17,18 @@ SELECT r.id FROM repository r
 JOIN "user" u ON r.namespace_user_id = u.id
 WHERE u.username = ? AND r.name = ?;
 
+-- name: RepositoryIsPublicByNamespaceName :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repository r
+  JOIN "user" u ON r.namespace_user_id = u.id
+  JOIN visibility v ON r.visibility_id = v.id
+  WHERE u.username = ?
+    AND r.name = ?
+    AND v.name = 'public'
+    AND r.state != 3
+);
+
 -- name: ListAllRepositories :many
 SELECT u.username AS namespace, r.name
 FROM repository r

--- a/internal/registry/distribution/app.go
+++ b/internal/registry/distribution/app.go
@@ -23,6 +23,7 @@ type Config struct {
 	DB               *sql.DB
 	Store            oci.MetadataStore
 	LibraryNamespace string
+	AnonymousAccess  *bool
 }
 
 // Registry wraps the distribution registry handler.
@@ -45,7 +46,7 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 
 	libraryNamespace := cfg.LibraryNamespace
 	if libraryNamespace == "" {
-		libraryNamespace = "library"
+		libraryNamespace = defaultLibraryNamespace
 	}
 
 	local.RegisterMetadataStore(cfg.Store)
@@ -66,13 +67,15 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 		},
 		Auth: configuration.Auth{
 			"quaydb": configuration.Parameters{
-				"realm": cfg.Hostname,
-				"db":    cfg.DB,
+				"realm":            cfg.Hostname,
+				"db":               cfg.DB,
+				"libraryNamespace": libraryNamespace,
+				"anonymousAccess":  anonymousAccessEnabled(cfg.AnonymousAccess),
 			},
 		},
 	}
 	distCfg.Middleware = map[string][]configuration.Middleware{
-		"repository": {{Name: registrymw.Name()}},
+		repositoryResourceType: {{Name: registrymw.Name()}},
 	}
 
 	distCfg.HTTP.Addr = cfg.ListenAddr
@@ -90,4 +93,11 @@ func (a *Registry) Handler() http.Handler {
 // Close releases resources held by the registry.
 func (a *Registry) Close() error {
 	return nil
+}
+
+func anonymousAccessEnabled(configured *bool) bool {
+	if configured == nil {
+		return true
+	}
+	return *configured
 }

--- a/internal/registry/distribution/auth.go
+++ b/internal/registry/distribution/auth.go
@@ -5,29 +5,34 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
-	"golang.org/x/crypto/bcrypt"
-
-	"github.com/distribution/distribution/v3/registry/auth"
+	distauth "github.com/distribution/distribution/v3/registry/auth"
+	"github.com/quay/quay/internal/auth"
 	"github.com/quay/quay/internal/dal/daldb"
 	"github.com/quay/quay/internal/oci"
 )
 
 func init() {
-	if err := auth.Register("quaydb", auth.InitFunc(newAccessController)); err != nil {
+	if err := distauth.Register("quaydb", distauth.InitFunc(newAccessController)); err != nil {
 		slog.Error("failed to register quaydb auth", "err", err)
 	}
 }
 
 type accessController struct {
-	queries *daldb.Queries
-	realm   string
+	authenticator    *auth.BasicAuthenticator
+	queries          *daldb.Queries
+	realm            string
+	libraryNamespace string
+	anonymousAccess  bool
 }
 
-var _ auth.AccessController = &accessController{}
-var _ oci.Authenticator = &accessController{}
+var (
+	_ distauth.AccessController = &accessController{}
+	_ oci.Authenticator         = &accessController{}
+)
 
-func newAccessController(options map[string]interface{}) (auth.AccessController, error) {
+func newAccessController(options map[string]interface{}) (distauth.AccessController, error) {
 	realm, ok := options["realm"].(string)
 	if !ok || realm == "" {
 		return nil, fmt.Errorf(`"realm" must be set for quaydb access controller`)
@@ -38,69 +43,128 @@ func newAccessController(options map[string]interface{}) (auth.AccessController,
 		return nil, fmt.Errorf(`"db" must be set to *sql.DB for quaydb access controller`)
 	}
 
+	libraryNamespace, _ := options["libraryNamespace"].(string)
+	if libraryNamespace == "" {
+		libraryNamespace = defaultLibraryNamespace
+	}
+
+	anonymousAccess, ok := options["anonymousAccess"].(bool)
+	if !ok {
+		anonymousAccess = true
+	}
+
 	return &accessController{
-		queries: daldb.New(db),
-		realm:   realm,
+		authenticator:    auth.NewBasicAuthenticator(db),
+		queries:          daldb.New(db),
+		realm:            realm,
+		libraryNamespace: libraryNamespace,
+		anonymousAccess:  anonymousAccess,
 	}, nil
 }
 
-// dummyHash is a valid bcrypt hash used when the user is not found, so that
-// bcrypt.CompareHashAndPassword always runs and timing is constant regardless
-// of whether the username exists.
-var dummyHash = []byte("$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy")
-
-func (ac *accessController) authenticateUser(r *http.Request) (string, bool) {
-	username, password, ok := r.BasicAuth()
-	if !ok {
-		return "", false
+func (ac *accessController) Authorized(req *http.Request, access ...distauth.Access) (*distauth.Grant, error) {
+	result := ac.authenticator.Authenticate(req)
+	// Only missing credentials may fall back to anonymous public pulls. Invalid
+	// credentials must fail instead of silently becoming anonymous.
+	if !result.Authenticated && !result.Presented && ac.canAnonymousPull(req, access) {
+		return &distauth.Grant{User: distauth.UserInfo{Name: auth.AnonymousPrincipal().Username}}, nil
 	}
 
-	var hashToCompare []byte
-
-	user, err := ac.queries.GetUserByUsername(r.Context(), username)
-	if err != nil || !user.Enabled || !user.PasswordHash.Valid {
-		hashToCompare = dummyHash
-	} else {
-		hashToCompare = []byte(user.PasswordHash.String)
-	}
-
-	if bcrypt.CompareHashAndPassword(hashToCompare, []byte(password)) != nil ||
-		err != nil || !user.Enabled || !user.PasswordHash.Valid {
-		slog.Debug("authentication failed", "username", username)
-		return username, false
-	}
-
-	return username, true
-}
-
-func (ac *accessController) Authorized(req *http.Request, access ...auth.Access) (*auth.Grant, error) {
-	username, ok := ac.authenticateUser(req)
-	if !ok && username == "" {
+	if !result.Authenticated && !result.Presented {
 		return nil, &challenge{
 			realm: ac.realm,
-			err:   auth.ErrInvalidCredential,
+			err:   distauth.ErrInvalidCredential,
 		}
 	}
-	if !ok {
+	if !result.Authenticated {
 		return nil, &challenge{
 			realm: ac.realm,
-			err:   auth.ErrAuthenticationFailure,
+			err:   distauth.ErrAuthenticationFailure,
 		}
 	}
 
-	return &auth.Grant{User: auth.UserInfo{Name: username}}, nil
+	return &distauth.Grant{User: distauth.UserInfo{Name: result.Principal.Username}}, nil
 }
 
-func (ac *accessController) Authenticate(r *http.Request, _ ...oci.Access) (*oci.Grant, error) {
-	username, ok := ac.authenticateUser(r)
-	if !ok {
+func (ac *accessController) Authenticate(r *http.Request, access ...oci.Access) (*oci.Grant, error) {
+	result := ac.authenticator.Authenticate(r)
+	// Only missing credentials may fall back to anonymous public pulls. Invalid
+	// credentials must fail instead of silently becoming anonymous.
+	if !result.Authenticated && !result.Presented && ac.canAnonymousOCIPull(r, access) {
+		return &oci.Grant{User: oci.User{Name: auth.AnonymousPrincipal().Username}}, nil
+	}
+
+	if !result.Authenticated {
 		return nil, &challenge{
 			realm: ac.realm,
 			err:   oci.ErrUnauthorized,
 		}
 	}
 
-	return &oci.Grant{User: oci.User{Name: username}}, nil
+	return &oci.Grant{User: oci.User{Name: result.Principal.Username}}, nil
+}
+
+func (ac *accessController) canAnonymousPull(req *http.Request, access []distauth.Access) bool {
+	if !ac.anonymousAccess || len(access) == 0 {
+		return false
+	}
+
+	for _, item := range access {
+		if item.Type != repositoryResourceType || item.Action != repositoryPullAction {
+			return false
+		}
+		if !ac.repositoryIsPublic(req, item.Name) {
+			return false
+		}
+	}
+	return true
+}
+
+func (ac *accessController) canAnonymousOCIPull(req *http.Request, access []oci.Access) bool {
+	if !ac.anonymousAccess || len(access) == 0 {
+		return false
+	}
+
+	for _, item := range access {
+		resourceType, resourceName, ok := strings.Cut(item.Resource, ":")
+		if !ok || resourceType != repositoryResourceType || item.Action != repositoryPullAction {
+			return false
+		}
+		if !ac.repositoryIsPublic(req, resourceName) {
+			return false
+		}
+	}
+	return true
+}
+
+func (ac *accessController) repositoryIsPublic(req *http.Request, name string) bool {
+	namespace, repository, ok := ac.repositoryParts(name)
+	if !ok {
+		return false
+	}
+
+	isPublic, err := ac.queries.RepositoryIsPublicByNamespaceName(req.Context(), daldb.RepositoryIsPublicByNamespaceNameParams{
+		Username: namespace,
+		Name:     repository,
+	})
+	if err != nil {
+		slog.Debug("anonymous repository visibility lookup failed", "repository", name, "err", err)
+		return false
+	}
+
+	return isPublic == 1
+}
+
+func (ac *accessController) repositoryParts(name string) (namespace, repository string, ok bool) {
+	namespace, repository, ok = strings.Cut(name, "/")
+	if !ok {
+		namespace = ac.libraryNamespace
+		repository = name
+	}
+	if namespace == "" || repository == "" {
+		return "", "", false
+	}
+	return namespace, repository, true
 }
 
 // challenge implements auth.Challenge for Basic auth 401 responses.
@@ -109,7 +173,7 @@ type challenge struct {
 	err   error
 }
 
-var _ auth.Challenge = challenge{}
+var _ distauth.Challenge = challenge{}
 
 func (ch challenge) SetHeaders(_ *http.Request, w http.ResponseWriter) {
 	w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", ch.realm))

--- a/internal/registry/distribution/auth_test.go
+++ b/internal/registry/distribution/auth_test.go
@@ -39,6 +39,29 @@ func setupTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("create table: %v", err)
 	}
 
+	_, err = db.ExecContext(ctx, `CREATE TABLE visibility (
+		id INTEGER PRIMARY KEY,
+		name VARCHAR(255) NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create visibility table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE repository (
+		id INTEGER PRIMARY KEY,
+		namespace_user_id INTEGER,
+		name VARCHAR(255) NOT NULL,
+		visibility_id INTEGER NOT NULL,
+		kind_id INTEGER NOT NULL DEFAULT 1,
+		state INTEGER NOT NULL DEFAULT 0
+	)`)
+	if err != nil {
+		t.Fatalf("create repository table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO visibility (id, name) VALUES (1, 'public'), (2, 'private')`)
+	if err != nil {
+		t.Fatalf("insert visibility: %v", err)
+	}
+
 	hash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
 	if err != nil {
 		t.Fatalf("bcrypt: %v", err)
@@ -58,14 +81,49 @@ func setupTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("insert disabled: %v", err)
 	}
 
+	for _, username := range []string{"public", "devtable", "library"} {
+		_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+			VALUES (?, ?, NULL, ?, 1, 0, 0, 1)`, "u-"+username, username, username+"@test.com")
+		if err != nil {
+			t.Fatalf("insert namespace %s: %v", username, err)
+		}
+	}
+
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'publicrepo', 1, 1, 0 FROM "user" WHERE username = 'public'`)
+	if err != nil {
+		t.Fatalf("insert public repo: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'simple', 2, 1, 0 FROM "user" WHERE username = 'devtable'`)
+	if err != nil {
+		t.Fatalf("insert private repo: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'deleted', 1, 1, 3 FROM "user" WHERE username = 'public'`)
+	if err != nil {
+		t.Fatalf("insert deleted repo: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'nginx', 1, 1, 0 FROM "user" WHERE username = 'library'`)
+	if err != nil {
+		t.Fatalf("insert library repo: %v", err)
+	}
+
 	return db
 }
 
 func newTestController(t *testing.T, db *sql.DB) auth.AccessController {
 	t.Helper()
+	return newTestControllerWithAnonymousAccess(t, db, true)
+}
+
+func newTestControllerWithAnonymousAccess(t *testing.T, db *sql.DB, anonymousAccess bool) auth.AccessController {
+	t.Helper()
 	ac, err := newAccessController(map[string]interface{}{
-		"realm": "test-realm",
-		"db":    db,
+		"realm":           "test-realm",
+		"db":              db,
+		"anonymousAccess": anonymousAccess,
 	})
 	if err != nil {
 		t.Fatalf("new access controller: %v", err)
@@ -159,10 +217,127 @@ func TestAuthorized_NoAuthHeader(t *testing.T) {
 	}
 }
 
+func TestAuthorized_AnonymousPullPublicRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+
+	grant, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
+	if err != nil {
+		t.Fatalf("expected anonymous pull to public repo to succeed, got: %v", err)
+	}
+	if grant.User.Name != "anonymous" {
+		t.Errorf("expected anonymous user, got %q", grant.User.Name)
+	}
+}
+
+func TestAuthorized_AnonymousPullDisabledByFeatureFlag(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestControllerWithAnonymousAccess(t, db, false)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+
+	_, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
+	if err == nil {
+		t.Fatal("expected missing auth challenge when anonymous access is disabled")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_AnonymousPullPrivateRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/devtable/simple/manifests/latest", http.NoBody)
+
+	_, err := ac.Authorized(req, repositoryAccess("devtable/simple", "pull"))
+	if err == nil {
+		t.Fatal("expected missing auth challenge for private repo")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_AnonymousPullDeletedPublicRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/deleted/manifests/latest", http.NoBody)
+
+	_, err := ac.Authorized(req, repositoryAccess("public/deleted", "pull"))
+	if err == nil {
+		t.Fatal("expected missing auth challenge for deleted public repo")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_AnonymousPushPublicRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+
+	_, err := ac.Authorized(
+		req,
+		repositoryAccess("public/publicrepo", "pull"),
+		repositoryAccess("public/publicrepo", "push"),
+	)
+	if err == nil {
+		t.Fatal("expected missing auth challenge for anonymous push")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_InvalidBasicAuthDoesNotFallBackToAnonymous(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+	req.SetBasicAuth("admin", "wrong-password")
+
+	_, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
+	if err == nil {
+		t.Fatal("expected auth failure for invalid basic credentials")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_AnonymousPullLibraryRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/nginx/manifests/latest", http.NoBody)
+
+	grant, err := ac.Authorized(req, repositoryAccess("nginx", "pull"))
+	if err != nil {
+		t.Fatalf("expected anonymous pull to library repo to succeed, got: %v", err)
+	}
+	if grant.User.Name != "anonymous" {
+		t.Errorf("expected anonymous user, got %q", grant.User.Name)
+	}
+}
+
 func assertChallenge(t *testing.T, err error) {
 	t.Helper()
 	var ch auth.Challenge
 	if !errors.As(err, &ch) {
 		t.Errorf("expected Challenge error, got %T: %v", err, err)
+	}
+}
+
+func repositoryAccess(name, action string) auth.Access {
+	return auth.Access{
+		Resource: auth.Resource{
+			Type: "repository",
+			Name: name,
+		},
+		Action: action,
 	}
 }

--- a/internal/registry/distribution/constants.go
+++ b/internal/registry/distribution/constants.go
@@ -1,0 +1,8 @@
+// Package distribution implements the OCI registry using go-distribution.
+package distribution
+
+const (
+	defaultLibraryNamespace = "library"
+	repositoryResourceType  = "repository"
+	repositoryPullAction    = "pull"
+)


### PR DESCRIPTION
Summary
- Allows anonymous pull grants for public repositories when FEATURE_ANONYMOUS_ACCESS is enabled.
- Keeps invalid Basic credentials distinct from missing credentials.
- Adds focused Go auth and registry tests.

Testing
- go test ./internal/auth ./internal/registry/distribution
- go test ./internal/cmd
- go vet ./internal/auth ./internal/cmd ./internal/dal/daldb ./internal/registry/distribution
- golangci-lint run ./internal/auth ./internal/cmd ./internal/dal/daldb ./internal/registry/distribution