### PR TITLE
PROJQUAY-12129: feat(bootstrap): add bootstrap token configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -875,6 +875,16 @@ class DefaultConfig(ImmutableConfig):
     # Feature Flag: If set to true, the first User account may be created via API /api/v1/user/initialize
     FEATURE_USER_INITIALIZE = False
 
+    # Feature Flag: Controls programmatic bootstrap token provisioning.
+    FEATURE_PROGRAMMATIC_BOOTSTRAP = False
+    BOOTSTRAP_APP_NAME = "__quay_bootstrap_app"
+    BOOTSTRAP_TOKEN_OWNER = None
+    BOOTSTRAP_TOKEN_PATH = "/var/lib/quay/quay-machine-token.json"
+    BOOTSTRAP_TOKEN_EXPIRATION = 3600  # 60 minutes in seconds
+    BOOTSTRAP_TOKEN_SCOPE = (
+        "org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read"
+    )
+
     # Allows "/" in repository names
     FEATURE_EXTENDED_REPOSITORY_NAMES = True
 

--- a/features/__init__.pyi
+++ b/features/__init__.pyi
@@ -230,3 +230,6 @@ IMAGE_EXPIRY_TRIGGER: FeatureNameValue
 UI_MODELCARD: FeatureNameValue
 
 OTEL_TRACING: FeatureNameValue
+
+# Feature Flag: If set to true, enables programmatic bootstrap token provisioning.
+PROGRAMMATIC_BOOTSTRAP: FeatureNameValue

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -132,6 +132,7 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_OTEL_TRACING":                          true,
 	"FEATURE_PARTIAL_USER_AUTOCOMPLETE":             true,
 	"FEATURE_PERMANENT_SESSIONS":                    true,
+	"FEATURE_PROGRAMMATIC_BOOTSTRAP":                true,
 	"FEATURE_PUBLIC_CATALOG":                        true,
 	"FEATURE_QUOTA_MANAGEMENT":                      true,
 	"FEATURE_QUOTA_SUPPRESS_FAILURES":               true,
@@ -162,6 +163,13 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_USER_RENAME":                           true,
 	"FEATURE_USERNAME_CONFIRMATION":                 true,
 	"FEATURE_VERIFY_QUOTA":                          true,
+
+	// Programmatic bootstrap token config
+	"BOOTSTRAP_APP_NAME":         true,
+	"BOOTSTRAP_TOKEN_OWNER":      true,
+	"BOOTSTRAP_TOKEN_EXPIRATION": true,
+	"BOOTSTRAP_TOKEN_PATH":       true,
+	"BOOTSTRAP_TOKEN_SCOPE":      true,
 
 	// Triggers & entitlements
 	"SUCCESSIVE_TRIGGER_FAILURE_DISABLE_THRESHOLD":        true,

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -120,6 +120,18 @@ CONFIG_SCHEMA = {
         "DEFAULT_TAG_EXPIRATION",
         "TAG_EXPIRATION_OPTIONS",
     ],
+    "allOf": [
+        {
+            "if": {
+                "properties": {"FEATURE_PROGRAMMATIC_BOOTSTRAP": {"const": True}},
+                "required": ["FEATURE_PROGRAMMATIC_BOOTSTRAP"],
+            },
+            "then": {
+                "required": ["BOOTSTRAP_TOKEN_OWNER"],
+                "properties": {"BOOTSTRAP_TOKEN_OWNER": {"type": "string", "minLength": 1}},
+            },
+        }
+    ],
     "properties": {
         "REGISTRY_STATE": {
             "type": "string",
@@ -1511,6 +1523,45 @@ CONFIG_SCHEMA = {
             "type": "boolean",
             "description": "If set to true, the first User account may be created via API /api/v1/user/initialize",
             "x-example": False,
+        },
+        "FEATURE_PROGRAMMATIC_BOOTSTRAP": {
+            "type": "boolean",
+            "description": "Feature flag for programmatic bootstrap token provisioning. Defaults to False.",
+            "x-example": False,
+        },
+        "BOOTSTRAP_APP_NAME": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "OAuth application name used for programmatic bootstrap tokens. Defaults to '__quay_bootstrap_app'.",
+            "x-example": "__quay_bootstrap_app",
+        },
+        "BOOTSTRAP_TOKEN_OWNER": {
+            "type": ["string", "null"],
+            "minLength": 1,
+            "maxLength": 255,
+            "description": "Username that owns the programmatic bootstrap OAuth application and tokens. Required when FEATURE_PROGRAMMATIC_BOOTSTRAP is enabled, and the user must also be listed in SUPER_USERS.",
+            "x-example": "admin",
+        },
+        "BOOTSTRAP_TOKEN_PATH": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": r"^/[^\x00]*$",
+            "description": "Filesystem path where the bootstrap token JSON is written.",
+            "x-example": "/var/lib/quay/quay-machine-token.json",
+        },
+        "BOOTSTRAP_TOKEN_EXPIRATION": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Bootstrap token lifetime in seconds. Defaults to 3600 (60 minutes).",
+            "x-example": 3600,
+        },
+        "BOOTSTRAP_TOKEN_SCOPE": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024,
+            "description": "Space-separated OAuth scopes for the bootstrap token.",
+            "x-example": "org:admin repo:admin repo:create repo:read repo:write super:user user:admin user:read",
         },
         # OCI artifact types
         "ALLOWED_OCI_ARTIFACT_TYPES": {

--- a/util/config/test/test_schema.py
+++ b/util/config/test/test_schema.py
@@ -1,3 +1,7 @@
+import pytest
+from jsonschema import ValidationError, validate
+
+from auth.scopes import validate_scope_string
 from config import DefaultConfig
 from util.config.schema import CONFIG_SCHEMA, INTERNAL_ONLY_PROPERTIES
 
@@ -6,3 +10,77 @@ def test_ensure_schema_defines_all_fields():
     for key in vars(DefaultConfig):
         has_key = key in CONFIG_SCHEMA["properties"] or key in INTERNAL_ONLY_PROPERTIES
         assert has_key, "Property `%s` is missing from config schema" % key
+
+
+def test_bootstrap_token_expiration_must_be_positive():
+    schema = CONFIG_SCHEMA["properties"]["BOOTSTRAP_TOKEN_EXPIRATION"]
+
+    validate(1, schema)
+
+    for value in [0, -1]:
+        with pytest.raises(ValidationError):
+            validate(value, schema)
+
+
+def test_bootstrap_token_owner_required_when_programmatic_bootstrap_enabled():
+    schema = {
+        "type": "object",
+        "allOf": CONFIG_SCHEMA["allOf"],
+        "properties": {
+            "FEATURE_PROGRAMMATIC_BOOTSTRAP": CONFIG_SCHEMA["properties"][
+                "FEATURE_PROGRAMMATIC_BOOTSTRAP"
+            ],
+            "BOOTSTRAP_TOKEN_OWNER": CONFIG_SCHEMA["properties"]["BOOTSTRAP_TOKEN_OWNER"],
+        },
+    }
+
+    validate({"FEATURE_PROGRAMMATIC_BOOTSTRAP": False, "BOOTSTRAP_TOKEN_OWNER": None}, schema)
+    validate({"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": "admin"}, schema)
+
+    for config in [
+        {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True},
+        {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": None},
+        {"FEATURE_PROGRAMMATIC_BOOTSTRAP": True, "BOOTSTRAP_TOKEN_OWNER": ""},
+    ]:
+        with pytest.raises(ValidationError):
+            validate(config, schema)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "/var/lib/quay/quay-machine-token.json",
+        "/tmp/token.json",
+    ],
+)
+def test_bootstrap_token_path_accepts_absolute_paths(value):
+    schema = CONFIG_SCHEMA["properties"]["BOOTSTRAP_TOKEN_PATH"]
+
+    validate(value, schema)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "../../../etc/shadow",
+        "var/lib/quay/token.json",
+        "/tmp/token\x00.json",
+    ],
+)
+def test_bootstrap_token_path_rejects_unsafe_paths(value):
+    schema = CONFIG_SCHEMA["properties"]["BOOTSTRAP_TOKEN_PATH"]
+
+    with pytest.raises(ValidationError):
+        validate(value, schema)
+
+
+def test_default_bootstrap_token_scope_uses_valid_oauth_scopes():
+    schema = CONFIG_SCHEMA["properties"]["BOOTSTRAP_TOKEN_SCOPE"]
+
+    validate(DefaultConfig.BOOTSTRAP_TOKEN_SCOPE, schema)
+    assert validate_scope_string(DefaultConfig.BOOTSTRAP_TOKEN_SCOPE)
+
+    for value in ["", "a" * 1025]:
+        with pytest.raises(ValidationError):
+            validate(value, schema)

--- a/util/config/test/test_schema.py
+++ b/util/config/test/test_schema.py
@@ -7,7 +7,7 @@ from util.config.schema import CONFIG_SCHEMA, INTERNAL_ONLY_PROPERTIES
 
 
 def test_ensure_schema_defines_all_fields():
-    for key in vars(DefaultConfig):
+    for key in (key for key in vars(DefaultConfig) if key.isupper()):
         has_key = key in CONFIG_SCHEMA["properties"] or key in INTERNAL_ONLY_PROPERTIES
         assert has_key, "Property `%s` is missing from config schema" % key
 

--- a/web/playwright/e2e/api/smoke.spec.ts
+++ b/web/playwright/e2e/api/smoke.spec.ts
@@ -72,6 +72,7 @@ test.describe('API Smoke', {tag: ['@api', '@smoke', '@auth:Database']}, () => {
     const body = await response.json();
     expect(body.features).toHaveProperty('PROGRAMMATIC_BOOTSTRAP');
     expect(typeof body.features.PROGRAMMATIC_BOOTSTRAP).toBe('boolean');
+    expect(body.config).not.toHaveProperty('BOOTSTRAP_APP_NAME');
     expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_OWNER');
     expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_PATH');
     expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_SCOPE');

--- a/web/playwright/e2e/api/smoke.spec.ts
+++ b/web/playwright/e2e/api/smoke.spec.ts
@@ -62,4 +62,19 @@ test.describe('API Smoke', {tag: ['@api', '@smoke', '@auth:Database']}, () => {
     // Quay returns 401 or 403 depending on auth configuration
     expect([401, 403]).toContain(response.status());
   });
+
+  test('public config exposes bootstrap feature flag without internal token settings', async ({
+    request,
+  }) => {
+    const response = await request.get('/config');
+    expect(response.ok()).toBeTruthy();
+
+    const body = await response.json();
+    expect(body.features).toHaveProperty('PROGRAMMATIC_BOOTSTRAP');
+    expect(typeof body.features.PROGRAMMATIC_BOOTSTRAP).toBe('boolean');
+    expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_OWNER');
+    expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_PATH');
+    expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_SCOPE');
+    expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_EXPIRATION');
+  });
 });


### PR DESCRIPTION
- `FEATURE_PROGRAMMATIC_BOOTSTRAP` gates bootstrap token provisioning, default `false`.
- `BOOTSTRAP_APP_NAME` defaults to `__quay_bootstrap_app`.
- `BOOTSTRAP_TOKEN_OWNER` is required when bootstrap provisioning is enabled.
- `BOOTSTRAP_TOKEN_PATH` defaults to `/var/lib/quay/quay-machine-token.json`.
- `BOOTSTRAP_TOKEN_EXPIRATION` defaults to `3600` seconds.
- `BOOTSTRAP_TOKEN_SCOPE` defaults to the full bootstrap OAuth scope set.
- Add schema and config tests for the new bootstrap settings.