### PR TITLE
PROJQUAY-12140: feat(bootstrap): add file-based startup provisioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,7 +188,7 @@ RUN set -ex\
 # symlink.
 	; ln -s $QUAYCONF /conf\
 # Make a grip of runtime directories.
-	; newdir /certificates "$QUAYDIR" "$QUAYDIR/conf" "$QUAYDIR/conf/stack" /datastorage\
+	; newdir /certificates "$QUAYDIR" "$QUAYDIR/conf" "$QUAYDIR/conf/stack" /datastorage /var/lib/quay\
 # Another Openshift-ism: it doesn't bother picking a uid that means
 # anything to the OS inside the container, so the process needs
 # permissions to modify the user database.

--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -200,7 +200,7 @@ RUN set -ex\
 # symlink.
 	; ln -s $QUAYCONF /conf\
 # Make a grip of runtime directories.
-	; newdir /certificates "$QUAYDIR" "$QUAYDIR/conf" "$QUAYDIR/conf/stack" /datastorage\
+	; newdir /certificates "$QUAYDIR" "$QUAYDIR/conf" "$QUAYDIR/conf/stack" /datastorage /var/lib/quay\
 # Another Openshift-ism: it doesn't bother picking a uid that means
 # anything to the OS inside the container, so the process needs
 # permissions to modify the user database.

--- a/boot.py
+++ b/boot.py
@@ -12,9 +12,21 @@ from jinja2 import Template
 import release
 from _init import CONF_DIR
 from app import app
-from data.model import ServiceKeyDoesNotExist
+from data.model import ServiceKeyDoesNotExist, db_transaction
+from data.model.oauth import (
+    create_bootstrap_application,
+    create_bootstrap_oauth_api_token,
+    delete_applications,
+    get_bootstrap_app_name,
+    get_bootstrap_application_candidates,
+    get_bootstrap_tokens,
+    lock_bootstrap_token_operation,
+    lookup_applications_by_name,
+)
 from data.model.release import set_region_release
 from data.model.service_keys import get_service_key
+from data.model.user import get_user
+from util.bootstrap_token import write_bootstrap_token
 from util.config.database import sync_database_with_config
 from util.generatepresharedkey import generate_key
 
@@ -93,6 +105,140 @@ def setup_instance_service_key():
             )
 
 
+def setup_bootstrap_token():
+    """Provision or revoke the startup bootstrap token based on feature configuration."""
+    if app.config.get("REGISTRY_STATE", "normal") == "readonly":
+        logger.debug("Registry is in read-only mode, skipping bootstrap token setup")
+        return
+
+    if "FEATURE_PROGRAMMATIC_BOOTSTRAP" not in app.config:
+        logger.debug("Programmatic bootstrap feature is not configured, skipping token setup")
+        return
+
+    if app.config["FEATURE_PROGRAMMATIC_BOOTSTRAP"]:
+        logger.debug("FEATURE_PROGRAMMATIC_BOOTSTRAP is true, will attempt to use bootstrap token")
+        _provision_bootstrap_token()
+    else:
+        logger.debug(
+            "FEATURE_PROGRAMMATIC_BOOTSTRAP exists and is false, "
+            "will attempt to delete the bootstrap token"
+        )
+        _revoke_bootstrap_tokens()
+
+
+def _get_bootstrap_token_owner_user():
+    owner_name = app.config.get("BOOTSTRAP_TOKEN_OWNER")
+    if not owner_name:
+        logger.error(
+            "BOOTSTRAP_TOKEN_OWNER must be set when FEATURE_PROGRAMMATIC_BOOTSTRAP is enabled"
+        )
+        return None
+
+    if owner_name not in (app.config.get("SUPER_USERS") or []):
+        logger.error("BOOTSTRAP_TOKEN_OWNER must be listed in SUPER_USERS")
+        return None
+
+    owner = get_user(owner_name)
+    if owner is None:
+        logger.error(
+            "Bootstrap token owner '%s' was not found in the database; "
+            "skipping bootstrap token provisioning",
+            owner_name,
+        )
+        return None
+
+    return owner
+
+
+def _provision_bootstrap_token():
+    owner = _get_bootstrap_token_owner_user()
+    if owner is None:
+        return
+
+    scope = app.config["BOOTSTRAP_TOKEN_SCOPE"]
+    expiration = app.config["BOOTSTRAP_TOKEN_EXPIRATION"]
+    bootstrap_application_name = get_bootstrap_app_name(app.config)
+
+    try:
+        with db_transaction():
+            lock_bootstrap_token_operation()
+
+            bootstrap_application, duplicate_applications = get_bootstrap_application_candidates(
+                owner,
+                app_config=app.config,
+            )
+            if bootstrap_application is not None:
+                if duplicate_applications:
+                    delete_applications(duplicate_applications)
+                    logger.info(
+                        "Deleted %s duplicate bootstrap applications",
+                        len(duplicate_applications),
+                    )
+
+                # Treat the database as the startup source of truth for Phase 1 local
+                # host-file storage in standalone installations. In multi-node setups
+                # using node-local files, this host may legitimately not have the file
+                # that another host wrote. The plaintext token cannot be reconstructed
+                # from the DB, so do not rotate or recreate it solely because the local
+                # file is missing or malformed.
+                logger.info("Bootstrap token already provisioned, skipping")
+                return
+
+            bootstrap_application = create_bootstrap_application(bootstrap_application_name, owner)
+            _, access_token = create_bootstrap_oauth_api_token(
+                bootstrap_application,
+                owner,
+                scope,
+                expiration_seconds=expiration,
+            )
+            write_bootstrap_token(app.config, access_token)
+            logger.info("Bootstrap token provisioned")
+            return
+    except OSError:
+        logger.exception("Failed to write bootstrap token, rolled back")
+        return
+
+
+def _get_bootstrap_revocation_owners():
+    owner_name = app.config.get("BOOTSTRAP_TOKEN_OWNER")
+    owner = get_user(owner_name) if owner_name else None
+    if owner is not None:
+        return [owner]
+
+    revocation_owners = []
+    seen_usernames = set()
+    for username in app.config.get("SUPER_USERS") or []:
+        if username in seen_usernames:
+            continue
+
+        seen_usernames.add(username)
+        super_user = get_user(username)
+        if super_user is not None:
+            revocation_owners.append(super_user)
+
+    return revocation_owners
+
+
+def _revoke_bootstrap_tokens():
+    bootstrap_application_name = get_bootstrap_app_name(app.config)
+    with db_transaction():
+        lock_bootstrap_token_operation()
+
+        bootstrap_applications = []
+        for owner in _get_bootstrap_revocation_owners():
+            applications = lookup_applications_by_name(owner, bootstrap_application_name)
+            for application in applications:
+                if get_bootstrap_tokens(application):
+                    bootstrap_applications.append(application)
+
+        delete_applications(bootstrap_applications)
+
+    logger.info(
+        "Deleted %s bootstrap applications (feature disabled)",
+        len(bootstrap_applications),
+    )
+
+
 def main():
     if not app.config.get("SETUP_COMPLETE", False):
         raise Exception(
@@ -101,6 +247,7 @@ def main():
 
     sync_database_with_config(app.config)
     setup_instance_service_key()
+    setup_bootstrap_token()
 
     # Record deploy
     if release.REGION and release.GIT_HEAD:

--- a/boot.py
+++ b/boot.py
@@ -26,7 +26,7 @@ from data.model.oauth import (
 from data.model.release import set_region_release
 from data.model.service_keys import get_service_key
 from data.model.user import get_user
-from util.bootstrap_token import write_bootstrap_token
+from util.bootstrap_token import delete_bootstrap_token, write_bootstrap_token
 from util.config.database import sync_database_with_config
 from util.generatepresharedkey import generate_key
 
@@ -232,6 +232,16 @@ def _revoke_bootstrap_tokens():
                     bootstrap_applications.append(application)
 
         delete_applications(bootstrap_applications)
+
+    try:
+        deleted_token_file = delete_bootstrap_token(app.config)
+    except OSError:
+        logger.exception("Failed to delete local bootstrap token file")
+    else:
+        if deleted_token_file:
+            logger.info("Deleted local bootstrap token file")
+        else:
+            logger.debug("Local bootstrap token file did not exist, skipping deletion")
 
     logger.info(
         "Deleted %s bootstrap applications (feature disabled)",

--- a/data/model/oauth.py
+++ b/data/model/oauth.py
@@ -13,6 +13,8 @@ from data.database import (
     OauthAssignedToken,
     OAuthAuthorizationCode,
     User,
+    compute_advisory_lock_id,
+    db_advisory_xact_lock,
     random_string_generator,
 )
 from data.fields import Credential, DecryptedValue
@@ -27,6 +29,11 @@ logger = logging.getLogger(__name__)
 ACCESS_TOKEN_PREFIX_LENGTH = 20
 ACCESS_TOKEN_MINIMUM_CODE_LENGTH = 20
 AUTHORIZATION_CODE_PREFIX_LENGTH = 20
+DEFAULT_TOKEN_EXPIRATION_SECONDS = int(60 * 60 * 24 * 365.25 * 10)  # 10 years
+BOOTSTRAP_APP_NAME = "__quay_bootstrap_app"
+BOOTSTRAP_APP_DESCRIPTION = "Auto-created by bootstrap token provisioning"
+BOOTSTRAP_TOKEN_DATA_KIND = "bootstrap"
+BOOTSTRAP_TOKEN_LOCK_ID = compute_advisory_lock_id("bootstrap_token", 0)
 
 
 class DatabaseAuthorizationProvider(AuthorizationProvider):
@@ -41,7 +48,7 @@ class DatabaseAuthorizationProvider(AuthorizationProvider):
         """
         Property method to get the token expiration time in seconds.
         """
-        return int(60 * 60 * 24 * 365.25 * 10)  # 10 Years
+        return DEFAULT_TOKEN_EXPIRATION_SECONDS
 
     def validate_client_id(self, client_id):
         return self.get_application_for_client_id(client_id) is not None
@@ -333,6 +340,211 @@ class DatabaseAuthorizationProvider(AuthorizationProvider):
         )
 
 
+def get_bootstrap_app_name(app_config=None):
+    """Return the configured bootstrap OAuth application name."""
+    if app_config is None:
+        app_config = config.app_config or {}
+
+    return app_config.get("BOOTSTRAP_APP_NAME", BOOTSTRAP_APP_NAME)
+
+
+def get_bootstrap_app_names(app_config=None):
+    """Return reserved bootstrap OAuth application names for the current config."""
+    return {BOOTSTRAP_APP_NAME, get_bootstrap_app_name(app_config)}
+
+
+def is_bootstrap_app_name(name, app_config=None):
+    """Return whether name is reserved for bootstrap OAuth applications."""
+    return name in get_bootstrap_app_names(app_config)
+
+
+def create_bootstrap_application(name, org):
+    """Create a bootstrap OAuth application for the owner."""
+    return create_application(
+        org,
+        name,
+        application_uri="",
+        redirect_uri="",
+        description=BOOTSTRAP_APP_DESCRIPTION,
+    )
+
+
+def _bootstrap_token_data(user_obj, application):
+    """Return metadata stored with bootstrap-created OAuth access tokens."""
+    return json.dumps(
+        {
+            "kind": BOOTSTRAP_TOKEN_DATA_KIND,
+            "owner": user_obj.username,
+            "application_name": application.name,
+        }
+    )
+
+
+def create_bootstrap_oauth_api_token(
+    application, user_obj, scope, expiration_seconds=DEFAULT_TOKEN_EXPIRATION_SECONDS
+):
+    """Create a bootstrap OAuth API access token for an application/user pair."""
+    return create_user_access_token_for_application(
+        user_obj,
+        application,
+        scope,
+        "Bearer",
+        expiration_seconds,
+        data=_bootstrap_token_data(user_obj, application),
+    )
+
+
+def _bootstrap_token_data_json(token):
+    try:
+        return json.loads(token.data or "{}")
+    except (TypeError, ValueError):
+        return {}
+
+
+def is_bootstrap_oauth_token(token, user_obj=None, application=None):
+    """Return whether an OAuth access token has bootstrap token metadata."""
+    token_data = _bootstrap_token_data_json(token)
+    if token_data.get("kind") != BOOTSTRAP_TOKEN_DATA_KIND:
+        return False
+
+    if user_obj is not None and token_data.get("owner") != user_obj.username:
+        return False
+
+    if application is not None and token_data.get("application_name") != application.name:
+        return False
+
+    return True
+
+
+def get_application_tokens(application, authorized_user=None):
+    """Return all OAuth access tokens for the given application."""
+    query = OAuthAccessToken.select().where(OAuthAccessToken.application == application)
+    if authorized_user is not None:
+        query = query.where(OAuthAccessToken.authorized_user == authorized_user)
+
+    return list(query)
+
+
+def get_bootstrap_tokens(application, authorized_user=None):
+    """Return bootstrap-marked OAuth access tokens for the given application."""
+    bootstrap_tokens = []
+    application_tokens = get_application_tokens(application, authorized_user=authorized_user)
+    for token in application_tokens:
+        if is_bootstrap_oauth_token(token, user_obj=authorized_user, application=application):
+            bootstrap_tokens.append(token)
+
+    return bootstrap_tokens
+
+
+def get_bootstrap_application_candidates(owner, app_config=None):
+    """Return the canonical and duplicate bootstrap-managed apps for an owner.
+
+    Applications are considered bootstrap-managed only when they are owned by the
+    configured bootstrap owner, have the configured bootstrap app name, and carry
+    at least one bootstrap-marked token for that owner. Results are ordered by
+    application ID descending through lookup_applications_by_name, so the first
+    token-bearing app is the canonical app and the remaining token-bearing apps
+    are duplicates.
+    """
+    bootstrap_application_name = get_bootstrap_app_name(app_config)
+    applications = lookup_applications_by_name(owner, bootstrap_application_name)
+
+    canonical_application = None
+    duplicate_applications = []
+    for application in applications:
+        bootstrap_tokens = get_bootstrap_tokens(application, authorized_user=owner)
+        if not bootstrap_tokens:
+            continue
+
+        if canonical_application is None:
+            canonical_application = application
+            continue
+
+        duplicate_applications.append(application)
+
+    return canonical_application, duplicate_applications
+
+
+def get_canonical_bootstrap_application(owner, app_config=None):
+    """Return the canonical bootstrap-managed app for an owner, if one exists."""
+    canonical_application, _ = get_bootstrap_application_candidates(
+        owner,
+        app_config=app_config,
+    )
+    return canonical_application
+
+
+def _get_bootstrap_owner_for_validation(app_config):
+    owner_name = app_config.get("BOOTSTRAP_TOKEN_OWNER")
+    if not owner_name:
+        return None
+
+    superusers = app_config.get("SUPER_USERS") or []
+    if owner_name not in superusers:
+        return None
+
+    return user.get_user(owner_name)
+
+
+def validate_bootstrap_token(access_token, app_config=None):
+    """Validate a token belongs to the configured canonical bootstrap app."""
+    if app_config is None:
+        app_config = config.app_config or {}
+
+    found = validate_access_token(access_token)
+    if found is None:
+        return None
+
+    owner = _get_bootstrap_owner_for_validation(app_config)
+    if owner is None:
+        return None
+
+    canonical_application = get_canonical_bootstrap_application(owner, app_config=app_config)
+    if canonical_application is None:
+        return None
+
+    if found.application_id != canonical_application.id:
+        return None
+
+    if found.authorized_user_id != owner.id:
+        return None
+
+    if not is_bootstrap_oauth_token(found, user_obj=owner, application=canonical_application):
+        return None
+
+    return found
+
+
+def lookup_applications_by_name(org, name):
+    """Look up OAuthApplications by organization and name in newest-first order."""
+    return list(
+        OAuthApplication.select()
+        .where(
+            OAuthApplication.organization == org,
+            OAuthApplication.name == name,
+        )
+        .order_by(OAuthApplication.id.desc())
+    )
+
+
+def lookup_application_by_name(org, name):
+    """Look up the newest OAuthApplication by organization and name."""
+    applications = lookup_applications_by_name(org, name)
+    return applications[0] if applications else None
+
+
+def delete_applications(applications):
+    """Delete OAuth applications and their dependent OAuth rows."""
+    for application in applications:
+        OauthAssignedToken.delete().where(OauthAssignedToken.application == application).execute()
+        application.delete_instance(recursive=True, delete_nullable=True)
+
+
+def lock_bootstrap_token_operation():
+    """Serialize bootstrap token mutations with a transaction-scoped DB lock."""
+    db_advisory_xact_lock(BOOTSTRAP_TOKEN_LOCK_ID)
+
+
 def create_application(org, name, application_uri, redirect_uri, **kwargs):
     client_secret = kwargs.pop("client_secret", random_string_generator(length=40)())
     return OAuthApplication.create(
@@ -481,6 +693,21 @@ def get_oauth_application_for_client_id(client_id):
 
 
 def create_user_access_token(user_obj, client_id, scope, access_token=None, expires_in=9000):
+    application = get_application_for_client_id(client_id)
+    return create_user_access_token_for_application(
+        user_obj,
+        application,
+        scope,
+        "token",
+        expires_in,
+        access_token=access_token,
+        data="",
+    )
+
+
+def create_user_access_token_for_application(
+    user_obj, application, scope, token_type, expires_in, access_token=None, data=""
+):
     access_token = access_token or random_string_generator(length=40)()
     token_name = access_token[:ACCESS_TOKEN_PREFIX_LENGTH]
     token_code = access_token[ACCESS_TOKEN_PREFIX_LENGTH:]
@@ -489,17 +716,16 @@ def create_user_access_token(user_obj, client_id, scope, access_token=None, expi
     assert len(token_code) >= ACCESS_TOKEN_MINIMUM_CODE_LENGTH
 
     expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
-    application = get_application_for_client_id(client_id)
     created = OAuthAccessToken.create(
         application=application,
         authorized_user=user_obj,
         scope=scope,
-        token_type="token",
+        token_type=token_type,
         access_token="",
         token_code=Credential.from_string(token_code),
         token_name=token_name,
         expires_at=expires_at,
-        data="",
+        data=data,
     )
     return created, access_token
 

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -693,6 +693,11 @@ class ApplicationInformation(ApiResource):
         }
 
 
+def _ensure_oauth_app_name_is_not_reserved(name):
+    if model.oauth.is_bootstrap_app_name(name, app.config):
+        request_error(message="Application name is reserved for bootstrap token provisioning")
+
+
 def app_view(application):
     is_admin = AdministerOrganizationPermission(application.organization.username).can()
     client_secret = None
@@ -788,6 +793,7 @@ class OrganizationApplications(ApiResource):
                 raise NotFound()
 
             app_data = request.get_json()
+            _ensure_oauth_app_name_is_not_reserved(app_data["name"])
             application = model.oauth.create_application(
                 org,
                 app_data["name"],
@@ -889,6 +895,7 @@ class OrganizationApplicationResource(ApiResource):
                 raise NotFound()
 
             app_data = request.get_json()
+            _ensure_oauth_app_name_is_not_reserved(app_data["name"])
             application.name = app_data["name"]
             application.application_uri = app_data["application_uri"]
             application.redirect_uri = app_data["redirect_uri"]

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -7,6 +7,8 @@ from data.database import Tag, get_epoch_timestamp_ms
 from endpoints.api import api
 from endpoints.api.organization import (
     Organization,
+    OrganizationApplicationResource,
+    OrganizationApplications,
     OrganizationCollaboratorList,
     OrganizationList,
     OrganizationProxyCacheConfig,
@@ -299,3 +301,79 @@ class TestProxyCacheConfigWithImmutableTags:
         has_immutable = namespace_has_immutable_tags(org.id)
         # Initially there should be no immutable tags
         assert isinstance(has_immutable, bool)
+
+
+def test_create_application_rejects_reserved_bootstrap_name(app):
+    with client_with_identity("devtable", app) as cl:
+        response = conduct_api_call(
+            cl,
+            OrganizationApplications,
+            "POST",
+            {"orgname": "buynlarge"},
+            {"name": model.oauth.BOOTSTRAP_APP_NAME},
+            400,
+        )
+
+    assert "reserved" in response.json["error_message"]
+
+
+def test_create_application_rejects_configured_bootstrap_name(app):
+    with patch.dict(realapp.config, {"BOOTSTRAP_APP_NAME": "custom-bootstrap-api"}):
+        with client_with_identity("devtable", app) as cl:
+            response = conduct_api_call(
+                cl,
+                OrganizationApplications,
+                "POST",
+                {"orgname": "buynlarge"},
+                {"name": "custom-bootstrap-api"},
+                400,
+            )
+
+    assert "reserved" in response.json["error_message"]
+
+
+def test_update_application_rejects_reserved_bootstrap_name(app):
+    org = model.organization.get_organization("buynlarge")
+    application = model.oauth.create_application(org, "legit-bootstrap-api-test", "", "")
+
+    with client_with_identity("devtable", app) as cl:
+        response = conduct_api_call(
+            cl,
+            OrganizationApplicationResource,
+            "PUT",
+            {"orgname": "buynlarge", "client_id": application.client_id},
+            {
+                "name": model.oauth.BOOTSTRAP_APP_NAME,
+                "redirect_uri": "",
+                "application_uri": "",
+            },
+            400,
+        )
+
+    application = model.oauth.lookup_application(org, application.client_id)
+    assert "reserved" in response.json["error_message"]
+    assert application.name == "legit-bootstrap-api-test"
+
+
+def test_update_application_rejects_configured_bootstrap_name(app):
+    org = model.organization.get_organization("buynlarge")
+    application = model.oauth.create_application(org, "legit-custom-bootstrap-api-test", "", "")
+
+    with patch.dict(realapp.config, {"BOOTSTRAP_APP_NAME": "custom-bootstrap-api"}):
+        with client_with_identity("devtable", app) as cl:
+            response = conduct_api_call(
+                cl,
+                OrganizationApplicationResource,
+                "PUT",
+                {"orgname": "buynlarge", "client_id": application.client_id},
+                {
+                    "name": "custom-bootstrap-api",
+                    "redirect_uri": "",
+                    "application_uri": "",
+                },
+                400,
+            )
+
+    application = model.oauth.lookup_application(org, application.client_id)
+    assert "reserved" in response.json["error_message"]
+    assert application.name == "legit-custom-bootstrap-api-test"

--- a/test/test_bootstrap_startup.py
+++ b/test/test_bootstrap_startup.py
@@ -1,0 +1,705 @@
+import json
+import os
+from unittest.mock import patch
+
+from data import model
+from data.database import db
+from test.fixtures import *
+
+
+def _app_config(tmp_path, feature_enabled=True, superusers=None, owner="devtable", app_name=None):
+    if superusers is None:
+        superusers = [owner] if owner is not None else []
+
+    config = {
+        "FEATURE_PROGRAMMATIC_BOOTSTRAP": feature_enabled,
+        "SUPER_USERS": superusers,
+        "BOOTSTRAP_TOKEN_PATH": str(tmp_path / "token.json"),
+        "BOOTSTRAP_TOKEN_EXPIRATION": 3600,
+        "BOOTSTRAP_TOKEN_SCOPE": "repo:read repo:write",
+        "REGISTRY_STATE": "normal",
+    }
+    if owner is not None:
+        config["BOOTSTRAP_TOKEN_OWNER"] = owner
+    if app_name is not None:
+        config["BOOTSTRAP_APP_NAME"] = app_name
+    return config
+
+
+def _stored_access_token(config):
+    with open(config["BOOTSTRAP_TOKEN_PATH"]) as f:
+        return json.load(f)["access_token"]
+
+
+def test_readonly_registry_skips_bootstrap_token_setup(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path)
+    config["REGISTRY_STATE"] = "readonly"
+    with (
+        patch("boot.app") as mock_app,
+        patch("boot._provision_bootstrap_token") as mock_provision,
+        patch("boot._revoke_bootstrap_tokens") as mock_revoke,
+    ):
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    mock_provision.assert_not_called()
+    mock_revoke.assert_not_called()
+
+
+def test_missing_bootstrap_feature_config_skips_bootstrap_token_setup(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path)
+    del config["FEATURE_PROGRAMMATIC_BOOTSTRAP"]
+    with (
+        patch("boot.app") as mock_app,
+        patch("boot._provision_bootstrap_token") as mock_provision,
+        patch("boot._revoke_bootstrap_tokens") as mock_revoke,
+    ):
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    mock_provision.assert_not_called()
+    mock_revoke.assert_not_called()
+
+
+def test_provision_creates_bootstrap_token_and_file(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path)
+    with (
+        patch("boot.app") as mock_app,
+        patch("boot.lock_bootstrap_token_operation") as mock_lock,
+    ):
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    mock_lock.assert_called_once_with()
+    assert os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+
+    owner = model.user.get_user("devtable")
+    application = model.oauth.lookup_application_by_name(
+        owner,
+        model.oauth.get_bootstrap_app_name(config),
+    )
+    tokens = model.oauth.get_bootstrap_tokens(application)
+    assert len(tokens) == 1
+
+    access_token = _stored_access_token(config)
+    assert model.oauth.validate_bootstrap_token(access_token, config).id == tokens[0].id
+
+
+def test_provision_reuses_valid_stored_token(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path)
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    first_access_token = _stored_access_token(config)
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert _stored_access_token(config) == first_access_token
+    owner = model.user.get_user("devtable")
+    application = model.oauth.lookup_application_by_name(
+        owner,
+        model.oauth.get_bootstrap_app_name(config),
+    )
+    assert len(model.oauth.get_bootstrap_tokens(application)) == 1
+
+
+def test_provision_selects_most_recent_duplicate_bootstrap_app(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, app_name="custom-bootstrap")
+    owner = model.user.get_user("devtable")
+    default_application = model.oauth.create_application(
+        owner, model.oauth.BOOTSTRAP_APP_NAME, "", ""
+    )
+    older_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    newer_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    default_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        default_application,
+        owner,
+        "repo:read",
+    )
+    old_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        older_application,
+        owner,
+        "repo:read",
+    )
+    keep_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        newer_application,
+        owner,
+        "repo:write",
+    )
+    with open(config["BOOTSTRAP_TOKEN_PATH"], "w") as f:
+        f.write("not-json")
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    newer_tokens = model.oauth.get_bootstrap_tokens(newer_application)
+    assert [token.uuid for token in model.oauth.get_bootstrap_tokens(default_application)] == [
+        default_token.uuid
+    ]
+    assert model.oauth.get_bootstrap_tokens(older_application) == []
+    assert [token.uuid for token in newer_tokens] == [keep_token.uuid]
+    assert model.oauth.lookup_access_token_by_uuid(default_token.uuid) is not None
+    assert model.oauth.lookup_access_token_by_uuid(old_token.uuid) is None
+    assert model.oauth.lookup_access_token_by_uuid(keep_token.uuid) is not None
+    with open(config["BOOTSTRAP_TOKEN_PATH"]) as f:
+        assert f.read() == "not-json"
+
+
+def test_validate_bootstrap_token_accepts_only_canonical_bootstrap_application(
+    initialized_db, tmp_path
+):
+    config = _app_config(tmp_path, app_name="custom-bootstrap")
+    owner = model.user.get_user("devtable")
+    other_owner = model.user.get_user("freshuser")
+
+    older_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    older_token, older_access_token = model.oauth.create_bootstrap_oauth_api_token(
+        older_application,
+        owner,
+        "repo:read",
+    )
+
+    other_owner_application = model.oauth.create_application(
+        other_owner,
+        "custom-bootstrap",
+        "",
+        "",
+    )
+    other_owner_token, other_owner_access_token = model.oauth.create_bootstrap_oauth_api_token(
+        other_owner_application,
+        other_owner,
+        "repo:read",
+    )
+
+    newer_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    newer_token, newer_access_token = model.oauth.create_bootstrap_oauth_api_token(
+        newer_application,
+        owner,
+        "repo:write",
+    )
+
+    assert model.oauth.validate_bootstrap_token(older_access_token, config) is None
+    assert model.oauth.validate_bootstrap_token(other_owner_access_token, config) is None
+
+    validated_token = model.oauth.validate_bootstrap_token(newer_access_token, config)
+    assert validated_token is not None
+    assert validated_token.uuid == newer_token.uuid
+    assert model.oauth.lookup_access_token_by_uuid(older_token.uuid) is not None
+    assert model.oauth.lookup_access_token_by_uuid(other_owner_token.uuid) is not None
+
+
+def test_provision_deletes_older_duplicate_bootstrap_apps_without_rewriting_file(
+    initialized_db, tmp_path
+):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, app_name="custom-bootstrap")
+    owner = model.user.get_user("devtable")
+    older_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    newer_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    old_token, old_access_token = model.oauth.create_bootstrap_oauth_api_token(
+        older_application,
+        owner,
+        "repo:read",
+    )
+    keep_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        newer_application,
+        owner,
+        "repo:write",
+    )
+    with open(config["BOOTSTRAP_TOKEN_PATH"], "w") as f:
+        json.dump({"access_token": old_access_token}, f)
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert _stored_access_token(config) == old_access_token
+    assert model.oauth.get_bootstrap_tokens(older_application) == []
+    assert [token.uuid for token in model.oauth.get_bootstrap_tokens(newer_application)] == [
+        keep_token.uuid
+    ]
+    assert model.oauth.lookup_access_token_by_uuid(old_token.uuid) is None
+    assert model.oauth.lookup_access_token_by_uuid(keep_token.uuid) is not None
+
+
+def test_provision_ignores_duplicate_app_with_non_bootstrap_tokens(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, app_name="custom-bootstrap")
+    owner = model.user.get_user("devtable")
+    safe_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    unsafe_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    old_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        safe_application,
+        owner,
+        "repo:read",
+    )
+    unmarked_token, _ = model.oauth.create_user_access_token_for_application(
+        owner,
+        unsafe_application,
+        "repo:write",
+        "Bearer",
+        3600,
+    )
+    with open(config["BOOTSTRAP_TOKEN_PATH"], "w") as f:
+        f.write("not-json")
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    safe_tokens = model.oauth.get_bootstrap_tokens(safe_application)
+    assert [token.uuid for token in safe_tokens] == [old_token.uuid]
+    assert [token.uuid for token in model.oauth.get_application_tokens(unsafe_application)] == [
+        unmarked_token.uuid
+    ]
+    assert model.oauth.lookup_access_token_by_uuid(old_token.uuid) is not None
+    assert model.oauth.lookup_access_token_by_uuid(unmarked_token.uuid) is not None
+    with open(config["BOOTSTRAP_TOKEN_PATH"]) as f:
+        assert f.read() == "not-json"
+
+
+def test_provision_creates_new_bootstrap_app_when_named_apps_have_no_bootstrap_tokens(
+    initialized_db, tmp_path
+):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, app_name="custom-bootstrap")
+    owner = model.user.get_user("devtable")
+    existing_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    unmarked_token, _ = model.oauth.create_user_access_token_for_application(
+        owner,
+        existing_application,
+        "repo:write",
+        "Bearer",
+        3600,
+    )
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    applications = model.oauth.lookup_applications_by_name(owner, "custom-bootstrap")
+    bootstrap_applications = [
+        application for application in applications if model.oauth.get_bootstrap_tokens(application)
+    ]
+    assert len(applications) == 2
+    assert len(bootstrap_applications) == 1
+    assert bootstrap_applications[0].id != existing_application.id
+    assert [token.uuid for token in model.oauth.get_application_tokens(existing_application)] == [
+        unmarked_token.uuid
+    ]
+    assert model.oauth.validate_bootstrap_token(_stored_access_token(config), config) is not None
+
+
+def test_provision_skips_file_write_when_bootstrap_token_exists(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path)
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        owner,
+    )
+    old_token, _ = model.oauth.create_bootstrap_oauth_api_token(application, owner, "repo:read")
+    second_token, _ = model.oauth.create_bootstrap_oauth_api_token(application, owner, "repo:write")
+    with open(config["BOOTSTRAP_TOKEN_PATH"], "w") as f:
+        f.write("not-json")
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    tokens = model.oauth.get_bootstrap_tokens(application)
+    assert {token.uuid for token in tokens} == {old_token.uuid, second_token.uuid}
+    assert model.oauth.lookup_access_token_by_uuid(old_token.uuid) is not None
+    with open(config["BOOTSTRAP_TOKEN_PATH"]) as f:
+        assert f.read() == "not-json"
+
+
+def test_provision_skips_file_write_when_existing_bootstrap_token_is_expired(
+    initialized_db, tmp_path
+):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path)
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        owner,
+    )
+    expired_token, expired_access_token = model.oauth.create_bootstrap_oauth_api_token(
+        application,
+        owner,
+        "repo:read",
+        expiration_seconds=-1,
+    )
+    with open(config["BOOTSTRAP_TOKEN_PATH"], "w") as f:
+        json.dump({"access_token": expired_access_token}, f)
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    tokens = model.oauth.get_bootstrap_tokens(application)
+    assert [token.uuid for token in tokens] == [expired_token.uuid]
+    assert _stored_access_token(config) == expired_access_token
+    assert model.oauth.lookup_access_token_by_uuid(expired_token.uuid) is not None
+
+
+def test_provision_file_write_failure_rolls_back_new_db_token(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path)
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        owner,
+    )
+
+    with (
+        patch("boot.app") as mock_app,
+        patch("boot.db_transaction", db.obj.transaction),
+        patch("boot.write_bootstrap_token", side_effect=OSError("boom")),
+    ):
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    applications = model.oauth.lookup_applications_by_name(
+        owner,
+        model.oauth.get_bootstrap_app_name(config),
+    )
+    assert [existing_application.id for existing_application in applications] == [application.id]
+    assert model.oauth.get_bootstrap_tokens(application) == []
+    assert not os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+
+
+def test_provision_missing_owner_user_skips_provisioning(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, superusers=["missingowner"], owner="missingowner")
+    with (
+        patch("boot.app") as mock_app,
+        patch("boot.lock_bootstrap_token_operation") as mock_lock,
+    ):
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert not os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+    mock_lock.assert_not_called()
+
+
+def test_provision_non_superuser_owner_skips_provisioning(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, superusers=[], owner="devtable")
+    with (
+        patch("boot.app") as mock_app,
+        patch("boot.lock_bootstrap_token_operation") as mock_lock,
+    ):
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert not os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+    mock_lock.assert_not_called()
+
+
+def test_feature_disabled_revokes_owner_bootstrap_applications(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, feature_enabled=False)
+    owner = model.user.get_user("devtable")
+    other_user = model.user.get_user("freshuser")
+    application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        owner,
+    )
+    owner_token, _ = model.oauth.create_bootstrap_oauth_api_token(application, owner, "repo:read")
+    other_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        application, other_user, "repo:write"
+    )
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert (
+        model.oauth.lookup_applications_by_name(
+            owner,
+            model.oauth.get_bootstrap_app_name(config),
+        )
+        == []
+    )
+    assert model.oauth.lookup_access_token_by_uuid(owner_token.uuid) is None
+    assert model.oauth.lookup_access_token_by_uuid(other_token.uuid) is None
+
+
+def test_feature_disabled_deletes_bootstrap_application_with_mixed_tokens(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, feature_enabled=False)
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        owner,
+    )
+    bootstrap_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        application,
+        owner,
+        "repo:read",
+    )
+    unmarked_token, _ = model.oauth.create_user_access_token_for_application(
+        owner,
+        application,
+        "repo:admin",
+        "Bearer",
+        3600,
+    )
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert (
+        model.oauth.lookup_applications_by_name(
+            owner,
+            model.oauth.get_bootstrap_app_name(config),
+        )
+        == []
+    )
+    assert model.oauth.lookup_access_token_by_uuid(bootstrap_token.uuid) is None
+    assert model.oauth.lookup_access_token_by_uuid(unmarked_token.uuid) is None
+
+
+def test_feature_disabled_ignores_application_without_bootstrap_tokens(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, feature_enabled=False)
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_application(
+        owner,
+        model.oauth.get_bootstrap_app_name(config),
+        "",
+        "",
+    )
+    unmarked_token, _ = model.oauth.create_user_access_token_for_application(
+        owner,
+        application,
+        "repo:admin",
+        "Bearer",
+        3600,
+    )
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    existing_application_ids = []
+    existing_applications = model.oauth.lookup_applications_by_name(
+        owner,
+        model.oauth.get_bootstrap_app_name(config),
+    )
+    for existing_application in existing_applications:
+        existing_application_ids.append(existing_application.id)
+
+    unmarked_token_uuids = []
+    for existing_token in model.oauth.get_application_tokens(application):
+        unmarked_token_uuids.append(existing_token.uuid)
+
+    assert existing_application_ids == [application.id]
+    assert unmarked_token_uuids == [unmarked_token.uuid]
+
+
+def test_feature_disabled_revokes_when_configured_owner_is_not_superuser(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, feature_enabled=False, superusers=[])
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        owner,
+    )
+    token, _ = model.oauth.create_bootstrap_oauth_api_token(application, owner, "repo:read")
+
+    with (
+        patch("boot.app") as mock_app,
+        patch("boot.lock_bootstrap_token_operation") as mock_lock,
+    ):
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert (
+        model.oauth.lookup_applications_by_name(
+            owner,
+            model.oauth.get_bootstrap_app_name(config),
+        )
+        == []
+    )
+    assert model.oauth.lookup_access_token_by_uuid(token.uuid) is None
+    mock_lock.assert_called_once_with()
+
+
+def test_feature_disabled_uses_configured_owner_when_present(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(
+        tmp_path,
+        feature_enabled=False,
+        superusers=["devtable", "freshuser"],
+        owner="devtable",
+    )
+    owner = model.user.get_user("devtable")
+    other_super_user = model.user.get_user("freshuser")
+    owner_application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        owner,
+    )
+    other_application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        other_super_user,
+    )
+    owner_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        owner_application,
+        owner,
+        "repo:read",
+    )
+    other_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        other_application,
+        other_super_user,
+        "repo:read",
+    )
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert (
+        model.oauth.lookup_applications_by_name(
+            owner,
+            model.oauth.get_bootstrap_app_name(config),
+        )
+        == []
+    )
+    other_super_user_application_ids = []
+    other_super_user_applications = model.oauth.lookup_applications_by_name(
+        other_super_user,
+        model.oauth.get_bootstrap_app_name(config),
+    )
+    for existing_application in other_super_user_applications:
+        other_super_user_application_ids.append(existing_application.id)
+
+    assert other_super_user_application_ids == [other_application.id]
+    assert model.oauth.lookup_access_token_by_uuid(owner_token.uuid) is None
+    assert model.oauth.lookup_access_token_by_uuid(other_token.uuid) is not None
+
+
+def test_feature_disabled_falls_back_to_superusers_when_owner_is_missing(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(
+        tmp_path,
+        feature_enabled=False,
+        superusers=["devtable", "freshuser", "missingowner"],
+        owner="missingowner",
+    )
+    first_super_user = model.user.get_user("devtable")
+    second_super_user = model.user.get_user("freshuser")
+    first_application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        first_super_user,
+    )
+    second_application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        second_super_user,
+    )
+    first_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        first_application,
+        first_super_user,
+        "repo:read",
+    )
+    second_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        second_application,
+        second_super_user,
+        "repo:read",
+    )
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert (
+        model.oauth.lookup_applications_by_name(
+            first_super_user,
+            model.oauth.get_bootstrap_app_name(config),
+        )
+        == []
+    )
+    assert (
+        model.oauth.lookup_applications_by_name(
+            second_super_user,
+            model.oauth.get_bootstrap_app_name(config),
+        )
+        == []
+    )
+    assert model.oauth.lookup_access_token_by_uuid(first_token.uuid) is None
+    assert model.oauth.lookup_access_token_by_uuid(second_token.uuid) is None
+
+
+def test_feature_disabled_revokes_duplicate_bootstrap_applications(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(
+        tmp_path,
+        feature_enabled=False,
+        app_name="custom-bootstrap",
+    )
+    owner = model.user.get_user("devtable")
+    default_application = model.oauth.create_application(
+        owner, model.oauth.BOOTSTRAP_APP_NAME, "", ""
+    )
+    older_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    newer_application = model.oauth.create_application(owner, "custom-bootstrap", "", "")
+    default_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        default_application,
+        owner,
+        "repo:read",
+    )
+    older_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        older_application,
+        owner,
+        "repo:read",
+    )
+    newer_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        newer_application,
+        owner,
+        "repo:write",
+    )
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    default_bootstrap_token_uuids = []
+    for token in model.oauth.get_bootstrap_tokens(default_application):
+        default_bootstrap_token_uuids.append(token.uuid)
+
+    assert default_bootstrap_token_uuids == [default_token.uuid]
+    assert model.oauth.lookup_applications_by_name(owner, "custom-bootstrap") == []
+    assert model.oauth.lookup_access_token_by_uuid(default_token.uuid) is not None
+    assert model.oauth.lookup_access_token_by_uuid(older_token.uuid) is None
+    assert model.oauth.lookup_access_token_by_uuid(newer_token.uuid) is None

--- a/test/test_bootstrap_startup.py
+++ b/test/test_bootstrap_startup.py
@@ -436,6 +436,8 @@ def test_feature_disabled_revokes_owner_bootstrap_applications(initialized_db, t
     other_token, _ = model.oauth.create_bootstrap_oauth_api_token(
         application, other_user, "repo:write"
     )
+    with open(config["BOOTSTRAP_TOKEN_PATH"], "w") as f:
+        f.write("stale-token")
 
     with patch("boot.app") as mock_app:
         mock_app.config = config
@@ -450,6 +452,66 @@ def test_feature_disabled_revokes_owner_bootstrap_applications(initialized_db, t
     )
     assert model.oauth.lookup_access_token_by_uuid(owner_token.uuid) is None
     assert model.oauth.lookup_access_token_by_uuid(other_token.uuid) is None
+    assert not os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+
+
+def test_feature_disabled_deletes_stale_token_file_without_bootstrap_application(
+    initialized_db, tmp_path
+):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, feature_enabled=False)
+    with open(config["BOOTSTRAP_TOKEN_PATH"], "w") as f:
+        f.write("stale-token")
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert not os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+
+
+def test_feature_disabled_ignores_missing_local_token_file(initialized_db, tmp_path):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, feature_enabled=False)
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        owner,
+    )
+    token, _ = model.oauth.create_bootstrap_oauth_api_token(application, owner, "repo:read")
+
+    with patch("boot.app") as mock_app:
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    assert not os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+    assert model.oauth.lookup_access_token_by_uuid(token.uuid) is None
+
+
+def test_feature_disabled_revokes_database_tokens_when_local_file_delete_fails(
+    initialized_db, tmp_path
+):
+    from boot import setup_bootstrap_token
+
+    config = _app_config(tmp_path, feature_enabled=False)
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(config),
+        owner,
+    )
+    token, _ = model.oauth.create_bootstrap_oauth_api_token(application, owner, "repo:read")
+
+    with (
+        patch("boot.app") as mock_app,
+        patch("boot.delete_bootstrap_token", side_effect=OSError("boom")) as mock_delete,
+    ):
+        mock_app.config = config
+        setup_bootstrap_token()
+
+    mock_delete.assert_called_once_with(config)
+    assert model.oauth.lookup_access_token_by_uuid(token.uuid) is None
 
 
 def test_feature_disabled_deletes_bootstrap_application_with_mixed_tokens(initialized_db, tmp_path):

--- a/test/test_bootstrap_startup.py
+++ b/test/test_bootstrap_startup.py
@@ -374,7 +374,10 @@ def test_provision_file_write_failure_rolls_back_new_db_token(initialized_db, tm
 
     with (
         patch("boot.app") as mock_app,
-        patch("boot.db_transaction", db.obj.transaction),
+        # The PostgreSQL test fixture already runs each test inside a transaction.
+        # Use atomic() so this rollback is scoped to the provisioning operation
+        # without rolling back this test's setup rows.
+        patch("boot.db_transaction", db.obj.atomic),
         patch("boot.write_bootstrap_token", side_effect=OSError("boom")),
     ):
         mock_app.config = config

--- a/util/bootstrap_token.py
+++ b/util/bootstrap_token.py
@@ -30,6 +30,20 @@ def read_token_file(path):
     return _access_token_from_json(token_json)
 
 
+def delete_token_file(path):
+    """Delete path if present, returning whether a file was removed.
+
+    Missing files are expected in multi-node installations where bootstrap token
+    files are node-local. Raises OSError for failures other than absence.
+    """
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        return False
+
+    return True
+
+
 def write_token_file(path, access_token):
     """Write {"access_token": "..."} to path with 0600 permissions.
 
@@ -71,3 +85,13 @@ def write_bootstrap_token(app_config, access_token):
     """
     token_path = app_config.get("BOOTSTRAP_TOKEN_PATH", DEFAULT_BOOTSTRAP_TOKEN_PATH)
     write_token_file(token_path, access_token)
+
+
+def delete_bootstrap_token(app_config):
+    """Delete the configured local bootstrap token if present.
+
+    Returns whether a file was removed. Missing files are not an error because
+    token files are node-local in multi-node installations.
+    """
+    token_path = app_config.get("BOOTSTRAP_TOKEN_PATH", DEFAULT_BOOTSTRAP_TOKEN_PATH)
+    return delete_token_file(token_path)

--- a/util/bootstrap_token.py
+++ b/util/bootstrap_token.py
@@ -1,0 +1,73 @@
+import json
+import os
+import tempfile
+
+DEFAULT_BOOTSTRAP_TOKEN_PATH = "/var/lib/quay/quay-machine-token.json"
+MAX_BOOTSTRAP_TOKEN_FILE_BYTES = 4096
+
+
+def _access_token_from_json(token_json):
+    try:
+        data = json.loads(token_json)
+    except (TypeError, ValueError):
+        return None
+
+    access_token = data.get("access_token") if isinstance(data, dict) else None
+    return access_token if isinstance(access_token, str) and access_token else None
+
+
+def read_token_file(path):
+    """Read an access token from path, returning None if it is missing or malformed."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            token_json = f.read(MAX_BOOTSTRAP_TOKEN_FILE_BYTES + 1)
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    if len(token_json) > MAX_BOOTSTRAP_TOKEN_FILE_BYTES:
+        return None
+
+    return _access_token_from_json(token_json)
+
+
+def write_token_file(path, access_token):
+    """Write {"access_token": "..."} to path with 0600 permissions.
+
+    Creates parent directories if they don't exist and uses atomic replacement to
+    prevent partial writes. Raises OSError on failure.
+    """
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, mode=0o700, exist_ok=True)
+
+    fd = None
+    tmp_path = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(dir=parent or None, suffix=".tmp")
+        content = json.dumps({"access_token": access_token})
+        os.write(fd, content.encode("utf-8"))
+        os.fchmod(fd, 0o600)
+        os.close(fd)
+        fd = None
+        os.replace(tmp_path, path)
+        tmp_path = None
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if tmp_path is not None and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def read_bootstrap_token(app_config):
+    """Read the configured local bootstrap token, returning None if absent or malformed."""
+    token_path = app_config.get("BOOTSTRAP_TOKEN_PATH", DEFAULT_BOOTSTRAP_TOKEN_PATH)
+    return read_token_file(token_path)
+
+
+def write_bootstrap_token(app_config, access_token):
+    """Write the configured local bootstrap token.
+
+    Raises OSError on failure so callers can roll back database token state.
+    """
+    token_path = app_config.get("BOOTSTRAP_TOKEN_PATH", DEFAULT_BOOTSTRAP_TOKEN_PATH)
+    write_token_file(token_path, access_token)

--- a/util/test/test_bootstrap_token.py
+++ b/util/test/test_bootstrap_token.py
@@ -1,0 +1,111 @@
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from config import DefaultConfig
+from util.bootstrap_token import (
+    DEFAULT_BOOTSTRAP_TOKEN_PATH,
+    MAX_BOOTSTRAP_TOKEN_FILE_BYTES,
+    read_bootstrap_token,
+    read_token_file,
+    write_bootstrap_token,
+    write_token_file,
+)
+
+
+def test_default_bootstrap_token_path_matches_config():
+    assert DEFAULT_BOOTSTRAP_TOKEN_PATH == DefaultConfig.BOOTSTRAP_TOKEN_PATH
+
+
+def test_write_token_file_creates_file_with_restrictive_permissions(tmp_path):
+    path = str(tmp_path / "token.json")
+
+    write_token_file(path, "mytoken123")
+
+    with open(path) as f:
+        assert json.load(f) == {"access_token": "mytoken123"}
+    assert os.stat(path).st_mode & 0o777 == 0o600
+
+
+def test_write_token_file_creates_parents_and_overwrites_existing_file(tmp_path):
+    path = str(tmp_path / "a" / "b" / "token.json")
+
+    write_token_file(path, "old")
+    write_token_file(path, "new")
+
+    with open(path) as f:
+        assert json.load(f) == {"access_token": "new"}
+    assert os.stat(tmp_path / "a" / "b").st_mode & 0o777 == 0o700
+
+
+def test_write_token_file_invalid_path_raises_oserror():
+    with pytest.raises(OSError):
+        write_token_file("/proc/nonexistent/path/token.json", "tok")
+
+
+def test_write_token_file_removes_temp_file_on_write_failure(tmp_path):
+    path = str(tmp_path / "token.json")
+
+    with patch("util.bootstrap_token.os.write", side_effect=OSError("boom")):
+        with pytest.raises(OSError, match="boom"):
+            write_token_file(path, "tok")
+
+    assert not os.path.exists(path)
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_read_token_file_returns_token(tmp_path):
+    path = str(tmp_path / "token.json")
+    write_token_file(path, "mytoken123")
+
+    assert read_token_file(path) == "mytoken123"
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        None,
+        "not-json",
+        "{}",
+        json.dumps({"access_token": ""}),
+        json.dumps({"access_token": None}),
+        json.dumps({"access_token": 123}),
+        json.dumps(["not", "object"]),
+    ],
+)
+def test_read_token_file_missing_or_malformed_returns_none(tmp_path, content):
+    path = tmp_path / "token.json"
+    if content is not None:
+        path.write_text(content)
+
+    assert read_token_file(str(path)) is None
+
+
+def test_read_token_file_invalid_utf8_returns_none(tmp_path):
+    path = tmp_path / "token.json"
+    path.write_bytes(b"\xff\xfe\x00")
+
+    assert read_token_file(str(path)) is None
+
+
+@pytest.mark.parametrize("error", [IsADirectoryError, PermissionError])
+def test_read_token_file_open_os_error_returns_none(error):
+    with patch("builtins.open", side_effect=error("boom")):
+        assert read_token_file("/unreadable/token.json") is None
+
+
+def test_read_token_file_oversized_returns_none(tmp_path):
+    path = tmp_path / "token.json"
+    path.write_text("{" + " " * MAX_BOOTSTRAP_TOKEN_FILE_BYTES + "}")
+
+    assert read_token_file(str(path)) is None
+
+
+def test_write_and_read_bootstrap_token_uses_configured_path(tmp_path):
+    config = {"BOOTSTRAP_TOKEN_PATH": str(tmp_path / "token.json")}
+
+    write_bootstrap_token(config, "mytoken")
+
+    assert read_bootstrap_token(config) == "mytoken"

--- a/util/test/test_bootstrap_token.py
+++ b/util/test/test_bootstrap_token.py
@@ -8,6 +8,8 @@ from config import DefaultConfig
 from util.bootstrap_token import (
     DEFAULT_BOOTSTRAP_TOKEN_PATH,
     MAX_BOOTSTRAP_TOKEN_FILE_BYTES,
+    delete_bootstrap_token,
+    delete_token_file,
     read_bootstrap_token,
     read_token_file,
     write_bootstrap_token,
@@ -63,6 +65,20 @@ def test_read_token_file_returns_token(tmp_path):
     assert read_token_file(path) == "mytoken123"
 
 
+def test_delete_token_file_removes_existing_file(tmp_path):
+    path = str(tmp_path / "token.json")
+    write_token_file(path, "mytoken123")
+
+    assert delete_token_file(path) is True
+    assert not os.path.exists(path)
+
+
+def test_delete_token_file_missing_file_returns_false(tmp_path):
+    path = str(tmp_path / "token.json")
+
+    assert delete_token_file(path) is False
+
+
 @pytest.mark.parametrize(
     "content",
     [
@@ -109,3 +125,17 @@ def test_write_and_read_bootstrap_token_uses_configured_path(tmp_path):
     write_bootstrap_token(config, "mytoken")
 
     assert read_bootstrap_token(config) == "mytoken"
+
+
+def test_delete_bootstrap_token_uses_configured_path(tmp_path):
+    config = {"BOOTSTRAP_TOKEN_PATH": str(tmp_path / "token.json")}
+    write_bootstrap_token(config, "mytoken")
+
+    assert delete_bootstrap_token(config) is True
+    assert not os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+
+
+def test_delete_bootstrap_token_missing_file_returns_false(tmp_path):
+    config = {"BOOTSTRAP_TOKEN_PATH": str(tmp_path / "token.json")}
+
+    assert delete_bootstrap_token(config) is False

--- a/web/playwright/e2e/api/api-v1-org-user.spec.ts
+++ b/web/playwright/e2e/api/api-v1-org-user.spec.ts
@@ -563,6 +563,65 @@ test.describe(
         await adminClient.delete(`/api/v1/organization/${orgName}`);
       }
     });
+
+    test('admin cannot use the reserved bootstrap app name', async ({
+      adminClient,
+    }) => {
+      const orgName = uniqueName('org');
+      const reservedAppName = '__quay_bootstrap_app';
+      let clientId = '';
+
+      try {
+        await adminClient.post('/api/v1/organization/', {
+          name: orgName,
+          email: `${orgName}@example.com`,
+        });
+
+        const createReservedResp = await adminClient.post(
+          `/api/v1/organization/${orgName}/applications`,
+          {name: reservedAppName},
+        );
+        expect(createReservedResp.status()).toBe(400);
+        const createReservedBody = await createReservedResp.json();
+        expect(createReservedBody.detail).toBe(
+          'Application name is reserved for bootstrap token provisioning',
+        );
+
+        const appName = uniqueName('app');
+        const createResp = await adminClient.post(
+          `/api/v1/organization/${orgName}/applications`,
+          {name: appName},
+        );
+        expect(createResp.status()).toBe(200);
+        const createBody = await createResp.json();
+        clientId = createBody.client_id;
+
+        const updateReservedResp = await adminClient.put(
+          `/api/v1/organization/${orgName}/applications/${clientId}`,
+          {
+            name: reservedAppName,
+            description: 'reserved app description',
+            application_uri: 'https://quay.io',
+            client_id: clientId,
+            client_secret: createBody.client_secret,
+            redirect_uri: 'https://quay.io',
+            avatar_email: 'apptest@redhat.com',
+          },
+        );
+        expect(updateReservedResp.status()).toBe(400);
+        const updateReservedBody = await updateReservedResp.json();
+        expect(updateReservedBody.detail).toBe(
+          'Application name is reserved for bootstrap token provisioning',
+        );
+      } finally {
+        if (clientId) {
+          await adminClient.delete(
+            `/api/v1/organization/${orgName}/applications/${clientId}`,
+          );
+        }
+        await adminClient.delete(`/api/v1/organization/${orgName}`);
+      }
+    });
   },
 );
 


### PR DESCRIPTION
Add feature-flagged startup provisioning for a bootstrap OAuth token stored in a local file:

- create or reuse the owner-scoped bootstrap OAuth application
- keep startup idempotent when a bootstrap DB token already exists
- roll back newly created DB token state when local file writes fail
- revoke bootstrap tokens when the feature is disabled
- add Docker runtime directory support and reserved app-name guardrails