### PR TITLE
NO-ISSUE: ci(sentinel): add config-tool as reusable workflow

### DIFF
--- a/.github/workflows/ci-config-tool.yaml
+++ b/.github/workflows/ci-config-tool.yaml
@@ -43,7 +43,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: docker.io/library/golang:1.24.8
+    container: docker.io/library/golang:1.25.0
     services:
       postgres:
         image: postgres:11.5

--- a/.github/workflows/ci-config-tool.yaml
+++ b/.github/workflows/ci-config-tool.yaml
@@ -1,0 +1,76 @@
+name: Config Tool
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: config-tool/go.mod
+          cache-dependency-path: config-tool/go.sum
+
+      - name: Verify go.mod
+        run: cd ./config-tool && go mod tidy && git diff --exit-code
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: config-tool/go.mod
+          cache-dependency-path: config-tool/go.sum
+
+      - name: Build
+        run: cd ./config-tool && go build -v ./...
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    container: docker.io/library/golang:1.24.8
+    services:
+      postgres:
+        image: postgres:11.5
+        env:
+          POSTGRES_USER: "user"
+          POSTGRES_PASSWORD: "password"
+          POSTGRES_DB: "quay"
+      redis:
+        image: redis:7.4
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: quay
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Workaround for dubious ownership issue
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Build
+        run: cd ./config-tool && go build -v ./...
+      - name: Tests
+        run: cd ./config-tool && go test ./pkg/lib/fieldgroups/...
+        env:
+          GODEBUG: x509ignoreCN=0

--- a/.github/workflows/sentinel.yaml
+++ b/.github/workflows/sentinel.yaml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       go: ${{ steps.filter.outputs.go }}
+      config-tool: ${{ steps.filter.outputs.config-tool }}
       python: ${{ steps.filter.outputs.python }}
       web: ${{ steps.filter.outputs.web }}
     steps:
@@ -51,6 +52,9 @@ jobs:
               - 'Makefile'
               - 'requirements.txt'
               - '!config-tool/**'
+            config-tool:
+              - 'config-tool/**'
+              - '.github/workflows/ci-config-tool.yaml'
             python:
               - '**/*.py'
               - 'requirements*.txt'
@@ -88,6 +92,8 @@ jobs:
               - '!OWNERS'
               - '!internal/**'
               - '!cmd/**'
+              - '!config-tool/**'
+              - '!.github/workflows/ci-config-tool.yaml'
 
   pr-lint:
     name: conventional commit check
@@ -121,6 +127,12 @@ jobs:
     if: ${{ needs.detect-changes.outputs.go == 'true' }}
     uses: ./.github/workflows/ci-go.yaml
 
+  config-tool-ci:
+    name: Config Tool
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.config-tool == 'true' }}
+    uses: ./.github/workflows/ci-config-tool.yaml
+
   web-ci:
     name: Web
     needs: detect-changes
@@ -133,7 +145,7 @@ jobs:
 
   all-green:
     name: all-green
-    needs: [detect-changes, pr-lint, python-ci, go-ci, web-ci]
+    needs: [detect-changes, pr-lint, python-ci, go-ci, config-tool-ci, web-ci]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -145,6 +157,8 @@ jobs:
               github.event_name != 'pull_request' && 'pr-lint,' || ''
             }}${{
               needs.go-ci.result == 'skipped' && 'go-ci,' || ''
+            }}${{
+              needs.config-tool-ci.result == 'skipped' && 'config-tool-ci,' || ''
             }}${{
               needs.python-ci.result == 'skipped' && 'python-ci,' || ''
             }}${{


### PR DESCRIPTION
## Summary
- Adds `ci-config-tool.yaml` as a reusable workflow called by the sentinel gate
- Config-tool CI (lint, build, tests) only runs when `config-tool/**` or its workflow file changes
- Excludes `config-tool/**` and `.github/workflows/ci-config-tool.yaml` from the `web` filter to avoid unnecessary runs