### PR TITLE
PROJQUAY-11712: chore(deps): update go version to 1.25.0

### DIFF
--- a/.github/workflows/config-tool.yaml
+++ b/.github/workflows/config-tool.yaml
@@ -55,7 +55,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: docker.io/library/golang:1.24.8
+    container: docker.io/library/golang:1.25.0
     services:
       postgres:
         image: postgres:11.5


### PR DESCRIPTION
Update go version 1.25.0

Fix for [https://github.com/quay/quay/actions/runs/28178354344/job/83460811800?pr=6239  [redhat-3.17] [PROJQUAY-11712](https://redhat.atlassian.net/browse/PROJQUAY-11712): deps: Bump golang.org/x/net to version 0.55.0 #1299](https://github.com/quay/quay/pull/6239) 