### PR TITLE
PROJQUAY-11857: fix(serve): FIPS blob upload failure from unflushed buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -458,6 +458,7 @@ GO_BUILD_DIR = bin
 GO_CMD_DIR = cmd/quay
 GO_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null)
 GO_LDFLAGS = $(if $(GO_VERSION),-ldflags "-X github.com/quay/quay/internal/cmd.version=$(GO_VERSION)")
+GO_BUILD_TAGS ?=
 
 SCHEMA_DIR := internal/dal/schema
 SCHEMA_TMP := /tmp/quay-schema-tmp
@@ -510,14 +511,18 @@ go-schema-check:
 	  (echo "ERROR: Generated Go code is out of date. Run 'make go-schema' and commit." && exit 1)
 	@echo "All checks passed."
 
-.PHONY: go-build go-test go-fmt go-vet go-clean
+.PHONY: go-build go-build-fips go-test go-fmt go-vet go-clean
 
 go-build:
 	@mkdir -p $(GO_BUILD_DIR)
-	go build $(GO_LDFLAGS) -o $(GO_BUILD_DIR)/$(GO_BINARY_NAME) ./$(GO_CMD_DIR)
+	go build $(GO_LDFLAGS) $(if $(GO_BUILD_TAGS),-tags='$(GO_BUILD_TAGS)',) -o $(GO_BUILD_DIR)/$(GO_BINARY_NAME) ./$(GO_CMD_DIR)
+
+go-build-fips:
+	@mkdir -p $(GO_BUILD_DIR)
+	GOFIPS140=latest go build $(GO_LDFLAGS) -tags='noresumabledigest' -o $(GO_BUILD_DIR)/$(GO_BINARY_NAME) ./$(GO_CMD_DIR)
 
 go-test:
-	go test -cover -race ./...
+	go test -cover -race $(if $(GO_BUILD_TAGS),-tags='$(GO_BUILD_TAGS)',) ./...
 
 go-fmt:
 	go fmt ./...

--- a/Makefile
+++ b/Makefile
@@ -458,6 +458,7 @@ GO_BUILD_DIR = bin
 GO_CMD_DIR = cmd/quay
 GO_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null)
 GO_LDFLAGS = $(if $(GO_VERSION),-ldflags "-X github.com/quay/quay/internal/mirrorregistry/cmd.version=$(GO_VERSION)")
+GO_BUILD_TAGS ?=
 
 SCHEMA_DIR := internal/dal/schema
 SCHEMA_TMP := /tmp/quay-schema-tmp
@@ -516,14 +517,18 @@ go-schema-check:
 	  (echo "ERROR: Generated Go code is out of date. Run 'make go-schema' and commit." && exit 1)
 	@echo "All checks passed."
 
-.PHONY: go-build go-test go-fmt go-vet go-clean
+.PHONY: go-build go-build-fips go-test go-fmt go-vet go-clean
 
 go-build:
 	@mkdir -p $(GO_BUILD_DIR)
-	go build $(GO_LDFLAGS) -o $(GO_BUILD_DIR)/$(GO_BINARY_NAME) ./$(GO_CMD_DIR)
+	go build $(GO_LDFLAGS) $(if $(GO_BUILD_TAGS),-tags='$(GO_BUILD_TAGS)',) -o $(GO_BUILD_DIR)/$(GO_BINARY_NAME) ./$(GO_CMD_DIR)
+
+go-build-fips:
+	@mkdir -p $(GO_BUILD_DIR)
+	GOFIPS140=latest go build $(GO_LDFLAGS) -tags='noresumabledigest' -o $(GO_BUILD_DIR)/$(GO_BINARY_NAME) ./$(GO_CMD_DIR)
 
 go-test:
-	go test -cover -race ./...
+	go test -cover -race $(if $(GO_BUILD_TAGS),-tags='$(GO_BUILD_TAGS)',) ./...
 
 go-fmt:
 	go fmt ./...

--- a/internal/cmd/fips_upload_test.go
+++ b/internal/cmd/fips_upload_test.go
@@ -63,7 +63,11 @@ func TestChunkedUploadOffsetMismatch(t *testing.T) {
 
 	// Step 1: POST to start a new upload
 	postURL := fmt.Sprintf("%s/v2/%s/blobs/uploads/", ts.URL, repo)
-	resp, err := http.Post(postURL, "", nil)
+	postReq, err := http.NewRequestWithContext(t.Context(), http.MethodPost, postURL, http.NoBody)
+	if err != nil {
+		t.Fatalf("POST request creation failed: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(postReq)
 	if err != nil {
 		t.Fatalf("POST failed: %v", err)
 	}
@@ -89,7 +93,7 @@ func TestChunkedUploadOffsetMismatch(t *testing.T) {
 	// Close() skips the flush, leaving the buffered bytes on disk.
 	chunkData := bytes.Repeat([]byte("A"), 8192)
 
-	patchReq, err := http.NewRequest(http.MethodPatch, uploadURL, bytes.NewReader(chunkData))
+	patchReq, err := http.NewRequestWithContext(t.Context(), http.MethodPatch, uploadURL, bytes.NewReader(chunkData))
 	if err != nil {
 		t.Fatalf("PATCH request creation failed: %v", err)
 	}
@@ -137,7 +141,7 @@ func TestChunkedUploadOffsetMismatch(t *testing.T) {
 	q.Set("digest", digest)
 	putURL.RawQuery = q.Encode()
 
-	putReq, err := http.NewRequest(http.MethodPut, putURL.String(), nil)
+	putReq, err := http.NewRequestWithContext(t.Context(), http.MethodPut, putURL.String(), http.NoBody)
 	if err != nil {
 		t.Fatalf("PUT request creation failed: %v", err)
 	}

--- a/internal/cmd/fips_upload_test.go
+++ b/internal/cmd/fips_upload_test.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/distribution/distribution/v3/configuration"
+	"github.com/distribution/distribution/v3/registry/handlers"
+	_ "github.com/distribution/distribution/v3/registry/storage/driver/filesystem"
+)
+
+// TestChunkedUploadOffsetMismatch reproduces the bug that causes HTTP 416
+// "invalid content range" errors when the distribution registry is built
+// with Red Hat's FIPS-enabled Go compiler (golang-fips).
+//
+// Root cause: blobWriter.Close() calls storeHashState(), which tries to
+// marshal the SHA-256 hash state via encoding.BinaryMarshaler. Under
+// golang-fips, the OpenSSL-backed hash implements the interface at the
+// type level but MarshalBinary() returns an error ("hash state is not
+// marshallable"). Close() treats this as a fatal error and returns early
+// WITHOUT flushing the fileWriter's bufio buffer. The state token then
+// records an Offset that includes buffered (unflushed) bytes, while the
+// actual file on disk is smaller. On the next request, the offset check
+// fails → HTTP 416.
+//
+// This test verifies the upload flow works correctly under normal (non-FIPS)
+// conditions. Under FIPS with golang-fips, the PATCH step would produce a
+// state token whose offset exceeds the file size, and the PUT step would
+// fail with 416.
+//
+// Building with -tags=noresumabledigest fixes the issue by replacing
+// storeHashState with a noop that returns errResumableDigestNotAvailable,
+// which Close() handles correctly (always flushes the buffer).
+func TestChunkedUploadOffsetMismatch(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := &configuration.Configuration{
+		Storage: configuration.Storage{
+			"filesystem": configuration.Parameters{
+				"rootdirectory": dir,
+			},
+			"delete": configuration.Parameters{
+				"enabled": true,
+			},
+		},
+	}
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.HTTP.Secret = "test-secret-for-hmac"
+
+	app := handlers.NewApp(t.Context(), cfg)
+	ts := httptest.NewServer(app)
+	defer ts.Close()
+
+	repo := "test/fips-upload"
+
+	// Step 1: POST to start a new upload
+	postURL := fmt.Sprintf("%s/v2/%s/blobs/uploads/", ts.URL, repo)
+	resp, err := http.Post(postURL, "", nil)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("POST: expected 202, got %d", resp.StatusCode)
+	}
+
+	uploadURL := resp.Header.Get("Location")
+	if uploadURL == "" {
+		t.Fatal("POST: no Location header")
+	}
+	if strings.HasPrefix(uploadURL, "/") {
+		uploadURL = ts.URL + uploadURL
+	}
+
+	t.Logf("Upload URL: %s", uploadURL)
+
+	// Step 2: PATCH to send chunk data
+	// Using 8KB — larger than bufio's default 4KB buffer so some data
+	// gets flushed and some stays buffered. Under FIPS (golang-fips),
+	// Close() skips the flush, leaving the buffered bytes on disk.
+	chunkData := bytes.Repeat([]byte("A"), 8192)
+
+	patchReq, err := http.NewRequest(http.MethodPatch, uploadURL, bytes.NewReader(chunkData))
+	if err != nil {
+		t.Fatalf("PATCH request creation failed: %v", err)
+	}
+	patchReq.Header.Set("Content-Type", "application/octet-stream")
+	patchReq.Header.Set("Content-Range", fmt.Sprintf("0-%d", len(chunkData)-1))
+	patchReq.Header.Set("Content-Length", fmt.Sprintf("%d", len(chunkData)))
+
+	resp, err = http.DefaultClient.Do(patchReq)
+	if err != nil {
+		t.Fatalf("PATCH failed: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("PATCH: expected 202, got %d; body: %s", resp.StatusCode, body)
+	}
+
+	patchLocation := resp.Header.Get("Location")
+	if patchLocation == "" {
+		t.Fatal("PATCH: no Location header")
+	}
+	if strings.HasPrefix(patchLocation, "/") {
+		patchLocation = ts.URL + patchLocation
+	}
+
+	rangeHeader := resp.Header.Get("Range")
+	t.Logf("PATCH response Range: %s", rangeHeader)
+
+	expectedRange := fmt.Sprintf("0-%d", len(chunkData)-1)
+	if rangeHeader != expectedRange {
+		t.Errorf("PATCH Range: expected %q, got %q — offset mismatch indicates unflushed buffer (FIPS bug)", expectedRange, rangeHeader)
+	}
+
+	// Step 3: PUT to finalize
+	// Under FIPS with golang-fips, this fails with 416 because the state
+	// token's offset (from PATCH) doesn't match the file on disk.
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(chunkData))
+
+	putURL, err := url.Parse(patchLocation)
+	if err != nil {
+		t.Fatalf("Failed to parse PATCH location: %v", err)
+	}
+	q := putURL.Query()
+	q.Set("digest", digest)
+	putURL.RawQuery = q.Encode()
+
+	putReq, err := http.NewRequest(http.MethodPut, putURL.String(), nil)
+	if err != nil {
+		t.Fatalf("PUT request creation failed: %v", err)
+	}
+
+	resp, err = http.DefaultClient.Do(putReq)
+	if err != nil {
+		t.Fatalf("PUT failed: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable {
+		var errResp struct {
+			Errors []struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		if err := json.Unmarshal(body, &errResp); err == nil {
+			for _, e := range errResp.Errors {
+				if e.Code == "RANGE_INVALID" {
+					t.Fatalf("PUT got 416 RANGE_INVALID: %s — "+
+						"This is the FIPS bug! The state token offset doesn't match "+
+						"the file on disk because Close() didn't flush the buffer. "+
+						"Build with -tags=noresumabledigest to fix.", e.Message)
+				}
+			}
+		}
+		t.Fatalf("PUT: got 416; body: %s", body)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("PUT: expected 201, got %d; body: %s", resp.StatusCode, body)
+	}
+
+	t.Log("Chunked upload succeeded — no offset mismatch")
+}

--- a/internal/mirrorregistry/cmd/fips_upload_test.go
+++ b/internal/mirrorregistry/cmd/fips_upload_test.go
@@ -63,7 +63,11 @@ func TestChunkedUploadOffsetMismatch(t *testing.T) {
 
 	// Step 1: POST to start a new upload
 	postURL := fmt.Sprintf("%s/v2/%s/blobs/uploads/", ts.URL, repo)
-	resp, err := http.Post(postURL, "", nil)
+	postReq, err := http.NewRequestWithContext(t.Context(), http.MethodPost, postURL, http.NoBody)
+	if err != nil {
+		t.Fatalf("POST request creation failed: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(postReq)
 	if err != nil {
 		t.Fatalf("POST failed: %v", err)
 	}
@@ -89,7 +93,7 @@ func TestChunkedUploadOffsetMismatch(t *testing.T) {
 	// Close() skips the flush, leaving the buffered bytes on disk.
 	chunkData := bytes.Repeat([]byte("A"), 8192)
 
-	patchReq, err := http.NewRequest(http.MethodPatch, uploadURL, bytes.NewReader(chunkData))
+	patchReq, err := http.NewRequestWithContext(t.Context(), http.MethodPatch, uploadURL, bytes.NewReader(chunkData))
 	if err != nil {
 		t.Fatalf("PATCH request creation failed: %v", err)
 	}
@@ -137,7 +141,7 @@ func TestChunkedUploadOffsetMismatch(t *testing.T) {
 	q.Set("digest", digest)
 	putURL.RawQuery = q.Encode()
 
-	putReq, err := http.NewRequest(http.MethodPut, putURL.String(), nil)
+	putReq, err := http.NewRequestWithContext(t.Context(), http.MethodPut, putURL.String(), http.NoBody)
 	if err != nil {
 		t.Fatalf("PUT request creation failed: %v", err)
 	}

--- a/internal/mirrorregistry/cmd/fips_upload_test.go
+++ b/internal/mirrorregistry/cmd/fips_upload_test.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/distribution/distribution/v3/configuration"
+	"github.com/distribution/distribution/v3/registry/handlers"
+	_ "github.com/distribution/distribution/v3/registry/storage/driver/filesystem"
+)
+
+// TestChunkedUploadOffsetMismatch reproduces the bug that causes HTTP 416
+// "invalid content range" errors when the distribution registry is built
+// with Red Hat's FIPS-enabled Go compiler (golang-fips).
+//
+// Root cause: blobWriter.Close() calls storeHashState(), which tries to
+// marshal the SHA-256 hash state via encoding.BinaryMarshaler. Under
+// golang-fips, the OpenSSL-backed hash implements the interface at the
+// type level but MarshalBinary() returns an error ("hash state is not
+// marshallable"). Close() treats this as a fatal error and returns early
+// WITHOUT flushing the fileWriter's bufio buffer. The state token then
+// records an Offset that includes buffered (unflushed) bytes, while the
+// actual file on disk is smaller. On the next request, the offset check
+// fails → HTTP 416.
+//
+// This test verifies the upload flow works correctly under normal (non-FIPS)
+// conditions. Under FIPS with golang-fips, the PATCH step would produce a
+// state token whose offset exceeds the file size, and the PUT step would
+// fail with 416.
+//
+// Building with -tags=noresumabledigest fixes the issue by replacing
+// storeHashState with a noop that returns errResumableDigestNotAvailable,
+// which Close() handles correctly (always flushes the buffer).
+func TestChunkedUploadOffsetMismatch(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := &configuration.Configuration{
+		Storage: configuration.Storage{
+			"filesystem": configuration.Parameters{
+				"rootdirectory": dir,
+			},
+			"delete": configuration.Parameters{
+				"enabled": true,
+			},
+		},
+	}
+	cfg.HTTP.Addr = "127.0.0.1:0"
+	cfg.HTTP.Secret = "test-secret-for-hmac"
+
+	app := handlers.NewApp(t.Context(), cfg)
+	ts := httptest.NewServer(app)
+	defer ts.Close()
+
+	repo := "test/fips-upload"
+
+	// Step 1: POST to start a new upload
+	postURL := fmt.Sprintf("%s/v2/%s/blobs/uploads/", ts.URL, repo)
+	resp, err := http.Post(postURL, "", nil)
+	if err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("POST: expected 202, got %d", resp.StatusCode)
+	}
+
+	uploadURL := resp.Header.Get("Location")
+	if uploadURL == "" {
+		t.Fatal("POST: no Location header")
+	}
+	if strings.HasPrefix(uploadURL, "/") {
+		uploadURL = ts.URL + uploadURL
+	}
+
+	t.Logf("Upload URL: %s", uploadURL)
+
+	// Step 2: PATCH to send chunk data
+	// Using 8KB — larger than bufio's default 4KB buffer so some data
+	// gets flushed and some stays buffered. Under FIPS (golang-fips),
+	// Close() skips the flush, leaving the buffered bytes on disk.
+	chunkData := bytes.Repeat([]byte("A"), 8192)
+
+	patchReq, err := http.NewRequest(http.MethodPatch, uploadURL, bytes.NewReader(chunkData))
+	if err != nil {
+		t.Fatalf("PATCH request creation failed: %v", err)
+	}
+	patchReq.Header.Set("Content-Type", "application/octet-stream")
+	patchReq.Header.Set("Content-Range", fmt.Sprintf("0-%d", len(chunkData)-1))
+	patchReq.Header.Set("Content-Length", fmt.Sprintf("%d", len(chunkData)))
+
+	resp, err = http.DefaultClient.Do(patchReq)
+	if err != nil {
+		t.Fatalf("PATCH failed: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("PATCH: expected 202, got %d; body: %s", resp.StatusCode, body)
+	}
+
+	patchLocation := resp.Header.Get("Location")
+	if patchLocation == "" {
+		t.Fatal("PATCH: no Location header")
+	}
+	if strings.HasPrefix(patchLocation, "/") {
+		patchLocation = ts.URL + patchLocation
+	}
+
+	rangeHeader := resp.Header.Get("Range")
+	t.Logf("PATCH response Range: %s", rangeHeader)
+
+	expectedRange := fmt.Sprintf("0-%d", len(chunkData)-1)
+	if rangeHeader != expectedRange {
+		t.Errorf("PATCH Range: expected %q, got %q — offset mismatch indicates unflushed buffer (FIPS bug)", expectedRange, rangeHeader)
+	}
+
+	// Step 3: PUT to finalize
+	// Under FIPS with golang-fips, this fails with 416 because the state
+	// token's offset (from PATCH) doesn't match the file on disk.
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(chunkData))
+
+	putURL, err := url.Parse(patchLocation)
+	if err != nil {
+		t.Fatalf("Failed to parse PATCH location: %v", err)
+	}
+	q := putURL.Query()
+	q.Set("digest", digest)
+	putURL.RawQuery = q.Encode()
+
+	putReq, err := http.NewRequest(http.MethodPut, putURL.String(), nil)
+	if err != nil {
+		t.Fatalf("PUT request creation failed: %v", err)
+	}
+
+	resp, err = http.DefaultClient.Do(putReq)
+	if err != nil {
+		t.Fatalf("PUT failed: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable {
+		var errResp struct {
+			Errors []struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		if err := json.Unmarshal(body, &errResp); err == nil {
+			for _, e := range errResp.Errors {
+				if e.Code == "RANGE_INVALID" {
+					t.Fatalf("PUT got 416 RANGE_INVALID: %s — "+
+						"This is the FIPS bug! The state token offset doesn't match "+
+						"the file on disk because Close() didn't flush the buffer. "+
+						"Build with -tags=noresumabledigest to fix.", e.Message)
+				}
+			}
+		}
+		t.Fatalf("PUT: got 416; body: %s", body)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("PUT: expected 201, got %d; body: %s", resp.StatusCode, body)
+	}
+
+	t.Log("Chunked upload succeeded — no offset mismatch")
+}


### PR DESCRIPTION
## Summary

- Add `go-build-fips` Makefile target that builds with `GOFIPS140=latest` and `-tags='noresumabledigest'`, and a `GO_BUILD_TAGS` variable so `go-build`/`go-test` can take extra tags
- Add chunked upload regression test (`POST → PATCH → PUT` flow)

## Problem

The OMR fails all chunked blob uploads with HTTP 416 "invalid content range" when built with Red Hat's FIPS Go compiler (`GOEXPERIMENT=strictfipsruntime`).

**Root cause:** Under `golang-fips`, the OpenSSL-backed SHA-256 hash implements `encoding.BinaryMarshaler` at the type level, but `MarshalBinary()` returns an error ("hash state is not marshallable") because OpenSSL won't expose internal hash state. In `distribution/v3`'s `blobWriter.Close()`, `storeHashState()` returns this error (which is NOT `errResumableDigestNotAvailable`), so `Close()` exits early **without flushing the fileWriter's bufio buffer**. The state token then records an offset that includes unflushed bytes, while the file on disk is smaller. On the next request, the offset check fails → HTTP 416.

**The fix:** Building with `-tags=noresumabledigest` replaces `storeHashState` with a noop that returns `errResumableDigestNotAvailable`, which `Close()` handles correctly — always flushing the buffer. Resumable digests don't work under FIPS anyway since OpenSSL hash state can't be serialized.

## Companion PR

- quay-konflux-components: https://github.com/quay/quay-konflux-components/pull/2829 — adds `noresumabledigest` to the quay-mirror Containerfile build tags

## Test plan

- [x] `make go-build` succeeds (standard build, backwards compatible)
- [x] `make go-build-fips` succeeds (FIPS build with noresumabledigest)
- [x] `go test -v -run TestChunkedUploadOffsetMismatch ./internal/cmd/` passes
- [x] Same test passes with `-tags=noresumabledigest`
- [x] Fresh OMR 3.0 install under FIPS — PASS
- [x] Push multi-layer images (chunked blob uploads) under FIPS — no 416 errors
- [x] OMR 2.0 → 3.0 migration under FIPS — PASS
- [x] FIPS crypto verified (OpenSSL `libcrypto.so.3` loaded, `X:strictfipsruntime` in binary)
- [ ] Konflux build with updated tags produces working OMR image

Rebased on master 2026-09-21 (resolved the `.PHONY` line against `go-test-postgres`); `make go-build`, `make go-build-fips`, `go test -race ./internal/mirrorregistry/cmd/` and `golangci-lint` pass on Linux.
