### PR TITLE
NO-ISSUE: fix(oci): unlink deleted repo blobs

### DIFF
--- a/internal/dal/daldb/storage.sql.go
+++ b/internal/dal/daldb/storage.sql.go
@@ -51,6 +51,27 @@ func (q *Queries) DeleteImageStorage(ctx context.Context, id int64) error {
 	return err
 }
 
+const deleteUploadedBlob = `-- name: DeleteUploadedBlob :execrows
+DELETE FROM uploadedblob
+WHERE repository_id = ?
+  AND blob_id IN (
+    SELECT id FROM imagestorage WHERE content_checksum = ?
+  )
+`
+
+type DeleteUploadedBlobParams struct {
+	RepositoryID    int64          `json:"repository_id"`
+	ContentChecksum sql.NullString `json:"content_checksum"`
+}
+
+func (q *Queries) DeleteUploadedBlob(ctx context.Context, arg DeleteUploadedBlobParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteUploadedBlob, arg.RepositoryID, arg.ContentChecksum)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const findOrphanedBlobs = `-- name: FindOrphanedBlobs :many
 SELECT s.id, s.content_checksum, s.uuid, s.image_size
 FROM imagestorage s

--- a/internal/dal/metastore/metastore_sqlite.go
+++ b/internal/dal/metastore/metastore_sqlite.go
@@ -501,6 +501,21 @@ func (s *SQLiteStore) PutUploadedBlob(ctx context.Context, repoID int64, dgst di
 	return tx.Commit()
 }
 
+// DeleteUploadedBlob removes a repository-scoped upload marker for a blob.
+func (s *SQLiteStore) DeleteUploadedBlob(ctx context.Context, repoID int64, dgst digest.Digest) (int64, error) {
+	q := daldb.New(s.db)
+	checksum := sql.NullString{String: dgst.String(), Valid: true}
+
+	rows, err := q.DeleteUploadedBlob(ctx, daldb.DeleteUploadedBlobParams{
+		RepositoryID:    repoID,
+		ContentChecksum: checksum,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("delete uploaded blob %s from repo %d: %w", dgst, repoID, err)
+	}
+	return rows, nil
+}
+
 // CleanExpiredUploadedBlobs removes uploaded blob markers that have expired.
 func (s *SQLiteStore) CleanExpiredUploadedBlobs(ctx context.Context) error {
 	q := daldb.New(s.db)

--- a/internal/dal/metastore/metastore_sqlite_read_test.go
+++ b/internal/dal/metastore/metastore_sqlite_read_test.go
@@ -262,6 +262,63 @@ func TestPutUploadedBlob(t *testing.T) {
 	}
 }
 
+func TestDeleteUploadedBlobRemovesOnlyRepoScopedUploadLink(t *testing.T) {
+	store, cleanup := testStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	repoOne, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "ns", Name: "one"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoTwo, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "ns", Name: "two"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dgst := digest.FromString("uploaded-blob")
+	if _, err := store.PutBlob(ctx, oci.BlobRecord{Digest: dgst, Size: 100}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutUploadedBlob(ctx, repoOne, dgst); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutUploadedBlob(ctx, repoTwo, dgst); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := store.DeleteUploadedBlob(ctx, repoOne, dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Fatalf("DeleteUploadedBlob rows = %d, want 1", rows)
+	}
+
+	linked, err := store.BlobLinkedToRepo(ctx, repoOne, dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linked {
+		t.Fatal("BlobLinkedToRepo = true for deleted repo upload link")
+	}
+
+	linked, err = store.BlobLinkedToRepo(ctx, repoTwo, dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !linked {
+		t.Fatal("BlobLinkedToRepo = false for untouched repo upload link")
+	}
+
+	exists, err := store.BlobExists(ctx, dgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("BlobExists = false after deleting one repo upload link")
+	}
+}
+
 func TestCleanExpiredUploadedBlobs(t *testing.T) {
 	store, cleanup := testStore(t)
 	defer cleanup()

--- a/internal/dal/queries/storage.sql
+++ b/internal/dal/queries/storage.sql
@@ -26,6 +26,13 @@ SELECT COALESCE(SUM(image_size), 0) FROM imagestorage WHERE uploading = 0;
 INSERT OR IGNORE INTO uploadedblob (repository_id, blob_id, uploaded_at, expires_at)
 VALUES (?, ?, datetime('now'), datetime('now', '+1 hour'));
 
+-- name: DeleteUploadedBlob :execrows
+DELETE FROM uploadedblob
+WHERE repository_id = ?
+  AND blob_id IN (
+    SELECT id FROM imagestorage WHERE content_checksum = ?
+  );
+
 -- name: CleanExpiredUploadedBlobs :exec
 DELETE FROM uploadedblob WHERE expires_at < datetime('now');
 

--- a/internal/oci/metadata.go
+++ b/internal/oci/metadata.go
@@ -29,6 +29,7 @@ type MetadataStore interface {
 
 	// Upload tracking (prevents GC of unreferenced blobs during push)
 	PutUploadedBlob(ctx context.Context, repoID int64, dgst digest.Digest) error
+	DeleteUploadedBlob(ctx context.Context, repoID int64, dgst digest.Digest) (int64, error)
 	CleanExpiredUploadedBlobs(ctx context.Context) error
 }
 

--- a/internal/oci/storage/local/distcompat.go
+++ b/internal/oci/storage/local/distcompat.go
@@ -122,20 +122,14 @@ func (d *DistDriver) resolveLink(ctx context.Context, repoID int64, path string)
 	return "", fmt.Errorf("unknown metadata path")
 }
 
-// resolveLayerLink checks if a blob is linked to the repo (via manifestblob or
-// uploadedblob), falling back to global existence for blobs uploaded but not
-// yet referenced by a manifest.
+// resolveLayerLink checks if a blob is linked to the repo via manifestblob or
+// uploadedblob, matching Python's repository-scoped blob lookup.
 func (d *DistDriver) resolveLayerLink(ctx context.Context, repoID int64, path string) (digest.Digest, error) {
 	dgst, err := digestFromLinkPath(path, "/_layers/")
 	if err != nil {
 		return "", err
 	}
 	if ok, err := d.meta.BlobLinkedToRepo(ctx, repoID, dgst); err != nil {
-		return "", err
-	} else if ok {
-		return dgst, nil
-	}
-	if ok, err := d.meta.BlobExists(ctx, dgst); err != nil {
 		return "", err
 	} else if ok {
 		return dgst, nil
@@ -518,8 +512,8 @@ func (d *DistDriver) Move(ctx context.Context, src, dst string) error {
 	return d.blobs.CommitUpload(ctx, id, dgst)
 }
 
-// Delete removes blobs by digest, upload directories by canceling the
-// upload, and is a no-op for metadata (handled by the middleware).
+// Delete removes blobs by digest, upload directories by canceling the upload,
+// and repo-scoped layer upload links by unlinking uploadedblob metadata.
 func (d *DistDriver) Delete(ctx context.Context, path string) error {
 	switch classify(path) {
 	case pathBlob:
@@ -542,8 +536,35 @@ func (d *DistDriver) Delete(ctx context.Context, path string) error {
 		return err
 
 	default:
+		if strings.Contains(path, "/_layers/") && strings.HasSuffix(path, "/link") {
+			return d.deleteLayerLink(ctx, path)
+		}
 		return nil // metadata deletion handled by middleware
 	}
+}
+
+func (d *DistDriver) deleteLayerLink(ctx context.Context, path string) error {
+	repo := repoFromPath(path)
+	if repo == "" {
+		return storagedriver.PathNotFoundError{Path: path}
+	}
+	repoID, err := d.meta.GetRepositoryID(ctx, repoNameFromString(repo))
+	if err != nil {
+		return storagedriver.PathNotFoundError{Path: path}
+	}
+	dgst, err := digestFromLinkPath(path, "/_layers/")
+	if err != nil {
+		return err
+	}
+	linked, err := d.meta.BlobLinkedToRepo(ctx, repoID, dgst)
+	if err != nil {
+		return err
+	}
+	if !linked {
+		return storagedriver.PathNotFoundError{Path: path}
+	}
+	_, err = d.meta.DeleteUploadedBlob(ctx, repoID, dgst)
+	return err
 }
 
 // RedirectURL returns empty — local storage serves content directly.

--- a/internal/oci/storage/local/distcompat_test.go
+++ b/internal/oci/storage/local/distcompat_test.go
@@ -40,6 +40,18 @@ func setupDistTest(t *testing.T) (*DistDriver, oci.BlobStore, oci.MetadataStore)
 	return dd, blobs, store
 }
 
+func layerLinkPath(dgst digest.Digest) string {
+	return "/docker/registry/v2/repositories/lib/test/_layers/sha256/" + dgst.Encoded() + "/link"
+}
+
+func requirePathNotFound(t *testing.T, err error) {
+	t.Helper()
+	var pnf storagedriver.PathNotFoundError
+	if !errors.As(err, &pnf) {
+		t.Fatalf("expected PathNotFoundError, got %v", err)
+	}
+}
+
 func TestDistDriver_Name(t *testing.T) {
 	dd, _, _ := setupDistTest(t)
 	if dd.Name() != "quay" {
@@ -125,10 +137,7 @@ func TestDistDriver_UploadLifecycle(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = dd.Stat(ctx, dataPath)
-	var pnf storagedriver.PathNotFoundError
-	if !errors.As(err, &pnf) {
-		t.Errorf("expected PathNotFoundError after delete, got %v", err)
-	}
+	requirePathNotFound(t, err)
 }
 
 func TestDistDriver_Move_UploadToBlob(t *testing.T) {
@@ -201,13 +210,117 @@ func TestDistDriver_MetadataLink_GetContent(t *testing.T) {
 	}
 
 	// Read layer link (repo-scoped via manifestblob)
-	layerPath := "/docker/registry/v2/repositories/lib/test/_layers/sha256/" + layerDgst.Encoded() + "/link"
+	layerPath := layerLinkPath(layerDgst)
 	got, err = dd.GetContent(ctx, layerPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(got) != layerDgst.String() {
 		t.Errorf("layer link = %q, want %q", got, layerDgst.String())
+	}
+}
+
+func TestDistDriver_LayerLinkRequiresRepoAssociation(t *testing.T) {
+	dd, _, store := setupDistTest(t)
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "lib", Name: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	layerDgst := digest.FromString("global-only-layer")
+	if _, err := store.PutBlob(ctx, oci.BlobRecord{Digest: layerDgst, Size: 100}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = dd.GetContent(ctx, layerLinkPath(layerDgst))
+	requirePathNotFound(t, err)
+
+	linked, err := store.BlobLinkedToRepo(ctx, repoID, layerDgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linked {
+		t.Fatal("BlobLinkedToRepo = true for global-only blob")
+	}
+}
+
+func TestDistDriver_DeleteLayerLinkRemovesUploadedAssociation(t *testing.T) {
+	dd, _, store := setupDistTest(t)
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "lib", Name: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	layerDgst := digest.FromString("uploaded-layer")
+	if _, err := store.PutBlob(ctx, oci.BlobRecord{Digest: layerDgst, Size: 100}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutUploadedBlob(ctx, repoID, layerDgst); err != nil {
+		t.Fatal(err)
+	}
+
+	layerPath := layerLinkPath(layerDgst)
+	got, err := dd.GetContent(ctx, layerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != layerDgst.String() {
+		t.Errorf("layer link = %q, want %q", got, layerDgst.String())
+	}
+
+	if err := dd.Delete(ctx, layerPath); err != nil {
+		t.Fatal(err)
+	}
+	_, err = dd.GetContent(ctx, layerPath)
+	requirePathNotFound(t, err)
+
+	exists, err := store.BlobExists(ctx, layerDgst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("BlobExists = false after deleting repo-scoped layer link")
+	}
+}
+
+func TestDistDriver_DeleteLayerLinkKeepsManifestAssociation(t *testing.T) {
+	dd, _, store := setupDistTest(t)
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "lib", Name: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	layerDgst := digest.FromString("manifest-layer")
+	if _, err := store.PutBlob(ctx, oci.BlobRecord{Digest: layerDgst, Size: 100}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutUploadedBlob(ctx, repoID, layerDgst); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:      digest.FromString("manifest-for-layer-delete"),
+		MediaType:   "application/vnd.oci.image.manifest.v1+json",
+		Content:     []byte(`{}`),
+		BlobDigests: []oci.BlobRef{{Digest: layerDgst, Size: 100}},
+		Tag:         "latest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	layerPath := layerLinkPath(layerDgst)
+	if err := dd.Delete(ctx, layerPath); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := dd.GetContent(ctx, layerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != layerDgst.String() {
+		t.Errorf("layer link after delete = %q, want %q", got, layerDgst.String())
 	}
 }
 

--- a/internal/registry/distribution/middleware/middleware_test.go
+++ b/internal/registry/distribution/middleware/middleware_test.go
@@ -109,6 +109,10 @@ func (m *mockStore) PutUploadedBlob(_ context.Context, _ int64, _ digest.Digest)
 	return nil
 }
 
+func (m *mockStore) DeleteUploadedBlob(_ context.Context, _ int64, _ digest.Digest) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockStore) CleanExpiredUploadedBlobs(_ context.Context) error {
 	return errNotImplemented
 }


### PR DESCRIPTION
## Summary
- Align Go registry layer-link lookup with the Python repository blob lookup model: repository-scoped UploadedBlob or ManifestBlob only.
- Add a repo-scoped uploadedblob delete for _layers/.../link deletes instead of treating metadata delete as a no-op.
- Preserve blob bytes and manifestblob associations so manifest-backed blobs stay pullable and other repositories are unaffected.

## Why
OCI conformance teardown for monolithic blob push deletes the blob URL it just used. When that DELETE returns 202, the later GET against the same repository blob URL is expected to return 404. The Go storage driver kept returning 200 because layer-link deletion was a no-op and layer-link resolution fell back to global imagestorage visibility.

## Python parity
Python get_repository_blob_by_digest checks UploadedBlob first, then ManifestBlob for the target repository, with no broad ImageStorage fallback. This mirrors that behavior in Go while keeping the distribution delete operation scoped to the uploadedblob association.

## Testing
- go test ./internal/dal/metastore ./internal/oci/storage/local ./internal/registry/distribution/middleware -count=1
- go test ./internal/... -count=1
- golangci-lint run --timeout=5m

## Local OCI conformance validation
Ran locally from this branch with the Go registry started via serve, not install:

```bash
/tmp/quay-oci-conformance-serve serve \
  -data-dir=/tmp/quay-oci-conformance... \
  -hostname=localhost \
  -addr=127.0.0.1:18443
```

Used opencontainers/distribution-spec v1.1.1.

- CI-equivalent scope: pull + push enabled, content discovery disabled, content management disabled: 49 passed, 0 failed, 30 skipped.
- Additional validation with content management enabled and content discovery still disabled for referrers: 59 passed, 0 failed, 20 skipped.

Local artifacts were saved under /tmp/oci-conformance-serve-logs/ and /tmp/oci-conformance-serve-logs-cm/ with conformance-output.log, junit.xml, and report.html for each run.