### PR TITLE
NO-ISSUE: fix(omr): avoid SQLite tag expiry collisions

### DIFF
--- a/internal/dal/daldb/tag.sql.go
+++ b/internal/dal/daldb/tag.sql.go
@@ -19,19 +19,18 @@ func (q *Queries) DeleteTagsByManifest(ctx context.Context, manifestID sql.NullI
 	return err
 }
 
-const expireActiveTag = `-- name: ExpireActiveTag :execresult
+const expireTagByID = `-- name: ExpireTagByID :execresult
 UPDATE tag SET lifetime_end_ms = ?
-WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL
+WHERE id = ? AND lifetime_end_ms IS NULL
 `
 
-type ExpireActiveTagParams struct {
+type ExpireTagByIDParams struct {
 	LifetimeEndMs sql.NullInt64 `json:"lifetime_end_ms"`
-	RepositoryID  int64         `json:"repository_id"`
-	Name          string        `json:"name"`
+	ID            int64         `json:"id"`
 }
 
-func (q *Queries) ExpireActiveTag(ctx context.Context, arg ExpireActiveTagParams) (sql.Result, error) {
-	return q.db.ExecContext(ctx, expireActiveTag, arg.LifetimeEndMs, arg.RepositoryID, arg.Name)
+func (q *Queries) ExpireTagByID(ctx context.Context, arg ExpireTagByIDParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, expireTagByID, arg.LifetimeEndMs, arg.ID)
 }
 
 const getActiveTagDigest = `-- name: GetActiveTagDigest :one
@@ -51,6 +50,46 @@ func (q *Queries) GetActiveTagDigest(ctx context.Context, arg GetActiveTagDigest
 	var digest string
 	err := row.Scan(&digest)
 	return digest, err
+}
+
+const getActiveTags = `-- name: GetActiveTags :many
+SELECT id, manifest_id
+FROM tag
+WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL
+ORDER BY id
+`
+
+type GetActiveTagsParams struct {
+	RepositoryID int64  `json:"repository_id"`
+	Name         string `json:"name"`
+}
+
+type GetActiveTagsRow struct {
+	ID         int64         `json:"id"`
+	ManifestID sql.NullInt64 `json:"manifest_id"`
+}
+
+func (q *Queries) GetActiveTags(ctx context.Context, arg GetActiveTagsParams) ([]GetActiveTagsRow, error) {
+	rows, err := q.db.QueryContext(ctx, getActiveTags, arg.RepositoryID, arg.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetActiveTagsRow
+	for rows.Next() {
+		var i GetActiveTagsRow
+		if err := rows.Scan(&i.ID, &i.ManifestID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getTagsByRepository = `-- name: GetTagsByRepository :many
@@ -105,14 +144,13 @@ func (q *Queries) GetTagsByRepository(ctx context.Context, arg GetTagsByReposito
 	return items, nil
 }
 
-const upsertTag = `-- name: UpsertTag :one
+const insertTag = `-- name: InsertTag :one
 INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, tag_kind_id)
 VALUES (?, ?, ?, ?, ?)
-ON CONFLICT (repository_id, name, lifetime_end_ms) DO UPDATE SET manifest_id = excluded.manifest_id
 RETURNING id
 `
 
-type UpsertTagParams struct {
+type InsertTagParams struct {
 	Name            string        `json:"name"`
 	RepositoryID    int64         `json:"repository_id"`
 	ManifestID      sql.NullInt64 `json:"manifest_id"`
@@ -120,13 +158,8 @@ type UpsertTagParams struct {
 	TagKindID       int64         `json:"tag_kind_id"`
 }
 
-// KNOWN LIMITATION: ON CONFLICT uses lifetime_end_ms which is nullable.
-// NULL != NULL in SQL, so active tags (lifetime_end_ms IS NULL) never conflict.
-// This inserts duplicates instead of updating. Proper fix requires a partial
-// unique index: CREATE UNIQUE INDEX ON tag (repository_id, name) WHERE lifetime_end_ms IS NULL.
-// Until then, callers should expire the old tag before inserting a new one.
-func (q *Queries) UpsertTag(ctx context.Context, arg UpsertTagParams) (int64, error) {
-	row := q.db.QueryRowContext(ctx, upsertTag,
+func (q *Queries) InsertTag(ctx context.Context, arg InsertTagParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, insertTag,
 		arg.Name,
 		arg.RepositoryID,
 		arg.ManifestID,
@@ -136,4 +169,24 @@ func (q *Queries) UpsertTag(ctx context.Context, arg UpsertTagParams) (int64, er
 	var id int64
 	err := row.Scan(&id)
 	return id, err
+}
+
+const tagLifetimeEndExists = `-- name: TagLifetimeEndExists :one
+SELECT EXISTS(
+  SELECT 1 FROM tag
+  WHERE repository_id = ? AND name = ? AND lifetime_end_ms = ?
+)
+`
+
+type TagLifetimeEndExistsParams struct {
+	RepositoryID  int64         `json:"repository_id"`
+	Name          string        `json:"name"`
+	LifetimeEndMs sql.NullInt64 `json:"lifetime_end_ms"`
+}
+
+func (q *Queries) TagLifetimeEndExists(ctx context.Context, arg TagLifetimeEndExistsParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, tagLifetimeEndExists, arg.RepositoryID, arg.Name, arg.LifetimeEndMs)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
 }

--- a/internal/dal/metastore/metastore_sqlite.go
+++ b/internal/dal/metastore/metastore_sqlite.go
@@ -27,6 +27,7 @@ type SQLiteStore struct {
 
 	mediaTypesMu sync.RWMutex
 	mediaTypes   map[string]int64
+	nowMs        func() int64
 }
 
 // compile-time check
@@ -35,10 +36,29 @@ var _ oci.MetadataStore = (*SQLiteStore)(nil)
 // DB returns the underlying database handle, primarily for use in tests.
 func (s *SQLiteStore) DB() *sql.DB { return s.db }
 
+// SQLiteStoreOption configures a SQLiteStore during construction.
+type SQLiteStoreOption func(*SQLiteStore)
+
+// WithNowFunc overrides the store clock. It is primarily useful for deterministic tests.
+func WithNowFunc(nowMs func() int64) SQLiteStoreOption {
+	return func(s *SQLiteStore) {
+		if nowMs != nil {
+			s.nowMs = nowMs
+		}
+	}
+}
+
 // NewSQLiteStore creates a Store backed by the given SQLite database. It
 // caches frequently-used enum IDs at construction time.
-func NewSQLiteStore(ctx context.Context, db *sql.DB) (*SQLiteStore, error) {
-	s := &SQLiteStore{db: db, mediaTypes: make(map[string]int64)}
+func NewSQLiteStore(ctx context.Context, db *sql.DB, opts ...SQLiteStoreOption) (*SQLiteStore, error) {
+	s := &SQLiteStore{
+		db:         db,
+		mediaTypes: make(map[string]int64),
+		nowMs:      func() int64 { return time.Now().UnixMilli() },
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
 	if err := s.cacheEnums(ctx); err != nil {
 		return nil, fmt.Errorf("metastore: cache enums: %w", err)
 	}
@@ -308,20 +328,28 @@ func (s *SQLiteStore) PutTag(ctx context.Context, repoID int64, t oci.TagRecord)
 }
 
 // putTag expires any active tag with the same name, then inserts a new one.
-// This avoids the NULL != NULL issue on the
-// (repository_id, name, lifetime_end_ms) unique index.
+// Re-pushing the same manifest digest is idempotent and preserves tag history.
 func (s *SQLiteStore) putTag(ctx context.Context, q *daldb.Queries, repoID, manifestID int64, tag string) (int64, error) {
-	now := time.Now().UnixMilli()
+	now := s.nowMs()
 
-	if _, err := q.ExpireActiveTag(ctx, daldb.ExpireActiveTagParams{
-		LifetimeEndMs: sql.NullInt64{Int64: now, Valid: true},
-		RepositoryID:  repoID,
-		Name:          tag,
-	}); err != nil {
+	activeTags, err := q.GetActiveTags(ctx, daldb.GetActiveTagsParams{
+		RepositoryID: repoID,
+		Name:         tag,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("lookup active tag %q: %w", tag, err)
+	}
+	if len(activeTags) == 1 &&
+		activeTags[0].ManifestID.Valid &&
+		activeTags[0].ManifestID.Int64 == manifestID {
+		return activeTags[0].ID, nil
+	}
+
+	if err := s.expireActiveTags(ctx, q, repoID, tag, activeTags, now); err != nil {
 		return 0, fmt.Errorf("expire tag %q: %w", tag, err)
 	}
 
-	id, err := q.UpsertTag(ctx, daldb.UpsertTagParams{
+	id, err := q.InsertTag(ctx, daldb.InsertTagParams{
 		Name:            tag,
 		RepositoryID:    repoID,
 		ManifestID:      sql.NullInt64{Int64: manifestID, Valid: true},
@@ -334,18 +362,67 @@ func (s *SQLiteStore) putTag(ctx context.Context, q *daldb.Queries, repoID, mani
 	return id, nil
 }
 
+func (s *SQLiteStore) expireActiveTags(ctx context.Context, q *daldb.Queries, repoID int64, tag string, activeTags []daldb.GetActiveTagsRow, now int64) error {
+	endMs := now
+	for _, activeTag := range activeTags {
+		for {
+			exists, err := q.TagLifetimeEndExists(ctx, daldb.TagLifetimeEndExistsParams{
+				RepositoryID:  repoID,
+				Name:          tag,
+				LifetimeEndMs: sql.NullInt64{Int64: endMs, Valid: true},
+			})
+			if err != nil {
+				return fmt.Errorf("check lifetime_end_ms %d: %w", endMs, err)
+			}
+			if exists == 0 {
+				break
+			}
+			endMs--
+		}
+
+		result, err := q.ExpireTagByID(ctx, daldb.ExpireTagByIDParams{
+			LifetimeEndMs: sql.NullInt64{Int64: endMs, Valid: true},
+			ID:            activeTag.ID,
+		})
+		if err != nil {
+			return fmt.Errorf("expire active tag row %d: %w", activeTag.ID, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("expire active tag row %d rows affected: %w", activeTag.ID, err)
+		}
+		if rows != 1 {
+			return fmt.Errorf("expire active tag row %d: updated %d rows", activeTag.ID, rows)
+		}
+
+		endMs--
+	}
+	return nil
+}
+
 // DeleteTag expires the active tag by setting lifetime_end_ms.
 func (s *SQLiteStore) DeleteTag(ctx context.Context, repoID int64, tag string) error {
-	q := daldb.New(s.db)
-	now := time.Now().UnixMilli()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+	q := daldb.New(tx)
 
-	_, err := q.ExpireActiveTag(ctx, daldb.ExpireActiveTagParams{
-		LifetimeEndMs: sql.NullInt64{Int64: now, Valid: true},
-		RepositoryID:  repoID,
-		Name:          tag,
+	activeTags, err := q.GetActiveTags(ctx, daldb.GetActiveTagsParams{
+		RepositoryID: repoID,
+		Name:         tag,
 	})
 	if err != nil {
+		return fmt.Errorf("lookup active tag %q: %w", tag, err)
+	}
+
+	if err := s.expireActiveTags(ctx, q, repoID, tag, activeTags, s.nowMs()); err != nil {
 		return fmt.Errorf("expire tag %q: %w", tag, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
 	}
 	return nil
 }
@@ -447,7 +524,7 @@ func (s *SQLiteStore) BlobExists(ctx context.Context, dgst digest.Digest) (bool,
 // ListTags returns all active tags for a repository.
 func (s *SQLiteStore) ListTags(ctx context.Context, repoID int64) ([]string, error) {
 	q := daldb.New(s.db)
-	now := time.Now().UnixMilli()
+	now := s.nowMs()
 	rows, err := q.GetTagsByRepository(ctx, daldb.GetTagsByRepositoryParams{
 		RepositoryID:  repoID,
 		LifetimeEndMs: sql.NullInt64{Int64: now, Valid: true},

--- a/internal/dal/metastore/metastore_sqlite_test.go
+++ b/internal/dal/metastore/metastore_sqlite_test.go
@@ -2,6 +2,7 @@ package metastore_test
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"testing"
 
@@ -14,13 +15,23 @@ import (
 
 func setupStore(t *testing.T) oci.MetadataStore {
 	t.Helper()
+	return setupStoreWithOptions(t)
+}
+
+func setupStoreWithNow(t *testing.T, nowMs func() int64) oci.MetadataStore {
+	t.Helper()
+	return setupStoreWithOptions(t, metastore.WithNowFunc(nowMs))
+}
+
+func setupStoreWithOptions(t *testing.T, opts ...metastore.SQLiteStoreOption) oci.MetadataStore {
+	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "quay.db")
 	db, err := dbcore.Setup(t.Context(), dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { db.Close() })
-	store, err := metastore.NewSQLiteStore(t.Context(), db)
+	store, err := metastore.NewSQLiteStore(t.Context(), db, opts...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,6 +231,104 @@ func TestPutManifest_TagReplace(t *testing.T) {
 	assertActiveTagCount(t, store.(*metastore.SQLiteStore), repoID, "latest", 1)
 }
 
+func TestPutManifest_SameDigestTagRetryNoop(t *testing.T) {
+	now := int64(10_000)
+	store := setupStoreWithNow(t, func() int64 { return now })
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "library", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dgst := digest.FromString("manifest-retry")
+	record := oci.ManifestRecord{
+		Digest:    dgst,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"v":1}`),
+		Tag:       "latest",
+	}
+
+	if _, err := store.PutManifest(ctx, repoID, record); err != nil {
+		t.Fatal(err)
+	}
+	rows := getTagRows(t, store.(*metastore.SQLiteStore), repoID, "latest")
+	if len(rows) != 1 {
+		t.Fatalf("tag rows after first push: got %d, want 1", len(rows))
+	}
+	firstTagID := rows[0].id
+
+	now++
+	if _, err := store.PutManifest(ctx, repoID, record); err != nil {
+		t.Fatal(err)
+	}
+
+	rows = getTagRows(t, store.(*metastore.SQLiteStore), repoID, "latest")
+	if len(rows) != 1 {
+		t.Fatalf("tag rows after retry: got %d, want 1", len(rows))
+	}
+	if rows[0].id != firstTagID {
+		t.Fatalf("tag row ID after retry: got %d, want %d", rows[0].id, firstTagID)
+	}
+	assertActiveTagCount(t, store.(*metastore.SQLiteStore), repoID, "latest", 1)
+}
+
+func TestPutManifest_TagRetargetAvoidsExpiredTimestampCollision(t *testing.T) {
+	now := int64(20_000)
+	store := setupStoreWithNow(t, func() int64 { return now })
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "library", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dgst1 := digest.FromString("manifest-collision-v1")
+	dgst2 := digest.FromString("manifest-collision-v2")
+	dgst3 := digest.FromString("manifest-collision-v3")
+
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    dgst1,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"v":1}`),
+		Tag:       "latest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	now++
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    dgst2,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"v":2}`),
+		Tag:       "latest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retarget in the same millisecond as the existing expired row. The old
+	// expire query attempted to reuse this lifetime_end_ms and violated the
+	// tag_repository_id_name_lifetime_end_ms unique index.
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    dgst3,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"v":3}`),
+		Tag:       "latest",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetTagDigest(ctx, repoID, "latest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != dgst3 {
+		t.Fatalf("active tag digest: got %s, want %s", got, dgst3)
+	}
+	assertActiveTagCount(t, store.(*metastore.SQLiteStore), repoID, "latest", 1)
+	assertDistinctExpiredTagEndMs(t, store.(*metastore.SQLiteStore), repoID, "latest", 2)
+}
+
 func TestPutManifest_IndexWithChildren(t *testing.T) {
 	store := setupStore(t)
 	ctx := t.Context()
@@ -367,7 +476,78 @@ func TestDeleteTag(t *testing.T) {
 	}
 }
 
+func TestDeleteTagAvoidsExpiredTimestampCollision(t *testing.T) {
+	now := int64(30_000)
+	store := setupStoreWithNow(t, func() int64 { return now })
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "library", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    digest.FromString("delete-collision-v1"),
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"v":1}`),
+		Tag:       "removeme",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	now++
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    digest.FromString("delete-collision-v2"),
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"v":2}`),
+		Tag:       "removeme",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.DeleteTag(ctx, repoID, "removeme"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertActiveTagCount(t, store.(*metastore.SQLiteStore), repoID, "removeme", 0)
+	assertDistinctExpiredTagEndMs(t, store.(*metastore.SQLiteStore), repoID, "removeme", 2)
+}
+
 // --- test helpers ---
+
+type tagRow struct {
+	id            int64
+	manifestID    sql.NullInt64
+	lifetimeEndMs sql.NullInt64
+}
+
+func getTagRows(t *testing.T, s *metastore.SQLiteStore, repoID int64, tag string) []tagRow {
+	t.Helper()
+	db := s.DB()
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT id, manifest_id, lifetime_end_ms
+		 FROM tag
+		 WHERE repository_id = ? AND name = ?
+		 ORDER BY id`,
+		repoID, tag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []tagRow
+	for rows.Next() {
+		var row tagRow
+		if err := rows.Scan(&row.id, &row.manifestID, &row.lifetimeEndMs); err != nil {
+			t.Fatal(err)
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
 
 func assertActiveTag(t *testing.T, s *metastore.SQLiteStore, repoID int64, tag string) {
 	t.Helper()
@@ -386,5 +566,23 @@ func assertActiveTagCount(t *testing.T, s *metastore.SQLiteStore, repoID int64, 
 	}
 	if count != want {
 		t.Errorf("active tags named %q: got %d, want %d", tag, count, want)
+	}
+}
+
+func assertDistinctExpiredTagEndMs(t *testing.T, s *metastore.SQLiteStore, repoID int64, tag string, want int) {
+	t.Helper()
+	rows := getTagRows(t, s, repoID, tag)
+	seen := map[int64]bool{}
+	for _, row := range rows {
+		if !row.lifetimeEndMs.Valid {
+			continue
+		}
+		if seen[row.lifetimeEndMs.Int64] {
+			t.Fatalf("duplicate expired lifetime_end_ms %d for tag %q", row.lifetimeEndMs.Int64, tag)
+		}
+		seen[row.lifetimeEndMs.Int64] = true
+	}
+	if len(seen) != want {
+		t.Fatalf("expired tags named %q: got %d, want %d", tag, len(seen), want)
 	}
 }

--- a/internal/dal/queries/tag.sql
+++ b/internal/dal/queries/tag.sql
@@ -1,17 +1,23 @@
--- name: UpsertTag :one
--- KNOWN LIMITATION: ON CONFLICT uses lifetime_end_ms which is nullable.
--- NULL != NULL in SQL, so active tags (lifetime_end_ms IS NULL) never conflict.
--- This inserts duplicates instead of updating. Proper fix requires a partial
--- unique index: CREATE UNIQUE INDEX ON tag (repository_id, name) WHERE lifetime_end_ms IS NULL.
--- Until then, callers should expire the old tag before inserting a new one.
+-- name: InsertTag :one
 INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, tag_kind_id)
 VALUES (?, ?, ?, ?, ?)
-ON CONFLICT (repository_id, name, lifetime_end_ms) DO UPDATE SET manifest_id = excluded.manifest_id
 RETURNING id;
 
--- name: ExpireActiveTag :execresult
+-- name: GetActiveTags :many
+SELECT id, manifest_id
+FROM tag
+WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL
+ORDER BY id;
+
+-- name: ExpireTagByID :execresult
 UPDATE tag SET lifetime_end_ms = ?
-WHERE repository_id = ? AND name = ? AND lifetime_end_ms IS NULL;
+WHERE id = ? AND lifetime_end_ms IS NULL;
+
+-- name: TagLifetimeEndExists :one
+SELECT EXISTS(
+  SELECT 1 FROM tag
+  WHERE repository_id = ? AND name = ? AND lifetime_end_ms = ?
+);
 
 -- name: DeleteTagsByManifest :exec
 DELETE FROM tag WHERE manifest_id = ?;


### PR DESCRIPTION
## Summary

- make OMR SQLite tag writes idempotent when a retry re-pushes the same tag to the same manifest
- replace the nullable `lifetime_end_ms` tag upsert with explicit active-tag lookup, row-ID expiration, and plain active tag insertion
- preserve tag history while allocating collision-free expired `lifetime_end_ms` values for retag and untag paths

## Root Cause

The SQLite tag table has a unique index on `(repository_id, name, lifetime_end_ms)`, but active tags use `NULL` for `lifetime_end_ms`. Because SQL treats `NULL` values as distinct, the previous `ON CONFLICT` path did not protect active tags. The metastore worked around that by expiring the active tag and inserting a new active row.

Rapid retries can hit the same millisecond as an existing expired tag row. In that case, expiring the active tag reuses an existing `lifetime_end_ms` for the same `(repository_id, name)` and SQLite raises a unique constraint error. That turns an otherwise successful manifest write into an HTTP 500 during OMR mirror retries.

## Fix

The Go SQLite metastore now looks up active tag rows first. If the tag already points to the requested manifest, the operation returns the existing tag row without creating extra history. If it is a real retarget, the old active row is expired by ID and the new active row is inserted.

Expiration now probes for an unused `lifetime_end_ms`, starting at the current millisecond and walking backward as needed. This keeps expired history intact and avoids the unique constraint collision. `DeleteTag` uses the same helper so untag is covered too.

## Testing

- `go test ./internal/...`

Added deterministic metastore coverage for:

- same-digest retry no-op behavior
- retargeting in the same millisecond as an existing expired row
- deleting a tag in the same millisecond as an existing expired row
