### PR TITLE
PROJQUAY-12148: feat(bootstrap): add bootstrap token renewal

### DIFF
--- a/conf/nginx/http-base.conf.jnj
+++ b/conf/nginx/http-base.conf.jnj
@@ -46,6 +46,11 @@ map $proxy_protocol_addr $proper_forwarded_for {
   default $proxy_protocol_addr;
 }
 
+map $realip_remote_addr $quay_original_remote_addr {
+  ""      $remote_addr;
+  default $realip_remote_addr;
+}
+
 map $http_x_forwarded_proto $proper_scheme {
   default $scheme;
   https   https;

--- a/conf/nginx/rate-limiting.conf.jnj
+++ b/conf/nginx/rate-limiting.conf.jnj
@@ -36,6 +36,13 @@ map $uri:$http_user_agent $miner_tag_block {
     default 0;
 }
 
+# Prefer Quay's original client address for bootstrap renewal limits. Fall back
+# to the direct nginx peer address when no original address was derived.
+map $quay_original_remote_addr $bootstrap_renew_bucket {
+  ""      $binary_remote_addr;
+  default $quay_original_remote_addr;
+}
+
 
 # Define two additional buckets that fall to $request_id (thus no effective rate limiting) if
 # a specific set of namespaces is matched. This allows us to turn off rate limiting selectively
@@ -64,6 +71,7 @@ map $namespace $namespaced_http2_bucket {
 
 {% if enable_rate_limits %}
 limit_req_zone $auth_namespace_bucket zone=namespace_auth:10m rate=120r/s;
+limit_req_zone $bootstrap_renew_bucket zone=bootstrap_renew:10m rate=10r/m;
 {% else %}
 limit_req_zone $request_id zone=namespace_auth:10m rate=300r/s;
 {% endif %}

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -11,6 +11,7 @@ add_header X-Frame-Options DENY;
 
 # Proxy Headers
 proxy_set_header X-Forwarded-For $proper_forwarded_for;
+proxy_set_header X-Quay-Original-Remote-Addr $quay_original_remote_addr;
 
 # Pass trusted protocol to Werkzeug
 proxy_set_header X-Forwarded-Proto $final_proto;
@@ -142,6 +143,16 @@ location ~ ^/v2/(.+)/_trust/tuf/(.*)$ {
   proxy_set_header Host "{{ tuf_host }}";
 }
 {% endif %}
+
+location = /api/v1/bootstrap/renew {
+    proxy_pass   http://web_app_server;
+
+    {% if enable_rate_limits %}
+    limit_req zone=bootstrap_renew burst=5 nodelay;
+    {% endif %}
+
+    keepalive_timeout 0; # Disables HTTP 1.1 keep-alive and forces round-robin.
+}
 
 location /api/ {
     proxy_pass   http://web_app_server;

--- a/config.py
+++ b/config.py
@@ -877,7 +877,7 @@ class DefaultConfig(ImmutableConfig):
 
     # Feature Flag: Controls programmatic bootstrap token provisioning.
     FEATURE_PROGRAMMATIC_BOOTSTRAP = False
-    BOOTSTRAP_TOKEN_OWNER = None
+    BOOTSTRAP_TOKEN_OWNER: Optional[str] = None
     BOOTSTRAP_TOKEN_PATH = "/var/lib/quay/quay-machine-token.json"
     BOOTSTRAP_TOKEN_EXPIRATION = 3600  # 60 minutes in seconds
     BOOTSTRAP_TOKEN_SCOPE = (

--- a/data/model/oauth.py
+++ b/data/model/oauth.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import posixpath

--- a/data/model/oauth.py
+++ b/data/model/oauth.py
@@ -2,6 +2,7 @@ import json
 import logging
 import posixpath
 from datetime import datetime, timedelta
+from typing import Any
 from urllib.parse import unquote, urlparse
 
 from flask import url_for
@@ -340,22 +341,22 @@ class DatabaseAuthorizationProvider(AuthorizationProvider):
         )
 
 
-def get_bootstrap_app_name():
+def get_bootstrap_app_name() -> str:
     """Return the reserved bootstrap OAuth application name."""
     return BOOTSTRAP_APP_NAME
 
 
-def get_bootstrap_app_names():
+def get_bootstrap_app_names() -> set[str]:
     """Return reserved bootstrap OAuth application names."""
     return {BOOTSTRAP_APP_NAME}
 
 
-def is_bootstrap_app_name(name):
+def is_bootstrap_app_name(name: str) -> bool:
     """Return whether name is reserved for bootstrap OAuth applications."""
     return name in get_bootstrap_app_names()
 
 
-def create_bootstrap_application(name, org):
+def create_bootstrap_application(name: str, org: User) -> OAuthApplication:
     """Create a bootstrap OAuth application for the owner."""
     return create_application(
         org,
@@ -366,7 +367,7 @@ def create_bootstrap_application(name, org):
     )
 
 
-def _bootstrap_token_data(user_obj, application):
+def _bootstrap_token_data(user_obj: User, application: OAuthApplication) -> str:
     """Return metadata stored with bootstrap-created OAuth access tokens."""
     return json.dumps(
         {
@@ -378,8 +379,11 @@ def _bootstrap_token_data(user_obj, application):
 
 
 def create_bootstrap_oauth_api_token(
-    application, user_obj, scope, expiration_seconds=DEFAULT_TOKEN_EXPIRATION_SECONDS
-):
+    application: OAuthApplication,
+    user_obj: User,
+    scope: str,
+    expiration_seconds: int = DEFAULT_TOKEN_EXPIRATION_SECONDS,
+) -> tuple[OAuthAccessToken, str]:
     """Create a bootstrap OAuth API access token for an application/user pair."""
     return create_user_access_token_for_application(
         user_obj,
@@ -391,14 +395,18 @@ def create_bootstrap_oauth_api_token(
     )
 
 
-def _bootstrap_token_data_json(token):
+def _bootstrap_token_data_json(token: OAuthAccessToken) -> dict[str, Any]:
     try:
         return json.loads(token.data or "{}")
     except (TypeError, ValueError):
         return {}
 
 
-def is_bootstrap_oauth_token(token, user_obj=None, application=None):
+def is_bootstrap_oauth_token(
+    token: OAuthAccessToken,
+    user_obj: User | None = None,
+    application: OAuthApplication | None = None,
+) -> bool:
     """Return whether an OAuth access token has bootstrap token metadata."""
     token_data = _bootstrap_token_data_json(token)
     if token_data.get("kind") != BOOTSTRAP_TOKEN_DATA_KIND:
@@ -413,7 +421,9 @@ def is_bootstrap_oauth_token(token, user_obj=None, application=None):
     return True
 
 
-def get_application_tokens(application, authorized_user=None):
+def get_application_tokens(
+    application: OAuthApplication, authorized_user: User | None = None
+) -> list[OAuthAccessToken]:
     """Return all OAuth access tokens for the given application."""
     query = OAuthAccessToken.select().where(OAuthAccessToken.application == application)
     if authorized_user is not None:
@@ -422,7 +432,9 @@ def get_application_tokens(application, authorized_user=None):
     return list(query)
 
 
-def get_bootstrap_tokens(application, authorized_user=None):
+def get_bootstrap_tokens(
+    application: OAuthApplication, authorized_user: User | None = None
+) -> list[OAuthAccessToken]:
     """Return bootstrap-marked OAuth access tokens for the given application."""
     bootstrap_tokens = []
     application_tokens = get_application_tokens(application, authorized_user=authorized_user)
@@ -433,7 +445,7 @@ def get_bootstrap_tokens(application, authorized_user=None):
     return bootstrap_tokens
 
 
-def get_bootstrap_managed_applications():
+def get_bootstrap_managed_applications() -> list[OAuthApplication]:
     """Return all fixed-name OAuth applications with bootstrap token metadata."""
     bootstrap_applications = []
     for application in lookup_bootstrap_named_applications():
@@ -443,7 +455,20 @@ def get_bootstrap_managed_applications():
     return bootstrap_applications
 
 
-def get_bootstrap_application_candidates(owner):
+def delete_bootstrap_tokens(
+    application: OAuthApplication, keep_token_id: int | None = None
+) -> None:
+    """Delete bootstrap-marked tokens for the application except the ID to keep."""
+    ids_to_delete = [
+        token.id for token in get_bootstrap_tokens(application) if token.id != keep_token_id
+    ]
+    if ids_to_delete:
+        OAuthAccessToken.delete().where(OAuthAccessToken.id << ids_to_delete).execute()
+
+
+def get_bootstrap_application_candidates(
+    owner: User,
+) -> tuple[OAuthApplication | None, list[OAuthApplication]]:
     """Return the canonical and duplicate bootstrap-managed apps for an owner.
 
     Applications are considered bootstrap-managed only when they are owned by the
@@ -456,8 +481,8 @@ def get_bootstrap_application_candidates(owner):
     bootstrap_application_name = get_bootstrap_app_name()
     applications = lookup_applications_by_name(owner, bootstrap_application_name)
 
-    canonical_application = None
-    duplicate_applications = []
+    canonical_application: OAuthApplication | None = None
+    duplicate_applications: list[OAuthApplication] = []
     for application in applications:
         bootstrap_tokens = get_bootstrap_tokens(application, authorized_user=owner)
         if not bootstrap_tokens:
@@ -472,7 +497,9 @@ def get_bootstrap_application_candidates(owner):
     return canonical_application, duplicate_applications
 
 
-def get_singleton_bootstrap_application_candidates(owner):
+def get_singleton_bootstrap_application_candidates(
+    owner: User,
+) -> tuple[OAuthApplication | None, list[OAuthApplication]]:
     """Return the current owner's canonical app and all stale global bootstrap apps.
 
     Programmatic bootstrap is a deployment-wide singleton. The configured owner
@@ -505,14 +532,14 @@ def get_singleton_bootstrap_application_candidates(owner):
     return canonical_application, stale_applications
 
 
-def get_canonical_bootstrap_application(owner):
+def get_canonical_bootstrap_application(owner: User) -> OAuthApplication | None:
     """Return the canonical bootstrap-managed app for an owner, if one exists."""
     # Assumes boot.py provisioning has already enforced singleton bootstrap app cleanup.
     canonical_application, _ = get_bootstrap_application_candidates(owner)
     return canonical_application
 
 
-def _get_bootstrap_owner_for_validation(app_config):
+def _get_bootstrap_owner_for_validation(app_config: dict[str, Any]) -> User | None:
     owner_name = app_config.get("BOOTSTRAP_TOKEN_OWNER")
     if not owner_name:
         return None
@@ -524,7 +551,9 @@ def _get_bootstrap_owner_for_validation(app_config):
     return user.get_user(owner_name)
 
 
-def validate_bootstrap_token(access_token, app_config=None):
+def validate_bootstrap_token(
+    access_token: str, app_config: dict[str, Any] | None = None
+) -> OAuthAccessToken | None:
     """Validate a token belongs to the configured canonical bootstrap app."""
     if app_config is None:
         app_config = config.app_config or {}
@@ -587,7 +616,7 @@ def delete_applications(applications):
         application.delete_instance(recursive=True, delete_nullable=True)
 
 
-def lock_bootstrap_token_operation():
+def lock_bootstrap_token_operation() -> None:
     """Serialize bootstrap token mutations with a transaction-scoped DB lock."""
     db_advisory_xact_lock(BOOTSTRAP_TOKEN_LOCK_ID)
 

--- a/data/model/test/test_oauth.py
+++ b/data/model/test/test_oauth.py
@@ -309,3 +309,41 @@ def test_validate_redirect_uri_blocks_path_prefix_mismatch(initialized_db):
         # Path that doesn't match configured prefix
         malicious_uri_2 = "http://foo/ba"
         assert not db_auth_provider.validate_redirect_uri(application.client_id, malicious_uri_2)
+
+
+def test_delete_bootstrap_tokens_keeps_requested_token_and_unmarked_tokens(initialized_db):
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_bootstrap_application("cleanup-bootstrap", owner)
+    keep_token, _ = model.oauth.create_bootstrap_oauth_api_token(application, owner, "repo:read")
+    stale_token, _ = model.oauth.create_bootstrap_oauth_api_token(application, owner, "repo:write")
+    unmarked_token, _ = model.oauth.create_user_access_token_for_application(
+        owner,
+        application,
+        "repo:read",
+        "Bearer",
+        3600,
+    )
+
+    model.oauth.delete_bootstrap_tokens(application, keep_token_id=keep_token.id)
+
+    assert model.oauth.lookup_access_token_by_uuid(keep_token.uuid) is not None
+    assert model.oauth.lookup_access_token_by_uuid(stale_token.uuid) is None
+    assert model.oauth.lookup_access_token_by_uuid(unmarked_token.uuid) is not None
+
+
+def test_delete_bootstrap_tokens_noops_when_only_kept_token_exists(initialized_db):
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_bootstrap_application("cleanup-bootstrap", owner)
+    keep_token, _ = model.oauth.create_bootstrap_oauth_api_token(application, owner, "repo:read")
+    unmarked_token, _ = model.oauth.create_user_access_token_for_application(
+        owner,
+        application,
+        "repo:read",
+        "Bearer",
+        3600,
+    )
+
+    model.oauth.delete_bootstrap_tokens(application, keep_token_id=keep_token.id)
+
+    assert model.oauth.lookup_access_token_by_uuid(keep_token.uuid) is not None
+    assert model.oauth.lookup_access_token_by_uuid(unmarked_token.uuid) is not None

--- a/endpoints/api/__init__.py
+++ b/endpoints/api/__init__.py
@@ -835,6 +835,7 @@ def deprecated():
 
 import endpoints.api.appspecifictokens
 import endpoints.api.billing
+import endpoints.api.bootstrap
 import endpoints.api.build
 import endpoints.api.capabilities
 import endpoints.api.discovery

--- a/endpoints/api/bootstrap.py
+++ b/endpoints/api/bootstrap.py
@@ -17,7 +17,7 @@ from data.model.oauth import (
 )
 from endpoints.api import ApiResource, nickname, resource, show_if
 from endpoints.decorators import anon_allowed
-from endpoints.exception import InvalidToken, Unauthorized
+from endpoints.exception import InvalidToken, TokenRotationError, Unauthorized
 from util.bootstrap_token import write_bootstrap_token
 
 logger = logging.getLogger(__name__)
@@ -146,9 +146,9 @@ class BootstrapTokenRenew(ApiResource):
                 write_bootstrap_token(app.config, new_access_token)
         except BootstrapTokenCleanupError:
             logger.exception("Bootstrap token renewal failed while deleting stale tokens")
-            return {"message": "Token rotation failed: could not clean up tokens"}, 500
+            raise TokenRotationError("Token rotation failed: could not clean up tokens")
         except OSError:
             logger.exception("Bootstrap token renewal failed while writing token")
-            return {"message": "Token rotation failed: could not write token"}, 500
+            raise TokenRotationError("Token rotation failed: could not write token")
 
         return {"status": "rotated"}, 200

--- a/endpoints/api/bootstrap.py
+++ b/endpoints/api/bootstrap.py
@@ -1,0 +1,154 @@
+import logging
+from datetime import UTC, datetime
+from ipaddress import ip_address
+
+from flask import Request, request
+
+import features
+from app import app
+from auth.auth_context import get_validated_oauth_token
+from data.database import OAuthAccessToken
+from data.model import db_transaction
+from data.model.oauth import (
+    create_bootstrap_oauth_api_token,
+    delete_bootstrap_tokens,
+    lock_bootstrap_token_operation,
+    validate_bootstrap_token,
+)
+from endpoints.api import ApiResource, nickname, resource, show_if
+from endpoints.decorators import anon_allowed
+from endpoints.exception import InvalidToken, Unauthorized
+from util.bootstrap_token import write_bootstrap_token
+
+logger = logging.getLogger(__name__)
+
+_INVALID_BOOTSTRAP_TOKEN_MESSAGE = "Requires valid bootstrap bearer token"
+_QUAY_NGINX_ORIGINAL_REMOTE_ADDR_HEADER = "X-Quay-Original-Remote-Addr"
+
+
+class BootstrapTokenCleanupError(Exception):
+    pass
+
+
+def _raise_invalid_bootstrap_token() -> None:
+    raise InvalidToken(_INVALID_BOOTSTRAP_TOKEN_MESSAGE)
+
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def _is_expired(token: OAuthAccessToken) -> bool:
+    return token.expires_at <= _utcnow_naive()
+
+
+def _is_loopback_remote_addr(remote_addr: str | None) -> bool:
+    if not remote_addr:
+        return False
+
+    try:
+        remote_ip = ip_address(remote_addr)
+    except ValueError:
+        return False
+
+    if remote_ip.is_loopback:
+        return True
+
+    ipv4_mapped = getattr(remote_ip, "ipv4_mapped", None)
+    return ipv4_mapped is not None and ipv4_mapped.is_loopback
+
+
+def _unproxied_remote_addr(req: Request) -> str | None:
+    proxy_fix_orig = req.environ.get("werkzeug.proxy_fix.orig") or {}
+    return proxy_fix_orig.get("REMOTE_ADDR") or req.environ.get("REMOTE_ADDR")
+
+
+def _has_forwarding_headers(req: Request) -> bool:
+    return bool(
+        req.headers.get("X-Forwarded-For")
+        or req.headers.get("X-Real-IP")
+        or req.headers.get("Forwarded")
+    )
+
+
+def _has_internal_or_unset_direct_peer(req: Request) -> bool:
+    direct_peer = _unproxied_remote_addr(req)
+    return not direct_peer or _is_loopback_remote_addr(direct_peer)
+
+
+def _is_loopback_bootstrap_renewal_request(req: Request) -> bool:
+    if _has_forwarding_headers(req):
+        # Standard Quay deployments route /api/ requests through the bundled
+        # nginx, which always adds X-Forwarded-For before proxying to gunicorn.
+        # Do not trust request.remote_addr here: ProxyFix derives it from
+        # X-Forwarded-For. Instead, trust only the original TCP peer address
+        # overwritten by Quay's own nginx configuration, and require the direct
+        # peer to be unset (Unix socket) or loopback (local TCP proxy).
+        return _is_loopback_remote_addr(
+            req.headers.get(_QUAY_NGINX_ORIGINAL_REMOTE_ADDR_HEADER)
+        ) and _has_internal_or_unset_direct_peer(req)
+
+    return _is_loopback_remote_addr(_unproxied_remote_addr(req))
+
+
+@resource("/v1/bootstrap/renew")
+@show_if(features.PROGRAMMATIC_BOOTSTRAP)
+class BootstrapTokenRenew(ApiResource):
+    """Rotate the bootstrap token."""
+
+    @anon_allowed
+    @nickname("renewBootstrapToken")
+    def post(self):
+        auth_header = request.headers.get("Authorization", "")
+        parts = auth_header.split(" ", 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            _raise_invalid_bootstrap_token()
+
+        token_string = parts[1].strip()
+        if not token_string:
+            _raise_invalid_bootstrap_token()
+
+        current_token = validate_bootstrap_token(token_string, app.config)
+        if current_token is None:
+            if get_validated_oauth_token() is not None:
+                raise Unauthorized()
+
+            _raise_invalid_bootstrap_token()
+
+        try:
+            with db_transaction():
+                lock_bootstrap_token_operation()
+
+                current_token = validate_bootstrap_token(token_string, app.config)
+                if current_token is None:
+                    _raise_invalid_bootstrap_token()
+
+                if _is_expired(current_token) and not _is_loopback_bootstrap_renewal_request(
+                    request
+                ):
+                    _raise_invalid_bootstrap_token()
+
+                scope = app.config["BOOTSTRAP_TOKEN_SCOPE"]
+                expiration = app.config["BOOTSTRAP_TOKEN_EXPIRATION"]
+
+                new_record, new_access_token = create_bootstrap_oauth_api_token(
+                    current_token.application,
+                    current_token.authorized_user,
+                    scope,
+                    expiration_seconds=expiration,
+                )
+
+                try:
+                    delete_bootstrap_tokens(current_token.application, keep_token_id=new_record.id)
+                except Exception as exc:
+                    raise BootstrapTokenCleanupError() from exc
+
+                write_bootstrap_token(app.config, new_access_token)
+        except BootstrapTokenCleanupError:
+            logger.exception("Bootstrap token renewal failed while deleting stale tokens")
+            return {"message": "Token rotation failed: could not clean up tokens"}, 500
+        except OSError:
+            logger.exception("Bootstrap token renewal failed while writing token")
+            return {"message": "Token rotation failed: could not write token"}, 500
+
+        return {"status": "rotated"}, 200

--- a/endpoints/api/test/test_bootstrap.py
+++ b/endpoints/api/test/test_bootstrap.py
@@ -129,6 +129,8 @@ def test_renew_file_write_fails_rolls_back_db_token_changes(app, initialized_db,
             )
 
     assert resp.status_code == 500
+    assert resp.get_json()["error_type"] == "token_rotation_failed"
+    assert resp.get_json()["error_message"] == "Token rotation failed: could not write token"
     assert model.oauth.lookup_access_token_by_uuid(old_record.uuid) is not None
     assert model.oauth.validate_bootstrap_token(access_token, config) is not None
     assert len(model.oauth.get_bootstrap_tokens(application)) == 1
@@ -155,7 +157,8 @@ def test_renew_db_cleanup_failure_happens_before_file_write(app, initialized_db,
             )
 
     assert resp.status_code == 500
-    assert resp.get_json() == {"message": "Token rotation failed: could not clean up tokens"}
+    assert resp.get_json()["error_type"] == "token_rotation_failed"
+    assert resp.get_json()["error_message"] == "Token rotation failed: could not clean up tokens"
     mock_write_token.assert_not_called()
     assert model.oauth.lookup_access_token_by_uuid(old_record.uuid) is not None
     assert model.oauth.validate_bootstrap_token(access_token, config) is not None

--- a/endpoints/api/test/test_bootstrap.py
+++ b/endpoints/api/test/test_bootstrap.py
@@ -1,0 +1,497 @@
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app import app as real_app
+from data import model
+from endpoints.api.bootstrap import _is_loopback_remote_addr
+from endpoints.test.shared import client_with_identity
+from test.fixtures import *
+
+
+def _bootstrap_config(tmp_path, owner="devtable"):
+    return {
+        "FEATURE_PROGRAMMATIC_BOOTSTRAP": True,
+        "SUPER_USERS": [owner],
+        "BOOTSTRAP_TOKEN_OWNER": owner,
+        "BOOTSTRAP_TOKEN_PATH": str(tmp_path / "token.json"),
+        "BOOTSTRAP_TOKEN_EXPIRATION": 3600,
+        "BOOTSTRAP_TOKEN_SCOPE": "repo:read",
+    }
+
+
+def _create_bootstrap_token(config):
+    owner = model.user.get_user(config["BOOTSTRAP_TOKEN_OWNER"])
+    application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(),
+        owner,
+    )
+    token_record, access_token = model.oauth.create_bootstrap_oauth_api_token(
+        application,
+        owner,
+        "repo:read repo:write",
+    )
+    return owner, application, token_record, access_token
+
+
+def _stored_access_token(config):
+    with open(config["BOOTSTRAP_TOKEN_PATH"]) as f:
+        return json.load(f)["access_token"]
+
+
+def _expired_time():
+    return datetime.now(UTC).replace(tzinfo=None) - timedelta(days=1)
+
+
+def test_renew_valid_token(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, _, _, access_token = _create_bootstrap_token(config)
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "rotated"}
+    assert os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+
+    new_access_token = _stored_access_token(config)
+    assert new_access_token != access_token
+    assert model.oauth.validate_bootstrap_token(new_access_token, config) is not None
+    assert model.oauth.validate_bootstrap_token(access_token, config) is None
+
+
+def test_renew_removes_stale_bootstrap_tokens_for_canonical_app_only(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    owner, application, _, access_token = _create_bootstrap_token(config)
+    stale_token, stale_access_token = model.oauth.create_bootstrap_oauth_api_token(
+        application,
+        owner,
+        "repo:read",
+    )
+    unmarked_token, _ = model.oauth.create_user_access_token_for_application(
+        owner,
+        application,
+        "repo:read",
+        "Bearer",
+        3600,
+    )
+
+    other_owner = model.user.get_user("freshuser")
+    other_application = model.oauth.create_bootstrap_application(
+        model.oauth.get_bootstrap_app_name(),
+        other_owner,
+    )
+    other_token, _ = model.oauth.create_bootstrap_oauth_api_token(
+        other_application,
+        other_owner,
+        "repo:read",
+    )
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+    assert resp.status_code == 200
+
+    new_access_token = _stored_access_token(config)
+    tokens = model.oauth.get_bootstrap_tokens(application)
+    assert len(tokens) == 1
+    assert model.oauth.validate_bootstrap_token(new_access_token, config).id == tokens[0].id
+    assert model.oauth.lookup_access_token_by_uuid(stale_token.uuid) is None
+    assert model.oauth.validate_bootstrap_token(stale_access_token, config) is None
+    assert model.oauth.lookup_access_token_by_uuid(unmarked_token.uuid) is not None
+    assert model.oauth.lookup_access_token_by_uuid(other_token.uuid) is not None
+
+
+def test_renew_file_write_fails_rolls_back_db_token_changes(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, application, old_record, access_token = _create_bootstrap_token(config)
+
+    with (
+        patch.dict(real_app.config, config),
+        patch("endpoints.api.bootstrap.db_transaction", lambda: model.db.atomic()),
+        patch("endpoints.api.bootstrap.write_bootstrap_token", side_effect=OSError("boom")),
+    ):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+    assert resp.status_code == 500
+    assert model.oauth.lookup_access_token_by_uuid(old_record.uuid) is not None
+    assert model.oauth.validate_bootstrap_token(access_token, config) is not None
+    assert len(model.oauth.get_bootstrap_tokens(application)) == 1
+    assert not os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+
+
+def test_renew_db_cleanup_failure_happens_before_file_write(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, application, old_record, access_token = _create_bootstrap_token(config)
+
+    with (
+        patch.dict(real_app.config, config),
+        patch("endpoints.api.bootstrap.db_transaction", lambda: model.db.atomic()),
+        patch(
+            "endpoints.api.bootstrap.delete_bootstrap_tokens",
+            side_effect=RuntimeError("cleanup failed"),
+        ),
+        patch("endpoints.api.bootstrap.write_bootstrap_token") as mock_write_token,
+    ):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+    assert resp.status_code == 500
+    assert resp.get_json() == {"message": "Token rotation failed: could not clean up tokens"}
+    mock_write_token.assert_not_called()
+    assert model.oauth.lookup_access_token_by_uuid(old_record.uuid) is not None
+    assert model.oauth.validate_bootstrap_token(access_token, config) is not None
+    assert len(model.oauth.get_bootstrap_tokens(application)) == 1
+    assert not os.path.exists(config["BOOTSTRAP_TOKEN_PATH"])
+
+
+def test_renew_revalidates_token_after_lock(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, _, token_record, access_token = _create_bootstrap_token(config)
+
+    with (
+        patch.dict(real_app.config, config),
+        patch(
+            "endpoints.api.bootstrap.validate_bootstrap_token",
+            side_effect=[token_record, None],
+        ),
+        patch("endpoints.api.bootstrap.lock_bootstrap_token_operation") as mock_lock,
+        patch("endpoints.api.bootstrap.write_bootstrap_token") as mock_write_token,
+    ):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+    mock_lock.assert_called_once_with()
+    mock_write_token.assert_not_called()
+
+
+def test_renew_without_bearer_reaches_handler_with_valid_csrf(app, initialized_db):
+    with app.test_client() as cl:
+        with cl.session_transaction() as sess:
+            sess["_csrf_token"] = "csrf-token"
+
+        resp = cl.post(
+            "/api/v1/bootstrap/renew",
+            headers={"X-CSRF-Token": "csrf-token"},
+        )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_without_auth_header_requires_csrf(app, initialized_db):
+    with app.test_client() as cl:
+        resp = cl.post("/api/v1/bootstrap/renew")
+
+    assert resp.status_code == 403
+
+
+def test_renew_basic_auth_requires_csrf(app, initialized_db):
+    with app.test_client() as cl:
+        resp = cl.post(
+            "/api/v1/bootstrap/renew",
+            headers={"Authorization": "Basic dGVzdDp0ZXN0"},
+        )
+
+    assert resp.status_code == 403
+
+
+def test_renew_basic_auth_reaches_handler_with_valid_csrf(app, initialized_db):
+    with app.test_client() as cl:
+        with cl.session_transaction() as sess:
+            sess["_csrf_token"] = "csrf-token"
+
+        resp = cl.post(
+            "/api/v1/bootstrap/renew",
+            headers={
+                "Authorization": "Basic dGVzdDp0ZXN0",
+                "X-CSRF-Token": "csrf-token",
+            },
+        )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_logged_in_session_without_bearer_uses_normal_csrf(app, initialized_db):
+    with client_with_identity("devtable", app) as cl:
+        resp = cl.post("/api/v1/bootstrap/renew")
+
+    assert resp.status_code == 403
+
+
+def test_renew_logged_in_session_without_bearer_reaches_handler_with_valid_csrf(
+    app, initialized_db
+):
+    with client_with_identity("devtable", app) as cl:
+        with cl.session_transaction() as sess:
+            sess["_csrf_token"] = "csrf-token"
+
+        resp = cl.post(
+            "/api/v1/bootstrap/renew",
+            headers={"X-CSRF-Token": "csrf-token"},
+        )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_logged_in_session_with_bearer_uses_normal_csrf(app, initialized_db):
+    with client_with_identity("devtable", app) as cl:
+        resp = cl.post(
+            "/api/v1/bootstrap/renew",
+            headers={"Authorization": "Bearer invalidtoken1234567890"},
+        )
+
+    assert resp.status_code == 403
+
+
+def test_renew_logged_in_session_with_bearer_reaches_handler_with_valid_csrf(app, initialized_db):
+    with client_with_identity("devtable", app) as cl:
+        with cl.session_transaction() as sess:
+            sess["_csrf_token"] = "csrf-token"
+
+        resp = cl.post(
+            "/api/v1/bootstrap/renew",
+            headers={
+                "Authorization": "Bearer invalidtoken1234567890",
+                "X-CSRF-Token": "csrf-token",
+            },
+        )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_invalid_bearer_token(app, initialized_db):
+    with app.test_client() as cl:
+        resp = cl.post(
+            "/api/v1/bootstrap/renew",
+            headers={"Authorization": "Bearer invalidtoken1234567890"},
+        )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_empty_bearer_token(app, initialized_db):
+    with app.test_client() as cl:
+        resp = cl.post(
+            "/api/v1/bootstrap/renew",
+            headers={"Authorization": "Bearer    "},
+        )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_non_bootstrap_bearer_token(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_application(owner, "regular-app", "", "")
+    _, access_token = model.oauth.create_user_access_token_for_application(
+        owner,
+        application,
+        "repo:read",
+        "Bearer",
+        3600,
+    )
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+    assert resp.status_code == 403
+    assert resp.get_json()["error_type"] == "insufficient_scope"
+
+
+def test_renew_expired_token_accepted_from_loopback(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, _, token_record, access_token = _create_bootstrap_token(config)
+    token_record.expires_at = _expired_time()
+    token_record.save()
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+                environ_base={"REMOTE_ADDR": "127.0.0.1"},
+            )
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "rotated"}
+
+
+def test_renew_expired_token_accepted_from_ipv6_loopback(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, _, token_record, access_token = _create_bootstrap_token(config)
+    token_record.expires_at = _expired_time()
+    token_record.save()
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+                environ_base={"REMOTE_ADDR": "::1"},
+            )
+
+    assert resp.status_code == 200
+
+
+def test_renew_expired_token_rejected_from_remote_addr(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, _, token_record, access_token = _create_bootstrap_token(config)
+    token_record.expires_at = _expired_time()
+    token_record.save()
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+                environ_base={"REMOTE_ADDR": "203.0.113.50"},
+            )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_expired_token_rejects_proxy_derived_loopback(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, _, token_record, access_token = _create_bootstrap_token(config)
+    token_record.expires_at = _expired_time()
+    token_record.save()
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "X-Forwarded-For": "127.0.0.1",
+                },
+                environ_base={"REMOTE_ADDR": "203.0.113.50"},
+            )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_expired_token_accepted_from_quay_nginx_loopback_unix_socket(
+    app, initialized_db, tmp_path
+):
+    config = _bootstrap_config(tmp_path)
+    _, _, token_record, access_token = _create_bootstrap_token(config)
+    token_record.expires_at = _expired_time()
+    token_record.save()
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "X-Forwarded-For": "127.0.0.1",
+                    "X-Quay-Original-Remote-Addr": "127.0.0.1",
+                },
+                environ_base={"REMOTE_ADDR": ""},
+            )
+
+    assert resp.status_code == 200
+
+
+def test_renew_expired_token_rejects_spoofed_forwarded_loopback(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, _, token_record, access_token = _create_bootstrap_token(config)
+    token_record.expires_at = _expired_time()
+    token_record.save()
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "X-Forwarded-For": "127.0.0.1",
+                    "X-Quay-Original-Remote-Addr": "203.0.113.50",
+                },
+                environ_base={"REMOTE_ADDR": "203.0.113.50"},
+            )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_expired_token_rejects_direct_peer_spoofed_nginx_header(
+    app, initialized_db, tmp_path
+):
+    config = _bootstrap_config(tmp_path)
+    _, _, token_record, access_token = _create_bootstrap_token(config)
+    token_record.expires_at = _expired_time()
+    token_record.save()
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "X-Forwarded-For": "127.0.0.1",
+                    "X-Quay-Original-Remote-Addr": "127.0.0.1",
+                },
+                environ_base={"REMOTE_ADDR": "203.0.113.50"},
+            )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["error_type"] == "invalid_token"
+
+
+def test_renew_valid_token_from_remote_addr(app, initialized_db, tmp_path):
+    config = _bootstrap_config(tmp_path)
+    _, _, _, access_token = _create_bootstrap_token(config)
+
+    with patch.dict(real_app.config, config):
+        with app.test_client() as cl:
+            resp = cl.post(
+                "/api/v1/bootstrap/renew",
+                headers={"Authorization": f"Bearer {access_token}"},
+                environ_base={"REMOTE_ADDR": "203.0.113.50"},
+            )
+
+    assert resp.status_code == 200
+
+
+def test_loopback_remote_addr_helper_handles_empty_invalid_and_ipv4_mapped():
+    assert _is_loopback_remote_addr(None) is False
+    assert _is_loopback_remote_addr("") is False
+    assert _is_loopback_remote_addr("not-an-ip") is False
+    assert _is_loopback_remote_addr("::ffff:127.0.0.1") is True
+    assert _is_loopback_remote_addr("::ffff:203.0.113.50") is False

--- a/endpoints/api/test/test_security.py
+++ b/endpoints/api/test/test_security.py
@@ -14,6 +14,7 @@ from data.model.user import get_user
 from endpoints.api import api
 from endpoints.api.appspecifictokens import *
 from endpoints.api.billing import *
+from endpoints.api.bootstrap import BootstrapTokenRenew
 from endpoints.api.build import *
 from endpoints.api.capabilities import *
 from endpoints.api.discovery import *
@@ -83,6 +84,8 @@ SECURITY_TESTS: List[
         int,  # Expected HTTP status code
     ]
 ] = [
+    (BootstrapTokenRenew, "POST", {}, {}, None, 401),
+    (BootstrapTokenRenew, "POST", {}, {}, "devtable", 401),
     (AppTokens, "GET", {}, {}, None, 401),
     (AppTokens, "GET", {}, {}, "freshuser", 200),
     (AppTokens, "GET", {}, {}, "reader", 200),

--- a/endpoints/csrf.py
+++ b/endpoints/csrf.py
@@ -8,7 +8,11 @@ from flask import Response, request, session
 
 import features
 from app import app
-from auth.auth_context import get_sso_token, get_validated_oauth_token
+from auth.auth_context import (
+    get_authenticated_user,
+    get_sso_token,
+    get_validated_oauth_token,
+)
 from util.http import abort
 
 logger = logging.getLogger(__name__)
@@ -53,6 +57,23 @@ def verify_csrf(
         abort(403, message="CSRF token was invalid or missing.")
 
 
+def _has_bootstrap_auth() -> bool:
+    if not features.PROGRAMMATIC_BOOTSTRAP:
+        return False
+    if request.path != "/api/v1/bootstrap/renew":
+        return False
+    if get_authenticated_user() is not None:
+        return False
+
+    session_user = session.get("_user_id") or session.get("user_id")
+    if session_user and session_user != "anonymous":
+        return False
+
+    auth_header = request.headers.get("Authorization", "")
+    scheme = auth_header.lower().split(" ", 1)[0] if auth_header else ""
+    return scheme == "bearer"
+
+
 def csrf_protect(
     session_token_name=_QUAY_CSRF_TOKEN_NAME,
     request_token_name=_QUAY_CSRF_TOKEN_NAME,
@@ -65,7 +86,8 @@ def csrf_protect(
             # Verify the CSRF token.
             if get_validated_oauth_token() is None and get_sso_token() is None:
                 if all_methods or (request.method != "GET" and request.method != "HEAD"):
-                    verify_csrf(session_token_name, request_token_name, check_header)
+                    if not _has_bootstrap_auth():
+                        verify_csrf(session_token_name, request_token_name, check_header)
 
             # Invoke the handler.
             resp = func(*args, **kwargs)

--- a/endpoints/exception.py
+++ b/endpoints/exception.py
@@ -18,6 +18,7 @@ class ApiErrorType(Enum):
     not_found = "not_found"
     downstream_issue = "downstream_issue"
     tag_immutable = "tag_immutable"
+    token_rotation_failed = "token_rotation_failed"
 
 
 ERROR_DESCRIPTION = {
@@ -32,6 +33,7 @@ ERROR_DESCRIPTION = {
     ApiErrorType.not_found.value: "The resource was not found.",
     ApiErrorType.downstream_issue.value: "An error occurred in a downstream service.",
     ApiErrorType.tag_immutable.value: "The tag is immutable and cannot be modified or deleted.",
+    ApiErrorType.token_rotation_failed.value: "Token rotation failed.",
 }
 
 
@@ -143,6 +145,13 @@ class NotFound(ApiException):
 class DownstreamIssue(ApiException):
     def __init__(self, error_description, payload=None):
         ApiException.__init__(self, ApiErrorType.downstream_issue, 520, error_description, payload)
+
+
+class TokenRotationError(ApiException):
+    def __init__(self, error_description, payload=None):
+        ApiException.__init__(
+            self, ApiErrorType.token_rotation_failed, 500, error_description, payload
+        )
 
 
 class TagImmutable(ApiException):

--- a/endpoints/test/test_csrf.py
+++ b/endpoints/test/test_csrf.py
@@ -1,8 +1,126 @@
+from unittest.mock import MagicMock, patch
+
+from flask import session
+
 from app import app
-from endpoints.csrf import generate_csrf_token
+from endpoints.csrf import _has_bootstrap_auth, generate_csrf_token
+
+BOOTSTRAP_PATH = "/api/v1/bootstrap/renew"
 
 
 def test_generate_csrf_token():
     with app.test_request_context():
         token = generate_csrf_token()
         assert isinstance(token, str)
+
+
+def test_generate_csrf_token_reuses_existing_token_unless_forced():
+    with app.test_request_context():
+        first = generate_csrf_token()
+        assert generate_csrf_token() == first
+
+        forced = generate_csrf_token(force=True)
+        assert forced != first
+        assert generate_csrf_token() == forced
+
+
+def test_has_bootstrap_auth_bypasses_csrf_when_no_session():
+    with app.test_request_context(
+        BOOTSTRAP_PATH,
+        headers={"Authorization": "Bearer some-token"},
+    ):
+        with (
+            patch("endpoints.csrf.features") as mock_features,
+            patch("endpoints.csrf.get_authenticated_user") as mock_get_user,
+        ):
+            mock_features.PROGRAMMATIC_BOOTSTRAP = True
+            mock_get_user.return_value = None
+            assert _has_bootstrap_auth() is True
+
+
+def test_has_bootstrap_auth_enforces_csrf_when_session_active():
+    with app.test_request_context(
+        BOOTSTRAP_PATH,
+        headers={"Authorization": "Bearer some-token"},
+    ):
+        with (
+            patch("endpoints.csrf.features") as mock_features,
+            patch("endpoints.csrf.get_authenticated_user") as mock_get_user,
+        ):
+            mock_features.PROGRAMMATIC_BOOTSTRAP = True
+            mock_get_user.return_value = MagicMock()
+            assert _has_bootstrap_auth() is False
+
+
+def test_has_bootstrap_auth_enforces_csrf_when_session_user_id_present():
+    with app.test_request_context(
+        BOOTSTRAP_PATH,
+        headers={"Authorization": "Bearer some-token"},
+    ):
+        with (
+            patch("endpoints.csrf.features") as mock_features,
+            patch("endpoints.csrf.get_authenticated_user") as mock_get_user,
+        ):
+            mock_features.PROGRAMMATIC_BOOTSTRAP = True
+            mock_get_user.return_value = None
+            session["_user_id"] = "devtable"
+            assert _has_bootstrap_auth() is False
+
+
+def test_has_bootstrap_auth_returns_false_when_feature_disabled():
+    with app.test_request_context(
+        BOOTSTRAP_PATH,
+        headers={"Authorization": "Bearer some-token"},
+    ):
+        with patch("endpoints.csrf.features") as mock_features:
+            mock_features.PROGRAMMATIC_BOOTSTRAP = False
+            assert _has_bootstrap_auth() is False
+
+
+def test_has_bootstrap_auth_rejects_basic_scheme():
+    with app.test_request_context(
+        BOOTSTRAP_PATH,
+        headers={"Authorization": "Basic dGVzdDp0ZXN0"},
+    ):
+        with (
+            patch("endpoints.csrf.features") as mock_features,
+            patch("endpoints.csrf.get_authenticated_user") as mock_get_user,
+        ):
+            mock_features.PROGRAMMATIC_BOOTSTRAP = True
+            mock_get_user.return_value = None
+            assert _has_bootstrap_auth() is False
+
+
+def test_has_bootstrap_auth_rejects_unknown_scheme():
+    with app.test_request_context(
+        BOOTSTRAP_PATH,
+        headers={"Authorization": "Digest abc123"},
+    ):
+        with (
+            patch("endpoints.csrf.features") as mock_features,
+            patch("endpoints.csrf.get_authenticated_user") as mock_get_user,
+        ):
+            mock_features.PROGRAMMATIC_BOOTSTRAP = True
+            mock_get_user.return_value = None
+            assert _has_bootstrap_auth() is False
+
+
+def test_has_bootstrap_auth_no_header():
+    with app.test_request_context(BOOTSTRAP_PATH):
+        with (
+            patch("endpoints.csrf.features") as mock_features,
+            patch("endpoints.csrf.get_authenticated_user") as mock_get_user,
+        ):
+            mock_features.PROGRAMMATIC_BOOTSTRAP = True
+            mock_get_user.return_value = None
+            assert _has_bootstrap_auth() is False
+
+
+def test_has_bootstrap_auth_rejects_non_bootstrap_path():
+    with app.test_request_context(
+        "/api/v1/superuser/",
+        headers={"Authorization": "Bearer some-token"},
+    ):
+        with patch("endpoints.csrf.features") as mock_features:
+            mock_features.PROGRAMMATIC_BOOTSTRAP = True
+            assert _has_bootstrap_auth() is False

--- a/test/test_bootstrap_api_registration.py
+++ b/test/test_bootstrap_api_registration.py
@@ -1,0 +1,12 @@
+from config import DefaultConfig
+from test.fixtures import *
+from test.testconfig import TestConfig
+
+
+def test_programmatic_bootstrap_disabled_by_default():
+    assert DefaultConfig.FEATURE_PROGRAMMATIC_BOOTSTRAP is False
+
+
+def test_pytest_config_registers_bootstrap_renew_route(app):
+    assert TestConfig.FEATURE_PROGRAMMATIC_BOOTSTRAP is True
+    assert any(rule.rule == "/api/v1/bootstrap/renew" for rule in app.url_map.iter_rules())

--- a/test/test_bootstrap_api_registration.py
+++ b/test/test_bootstrap_api_registration.py
@@ -10,3 +10,7 @@ def test_programmatic_bootstrap_disabled_by_default():
 def test_pytest_config_registers_bootstrap_renew_route(app):
     assert TestConfig.FEATURE_PROGRAMMATIC_BOOTSTRAP is True
     assert any(rule.rule == "/api/v1/bootstrap/renew" for rule in app.url_map.iter_rules())
+
+
+def test_pytest_config_bootstrap_token_path_uses_unique_db_filename():
+    assert TestConfig.BOOTSTRAP_TOKEN_PATH == f"{TestConfig.TEST_DB_FILE.name}-bootstrap-token.json"

--- a/test/test_nginx_bootstrap.py
+++ b/test/test_nginx_bootstrap.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_nginx_maps_original_remote_addr_for_quay_header():
+    http_base = (ROOT / "conf/nginx/http-base.conf.jnj").read_text()
+
+    assert "map $realip_remote_addr $quay_original_remote_addr" in http_base
+    assert '""      $remote_addr;' in http_base
+    assert "default $realip_remote_addr;" in http_base
+
+
+def test_nginx_forwards_original_remote_addr_to_web_app():
+    server_base = (ROOT / "conf/nginx/server-base.conf.jnj").read_text()
+
+    assert "proxy_set_header X-Quay-Original-Remote-Addr $quay_original_remote_addr;" in server_base
+
+
+def test_nginx_defines_bootstrap_renew_rate_limit_bucket():
+    rate_limiting = (ROOT / "conf/nginx/rate-limiting.conf.jnj").read_text()
+
+    assert "map $quay_original_remote_addr $bootstrap_renew_bucket" in rate_limiting
+    assert '""      $binary_remote_addr;' in rate_limiting
+    assert (
+        "limit_req_zone $bootstrap_renew_bucket zone=bootstrap_renew:10m rate=10r/m;"
+        in rate_limiting
+    )
+
+
+def test_nginx_rate_limits_bootstrap_renew_endpoint():
+    server_base = (ROOT / "conf/nginx/server-base.conf.jnj").read_text()
+
+    assert "location = /api/v1/bootstrap/renew" in server_base
+    assert "limit_req zone=bootstrap_renew burst=5 nodelay;" in server_base
+    assert server_base.index("location = /api/v1/bootstrap/renew") < server_base.index(
+        "location /api/"
+    )

--- a/test/testconfig.py
+++ b/test/testconfig.py
@@ -49,7 +49,7 @@ class TestConfig(DefaultConfig):
     FEATURE_SUPERUSERS_FULL_ACCESS = True
     FEATURE_PROGRAMMATIC_BOOTSTRAP = True
     BOOTSTRAP_TOKEN_OWNER = "devtable"
-    BOOTSTRAP_TOKEN_PATH = os.path.join(os.path.dirname(TEST_DB_FILE.name), "bootstrap-token.json")
+    BOOTSTRAP_TOKEN_PATH = f"{TEST_DB_FILE.name}-bootstrap-token.json"
     FEATURE_BILLING = True
     FEATURE_MAILING = True
     SUPER_USERS = ["devtable"]

--- a/test/testconfig.py
+++ b/test/testconfig.py
@@ -47,6 +47,9 @@ class TestConfig(DefaultConfig):
 
     FEATURE_SUPER_USERS = True
     FEATURE_SUPERUSERS_FULL_ACCESS = True
+    FEATURE_PROGRAMMATIC_BOOTSTRAP = True
+    BOOTSTRAP_TOKEN_OWNER = "devtable"
+    BOOTSTRAP_TOKEN_PATH = os.path.join(os.path.dirname(TEST_DB_FILE.name), "bootstrap-token.json")
     FEATURE_BILLING = True
     FEATURE_MAILING = True
     SUPER_USERS = ["devtable"]

--- a/web/playwright/e2e/api/bootstrap-renew.spec.ts
+++ b/web/playwright/e2e/api/bootstrap-renew.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Bootstrap token renewal API tests.
+ *
+ * Successful token rotation is covered by pytest because it needs access to the
+ * generated bootstrap token and server-side token storage. This E2E check
+ * verifies the externally observable bearer-auth behavior for the endpoint.
+ */
+
+import {test, expect} from '../../fixtures';
+import {API_URL} from '../../utils/config';
+
+const BOOTSTRAP_RENEW_PATH = '/api/v1/bootstrap/renew';
+
+function isProgrammaticBootstrapEnabled(features: unknown): boolean {
+  const featureMap = features as Record<string, boolean | undefined>;
+  return featureMap.PROGRAMMATIC_BOOTSTRAP === true;
+}
+
+test.describe(
+  'Bootstrap token renewal API',
+  {tag: ['@api', '@auth:Database', '@PROJQUAY-12148']},
+  () => {
+    test('rejects invalid bearer token without accepting CSRF fallback', async ({
+      playwright,
+      quayConfig,
+    }) => {
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+
+      try {
+        const response = await request.post(
+          `${API_URL}${BOOTSTRAP_RENEW_PATH}`,
+          {
+            headers: {
+              Authorization: 'Bearer definitely-invalid-bootstrap-token',
+            },
+            timeout: 10_000,
+          },
+        );
+
+        if (!isProgrammaticBootstrapEnabled(quayConfig.features)) {
+          // The API resource is not registered, but Quay's GET-only web
+          // catch-all route still matches the path and rejects POST.
+          expect(response.status()).toBe(405);
+          return;
+        }
+
+        expect(response.status()).toBe(401);
+        const body = await response.json();
+        expect(body.error_type).toBe('invalid_token');
+      } finally {
+        await request.dispose();
+      }
+    });
+  },
+);


### PR DESCRIPTION
- Add `POST /api/v1/bootstrap/renew` for exchanging bootstrap Bearer tokens
- Rotate bootstrap tokens in the configured local token store and canonical bootstrap app
- Forward original client addresses through nginx with `X-Quay-Original-Remote-Addr`
- Restrict expired-token renewal to loopback original client addresses