### PR TITLE
PROJQUAY-12151: fix(ui): remove hardcoded wizard width causing modal overflow

### DIFF
--- a/web/playwright/e2e/organization/default-permissions.spec.ts
+++ b/web/playwright/e2e/organization/default-permissions.spec.ts
@@ -562,6 +562,56 @@ test.describe('Default Permissions', {tag: ['@organization']}, () => {
     await expect(defaultPermPanel.getByText(robot.fullName)).toBeVisible();
   });
 
+  test(
+    'Create Team wizard fits within modal without overflow (PROJQUAY-12151)',
+    {tag: '@PROJQUAY-12151'},
+    async ({authenticatedPage, api}) => {
+      const org = await api.organization('teamoverflow');
+      const newTeamName = uniqueName('overflow').substring(0, 20);
+
+      await authenticatedPage.goto(
+        `/organization/${org.name}?tab=Defaultpermissions`,
+      );
+
+      await authenticatedPage
+        .getByTestId('create-default-permissions-btn')
+        .click();
+
+      await authenticatedPage.getByTestId('Anyone').click();
+
+      await authenticatedPage.locator('#applied-to-dropdown').click();
+      await authenticatedPage.getByTestId('create-new-team-btn').click();
+
+      await authenticatedPage
+        .getByTestId('new-team-name-input')
+        .fill(newTeamName);
+      await authenticatedPage.getByTestId('create-team-confirm').click();
+
+      await expect(
+        authenticatedPage.locator('.pf-v6-c-alert.pf-m-success').last(),
+      ).toContainText(`Successfully created new team: ${newTeamName}`);
+
+      const modal = authenticatedPage.locator('#create-team-modal');
+      await expect(modal).toBeVisible();
+
+      const wizard = modal.locator('.pf-v6-c-wizard');
+      await expect(wizard).toBeVisible();
+
+      const modalBox = await modal.boundingBox();
+      const wizardBox = await wizard.boundingBox();
+
+      expect(modalBox).not.toBeNull();
+      expect(wizardBox).not.toBeNull();
+      if (modalBox && wizardBox) {
+        expect(wizardBox.width).toBeLessThanOrEqual(modalBox.width);
+        expect(wizardBox.x).toBeGreaterThanOrEqual(modalBox.x);
+        expect(wizardBox.x + wizardBox.width).toBeLessThanOrEqual(
+          modalBox.x + modalBox.width + 1,
+        );
+      }
+    },
+  );
+
   test('can bulk delete default permissions', async ({
     authenticatedPage,
     api,

--- a/web/playwright/e2e/organization/robot-accounts.spec.ts
+++ b/web/playwright/e2e/organization/robot-accounts.spec.ts
@@ -229,13 +229,6 @@ test.describe(
         'Robot for Docker config test',
       );
 
-      // Get server hostname from config
-      const configResponse = await authenticatedRequest.get(
-        `${API_URL}/config`,
-      );
-      const config = await configResponse.json();
-      const serverHostname = config.config.SERVER_HOSTNAME;
-
       // Get robot token from API
       const robotResponse = await authenticatedRequest.get(
         `${API_URL}/api/v1/organization/${org.name}/robots/${robot.shortname}`,
@@ -1018,6 +1011,41 @@ test.describe(
         expect(robotData.token).toBe(robot.token);
       });
     });
+
+    test(
+      'robot wizard fits within modal without overflow (PROJQUAY-12151)',
+      {tag: '@PROJQUAY-12151'},
+      async ({authenticatedPage, api}) => {
+        const org = await api.organization('wizoverflow');
+
+        await authenticatedPage.goto(
+          `/organization/${org.name}?tab=Robotaccounts`,
+        );
+
+        await authenticatedPage
+          .getByRole('button', {name: 'Create robot account'})
+          .click();
+
+        const modal = authenticatedPage.locator('#create-robot-account-modal');
+        await expect(modal).toBeVisible();
+
+        const wizard = modal.locator('.pf-v6-c-wizard');
+        await expect(wizard).toBeVisible();
+
+        const modalBox = await modal.boundingBox();
+        const wizardBox = await wizard.boundingBox();
+
+        expect(modalBox).not.toBeNull();
+        expect(wizardBox).not.toBeNull();
+        if (modalBox && wizardBox) {
+          expect(wizardBox.width).toBeLessThanOrEqual(modalBox.width);
+          expect(wizardBox.x).toBeGreaterThanOrEqual(modalBox.x);
+          expect(wizardBox.x + wizardBox.width).toBeLessThanOrEqual(
+            modalBox.x + modalBox.width + 1,
+          );
+        }
+      },
+    );
 
     test.describe(
       'with ROBOTS_DISALLOW enabled',

--- a/web/src/components/modals/CreateRobotAccountModal.tsx
+++ b/web/src/components/modals/CreateRobotAccountModal.tsx
@@ -256,7 +256,6 @@ export default function CreateRobotAccountModal(
       <Wizard
         onClose={handleModalToggle}
         height={600}
-        width={1170}
         header={
           <WizardHeader
             onClose={handleModalToggle}

--- a/web/src/components/modals/CreateRobotAccountModal.tsx
+++ b/web/src/components/modals/CreateRobotAccountModal.tsx
@@ -281,7 +281,9 @@ interface CreateRobotAccountModalProps {
   isModalOpen: boolean;
   handleModalToggle?: () => void;
   orgName: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   teams: any[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   RepoPermissionDropdownItems: any[];
   setEntity?: React.Dispatch<SetStateAction<Entity>>;
   showSuccessAlert: (msg: string) => void;

--- a/web/src/components/modals/CreateRobotAccountModal.tsx
+++ b/web/src/components/modals/CreateRobotAccountModal.tsx
@@ -251,7 +251,6 @@ export default function CreateRobotAccountModal(
       aria-label="CreateRobotAccount"
       variant={ModalVariant.large}
       isOpen={props.isModalOpen}
-      onClose={handleModalToggle}
     >
       <Wizard
         onClose={handleModalToggle}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/CreateTeamWizard.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/CreateTeamWizard.tsx
@@ -147,10 +147,6 @@ export const CreateTeamWizard = (props: CreateTeamWizardProps): JSX.Element => {
         aria-label="CreateTeam"
         variant={ModalVariant.large}
         isOpen={props.isTeamWizardOpen}
-        onClose={() => {
-          props.handleWizardToggle();
-          setSelectedRepoPerms([]);
-        }}
       >
         <Wizard
           onClose={() => {

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/CreateTeamWizard.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/createTeamWizard/CreateTeamWizard.tsx
@@ -158,7 +158,6 @@ export const CreateTeamWizard = (props: CreateTeamWizardProps): JSX.Element => {
             setSelectedRepoPerms([]);
           }}
           height={600}
-          width={1170}
           header={
             <WizardHeader
               onClose={() => {

--- a/web/src/routes/RepositoryDetails/Builds/BuildTriggerSetupModal.tsx
+++ b/web/src/routes/RepositoryDetails/Builds/BuildTriggerSetupModal.tsx
@@ -79,11 +79,10 @@ export default function SetupBuildTriggerModal(props: SetupBuildTriggerWizard) {
 
   return (
     <Modal
-      id="create-robot-account-modal"
-      aria-label="CreateRobotAccount"
+      id="setup-build-trigger-modal"
+      aria-label="SetupBuildTrigger"
       variant={ModalVariant.large}
       isOpen={props.isOpen}
-      onClose={props.onClose}
     >
       {modalContent}
     </Modal>

--- a/web/src/routes/RepositoryDetails/Builds/BuildTriggerSetupWizard.tsx
+++ b/web/src/routes/RepositoryDetails/Builds/BuildTriggerSetupWizard.tsx
@@ -154,7 +154,6 @@ export default function BuildTriggerSetupWizard(
   return (
     <Wizard
       height={600}
-      width={1170}
       isVisitRequired
       header={
         <WizardHeader


### PR DESCRIPTION
## Summary

Fix wizard panel overflow and duplicate close button artifacts in Create Robot Account, Create Team, and Build Trigger Setup modals.

### Changes

**1. Remove hardcoded `width={1170}` from Wizard components**
- The 1170px inline width overflowed the `ModalVariant.large` container (~962px on ~994px viewports), clipping wizard content
- PatternFly's modal variant already constrains width responsively, so the wizard naturally fills 100% of its parent
- Affected files:
  - `web/src/components/modals/CreateRobotAccountModal.tsx`
  - `web/src/routes/.../createTeamWizard/CreateTeamWizard.tsx`
  - `web/src/routes/.../Builds/BuildTriggerSetupWizard.tsx`

**2. Remove duplicate modal close buttons**
- When `<Modal onClose={...}>` wraps a `<Wizard>` with `<WizardHeader onClose={...}>`, both render their own close button in the top-right corner, creating a visual artifact (white protrusion / overlapping buttons)
- Fix: remove `onClose` from the `<Modal>` since `<WizardHeader>` already handles closing
- Affected files:
  - `web/src/components/modals/CreateRobotAccountModal.tsx`
  - `web/src/routes/.../createTeamWizard/CreateTeamWizard.tsx`
  - `web/src/routes/.../Builds/BuildTriggerSetupModal.tsx`

**3. Fix copy-paste `id` and `aria-label` in BuildTriggerSetupModal**
- Changed from `id="create-robot-account-modal" aria-label="CreateRobotAccount"` to `id="setup-build-trigger-modal" aria-label="SetupBuildTrigger"`

**4. Fix pre-existing lint warnings in touched files**
- Remove unused `serverHostname` variable in `robot-accounts.spec.ts`
- Add `eslint-disable` for pre-existing `any[]` props in `CreateRobotAccountModal.tsx`

## Validation Testing Results:
<img width="2302" height="1178" alt="image" src="https://github.com/user-attachments/assets/cef8f7dc-ca1a-41bc-9fa1-2126a0540b41" />
<img width="2302" height="1178" alt="image" src="https://github.com/user-attachments/assets/f564da1b-15dd-470d-af5d-513b51a8c48d" />
<img width="2317" height="1200" alt="image" src="https://github.com/user-attachments/assets/1415b1b3-f609-4bfa-b6e0-f4a3f1e3e792" />


## Test plan
- [x] Open Create Robot Account wizard → verify it fits within the modal without overflow
- [x] Open Create Team wizard → verify same
- [x] Open Build Trigger Setup wizard → verify same
- [x] Verify only one close button (✕) appears in wizard modals, no duplicate/overlapping buttons
- [ ] Test at various viewport widths (~994px, 1200px, 1440px)

## E2E tests added
- `robot-accounts.spec.ts`: bounding-box test verifying Create Robot Account wizard fits within modal
- `default-permissions.spec.ts`: bounding-box test for Create Team wizard (full flow: Create default permission → Anyone → dropdown → Create new team)

🤖 Generated with [Claude Code](https://claude.ai/code)