### PR TITLE
PROJQUAY-12082: fix(cve): CVE-2026-13676 - FastUri

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11062,9 +11062,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -118,7 +118,7 @@
     "axios": "^1.16.1",
     "immutable": "^5.1.5",
     "svgo": "4.0.1",
-    "fast-uri":"3.1.2"
+    "fast-uri":"3.1.3"
   },
   "optionalDependencies": {
     "cypress": "^13.13.2"


### PR DESCRIPTION
## CVE Details
- **CVE ID**: CVE-2026-13676
- **Severity**: HIGH (CVSS 7.8)
- **Package**: fast-uri
- **Affected versions**: >= 2.3.1, <= 3.1.2; 4.0.0
- **Fixed version**: 3.1.3
- **Advisory**: https://github.com/fastify/fast-uri/security/advisories/GHSA-4c8g-83qw-93j6

## Fix Summary
Overided Fast-URI to 3.1.3 in  `package.json` and regenerated `package-lock.json`.

## Jira References
- Resolves: [PROJQUAY-12082](https://issues.redhat.com/browse/PROJQUAY-12082)