### PR TITLE
PROJQUAY-12119: fix(cve): CVE-2026-45822 - decode-uri-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "bootbox": "^4.1.0",
         "clipboard": "^1.6.1",
         "core-js": "^2.4.1",
+        "decode-uri-component": "^0.2.0",
         "elliptic": "^6.5.7",
         "file-saver": "^1.3.3",
         "highlight.js": "^9.12.0",
@@ -2459,13 +2460,12 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
-      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
-      "dev": true,
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
       "license": "MIT",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=0.10"
       }
     },
     "node_modules/deep-extend": {
@@ -13967,10 +13967,9 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
-      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
-      "dev": true
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -19652,7 +19651,7 @@
       "dev": true,
       "requires": {
         "atob": "^2.1.1",
-        "decode-uri-component": "^0.5.0",
+        "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2459,12 +2459,13 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=14.16"
       }
     },
     "node_modules/deep-extend": {
@@ -13966,9 +13967,9 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
       "dev": true
     },
     "deep-extend": {
@@ -19651,7 +19652,7 @@
       "dev": true,
       "requires": {
         "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
+        "decode-uri-component": "^0.5.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
   "overrides": {
     "cross-spawn": "^6.0.6",
     "qs": "^6.14.0",
-    "form-data": "^2.5.6"
+    "form-data": "^2.5.6",
+    "decode-uri-component": "^0.5.0"
+
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/quay/quay#readme",
   "dependencies": {
+    "@sentry/browser": "^7.100.0",
     "angular": "1.6.4",
     "angular-route": "1.6.4",
     "angular-sanitize": "1.6.4",
@@ -27,6 +28,7 @@
     "bootbox": "^4.1.0",
     "clipboard": "^1.6.1",
     "core-js": "^2.4.1",
+    "decode-uri-component": "^0.2.0",
     "elliptic": "^6.5.7",
     "file-saver": "^1.3.3",
     "highlight.js": "^9.12.0",
@@ -35,7 +37,6 @@
     "ng-metadata": "^4.0.1",
     "package.json": "^2.0.1",
     "process": "^0.11.10",
-    "@sentry/browser": "^7.100.0",
     "rxjs": "5.5.7",
     "showdown": "^1.6.4",
     "url-parse": "^1.5.9"
@@ -79,8 +80,6 @@
   "overrides": {
     "cross-spawn": "^6.0.6",
     "qs": "^6.14.0",
-    "form-data": "^2.5.6",
-    "decode-uri-component": "^0.5.0"
-
+    "form-data": "^2.5.6"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7332,11 +7332,12 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=14.16"
       }
     },
     "node_modules/deep-extend": {

--- a/web/package.json
+++ b/web/package.json
@@ -139,6 +139,7 @@
     "minimatch": "3.1.5",
     "immutable": "^5.1.5",
     "svgo": "4.0.1",
-    "fast-uri":"3.1.2"
+    "fast-uri": "3.1.2",
+    "decode-uri-component": "^0.5.0" 
   }
 }


### PR DESCRIPTION
## Summary                                                                               
  Security fix for CVE-2026-45822 affecting decode-uri-component                           

  ## Details                                                                               
  - **CVE**: CVE-2026-45822                                                                
  - **Severity**: Important (CVSSv3: 7.5)                                                  
  - **Impact**: Denial of Service via crafted input                                        
  - **Component**: decode-uri-component                                                    
  - **Old Version**: 0.2.2                                                                 
  - **New Version**: 0.5.0                                                                 

  ## Changes                                                                               
  - Updated decode-uri-component from 0.2.2 to 0.5.0 in web/package-lock.json
  - Updated decode-uri-component from 0.2.2 to 0.5.0 in package-lock.json                            

  ## References                                                                            
  - https://access.redhat.com/security/cve/cve-2026-45822
  - https://www.npmjs.com/package/decode-uri-component                                     

  Resolves: [PROJQUAY-12119](https://redhat.atlassian.net/browse/PROJQUAY-12119)                                                                