### PR TITLE
PROJQUAY-12119: fix(cve): CVE-2026-45822 - decode-uri-component

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7332,11 +7332,12 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=14.16"
       }
     },
     "node_modules/deep-extend": {

--- a/web/package.json
+++ b/web/package.json
@@ -139,6 +139,7 @@
     "minimatch": "3.1.5",
     "immutable": "^5.1.5",
     "svgo": "4.0.1",
-    "fast-uri":"3.1.2"
+    "fast-uri":"3.1.2",
+    "decode-uri-component":"^0.5.0"
   }
 }


### PR DESCRIPTION
## Summary                                                                               
  Security fix for CVE-2026-45822 affecting decode-uri-component                           

  ## Details                                                                               
  - **CVE**: CVE-2026-45822                                                                
  - **Severity**: Important (CVSSv3: 7.5)                                                  
  - **Impact**: Denial of Service via crafted input                                        
  - **Component**: decode-uri-component                                                    
  - **Old Version**: 0.2.2                                                                 
  - **New Version**: 0.5.0                                                                 

  ## Changes                                                                               
  - Updated decode-uri-component from 0.2.2 to 0.5.0 in web/package-lock.json
  - Updated decode-uri-component from 0.2.2 to 0.5.0 in package-lock.json                                               

  ## References                                                                            
  - https://access.redhat.com/security/cve/cve-2026-45822
  - https://www.npmjs.com/package/decode-uri-component                                     

  Resolves: [PROJQUAY-12119](https://redhat.atlassian.net/browse/PROJQUAY-12119)                            