### PR TITLE
[redhat-3.14] PROJQUAY-11957: deps: bump sanitize-html to 2.17.5

### DIFF
--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -51,7 +51,7 @@
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",
     "redux": "4.0.1",
-    "sanitize-html": "1.x",
+    "sanitize-html": "^2.17.5",
     "screenfull": "4.x",
     "semver": "^6.0.0",
     "showdown": "1.8.x",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24661,9 +24661,9 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.1.tgz",
-      "integrity": "sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",


### PR DESCRIPTION
Bump sanitize-html transitive dependency to 2.17.5 to fix stored XSS via xmp tag bypass.

File	                                                         Change
web/package-lock.json                        sanitize-html 2.17.1 -> 2.17.5 (version, resolved, integrity)
integration_tests/package.json          "1.x" -> "^2.17.5"

This resolves [PROJQUAY-11957](https://redhat.atlassian.net/browse/PROJQUAY-11957)