### PR TITLE
[redhat-3.10] PROJQUAY-11961: deps: bump sanitize-html to 2.17.5

### DIFF
--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -51,7 +51,7 @@
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",
     "redux": "4.0.1",
-    "sanitize-html": "1.x",
+    "sanitize-html": "^2.17.5",
     "screenfull": "4.x",
     "semver": "^6.0.0",
     "showdown": "1.8.x",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22899,9 +22899,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sanitize-html": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.10.0.tgz",
-      "integrity": "sha512-JqdovUd81dG4k87vZt6uA6YhDfWkUGruUu/aPmXLxXi45gZExnt9Bnw/qeQU8oGf82vPyaE0vO4aH0PbobB9JQ==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -43260,9 +43260,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-html": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.10.0.tgz",
-      "integrity": "sha512-JqdovUd81dG4k87vZt6uA6YhDfWkUGruUu/aPmXLxXi45gZExnt9Bnw/qeQU8oGf82vPyaE0vO4aH0PbobB9JQ==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
       "requires": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",


### PR DESCRIPTION
Bump sanitize-html transitive dependency to 2.17.5 to fix stored XSS via xmp tag bypass.

File	                                      ----------------Change
web/package-lock.json      ----------------sanitize-html 2.10.0 -> 2.17.5 in both the v3 packages section AND v2 dependencies section (version, resolved, integrity)

integration_tests/package.json --------"1.x" -> "^2.17.5"

This resolves [PROJQUAY-11961](https://redhat.atlassian.net/browse/PROJQUAY-11961)