### PR TITLE
[redhat-3.9] PROJQUAY-11958: deps: bump sanitize-html to 2.17.5

### DIFF
--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -54,7 +54,7 @@
     "react-transition-group": "2.3.x",
     "react-virtualized": "9.x",
     "redux": "4.0.1",
-    "sanitize-html": "1.x",
+    "sanitize-html": "^2.17.5",
     "screenfull": "4.x",
     "semver": "^6.0.0",
     "showdown": "1.8.x",
@@ -129,4 +129,3 @@
     "node": ">=8.x"
   }
 }
-

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21465,9 +21465,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
-      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",


### PR DESCRIPTION
Bump sanitize-html transitive dependency to 2.17.5 to fix stored XSS via xmp tag bypass.

File -------------------------------------------------------Change
web/package-lock.json ----------------------------sanitize-html 2.17.0 -> 2.17.5 (version, resolved, integrity)
integration_tests/package.json ----------------"1.x" -> "^2.17.5"

This resolves [PROJQUAY-11958](https://redhat.atlassian.net/browse/PROJQUAY-11958) 