### PR TITLE
NO-ISSUE: chore(deps): disable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "enabled": true
   },
   "osvVulnerabilityAlerts": false,
-  "dependencyDashboard": true,
+  "dependencyDashboard": false,
   "extends": [
     "github>konflux-ci/mintmaker-presets:cve-automerge-all"
   ],


### PR DESCRIPTION
## Description

Disables the Renovate dependency dashboard GitHub issue. The dashboard issue adds noise to the repository's issue tracker without providing significant value for our workflow.

### Changes

- Set `dependencyDashboard` to `false` in `renovate.json`

This does **not** affect dependency update PRs — MintMaker will continue to open PRs for dependency updates as configured. It only disables the tracking issue that Renovate creates in GitHub Issues.

## Checklist

- [x] Change is config-only (no code changes)
- [x] No tests needed