### PR TITLE
PROJQUAY-10149: fix(api): reject duplicate email on org creation

### DIFF
--- a/data/model/organization.py
+++ b/data/model/organization.py
@@ -60,6 +60,15 @@ def create_organization(
                     "Email has already been used: %s" % effective_email
                 )
 
+            if (
+                effective_email
+                and not features.ORG_SHARED_EMAIL
+                and find_organizations_by_email(effective_email).count() > 0
+            ):
+                raise InvalidEmailAddressException(
+                    "Email is already associated with another organization: %s" % effective_email
+                )
+
             new_org = _create_org_user(name, effective_email, is_possible_abuser)
 
             owners_team = team.create_team("owners", new_org, "admin")

--- a/data/model/test/test_organization.py
+++ b/data/model/test/test_organization.py
@@ -1,5 +1,8 @@
 import pytest
 from playhouse.test_utils import assert_query_count
+from unittest.mock import patch
+
+from features import FeatureNameValue
 
 from data.model.organization import (
     create_organization,
@@ -210,11 +213,13 @@ class TestCreateOrganizationEmail:
         assert org.email == "fallback@example.com"
 
     def test_two_orgs_can_share_same_email(self, initialized_db):
-        """Test that two organizations can have the same email address."""
+        """Test that two organizations can have the same email address when
+        FEATURE_ORG_SHARED_EMAIL is enabled."""
         admin = get_user("devtable")
         shared = "shared@example.com"
-        org1 = create_organization("sharedorg1", shared, admin)
-        org2 = create_organization("sharedorg2", shared, admin)
+        with patch("features.ORG_SHARED_EMAIL", FeatureNameValue("ORG_SHARED_EMAIL", True)):
+            org1 = create_organization("sharedorg1", shared, admin)
+            org2 = create_organization("sharedorg2", shared, admin)
         assert org1.email == shared
         assert org2.email == shared
         assert org1.id != org2.id
@@ -227,10 +232,6 @@ class TestCreateOrganizationEmail:
         so the partial unique index fires during INSERT. The fix is to insert
         with a placeholder email, set organization=true, then apply the real email.
         """
-        from unittest.mock import patch
-
-        from features import FeatureNameValue
-
         admin = get_user("devtable")
         user_email = admin.email  # devtable's email
         with patch("features.ORG_SHARED_EMAIL", FeatureNameValue("ORG_SHARED_EMAIL", True)):
@@ -262,13 +263,24 @@ class TestCreateOrganizationEmail:
         """Test find_organizations_by_email returns multiple matching orgs."""
         admin = get_user("devtable")
         shared = "shared-find@example.com"
-        org1 = create_organization("findorg2a", shared, admin)
-        org2 = create_organization("findorg2b", shared, admin)
+        with patch("features.ORG_SHARED_EMAIL", FeatureNameValue("ORG_SHARED_EMAIL", True)):
+            org1 = create_organization("findorg2a", shared, admin)
+            org2 = create_organization("findorg2b", shared, admin)
         results = list(find_organizations_by_email(shared))
         assert len(results) == 2
         result_ids = {r.id for r in results}
         assert org1.id in result_ids
         assert org2.id in result_ids
+
+    def test_org_to_org_shared_email_blocked_when_flag_off(self, initialized_db):
+        """Test that creating an org with another org's email is blocked when
+        FEATURE_ORG_SHARED_EMAIL is disabled (the default)."""
+        from data.model import InvalidEmailAddressException
+
+        admin = get_user("devtable")
+        create_organization("firstsharedorg", "orgshared@example.com", admin)
+        with pytest.raises(InvalidEmailAddressException):
+            create_organization("secondsharedorg", "orgshared@example.com", admin)
 
     def test_find_organizations_by_email_no_match(self, initialized_db):
         """Test find_organizations_by_email returns empty when no match."""
@@ -283,10 +295,6 @@ class TestCreateOrganizationEmail:
         Regression test for the combined recovery email flow where a single
         email may now match a personal user AND multiple organizations.
         """
-        from unittest.mock import patch
-
-        from features import FeatureNameValue
-
         admin = get_user("devtable")
         shared = admin.email  # e.g. devtable@devtable.com
 

--- a/test/test_api_usage.py
+++ b/test/test_api_usage.py
@@ -1264,6 +1264,23 @@ class TestCreateOrganization(ApiTestCase):
 
         self.assertEqual("A user or organization with this name already exists", json["detail"])
 
+    def test_createorg_duplicate_email(self):
+        self.login(ADMIN_ACCESS_USER)
+
+        self.postResponse(
+            OrganizationList,
+            data=dict(name="dupemailorg1", email="shared@example.com"),
+            expected_code=201,
+        )
+
+        json = self.postJsonResponse(
+            OrganizationList,
+            data=dict(name="dupemailorg2", email="shared@example.com"),
+            expected_code=400,
+        )
+
+        self.assertIn("already associated", json["detail"])
+
     def test_createorg(self):
         self.login(ADMIN_ACCESS_USER)
 


### PR DESCRIPTION
When a user provides an email address for a new organization and that email is already associated with an existing organization, raise InvalidEmailAddressException so the endpoint returns HTTP 400 with a clear error message instead of silently succeeding with HTTP 201.

Previously the uniqueness check was gated on email_required (features.MAILING), so duplicate org emails were accepted regardless of the FEATURE_MAILING setting. The fix calls the existing find_organizations_by_email() helper unconditionally whenever an email is supplied during org creation.

Also adds test_createorg_duplicate_email to test/test_api_usage.py to cover this path.

Jira : https://redhat.atlassian.net/browse/PROJQUAY-10149
