### PR TITLE
NO-ISSUE: feat(auth): add robot token authentication

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -429,28 +429,34 @@ jobs:
       - name: Verify mirrored repositories
         run: |
           PASSWORD=$(sudo cat /var/lib/quay/auth/admin-password)
-          curl -fs -u "admin:$PASSWORD" \
-            https://localhost:8443/v2/_catalog | tee /tmp/catalog.json
 
-          COUNT=$(jq '.repositories | length' /tmp/catalog.json)
-          echo "Found $COUNT repositories:"
-          jq -r '.repositories[]' /tmp/catalog.json
+          expected_repos=(
+            projectquay/quay
+            projectquay/quay-builder
+            projectquay/clair
+            quay/quay-operator
+            prometheus/prometheus
+            prometheus/alertmanager
+            prometheus/node-exporter
+            prometheus/pushgateway
+            coreos/etcd
+          )
 
-          if [ "$COUNT" -lt 9 ]; then
-            echo "FAIL: expected at least 9 repositories, got $COUNT"
-            exit 1
-          fi
+          for repo in "${expected_repos[@]}"; do
+            safe_repo="${repo//\//-}"
+            curl -fs -u "admin:$PASSWORD" \
+              "https://localhost:8443/v2/${repo}/tags/list" \
+              | tee "/tmp/tags-${safe_repo}.json"
+            jq -e --arg repo "$repo" \
+              '.name == $repo and (.tags | type == "array") and (.tags | length > 0)' \
+              "/tmp/tags-${safe_repo}.json"
+          done
           echo "All repositories verified"
 
       - name: Pull mirrored image
         run: |
-          PASSWORD=$(sudo cat /var/lib/quay/auth/admin-password)
-          REPO=$(curl -fs -u "admin:$PASSWORD" \
-            https://localhost:8443/v2/_catalog | jq -r '.repositories[0]')
-          TAG=$(curl -fs -u "admin:$PASSWORD" \
-            "https://localhost:8443/v2/$REPO/tags/list" | jq -r '.tags[0]')
-          echo "Pulling localhost:8443/$REPO:$TAG"
-          podman pull "localhost:8443/$REPO:$TAG"
+          echo "Pulling localhost:8443/projectquay/quay:3.13.2"
+          podman pull "localhost:8443/projectquay/quay:3.13.2"
           echo "Successfully pulled mirrored image"
 
       - name: Collect diagnostics
@@ -550,6 +556,96 @@ jobs:
           sudo podman manifest add localhost:8443/init/test-index:latest registry.access.redhat.com/ubi9/ubi-micro:latest
           sudo podman manifest push --all --tls-verify=false \
             localhost:8443/init/test-index:latest docker://localhost:8443/init/test-index:latest
+
+      - name: Create and verify old OMR robot token
+        run: |
+          set -euo pipefail
+
+          mkdir -p /tmp/e2e-migrate-state
+          secret_dir="/tmp/e2e-migrate-secrets"
+          mkdir -p "$secret_dir"
+          chmod 700 "$secret_dir"
+
+          cookie_jar="${secret_dir}/omr-api.cookies"
+          signin_json="${secret_dir}/omr-signin.json"
+          robot_json="${secret_dir}/omr-robot.json"
+          permission_json="/tmp/e2e-migrate-state/omr-robot-permission.json"
+          robot_env="${secret_dir}/robot.env"
+          robot_authfile="${secret_dir}/robot-source-auth.json"
+
+          get_csrf_token() {
+            curl -kfsS -b "$cookie_jar" -c "$cookie_jar" \
+              https://localhost:8443/csrf_token \
+              | jq -r '.csrf_token // empty'
+          }
+
+          csrf_token=$(get_csrf_token)
+          if [ -z "$csrf_token" ]; then
+            echo "FAIL: old OMR did not return an initial CSRF token"
+            exit 1
+          fi
+
+          curl -kfsS -b "$cookie_jar" -c "$cookie_jar" \
+            -H "X-CSRF-Token: ${csrf_token}" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d '{"username":"init","password":"testpassword123"}' \
+            -o "$signin_json" \
+            https://localhost:8443/api/v1/signin
+
+          csrf_token=$(get_csrf_token)
+          if [ -z "$csrf_token" ]; then
+            echo "FAIL: old OMR did not return a post-login CSRF token"
+            exit 1
+          fi
+
+          curl -kfsS -b "$cookie_jar" -c "$cookie_jar" \
+            -H "X-CSRF-Token: ${csrf_token}" \
+            -H "Content-Type: application/json" \
+            -X PUT \
+            -d '{"description":"migration e2e robot token compatibility"}' \
+            -o "$robot_json" \
+            https://localhost:8443/api/v1/user/robots/migratebot
+
+          robot_username=$(jq -r '.name // empty' "$robot_json")
+          robot_token=$(jq -r '.token // empty' "$robot_json")
+          if [ "$robot_username" != "init+migratebot" ]; then
+            echo "FAIL: expected old OMR robot username init+migratebot, got ${robot_username}"
+            exit 1
+          fi
+          if [ -z "$robot_token" ]; then
+            echo "FAIL: old OMR robot create response did not include a token"
+            exit 1
+          fi
+          echo "::add-mask::${robot_token}"
+
+          curl -kfsS -b "$cookie_jar" -c "$cookie_jar" \
+            -H "X-CSRF-Token: ${csrf_token}" \
+            -H "Content-Type: application/json" \
+            -X PUT \
+            -d '{"role":"write"}' \
+            -o "$permission_json" \
+            https://localhost:8443/api/v1/repository/init/test-image/permissions/user/init%2Bmigratebot
+          jq -e '.role == "write"' "$permission_json"
+
+          {
+            printf 'ROBOT_USERNAME=%s\n' "$robot_username"
+            printf 'ROBOT_TOKEN=%s\n' "$robot_token"
+          } > "$robot_env"
+          chmod 600 "$robot_env"
+
+          printf '%s\n' "$robot_token" | sudo podman login localhost:8443 \
+            -u "$robot_username" \
+            --password-stdin \
+            --authfile "$robot_authfile" \
+            --tls-verify=false
+
+          sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest \
+            localhost:8443/init/test-image:robot-source
+          sudo podman push --authfile "$robot_authfile" --tls-verify=false \
+            localhost:8443/init/test-image:robot-source
+          sudo podman pull --authfile "$robot_authfile" --tls-verify=false \
+            localhost:8443/init/test-image:robot-source
 
       - name: Record source registry state
         run: |
@@ -662,9 +758,10 @@ jobs:
           record_digest SHARED_A_DIGEST init/shared-a v1
           record_digest SHARED_B_DIGEST init/shared-b v1
           record_digest INDEX_DIGEST init/test-index latest
+          record_digest ROBOT_SOURCE_DIGEST init/test-image robot-source
 
           . /tmp/e2e-migrate-state/digests.env
-          for var in TEST_IMAGE_DIGEST TEST_IMAGE_2_DIGEST SHARED_V1_DIGEST SHARED_V2_DIGEST SHARED_A_DIGEST SHARED_B_DIGEST INDEX_DIGEST; do
+          for var in TEST_IMAGE_DIGEST TEST_IMAGE_2_DIGEST SHARED_V1_DIGEST SHARED_V2_DIGEST SHARED_A_DIGEST SHARED_B_DIGEST INDEX_DIGEST ROBOT_SOURCE_DIGEST; do
             if [ -z "${!var}" ]; then
               echo "FAIL: ${var} was not captured"
               exit 1
@@ -834,6 +931,7 @@ jobs:
           verify_manifest_digest init/shared-a v1 "$SHARED_A_DIGEST"
           verify_manifest_digest init/shared-b v1 "$SHARED_B_DIGEST"
           verify_manifest_digest init/test-index latest "$INDEX_DIGEST"
+          verify_manifest_digest init/test-image robot-source "$ROBOT_SOURCE_DIGEST"
 
           curl -fsS -u init:testpassword123 \
             https://localhost:8443/v2/init/shared/tags/list \
@@ -846,6 +944,24 @@ jobs:
           sudo podman pull localhost:8443/init/shared:v2
           sudo podman pull localhost:8443/init/test-index:latest
 
+          . /tmp/e2e-migrate-secrets/robot.env
+          echo "::add-mask::${ROBOT_TOKEN}"
+          robot_authfile="/tmp/e2e-migrate-secrets/robot-target-auth.json"
+          printf '%s\n' "$ROBOT_TOKEN" | sudo podman login localhost:8443 \
+            -u "$ROBOT_USERNAME" \
+            --password-stdin \
+            --authfile "$robot_authfile"
+
+          sudo podman pull --authfile "$robot_authfile" \
+            localhost:8443/init/test-image:robot-source
+          sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest \
+            localhost:8443/init/test-image:robot-target
+          sudo podman push --authfile "$robot_authfile" \
+            localhost:8443/init/test-image:robot-target
+          sudo podman pull --authfile "$robot_authfile" \
+            localhost:8443/init/test-image:robot-target
+
+          sudo podman login localhost:8443 -u init -p testpassword123
           sudo podman tag registry.access.redhat.com/ubi9/ubi-micro:latest localhost:8443/init/post-migrate:latest
           sudo podman push localhost:8443/init/post-migrate:latest
           sudo podman pull localhost:8443/init/post-migrate:latest

--- a/internal/api/v1/repository/visibility_test.go
+++ b/internal/api/v1/repository/visibility_test.go
@@ -272,7 +272,7 @@ func newAPITestHandlerWithSuperUsers(t *testing.T, db *sql.DB, superUsers []stri
 	}
 
 	handler, err := apiv1.New(apiv1.Config{
-		Authenticator: auth.NewBasicAuthenticator(db),
+		Authenticator: auth.NewBasicAuthenticator(auth.NewUserPasswordVerifier(db)),
 		Realm:         "test",
 	},
 		NewModule(repositoryService),

--- a/internal/auth/basic.go
+++ b/internal/auth/basic.go
@@ -3,13 +3,8 @@ package auth
 
 import (
 	"database/sql"
-	"log/slog"
 	"net/http"
 	"strings"
-
-	"golang.org/x/crypto/bcrypt"
-
-	"github.com/quay/quay/internal/dal/daldb"
 )
 
 // PrincipalKind identifies the kind of authenticated identity.
@@ -59,26 +54,20 @@ type Result struct {
 	Authenticated bool
 }
 
-// BasicAuthenticator validates HTTP Basic credentials against the Quay user table.
+// BasicAuthenticator adapts HTTP Basic credentials to a credential verifier.
 type BasicAuthenticator struct {
-	queries *daldb.Queries
+	verifier Verifier
 }
 
-// NewBasicAuthenticator creates a BasicAuthenticator backed by db.
-func NewBasicAuthenticator(db *sql.DB) *BasicAuthenticator {
-	return &BasicAuthenticator{queries: daldb.New(db)}
+// NewBasicAuthenticator creates a BasicAuthenticator backed by verifier.
+func NewBasicAuthenticator(verifier Verifier) *BasicAuthenticator {
+	return &BasicAuthenticator{verifier: verifier}
 }
 
-// dummyHash is a valid bcrypt hash used when the user is not found, so that
-// bcrypt.CompareHashAndPassword always runs and timing is constant regardless
-// of whether the username exists.
-var dummyHash = []byte("$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy")
-
-// Authenticate validates request Basic credentials.
+// Authenticate extracts request Basic credentials and delegates verification.
 //
 // Result.Username is set when credentials were presented, even if they did not
-// validate. Callers can distinguish missing credentials from failed credentials
-// while preserving constant-time password comparison.
+// validate. Callers can distinguish missing credentials from failed credentials.
 func (a *BasicAuthenticator) Authenticate(r *http.Request) Result {
 	basicPresented := hasBasicAuthorizationHeader(r.Header.Get("Authorization"))
 	username, password, presented := r.BasicAuth()
@@ -89,31 +78,11 @@ func (a *BasicAuthenticator) Authenticate(r *http.Request) Result {
 		return Result{}
 	}
 
-	dbUser, err := a.queries.GetUserByUsername(r.Context(), username)
-
-	hashToCompare := dummyHash
-	if err == nil && dbUser.Enabled && dbUser.PasswordHash.Valid {
-		hashToCompare = []byte(dbUser.PasswordHash.String)
-	}
-
-	if bcrypt.CompareHashAndPassword(hashToCompare, []byte(password)) != nil ||
-		err != nil || !dbUser.Enabled || !dbUser.PasswordHash.Valid {
-		slog.Debug("authentication failed", "username", username)
+	if a == nil || a.verifier == nil {
 		return Result{Username: username, Presented: true}
 	}
 
-	return Result{
-		Principal: Principal{
-			ID:       dbUser.ID,
-			UUID:     dbUser.Uuid,
-			Username: dbUser.Username,
-			Email:    dbUser.Email,
-			Kind:     PrincipalUser,
-		},
-		Username:      username,
-		Presented:     true,
-		Authenticated: true,
-	}
+	return a.verifier.Verify(r.Context(), Credentials{Username: username, Secret: password})
 }
 
 func hasBasicAuthorizationHeader(authHeader string) bool {

--- a/internal/auth/basic_test.go
+++ b/internal/auth/basic_test.go
@@ -1,9 +1,13 @@
 package auth
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"golang.org/x/crypto/bcrypt"
@@ -46,29 +50,164 @@ func setupAuthTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
-func TestBasicAuthenticatorResult(t *testing.T) {
-	db := setupAuthTestDB(t)
-	defer db.Close()
-	authenticator := NewBasicAuthenticator(db)
+type recordingVerifier struct {
+	called      bool
+	ctx         context.Context
+	credentials Credentials
+	result      Result
+}
 
-	t.Run("missing credentials", func(t *testing.T) {
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+func (v *recordingVerifier) Verify(ctx context.Context, credentials Credentials) Result {
+	v.called = true
+	v.ctx = ctx
+	v.credentials = credentials
+	return v.result
+}
+
+func TestBasicAuthenticatorDelegatesParsedCredentialsToVerifier(t *testing.T) {
+	verifierResult := Result{
+		Principal:     Principal{ID: 17, Username: "verified-user", Kind: PrincipalUser},
+		Username:      "verified-user",
+		Presented:     true,
+		Authenticated: true,
+	}
+	verifier := &recordingVerifier{result: verifierResult}
+	authenticator := NewBasicAuthenticator(verifier)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+
+	result := authenticator.Authenticate(req)
+
+	if !verifier.called {
+		t.Fatal("verifier was not called")
+	}
+	if verifier.ctx != req.Context() {
+		t.Fatal("verifier context does not match request context")
+	}
+	if verifier.credentials.Username != "admin" {
+		t.Fatalf("username = %q, want admin", verifier.credentials.Username)
+	}
+	if verifier.credentials.Secret != "correct-password" {
+		t.Fatalf("secret = %q, want correct-password", verifier.credentials.Secret)
+	}
+	if result != verifierResult {
+		t.Fatalf("result = %#v, want %#v", result, verifierResult)
+	}
+}
+
+func TestBasicAuthenticatorMissingCredentialsDoesNotCallVerifier(t *testing.T) {
+	verifier := &recordingVerifier{result: Result{Authenticated: true}}
+	authenticator := NewBasicAuthenticator(verifier)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+
+	result := authenticator.Authenticate(req)
+
+	if verifier.called {
+		t.Fatal("verifier was called")
+	}
+	if result.Presented {
+		t.Fatal("presented = true, want false")
+	}
+	if result.Authenticated {
+		t.Fatal("authenticated = true, want false")
+	}
+}
+
+func TestBasicAuthenticatorMalformedBasicHeaderDoesNotCallVerifier(t *testing.T) {
+	verifier := &recordingVerifier{result: Result{Authenticated: true}}
+	authenticator := NewBasicAuthenticator(verifier)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+	req.Header.Set("Authorization", "Basic not-base64")
+
+	result := authenticator.Authenticate(req)
+
+	if verifier.called {
+		t.Fatal("verifier was called")
+	}
+	if !result.Presented {
+		t.Fatal("presented = false, want true")
+	}
+	if result.Authenticated {
+		t.Fatal("authenticated = true, want false")
+	}
+	if result.Username != "" {
+		t.Fatalf("username = %q, want empty", result.Username)
+	}
+}
+
+func TestBasicAuthenticatorNilVerifierFailsAfterParsingCredentials(t *testing.T) {
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+
+	t.Run("nil authenticator", func(t *testing.T) {
+		var authenticator *BasicAuthenticator
 
 		result := authenticator.Authenticate(req)
 
-		if result.Presented {
-			t.Fatal("presented = true, want false")
+		if !result.Presented {
+			t.Fatal("presented = false, want true")
 		}
 		if result.Authenticated {
 			t.Fatal("authenticated = true, want false")
 		}
+		if result.Username != "admin" {
+			t.Fatalf("username = %q, want admin", result.Username)
+		}
 	})
 
-	t.Run("valid credentials", func(t *testing.T) {
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
-		req.SetBasicAuth("admin", "correct-password")
+	t.Run("nil verifier", func(t *testing.T) {
+		authenticator := NewBasicAuthenticator(nil)
 
 		result := authenticator.Authenticate(req)
+
+		if !result.Presented {
+			t.Fatal("presented = false, want true")
+		}
+		if result.Authenticated {
+			t.Fatal("authenticated = true, want false")
+		}
+		if result.Username != "admin" {
+			t.Fatalf("username = %q, want admin", result.Username)
+		}
+	})
+}
+
+func TestUserPasswordVerifierLogsLookupErrorsOnly(t *testing.T) {
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(previousLogger)
+
+	db := setupAuthTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	verifier := NewUserPasswordVerifier(db)
+
+	verifier.Verify(t.Context(), Credentials{Username: "admin", Secret: "wrong-password"})
+	if strings.Contains(logs.String(), "err=") {
+		t.Fatalf("invalid credentials log included lookup error: %s", logs.String())
+	}
+
+	logs.Reset()
+	brokenDB, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open broken db: %v", err)
+	}
+	t.Cleanup(func() { _ = brokenDB.Close() })
+	brokenDB.SetMaxOpenConns(1)
+
+	NewUserPasswordVerifier(brokenDB).Verify(t.Context(), Credentials{Username: "admin", Secret: "wrong-password"})
+	if !strings.Contains(logs.String(), "err=") {
+		t.Fatalf("lookup failure log missing error: %s", logs.String())
+	}
+}
+
+func TestUserPasswordVerifierResult(t *testing.T) {
+	db := setupAuthTestDB(t)
+	defer db.Close()
+	verifier := NewUserPasswordVerifier(db)
+
+	t.Run("valid credentials", func(t *testing.T) {
+		result := verifier.Verify(t.Context(), Credentials{Username: "admin", Secret: "correct-password"})
 
 		if !result.Presented {
 			t.Fatal("presented = false, want true")
@@ -88,10 +227,7 @@ func TestBasicAuthenticatorResult(t *testing.T) {
 	})
 
 	t.Run("invalid credentials", func(t *testing.T) {
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
-		req.SetBasicAuth("admin", "wrong-password")
-
-		result := authenticator.Authenticate(req)
+		result := verifier.Verify(t.Context(), Credentials{Username: "admin", Secret: "wrong-password"})
 
 		if !result.Presented {
 			t.Fatal("presented = false, want true")
@@ -104,11 +240,8 @@ func TestBasicAuthenticatorResult(t *testing.T) {
 		}
 	})
 
-	t.Run("malformed basic credentials", func(t *testing.T) {
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
-		req.Header.Set("Authorization", "Basic not-base64")
-
-		result := authenticator.Authenticate(req)
+	t.Run("unknown user", func(t *testing.T) {
+		result := verifier.Verify(t.Context(), Credentials{Username: "unknown", Secret: "wrong-password"})
 
 		if !result.Presented {
 			t.Fatal("presented = false, want true")
@@ -116,8 +249,8 @@ func TestBasicAuthenticatorResult(t *testing.T) {
 		if result.Authenticated {
 			t.Fatal("authenticated = true, want false")
 		}
-		if result.Username != "" {
-			t.Fatalf("username = %q, want empty", result.Username)
+		if result.Username != "unknown" {
+			t.Fatalf("username = %q, want unknown", result.Username)
 		}
 	})
 }

--- a/internal/auth/database_verifier.go
+++ b/internal/auth/database_verifier.go
@@ -1,0 +1,46 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+)
+
+// DatabaseVerifierConfig configures DB-backed credential verification.
+type DatabaseVerifierConfig struct {
+	DatabaseSecretKey              string
+	RobotsDisallow                 bool
+	RobotsWhitelist                []string
+	FeatureUserLastAccessed        bool
+	LastAccessedUpdateThresholdSec int
+}
+
+type databaseVerifier struct {
+	user  Verifier
+	robot Verifier
+}
+
+// NewDatabaseVerifier creates a DB-backed verifier for user and robot credentials.
+func NewDatabaseVerifier(db *sql.DB, cfg DatabaseVerifierConfig) Verifier {
+	return &databaseVerifier{
+		user:  NewUserPasswordVerifier(db),
+		robot: newRobotVerifier(db, cfg),
+	}
+}
+
+func (v *databaseVerifier) Verify(ctx context.Context, creds Credentials) Result {
+	if v == nil {
+		return Result{Username: creds.Username, Presented: true}
+	}
+
+	if isRobotUsername(creds.Username) {
+		if v.robot == nil {
+			return Result{Username: creds.Username, Presented: true}
+		}
+		return v.robot.Verify(ctx, creds)
+	}
+
+	if v.user == nil {
+		return Result{Username: creds.Username, Presented: true}
+	}
+	return v.user.Verify(ctx, creds)
+}

--- a/internal/auth/robot_name.go
+++ b/internal/auth/robot_name.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+var usernamePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*$`)
+
+func parseRobotUsername(username string) (owner, shortname string, ok bool) {
+	if strings.Count(username, "+") != 1 {
+		return "", "", false
+	}
+
+	owner, shortname, ok = strings.Cut(username, "+")
+	if !ok || !validUsername(owner) || !validUsername(shortname) {
+		return "", "", false
+	}
+
+	return owner, shortname, true
+}
+
+func isRobotUsername(username string) bool {
+	_, _, ok := parseRobotUsername(username)
+	return ok
+}
+
+func validUsername(username string) bool {
+	if len(username) < 2 || len(username) > 255 {
+		return false
+	}
+	return usernamePattern.MatchString(username)
+}
+
+func isASCII(s string) bool {
+	for s != "" {
+		r, size := utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError && size == 1 {
+			return false
+		}
+		if r > 0x7f {
+			return false
+		}
+		s = s[size:]
+	}
+	return true
+}

--- a/internal/auth/robot_name_test.go
+++ b/internal/auth/robot_name_test.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRobotUsername(t *testing.T) {
+	tests := []struct {
+		name          string
+		username      string
+		wantOwner     string
+		wantShortname string
+		wantOK        bool
+	}{
+		{
+			name:          "valid",
+			username:      "acme+deploy",
+			wantOwner:     "acme",
+			wantShortname: "deploy",
+			wantOK:        true,
+		},
+		{
+			name:     "missing plus",
+			username: "acmedeploy",
+			wantOK:   false,
+		},
+		{
+			name:     "multiple plus",
+			username: "acme+deploy+extra",
+			wantOK:   false,
+		},
+		{
+			name:     "empty owner",
+			username: "+deploy",
+			wantOK:   false,
+		},
+		{
+			name:     "empty shortname",
+			username: "acme+",
+			wantOK:   false,
+		},
+		{
+			name:     "uppercase owner",
+			username: "Acme+deploy",
+			wantOK:   false,
+		},
+		{
+			name:     "short owner",
+			username: "a+deploy",
+			wantOK:   false,
+		},
+		{
+			name:     "short shortname",
+			username: "acme+d",
+			wantOK:   false,
+		},
+		{
+			name:          "minimum lengths",
+			username:      "aa+bb",
+			wantOwner:     "aa",
+			wantShortname: "bb",
+			wantOK:        true,
+		},
+		{
+			name:          "maximum shortname length",
+			username:      "acme+" + strings.Repeat("a", 255),
+			wantOwner:     "acme",
+			wantShortname: strings.Repeat("a", 255),
+			wantOK:        true,
+		},
+		{
+			name:     "long username",
+			username: "acme+" + strings.Repeat("a", 256),
+			wantOK:   false,
+		},
+		{
+			name:     "SQL-ish syntax",
+			username: "acme+deploy';drop",
+			wantOK:   false,
+		},
+		{
+			name:          "valid separators",
+			username:      "acme-inc+deploy.01",
+			wantOwner:     "acme-inc",
+			wantShortname: "deploy.01",
+			wantOK:        true,
+		},
+		{
+			name:     "multiple plus separators",
+			username: "acme++deploy",
+			wantOK:   false,
+		},
+		{
+			name:     "leading separator",
+			username: "acme+.deploy",
+			wantOK:   false,
+		},
+		{
+			name:     "trailing separator",
+			username: "acme+deploy-",
+			wantOK:   false,
+		},
+		{
+			name:     "repeated separator",
+			username: "acme+deploy..prod",
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, shortname, ok := parseRobotUsername(tt.username)
+
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if owner != tt.wantOwner {
+				t.Fatalf("owner = %q, want %q", owner, tt.wantOwner)
+			}
+			if shortname != tt.wantShortname {
+				t.Fatalf("shortname = %q, want %q", shortname, tt.wantShortname)
+			}
+		})
+	}
+}
+
+func TestIsASCII(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{
+			name: "ASCII",
+			s:    "abc123!@#",
+			want: true,
+		},
+		{
+			name: "non-ASCII",
+			s:    "é",
+			want: false,
+		},
+		{
+			name: "invalid UTF-8",
+			s:    string([]byte{0xff}),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isASCII(tt.s); got != tt.want {
+				t.Fatalf("isASCII(%q) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/auth/robot_static_token.go
+++ b/internal/auth/robot_static_token.go
@@ -1,0 +1,192 @@
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"database/sql"
+	"log/slog"
+	"time"
+
+	"github.com/quay/quay/internal/credentials/encryptedfield"
+	"github.com/quay/quay/internal/dal/daldb"
+)
+
+// dummyEncryptedRobotValue keeps early robot auth failures on the decrypt/compare path.
+const dummyEncryptedRobotValue = "v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==" // #nosec G101 -- encrypted dummy value, not a credential.
+
+type robotVerifier struct {
+	static *staticRobotTokenVerifier
+}
+
+func newRobotVerifier(db *sql.DB, cfg DatabaseVerifierConfig) Verifier {
+	if db == nil {
+		return nil
+	}
+
+	return &robotVerifier{static: newStaticRobotTokenVerifier(db, cfg)}
+}
+
+func (v *robotVerifier) Verify(ctx context.Context, creds Credentials) Result {
+	if v == nil || v.static == nil {
+		return failedRobotResult(creds.Username)
+	}
+
+	return v.static.Verify(ctx, creds)
+}
+
+type staticRobotTokenVerifier struct {
+	queries                        *daldb.Queries
+	databaseSecretKey              string
+	robotsDisallow                 bool
+	robotsWhitelist                map[string]struct{}
+	featureUserLastAccessed        bool
+	lastAccessedUpdateThresholdSec int
+}
+
+func newStaticRobotTokenVerifier(db *sql.DB, cfg DatabaseVerifierConfig) *staticRobotTokenVerifier {
+	whitelist := make(map[string]struct{}, len(cfg.RobotsWhitelist))
+	for _, username := range cfg.RobotsWhitelist {
+		whitelist[username] = struct{}{}
+	}
+
+	return &staticRobotTokenVerifier{
+		queries:                        daldb.New(db),
+		databaseSecretKey:              cfg.DatabaseSecretKey,
+		robotsDisallow:                 cfg.RobotsDisallow,
+		robotsWhitelist:                whitelist,
+		featureUserLastAccessed:        cfg.FeatureUserLastAccessed,
+		lastAccessedUpdateThresholdSec: cfg.LastAccessedUpdateThresholdSec,
+	}
+}
+
+func (v *staticRobotTokenVerifier) Verify(ctx context.Context, creds Credentials) Result {
+	if v == nil || v.queries == nil {
+		return failedRobotResult(creds.Username)
+	}
+
+	owner, ok := v.validateRequest(creds)
+	if !ok {
+		v.dummySecretMatch(creds)
+		return failedRobotResult(creds.Username)
+	}
+
+	robot, ok := v.enabledRobot(ctx, creds.Username)
+	if !ok {
+		v.dummySecretMatch(creds)
+		return failedRobotResult(creds.Username)
+	}
+	if !v.ownerEnabled(ctx, owner, creds.Username) {
+		v.dummySecretMatch(creds)
+		return failedRobotResult(creds.Username)
+	}
+	if !v.secretMatches(ctx, robot.ID, creds) {
+		return failedRobotResult(creds.Username)
+	}
+
+	v.updateLastAccessed(ctx, robot.ID, robot.LastAccessed, creds.Username)
+
+	return Result{
+		Principal: Principal{
+			ID:       robot.ID,
+			UUID:     robot.Uuid,
+			Username: robot.Username,
+			Email:    robot.Email,
+			Kind:     PrincipalRobot,
+		},
+		Username:      creds.Username,
+		Presented:     true,
+		Authenticated: true,
+	}
+}
+
+func (v *staticRobotTokenVerifier) validateRequest(creds Credentials) (string, bool) {
+	owner, _, ok := parseRobotUsername(creds.Username)
+	if !ok {
+		slog.Debug("robot authentication failed", "username", creds.Username, "reason", "invalid robot username")
+		return "", false
+	}
+	if v.databaseSecretKey == "" {
+		slog.Debug("robot authentication failed", "username", creds.Username, "reason", "missing database secret key")
+		return "", false
+	}
+	if !isASCII(creds.Secret) {
+		slog.Debug("robot authentication failed", "username", creds.Username, "reason", "non-ASCII secret")
+		return "", false
+	}
+	if v.robotsDisallow {
+		if _, ok := v.robotsWhitelist[creds.Username]; !ok {
+			slog.Debug("robot authentication failed", "username", creds.Username, "reason", "robot disallowed")
+			return "", false
+		}
+	}
+	return owner, true
+}
+
+func (v *staticRobotTokenVerifier) enabledRobot(ctx context.Context, username string) (daldb.GetRobotByUsernameRow, bool) {
+	robot, err := v.queries.GetRobotByUsername(ctx, username)
+	if err != nil || !robot.Enabled {
+		slog.Debug("robot authentication failed", "username", username, "reason", "robot missing or disabled")
+		return daldb.GetRobotByUsernameRow{}, false
+	}
+	return robot, true
+}
+
+func (v *staticRobotTokenVerifier) ownerEnabled(ctx context.Context, owner, username string) bool {
+	ownerUser, err := v.queries.GetNamespaceUserByUsername(ctx, owner)
+	if err != nil || !ownerUser.Enabled {
+		slog.Debug("robot authentication failed", "username", username, "reason", "owner missing or disabled")
+		return false
+	}
+	return true
+}
+
+func (v *staticRobotTokenVerifier) secretMatches(ctx context.Context, robotID int64, creds Credentials) bool {
+	encryptedToken, err := v.queries.GetRobotTokenByRobotID(ctx, robotID)
+	if err != nil {
+		slog.Debug("robot authentication failed", "username", creds.Username, "reason", "token row missing")
+		return false
+	}
+
+	token, err := encryptedfield.Decrypt(v.databaseSecretKey, encryptedToken)
+	if err != nil {
+		slog.Debug("robot authentication failed", "username", creds.Username, "reason", "decrypt failed")
+		return false
+	}
+	if subtle.ConstantTimeCompare([]byte(token), []byte(creds.Secret)) != 1 {
+		slog.Debug("robot authentication failed", "username", creds.Username, "reason", "token mismatch")
+		return false
+	}
+	return true
+}
+
+func (v *staticRobotTokenVerifier) dummySecretMatch(creds Credentials) {
+	token, _ := encryptedfield.Decrypt(v.databaseSecretKey, dummyEncryptedRobotValue)
+	subtle.ConstantTimeCompare([]byte(token), []byte(creds.Secret))
+}
+
+func (v *staticRobotTokenVerifier) updateLastAccessed(ctx context.Context, robotID int64, lastAccessed sql.NullTime, username string) {
+	if !v.featureUserLastAccessed {
+		return
+	}
+	if v.lastAccessedIsFresh(lastAccessed) {
+		return
+	}
+	if err := v.queries.UpdateUserLastAccessedIfOlder(ctx, daldb.UpdateUserLastAccessedIfOlderParams{
+		UserID:           robotID,
+		ThresholdSeconds: int64(v.lastAccessedUpdateThresholdSec),
+	}); err != nil {
+		slog.Debug("robot last_accessed update failed", "username", username, "err", err)
+	}
+}
+
+func (v *staticRobotTokenVerifier) lastAccessedIsFresh(lastAccessed sql.NullTime) bool {
+	if !lastAccessed.Valid || v.lastAccessedUpdateThresholdSec <= 0 {
+		return false
+	}
+	threshold := time.Duration(v.lastAccessedUpdateThresholdSec) * time.Second
+	return time.Since(lastAccessed.Time) < threshold
+}
+
+func failedRobotResult(username string) Result {
+	return Result{Username: username, Presented: true}
+}

--- a/internal/auth/robot_static_token_test.go
+++ b/internal/auth/robot_static_token_test.go
@@ -1,0 +1,397 @@
+package auth
+
+import (
+	"bytes"
+	"database/sql"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+	_ "modernc.org/sqlite"
+)
+
+const testEncryptedRobotToken = "v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA=="
+
+func setupRobotStaticTokenTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	return setupRobotStaticTokenTestDBWithDSN(t, ":memory:", 1)
+}
+
+func setupRobotStaticTokenTestDBWithDSN(t *testing.T, dsn string, maxOpenConns int) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(maxOpenConns)
+
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE "user" (
+		id INTEGER PRIMARY KEY,
+		uuid VARCHAR(36),
+		username VARCHAR(255) NOT NULL,
+		password_hash VARCHAR(255),
+		email VARCHAR(255) NOT NULL,
+		verified INTEGER NOT NULL DEFAULT 0,
+		organization INTEGER NOT NULL DEFAULT 0,
+		robot INTEGER NOT NULL DEFAULT 0,
+		enabled INTEGER NOT NULL DEFAULT 1,
+		last_accessed DATETIME
+	)`)
+	if err != nil {
+		t.Fatalf("create user table: %v", err)
+	}
+
+	_, err = db.ExecContext(t.Context(), `CREATE TABLE robotaccounttoken (
+		id INTEGER PRIMARY KEY,
+		robot_account_id INTEGER NOT NULL,
+		token TEXT NOT NULL,
+		fully_migrated INTEGER NOT NULL DEFAULT 0
+	)`)
+	if err != nil {
+		t.Fatalf("create robotaccounttoken table: %v", err)
+	}
+
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+
+	rows := []struct {
+		id           int64
+		uuid         string
+		username     string
+		passwordHash sql.NullString
+		email        string
+		verified     bool
+		organization bool
+		robot        bool
+		enabled      bool
+	}{
+		{id: 1, uuid: "owner-acme", username: "acme", email: "acme@example.com", verified: true, organization: true, enabled: true},
+		{id: 2, uuid: "robot-acme-deploy", username: "acme+deploy", email: "acme+deploy@example.com", verified: true, robot: true, enabled: true},
+		{id: 3, uuid: "owner-disabledorg", username: "disabledorg", email: "disabledorg@example.com", verified: true, organization: true, enabled: false},
+		{id: 4, uuid: "robot-disabledorg-deploy", username: "disabledorg+deploy", email: "disabledorg+deploy@example.com", verified: true, robot: true, enabled: true},
+		{id: 5, uuid: "robot-acme-disabled", username: "acme+disabled", email: "acme+disabled@example.com", verified: true, robot: true, enabled: false},
+		{id: 6, uuid: "robot-missing", username: "missing+robot", email: "missing+robot@example.com", verified: true, robot: true, enabled: true},
+		{id: 7, uuid: "user-admin", username: "admin", passwordHash: sql.NullString{String: string(passwordHash), Valid: true}, email: "admin@example.com", verified: true, enabled: true},
+	}
+	for _, row := range rows {
+		_, err = db.ExecContext(
+			t.Context(),
+			`INSERT INTO "user" (id, uuid, username, password_hash, email, verified, organization, robot, enabled)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			row.id,
+			row.uuid,
+			row.username,
+			row.passwordHash,
+			row.email,
+			row.verified,
+			row.organization,
+			row.robot,
+			row.enabled,
+		)
+		if err != nil {
+			t.Fatalf("insert user %q: %v", row.username, err)
+		}
+	}
+
+	tokenRows := []struct {
+		id      int64
+		robotID int64
+	}{
+		{id: 1, robotID: 2},
+		{id: 2, robotID: 4},
+		{id: 3, robotID: 5},
+		{id: 4, robotID: 6},
+	}
+	for _, row := range tokenRows {
+		_, err = db.ExecContext(
+			t.Context(),
+			`INSERT INTO robotaccounttoken (id, robot_account_id, token, fully_migrated)
+			 VALUES (?, ?, ?, 0)`,
+			row.id,
+			row.robotID,
+			testEncryptedRobotToken,
+		)
+		if err != nil {
+			t.Fatalf("insert token for robot %d: %v", row.robotID, err)
+		}
+	}
+
+	return db
+}
+
+func TestDatabaseVerifierStaticRobotToken(t *testing.T) {
+	db := setupRobotStaticTokenTestDB(t)
+	defer db.Close()
+
+	verifier := NewDatabaseVerifier(db, DatabaseVerifierConfig{
+		DatabaseSecretKey:              "test1234",
+		FeatureUserLastAccessed:        true,
+		LastAccessedUpdateThresholdSec: 0,
+	})
+
+	result := verifier.Verify(t.Context(), Credentials{Username: "acme+deploy", Secret: "hello world"})
+
+	if !result.Presented {
+		t.Fatal("presented = false, want true")
+	}
+	if !result.Authenticated {
+		t.Fatal("authenticated = false, want true")
+	}
+	if result.Username != "acme+deploy" {
+		t.Fatalf("username = %q, want acme+deploy", result.Username)
+	}
+	if result.Principal.Username != "acme+deploy" {
+		t.Fatalf("principal username = %q, want acme+deploy", result.Principal.Username)
+	}
+	if result.Principal.Kind != PrincipalRobot {
+		t.Fatalf("principal kind = %q, want robot", result.Principal.Kind)
+	}
+}
+
+func TestDatabaseVerifierRoutesRegularUsers(t *testing.T) {
+	db := setupRobotStaticTokenTestDB(t)
+	defer db.Close()
+
+	verifier := NewDatabaseVerifier(db, DatabaseVerifierConfig{DatabaseSecretKey: "test1234"})
+
+	result := verifier.Verify(t.Context(), Credentials{Username: "admin", Secret: "correct-password"})
+
+	if !result.Presented {
+		t.Fatal("presented = false, want true")
+	}
+	if !result.Authenticated {
+		t.Fatal("authenticated = false, want true")
+	}
+	if result.Username != "admin" {
+		t.Fatalf("username = %q, want admin", result.Username)
+	}
+	if result.Principal.Username != "admin" {
+		t.Fatalf("principal username = %q, want admin", result.Principal.Username)
+	}
+	if result.Principal.Kind != PrincipalUser {
+		t.Fatalf("principal kind = %q, want user", result.Principal.Kind)
+	}
+}
+
+func TestDatabaseVerifierRobotFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      DatabaseVerifierConfig
+		username string
+		secret   string
+	}{
+		{
+			name:     "wrong token",
+			cfg:      DatabaseVerifierConfig{DatabaseSecretKey: "test1234"},
+			username: "acme+deploy",
+			secret:   "wrong",
+		},
+		{
+			name:     "wrong key",
+			cfg:      DatabaseVerifierConfig{DatabaseSecretKey: "wrong-key"},
+			username: "acme+deploy",
+			secret:   "hello world",
+		},
+		{
+			name:     "empty key",
+			cfg:      DatabaseVerifierConfig{},
+			username: "acme+deploy",
+			secret:   "hello world",
+		},
+		{
+			name:     "disabled robot",
+			cfg:      DatabaseVerifierConfig{DatabaseSecretKey: "test1234"},
+			username: "acme+disabled",
+			secret:   "hello world",
+		},
+		{
+			name:     "orphan robot",
+			cfg:      DatabaseVerifierConfig{DatabaseSecretKey: "test1234"},
+			username: "missing+robot",
+			secret:   "hello world",
+		},
+		{
+			name:     "disabled owner",
+			cfg:      DatabaseVerifierConfig{DatabaseSecretKey: "test1234"},
+			username: "disabledorg+deploy",
+			secret:   "hello world",
+		},
+		{
+			name:     "non-ASCII secret",
+			cfg:      DatabaseVerifierConfig{DatabaseSecretKey: "test1234"},
+			username: "acme+deploy",
+			secret:   "hello worldé",
+		},
+		{
+			name:     "JWT-shaped wrong secret",
+			cfg:      DatabaseVerifierConfig{DatabaseSecretKey: "test1234"},
+			username: "acme+deploy",
+			secret:   "a.b.c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupRobotStaticTokenTestDB(t)
+			defer db.Close()
+
+			verifier := NewDatabaseVerifier(db, tt.cfg)
+			result := verifier.Verify(t.Context(), Credentials{Username: tt.username, Secret: tt.secret})
+
+			if !result.Presented {
+				t.Fatal("presented = false, want true")
+			}
+			if result.Authenticated {
+				t.Fatal("authenticated = true, want false")
+			}
+			if result.Username != tt.username {
+				t.Fatalf("username = %q, want %q", result.Username, tt.username)
+			}
+		})
+	}
+}
+
+func TestDatabaseVerifierRobotsDisallowWhitelist(t *testing.T) {
+	t.Run("non-whitelisted robot denied", func(t *testing.T) {
+		db := setupRobotStaticTokenTestDB(t)
+		defer db.Close()
+
+		verifier := NewDatabaseVerifier(db, DatabaseVerifierConfig{
+			DatabaseSecretKey: "test1234",
+			RobotsDisallow:    true,
+		})
+		result := verifier.Verify(t.Context(), Credentials{Username: "acme+deploy", Secret: "hello world"})
+
+		if !result.Presented {
+			t.Fatal("presented = false, want true")
+		}
+		if result.Authenticated {
+			t.Fatal("authenticated = true, want false")
+		}
+	})
+
+	t.Run("whitelisted robot accepted", func(t *testing.T) {
+		db := setupRobotStaticTokenTestDB(t)
+		defer db.Close()
+
+		verifier := NewDatabaseVerifier(db, DatabaseVerifierConfig{
+			DatabaseSecretKey: "test1234",
+			RobotsDisallow:    true,
+			RobotsWhitelist:   []string{"acme+deploy"},
+		})
+		result := verifier.Verify(t.Context(), Credentials{Username: "acme+deploy", Secret: "hello world"})
+
+		if !result.Presented {
+			t.Fatal("presented = false, want true")
+		}
+		if !result.Authenticated {
+			t.Fatal("authenticated = false, want true")
+		}
+		if result.Principal.Kind != PrincipalRobot {
+			t.Fatalf("principal kind = %q, want robot", result.Principal.Kind)
+		}
+	})
+}
+
+func TestStaticRobotTokenUpdatesLastAccessed(t *testing.T) {
+	db := setupRobotStaticTokenTestDB(t)
+	defer db.Close()
+
+	verifier := NewDatabaseVerifier(db, DatabaseVerifierConfig{
+		DatabaseSecretKey:              "test1234",
+		FeatureUserLastAccessed:        true,
+		LastAccessedUpdateThresholdSec: 0,
+	})
+
+	result := verifier.Verify(t.Context(), Credentials{Username: "acme+deploy", Secret: "hello world"})
+	if !result.Authenticated {
+		t.Fatal("authenticated = false, want true")
+	}
+
+	var lastAccessed sql.NullString
+	if err := db.QueryRowContext(t.Context(), `SELECT last_accessed FROM "user" WHERE username = ?`, "acme+deploy").Scan(&lastAccessed); err != nil {
+		t.Fatalf("select last_accessed: %v", err)
+	}
+	if !lastAccessed.Valid {
+		t.Fatal("last_accessed is NULL, want timestamp")
+	}
+}
+
+func TestStaticRobotTokenSkipsFreshLastAccessedUpdate(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "robots.db")
+	dsn := "file:" + dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(1)"
+	db := setupRobotStaticTokenTestDBWithDSN(t, dsn, 5)
+	defer db.Close()
+
+	freshLastAccessed := time.Now().UTC()
+	if _, err := db.ExecContext(t.Context(), `UPDATE "user" SET last_accessed = ? WHERE username = ?`, freshLastAccessed, "acme+deploy"); err != nil {
+		t.Fatalf("seed last_accessed: %v", err)
+	}
+
+	lockDB, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open lock db: %v", err)
+	}
+	defer lockDB.Close()
+
+	lockConn, err := lockDB.Conn(t.Context())
+	if err != nil {
+		t.Fatalf("open lock conn: %v", err)
+	}
+	defer lockConn.Close()
+	if _, err := lockConn.ExecContext(t.Context(), `BEGIN IMMEDIATE`); err != nil {
+		t.Fatalf("begin lock transaction: %v", err)
+	}
+	defer lockConn.ExecContext(t.Context(), `ROLLBACK`)
+
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(previousLogger)
+
+	verifier := NewDatabaseVerifier(db, DatabaseVerifierConfig{
+		DatabaseSecretKey:              "test1234",
+		FeatureUserLastAccessed:        true,
+		LastAccessedUpdateThresholdSec: int((1 * time.Hour).Seconds()),
+	})
+
+	result := verifier.Verify(t.Context(), Credentials{Username: "acme+deploy", Secret: "hello world"})
+	if !result.Authenticated {
+		t.Fatal("authenticated = false, want true")
+	}
+	if strings.Contains(logs.String(), "robot last_accessed update failed") {
+		t.Fatalf("fresh last_accessed attempted update under write lock: %s", logs.String())
+	}
+}
+
+func TestStaticRobotTokenConcurrentAuth(t *testing.T) {
+	db := setupRobotStaticTokenTestDB(t)
+	defer db.Close()
+
+	verifier := NewDatabaseVerifier(db, DatabaseVerifierConfig{DatabaseSecretKey: "test1234"})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			result := verifier.Verify(t.Context(), Credentials{Username: "acme+deploy", Secret: "hello world"})
+			if !result.Authenticated {
+				t.Errorf("authenticated = false, want true")
+			}
+			if result.Principal.Kind != PrincipalRobot {
+				t.Errorf("principal kind = %q, want robot", result.Principal.Kind)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/auth/user_password.go
+++ b/internal/auth/user_password.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/quay/quay/internal/dal/daldb"
+)
+
+type userPasswordVerifier struct {
+	queries *daldb.Queries
+}
+
+// NewUserPasswordVerifier creates a verifier for regular Quay user passwords.
+func NewUserPasswordVerifier(db *sql.DB) Verifier {
+	if db == nil {
+		return nil
+	}
+	return &userPasswordVerifier{queries: daldb.New(db)}
+}
+
+// dummyHash is a valid bcrypt hash used when the user is not found, so that
+// bcrypt.CompareHashAndPassword always runs and timing is constant regardless
+// of whether the username exists.
+var dummyHash = []byte("$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy")
+
+func (v *userPasswordVerifier) Verify(ctx context.Context, credentials Credentials) Result {
+	username := credentials.Username
+	if v == nil || v.queries == nil {
+		slog.Debug("authentication failed", "username", username)
+		return Result{Username: username, Presented: true}
+	}
+
+	dbUser, err := v.queries.GetUserByUsername(ctx, username)
+
+	hashToCompare := dummyHash
+	if err == nil && dbUser.Enabled && dbUser.PasswordHash.Valid {
+		hashToCompare = []byte(dbUser.PasswordHash.String)
+	}
+
+	if bcrypt.CompareHashAndPassword(hashToCompare, []byte(credentials.Secret)) != nil ||
+		err != nil || !dbUser.Enabled || !dbUser.PasswordHash.Valid {
+		attrs := []any{"username", username}
+		if err != nil {
+			attrs = append(attrs, "err", err)
+		}
+		slog.Debug("authentication failed", attrs...)
+		return Result{Username: username, Presented: true}
+	}
+
+	return Result{
+		Principal: Principal{
+			ID:       dbUser.ID,
+			UUID:     dbUser.Uuid,
+			Username: dbUser.Username,
+			Email:    dbUser.Email,
+			Kind:     PrincipalUser,
+		},
+		Username:      username,
+		Presented:     true,
+		Authenticated: true,
+	}
+}

--- a/internal/auth/verifier.go
+++ b/internal/auth/verifier.go
@@ -1,0 +1,14 @@
+package auth
+
+import "context"
+
+// Credentials are transport-neutral authentication credentials.
+type Credentials struct {
+	Username string
+	Secret   string
+}
+
+// Verifier validates credentials and returns an authentication result.
+type Verifier interface {
+	Verify(context.Context, Credentials) Result
+}

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -44,7 +44,7 @@ func runInstall(ctx context.Context, hostname, dataDir, imageArchive, image stri
 		return 1
 	}
 
-	if err := inst.Run(ctx, installer.Config{
+	if err := inst.Run(ctx, &installer.Config{
 		Hostname:     hostname,
 		DataDir:      dataDir,
 		ImageArchive: imageArchive,

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -71,14 +71,32 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUse
 		return 1
 	}
 
+	featureUserLastAccessed := featureEnabled(resolved.Config.FeatureUserLastAccessed)
+	lastAccessedUpdateThresholdSeconds := resolved.Config.LastAccessedUpdateThresholdS
+	databaseVerifierConfig := auth.DatabaseVerifierConfig{
+		DatabaseSecretKey:              resolved.Config.DatabaseSecretKey,
+		RobotsDisallow:                 resolved.Config.RobotsDisallow,
+		RobotsWhitelist:                resolved.Config.RobotsWhitelist,
+		FeatureUserLastAccessed:        featureUserLastAccessed,
+		LastAccessedUpdateThresholdSec: lastAccessedUpdateThresholdSeconds,
+	}
+	superUsersFullAccess := featureEnabled(resolved.Config.FeatureSuperUsers) && featureEnabled(resolved.Config.FeatureSuperUsersFullAccess)
+
 	reg, err := distribution.NewRegistry(ctx, &distribution.Config{
-		StoragePath:      resolved.StoragePath,
-		Hostname:         resolved.Config.ServerHostname,
-		ListenAddr:       addr,
-		DB:               db,
-		Store:            store,
-		LibraryNamespace: resolved.Config.LibraryNamespace,
-		AnonymousAccess:  resolved.Config.FeatureAnonymousAccess,
+		StoragePath:                        resolved.StoragePath,
+		Hostname:                           resolved.Config.ServerHostname,
+		ListenAddr:                         addr,
+		DB:                                 db,
+		Store:                              store,
+		LibraryNamespace:                   resolved.Config.LibraryNamespace,
+		AnonymousAccess:                    resolved.Config.FeatureAnonymousAccess,
+		DatabaseSecretKey:                  resolved.Config.DatabaseSecretKey,
+		RobotsDisallow:                     resolved.Config.RobotsDisallow,
+		RobotsWhitelist:                    resolved.Config.RobotsWhitelist,
+		FeatureUserLastAccessed:            featureUserLastAccessed,
+		LastAccessedUpdateThresholdSeconds: lastAccessedUpdateThresholdSeconds,
+		SuperUsers:                         resolved.Config.SuperUsers,
+		SuperUsersFullAccess:               superUsersFullAccess,
 	})
 	if err != nil {
 		slog.Error("registry setup error", "err", err)
@@ -90,7 +108,7 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUse
 		repositorydal.NewStore(db),
 		repositorydal.NewAuthorizer(db, repositorydal.AuthorizerConfig{
 			SuperUsers:           resolved.Config.SuperUsers,
-			SuperUsersFullAccess: featureEnabled(resolved.Config.FeatureSuperUsers) && featureEnabled(resolved.Config.FeatureSuperUsersFullAccess),
+			SuperUsersFullAccess: superUsersFullAccess,
 		}),
 	)
 	if err != nil {
@@ -99,7 +117,7 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUse
 	}
 
 	api, err := apiv1.New(apiv1.Config{
-		Authenticator: auth.NewBasicAuthenticator(db),
+		Authenticator: auth.NewBasicAuthenticator(auth.NewDatabaseVerifier(db, databaseVerifierConfig)),
 		Realm:         resolved.Config.ServerHostname,
 	},
 		repositoryapi.NewModule(repositoryService),
@@ -114,10 +132,17 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUse
 	referrersEnabled := resolved.Config.FeatureReferrersAPI == nil || *resolved.Config.FeatureReferrersAPI
 	v2Handler := distHandler
 	if referrersEnabled {
-		referrersHandler := registry.NewReferrersHandler(db, store, registry.ReferrersConfig{
-			LibraryNamespace: resolved.Config.LibraryNamespace,
-			AnonymousAccess:  resolved.Config.FeatureAnonymousAccess == nil || *resolved.Config.FeatureAnonymousAccess,
-			LibrarySupport:   resolved.Config.FeatureLibrarySupport == nil || *resolved.Config.FeatureLibrarySupport,
+		referrersHandler := registry.NewReferrersHandler(db, store, &registry.ReferrersConfig{
+			LibraryNamespace:                   resolved.Config.LibraryNamespace,
+			AnonymousAccess:                    resolved.Config.FeatureAnonymousAccess == nil || *resolved.Config.FeatureAnonymousAccess,
+			LibrarySupport:                     resolved.Config.FeatureLibrarySupport == nil || *resolved.Config.FeatureLibrarySupport,
+			DatabaseSecretKey:                  databaseVerifierConfig.DatabaseSecretKey,
+			RobotsDisallow:                     databaseVerifierConfig.RobotsDisallow,
+			RobotsWhitelist:                    databaseVerifierConfig.RobotsWhitelist,
+			FeatureUserLastAccessed:            databaseVerifierConfig.FeatureUserLastAccessed,
+			LastAccessedUpdateThresholdSeconds: databaseVerifierConfig.LastAccessedUpdateThresholdSec,
+			SuperUsers:                         resolved.Config.SuperUsers,
+			SuperUsersFullAccess:               superUsersFullAccess,
 		})
 		v2Handler = registry.WrapWithReferrers(referrersHandler, distHandler)
 	}

--- a/internal/config/access.go
+++ b/internal/config/access.go
@@ -1,0 +1,6 @@
+package config
+
+// AccessLog holds access timestamp tracking settings.
+type AccessLog struct {
+	LastAccessedUpdateThresholdS int `yaml:"LAST_ACCESSED_UPDATE_THRESHOLD_S"`
+}

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -4,6 +4,8 @@ package config
 type Auth struct {
 	AuthenticationType string   `yaml:"AUTHENTICATION_TYPE"`
 	SuperUsers         []string `yaml:"SUPER_USERS"`
+	RobotsDisallow     bool     `yaml:"ROBOTS_DISALLOW"`
+	RobotsWhitelist    []string `yaml:"ROBOTS_WHITELIST"`
 }
 
 // validateAuth checks authentication enum values.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,14 +16,15 @@ import (
 
 // Config is the top-level Quay configuration.
 type Config struct {
-	Server   `yaml:",inline"`
-	Database `yaml:",inline"`
-	Storage  `yaml:",inline"`
-	Redis    `yaml:",inline"`
-	Auth     `yaml:",inline"`
-	Features `yaml:",inline"`
-	Security `yaml:",inline"`
-	Keys     `yaml:",inline"`
+	Server    `yaml:",inline"`
+	Database  `yaml:",inline"`
+	Storage   `yaml:",inline"`
+	Redis     `yaml:",inline"`
+	Auth      `yaml:",inline"`
+	Features  `yaml:",inline"`
+	Security  `yaml:",inline"`
+	Keys      `yaml:",inline"`
+	AccessLog `yaml:",inline"`
 
 	// Extra holds YAML keys not mapped to struct fields.
 	// The Python config has 200+ keys; the Go struct covers a subset.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -58,6 +58,47 @@ func TestParseDefaults(t *testing.T) {
 	assert.True(t, *cfg.FeatureDirectLogin)
 }
 
+func TestParseRobotAuthConfig(t *testing.T) {
+	cfg, err := Parse([]byte(`
+SERVER_HOSTNAME: test
+ROBOTS_DISALLOW: true
+ROBOTS_WHITELIST:
+  - acme+deploy
+  - mirror+sync
+FEATURE_USER_LAST_ACCESSED: false
+LAST_ACCESSED_UPDATE_THRESHOLD_S: 300
+`))
+	require.NoError(t, err)
+
+	assert.True(t, cfg.RobotsDisallow)
+	assert.Equal(t, []string{"acme+deploy", "mirror+sync"}, cfg.RobotsWhitelist)
+	require.NotNil(t, cfg.FeatureUserLastAccessed)
+	assert.False(t, *cfg.FeatureUserLastAccessed)
+	assert.Equal(t, 300, cfg.LastAccessedUpdateThresholdS)
+}
+
+func TestParseRobotAuthDefaults(t *testing.T) {
+	cfg, err := Parse([]byte("SERVER_HOSTNAME: test\n"))
+	require.NoError(t, err)
+
+	assert.False(t, cfg.RobotsDisallow)
+	assert.Empty(t, cfg.RobotsWhitelist)
+	require.NotNil(t, cfg.FeatureUserLastAccessed)
+	assert.True(t, *cfg.FeatureUserLastAccessed)
+	assert.Equal(t, 60, cfg.LastAccessedUpdateThresholdS)
+}
+
+func TestNewDefaultConfiguresStandaloneAdminFullAccess(t *testing.T) {
+	cfg := NewDefault("localhost", "/data/storage")
+
+	assert.Equal(t, "Database", cfg.AuthenticationType)
+	assert.Equal(t, []string{"admin"}, cfg.SuperUsers)
+	require.NotNil(t, cfg.FeatureSuperUsers)
+	assert.True(t, *cfg.FeatureSuperUsers)
+	require.NotNil(t, cfg.FeatureSuperUsersFullAccess)
+	assert.True(t, *cfg.FeatureSuperUsersFullAccess)
+}
+
 func TestParseExplicitFalseNotOverridden(t *testing.T) {
 	yaml := "FEATURE_DIRECT_LOGIN: false\n"
 	cfg, err := Parse([]byte(yaml))

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -2,11 +2,12 @@ package config
 
 // Default values for Quay configuration fields.
 const (
-	DefaultPreferredURLScheme = "http"
-	DefaultRegistryTitle      = "Red Hat Quay"
-	DefaultAuthenticationType = "Database"
-	DefaultTagExpiration      = "2w"
-	DefaultLibraryNamespace   = "library"
+	DefaultPreferredURLScheme           = "http"
+	DefaultRegistryTitle                = "Red Hat Quay"
+	DefaultAuthenticationType           = "Database"
+	DefaultTagExpiration                = "2w"
+	DefaultLibraryNamespace             = "library"
+	DefaultLastAccessedUpdateThresholdS = 60
 )
 
 // newDefaultConfig returns a Config pre-populated with Quay's documented
@@ -35,6 +36,10 @@ func newDefaultConfig() Config {
 			FeatureSuperUsers:          boolPtr(true),
 			FeatureReferrersAPI:        boolPtr(true),
 			FeatureLibrarySupport:      boolPtr(true),
+			FeatureUserLastAccessed:    boolPtr(true),
+		},
+		AccessLog: AccessLog{
+			LastAccessedUpdateThresholdS: DefaultLastAccessedUpdateThresholdS,
 		},
 	}
 }

--- a/internal/config/features.go
+++ b/internal/config/features.go
@@ -18,4 +18,5 @@ type Features struct {
 	FeatureOrgSharedEmail       *bool `yaml:"FEATURE_ORG_SHARED_EMAIL"`
 	FeatureReferrersAPI         *bool `yaml:"FEATURE_REFERRERS_API"`
 	FeatureLibrarySupport       *bool `yaml:"FEATURE_LIBRARY_SUPPORT"`
+	FeatureUserLastAccessed     *bool `yaml:"FEATURE_USER_LAST_ACCESSED"`
 }

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -118,6 +118,14 @@ func NewDefault(hostname, storagePath string) *Config {
 			ServerHostname:     hostname,
 			PreferredURLScheme: "https",
 		},
+		Auth: Auth{
+			AuthenticationType: "Database",
+			SuperUsers:         []string{"admin"},
+		},
+		Features: Features{
+			FeatureSuperUsers:           boolPtr(true),
+			FeatureSuperUsersFullAccess: boolPtr(true),
+		},
 		Storage: Storage{
 			DistributedStorageConfig: StorageEntries{
 				"default": {

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -153,7 +153,6 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_UI_V2":                                 true,
 	"FEATURE_USER_EVENTS":                           true,
 	"FEATURE_USER_INITIALIZE":                       true,
-	"FEATURE_USER_LAST_ACCESSED":                    true,
 	"FEATURE_USER_LOG_ACCESS":                       true,
 	"FEATURE_USER_METADATA":                         true,
 	"FEATURE_USER_RENAME":                           true,
@@ -221,7 +220,6 @@ var knownUnmapped = map[string]bool{
 	"WEBHOOK_HOSTNAME_BLACKLIST":  true,
 	"RESTRICTED_USERS_WHITELIST":  true,
 	"BLACKLISTED_EMAIL_DOMAINS":   true,
-	"ROBOTS_WHITELIST":            true,
 
 	// Misc continued
 	"ALLOWED_OCI_ARTIFACT_TYPES":                     true,
@@ -246,7 +244,6 @@ var knownUnmapped = map[string]bool{
 	"ORG_MIRROR_MAX_DISCOVERY_DURATION":              true,
 	"PERMANENTLY_DELETE_TAGS":                        true,
 	"RESET_CHILD_MANIFEST_EXPIRATION":                true,
-	"ROBOTS_DISALLOW":                                true,
 	"SECURITY_SCANNER_INDEXING_INTERVAL":             true,
 	"SECURITY_SCANNER_V4_INDEX_MAX_LAYER_SIZE":       true,
 	"SESSION_TIMEOUT":                                true,
@@ -258,9 +255,10 @@ var knownUnmapped = map[string]bool{
 // INTERNAL_ONLY_PROPERTIES) that the Go CLI needs but are not part of the
 // public schema.
 var goOnlyFields = map[string]bool{
-	"DATABASE_SECRET_KEY": true,
-	"SECRET_KEY":          true,
-	"LIBRARY_NAMESPACE":   true, // QUAY.IO-only in Python schema but needed by Go middleware
+	"DATABASE_SECRET_KEY":              true,
+	"LAST_ACCESSED_UPDATE_THRESHOLD_S": true,
+	"SECRET_KEY":                       true,
+	"LIBRARY_NAMESPACE":                true, // QUAY.IO-only in Python schema but needed by Go middleware
 }
 
 // TestSchemaFieldCoverage compares the Python schema keys against the Go struct

--- a/internal/credentials/encryptedfield/encryptedfield.go
+++ b/internal/credentials/encryptedfield/encryptedfield.go
@@ -1,0 +1,60 @@
+// Package encryptedfield decrypts Python encrypted-field values stored in the Quay database.
+package encryptedfield
+
+import (
+	"crypto/aes"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/quay/quay/internal/credentials/encryptedfield/internal/ccm"
+)
+
+const (
+	separator = "$$"
+	versionV0 = "v0"
+	nonceSize = 13
+	tagSize   = 16
+)
+
+// Decrypt decrypts a Python v0 encrypted-field value using the database secret key.
+func Decrypt(secretKey, encryptedValue string) (string, error) {
+	key, err := ConvertSecretKey(secretKey)
+	if err != nil {
+		return "", err
+	}
+
+	version, data, ok := strings.Cut(encryptedValue, separator)
+	if !ok {
+		return "", ErrInvalidFormat
+	}
+	if version != versionV0 {
+		return "", ErrUnsupportedVersion
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return "", fmt.Errorf("%w: base64", ErrInvalidFormat)
+	}
+	if len(decoded) < nonceSize+tagSize {
+		return "", ErrInvalidFormat
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("%w: aes", ErrInvalidKey)
+	}
+	aead, err := ccm.NewCCM(block, tagSize, nonceSize)
+	if err != nil {
+		return "", fmt.Errorf("%w: ccm", ErrInvalidKey)
+	}
+
+	nonce := decoded[:nonceSize]
+	ciphertext := decoded[nonceSize:]
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", ErrDecrypt
+	}
+
+	return string(plaintext), nil
+}

--- a/internal/credentials/encryptedfield/encryptedfield_test.go
+++ b/internal/credentials/encryptedfield/encryptedfield_test.go
@@ -1,0 +1,57 @@
+package encryptedfield
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDecryptPythonVectors(t *testing.T) {
+	tests := []struct {
+		name      string
+		secretKey string
+		encrypted string
+		want      string
+	}{
+		{name: "empty", secretKey: "test1234", encrypted: "v0$$iE+87Qefu/2i+5zC87nlUtOskypk8MUUDS/QZPs=", want: ""},
+		{name: "hello world", secretKey: "test1234", encrypted: "v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==", want: "hello world"},
+		{name: "hello world second nonce", secretKey: "test1234", encrypted: "v0$$9LadVsSvfAr9r1OvghSYcJqrJpv46t+U6NgLKrcFY6y2bQsASIN36g==", want: "hello world"},
+		{name: "control key material", secretKey: "\x01\x02\x03\x04\x05\x06", encrypted: "v0$$2wwWX8IhUYzuh4cyMgSXF3MEVDlEhrf0CNimTghlHgCuK6E4+bLJb1xJOKxsXMs=", want: "hello world, again"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Decrypt(tc.secretKey, tc.encrypted)
+			if err != nil {
+				t.Fatalf("Decrypt: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecryptFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		secretKey string
+		encrypted string
+		wantErr   error
+	}{
+		{name: "empty value", secretKey: "test1234", encrypted: "", wantErr: ErrInvalidFormat},
+		{name: "missing separator", secretKey: "test1234", encrypted: "somerandomvalue", wantErr: ErrInvalidFormat},
+		{name: "unsupported version", secretKey: "test1234", encrypted: "v1$$abcd", wantErr: ErrUnsupportedVersion},
+		{name: "invalid base64", secretKey: "test1234", encrypted: "v0$$not-base64", wantErr: ErrInvalidFormat},
+		{name: "too short decoded payload", secretKey: "test1234", encrypted: "v0$$abcd", wantErr: ErrInvalidFormat},
+		{name: "wrong key", secretKey: "wrong-key", encrypted: "v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==", wantErr: ErrDecrypt},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Decrypt(tc.secretKey, tc.encrypted)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/credentials/encryptedfield/internal/ccm/ccm.go
+++ b/internal/credentials/encryptedfield/internal/ccm/ccm.go
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+
+// Package ccm implements Counter with CBC-MAC (CCM) AEAD for encrypted fields.
+//
+// This package is copied or adapted from Pion DTLS pkg/crypto/ccm and kept
+// internal to avoid adding Pion DTLS as a module dependency.
+package ccm
+
+import (
+	"crypto/cipher"
+	"crypto/subtle"
+	"encoding/binary"
+	"errors"
+	"math"
+)
+
+const (
+	blockSize     = 16
+	minNonceSize  = 7
+	maxNonceSize  = 13
+	maxLengthSize = 8
+)
+
+var (
+	errInvalidBlockSize = errors.New("ccm: invalid block size")
+	errInvalidTagSize   = errors.New("ccm: invalid tag size")
+	errInvalidNonceSize = errors.New("ccm: invalid nonce size")
+	errMessageTooLarge  = errors.New("ccm: message too large")
+	errAuth             = errors.New("ccm: message authentication failed")
+)
+
+type ccm struct {
+	block      cipher.Block
+	tagSize    int
+	nonceSize  int
+	lengthSize int
+}
+
+// NewCCM returns a CCM AEAD for the given AES block cipher, tag size, and nonce size.
+func NewCCM(b cipher.Block, tagSize, nonceSize int) (cipher.AEAD, error) {
+	if b.BlockSize() != blockSize {
+		return nil, errInvalidBlockSize
+	}
+	if tagSize < 4 || tagSize > 16 || tagSize%2 != 0 {
+		return nil, errInvalidTagSize
+	}
+	if nonceSize < minNonceSize || nonceSize > maxNonceSize {
+		return nil, errInvalidNonceSize
+	}
+
+	return &ccm{
+		block:      b,
+		tagSize:    tagSize,
+		nonceSize:  nonceSize,
+		lengthSize: blockSize - 1 - nonceSize,
+	}, nil
+}
+
+func (c *ccm) NonceSize() int {
+	return c.nonceSize
+}
+
+func (c *ccm) Overhead() int {
+	return c.tagSize
+}
+
+func (c *ccm) Seal(dst, nonce, plaintext, additionalData []byte) []byte {
+	if len(nonce) != c.nonceSize {
+		panic(errInvalidNonceSize)
+	}
+	if !c.validPayloadSize(len(plaintext)) {
+		panic(errMessageTooLarge)
+	}
+
+	ret, out := sliceForAppend(dst, len(plaintext)+c.tagSize)
+
+	tag := c.auth(nonce, plaintext, additionalData)
+	c.crypt(out[:len(plaintext)], plaintext, nonce, 1)
+	c.maskTag(tag, nonce)
+	copy(out[len(plaintext):], tag)
+
+	return ret
+}
+
+func (c *ccm) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, error) {
+	if len(nonce) != c.nonceSize {
+		return nil, errInvalidNonceSize
+	}
+	if len(ciphertext) < c.tagSize {
+		return nil, errAuth
+	}
+
+	payloadSize := len(ciphertext) - c.tagSize
+	if !c.validPayloadSize(payloadSize) {
+		return nil, errMessageTooLarge
+	}
+
+	ret, out := sliceForAppend(dst, payloadSize)
+	c.crypt(out, ciphertext[:payloadSize], nonce, 1)
+
+	tag := c.auth(nonce, out, additionalData)
+	c.maskTag(tag, nonce)
+	if subtle.ConstantTimeCompare(tag, ciphertext[payloadSize:]) != 1 {
+		clear(out)
+		return nil, errAuth
+	}
+
+	return ret, nil
+}
+
+func (c *ccm) auth(nonce, plaintext, additionalData []byte) []byte {
+	var mac [blockSize]byte
+	var b0 [blockSize]byte
+
+	b0[0] = byte(c.lengthSize - 1)      // #nosec G115 -- lengthSize is derived from validated nonceSize.
+	b0[0] |= byte((c.tagSize-2)/2) << 3 // #nosec G115 -- tagSize is validated to the CCM range.
+	if len(additionalData) > 0 {
+		b0[0] |= 1 << 6
+	}
+	copy(b0[1:], nonce)
+	c.putLength(b0[blockSize-c.lengthSize:], uint64(len(plaintext)))
+
+	c.block.Encrypt(mac[:], b0[:])
+
+	if len(additionalData) > 0 {
+		c.updateAuth(&mac, formatAdditionalData(additionalData))
+	}
+	c.updateAuth(&mac, plaintext)
+
+	tag := make([]byte, c.tagSize)
+	copy(tag, mac[:])
+	return tag
+}
+
+func (c *ccm) updateAuth(mac *[blockSize]byte, data []byte) {
+	for len(data) >= blockSize {
+		xorBlock(mac[:], data[:blockSize])
+		c.block.Encrypt(mac[:], mac[:])
+		data = data[blockSize:]
+	}
+
+	if len(data) > 0 {
+		var padded [blockSize]byte
+		copy(padded[:], data)
+		xorBlock(mac[:], padded[:])
+		c.block.Encrypt(mac[:], mac[:])
+	}
+}
+
+func (c *ccm) crypt(dst, src, nonce []byte, counter uint64) {
+	var counterBlock [blockSize]byte
+	var streamBlock [blockSize]byte
+
+	for len(src) > 0 {
+		c.counterBlock(counterBlock[:], nonce, counter)
+		c.block.Encrypt(streamBlock[:], counterBlock[:])
+
+		n := blockSize
+		if len(src) < n {
+			n = len(src)
+		}
+		for i := range n {
+			dst[i] = src[i] ^ streamBlock[i]
+		}
+
+		dst = dst[n:]
+		src = src[n:]
+		counter++
+	}
+}
+
+func (c *ccm) maskTag(tag, nonce []byte) {
+	var counterBlock [blockSize]byte
+	var streamBlock [blockSize]byte
+
+	c.counterBlock(counterBlock[:], nonce, 0)
+	c.block.Encrypt(streamBlock[:], counterBlock[:])
+	xorBlock(tag, streamBlock[:len(tag)])
+}
+
+func (c *ccm) counterBlock(out, nonce []byte, counter uint64) {
+	clear(out)
+	out[0] = byte(c.lengthSize - 1) // #nosec G115 -- lengthSize is derived from validated nonceSize.
+	copy(out[1:], nonce)
+	c.putLength(out[blockSize-c.lengthSize:], counter)
+}
+
+func (c *ccm) putLength(out []byte, n uint64) {
+	for i := len(out) - 1; i >= 0; i-- {
+		out[i] = byte(n)
+		n >>= 8
+	}
+}
+
+func (c *ccm) validPayloadSize(size int) bool {
+	if c.lengthSize == maxLengthSize {
+		return true
+	}
+
+	return uint64(size) < (uint64(1) << (8 * c.lengthSize)) // #nosec G115 -- len-derived sizes are non-negative.
+}
+
+func formatAdditionalData(additionalData []byte) []byte {
+	size := len(additionalData)
+	switch {
+	case size < 0xff00:
+		out := make([]byte, 2+size)
+		binary.BigEndian.PutUint16(out, uint16(size))
+		copy(out[2:], additionalData)
+		return out
+	case uint64(size) <= math.MaxUint32:
+		out := make([]byte, 6+size)
+		out[0] = 0xff
+		out[1] = 0xfe
+		binary.BigEndian.PutUint32(out[2:], uint32(size))
+		copy(out[6:], additionalData)
+		return out
+	default:
+		out := make([]byte, 10+size)
+		out[0] = 0xff
+		out[1] = 0xff
+		binary.BigEndian.PutUint64(out[2:], uint64(size))
+		copy(out[10:], additionalData)
+		return out
+	}
+}
+
+func xorBlock(dst, src []byte) {
+	for i := range dst {
+		dst[i] ^= src[i]
+	}
+}
+
+func sliceForAppend(in []byte, n int) (head, tail []byte) {
+	if total := len(in) + n; cap(in) >= total {
+		head = in[:total]
+	} else {
+		head = make([]byte, total)
+		copy(head, in)
+	}
+	tail = head[len(in):]
+	return head, tail
+}

--- a/internal/credentials/encryptedfield/internal/ccm/ccm_test.go
+++ b/internal/credentials/encryptedfield/internal/ccm/ccm_test.go
@@ -1,0 +1,54 @@
+package ccm
+
+import (
+	"bytes"
+	"crypto/aes"
+	"testing"
+)
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	block, err := aes.NewCipher([]byte("test1234test1234test1234test1234"))
+	if err != nil {
+		t.Fatalf("aes.NewCipher: %v", err)
+	}
+	aead, err := NewCCM(block, 16, 13)
+	if err != nil {
+		t.Fatalf("NewCCM: %v", err)
+	}
+
+	nonce := []byte("1234567890123")
+	plaintext := []byte("hello world")
+	additionalData := []byte("metadata")
+
+	ciphertext := aead.Seal(nil, nonce, plaintext, additionalData)
+	if bytes.Equal(ciphertext[:len(plaintext)], plaintext) {
+		t.Fatal("ciphertext payload matches plaintext")
+	}
+
+	got, err := aead.Open(nil, nonce, ciphertext, additionalData)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("plaintext = %q, want %q", got, plaintext)
+	}
+}
+
+func TestOpenRejectsModifiedCiphertext(t *testing.T) {
+	block, err := aes.NewCipher([]byte("test1234test1234test1234test1234"))
+	if err != nil {
+		t.Fatalf("aes.NewCipher: %v", err)
+	}
+	aead, err := NewCCM(block, 16, 13)
+	if err != nil {
+		t.Fatalf("NewCCM: %v", err)
+	}
+
+	nonce := []byte("1234567890123")
+	ciphertext := aead.Seal(nil, nonce, []byte("hello world"), nil)
+	ciphertext[0] ^= 0xff
+
+	if _, err := aead.Open(nil, nonce, ciphertext, nil); err == nil {
+		t.Fatal("err = nil, want authentication failure")
+	}
+}

--- a/internal/credentials/encryptedfield/secret.go
+++ b/internal/credentials/encryptedfield/secret.go
@@ -1,0 +1,66 @@
+package encryptedfield
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/google/uuid"
+)
+
+const aesKeySize = 32
+
+var (
+	// ErrInvalidKey indicates a database secret key cannot be converted to an AES key.
+	ErrInvalidKey = errors.New("encryptedfield: invalid key")
+	// ErrInvalidFormat indicates an encrypted value is not a supported v0 encoded payload.
+	ErrInvalidFormat = errors.New("encryptedfield: invalid format")
+	// ErrUnsupportedVersion indicates an encrypted value uses a version this package cannot decrypt.
+	ErrUnsupportedVersion = errors.New("encryptedfield: unsupported version")
+	// ErrDecrypt indicates authenticated decryption failed.
+	ErrDecrypt = errors.New("encryptedfield: decrypt")
+)
+
+// ConvertSecretKey converts Quay's Python DATABASE_SECRET_KEY formats to a 32-byte AES key.
+func ConvertSecretKey(secret string) ([]byte, error) {
+	source, err := secretSourceBytes(secret)
+	if err != nil {
+		return nil, err
+	}
+	if len(source) == 0 {
+		return nil, ErrInvalidKey
+	}
+
+	key := make([]byte, aesKeySize)
+	for i := range key {
+		key[i] = source[i%len(source)]
+	}
+
+	return key, nil
+}
+
+func secretSourceBytes(secret string) ([]byte, error) {
+	if i, ok := new(big.Int).SetString(secret, 10); ok {
+		hexText := fmt.Sprintf("%02x", i)
+		if source, err := hex.DecodeString(hexText); err == nil {
+			return source, nil
+		}
+	}
+
+	if id, err := uuid.Parse(secret); err == nil {
+		source := make([]byte, 16)
+		copy(source, id[:])
+		return source, nil
+	}
+
+	var source []byte
+	for _, r := range secret {
+		if r > 0xff {
+			return nil, ErrInvalidKey
+		}
+		source = append(source, byte(r)) // #nosec G115 -- Python compatibility rejects runes above one byte.
+	}
+
+	return source, nil
+}

--- a/internal/credentials/encryptedfield/secret_test.go
+++ b/internal/credentials/encryptedfield/secret_test.go
@@ -1,0 +1,46 @@
+package encryptedfield
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestConvertSecretKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		prefix  []byte
+		wantErr error
+	}{
+		{name: "plain string", input: "test1234", prefix: []byte("test1234")},
+		{name: "zero integer", input: "0", prefix: []byte{0x00, 0x00, 0x00, 0x00}},
+		{name: "byte integer", input: "255", prefix: []byte{0xff, 0xff, 0xff, 0xff}},
+		{name: "odd hex integer fallback", input: "256", prefix: []byte("2562")},
+		{name: "latin one rune", input: "é", prefix: []byte{0xe9, 0xe9, 0xe9, 0xe9}},
+		{name: "zero uuid", input: "00000000-0000-0000-0000-000000000000", prefix: []byte{0x00, 0x00, 0x00, 0x00}},
+		{name: "empty", input: "", wantErr: ErrInvalidKey},
+		{name: "above byte rune", input: "😇", wantErr: ErrInvalidKey},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ConvertSecretKey(tc.input)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ConvertSecretKey: %v", err)
+			}
+			if len(got) != 32 {
+				t.Fatalf("len = %d, want 32", len(got))
+			}
+			if !bytes.Equal(got[:len(tc.prefix)], tc.prefix) {
+				t.Fatalf("prefix = %x, want %x", got[:len(tc.prefix)], tc.prefix)
+			}
+		})
+	}
+}

--- a/internal/dal/daldb/repository.sql.go
+++ b/internal/dal/daldb/repository.sql.go
@@ -59,7 +59,7 @@ func (q *Queries) GetOrCreateRepository(ctx context.Context, arg GetOrCreateRepo
 }
 
 const getRepositoryAccessByNamespaceName = `-- name: GetRepositoryAccessByNamespaceName :one
-SELECT r.id, u.id AS namespace_user_id, u.username AS namespace, r.name, r.visibility_id, v.name AS visibility, r.state
+SELECT r.id, u.id AS namespace_user_id, u.username AS namespace, r.name, r.visibility_id, v.name AS visibility, r.state, r.kind_id, u.enabled AS namespace_enabled
 FROM repository r
 JOIN "user" u ON r.namespace_user_id = u.id
 JOIN visibility v ON r.visibility_id = v.id
@@ -72,13 +72,15 @@ type GetRepositoryAccessByNamespaceNameParams struct {
 }
 
 type GetRepositoryAccessByNamespaceNameRow struct {
-	ID              int64  `json:"id"`
-	NamespaceUserID int64  `json:"namespace_user_id"`
-	Namespace       string `json:"namespace"`
-	Name            string `json:"name"`
-	VisibilityID    int64  `json:"visibility_id"`
-	Visibility      string `json:"visibility"`
-	State           int64  `json:"state"`
+	ID               int64  `json:"id"`
+	NamespaceUserID  int64  `json:"namespace_user_id"`
+	Namespace        string `json:"namespace"`
+	Name             string `json:"name"`
+	VisibilityID     int64  `json:"visibility_id"`
+	Visibility       string `json:"visibility"`
+	State            int64  `json:"state"`
+	KindID           int64  `json:"kind_id"`
+	NamespaceEnabled bool   `json:"namespace_enabled"`
 }
 
 func (q *Queries) GetRepositoryAccessByNamespaceName(ctx context.Context, arg GetRepositoryAccessByNamespaceNameParams) (GetRepositoryAccessByNamespaceNameRow, error) {
@@ -92,6 +94,8 @@ func (q *Queries) GetRepositoryAccessByNamespaceName(ctx context.Context, arg Ge
 		&i.VisibilityID,
 		&i.Visibility,
 		&i.State,
+		&i.KindID,
+		&i.NamespaceEnabled,
 	)
 	return i, err
 }
@@ -245,6 +249,22 @@ func (q *Queries) MarkRepositoryDeleted(ctx context.Context, arg MarkRepositoryD
 	return q.db.ExecContext(ctx, markRepositoryDeleted, arg.DeletedName, arg.RepositoryID)
 }
 
+const namespaceIsOrgMirrored = `-- name: NamespaceIsOrgMirrored :one
+SELECT EXISTS(
+  SELECT 1
+  FROM "user" ns
+  JOIN orgmirrorconfig omc ON omc.organization_id = ns.id
+  WHERE ns.username = ?1
+)
+`
+
+func (q *Queries) NamespaceIsOrgMirrored(ctx context.Context, namespace string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, namespaceIsOrgMirrored, namespace)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const repositoryIsPublicByNamespaceName = `-- name: RepositoryIsPublicByNamespaceName :one
 SELECT EXISTS(
   SELECT 1
@@ -255,6 +275,7 @@ SELECT EXISTS(
     AND r.name = ?
     AND v.name = 'public'
     AND r.state != 3
+    AND u.enabled = 1
 )
 `
 
@@ -351,6 +372,193 @@ type UserCanAdminRepositoryParams struct {
 
 func (q *Queries) UserCanAdminRepository(ctx context.Context, arg UserCanAdminRepositoryParams) (int64, error) {
 	row := q.db.QueryRowContext(ctx, userCanAdminRepository, arg.RepositoryID, arg.Username, arg.UserID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const userCanCreateRepositoryInNamespace = `-- name: UserCanCreateRepositoryInNamespace :one
+SELECT EXISTS(
+  SELECT 1
+  FROM "user" ns
+  WHERE ns.username = ?1
+    AND ns.username = ?2
+    AND ns.id = ?3
+    AND ns.enabled = 1
+
+  UNION ALL
+
+  SELECT 1
+  FROM "user" ns
+  JOIN team t ON t.organization_id = ns.id
+  JOIN teamrole tr ON t.role_id = tr.id
+  JOIN teammember tm ON tm.team_id = t.id
+  WHERE ns.username = ?1
+    AND ns.enabled = 1
+    AND tm.user_id = ?3
+    AND tr.name IN ('creator', 'admin')
+)
+`
+
+type UserCanCreateRepositoryInNamespaceParams struct {
+	Namespace string `json:"namespace"`
+	Username  string `json:"username"`
+	UserID    int64  `json:"user_id"`
+}
+
+func (q *Queries) UserCanCreateRepositoryInNamespace(ctx context.Context, arg UserCanCreateRepositoryInNamespaceParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, userCanCreateRepositoryInNamespace, arg.Namespace, arg.Username, arg.UserID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const userCanPullRepository = `-- name: UserCanPullRepository :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repository r
+  JOIN "user" ns ON r.namespace_user_id = ns.id
+  WHERE r.id = ?1
+    AND ns.username = ?2
+    AND ns.enabled = 1
+
+  UNION ALL
+
+  SELECT 1
+  FROM repositorypermission rp
+  JOIN role ro ON rp.role_id = ro.id
+  WHERE rp.repository_id = ?1
+    AND rp.user_id = ?3
+    AND ro.name IN ('read', 'write', 'admin')
+
+  UNION ALL
+
+  SELECT 1
+  FROM repositorypermission rp
+  JOIN role ro ON rp.role_id = ro.id
+  JOIN teammember tm ON rp.team_id = tm.team_id
+  WHERE rp.repository_id = ?1
+    AND tm.user_id = ?3
+    AND ro.name IN ('read', 'write', 'admin')
+
+  UNION ALL
+
+  SELECT 1
+  FROM repository r
+  JOIN team t ON t.organization_id = r.namespace_user_id
+  JOIN teamrole tr ON t.role_id = tr.id
+  JOIN teammember tm ON tm.team_id = t.id
+  WHERE r.id = ?1
+    AND tm.user_id = ?3
+    AND tr.name = 'admin'
+)
+`
+
+type UserCanPullRepositoryParams struct {
+	RepositoryID int64         `json:"repository_id"`
+	Username     string        `json:"username"`
+	UserID       sql.NullInt64 `json:"user_id"`
+}
+
+func (q *Queries) UserCanPullRepository(ctx context.Context, arg UserCanPullRepositoryParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, userCanPullRepository, arg.RepositoryID, arg.Username, arg.UserID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const userCanPushRepository = `-- name: UserCanPushRepository :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repository r
+  JOIN "user" ns ON r.namespace_user_id = ns.id
+  WHERE r.id = ?1
+    AND ns.username = ?2
+    AND ns.enabled = 1
+
+  UNION ALL
+
+  SELECT 1
+  FROM repositorypermission rp
+  JOIN role ro ON rp.role_id = ro.id
+  WHERE rp.repository_id = ?1
+    AND rp.user_id = ?3
+    AND ro.name IN ('write', 'admin')
+
+  UNION ALL
+
+  SELECT 1
+  FROM repositorypermission rp
+  JOIN role ro ON rp.role_id = ro.id
+  JOIN teammember tm ON rp.team_id = tm.team_id
+  WHERE rp.repository_id = ?1
+    AND tm.user_id = ?3
+    AND ro.name IN ('write', 'admin')
+
+  UNION ALL
+
+  SELECT 1
+  FROM repository r
+  JOIN team t ON t.organization_id = r.namespace_user_id
+  JOIN teamrole tr ON t.role_id = tr.id
+  JOIN teammember tm ON tm.team_id = t.id
+  WHERE r.id = ?1
+    AND tm.user_id = ?3
+    AND tr.name = 'admin'
+)
+`
+
+type UserCanPushRepositoryParams struct {
+	RepositoryID int64         `json:"repository_id"`
+	Username     string        `json:"username"`
+	UserID       sql.NullInt64 `json:"user_id"`
+}
+
+func (q *Queries) UserCanPushRepository(ctx context.Context, arg UserCanPushRepositoryParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, userCanPushRepository, arg.RepositoryID, arg.Username, arg.UserID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const userIsOrgMirrorRobot = `-- name: UserIsOrgMirrorRobot :one
+SELECT EXISTS(
+  SELECT 1
+  FROM orgmirrorrepository omr
+  JOIN orgmirrorconfig omc ON omr.org_mirror_config_id = omc.id
+  WHERE omr.repository_id = ?1
+    AND omc.internal_robot_id = ?2
+)
+`
+
+type UserIsOrgMirrorRobotParams struct {
+	RepositoryID sql.NullInt64 `json:"repository_id"`
+	UserID       int64         `json:"user_id"`
+}
+
+func (q *Queries) UserIsOrgMirrorRobot(ctx context.Context, arg UserIsOrgMirrorRobotParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, userIsOrgMirrorRobot, arg.RepositoryID, arg.UserID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
+const userIsRepoMirrorRobot = `-- name: UserIsRepoMirrorRobot :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repomirrorconfig rmc
+  WHERE rmc.repository_id = ?1
+    AND rmc.internal_robot_id = ?2
+)
+`
+
+type UserIsRepoMirrorRobotParams struct {
+	RepositoryID int64 `json:"repository_id"`
+	UserID       int64 `json:"user_id"`
+}
+
+func (q *Queries) UserIsRepoMirrorRobot(ctx context.Context, arg UserIsRepoMirrorRobotParams) (int64, error) {
+	row := q.db.QueryRowContext(ctx, userIsRepoMirrorRobot, arg.RepositoryID, arg.UserID)
 	var column_1 int64
 	err := row.Scan(&column_1)
 	return column_1, err

--- a/internal/dal/daldb/user.sql.go
+++ b/internal/dal/daldb/user.sql.go
@@ -66,6 +66,67 @@ func (q *Queries) EnsureUser(ctx context.Context, username string) (int64, error
 	return id, err
 }
 
+const getNamespaceUserByUsername = `-- name: GetNamespaceUserByUsername :one
+SELECT id, username, enabled
+FROM "user"
+WHERE username = ?1
+`
+
+type GetNamespaceUserByUsernameRow struct {
+	ID       int64  `json:"id"`
+	Username string `json:"username"`
+	Enabled  bool   `json:"enabled"`
+}
+
+func (q *Queries) GetNamespaceUserByUsername(ctx context.Context, username string) (GetNamespaceUserByUsernameRow, error) {
+	row := q.db.QueryRowContext(ctx, getNamespaceUserByUsername, username)
+	var i GetNamespaceUserByUsernameRow
+	err := row.Scan(&i.ID, &i.Username, &i.Enabled)
+	return i, err
+}
+
+const getRobotByUsername = `-- name: GetRobotByUsername :one
+SELECT id, uuid, username, email, enabled, last_accessed
+FROM "user"
+WHERE username = ?1 AND robot = 1
+`
+
+type GetRobotByUsernameRow struct {
+	ID           int64          `json:"id"`
+	Uuid         sql.NullString `json:"uuid"`
+	Username     string         `json:"username"`
+	Email        string         `json:"email"`
+	Enabled      bool           `json:"enabled"`
+	LastAccessed sql.NullTime   `json:"last_accessed"`
+}
+
+func (q *Queries) GetRobotByUsername(ctx context.Context, username string) (GetRobotByUsernameRow, error) {
+	row := q.db.QueryRowContext(ctx, getRobotByUsername, username)
+	var i GetRobotByUsernameRow
+	err := row.Scan(
+		&i.ID,
+		&i.Uuid,
+		&i.Username,
+		&i.Email,
+		&i.Enabled,
+		&i.LastAccessed,
+	)
+	return i, err
+}
+
+const getRobotTokenByRobotID = `-- name: GetRobotTokenByRobotID :one
+SELECT token
+FROM robotaccounttoken
+WHERE robot_account_id = ?1
+`
+
+func (q *Queries) GetRobotTokenByRobotID(ctx context.Context, robotID int64) (string, error) {
+	row := q.db.QueryRowContext(ctx, getRobotTokenByRobotID, robotID)
+	var token string
+	err := row.Scan(&token)
+	return token, err
+}
+
 const getUserByUsername = `-- name: GetUserByUsername :one
 SELECT id, uuid, username, password_hash, email, enabled
 FROM "user"
@@ -93,4 +154,25 @@ func (q *Queries) GetUserByUsername(ctx context.Context, username string) (GetUs
 		&i.Enabled,
 	)
 	return i, err
+}
+
+const updateUserLastAccessedIfOlder = `-- name: UpdateUserLastAccessedIfOlder :exec
+UPDATE "user"
+SET last_accessed = datetime('now')
+WHERE id = ?1
+  AND (
+    last_accessed IS NULL
+    OR ?2 <= 0
+    OR last_accessed <= datetime('now', '-' || ?2 || ' seconds')
+  )
+`
+
+type UpdateUserLastAccessedIfOlderParams struct {
+	UserID           int64       `json:"user_id"`
+	ThresholdSeconds interface{} `json:"threshold_seconds"`
+}
+
+func (q *Queries) UpdateUserLastAccessedIfOlder(ctx context.Context, arg UpdateUserLastAccessedIfOlderParams) error {
+	_, err := q.db.ExecContext(ctx, updateUserLastAccessedIfOlder, arg.UserID, arg.ThresholdSeconds)
+	return err
 }

--- a/internal/dal/queries/repository.sql
+++ b/internal/dal/queries/repository.sql
@@ -18,7 +18,7 @@ JOIN "user" u ON r.namespace_user_id = u.id
 WHERE u.username = ? AND r.name = ?;
 
 -- name: GetRepositoryAccessByNamespaceName :one
-SELECT r.id, u.id AS namespace_user_id, u.username AS namespace, r.name, r.visibility_id, v.name AS visibility, r.state
+SELECT r.id, u.id AS namespace_user_id, u.username AS namespace, r.name, r.visibility_id, v.name AS visibility, r.state, r.kind_id, u.enabled AS namespace_enabled
 FROM repository r
 JOIN "user" u ON r.namespace_user_id = u.id
 JOIN visibility v ON r.visibility_id = v.id
@@ -34,6 +34,7 @@ SELECT EXISTS(
     AND r.name = ?
     AND v.name = 'public'
     AND r.state != 3
+    AND u.enabled = 1
 );
 
 -- name: UpdateRepositoryVisibility :execresult
@@ -105,6 +106,133 @@ SELECT EXISTS(
   WHERE r.id = @repository_id
     AND tm.user_id = @user_id
     AND tr.name = 'admin'
+);
+
+-- name: UserCanPullRepository :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repository r
+  JOIN "user" ns ON r.namespace_user_id = ns.id
+  WHERE r.id = @repository_id
+    AND ns.username = @username
+    AND ns.enabled = 1
+
+  UNION ALL
+
+  SELECT 1
+  FROM repositorypermission rp
+  JOIN role ro ON rp.role_id = ro.id
+  WHERE rp.repository_id = @repository_id
+    AND rp.user_id = @user_id
+    AND ro.name IN ('read', 'write', 'admin')
+
+  UNION ALL
+
+  SELECT 1
+  FROM repositorypermission rp
+  JOIN role ro ON rp.role_id = ro.id
+  JOIN teammember tm ON rp.team_id = tm.team_id
+  WHERE rp.repository_id = @repository_id
+    AND tm.user_id = @user_id
+    AND ro.name IN ('read', 'write', 'admin')
+
+  UNION ALL
+
+  SELECT 1
+  FROM repository r
+  JOIN team t ON t.organization_id = r.namespace_user_id
+  JOIN teamrole tr ON t.role_id = tr.id
+  JOIN teammember tm ON tm.team_id = t.id
+  WHERE r.id = @repository_id
+    AND tm.user_id = @user_id
+    AND tr.name = 'admin'
+);
+
+-- name: UserCanPushRepository :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repository r
+  JOIN "user" ns ON r.namespace_user_id = ns.id
+  WHERE r.id = @repository_id
+    AND ns.username = @username
+    AND ns.enabled = 1
+
+  UNION ALL
+
+  SELECT 1
+  FROM repositorypermission rp
+  JOIN role ro ON rp.role_id = ro.id
+  WHERE rp.repository_id = @repository_id
+    AND rp.user_id = @user_id
+    AND ro.name IN ('write', 'admin')
+
+  UNION ALL
+
+  SELECT 1
+  FROM repositorypermission rp
+  JOIN role ro ON rp.role_id = ro.id
+  JOIN teammember tm ON rp.team_id = tm.team_id
+  WHERE rp.repository_id = @repository_id
+    AND tm.user_id = @user_id
+    AND ro.name IN ('write', 'admin')
+
+  UNION ALL
+
+  SELECT 1
+  FROM repository r
+  JOIN team t ON t.organization_id = r.namespace_user_id
+  JOIN teamrole tr ON t.role_id = tr.id
+  JOIN teammember tm ON tm.team_id = t.id
+  WHERE r.id = @repository_id
+    AND tm.user_id = @user_id
+    AND tr.name = 'admin'
+);
+
+-- name: UserCanCreateRepositoryInNamespace :one
+SELECT EXISTS(
+  SELECT 1
+  FROM "user" ns
+  WHERE ns.username = @namespace
+    AND ns.username = @username
+    AND ns.id = @user_id
+    AND ns.enabled = 1
+
+  UNION ALL
+
+  SELECT 1
+  FROM "user" ns
+  JOIN team t ON t.organization_id = ns.id
+  JOIN teamrole tr ON t.role_id = tr.id
+  JOIN teammember tm ON tm.team_id = t.id
+  WHERE ns.username = @namespace
+    AND ns.enabled = 1
+    AND tm.user_id = @user_id
+    AND tr.name IN ('creator', 'admin')
+);
+
+-- name: NamespaceIsOrgMirrored :one
+SELECT EXISTS(
+  SELECT 1
+  FROM "user" ns
+  JOIN orgmirrorconfig omc ON omc.organization_id = ns.id
+  WHERE ns.username = @namespace
+);
+
+-- name: UserIsRepoMirrorRobot :one
+SELECT EXISTS(
+  SELECT 1
+  FROM repomirrorconfig rmc
+  WHERE rmc.repository_id = @repository_id
+    AND rmc.internal_robot_id = @user_id
+);
+
+-- name: UserIsOrgMirrorRobot :one
+SELECT EXISTS(
+  SELECT 1
+  FROM orgmirrorrepository omr
+  JOIN orgmirrorconfig omc ON omr.org_mirror_config_id = omc.id
+  WHERE omr.repository_id = @repository_id
+    AND omc.internal_robot_id = @user_id
 );
 
 -- name: ListAllRepositories :many

--- a/internal/dal/queries/user.sql
+++ b/internal/dal/queries/user.sql
@@ -22,3 +22,28 @@ RETURNING id;
 
 -- name: CountUsers :one
 SELECT count(*) FROM "user" WHERE organization = 0 AND robot = 0;
+
+-- name: GetRobotByUsername :one
+SELECT id, uuid, username, email, enabled, last_accessed
+FROM "user"
+WHERE username = @username AND robot = 1;
+
+-- name: GetNamespaceUserByUsername :one
+SELECT id, username, enabled
+FROM "user"
+WHERE username = @username;
+
+-- name: GetRobotTokenByRobotID :one
+SELECT token
+FROM robotaccounttoken
+WHERE robot_account_id = @robot_id;
+
+-- name: UpdateUserLastAccessedIfOlder :exec
+UPDATE "user"
+SET last_accessed = datetime('now')
+WHERE id = @user_id
+  AND (
+    last_accessed IS NULL
+    OR @threshold_seconds <= 0
+    OR last_accessed <= datetime('now', '-' || @threshold_seconds || ' seconds')
+  );

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -29,6 +29,7 @@ type Config struct {
 	DataDir      string
 	ImageArchive string
 	Image        string
+	ConfigPath   string
 }
 
 // Installer orchestrates fresh installs and upgrades of the registry
@@ -65,7 +66,11 @@ func New(stderr io.Writer) (*Installer, error) {
 
 // Run performs an install or upgrade based on whether a Quadlet unit already
 // exists.
-func (inst *Installer) Run(ctx context.Context, cfg Config) error {
+func (inst *Installer) Run(ctx context.Context, cfg *Config) error {
+	if cfg == nil {
+		return fmt.Errorf("nil installer config")
+	}
+
 	imageRef, err := inst.resolveImage(ctx, cfg.ImageArchive, cfg.Image)
 	if err != nil {
 		return fmt.Errorf("image resolution: %w", err)
@@ -133,7 +138,7 @@ func (inst *Installer) upgrade(ctx context.Context, imageRef string) error {
 	return nil
 }
 
-func (inst *Installer) freshInstall(ctx context.Context, cfg Config, imageRef string) error {
+func (inst *Installer) freshInstall(ctx context.Context, cfg *Config, imageRef string) error {
 	for _, dir := range []string{cfg.DataDir, filepath.Join(cfg.DataDir, "storage")} {
 		if err := inst.fs.MkdirAll(dir, 0o750); err != nil {
 			return fmt.Errorf("create directory %s: %w", dir, err)
@@ -141,12 +146,13 @@ func (inst *Installer) freshInstall(ctx context.Context, cfg Config, imageRef st
 	}
 
 	spec := system.QuadletSpec{
-		Image:    imageRef,
-		DataDir:  cfg.DataDir,
-		Hostname: cfg.Hostname,
-		Port:     "8443",
+		Image:      imageRef,
+		DataDir:    cfg.DataDir,
+		Hostname:   cfg.Hostname,
+		Port:       "8443",
+		ConfigPath: cfg.ConfigPath,
 	}
-	if err := inst.quadlet.Install(quadletServiceName, spec); err != nil {
+	if err := inst.quadlet.Install(quadletServiceName, &spec); err != nil {
 		return fmt.Errorf("install quadlet: %w", err)
 	}
 	slog.Info("quadlet installed", "path", inst.env.QuadletPath(quadletServiceName))

--- a/internal/migrate/copy.go
+++ b/internal/migrate/copy.go
@@ -9,8 +9,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/quay/quay/internal/config"
 	"github.com/quay/quay/internal/dal/dbcore"
+	"gopkg.in/yaml.v3"
 )
+
+const runtimeConfigFile = "config.yaml"
 
 func (m *Migrator) copyData(ctx context.Context) error {
 	if err := os.MkdirAll(m.DataDir, 0o750); err != nil {
@@ -59,6 +63,10 @@ func (m *Migrator) copyData(ctx context.Context) error {
 			}
 			slog.Info("copied cert", "src", src, "dst", dst)
 		}
+
+		if err := m.writeRuntimeConfig(); err != nil {
+			return err
+		}
 	}
 
 	// Copy blob storage recursively.
@@ -71,6 +79,62 @@ func (m *Migrator) copyData(ctx context.Context) error {
 		slog.Info("copied storage", "files", count, "bytes", totalBytes)
 	}
 
+	return nil
+}
+
+func (m *Migrator) writeRuntimeConfig() error {
+	sourcePath := filepath.Join(m.Source.ConfigDir, runtimeConfigFile)
+	if _, err := os.Stat(sourcePath); err != nil {
+		if os.IsNotExist(err) {
+			slog.Warn("source config not found, skipping runtime config generation", "path", sourcePath)
+			return nil
+		}
+		return fmt.Errorf("stat source config: %w", err)
+	}
+
+	sourceCfg, err := config.Load(sourcePath)
+	if err != nil {
+		return fmt.Errorf("load source config: %w", err)
+	}
+
+	runtimeCfg := map[string]any{
+		"SERVER_HOSTNAME":      m.Source.Hostname,
+		"PREFERRED_URL_SCHEME": "https",
+		"DB_URI":               "sqlite:////data/quay.db",
+		"DISTRIBUTED_STORAGE_CONFIG": map[string]any{
+			"default": []any{
+				"LocalStorage",
+				map[string]any{"storage_path": "/data/storage"},
+			},
+		},
+		"DISTRIBUTED_STORAGE_PREFERENCE": []string{"default"},
+		"SECRET_KEY":                     sourceCfg.SecretKey,
+		"DATABASE_SECRET_KEY":            sourceCfg.DatabaseSecretKey,
+		"AUTHENTICATION_TYPE":            sourceCfg.AuthenticationType,
+		"ROBOTS_DISALLOW":                sourceCfg.RobotsDisallow,
+		"ROBOTS_WHITELIST":               sourceCfg.RobotsWhitelist,
+		"SUPER_USERS":                    sourceCfg.SuperUsers,
+	}
+	if sourceCfg.FeatureSuperUsers != nil {
+		runtimeCfg["FEATURE_SUPER_USERS"] = *sourceCfg.FeatureSuperUsers
+	}
+	if sourceCfg.FeatureSuperUsersFullAccess != nil {
+		runtimeCfg["FEATURE_SUPERUSERS_FULL_ACCESS"] = *sourceCfg.FeatureSuperUsersFullAccess
+	}
+	if sourceCfg.FeatureUserLastAccessed != nil {
+		runtimeCfg["FEATURE_USER_LAST_ACCESSED"] = *sourceCfg.FeatureUserLastAccessed
+	}
+
+	data, err := yaml.Marshal(runtimeCfg)
+	if err != nil {
+		return fmt.Errorf("marshal runtime config: %w", err)
+	}
+
+	targetPath := filepath.Join(m.DataDir, runtimeConfigFile)
+	if err := os.WriteFile(targetPath, data, 0o600); err != nil {
+		return fmt.Errorf("write runtime config: %w", err)
+	}
+	slog.Info("wrote runtime config", "src", sourcePath, "dst", targetPath)
 	return nil
 }
 

--- a/internal/migrate/copy_test.go
+++ b/internal/migrate/copy_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/quay/quay/internal/config"
 	"github.com/quay/quay/internal/dal/dbcore"
 )
 
@@ -56,6 +57,118 @@ func TestCopyData(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(targetDir, markerFile)); err != nil {
 		t.Error("marker file should exist after copy")
+	}
+}
+
+func TestCopyData_WritesRuntimeConfigWithSourceSecrets(t *testing.T) {
+	srcDir := t.TempDir()
+	dbDir := t.TempDir()
+	storageDir := t.TempDir()
+
+	dbPath := filepath.Join(dbDir, "quay_sqlite.db")
+	createCopyTestDB(t, dbPath)
+	writeCopyTestFile(t, filepath.Join(srcDir, "config.yaml"), []byte(`
+SERVER_HOSTNAME: old.example.com
+PREFERRED_URL_SCHEME: https
+DB_URI: sqlite:////old/quay_sqlite.db
+DISTRIBUTED_STORAGE_CONFIG:
+  old:
+    - LocalStorage
+    - storage_path: /old/storage
+SECRET_KEY: old-secret
+DATABASE_SECRET_KEY: old-database-secret
+AUTHENTICATION_TYPE: LDAP
+ROBOTS_DISALLOW: true
+ROBOTS_WHITELIST:
+  - init+migratebot
+SUPER_USERS:
+  - ops-admin
+FEATURE_SUPER_USERS: true
+FEATURE_SUPERUSERS_FULL_ACCESS: true
+FEATURE_USER_LAST_ACCESSED: false
+`), 0o600)
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+	m := &Migrator{
+		DataDir: targetDir,
+		Out:     &bytes.Buffer{},
+		Source: OMRSource{
+			ConfigDir:   srcDir,
+			DBPath:      dbPath,
+			StoragePath: storageDir,
+			Hostname:    "localhost",
+		},
+	}
+
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("copyData: %v", err)
+	}
+
+	cfg, err := config.Load(filepath.Join(targetDir, "config.yaml"))
+	if err != nil {
+		t.Fatalf("load generated runtime config: %v", err)
+	}
+	if cfg.SecretKey != "old-secret" {
+		t.Fatalf("SecretKey = %q, want source secret", cfg.SecretKey)
+	}
+	if cfg.DatabaseSecretKey != "old-database-secret" {
+		t.Fatalf("DatabaseSecretKey = %q, want source database secret", cfg.DatabaseSecretKey)
+	}
+	if cfg.DBURI != "sqlite:////data/quay.db" {
+		t.Fatalf("DBURI = %q, want migrated runtime DB path", cfg.DBURI)
+	}
+	if cfg.AuthenticationType != "LDAP" {
+		t.Fatalf("AuthenticationType = %q, want source authentication type", cfg.AuthenticationType)
+	}
+	entry := cfg.DistributedStorageConfig["default"]
+	if entry.Driver != "LocalStorage" || entry.Params["storage_path"] != "/data/storage" {
+		t.Fatalf("storage config = %#v, want LocalStorage at /data/storage", entry)
+	}
+	if !cfg.RobotsDisallow {
+		t.Fatal("RobotsDisallow = false, want source setting preserved")
+	}
+	if got := cfg.RobotsWhitelist; len(got) != 1 || got[0] != "init+migratebot" {
+		t.Fatalf("RobotsWhitelist = %#v, want source whitelist", got)
+	}
+	if got := cfg.SuperUsers; len(got) != 1 || got[0] != "ops-admin" {
+		t.Fatalf("SuperUsers = %#v, want source superusers", got)
+	}
+	if cfg.FeatureSuperUsers == nil || !*cfg.FeatureSuperUsers {
+		t.Fatalf("FeatureSuperUsers = %#v, want source true", cfg.FeatureSuperUsers)
+	}
+	if cfg.FeatureSuperUsersFullAccess == nil || !*cfg.FeatureSuperUsersFullAccess {
+		t.Fatalf("FeatureSuperUsersFullAccess = %#v, want source true", cfg.FeatureSuperUsersFullAccess)
+	}
+	if cfg.FeatureUserLastAccessed == nil || *cfg.FeatureUserLastAccessed {
+		t.Fatalf("FeatureUserLastAccessed = %#v, want source false", cfg.FeatureUserLastAccessed)
+	}
+}
+
+func TestCopyData_SkipsRuntimeConfigWhenSourceConfigMissing(t *testing.T) {
+	srcDir := t.TempDir()
+	dbDir := t.TempDir()
+
+	dbPath := filepath.Join(dbDir, "quay_sqlite.db")
+	createCopyTestDB(t, dbPath)
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+	m := &Migrator{
+		DataDir: targetDir,
+		Out:     &bytes.Buffer{},
+		Source: OMRSource{
+			ConfigDir: srcDir,
+			DBPath:    dbPath,
+		},
+	}
+
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("copyData: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "quay.db")); err != nil {
+		t.Fatalf("quay.db not found in target: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, runtimeConfigFile)); !os.IsNotExist(err) {
+		t.Fatalf("runtime config stat err = %v, want not exist", err)
 	}
 }
 

--- a/internal/migrate/schema.go
+++ b/internal/migrate/schema.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 
 	"github.com/quay/quay/internal/dal/dbcore"
@@ -93,11 +94,19 @@ func (m *Migrator) install(ctx context.Context) error {
 		return fmt.Errorf("create installer: %w", err)
 	}
 
-	cfg := installer.Config{
+	configPath := ""
+	if _, err := os.Stat(filepath.Join(m.DataDir, runtimeConfigFile)); err == nil {
+		configPath = "/data/" + runtimeConfigFile
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat runtime config: %w", err)
+	}
+
+	cfg := &installer.Config{
 		Hostname:     m.Source.Hostname,
 		DataDir:      m.DataDir,
 		ImageArchive: m.Source.ImageArchive,
 		Image:        m.Source.Image,
+		ConfigPath:   configPath,
 	}
 
 	slog.Info("installing new registry", "hostname", cfg.Hostname, "data-dir", cfg.DataDir)

--- a/internal/registry/distribution/app.go
+++ b/internal/registry/distribution/app.go
@@ -17,13 +17,20 @@ import (
 
 // Config holds the parameters needed to construct the distribution registry.
 type Config struct {
-	StoragePath      string
-	Hostname         string
-	ListenAddr       string
-	DB               *sql.DB
-	Store            oci.MetadataStore
-	LibraryNamespace string
-	AnonymousAccess  *bool
+	StoragePath                        string
+	Hostname                           string
+	ListenAddr                         string
+	DB                                 *sql.DB
+	Store                              oci.MetadataStore
+	LibraryNamespace                   string
+	AnonymousAccess                    *bool
+	DatabaseSecretKey                  string
+	RobotsDisallow                     bool
+	RobotsWhitelist                    []string
+	FeatureUserLastAccessed            bool
+	LastAccessedUpdateThresholdSeconds int
+	SuperUsers                         []string
+	SuperUsersFullAccess               bool
 }
 
 // Registry wraps the distribution registry handler.
@@ -67,10 +74,17 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 		},
 		Auth: configuration.Auth{
 			"quaydb": configuration.Parameters{
-				"realm":            cfg.Hostname,
-				"db":               cfg.DB,
-				"libraryNamespace": libraryNamespace,
-				"anonymousAccess":  anonymousAccessEnabled(cfg.AnonymousAccess),
+				authOptionRealm:                      cfg.Hostname,
+				"db":                                 cfg.DB,
+				"libraryNamespace":                   libraryNamespace,
+				authOptionAnonAccess:                 anonymousAccessEnabled(cfg.AnonymousAccess),
+				"databaseSecretKey":                  cfg.DatabaseSecretKey,
+				"robotsDisallow":                     cfg.RobotsDisallow,
+				"robotsWhitelist":                    cfg.RobotsWhitelist,
+				"featureUserLastAccessed":            cfg.FeatureUserLastAccessed,
+				"lastAccessedUpdateThresholdSeconds": cfg.LastAccessedUpdateThresholdSeconds,
+				"superUsers":                         cfg.SuperUsers,
+				"superUsersFullAccess":               cfg.SuperUsersFullAccess,
 			},
 		},
 	}

--- a/internal/registry/distribution/auth.go
+++ b/internal/registry/distribution/auth.go
@@ -2,6 +2,7 @@ package distribution
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 	"github.com/quay/quay/internal/auth"
 	"github.com/quay/quay/internal/dal/daldb"
 	"github.com/quay/quay/internal/oci"
+	repo "github.com/quay/quay/internal/repository"
+	repositorydal "github.com/quay/quay/internal/repository/dal"
 )
 
 func init() {
@@ -21,6 +24,7 @@ func init() {
 
 type accessController struct {
 	authenticator    *auth.BasicAuthenticator
+	authorizer       *repositorydal.Authorizer
 	queries          *daldb.Queries
 	realm            string
 	libraryNamespace string
@@ -32,10 +36,20 @@ var (
 	_ oci.Authenticator         = &accessController{}
 )
 
+const (
+	repositoryPushAction   = "push"
+	repositoryDeleteAction = "delete"
+	registryResourceType   = "registry"
+	registryCatalogName    = "catalog"
+	registryCatalogAction  = "*"
+	authOptionRealm        = "realm"
+	authOptionAnonAccess   = "anonymousAccess"
+)
+
 func newAccessController(options map[string]interface{}) (distauth.AccessController, error) {
-	realm, ok := options["realm"].(string)
+	realm, ok := options[authOptionRealm].(string)
 	if !ok || realm == "" {
-		return nil, fmt.Errorf(`"realm" must be set for quaydb access controller`)
+		return nil, fmt.Errorf("%q must be set for quaydb access controller", authOptionRealm)
 	}
 
 	db, ok := options["db"].(*sql.DB)
@@ -48,13 +62,33 @@ func newAccessController(options map[string]interface{}) (distauth.AccessControl
 		libraryNamespace = defaultLibraryNamespace
 	}
 
-	anonymousAccess, ok := options["anonymousAccess"].(bool)
+	anonymousAccess, ok := options[authOptionAnonAccess].(bool)
 	if !ok {
 		anonymousAccess = true
 	}
 
+	databaseSecretKey, _ := options["databaseSecretKey"].(string)
+	robotsDisallow, _ := options["robotsDisallow"].(bool)
+	robotsWhitelist, _ := options["robotsWhitelist"].([]string)
+	featureUserLastAccessed, _ := options["featureUserLastAccessed"].(bool)
+	lastAccessedUpdateThresholdSeconds, _ := options["lastAccessedUpdateThresholdSeconds"].(int)
+	superUsers, _ := options["superUsers"].([]string)
+	superUsersFullAccess, _ := options["superUsersFullAccess"].(bool)
+
+	verifier := auth.NewDatabaseVerifier(db, auth.DatabaseVerifierConfig{
+		DatabaseSecretKey:              databaseSecretKey,
+		RobotsDisallow:                 robotsDisallow,
+		RobotsWhitelist:                robotsWhitelist,
+		FeatureUserLastAccessed:        featureUserLastAccessed,
+		LastAccessedUpdateThresholdSec: lastAccessedUpdateThresholdSeconds,
+	})
+
 	return &accessController{
-		authenticator:    auth.NewBasicAuthenticator(db),
+		authenticator: auth.NewBasicAuthenticator(verifier),
+		authorizer: repositorydal.NewAuthorizer(db, repositorydal.AuthorizerConfig{
+			SuperUsers:           superUsers,
+			SuperUsersFullAccess: superUsersFullAccess,
+		}),
 		queries:          daldb.New(db),
 		realm:            realm,
 		libraryNamespace: libraryNamespace,
@@ -83,6 +117,13 @@ func (ac *accessController) Authorized(req *http.Request, access ...distauth.Acc
 		}
 	}
 
+	if err := ac.authorizeDistributionAccess(req, &result.Principal, access); err != nil {
+		return nil, &challenge{
+			realm: ac.realm,
+			err:   distauth.ErrAuthenticationFailure,
+		}
+	}
+
 	return &distauth.Grant{User: distauth.UserInfo{Name: result.Principal.Username}}, nil
 }
 
@@ -95,6 +136,13 @@ func (ac *accessController) Authenticate(r *http.Request, access ...oci.Access) 
 	}
 
 	if !result.Authenticated {
+		return nil, &challenge{
+			realm: ac.realm,
+			err:   oci.ErrUnauthorized,
+		}
+	}
+
+	if err := ac.authorizeOCIAccess(r, &result.Principal, access); err != nil {
 		return nil, &challenge{
 			realm: ac.realm,
 			err:   oci.ErrUnauthorized,
@@ -153,6 +201,158 @@ func (ac *accessController) repositoryIsPublic(req *http.Request, name string) b
 	}
 
 	return isPublic == 1
+}
+
+func (ac *accessController) authorizeDistributionAccess(req *http.Request, principal *auth.Principal, access []distauth.Access) error {
+	if len(access) == 0 {
+		return nil
+	}
+
+	for _, item := range access {
+		switch item.Type {
+		case repositoryResourceType:
+			if err := ac.authorizeRepositoryAccess(req, principal, item, access); err != nil {
+				return err
+			}
+		case registryResourceType:
+			if item.Name == registryCatalogName && item.Action == registryCatalogAction {
+				return fmt.Errorf("registry catalog is not supported by quaydb auth")
+			}
+			return fmt.Errorf("unsupported access resource type %q", item.Type)
+		default:
+			return fmt.Errorf("unsupported access resource type %q", item.Type)
+		}
+	}
+
+	return nil
+}
+
+func (ac *accessController) authorizeOCIAccess(req *http.Request, principal *auth.Principal, access []oci.Access) error {
+	if len(access) == 0 {
+		return nil
+	}
+
+	distributionAccess := make([]distauth.Access, 0, len(access))
+	for _, item := range access {
+		resourceType, resourceName, ok := strings.Cut(item.Resource, ":")
+		if !ok {
+			return fmt.Errorf("invalid OCI access resource %q", item.Resource)
+		}
+		distributionAccess = append(distributionAccess, distauth.Access{
+			Resource: distauth.Resource{
+				Type: resourceType,
+				Name: resourceName,
+			},
+			Action: item.Action,
+		})
+	}
+
+	return ac.authorizeDistributionAccess(req, principal, distributionAccess)
+}
+
+func (ac *accessController) authorizeRepositoryAccess(req *http.Request, principal *auth.Principal, item distauth.Access, access []distauth.Access) error {
+	repositoryRecord, err := ac.resolveRepository(req, item.Name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ac.authorizeMissingRepositoryAccess(req, principal, item, access)
+		}
+		return err
+	}
+	if repositoryRecord.KindID != repo.KindImage {
+		return fmt.Errorf("repository %q is not an image repository", item.Name)
+	}
+
+	var allowed bool
+	switch item.Action {
+	case repositoryPullAction:
+		allowed, err = ac.authorizer.CanPullRepository(req.Context(), principal, &repositoryRecord)
+	case repositoryPushAction, repositoryDeleteAction:
+		allowed, err = ac.authorizer.CanPushRepository(req.Context(), principal, &repositoryRecord)
+	default:
+		return fmt.Errorf("unsupported repository action %q", item.Action)
+	}
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return fmt.Errorf("repository action %q denied for %s", item.Action, principal.Username)
+	}
+
+	return nil
+}
+
+func (ac *accessController) authorizeMissingRepositoryAccess(req *http.Request, principal *auth.Principal, item distauth.Access, access []distauth.Access) error {
+	switch item.Action {
+	case repositoryPullAction:
+		if accessIncludesRepositoryAction(access, item.Name, repositoryPushAction) {
+			return nil
+		}
+		namespace, _, ok := ac.repositoryParts(item.Name)
+		if !ok {
+			return fmt.Errorf("invalid repository name %q", item.Name)
+		}
+		allowed, err := ac.authorizer.CanCreateRepository(req.Context(), principal, namespace)
+		if err != nil {
+			return err
+		}
+		if allowed {
+			return nil
+		}
+		return sql.ErrNoRows
+	case repositoryPushAction:
+		namespace, _, ok := ac.repositoryParts(item.Name)
+		if !ok {
+			return fmt.Errorf("invalid repository name %q", item.Name)
+		}
+		allowed, err := ac.authorizer.CanCreateRepository(req.Context(), principal, namespace)
+		if err != nil {
+			return err
+		}
+		if !allowed {
+			return fmt.Errorf("repository create denied for %s", principal.Username)
+		}
+		return nil
+	case repositoryDeleteAction:
+		return sql.ErrNoRows
+	default:
+		return fmt.Errorf("unsupported repository action %q", item.Action)
+	}
+}
+
+func accessIncludesRepositoryAction(access []distauth.Access, name, action string) bool {
+	for _, item := range access {
+		if item.Type == repositoryResourceType && item.Name == name && item.Action == action {
+			return true
+		}
+	}
+	return false
+}
+
+func (ac *accessController) resolveRepository(req *http.Request, name string) (repo.Repository, error) {
+	namespace, repository, ok := ac.repositoryParts(name)
+	if !ok {
+		return repo.Repository{}, fmt.Errorf("invalid repository name %q", name)
+	}
+
+	row, err := ac.queries.GetRepositoryAccessByNamespaceName(req.Context(), daldb.GetRepositoryAccessByNamespaceNameParams{
+		Username: namespace,
+		Name:     repository,
+	})
+	if err != nil {
+		return repo.Repository{}, err
+	}
+
+	return repo.Repository{
+		ID: row.ID,
+		Ref: repo.Ref{
+			Namespace: row.Namespace,
+			Name:      row.Name,
+		},
+		Visibility:       repo.Visibility(row.Visibility),
+		State:            row.State,
+		KindID:           row.KindID,
+		NamespaceEnabled: row.NamespaceEnabled,
+	}, nil
 }
 
 func (ac *accessController) repositoryParts(name string) (namespace, repository string, ok bool) {

--- a/internal/registry/distribution/auth_test.go
+++ b/internal/registry/distribution/auth_test.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/distribution/distribution/v3/registry/auth"
+	"github.com/quay/quay/internal/oci"
 	_ "modernc.org/sqlite"
 )
 
@@ -33,7 +34,8 @@ func setupTestDB(t *testing.T) *sql.DB {
 		verified INTEGER NOT NULL DEFAULT 0,
 		organization INTEGER NOT NULL DEFAULT 0,
 		robot INTEGER NOT NULL DEFAULT 0,
-		enabled INTEGER NOT NULL DEFAULT 1
+		enabled INTEGER NOT NULL DEFAULT 1,
+		last_accessed DATETIME
 	)`)
 	if err != nil {
 		t.Fatalf("create table: %v", err)
@@ -57,9 +59,92 @@ func setupTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("create repository table: %v", err)
 	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE role (
+		id INTEGER PRIMARY KEY,
+		name VARCHAR(255) NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create role table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE teamrole (
+		id INTEGER PRIMARY KEY,
+		name VARCHAR(255) NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create teamrole table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE team (
+		id INTEGER PRIMARY KEY,
+		name VARCHAR(255) NOT NULL,
+		organization_id INTEGER NOT NULL,
+		role_id INTEGER NOT NULL,
+		description TEXT NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create team table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE teammember (
+		id INTEGER PRIMARY KEY,
+		user_id INTEGER NOT NULL,
+		team_id INTEGER NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create teammember table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE repositorypermission (
+		id INTEGER PRIMARY KEY,
+		team_id INTEGER,
+		user_id INTEGER,
+		repository_id INTEGER NOT NULL,
+		role_id INTEGER NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create repositorypermission table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE repomirrorconfig (
+		id INTEGER PRIMARY KEY,
+		repository_id INTEGER NOT NULL,
+		internal_robot_id INTEGER
+	)`)
+	if err != nil {
+		t.Fatalf("create repomirrorconfig table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE orgmirrorconfig (
+		id INTEGER PRIMARY KEY,
+		organization_id INTEGER NOT NULL,
+		internal_robot_id INTEGER
+	)`)
+	if err != nil {
+		t.Fatalf("create orgmirrorconfig table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE orgmirrorrepository (
+		id INTEGER PRIMARY KEY,
+		org_mirror_config_id INTEGER NOT NULL,
+		repository_id INTEGER
+	)`)
+	if err != nil {
+		t.Fatalf("create orgmirrorrepository table: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE TABLE robotaccounttoken (
+		id INTEGER PRIMARY KEY,
+		robot_account_id INTEGER NOT NULL,
+		token VARCHAR(255) NOT NULL,
+		fully_migrated BOOLEAN DEFAULT 0 NOT NULL
+	)`)
+	if err != nil {
+		t.Fatalf("create robotaccounttoken table: %v", err)
+	}
 	_, err = db.ExecContext(ctx, `INSERT INTO visibility (id, name) VALUES (1, 'public'), (2, 'private')`)
 	if err != nil {
 		t.Fatalf("insert visibility: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO role (id, name) VALUES (1, 'read'), (2, 'write'), (3, 'admin')`)
+	if err != nil {
+		t.Fatalf("insert roles: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO teamrole (id, name) VALUES (1, 'admin'), (2, 'creator'), (3, 'member')`)
+	if err != nil {
+		t.Fatalf("insert teamroles: %v", err)
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
@@ -79,6 +164,32 @@ func setupTestDB(t *testing.T) *sql.DB {
 		VALUES ('u2', 'disabled', ?, 'disabled@test.com', 1, 0, 0, 0)`, string(hash))
 	if err != nil {
 		t.Fatalf("insert disabled: %v", err)
+	}
+
+	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+		VALUES ('org-1', 'acme', NULL, 'acme@example.com', 1, 1, 0, 1)`)
+	if err != nil {
+		t.Fatalf("insert acme org: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+		VALUES ('robot-read', 'acme+reader', NULL, 'robot@example.com', 1, 0, 1, 1)`)
+	if err != nil {
+		t.Fatalf("insert reader robot: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+		VALUES ('robot-write', 'acme+writer', NULL, 'robot@example.com', 1, 0, 1, 1)`)
+	if err != nil {
+		t.Fatalf("insert writer robot: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+		VALUES ('disabled-org', 'disabled-org', NULL, 'disabled-org@example.com', 1, 1, 0, 0)`)
+	if err != nil {
+		t.Fatalf("insert disabled org: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
+		VALUES ('disabled-creator', 'disabled-org+creator', NULL, 'robot@example.com', 1, 0, 1, 1)`)
+	if err != nil {
+		t.Fatalf("insert disabled org creator robot: %v", err)
 	}
 
 	for _, username := range []string{"public", "devtable", "library"} {
@@ -109,6 +220,31 @@ func setupTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("insert library repo: %v", err)
 	}
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'private', 2, 1, 0 FROM "user" WHERE username = 'acme'`)
+	if err != nil {
+		t.Fatalf("insert acme private repo: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
+		SELECT id, 'publicrepo', 1, 1, 0 FROM "user" WHERE username = 'disabled-org'`)
+	if err != nil {
+		t.Fatalf("insert disabled org public repo: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO robotaccounttoken (robot_account_id, token, fully_migrated)
+		SELECT id, 'v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==', 1 FROM "user" WHERE username = 'acme+reader'`)
+	if err != nil {
+		t.Fatalf("insert reader robot token: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO robotaccounttoken (robot_account_id, token, fully_migrated)
+		SELECT id, 'v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==', 1 FROM "user" WHERE username = 'acme+writer'`)
+	if err != nil {
+		t.Fatalf("insert writer robot token: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO robotaccounttoken (robot_account_id, token, fully_migrated)
+		SELECT id, 'v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==', 1 FROM "user" WHERE username = 'disabled-org+creator'`)
+	if err != nil {
+		t.Fatalf("insert disabled org creator token: %v", err)
+	}
 
 	return db
 }
@@ -121,14 +257,115 @@ func newTestController(t *testing.T, db *sql.DB) auth.AccessController {
 func newTestControllerWithAnonymousAccess(t *testing.T, db *sql.DB, anonymousAccess bool) auth.AccessController {
 	t.Helper()
 	ac, err := newAccessController(map[string]interface{}{
-		"realm":           "test-realm",
-		"db":              db,
-		"anonymousAccess": anonymousAccess,
+		authOptionRealm:      "test-realm",
+		"db":                 db,
+		authOptionAnonAccess: anonymousAccess,
 	})
 	if err != nil {
 		t.Fatalf("new access controller: %v", err)
 	}
 	return ac
+}
+
+func newTestControllerWithRobotAuth(t *testing.T, db *sql.DB) auth.AccessController {
+	t.Helper()
+	ac, err := newAccessController(map[string]interface{}{
+		authOptionRealm:                      "test-realm",
+		"db":                                 db,
+		authOptionAnonAccess:                 true,
+		"databaseSecretKey":                  "test1234",
+		"featureUserLastAccessed":            true,
+		"lastAccessedUpdateThresholdSeconds": 0,
+	})
+	if err != nil {
+		t.Fatalf("new access controller: %v", err)
+	}
+	return ac
+}
+
+func newTestControllerWithSuperUserFullAccess(t *testing.T, db *sql.DB) auth.AccessController {
+	t.Helper()
+	ac, err := newAccessController(map[string]interface{}{
+		authOptionRealm:        "test-realm",
+		"db":                   db,
+		authOptionAnonAccess:   true,
+		"superUsers":           []string{"admin"},
+		"superUsersFullAccess": true,
+	})
+	if err != nil {
+		t.Fatalf("new access controller: %v", err)
+	}
+	return ac
+}
+
+func seedRobotPermission(t *testing.T, db *sql.DB, robotUsername, roleName string) {
+	t.Helper()
+	ctx := t.Context()
+
+	var userID int64
+	err := db.QueryRowContext(ctx, `SELECT id FROM "user" WHERE username = ?`, robotUsername).Scan(&userID)
+	if err != nil {
+		t.Fatalf("find robot user %s: %v", robotUsername, err)
+	}
+
+	var repoID int64
+	err = db.QueryRowContext(ctx, `SELECT r.id
+		FROM repository r
+		JOIN "user" u ON r.namespace_user_id = u.id
+		WHERE u.username = 'acme' AND r.name = 'private'`).Scan(&repoID)
+	if err != nil {
+		t.Fatalf("find repository acme/private: %v", err)
+	}
+
+	var roleID int64
+	err = db.QueryRowContext(ctx, `SELECT id FROM role WHERE name = ?`, roleName).Scan(&roleID)
+	if err != nil {
+		t.Fatalf("find role %s: %v", roleName, err)
+	}
+
+	_, err = db.ExecContext(ctx, `INSERT INTO repositorypermission (team_id, user_id, repository_id, role_id)
+		VALUES (NULL, ?, ?, ?)`, userID, repoID, roleID)
+	if err != nil {
+		t.Fatalf("insert robot permission: %v", err)
+	}
+}
+
+func seedNamespaceTeamMembership(t *testing.T, db *sql.DB, username, namespace, teamRole string) {
+	t.Helper()
+	ctx := t.Context()
+
+	var userID int64
+	err := db.QueryRowContext(ctx, `SELECT id FROM "user" WHERE username = ?`, username).Scan(&userID)
+	if err != nil {
+		t.Fatalf("find user %s: %v", username, err)
+	}
+
+	var namespaceID int64
+	err = db.QueryRowContext(ctx, `SELECT id FROM "user" WHERE username = ?`, namespace).Scan(&namespaceID)
+	if err != nil {
+		t.Fatalf("find namespace %s: %v", namespace, err)
+	}
+
+	var roleID int64
+	err = db.QueryRowContext(ctx, `SELECT id FROM teamrole WHERE name = ?`, teamRole).Scan(&roleID)
+	if err != nil {
+		t.Fatalf("find team role %s: %v", teamRole, err)
+	}
+
+	result, err := db.ExecContext(ctx, `INSERT INTO team (name, organization_id, role_id, description)
+		VALUES (?, ?, ?, '')`, username+"-"+teamRole, namespaceID, roleID)
+	if err != nil {
+		t.Fatalf("insert team: %v", err)
+	}
+
+	teamID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("team id: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO teammember (user_id, team_id) VALUES (?, ?)`, userID, teamID)
+	if err != nil {
+		t.Fatalf("insert team member: %v", err)
+	}
 }
 
 func TestAuthorized_ValidCredentials(t *testing.T) {
@@ -308,6 +545,23 @@ func TestAuthorized_InvalidBasicAuthDoesNotFallBackToAnonymous(t *testing.T) {
 	assertChallenge(t, err)
 }
 
+func TestAuthorized_AuthenticatedUserCanPullPublicRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+
+	grant, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
+	if err != nil {
+		t.Fatalf("expected authenticated public pull to succeed, got: %v", err)
+	}
+	if grant.User.Name != "admin" {
+		t.Errorf("expected grant user 'admin', got %q", grant.User.Name)
+	}
+}
+
 func TestAuthorized_AnonymousPullLibraryRepository(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
@@ -321,6 +575,344 @@ func TestAuthorized_AnonymousPullLibraryRepository(t *testing.T) {
 	}
 	if grant.User.Name != "anonymous" {
 		t.Errorf("expected anonymous user, got %q", grant.User.Name)
+	}
+}
+
+func TestAuthorized_RobotCreatorCanPushNewRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedNamespaceTeamMembership(t, db, "acme+writer", "acme", "creator")
+	ac := newTestControllerWithRobotAuth(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/newrepo/manifests/latest", http.NoBody)
+	req.SetBasicAuth("acme+writer", "hello world")
+
+	grant, err := ac.Authorized(
+		req,
+		repositoryAccess("acme/newrepo", "pull"),
+		repositoryAccess("acme/newrepo", "push"),
+	)
+	if err != nil {
+		t.Fatalf("expected creator robot push to new repository to succeed, got: %v", err)
+	}
+	if grant.User.Name != "acme+writer" {
+		t.Errorf("expected grant user 'acme+writer', got %q", grant.User.Name)
+	}
+}
+
+func TestAuthorized_NamespaceOwnerCanCheckMissingRepositoryBlobBeforePush(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "HEAD", "/v2/admin/newrepo/blobs/sha256:abc", http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+
+	grant, err := ac.Authorized(req, repositoryAccess("admin/newrepo", "pull"))
+	if err != nil {
+		t.Fatalf("expected namespace owner missing repository blob check to succeed, got: %v", err)
+	}
+	if grant.User.Name != "admin" {
+		t.Errorf("expected grant user 'admin', got %q", grant.User.Name)
+	}
+}
+
+func TestAuthorized_RepositoryDeleteRequiresWrite(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedRobotPermission(t, db, "acme+reader", "read")
+	seedRobotPermission(t, db, "acme+writer", "write")
+	ac := newTestControllerWithRobotAuth(t, db)
+
+	readerReq := httptest.NewRequestWithContext(t.Context(), "DELETE", "/v2/acme/private/manifests/latest", http.NoBody)
+	readerReq.SetBasicAuth("acme+reader", "hello world")
+	_, err := ac.Authorized(readerReq, repositoryAccess("acme/private", "delete"))
+	if err == nil {
+		t.Fatal("expected read robot delete to fail")
+	}
+	assertChallenge(t, err)
+
+	writerReq := httptest.NewRequestWithContext(t.Context(), "DELETE", "/v2/acme/private/manifests/latest", http.NoBody)
+	writerReq.SetBasicAuth("acme+writer", "hello world")
+	grant, err := ac.Authorized(writerReq, repositoryAccess("acme/private", "delete"))
+	if err != nil {
+		t.Fatalf("expected write robot delete to succeed, got: %v", err)
+	}
+	if grant.User.Name != "acme+writer" {
+		t.Errorf("expected grant user 'acme+writer', got %q", grant.User.Name)
+	}
+}
+
+func TestAuthorized_CatalogIsDeniedUntilQuayFilteredCatalogExists(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/_catalog", http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+
+	_, err := ac.Authorized(req, auth.Access{
+		Resource: auth.Resource{Type: "registry", Name: "catalog"},
+		Action:   "*",
+	})
+	if err == nil {
+		t.Fatal("expected unfiltered distribution catalog to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_WriteRobotCannotPushReadOnlyRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedRobotPermission(t, db, "acme+writer", "write")
+	if _, err := db.ExecContext(t.Context(), `UPDATE repository SET state = 1 WHERE name = 'private' AND namespace_user_id = (SELECT id FROM "user" WHERE username = 'acme')`); err != nil {
+		t.Fatalf("mark repo read-only: %v", err)
+	}
+	ac := newTestControllerWithRobotAuth(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
+	req.SetBasicAuth("acme+writer", "hello world")
+	_, err := ac.Authorized(req, repositoryAccess("acme/private", "push"))
+	if err == nil {
+		t.Fatal("expected read-only repository push to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_WriteRobotCannotPushApplicationRepository(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedRobotPermission(t, db, "acme+writer", "write")
+	if _, err := db.ExecContext(t.Context(), `UPDATE repository SET kind_id = 2 WHERE name = 'private' AND namespace_user_id = (SELECT id FROM "user" WHERE username = 'acme')`); err != nil {
+		t.Fatalf("mark repo application kind: %v", err)
+	}
+	ac := newTestControllerWithRobotAuth(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
+	req.SetBasicAuth("acme+writer", "hello world")
+	_, err := ac.Authorized(req, repositoryAccess("acme/private", "push"))
+	if err == nil {
+		t.Fatal("expected application repository push to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_DisabledNamespacePublicPullDenied(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestController(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/disabled-org/publicrepo/manifests/latest", http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+	_, err := ac.Authorized(req, repositoryAccess("disabled-org/publicrepo", "pull"))
+	if err == nil {
+		t.Fatal("expected disabled namespace public pull to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_DisabledNamespaceCreateDenied(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedNamespaceTeamMembership(t, db, "disabled-org+creator", "disabled-org", "creator")
+	ac := newTestControllerWithRobotAuth(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/disabled-org/newrepo/manifests/latest", http.NoBody)
+	req.SetBasicAuth("disabled-org+creator", "hello world")
+	_, err := ac.Authorized(
+		req,
+		repositoryAccess("disabled-org/newrepo", "pull"),
+		repositoryAccess("disabled-org/newrepo", "push"),
+	)
+	if err == nil {
+		t.Fatal("expected disabled namespace create to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_SuperUserCannotCreateInDisabledNamespace(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac := newTestControllerWithSuperUserFullAccess(t, db)
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/disabled-org/newrepo/manifests/latest", http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+	_, err := ac.Authorized(
+		req,
+		repositoryAccess("disabled-org/newrepo", "pull"),
+		repositoryAccess("disabled-org/newrepo", "push"),
+	)
+	if err == nil {
+		t.Fatal("expected superuser disabled namespace create to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_RobotReadCanPullNotPush(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedRobotPermission(t, db, "acme+reader", "read")
+	ac := newTestControllerWithRobotAuth(t, db)
+
+	pullReq := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/acme/private/manifests/latest", http.NoBody)
+	pullReq.SetBasicAuth("acme+reader", "hello world")
+
+	grant, err := ac.Authorized(pullReq, repositoryAccess("acme/private", "pull"))
+	if err != nil {
+		t.Fatalf("expected robot pull to succeed, got: %v", err)
+	}
+	if grant.User.Name != "acme+reader" {
+		t.Errorf("expected grant user 'acme+reader', got %q", grant.User.Name)
+	}
+
+	pushReq := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
+	pushReq.SetBasicAuth("acme+reader", "hello world")
+
+	_, err = ac.Authorized(pushReq, repositoryAccess("acme/private", "push"))
+	if err == nil {
+		t.Fatal("expected read robot push to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthorized_RobotWriteCanPullAndPush(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedRobotPermission(t, db, "acme+writer", "write")
+	ac := newTestControllerWithRobotAuth(t, db)
+
+	pullReq := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/acme/private/manifests/latest", http.NoBody)
+	pullReq.SetBasicAuth("acme+writer", "hello world")
+
+	pullGrant, err := ac.Authorized(pullReq, repositoryAccess("acme/private", "pull"))
+	if err != nil {
+		t.Fatalf("expected robot pull to succeed, got: %v", err)
+	}
+	if pullGrant.User.Name != "acme+writer" {
+		t.Errorf("expected pull grant user 'acme+writer', got %q", pullGrant.User.Name)
+	}
+
+	pushReq := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
+	pushReq.SetBasicAuth("acme+writer", "hello world")
+
+	pushGrant, err := ac.Authorized(pushReq, repositoryAccess("acme/private", "push"))
+	if err != nil {
+		t.Fatalf("expected robot push to succeed, got: %v", err)
+	}
+	if pushGrant.User.Name != "acme+writer" {
+		t.Errorf("expected push grant user 'acme+writer', got %q", pushGrant.User.Name)
+	}
+}
+
+func TestAuthenticate_InvalidRobotCredentialsDoNotFallBackToAnonymous(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac, ok := newTestControllerWithRobotAuth(t, db).(*accessController)
+	if !ok {
+		t.Fatal("expected concrete accessController")
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+	req.SetBasicAuth("acme+reader", "wrong")
+
+	_, err := ac.Authenticate(req, oci.Access{Resource: "repository:public/publicrepo", Action: "pull"})
+	if err == nil {
+		t.Fatal("expected auth failure for invalid robot credentials")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthenticate_ValidUserCannotPullPrivateRepositoryWithoutPermission(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac, ok := newTestController(t, db).(*accessController)
+	if !ok {
+		t.Fatal("expected concrete accessController")
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/devtable/simple/manifests/latest", http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+
+	_, err := ac.Authenticate(req, ociRepositoryAccess("devtable/simple", repositoryPullAction))
+	if err == nil {
+		t.Fatal("expected valid user without pull permission to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthenticate_ValidUserCannotPushRepositoryWithoutPermission(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac, ok := newTestController(t, db).(*accessController)
+	if !ok {
+		t.Fatal("expected concrete accessController")
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/public/publicrepo/manifests/latest", http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+
+	_, err := ac.Authenticate(req, ociRepositoryAccess("public/publicrepo", repositoryPushAction))
+	if err == nil {
+		t.Fatal("expected valid user without push permission to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthenticate_ValidRobotCannotPullPrivateRepositoryWithoutPermission(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	ac, ok := newTestControllerWithRobotAuth(t, db).(*accessController)
+	if !ok {
+		t.Fatal("expected concrete accessController")
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/acme/private/manifests/latest", http.NoBody)
+	req.SetBasicAuth("acme+reader", "hello world")
+
+	_, err := ac.Authenticate(req, ociRepositoryAccess("acme/private", repositoryPullAction))
+	if err == nil {
+		t.Fatal("expected valid robot without pull permission to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthenticate_ValidRobotCannotPushPrivateRepositoryWithReadOnlyPermission(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedRobotPermission(t, db, "acme+reader", "read")
+	ac, ok := newTestControllerWithRobotAuth(t, db).(*accessController)
+	if !ok {
+		t.Fatal("expected concrete accessController")
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
+	req.SetBasicAuth("acme+reader", "hello world")
+
+	_, err := ac.Authenticate(req, ociRepositoryAccess("acme/private", repositoryPushAction))
+	if err == nil {
+		t.Fatal("expected valid read robot push to fail")
+	}
+	assertChallenge(t, err)
+}
+
+func TestAuthenticate_ValidRobotCanPushPrivateRepositoryWithWritePermission(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	seedRobotPermission(t, db, "acme+writer", "write")
+	ac, ok := newTestControllerWithRobotAuth(t, db).(*accessController)
+	if !ok {
+		t.Fatal("expected concrete accessController")
+	}
+
+	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
+	req.SetBasicAuth("acme+writer", "hello world")
+
+	grant, err := ac.Authenticate(req, ociRepositoryAccess("acme/private", repositoryPushAction))
+	if err != nil {
+		t.Fatalf("expected write robot push to succeed, got: %v", err)
+	}
+	if grant.User.Name != "acme+writer" {
+		t.Errorf("expected grant user 'acme+writer', got %q", grant.User.Name)
 	}
 }
 
@@ -339,5 +931,12 @@ func repositoryAccess(name, action string) auth.Access {
 			Name: name,
 		},
 		Action: action,
+	}
+}
+
+func ociRepositoryAccess(name, action string) oci.Access {
+	return oci.Access{
+		Resource: "repository:" + name,
+		Action:   action,
 	}
 }

--- a/internal/registry/referrers.go
+++ b/internal/registry/referrers.go
@@ -15,6 +15,8 @@ import (
 	"github.com/quay/quay/internal/auth"
 	"github.com/quay/quay/internal/dal/daldb"
 	"github.com/quay/quay/internal/oci"
+	"github.com/quay/quay/internal/repository"
+	repositorydal "github.com/quay/quay/internal/repository/dal"
 )
 
 const (
@@ -29,29 +31,51 @@ var (
 
 // ReferrersConfig holds the configuration for the referrers handler.
 type ReferrersConfig struct {
-	LibraryNamespace string
-	AnonymousAccess  bool
-	LibrarySupport   bool
+	LibraryNamespace                   string
+	AnonymousAccess                    bool
+	LibrarySupport                     bool
+	DatabaseSecretKey                  string
+	RobotsDisallow                     bool
+	RobotsWhitelist                    []string
+	FeatureUserLastAccessed            bool
+	LastAccessedUpdateThresholdSeconds int
+	SuperUsers                         []string
+	SuperUsersFullAccess               bool
 }
 
 // ReferrersHandler serves the OCI referrers API.
 type ReferrersHandler struct {
 	store         oci.MetadataStore
 	authenticator *auth.BasicAuthenticator
+	authorizer    *repositorydal.Authorizer
 	queries       *daldb.Queries
 	config        ReferrersConfig
 }
 
 // NewReferrersHandler creates a handler for GET /v2/{name}/referrers/{digest}.
-func NewReferrersHandler(db *sql.DB, store oci.MetadataStore, cfg ReferrersConfig) *ReferrersHandler {
-	if cfg.LibraryNamespace == "" {
-		cfg.LibraryNamespace = defaultLibraryNamespace
+func NewReferrersHandler(db *sql.DB, store oci.MetadataStore, cfg *ReferrersConfig) *ReferrersHandler {
+	config := ReferrersConfig{}
+	if cfg != nil {
+		config = *cfg
+	}
+	if config.LibraryNamespace == "" {
+		config.LibraryNamespace = defaultLibraryNamespace
 	}
 	return &ReferrersHandler{
-		store:         store,
-		authenticator: auth.NewBasicAuthenticator(db),
-		queries:       daldb.New(db),
-		config:        cfg,
+		store: store,
+		authenticator: auth.NewBasicAuthenticator(auth.NewDatabaseVerifier(db, auth.DatabaseVerifierConfig{
+			DatabaseSecretKey:              config.DatabaseSecretKey,
+			RobotsDisallow:                 config.RobotsDisallow,
+			RobotsWhitelist:                config.RobotsWhitelist,
+			FeatureUserLastAccessed:        config.FeatureUserLastAccessed,
+			LastAccessedUpdateThresholdSec: config.LastAccessedUpdateThresholdSeconds,
+		})),
+		authorizer: repositorydal.NewAuthorizer(db, repositorydal.AuthorizerConfig{
+			SuperUsers:           config.SuperUsers,
+			SuperUsersFullAccess: config.SuperUsersFullAccess,
+		}),
+		queries: daldb.New(db),
+		config:  config,
 	}
 }
 
@@ -155,7 +179,7 @@ func (h *ReferrersHandler) authorize(r *http.Request, namespace, repo string) bo
 	}
 	result := h.authenticator.Authenticate(r)
 	if result.Authenticated {
-		return true
+		return h.canPullRepository(r, &result.Principal, namespace, repo)
 	}
 	if result.Presented {
 		return false
@@ -170,6 +194,39 @@ func (h *ReferrersHandler) authorize(r *http.Request, namespace, repo string) bo
 		}
 	}
 	return false
+}
+
+func (h *ReferrersHandler) canPullRepository(r *http.Request, principal *auth.Principal, namespace, repoName string) bool {
+	if h.queries == nil || h.authorizer == nil {
+		return false
+	}
+
+	row, err := h.queries.GetRepositoryAccessByNamespaceName(r.Context(), daldb.GetRepositoryAccessByNamespaceNameParams{
+		Username: namespace,
+		Name:     repoName,
+	})
+	if err != nil {
+		slog.Debug("referrers repository lookup failed", "namespace", namespace, "repository", repoName, "err", err)
+		return false
+	}
+
+	repo := repository.Repository{
+		ID: row.ID,
+		Ref: repository.Ref{
+			Namespace: row.Namespace,
+			Name:      row.Name,
+		},
+		Visibility:       repository.Visibility(row.Visibility),
+		State:            row.State,
+		KindID:           row.KindID,
+		NamespaceEnabled: row.NamespaceEnabled,
+	}
+	allowed, err := h.authorizer.CanPullRepository(r.Context(), principal, &repo)
+	if err != nil {
+		slog.Debug("referrers pull authorization failed", "namespace", namespace, "repository", repoName, "err", err)
+		return false
+	}
+	return allowed
 }
 
 type ociIndex struct {

--- a/internal/registry/referrers_test.go
+++ b/internal/registry/referrers_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,8 +10,10 @@ import (
 	"testing"
 
 	"github.com/opencontainers/go-digest"
+	"golang.org/x/crypto/bcrypt"
 
 	"github.com/quay/quay/internal/oci"
+	_ "modernc.org/sqlite"
 )
 
 // --- mock store ---
@@ -38,6 +41,7 @@ func (m *mockStore) ListReferrers(_ context.Context, _ int64, subject digest.Dig
 func (m *mockStore) EnsureRepository(context.Context, oci.RepositoryName) (int64, error) {
 	return 0, nil
 }
+
 func (m *mockStore) PutManifest(context.Context, int64, oci.ManifestRecord) (int64, error) { //nolint:gocritic // interface compliance
 	return 0, nil
 }
@@ -48,9 +52,11 @@ func (m *mockStore) DeleteTag(context.Context, int64, string) error             
 func (m *mockStore) GetTagDigest(context.Context, int64, string) (digest.Digest, error) {
 	return "", nil
 }
+
 func (m *mockStore) GetManifestDigest(context.Context, int64, digest.Digest) (digest.Digest, error) {
 	return "", nil
 }
+
 func (m *mockStore) GetManifestContent(context.Context, digest.Digest) ([]byte, error) {
 	return nil, nil
 }
@@ -72,6 +78,122 @@ func newTestHandler(store oci.MetadataStore) *ReferrersHandler {
 	return &ReferrersHandler{
 		store:  store,
 		config: ReferrersConfig{LibraryNamespace: "library", AnonymousAccess: true, LibrarySupport: true},
+	}
+}
+
+func TestNewReferrersHandlerConstructsDatabaseVerifier(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	handler := NewReferrersHandler(db, &mockStore{}, &ReferrersConfig{
+		AnonymousAccess:                    true,
+		LibrarySupport:                     true,
+		DatabaseSecretKey:                  "test1234",
+		RobotsDisallow:                     true,
+		RobotsWhitelist:                    []string{"acme+deploy"},
+		FeatureUserLastAccessed:            true,
+		LastAccessedUpdateThresholdSeconds: 60,
+	})
+
+	if handler == nil {
+		t.Fatal("expected handler")
+	}
+	if handler.authenticator == nil {
+		t.Fatal("expected database-backed authenticator")
+	}
+	if handler.queries == nil {
+		t.Fatal("expected database queries")
+	}
+	if handler.config.LibraryNamespace != defaultLibraryNamespace {
+		t.Fatalf("library namespace = %q, want default %q", handler.config.LibraryNamespace, defaultLibraryNamespace)
+	}
+}
+
+func setupReferrersAuthDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+
+	statements := []string{
+		`CREATE TABLE "user" (id INTEGER PRIMARY KEY, uuid VARCHAR(36), username VARCHAR(255) NOT NULL, password_hash VARCHAR(255), email VARCHAR(255) NOT NULL, verified INTEGER NOT NULL DEFAULT 0, organization INTEGER NOT NULL DEFAULT 0, robot INTEGER NOT NULL DEFAULT 0, enabled INTEGER NOT NULL DEFAULT 1, last_accessed DATETIME)`,
+		`CREATE TABLE visibility (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
+		`CREATE TABLE repository (id INTEGER PRIMARY KEY, namespace_user_id INTEGER, name VARCHAR(255) NOT NULL, visibility_id INTEGER NOT NULL, kind_id INTEGER NOT NULL DEFAULT 1, state INTEGER NOT NULL DEFAULT 0)`,
+		`CREATE TABLE role (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
+		`CREATE TABLE teamrole (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
+		`CREATE TABLE team (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL, organization_id INTEGER NOT NULL, role_id INTEGER NOT NULL, description TEXT NOT NULL)`,
+		`CREATE TABLE teammember (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, team_id INTEGER NOT NULL)`,
+		`CREATE TABLE repositorypermission (id INTEGER PRIMARY KEY, team_id INTEGER, user_id INTEGER, repository_id INTEGER NOT NULL, role_id INTEGER NOT NULL)`,
+		`CREATE TABLE repomirrorconfig (id INTEGER PRIMARY KEY, repository_id INTEGER NOT NULL, internal_robot_id INTEGER)`,
+		`CREATE TABLE orgmirrorconfig (id INTEGER PRIMARY KEY, organization_id INTEGER NOT NULL, internal_robot_id INTEGER)`,
+		`CREATE TABLE orgmirrorrepository (id INTEGER PRIMARY KEY, org_mirror_config_id INTEGER NOT NULL, repository_id INTEGER)`,
+		`INSERT INTO visibility (id, name) VALUES (1, 'public'), (2, 'private')`,
+		`INSERT INTO role (id, name) VALUES (1, 'read'), (2, 'write'), (3, 'admin')`,
+		`INSERT INTO teamrole (id, name) VALUES (1, 'admin'), (2, 'creator'), (3, 'member')`,
+		`INSERT INTO "user" (id, uuid, username, password_hash, email, verified, organization, robot, enabled) VALUES (2, 'org-acme', 'acme', NULL, 'acme@example.com', 1, 1, 0, 1)`,
+		`INSERT INTO repository (id, namespace_user_id, name, visibility_id, kind_id, state) VALUES (10, 2, 'private', 2, 1, 0)`,
+	}
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(t.Context(), stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt: %v", err)
+	}
+	if _, err := db.ExecContext(t.Context(), `INSERT INTO "user" (id, uuid, username, password_hash, email, verified, organization, robot, enabled) VALUES (1, 'user-admin', 'admin', ?, 'admin@example.com', 1, 0, 0, 1)`, string(hash)); err != nil {
+		t.Fatalf("insert admin: %v", err)
+	}
+	return db
+}
+
+func TestReferrers_AuthenticatedUserRequiresPullPermission(t *testing.T) {
+	db := setupReferrersAuthDB(t)
+	defer db.Close()
+
+	handler := NewReferrersHandler(db, &mockStore{repoID: 10}, &ReferrersConfig{
+		AnonymousAccess: false,
+		LibrarySupport:  true,
+	})
+	subjectDgst := digest.FromString("subject")
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/acme/private/referrers/"+subjectDgst.String(), http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestReferrers_AuthenticatedUserWithPullPermissionAllowed(t *testing.T) {
+	db := setupReferrersAuthDB(t)
+	defer db.Close()
+	if _, err := db.ExecContext(t.Context(), `INSERT INTO repositorypermission (id, user_id, repository_id, role_id) VALUES (1, 1, 10, 1)`); err != nil {
+		t.Fatalf("insert permission: %v", err)
+	}
+
+	handler := NewReferrersHandler(db, &mockStore{repoID: 10}, &ReferrersConfig{
+		AnonymousAccess: false,
+		LibrarySupport:  true,
+	})
+	subjectDgst := digest.FromString("subject")
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/acme/private/referrers/"+subjectDgst.String(), http.NoBody)
+	req.SetBasicAuth("admin", "correct-password")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
 }
 

--- a/internal/repository/dal/authz.go
+++ b/internal/repository/dal/authz.go
@@ -3,6 +3,7 @@ package dal
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/quay/quay/internal/auth"
 	"github.com/quay/quay/internal/dal/daldb"
@@ -39,7 +40,10 @@ func NewAuthorizer(db *sql.DB, cfg AuthorizerConfig) *Authorizer {
 }
 
 // CanAdminRepository reports whether principal can administer repo.
-func (a *Authorizer) CanAdminRepository(ctx context.Context, principal *auth.Principal, repo repository.Repository) (bool, error) {
+func (a *Authorizer) CanAdminRepository(ctx context.Context, principal *auth.Principal, repo *repository.Repository) (bool, error) {
+	if repo == nil {
+		return false, nil
+	}
 	if principal.IsAnonymous() {
 		return false, nil
 	}
@@ -51,6 +55,145 @@ func (a *Authorizer) CanAdminRepository(ctx context.Context, principal *auth.Pri
 		RepositoryID: repo.ID,
 		Username:     principal.Username,
 		UserID:       sql.NullInt64{Int64: principal.ID, Valid: true},
+	})
+	if err != nil {
+		return false, err
+	}
+	return allowed != 0, nil
+}
+
+// CanPullRepository reports whether principal can pull repo contents.
+func (a *Authorizer) CanPullRepository(ctx context.Context, principal *auth.Principal, repo *repository.Repository) (bool, error) {
+	if repo == nil {
+		return false, nil
+	}
+	if !repo.NamespaceEnabled {
+		return false, nil
+	}
+	if repo.State == repository.StateMarkedForDeletion {
+		return false, nil
+	}
+	if repo.Visibility == repository.VisibilityPublic {
+		return true, nil
+	}
+	if principal.IsAnonymous() {
+		return false, nil
+	}
+	if _, ok := a.superUsers[principal.Username]; ok {
+		return true, nil
+	}
+
+	allowed, err := a.queries.UserCanPullRepository(ctx, daldb.UserCanPullRepositoryParams{
+		RepositoryID: repo.ID,
+		Username:     principal.Username,
+		UserID:       sql.NullInt64{Int64: principal.ID, Valid: true},
+	})
+	if err != nil {
+		return false, err
+	}
+	return allowed != 0, nil
+}
+
+// CanPushRepository reports whether principal can push repo contents.
+func (a *Authorizer) CanPushRepository(ctx context.Context, principal *auth.Principal, repo *repository.Repository) (bool, error) {
+	if repo == nil {
+		return false, nil
+	}
+	if principal.IsAnonymous() {
+		return false, nil
+	}
+	if !repo.NamespaceEnabled {
+		return false, nil
+	}
+	if repo.KindID != repository.KindImage {
+		return false, nil
+	}
+	switch repo.State {
+	case repository.StateNormal:
+	case repository.StateMirror:
+		return a.canPushMirrorRepository(ctx, principal, repo.ID)
+	case repository.StateOrgMirror:
+		return a.canPushOrgMirrorRepository(ctx, principal, repo.ID)
+	default:
+		return false, nil
+	}
+	if _, ok := a.superUsers[principal.Username]; ok {
+		return true, nil
+	}
+
+	allowed, err := a.queries.UserCanPushRepository(ctx, daldb.UserCanPushRepositoryParams{
+		RepositoryID: repo.ID,
+		Username:     principal.Username,
+		UserID:       sql.NullInt64{Int64: principal.ID, Valid: true},
+	})
+	if err != nil {
+		return false, err
+	}
+	return allowed != 0, nil
+}
+
+// CanCreateRepository reports whether principal can create repos in namespace.
+func (a *Authorizer) CanCreateRepository(ctx context.Context, principal *auth.Principal, namespace string) (bool, error) {
+	if principal.IsAnonymous() {
+		return false, nil
+	}
+	_, isSuperUser := a.superUsers[principal.Username]
+	namespaceUser, err := a.queries.GetNamespaceUserByUsername(ctx, namespace)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			if isSuperUser {
+				return true, nil
+			}
+			return false, nil
+		}
+		return false, err
+	}
+	if !namespaceUser.Enabled {
+		return false, nil
+	}
+	isOrgMirrored, err := a.queries.NamespaceIsOrgMirrored(ctx, namespace)
+	if err != nil {
+		return false, err
+	}
+	if isOrgMirrored != 0 {
+		return false, nil
+	}
+	if isSuperUser {
+		return true, nil
+	}
+
+	allowed, err := a.queries.UserCanCreateRepositoryInNamespace(ctx, daldb.UserCanCreateRepositoryInNamespaceParams{
+		Namespace: namespace,
+		Username:  principal.Username,
+		UserID:    principal.ID,
+	})
+	if err != nil {
+		return false, err
+	}
+	return allowed != 0, nil
+}
+
+func (a *Authorizer) canPushMirrorRepository(ctx context.Context, principal *auth.Principal, repositoryID int64) (bool, error) {
+	if principal.Kind != auth.PrincipalRobot {
+		return false, nil
+	}
+	allowed, err := a.queries.UserIsRepoMirrorRobot(ctx, daldb.UserIsRepoMirrorRobotParams{
+		RepositoryID: repositoryID,
+		UserID:       principal.ID,
+	})
+	if err != nil {
+		return false, err
+	}
+	return allowed != 0, nil
+}
+
+func (a *Authorizer) canPushOrgMirrorRepository(ctx context.Context, principal *auth.Principal, repositoryID int64) (bool, error) {
+	if principal.Kind != auth.PrincipalRobot {
+		return false, nil
+	}
+	allowed, err := a.queries.UserIsOrgMirrorRobot(ctx, daldb.UserIsOrgMirrorRobotParams{
+		RepositoryID: sql.NullInt64{Int64: repositoryID, Valid: true},
+		UserID:       principal.ID,
 	})
 	if err != nil {
 		return false, err

--- a/internal/repository/dal/authz_test.go
+++ b/internal/repository/dal/authz_test.go
@@ -1,0 +1,418 @@
+package dal
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/quay/quay/internal/auth"
+	"github.com/quay/quay/internal/dal/daldb"
+	"github.com/quay/quay/internal/repository"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupAuthzTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	ctx := t.Context()
+	statements := []string{
+		`CREATE TABLE "user" (id INTEGER PRIMARY KEY, username VARCHAR(255) NOT NULL, enabled INTEGER NOT NULL DEFAULT 1)`,
+		`CREATE TABLE visibility (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
+		`CREATE TABLE repository (id INTEGER PRIMARY KEY, namespace_user_id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, visibility_id INTEGER NOT NULL, state INTEGER NOT NULL DEFAULT 0)`,
+		`CREATE TABLE role (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
+		`CREATE TABLE teamrole (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
+		`CREATE TABLE team (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL, organization_id INTEGER NOT NULL, role_id INTEGER NOT NULL, description TEXT NOT NULL)`,
+		`CREATE TABLE teammember (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, team_id INTEGER NOT NULL)`,
+		`CREATE TABLE repositorypermission (id INTEGER PRIMARY KEY, team_id INTEGER, user_id INTEGER, repository_id INTEGER NOT NULL, role_id INTEGER NOT NULL)`,
+		`CREATE TABLE repomirrorconfig (id INTEGER PRIMARY KEY, repository_id INTEGER NOT NULL, internal_robot_id INTEGER)`,
+		`CREATE TABLE orgmirrorconfig (id INTEGER PRIMARY KEY, organization_id INTEGER NOT NULL, internal_robot_id INTEGER NOT NULL)`,
+		`CREATE TABLE orgmirrorrepository (id INTEGER PRIMARY KEY, org_mirror_config_id INTEGER NOT NULL, repository_id INTEGER NOT NULL, repository_name VARCHAR(255) NOT NULL)`,
+		`INSERT INTO "user" (id, username, enabled) VALUES (1, 'acme', 1), (2, 'alice', 1), (3, 'acme+reader', 1), (4, 'acme+writer', 1), (5, 'acme+admin', 1), (6, 'acme+teamrobot', 1), (7, 'acme+orgadmin', 1), (8, 'acme+creator', 1), (9, 'disabled-org', 0), (10, 'disabled-org+creator', 1), (11, 'acme+mirror', 1), (12, 'acme+orgmirror', 1), (13, 'acme+wrongmirror', 1), (15, 'plain', 1), (16, 'plain+creator', 1)`,
+		`INSERT INTO visibility (id, name) VALUES (1, 'public'), (2, 'private')`,
+		`INSERT INTO repository (id, namespace_user_id, name, visibility_id, state) VALUES (10, 1, 'private', 2, 0), (11, 1, 'public', 1, 0), (12, 9, 'public', 1, 0), (13, 1, 'mirror', 2, 2), (14, 1, 'orgmirror', 2, 4), (15, 1, 'deleted', 1, 3)`,
+		`INSERT INTO role (id, name) VALUES (1, 'read'), (2, 'write'), (3, 'admin')`,
+		`INSERT INTO teamrole (id, name) VALUES (1, 'admin'), (2, 'creator'), (3, 'member')`,
+		`INSERT INTO repositorypermission (id, user_id, repository_id, role_id) VALUES (1, 3, 10, 1), (2, 4, 10, 2), (3, 5, 10, 3)`,
+		`INSERT INTO team (id, name, organization_id, role_id, description) VALUES (20, 'writers', 1, 3, ''), (21, 'owners', 1, 1, ''), (22, 'creators', 1, 2, ''), (23, 'disabled-creators', 9, 2, ''), (24, 'plain-creators', 15, 2, '')`,
+		`INSERT INTO teammember (id, user_id, team_id) VALUES (30, 6, 20), (31, 7, 21), (32, 8, 22), (33, 10, 23), (34, 16, 24)`,
+		`INSERT INTO repositorypermission (id, team_id, repository_id, role_id) VALUES (4, 20, 10, 2)`,
+		`INSERT INTO repomirrorconfig (id, repository_id, internal_robot_id) VALUES (40, 13, 11)`,
+		`INSERT INTO orgmirrorconfig (id, organization_id, internal_robot_id) VALUES (50, 1, 12)`,
+		`INSERT INTO orgmirrorrepository (id, org_mirror_config_id, repository_id, repository_name) VALUES (60, 50, 14, 'orgmirror')`,
+	}
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+	return db
+}
+
+func TestAuthorizerCanPullAndPushRepository(t *testing.T) {
+	db := setupAuthzTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	privateRepo := repository.Repository{
+		ID:               10,
+		Ref:              repository.Ref{Namespace: "acme", Name: "private"},
+		Visibility:       repository.VisibilityPrivate,
+		State:            repository.StateNormal,
+		KindID:           repository.KindImage,
+		NamespaceEnabled: true,
+	}
+	publicRepo := repository.Repository{
+		ID:               11,
+		Ref:              repository.Ref{Namespace: "acme", Name: "public"},
+		Visibility:       repository.VisibilityPublic,
+		State:            repository.StateNormal,
+		KindID:           repository.KindImage,
+		NamespaceEnabled: true,
+	}
+	deletedPublicRepo := repository.Repository{
+		ID:               15,
+		Ref:              repository.Ref{Namespace: "acme", Name: "deleted"},
+		Visibility:       repository.VisibilityPublic,
+		State:            repository.StateMarkedForDeletion,
+		KindID:           repository.KindImage,
+		NamespaceEnabled: true,
+	}
+	disabledNamespacePublicRepo := repository.Repository{
+		ID:         12,
+		Ref:        repository.Ref{Namespace: "disabled-org", Name: "public"},
+		Visibility: repository.VisibilityPublic,
+		State:      repository.StateNormal,
+		KindID:     repository.KindImage,
+	}
+	mirrorRepo := repository.Repository{
+		ID:               13,
+		Ref:              repository.Ref{Namespace: "acme", Name: "mirror"},
+		Visibility:       repository.VisibilityPrivate,
+		State:            repository.StateMirror,
+		KindID:           repository.KindImage,
+		NamespaceEnabled: true,
+	}
+	orgMirrorRepo := repository.Repository{
+		ID:               14,
+		Ref:              repository.Ref{Namespace: "acme", Name: "orgmirror"},
+		Visibility:       repository.VisibilityPrivate,
+		State:            repository.StateOrgMirror,
+		KindID:           repository.KindImage,
+		NamespaceEnabled: true,
+	}
+
+	tests := []struct {
+		name      string
+		cfg       AuthorizerConfig
+		principal *auth.Principal
+		repo      repository.Repository
+		wantPull  bool
+		wantPush  bool
+	}{
+		{
+			name:      "namespace owner can pull and push private repo",
+			principal: &auth.Principal{ID: 1, Username: "acme", Kind: auth.PrincipalUser},
+			repo:      privateRepo,
+			wantPull:  true,
+			wantPush:  true,
+		},
+		{
+			name:      "robot with direct read can pull but not push private repo",
+			principal: &auth.Principal{ID: 3, Username: "acme+reader", Kind: auth.PrincipalRobot},
+			repo:      privateRepo,
+			wantPull:  true,
+		},
+		{
+			name:      "robot with direct write can pull and push private repo",
+			principal: &auth.Principal{ID: 4, Username: "acme+writer", Kind: auth.PrincipalRobot},
+			repo:      privateRepo,
+			wantPull:  true,
+			wantPush:  true,
+		},
+		{
+			name:      "robot with direct admin can pull and push private repo",
+			principal: &auth.Principal{ID: 5, Username: "acme+admin", Kind: auth.PrincipalRobot},
+			repo:      privateRepo,
+			wantPull:  true,
+			wantPush:  true,
+		},
+		{
+			name:      "robot with team write can pull and push private repo",
+			principal: &auth.Principal{ID: 6, Username: "acme+teamrobot", Kind: auth.PrincipalRobot},
+			repo:      privateRepo,
+			wantPull:  true,
+			wantPush:  true,
+		},
+		{
+			name:      "robot with org admin team membership can pull and push private repo",
+			principal: &auth.Principal{ID: 7, Username: "acme+orgadmin", Kind: auth.PrincipalRobot},
+			repo:      privateRepo,
+			wantPull:  true,
+			wantPush:  true,
+		},
+		{
+			name:      "unrelated robot cannot pull or push private repo",
+			principal: &auth.Principal{ID: 8, Username: "acme+other", Kind: auth.PrincipalRobot},
+			repo:      privateRepo,
+		},
+		{
+			name:      "authenticated user without permission can pull public repo but cannot push",
+			principal: &auth.Principal{ID: 2, Username: "alice", Kind: auth.PrincipalUser},
+			repo:      publicRepo,
+			wantPull:  true,
+		},
+		{
+			name:      "authenticated user cannot pull deleted public repo",
+			principal: &auth.Principal{ID: 2, Username: "alice", Kind: auth.PrincipalUser},
+			repo:      deletedPublicRepo,
+		},
+		{
+			name:      "disabled namespace public repo cannot be pulled",
+			principal: &auth.Principal{ID: 2, Username: "alice", Kind: auth.PrincipalUser},
+			repo:      disabledNamespacePublicRepo,
+		},
+		{
+			name:      "writer cannot push read-only repo",
+			principal: &auth.Principal{ID: 4, Username: "acme+writer", Kind: auth.PrincipalRobot},
+			repo: repository.Repository{
+				ID:               privateRepo.ID,
+				Ref:              privateRepo.Ref,
+				Visibility:       privateRepo.Visibility,
+				State:            1,
+				KindID:           privateRepo.KindID,
+				NamespaceEnabled: privateRepo.NamespaceEnabled,
+			},
+			wantPull: true,
+		},
+		{
+			name:      "configured mirror robot can push mirror repo",
+			principal: &auth.Principal{ID: 11, Username: "acme+mirror", Kind: auth.PrincipalRobot},
+			repo:      mirrorRepo,
+			wantPush:  true,
+		},
+		{
+			name:      "non-mirror robot cannot push mirror repo",
+			principal: &auth.Principal{ID: 13, Username: "acme+wrongmirror", Kind: auth.PrincipalRobot},
+			repo:      mirrorRepo,
+		},
+		{
+			name:      "configured org mirror robot can push org mirror repo",
+			principal: &auth.Principal{ID: 12, Username: "acme+orgmirror", Kind: auth.PrincipalRobot},
+			repo:      orgMirrorRepo,
+			wantPush:  true,
+		},
+		{
+			name:      "repo mirror robot cannot push org mirror repo",
+			principal: &auth.Principal{ID: 11, Username: "acme+mirror", Kind: auth.PrincipalRobot},
+			repo:      orgMirrorRepo,
+		},
+		{
+			name: "configured superuser cannot push mirror repo",
+			cfg: AuthorizerConfig{
+				SuperUsers:           []string{"super"},
+				SuperUsersFullAccess: true,
+			},
+			principal: &auth.Principal{ID: 99, Username: "super", Kind: auth.PrincipalUser},
+			repo:      mirrorRepo,
+			wantPull:  true,
+		},
+		{
+			name:      "anonymous can pull public repo",
+			principal: auth.AnonymousPrincipal(),
+			repo:      publicRepo,
+			wantPull:  true,
+		},
+		{
+			name:      "anonymous cannot pull or push private repo",
+			principal: auth.AnonymousPrincipal(),
+			repo:      privateRepo,
+		},
+		{
+			name:      "anonymous cannot push public repo",
+			principal: auth.AnonymousPrincipal(),
+			repo:      publicRepo,
+			wantPull:  true,
+		},
+		{
+			name: "configured superuser with full access can pull and push",
+			cfg: AuthorizerConfig{
+				SuperUsers:           []string{"super"},
+				SuperUsersFullAccess: true,
+			},
+			principal: &auth.Principal{ID: 99, Username: "super", Kind: auth.PrincipalUser},
+			repo:      privateRepo,
+			wantPull:  true,
+			wantPush:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := NewAuthorizer(db, tt.cfg)
+
+			gotPull, err := authorizer.CanPullRepository(t.Context(), tt.principal, &tt.repo)
+			if err != nil {
+				t.Fatalf("CanPullRepository: %v", err)
+			}
+			if gotPull != tt.wantPull {
+				t.Fatalf("CanPullRepository = %v, want %v", gotPull, tt.wantPull)
+			}
+
+			gotPush, err := authorizer.CanPushRepository(t.Context(), tt.principal, &tt.repo)
+			if err != nil {
+				t.Fatalf("CanPushRepository: %v", err)
+			}
+			if gotPush != tt.wantPush {
+				t.Fatalf("CanPushRepository = %v, want %v", gotPush, tt.wantPush)
+			}
+		})
+	}
+}
+
+func TestAuthorizerQueriesRequireEnabledNamespaceForOwnerAccess(t *testing.T) {
+	db := setupAuthzTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	queries := daldb.New(db)
+	for _, tc := range []struct {
+		name string
+		fn   func() (int64, error)
+	}{
+		{
+			name: "pull",
+			fn: func() (int64, error) {
+				return queries.UserCanPullRepository(t.Context(), daldb.UserCanPullRepositoryParams{
+					RepositoryID: 12,
+					Username:     "disabled-org",
+					UserID:       sql.NullInt64{Int64: 9, Valid: true},
+				})
+			},
+		},
+		{
+			name: "push",
+			fn: func() (int64, error) {
+				return queries.UserCanPushRepository(t.Context(), daldb.UserCanPushRepositoryParams{
+					RepositoryID: 12,
+					Username:     "disabled-org",
+					UserID:       sql.NullInt64{Int64: 9, Valid: true},
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			allowed, err := tc.fn()
+			if err != nil {
+				t.Fatalf("%s query: %v", tc.name, err)
+			}
+			if allowed != 0 {
+				t.Fatalf("%s allowed = %d, want 0", tc.name, allowed)
+			}
+		})
+	}
+}
+
+func TestAuthorizerCanCreateRepository(t *testing.T) {
+	db := setupAuthzTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := []struct {
+		name      string
+		cfg       AuthorizerConfig
+		principal *auth.Principal
+		namespace string
+		want      bool
+	}{
+		{
+			name:      "namespace owner cannot push-create in org mirrored namespace",
+			principal: &auth.Principal{ID: 1, Username: "acme", Kind: auth.PrincipalUser},
+			namespace: "acme",
+		},
+		{
+			name:      "creator team member cannot push-create in org mirrored namespace",
+			principal: &auth.Principal{ID: 8, Username: "acme+creator", Kind: auth.PrincipalRobot},
+			namespace: "acme",
+		},
+		{
+			name:      "namespace owner can create in non-mirrored namespace",
+			principal: &auth.Principal{ID: 15, Username: "plain", Kind: auth.PrincipalUser},
+			namespace: "plain",
+			want:      true,
+		},
+		{
+			name:      "creator team member can create in non-mirrored namespace",
+			principal: &auth.Principal{ID: 16, Username: "plain+creator", Kind: auth.PrincipalRobot},
+			namespace: "plain",
+			want:      true,
+		},
+		{
+			name:      "org mirror robot cannot push-create in org mirrored namespace",
+			principal: &auth.Principal{ID: 12, Username: "acme+orgmirror", Kind: auth.PrincipalRobot},
+			namespace: "acme",
+		},
+		{
+			name: "superuser cannot push-create in org mirrored namespace",
+			cfg: AuthorizerConfig{
+				SuperUsers:           []string{"alice"},
+				SuperUsersFullAccess: true,
+			},
+			principal: &auth.Principal{ID: 2, Username: "alice", Kind: auth.PrincipalUser},
+			namespace: "acme",
+		},
+		{
+			name:      "disabled namespace creator cannot create",
+			principal: &auth.Principal{ID: 10, Username: "disabled-org+creator", Kind: auth.PrincipalRobot},
+			namespace: "disabled-org",
+		},
+		{
+			name: "superuser cannot create in disabled namespace",
+			cfg: AuthorizerConfig{
+				SuperUsers:           []string{"alice"},
+				SuperUsersFullAccess: true,
+			},
+			principal: &auth.Principal{ID: 2, Username: "alice", Kind: auth.PrincipalUser},
+			namespace: "disabled-org",
+		},
+		{
+			name: "superuser can create missing namespace",
+			cfg: AuthorizerConfig{
+				SuperUsers:           []string{"alice"},
+				SuperUsersFullAccess: true,
+			},
+			principal: &auth.Principal{ID: 2, Username: "alice", Kind: auth.PrincipalUser},
+			namespace: "missing",
+			want:      true,
+		},
+		{
+			name:      "unrelated user cannot create",
+			principal: &auth.Principal{ID: 2, Username: "alice", Kind: auth.PrincipalUser},
+			namespace: "acme",
+		},
+		{
+			name:      "missing namespace denies create without error",
+			principal: &auth.Principal{ID: 2, Username: "alice", Kind: auth.PrincipalUser},
+			namespace: "missing",
+		},
+		{
+			name:      "anonymous cannot create",
+			principal: auth.AnonymousPrincipal(),
+			namespace: "acme",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := NewAuthorizer(db, tt.cfg)
+
+			got, err := authorizer.CanCreateRepository(t.Context(), tt.principal, tt.namespace)
+			if err != nil {
+				t.Fatalf("CanCreateRepository: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("CanCreateRepository = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/repository/dal/store.go
+++ b/internal/repository/dal/store.go
@@ -52,7 +52,10 @@ func (s *Store) Get(ctx context.Context, ref repository.Ref) (repository.Reposit
 			Namespace: row.Namespace,
 			Name:      row.Name,
 		},
-		Visibility: repository.Visibility(row.Visibility),
+		Visibility:       repository.Visibility(row.Visibility),
+		State:            row.State,
+		KindID:           row.KindID,
+		NamespaceEnabled: row.NamespaceEnabled,
 	}, nil
 }
 
@@ -72,7 +75,11 @@ func (s *Store) SetVisibility(ctx context.Context, id int64, visibility reposito
 }
 
 // MarkDeleted renames and marks a repository deleted with its deletedrepository marker.
-func (s *Store) MarkDeleted(ctx context.Context, repo repository.Repository, deletedName string) (retErr error) {
+func (s *Store) MarkDeleted(ctx context.Context, repo *repository.Repository, deletedName string) (retErr error) {
+	if repo == nil {
+		return repository.ErrNotFound
+	}
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -136,7 +143,7 @@ func (s *Store) MarkDeleted(ctx context.Context, repo repository.Repository, del
 	return tx.Commit()
 }
 
-func repositoryGCQueueItemName(repo repository.Repository) string {
+func repositoryGCQueueItemName(repo *repository.Repository) string {
 	return fmt.Sprintf("%s/%s/%d/", repositoryGCQueueName, repo.Ref.Namespace, repo.ID)
 }
 

--- a/internal/repository/dal/store_test.go
+++ b/internal/repository/dal/store_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/quay/quay/internal/repository"
+
+	_ "modernc.org/sqlite"
 )
 
 type fakeResult struct {
@@ -50,6 +52,88 @@ func TestRequireRowsAffected(t *testing.T) {
 			err := requireRowsAffected(tc.result)
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("err = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func setupStoreTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+
+	ctx := t.Context()
+	statements := []string{
+		`CREATE TABLE "user" (id INTEGER PRIMARY KEY, username VARCHAR(255) NOT NULL, enabled INTEGER NOT NULL DEFAULT 1)`,
+		`CREATE TABLE visibility (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
+		`CREATE TABLE repository (id INTEGER PRIMARY KEY, namespace_user_id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, visibility_id INTEGER NOT NULL, kind_id INTEGER NOT NULL DEFAULT 1, state INTEGER NOT NULL DEFAULT 0)`,
+		`INSERT INTO "user" (id, username, enabled) VALUES (1, 'disabled-org', 0), (2, 'enabled-org', 1)`,
+		`INSERT INTO visibility (id, name) VALUES (1, 'public'), (2, 'private')`,
+		`INSERT INTO repository (id, namespace_user_id, name, visibility_id, kind_id, state) VALUES (10, 1, 'publicrepo', 1, 1, 0), (11, 2, 'publicrepo', 1, 1, 0)`,
+	}
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+	return db
+}
+
+func TestStoreGetReturnsRepositoryForDisabledNamespace(t *testing.T) {
+	db := setupStoreTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewStore(db)
+	for _, tc := range []struct {
+		name          string
+		ref           repository.Ref
+		wantID        int64
+		wantNamespace bool
+		wantNotFound  bool
+	}{
+		{
+			name:          "disabled namespace",
+			ref:           repository.Ref{Namespace: "disabled-org", Name: "publicrepo"},
+			wantID:        10,
+			wantNamespace: false,
+		},
+		{
+			name:          "enabled namespace",
+			ref:           repository.Ref{Namespace: "enabled-org", Name: "publicrepo"},
+			wantID:        11,
+			wantNamespace: true,
+		},
+		{
+			name:         "missing namespace",
+			ref:          repository.Ref{Namespace: "missing-org", Name: "publicrepo"},
+			wantNotFound: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, err := store.Get(t.Context(), tc.ref)
+			if tc.wantNotFound {
+				if !errors.Is(err, repository.ErrNotFound) {
+					t.Fatalf("Get err = %v, want ErrNotFound", err)
+				}
+				if repo != (repository.Repository{}) {
+					t.Fatalf("repo = %#v, want zero value", repo)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if repo.NamespaceEnabled != tc.wantNamespace {
+				t.Fatalf("NamespaceEnabled = %v, want %v", repo.NamespaceEnabled, tc.wantNamespace)
+			}
+			if repo.ID != tc.wantID {
+				t.Fatalf("ID = %d, want %d", repo.ID, tc.wantID)
+			}
+			if repo.Visibility != repository.VisibilityPublic {
+				t.Fatalf("Visibility = %q, want public", repo.Visibility)
 			}
 		})
 	}

--- a/internal/repository/service.go
+++ b/internal/repository/service.go
@@ -12,12 +12,12 @@ import (
 type Store interface {
 	Get(ctx context.Context, ref Ref) (Repository, error)
 	SetVisibility(ctx context.Context, id int64, visibility Visibility) error
-	MarkDeleted(ctx context.Context, repo Repository, deletedName string) error
+	MarkDeleted(ctx context.Context, repo *Repository, deletedName string) error
 }
 
 // Authorizer decides whether an actor can perform repository operations.
 type Authorizer interface {
-	CanAdminRepository(ctx context.Context, principal *auth.Principal, repo Repository) (bool, error)
+	CanAdminRepository(ctx context.Context, principal *auth.Principal, repo *Repository) (bool, error)
 }
 
 // Service implements repository business operations.
@@ -62,7 +62,7 @@ func (s *Service) Delete(ctx context.Context, principal *auth.Principal, ref Ref
 		return err
 	}
 
-	return s.store.MarkDeleted(ctx, repo, uuid.NewString())
+	return s.store.MarkDeleted(ctx, &repo, uuid.NewString())
 }
 
 func (s *Service) getAuthorized(ctx context.Context, principal *auth.Principal, ref Ref) (Repository, error) {
@@ -71,7 +71,7 @@ func (s *Service) getAuthorized(ctx context.Context, principal *auth.Principal, 
 		return Repository{}, err
 	}
 
-	allowed, err := s.authorizer.CanAdminRepository(ctx, principal, repo)
+	allowed, err := s.authorizer.CanAdminRepository(ctx, principal, &repo)
 	if err != nil {
 		return Repository{}, err
 	}

--- a/internal/repository/service_test.go
+++ b/internal/repository/service_test.go
@@ -35,9 +35,9 @@ func (s *fakeStore) SetVisibility(_ context.Context, id int64, visibility Visibi
 	return s.setErr
 }
 
-func (s *fakeStore) MarkDeleted(_ context.Context, repo Repository, deletedName string) error {
+func (s *fakeStore) MarkDeleted(_ context.Context, repo *Repository, deletedName string) error {
 	s.deleteCalled = true
-	s.deletedRepo = repo
+	s.deletedRepo = *repo
 	s.deletedName = deletedName
 	return s.deleteErr
 }
@@ -47,7 +47,7 @@ type fakeAuthorizer struct {
 	err     error
 }
 
-func (a fakeAuthorizer) CanAdminRepository(context.Context, *auth.Principal, Repository) (bool, error) {
+func (a fakeAuthorizer) CanAdminRepository(context.Context, *auth.Principal, *Repository) (bool, error) {
 	return a.allowed, a.err
 }
 

--- a/internal/repository/types.go
+++ b/internal/repository/types.go
@@ -15,6 +15,20 @@ const (
 	VisibilityPublic Visibility = "public"
 	// VisibilityPrivate requires authentication and permission to pull.
 	VisibilityPrivate Visibility = "private"
+
+	// StateNormal allows repository writes.
+	StateNormal int64 = 0
+	// StateReadOnly denies repository writes.
+	StateReadOnly int64 = 1
+	// StateMirror allows writes only from the configured repository mirror robot.
+	StateMirror int64 = 2
+	// StateMarkedForDeletion hides repositories from normal operations.
+	StateMarkedForDeletion int64 = 3
+	// StateOrgMirror allows writes only from the configured organization mirror robot.
+	StateOrgMirror int64 = 4
+
+	// KindImage is the repositorykind id for image repositories.
+	KindImage int64 = 1
 )
 
 // Valid reports whether v is a supported repository visibility.
@@ -24,7 +38,10 @@ func (v Visibility) Valid() bool {
 
 // Repository contains repository fields needed by business operations.
 type Repository struct {
-	ID         int64
-	Ref        Ref
-	Visibility Visibility
+	ID               int64
+	Ref              Ref
+	Visibility       Visibility
+	State            int64
+	KindID           int64
+	NamespaceEnabled bool
 }

--- a/internal/system/quadlet.go
+++ b/internal/system/quadlet.go
@@ -8,10 +8,11 @@ import (
 
 // QuadletSpec describes a Quadlet container unit.
 type QuadletSpec struct {
-	Image    string
-	DataDir  string
-	Hostname string
-	Port     string
+	Image      string
+	DataDir    string
+	Hostname   string
+	Port       string
+	ConfigPath string
 }
 
 // QuadletManager handles Quadlet .container files.
@@ -32,10 +33,18 @@ func (q *QuadletManager) Exists(service string) bool {
 }
 
 // Install writes a new Quadlet .container file.
-func (q *QuadletManager) Install(service string, spec QuadletSpec) error {
+func (q *QuadletManager) Install(service string, spec *QuadletSpec) error {
 	dir := q.env.QuadletDir()
 	if err := q.fs.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create quadlet dir: %w", err)
+	}
+	if spec == nil {
+		return fmt.Errorf("nil quadlet spec")
+	}
+
+	serveCommand := fmt.Sprintf("serve --data-dir /data --hostname %s", spec.Hostname)
+	if spec.ConfigPath != "" {
+		serveCommand = fmt.Sprintf("serve --config %s", spec.ConfigPath)
 	}
 
 	content := fmt.Sprintf(`[Unit]
@@ -46,11 +55,11 @@ After=network-online.target
 Image=%s
 Volume=%s:/data:Z
 PublishPort=%s:%s
-Exec=serve --data-dir /data --hostname %s
+Exec=%s
 
 [Install]
 WantedBy=default.target
-`, spec.Image, spec.DataDir, spec.Port, spec.Port, spec.Hostname)
+`, spec.Image, spec.DataDir, spec.Port, spec.Port, serveCommand)
 
 	path := q.env.QuadletPath(service)
 	if err := q.fs.WriteFile(path, []byte(content), 0o600); err != nil {

--- a/internal/system/quadlet_test.go
+++ b/internal/system/quadlet_test.go
@@ -1,0 +1,61 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestQuadletInstallUsesConfigPathWhenProvided(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+
+	err := manager.Install("quay", &QuadletSpec{
+		Image:      "localhost/quay:test",
+		DataDir:    "/var/lib/quay",
+		Hostname:   "localhost",
+		Port:       "8443",
+		ConfigPath: "/data/config.yaml",
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	content := readQuadletTestFile(t, env.QuadletPath("quay"))
+	if !strings.Contains(content, "Exec=serve --config /data/config.yaml") {
+		t.Fatalf("quadlet does not use config path:\n%s", content)
+	}
+	if strings.Contains(content, "--data-dir") {
+		t.Fatalf("quadlet should not use default serve args when config path is set:\n%s", content)
+	}
+}
+
+func TestQuadletInstallUsesDefaultServeArgsWithoutConfigPath(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+
+	err := manager.Install("quay", &QuadletSpec{
+		Image:    "localhost/quay:test",
+		DataDir:  "/var/lib/quay",
+		Hostname: "localhost",
+		Port:     "8443",
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	content := readQuadletTestFile(t, env.QuadletPath("quay"))
+	if !strings.Contains(content, "Exec=serve --data-dir /data --hostname localhost") {
+		t.Fatalf("quadlet does not use default serve args:\n%s", content)
+	}
+}
+
+func readQuadletTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read quadlet file: %v", err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary
Add static robot token authentication to the Go rewrite while preserving compatibility with robot tokens created by the existing Python/OMR registry.

## Related Issue
NO-ISSUE: Go rewrite parity work for migrated robot credentials.

## Changes
- Split HTTP Basic parsing from credential verification and add a database-backed verifier for users and static robot tokens.
- Add Python encrypted-field compatibility for legacy `RobotAccountToken` rows, including `DATABASE_SECRET_KEY` conversion and AES-CCM decryption without a Pion dependency.
- Enforce repository pull, push, delete, and create-on-push authorization for user and robot principals in the Go distribution path.
- Add pull/push/create repository authz queries and tests, including disabled namespace and missing namespace handling.
- Extend the Go OMR migration E2E job to create a robot through old OMR's session+CSRF API flow, verify it before migration, and reuse the migrated token against Go.

## Testing
- [x] `go test ./internal/credentials/encryptedfield/... ./internal/auth ./internal/repository/dal ./internal/registry/distribution ./internal/config -count=1`
- [x] `go test ./internal/... -count=1`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-go.yaml")'`
- [x] Extracted `e2e-migrate` workflow run blocks and checked them with `bash -n`
- [x] `git diff --check`
- [x] `git diff --exit-code internal/dal/daldb`

## Notes
- Draft PR for review.
- The migration E2E stores robot token material under `/tmp/e2e-migrate-secrets`, outside uploaded diagnostics.
- JWT/federated robot tokens remain out of scope for this change.
