### PR TITLE
[redhat-3.15] PROJQUAY-12115: fix(cve): CVE-2026-45822 - decode-uri-component

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react": "^17.0.2",
         "axios": "^1.16.1",
         "buffer": "^4.9.2",
+        "decode-uri-component": "^0.5.0",
         "js-sha1": "^0.6.0",
         "mini-css-extract-plugin": "^2.6.1",
         "null-loader": "^4.0.1",
@@ -8951,13 +8952,12 @@
       "license": "MIT"
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": ">=0.10"
+        "node": ">=14.16"
       }
     },
     "node_modules/dedent": {
@@ -22521,6 +22521,15 @@
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"
+      }
+    },
+    "node_modules/source-map-resolve/node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/source-map-support": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^17.0.2",
     "axios": "^1.16.1",
     "buffer": "^4.9.2",
+    "decode-uri-component": "^0.5.0",
     "js-sha1": "^0.6.0",
     "mini-css-extract-plugin": "^2.6.1",
     "null-loader": "^4.0.1",


### PR DESCRIPTION
Summary

Security fix for CVE-2026-45822 affecting decode-uri-component
Details

CVE: CVE-2026-45822
Severity: Important (CVSSv3: 7.5)
Impact: Denial of Service via crafted input
Component: decode-uri-component
Old Version: 0.2.2
New Version: 0.5.0

Changes

Updated decode-uri-component from 0.2.2 to 0.5.0 in web/package-lock.json
Updated decode-uri-component from 0.2.2 to 0.5.0 in package-lock.json

References

https://access.redhat.com/security/cve/cve-2026-45822
https://www.npmjs.com/package/decode-uri-component

Resolves: [PROJQUAY-12114](https://redhat.atlassian.net/browse/PROJQUAY-12114)