### PR TITLE
PROJQUAY-6975: feat(config): add FEATURE_ORG_SHARED_EMAIL flag for safe canary deployment

### DIFF
--- a/config.py
+++ b/config.py
@@ -361,6 +361,9 @@ class DefaultConfig(ImmutableConfig):
     # Feature Flag: Whether emails are enabled.
     FEATURE_MAILING = True
 
+    # Feature Flag: Whether organizations can share email addresses with other users/orgs.
+    FEATURE_ORG_SHARED_EMAIL = False
+
     # Feature Flag: Whether users can be created (by non-super users).
     FEATURE_USER_CREATION = True
 

--- a/data/model/organization.py
+++ b/data/model/organization.py
@@ -1,3 +1,4 @@
+import features
 from data.database import (
     DeletedNamespace,
     FederatedLogin,
@@ -49,6 +50,15 @@ def create_organization(
                     raise InvalidEmailAddressException(
                         "Invalid email address: %s" % effective_email
                     )
+
+            if (
+                effective_email
+                and not features.ORG_SHARED_EMAIL
+                and user.find_user_by_email(effective_email)
+            ):
+                raise InvalidEmailAddressException(
+                    "Email has already been used: %s" % effective_email
+                )
 
             new_org = _create_org_user(name, effective_email, is_possible_abuser)
 

--- a/data/model/test/test_organization.py
+++ b/data/model/test/test_organization.py
@@ -220,20 +220,35 @@ class TestCreateOrganizationEmail:
         assert org1.id != org2.id
 
     def test_org_can_share_email_with_user(self, initialized_db):
-        """Test that an org can be created with the same email as an existing user.
+        """Test that an org can be created with the same email as an existing user
+        when FEATURE_ORG_SHARED_EMAIL is enabled.
 
         Regression test: create_user_noverify INSERTs with organization=false,
         so the partial unique index fires during INSERT. The fix is to insert
         with a placeholder email, set organization=true, then apply the real email.
         """
+        from unittest.mock import patch
+
+        from features import FeatureNameValue
+
         admin = get_user("devtable")
         user_email = admin.email  # devtable's email
-        org = create_organization("overlaporg", user_email, admin)
+        with patch("features.ORG_SHARED_EMAIL", FeatureNameValue("ORG_SHARED_EMAIL", True)):
+            org = create_organization("overlaporg", user_email, admin)
         assert org.email == user_email
         assert org.organization is True
         # The original user still has their email
         admin_refreshed = get_user("devtable")
         assert admin_refreshed.email == user_email
+
+    def test_org_shared_email_blocked_when_flag_off(self, initialized_db):
+        """Test that creating an org with a user's email is blocked when
+        FEATURE_ORG_SHARED_EMAIL is disabled (the default)."""
+        from data.model import InvalidEmailAddressException
+
+        admin = get_user("devtable")
+        with pytest.raises(InvalidEmailAddressException):
+            create_organization("blockedorg", admin.email, admin)
 
     def test_find_organizations_by_email_single_match(self, initialized_db):
         """Test find_organizations_by_email returns a single matching org."""
@@ -268,11 +283,16 @@ class TestCreateOrganizationEmail:
         Regression test for the combined recovery email flow where a single
         email may now match a personal user AND multiple organizations.
         """
+        from unittest.mock import patch
+
+        from features import FeatureNameValue
+
         admin = get_user("devtable")
         shared = admin.email  # e.g. devtable@devtable.com
 
-        org1 = create_organization("recoveryorg1", shared, admin)
-        org2 = create_organization("recoveryorg2", shared, admin)
+        with patch("features.ORG_SHARED_EMAIL", FeatureNameValue("ORG_SHARED_EMAIL", True)):
+            org1 = create_organization("recoveryorg1", shared, admin)
+            org2 = create_organization("recoveryorg2", shared, admin)
 
         # find_user_by_email should return ONLY the non-org user
         found_user = find_user_by_email(shared)

--- a/features/__init__.pyi
+++ b/features/__init__.pyi
@@ -46,6 +46,9 @@ BUILD_SUPPORT: FeatureNameValue
 # Feature Flag: Whether emails are enabled.
 MAILING: FeatureNameValue
 
+# Feature Flag: Whether organizations can share email addresses with other users/orgs.
+ORG_SHARED_EMAIL: FeatureNameValue
+
 # Feature Flag: Whether users can be created (by non-super users).
 USER_CREATION: FeatureNameValue
 

--- a/internal/config/features.go
+++ b/internal/config/features.go
@@ -15,4 +15,5 @@ type Features struct {
 	FeatureAppSpecificTokens    *bool `yaml:"FEATURE_APP_SPECIFIC_TOKENS"`
 	FeatureSuperUsers           *bool `yaml:"FEATURE_SUPER_USERS"`
 	FeatureSuperUsersFullAccess *bool `yaml:"FEATURE_SUPERUSERS_FULL_ACCESS"`
+	FeatureOrgSharedEmail       *bool `yaml:"FEATURE_ORG_SHARED_EMAIL"`
 }

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -227,6 +227,11 @@ CONFIG_SCHEMA = {
             "description": "Whether emails are enabled. Defaults to True",
             "x-example": True,
         },
+        "FEATURE_ORG_SHARED_EMAIL": {
+            "type": "boolean",
+            "description": "Whether organizations can share email addresses with existing user accounts. Defaults to False",
+            "x-example": False,
+        },
         "MAIL_SERVER": {
             "type": "string",
             "description": "The SMTP server to use for sending e-mails. Only required if FEATURE_MAILING is set to true.",

--- a/web/playwright/e2e/organization/contact-email.spec.ts
+++ b/web/playwright/e2e/organization/contact-email.spec.ts
@@ -687,5 +687,62 @@ test.describe(
         ).toBeVisible();
       });
     });
+
+    // =========================================================================
+    // Group 6: Feature Flag — FEATURE_ORG_SHARED_EMAIL
+    // =========================================================================
+
+    test.describe('FEATURE_ORG_SHARED_EMAIL flag', () => {
+      test('two orgs can always share the same email (flag-independent)', async ({
+        api,
+      }) => {
+        const shared = `shared-${Date.now()}@example.com`;
+        const org1 = await api.organization('flagtest1', shared);
+        const org2 = await api.organization('flagtest2', shared);
+
+        const data1 = await api.raw.getOrganization(org1.name);
+        const data2 = await api.raw.getOrganization(org2.name);
+        expect(data1.email).toBe(shared);
+        expect(data2.email).toBe(shared);
+      });
+
+      test('org cannot share email with a user when flag is off (default)', async ({
+        authenticatedRequest,
+      }) => {
+        // FEATURE_ORG_SHARED_EMAIL defaults to false.
+        // The authenticated user's email is already in use — creating an org
+        // with that same email should be rejected.
+        const token = await (async () => {
+          const resp = await authenticatedRequest.get(`${API_URL}/csrf_token`);
+          const data = await resp.json();
+          return data.csrf_token;
+        })();
+
+        // Get the current user's email
+        const userResp = await authenticatedRequest.get(
+          `${API_URL}/api/v1/user/`,
+        );
+        const userEmail = (await userResp.json()).email;
+        expect(userEmail).toBeTruthy();
+
+        // Try to create an org with the user's email — should fail
+        const orgName = uniqueName('flagblocked');
+        const createResp = await authenticatedRequest.post(
+          `${API_URL}/api/v1/organization/`,
+          {
+            headers: {'X-CSRF-Token': token},
+            data: {name: orgName, email: userEmail},
+          },
+        );
+
+        expect(createResp.status()).toBe(400);
+
+        // Verify the org was NOT created
+        const getResp = await authenticatedRequest.get(
+          `${API_URL}/api/v1/organization/${orgName}`,
+        );
+        expect(getResp.status()).toBe(404);
+      });
+    });
   },
 );


### PR DESCRIPTION
## Summary

Adds a feature flag `FEATURE_ORG_SHARED_EMAIL` (default: `false`) that gates whether organizations can be created with an email already in use by a regular user account.

This is a follow-up to #6223 to enable safe canary deployments. During a canary rollout, old pods lack the `organization == False` query filters added in #6223. If a user creates an org sharing their personal email on a new pod, subsequent requests to old pods could fail:
- Login by email could match the org instead of the user
- Password recovery could return an org recovery response instead of a reset link

With this flag defaulting to `false`, shared org/user emails are blocked until the canary completes and all pods are on the new version.

### Deployment steps

1. Deploy with `FEATURE_ORG_SHARED_EMAIL: false` (default — no config change needed)
2. Complete canary rollout — all pods running the new version
3. Set `FEATURE_ORG_SHARED_EMAIL: true` in config to enable the shared email feature

### Changes

| File | Change |
|------|--------|
| `config.py` | Default `FEATURE_ORG_SHARED_EMAIL = False` |
| `features/__init__.pyi` | Type stub |
| `internal/config/features.go` | Go schema entry |
| `data/model/organization.py` | Guard: reject org creation with a user's email when flag is off |
| `data/model/test/test_organization.py` | Tests for flag-on (allows), flag-off (blocks), recovery with shared email |

## Test plan

- [x] 23 org model tests pass (including new flag-on/flag-off tests)
- [x] Pre-commit hooks pass (Black, isort, flake8, gitleaks)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)