### PR TITLE
PROJQUAY-12543: fix(secscan): wrap speculative create in savepoint to prevent transaction poisoning

### DIFF
--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -617,15 +617,19 @@ class V4SecurityScanner(SecurityScannerInterface):
             if rows_updated == 0:
                 # UPDATE missed: either row doesn't exist, or another worker owns it.
                 # Try to create the row; if it already exists, another worker has it.
+                # Wrapped in db_transaction() so that an IntegrityError only rolls back
+                # the savepoint, not the outer transaction (PostgreSQL aborts the entire
+                # transaction on constraint violations otherwise).
                 try:
-                    ManifestSecurityStatus.create(
-                        manifest=candidate,
-                        repository=candidate.repository,
-                        index_status=IndexStatus.IN_PROGRESS,
-                        indexer_hash="in_progress",
-                        indexer_version=IndexerVersion.V4,
-                        metadata_json={},
-                    )
+                    with db_transaction():
+                        ManifestSecurityStatus.create(
+                            manifest=candidate,
+                            repository=candidate.repository,
+                            index_status=IndexStatus.IN_PROGRESS,
+                            indexer_hash="in_progress",
+                            indexer_version=IndexerVersion.V4,
+                            metadata_json={},
+                        )
                 except IntegrityError:
                     logger.debug("Manifest %d already claimed by another worker", candidate.id)
                     abt.set()

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 import mock
 import pytest
-from peewee import fn
+from peewee import IntegrityError, fn
 
 from app import app as application
 from app import instance_keys, storage
@@ -1501,9 +1501,12 @@ def test_connection_failure_does_not_increment_retry_count(initialized_db, set_s
 
     secscan.perform_indexing(batch_size=100)
 
+    failed_count = 0
     for mss in ManifestSecurityStatus.select():
         assert mss.index_status == IndexStatus.FAILED
         assert mss.metadata_json.get("retry_count") is None
+        failed_count += 1
+    assert failed_count > 0, "Expected at least one FAILED manifest"
 
 
 def test_non200_response_increments_retry_count(initialized_db, set_secscan_config):
@@ -1748,3 +1751,48 @@ def test_load_security_information_scan_retries_exhausted(initialized_db, set_se
 
     result = secscan.load_security_information(manifest)
     assert result.status == ScanLookupStatus.FAILED_TO_INDEX
+
+
+def test_duplicate_create_in_savepoint_preserves_outer_transaction(initialized_db, set_secscan_config):
+    """
+    Regression test: a duplicate ManifestSecurityStatus.create() wrapped in
+    db_transaction() (savepoint) must not poison the outer PostgreSQL transaction.
+    Without the savepoint, PostgreSQL aborts the entire transaction on IntegrityError
+    and all subsequent queries fail with 'current transaction is aborted'.
+    """
+    manifest = Manifest.select().first()
+    if manifest is None:
+        pytest.skip("No manifests in test database")
+
+    # Ensure a row exists so the second create will hit a constraint violation.
+    ManifestSecurityStatus.delete().where(
+        ManifestSecurityStatus.manifest == manifest,
+    ).execute()
+    ManifestSecurityStatus.create(
+        manifest=manifest,
+        repository=manifest.repository,
+        index_status=IndexStatus.COMPLETED,
+        indexer_hash="existing",
+        indexer_version=IndexerVersion.V4,
+        metadata_json={},
+    )
+
+    # Duplicate create inside a savepoint — the IntegrityError should only
+    # roll back the savepoint, leaving the outer transaction intact.
+    try:
+        with db_transaction():
+            ManifestSecurityStatus.create(
+                manifest=manifest,
+                repository=manifest.repository,
+                index_status=IndexStatus.IN_PROGRESS,
+                indexer_hash="duplicate",
+                indexer_version=IndexerVersion.V4,
+                metadata_json={},
+            )
+        pytest.fail("Expected IntegrityError from duplicate create")
+    except IntegrityError:
+        pass
+
+    # This query must succeed — proves the outer transaction was not poisoned.
+    row = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == manifest)
+    assert row.indexer_hash == "existing"


### PR DESCRIPTION
## Summary

- Wraps the speculative `ManifestSecurityStatus.create()` in `_index()` with `db_transaction()` (savepoint) to prevent PostgreSQL transaction poisoning when an `IntegrityError` occurs on a duplicate key race

## Problem

When two secscan workers race to claim the same manifest, the fallback `create()` can raise `IntegrityError`. PostgreSQL aborts the entire transaction on constraint violations, so all subsequent queries in the indexing loop fail with `current transaction is aborted, commands ignored until end of transaction block`. This causes flaky CI failures in `test_deduplicate_recent_vs_full_catalog` under PostgreSQL.

SQLite doesn't exhibit this behavior because it doesn't abort transactions on constraint violations.

## Fix

`db_transaction()` creates a savepoint when already inside a transaction. The `IntegrityError` rolls back only the savepoint, and the outer transaction continues cleanly.

Closes #6407

## Test plan

- [x] All 54 tests in `data/secscan_model/test/test_secscan_v4_model.py` pass locally
- [ ] PostgreSQL Integration Test passes in CI (previously flaky due to this bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)