### PR TITLE
NO-ISSUE: feat(ui): simplify pull popover to show image references

### DIFF
--- a/web/playwright/e2e/repository/tag-crud.spec.ts
+++ b/web/playwright/e2e/repository/tag-crud.spec.ts
@@ -139,10 +139,8 @@ test.describe(
       const popover = authenticatedPage.getByTestId('pull-popover');
       await expect(popover).toBeVisible({timeout: 10000});
       await expect(popover).toContainText('Fetch Tag');
-      await expect(popover).toContainText('Podman Pull (By Tag)');
-      await expect(popover).toContainText('Docker Pull (By Tag)');
-      await expect(popover).toContainText('Podman Pull (By Digest)');
-      await expect(popover).toContainText('Docker Pull (By Digest)');
+      await expect(popover).toContainText('Image (By Tag)');
+      await expect(popover).toContainText('Image (By Digest)');
 
       const inputs = popover.locator('input');
       await expect(inputs.first()).toHaveValue(

--- a/web/src/routes/RepositoryDetails/Tags/TablePopover.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TablePopover.tsx
@@ -22,51 +22,27 @@ export default function TablePopover(props: TablePopoverProps) {
       bodyContent={
         <div>
           <Content component="p" style={{fontWeight: 'bold'}}>
-            Podman Pull (By Tag)
+            Image (By Tag)
           </Content>
           <ClipboardCopy
-            data-testid="copy-tag-podman"
+            data-testid="copy-tag"
             isReadOnly
             hoverTip="Copy"
             clickTip="Copied"
           >
-            {`podman pull ${domain}/${props.org}/${props.repo}:${props.tag}`}
+            {`${domain}/${props.org}/${props.repo}:${props.tag}`}
           </ClipboardCopy>
           <br />
           <Content component="p" style={{fontWeight: 'bold'}}>
-            Podman Pull (By Digest)
+            Image (By Digest)
           </Content>
           <ClipboardCopy
-            data-testid="copy-digest-podman"
+            data-testid="copy-digest"
             isReadOnly
             hoverTip="Copy"
             clickTip="Copied"
           >
-            {`podman pull ${domain}/${props.org}/${props.repo}@${props.digest}`}
-          </ClipboardCopy>
-          <br />
-          <Content component="p" style={{fontWeight: 'bold'}}>
-            Docker Pull (By Tag)
-          </Content>
-          <ClipboardCopy
-            data-testid="copy-tag-docker"
-            isReadOnly
-            hoverTip="Copy"
-            clickTip="Copied"
-          >
-            {`docker pull ${domain}/${props.org}/${props.repo}:${props.tag}`}
-          </ClipboardCopy>
-          <br />
-          <Content component="p" style={{fontWeight: 'bold'}}>
-            Docker Pull (By Digest)
-          </Content>
-          <ClipboardCopy
-            data-testid="copy-digest-docker"
-            isReadOnly
-            hoverTip="Copy"
-            clickTip="Copied"
-          >
-            {`docker pull ${domain}/${props.org}/${props.repo}@${props.digest}`}
+            {`${domain}/${props.org}/${props.repo}@${props.digest}`}
           </ClipboardCopy>
         </div>
       }


### PR DESCRIPTION
Replace the four podman/docker pull-by-tag/digest fields with two fields showing the bare image reference (by tag and by digest).