### PR TITLE
[redhat-3.17] NO-ISSUE: test(playwright): align container helper context

### DIFF
--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -205,6 +205,36 @@ export async function pushUniqueImage(
 }
 
 /**
+ * Pull an image from the registry. Removes it afterwards to avoid
+ * polluting the local image store during tests.
+ */
+export async function pullImage(
+  namespace: string,
+  repo: string,
+  tag: string,
+  username: string,
+  password: string,
+): Promise<void> {
+  const runtime = await detectContainerRuntime();
+  if (!runtime) {
+    throw new Error('No container runtime available (podman or docker)');
+  }
+
+  const image = `${REGISTRY_HOST}/${namespace}/${repo}:${tag}`;
+  const tlsFlag = runtime === 'podman' ? '--tls-verify=false' : '';
+
+  await ensureLogin(runtime, username, password, tlsFlag);
+
+  const creds = credsFlag(runtime, username, password);
+  const authCfg = authFileFlag(runtime, username);
+
+  await execAsync(
+    `${runtime} ${authCfg} pull ${image} ${creds} ${tlsFlag}`.trim(),
+  );
+  await execAsync(`${runtime} rmi ${image}`).catch(() => undefined);
+}
+
+/**
  * Check if a container runtime (podman or docker) is available
  *
  * @returns true if podman or docker is available
@@ -282,6 +312,15 @@ export function orasAttach(
 
 /**
  * Push an image in OCI manifest format to the registry using skopeo.
+ *
+ * Uses `--format=oci` to guarantee the manifest uses the OCI content type,
+ * which exercises a different code path in the security scanner than
+ * Docker v2 schema 2 manifests.
+ *
+ * @example
+ * ```typescript
+ * await pushOCIImage('myorg', 'myrepo', 'latest', 'testuser', 'password');
+ * ```
  */
 export async function pushOCIImage(
   namespace: string,
@@ -292,38 +331,10 @@ export async function pushOCIImage(
 ): Promise<void> {
   const targetImage = `${REGISTRY_HOST}/${namespace}/${repo}:${tag}`;
   const sourceImage = 'quay.io/prometheus/busybox:latest';
+
   await retryPush(
     `skopeo copy --format=oci --override-os=linux --override-arch=amd64 docker://${sourceImage} docker://${targetImage} --dest-tls-verify=false --dest-creds=${username}:${password}`,
   );
-}
-
-/**
- * Pull an image from the registry using podman or docker.
- */
-export async function pullImage(
-  namespace: string,
-  repo: string,
-  tag: string,
-  username: string,
-  password: string,
-): Promise<void> {
-  const runtime = await detectContainerRuntime();
-  if (!runtime) {
-    throw new Error('No container runtime available (podman or docker)');
-  }
-
-  const image = `${REGISTRY_HOST}/${namespace}/${repo}:${tag}`;
-  const tlsFlag = runtime === 'podman' ? '--tls-verify=false' : '';
-
-  await ensureLogin(runtime, username, password, tlsFlag);
-
-  const creds = credsFlag(runtime, username, password);
-  const authCfg = authFileFlag(runtime, username);
-
-  await execAsync(
-    `${runtime} ${authCfg} pull ${image} ${creds} ${tlsFlag}`.trim(),
-  );
-  await execAsync(`${runtime} rmi ${image}`).catch(() => undefined);
 }
 
 /**


### PR DESCRIPTION
## Summary
Align the redhat-3.17 Playwright container helper layout with master's pre-6267 context so PR 6267 can be cherry-picked by automation.

## Related Issue
NO-ISSUE: release-branch-only context alignment for a failed automated cherry-pick.

## Changes
- Move the existing `pullImage` helper to match the layout on master before PR 6267.
- Restore the matching `pushOCIImage` documentation block.
- No intended behavior change.

## Testing
- [x] `node_modules/.bin/prettier --check playwright/utils/container.ts` passes
- [x] `node_modules/.bin/tsc --noEmit --pretty false --target es2020 --module commonjs --moduleResolution node --esModuleInterop --skipLibCheck playwright/utils/container.ts` passes
- [x] `node_modules/.bin/eslint playwright/utils/container.ts` passes with one existing warning
- [x] `git diff --check upstream/redhat-3.17...HEAD` passes
- [ ] `node_modules/.bin/tsc --noEmit --pretty false` not passing: redhat-3.17 currently reports unrelated web-wide type errors outside this diff

## Notes
This change was tested locally by cherry-picking PR 6267 on top of the alignment commit; the cherry-pick applied cleanly afterward.
