### PR TITLE
[redhat-3.16] PROJQUAY-10893: fix(proxy): prevent SSRF in proxy cache upstream registry configuration

### DIFF
--- a/data/model/proxy_cache.py
+++ b/data/model/proxy_cache.py
@@ -1,6 +1,7 @@
 from data.database import DEFAULT_PROXY_CACHE_EXPIRATION, ProxyCacheConfig, User
-from data.model import InvalidProxyCacheConfigException
+from data.model import DataModelException, InvalidProxyCacheConfigException
 from data.model.organization import get_organization
+from util.security.ssrf import validate_external_registry_url
 
 
 def has_proxy_cache_config(org_name):
@@ -18,10 +19,20 @@ def create_proxy_cache_config(
     upstream_registry_password=None,
     expiration_s=DEFAULT_PROXY_CACHE_EXPIRATION,
     insecure=False,
+    allowed_hosts=None,
 ):
     """
     Creates proxy cache configuration for the given organization name
     """
+    hostname = upstream_registry.split("/", 1)[0]
+    scheme = "http" if insecure else "https"
+    try:
+        validate_external_registry_url(
+            f"{scheme}://{hostname}", resolve_dns=False, allowed_hosts=allowed_hosts or []
+        )
+    except ValueError as e:
+        raise DataModelException(str(e))
+
     org = get_organization(org_name)
 
     new_entry = ProxyCacheConfig.create(

--- a/endpoints/api/organization.py
+++ b/endpoints/api/organization.py
@@ -51,8 +51,27 @@ from proxy import Proxy, UpstreamRegistryError
 from util.marketplace import MarketplaceSubscriptionApi
 from util.names import parse_robot_username
 from util.request import get_request_ip
+from util.security.ssrf import SSRFBlockedError, validate_external_registry_url
 
 logger = logging.getLogger(__name__)
+
+SSRF_GENERIC_ERROR = "The provided registry URL is not allowed"
+
+
+def _get_ssrf_allowed_hosts():
+    return app.config.get("SSRF_ALLOWED_HOSTS", [])
+
+
+def _validate_upstream_registry(upstream_registry, insecure=False):
+    hostname = upstream_registry.split("/", 1)[0]
+    scheme = "http" if insecure else "https"
+    url = f"{scheme}://{hostname}"
+    try:
+        validate_external_registry_url(url, allowed_hosts=_get_ssrf_allowed_hosts())
+    except SSRFBlockedError:
+        raise request_error(SSRF_GENERIC_ERROR)
+    except ValueError as e:
+        raise request_error(str(e))
 
 
 def quota_view(quota):
@@ -1013,6 +1032,11 @@ class OrganizationProxyCacheConfig(ApiResource):
 
         data = request.get_json()
 
+        _validate_upstream_registry(
+            data.get("upstream_registry", ""),
+            insecure=data.get("insecure", False),
+        )
+
         try:
             config = model.proxy_cache.create_proxy_cache_config(
                 org_name=orgname,
@@ -1021,6 +1045,7 @@ class OrganizationProxyCacheConfig(ApiResource):
                 upstream_registry_password=data.get("upstream_registry_password"),
                 expiration_s=data.get("expiration_s", 86400),
                 insecure=data.get("insecure", False),
+                allowed_hosts=_get_ssrf_allowed_hosts(),
             )
             if config is not None:
                 log_action(
@@ -1092,7 +1117,7 @@ class ProxyCacheConfigValidation(ApiResource):
 
         try:
             model.proxy_cache.get_proxy_cache_config_for_org(orgname)
-            request_error("Proxy Cache Configuration already exists")
+            raise request_error("Proxy Cache Configuration already exists")
         except model.InvalidProxyCacheConfigException:
             pass
 
@@ -1100,6 +1125,11 @@ class ProxyCacheConfigValidation(ApiResource):
 
         # filter None values
         data = {k: v for k, v in data.items() if v is not None}
+
+        _validate_upstream_registry(
+            data.get("upstream_registry", ""),
+            insecure=data.get("insecure", False),
+        )
 
         try:
             config = ProxyCacheConfig(**data)
@@ -1112,6 +1142,8 @@ class ProxyCacheConfigValidation(ApiResource):
                 return "Valid", 202
             if response.status_code == 401:
                 return "Anonymous", 202
+        except SSRFBlockedError:
+            raise request_error(SSRF_GENERIC_ERROR)
         except UpstreamRegistryError as e:
             raise request_error(
                 message="Failed login to remote registry. Please verify entered details and try again."

--- a/endpoints/api/test/test_organization.py
+++ b/endpoints/api/test/test_organization.py
@@ -8,9 +8,11 @@ from endpoints.api.organization import (
     Organization,
     OrganizationCollaboratorList,
     OrganizationList,
+    OrganizationProxyCacheConfig,
+    ProxyCacheConfigValidation,
 )
 from endpoints.api.test.shared import conduct_api_call
-from endpoints.test.shared import client_with_identity
+from endpoints.test.shared import client_with_identity, toggle_feature
 from features import FeatureNameValue
 from test.fixtures import *
 
@@ -140,3 +142,122 @@ def test_create_org_ldap_restricted_user_no_whitelist(
                     conduct_api_call(
                         cl, OrganizationList, "POST", None, body=body, expected_code=expected_code
                     )
+
+
+@pytest.fixture()
+def _mock_dns_for_ssrf_validation():
+    with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+        mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        yield mock_dns
+
+
+@pytest.mark.usefixtures("_mock_dns_for_ssrf_validation")
+class TestProxyCacheSSRFProtection:
+    """Tests for SSRF protection in proxy cache configuration endpoints (CVE-2026-32591)."""
+
+    def _cleanup_proxy_cache_config(self, orgname):
+        try:
+            model.proxy_cache.delete_proxy_cache_config(orgname)
+        except Exception:
+            pass
+
+    def test_create_with_private_ip_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "10.0.0.1"}
+                resp = conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_create_with_loopback_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "127.0.0.1"}
+                resp = conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_create_with_aws_metadata_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "169.254.169.254"}
+                resp = conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_create_with_kubernetes_hostname_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "kubernetes.default.svc"}
+                resp = conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_create_with_gcp_metadata_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "metadata.google.internal"}
+                resp = conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_create_with_valid_registry_succeeds(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "docker.io"}
+                conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 201)
+
+        self._cleanup_proxy_cache_config("buynlarge")
+
+    def test_validate_with_private_ip_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "10.0.0.1"}
+                resp = conduct_api_call(cl, ProxyCacheConfigValidation, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_validate_with_aws_metadata_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "169.254.169.254"}
+                resp = conduct_api_call(cl, ProxyCacheConfigValidation, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_validate_with_localhost_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "localhost"}
+                resp = conduct_api_call(cl, ProxyCacheConfigValidation, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")
+
+    def test_create_with_upstream_namespace_and_private_ip_rejected(self, app):
+        self._cleanup_proxy_cache_config("buynlarge")
+
+        with toggle_feature("PROXY_CACHE", True):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                body = {"upstream_registry": "10.0.0.1/myorg"}
+                resp = conduct_api_call(cl, OrganizationProxyCacheConfig, "POST", params, body, 400)
+                assert "not allowed" in resp.json.get("error_message", "")

--- a/endpoints/api/test/test_security.py
+++ b/endpoints/api/test/test_security.py
@@ -6040,7 +6040,7 @@ SECURITY_TESTS: List[
         OrganizationProxyCacheConfig,
         "POST",
         {"orgname": "library"},
-        {"org_name": "library", "upstream_registry": "some-upstream-registry"},
+        {"upstream_registry": "docker.io"},
         "devtable",
         201,
     ),
@@ -7002,7 +7002,11 @@ def _filter_security_tests():
 
 @pytest.mark.parametrize("resource,method,params,body,identity,expected", _filter_security_tests())
 def test_api_security(resource, method, params, body, identity, expected, app):
-    with client_with_identity(identity, app) as cl:
+    mock_dns = patch(
+        "util.security.ssrf._getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    )
+    with mock_dns, client_with_identity(identity, app) as cl:
         conduct_api_call(cl, resource, method, params, body, expected)
 
 

--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -10,9 +10,10 @@ from urllib.parse import urlencode
 import requests
 from requests.exceptions import RequestException
 
-from app import model_cache
+from app import app, model_cache
 from data.cache import cache_key
 from data.database import ProxyCacheConfig
+from util.security.ssrf import validate_external_registry_url
 
 WWW_AUTHENTICATE_REGEX = re.compile(r'(\w+)[=] ?"?([^",]+)"?')
 TOKEN_VALIDITY_LIFETIME_S = 60 * 60  # 1 hour, in seconds - Quay's default
@@ -61,6 +62,10 @@ class Proxy:
         url = f"https://{hostname}"
         if config.insecure:
             url = f"http://{hostname}"
+
+        validate_external_registry_url(
+            url, resolve_dns=False, allowed_hosts=app.config.get("SSRF_ALLOWED_HOSTS", [])
+        )
 
         self.base_url = url
         self._session = requests.Session()

--- a/proxy/test_proxy.py
+++ b/proxy/test_proxy.py
@@ -12,6 +12,7 @@ from data.database import ProxyCacheConfig, User
 from data.encryption import FieldEncrypter
 from data.fields import LazyEncryptedValue
 from proxy import Proxy, UpstreamRegistryError, parse_www_auth
+from util.security.ssrf import SSRFBlockedError
 
 ANONYMOUS_TOKEN = "anonymous-token"
 USER_TOKEN = "user-token"
@@ -368,3 +369,61 @@ class TestProxy(unittest.TestCase):
             with pytest.raises(UpstreamRegistryError) as excinfo:
                 proxy.blob_exists(digest=DIGEST_404)
         self.assertIn("404", str(excinfo.value))
+
+
+class TestProxySSRFProtection(unittest.TestCase):
+    """Defense-in-depth SSRF validation in Proxy constructor (CVE-2026-32591)."""
+
+    def _make_config(self, hostname, insecure=False):
+        return ProxyCacheConfig(
+            upstream_registry=hostname,
+            organization=User(username="cache-org", organization=True),
+            insecure=insecure,
+        )
+
+    def test_private_ip_rejected(self):
+        config = self._make_config("10.0.0.1")
+        with pytest.raises(SSRFBlockedError):
+            Proxy(config, "library/postgres")
+
+    def test_loopback_rejected(self):
+        config = self._make_config("127.0.0.1")
+        with pytest.raises(SSRFBlockedError):
+            Proxy(config, "library/postgres")
+
+    def test_aws_metadata_rejected(self):
+        config = self._make_config("169.254.169.254")
+        with pytest.raises(SSRFBlockedError):
+            Proxy(config, "library/postgres")
+
+    def test_localhost_rejected(self):
+        config = self._make_config("localhost")
+        with pytest.raises(SSRFBlockedError):
+            Proxy(config, "library/postgres")
+
+    def test_kubernetes_hostname_rejected(self):
+        config = self._make_config("kubernetes.default.svc")
+        with pytest.raises(SSRFBlockedError):
+            Proxy(config, "library/postgres")
+
+    def test_hostname_with_namespace_extracts_correctly(self):
+        config = self._make_config("10.0.0.1/myorg")
+        with pytest.raises(SSRFBlockedError):
+            Proxy(config, "library/postgres")
+
+    def test_valid_registry_allowed(self):
+        config = self._make_config("docker.io")
+        with HTTMock(docker_registry_mock):
+            proxy = Proxy(config, "library/postgres")
+        self.assertIsNotNone(proxy.base_url)
+
+    def test_allowlisted_private_ip_allowed(self):
+        config = self._make_config("10.0.0.1")
+        original = app.config.get("SSRF_ALLOWED_HOSTS", [])
+        app.config["SSRF_ALLOWED_HOSTS"] = ["10.0.0.0/8"]
+        try:
+            with HTTMock(docker_registry_mock):
+                proxy = Proxy(config, "library/postgres")
+            self.assertIsNotNone(proxy.base_url)
+        finally:
+            app.config["SSRF_ALLOWED_HOSTS"] = original

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ max-line-length = 100
 branch = true
 
 [tool.coverage.report]
-omit = ['test/**', 'venv/**', '**/test/**']
+omit = ['test/**', 'venv/**', '**/test/**', 'tools/**', '**/test_*.py']
 
 [tool.pyright]
 stubPath = 'mypy_stubs'

--- a/web/playwright/e2e/organization/proxy-cache.spec.ts
+++ b/web/playwright/e2e/organization/proxy-cache.spec.ts
@@ -120,6 +120,64 @@ test.describe(
       ).toBeEnabled();
     });
 
+    test('proxy cache rejects private IP as upstream registry (PROJQUAY-11180)', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('proxyssrf');
+
+      await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
+      await authenticatedPage.getByText('Proxy Cache').click();
+
+      await authenticatedPage
+        .getByTestId('remote-registry-input')
+        .fill('10.0.0.1');
+      await authenticatedPage.getByTestId('save-proxy-cache-btn').click();
+
+      await expect(
+        authenticatedPage
+          .getByText('The provided registry URL is not allowed')
+          .first(),
+      ).toBeVisible();
+
+      await expect(
+        authenticatedPage.getByTestId('save-proxy-cache-btn'),
+      ).toBeEnabled();
+
+      await expect(
+        authenticatedPage.getByTestId('delete-proxy-cache-btn'),
+      ).toBeDisabled();
+    });
+
+    test('proxy cache rejects cloud metadata endpoint as upstream registry (PROJQUAY-11180)', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('proxymeta');
+
+      await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
+      await authenticatedPage.getByText('Proxy Cache').click();
+
+      await authenticatedPage
+        .getByTestId('remote-registry-input')
+        .fill('169.254.169.254');
+      await authenticatedPage.getByTestId('save-proxy-cache-btn').click();
+
+      await expect(
+        authenticatedPage
+          .getByText('The provided registry URL is not allowed')
+          .first(),
+      ).toBeVisible();
+
+      await expect(
+        authenticatedPage.getByTestId('save-proxy-cache-btn'),
+      ).toBeEnabled();
+
+      await expect(
+        authenticatedPage.getByTestId('delete-proxy-cache-btn'),
+      ).toBeDisabled();
+    });
+
     test('proxy cache tab not visible for user namespaces', async ({
       authenticatedPage,
     }) => {


### PR DESCRIPTION
## Summary
Cherry-pick of #6058 to `redhat-3.16`.
* Prevent Server-Side Request Forgery (SSRF) in the Proxy Cache configuration feature (CVE-2026-32591)
* Validate `upstream_registry` against private/reserved IP ranges, blocked hostnames, and cloud metadata endpoints
* Apply three-layer defense matching the org mirror SSRF fix ([PROJQUAY-10572](https://redhat.atlassian.net/browse/PROJQUAY-10572))
## Changes
* **`endpoints/api/organization.py`**: Added `_validate_upstream_registry()` helper with DNS resolution and `SSRF_ALLOWED_HOSTS` allowlist support. Called in both `OrganizationProxyCacheConfig.post()` and `ProxyCacheConfigValidation.post()`. Fixed missing `raise` in duplicate config check.
* **`data/model/proxy_cache.py`**: Defense-in-depth validation in `create_proxy_cache_config()` with `resolve_dns=False`. Added `allowed_hosts` parameter.
* **`proxy/__init__.py`**: Defense-in-depth validation in `Proxy.__init__()` before network requests.
* **`endpoints/api/test/test_organization.py`**: 11 SSRF regression tests for API endpoints
* **`proxy/test_proxy.py`**: 8 regression tests for Proxy constructor
* **`endpoints/api/test/test_security.py`**: Mocked DNS + fixed test body for SSRF-aware validation
* **`web/playwright/e2e/organization/proxy-cache.spec.ts`**: 2 e2e tests for SSRF rejection in UI
* **`pyproject.toml`**: Exclude module-level test files from coverage reporting

This resolves [PROJQUAY-10893](https://redhat.atlassian.net/browse/PROJQUAY-10893)