### PR TITLE
QUAYIO-1708: feat(deploy): mount only TLS cert/key from config secret

### DIFF
--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -113,6 +113,11 @@ objects:
         - name: tls
           secret:
             secretName: ${{ENVOY_TLS_SECRET}}
+            items:
+            - key: ssl.cert
+              path: ssl.cert
+            - key: ssl.key
+              path: ssl.key
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
Use items in the TLS volume mount to expose only ssl.cert and ssl.key from the secret, rather than the entire secret contents. This allows Envoy to reuse the existing Quay config secret for TLS instead of requiring a dedicated secret.