### PR TITLE
PROJQUAY-12196: fix(buildman): fire build_start notification on phase transition

### DIFF
--- a/buildman/manager/ephemeral.py
+++ b/buildman/manager/ephemeral.py
@@ -491,6 +491,9 @@ class EphemeralBuilderManager(BuildStateInterface):
                 build_job.build_uuid, phase, self._build_logs.PHASE, phase_metadata
             )
 
+            if phase == BUILD_PHASE.BUILDING:
+                build_job.send_notification("build_start")
+
         # Check if on_job_complete needs to be called
         if updated and phase in EphemeralBuilderManager.COMPLETED_PHASES:
             executor_name = job_data_json.get("executor_name")

--- a/web/playwright/e2e/repository/notifications.spec.ts
+++ b/web/playwright/e2e/repository/notifications.spec.ts
@@ -890,4 +890,46 @@ test.describe('Repository Notifications', {tag: ['@repository']}, () => {
       }
     },
   );
+
+  test(
+    'build_start notification delivered via webhook',
+    {tag: ['@feature:BUILD_SUPPORT', '@PROJQUAY-12196']},
+    async ({api}) => {
+      test.setTimeout(300_000);
+      const org = await api.organization('buildstartwh');
+      const repo = await api.repository(org.name, 'buildstartrepo');
+
+      const receiver = new WebhookReceiver();
+      await receiver.start();
+
+      try {
+        await api.notification(
+          org.name,
+          repo.name,
+          'build_start',
+          'webhook',
+          {url: receiver.getUrl()},
+          'Build Start Webhook',
+        );
+
+        const build = await api.build(
+          org.name,
+          repo.name,
+          'FROM scratch\nLABEL build="build-start-test"\n',
+        );
+
+        const webhook = await receiver.waitForWebhook(
+          (req) =>
+            req.body.build_id === build.buildId &&
+            req.body.repository === `${org.name}/${repo.name}`,
+          240000,
+        );
+        expect(webhook, 'build_start webhook not received').not.toBeNull();
+        expect(webhook!.body.repository).toBe(`${org.name}/${repo.name}`);
+        expect(webhook!.body.build_id).toBe(build.buildId);
+      } finally {
+        await receiver.stop();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- The `BuildStartEvent` notification event was defined in `notifications/notificationevent.py` and configurable via the UI, but never actually triggered when a build starts
- Added `send_notification("build_start")` in `buildman/manager/ephemeral.py` when build phase transitions to `BUILDING`
- Issue confirmed on master, redhat-3.17, and redhat-3.16 branches

## Test plan
- [ ] Configure a repository notification with event type "Image build started" and method "Webhook POST"
- [ ] Trigger a build on the repository
- [ ] Verify the webhook receives a POST request when the build transitions to the BUILDING phase
- [ ] Verify existing build_success and build_failure notifications still work correctly

Jira: https://redhat.atlassian.net/browse/PROJQUAY-12196

🤖 Generated with [Claude Code](https://claude.ai/code)