### PR TITLE
fix: remove accidental sed backup file from prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -60,7 +60,8 @@ jobs:
         run: |
           echo "modifying changelog URL to point to current y-stream release."
           QUAY_VERSION=$(echo "$RELEASE_BRANCH" | cut -d'-' -f2)
-          sed -in --regexp-extended "s/\/[0-9\.]+\//\/$QUAY_VERSION\//" CHANGELOG.md
+          sed -i --regexp-extended "s/\/[0-9\.]+\//\/$QUAY_VERSION\//" CHANGELOG.md
+          rm -f CHANGELOG.mdn
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:


### PR DESCRIPTION
## Summary
- `sed -in` was interpreted as `-i` with backup suffix `n`, creating a junk `CHANGELOG.mdn` backup file on every prepare-release run
- The growing file (570KB on redhat-3.16) caused GitHub to timeout validating the push, breaking the workflow
- Also cleans up existing `CHANGELOG.mdn` from branches where it already exists

## Test plan
- [ ] Trigger prepare-release workflow and verify no `CHANGELOG.mdn` is created
- [ ] Verify changelog PR is successfully opened