### PR TITLE
PROJQUAY-12193: feat(oauth): track token last-used metadata

### DIFF
--- a/config.py
+++ b/config.py
@@ -755,6 +755,10 @@ class DefaultConfig(ImmutableConfig):
     # token will be updated after the previous update.
     LAST_ACCESSED_UPDATE_THRESHOLD_S = 60
 
+    # Defines the delay required (in seconds) before the last_accessed field of an OAuth access
+    # token will be updated after the previous update.
+    OAUTH_TOKEN_LAST_ACCESSED_UPDATE_THRESHOLD_S = 60
+
     # Defines the number of results per page used to show search results
     SEARCH_RESULTS_PER_PAGE = 10
 

--- a/data/model/oauth.py
+++ b/data/model/oauth.py
@@ -8,6 +8,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from flask import url_for
+from peewee import PeeweeException
 
 from auth import scopes
 from data.database import (
@@ -23,6 +24,7 @@ from data.database import (
 from data.fields import Credential, DecryptedValue
 from data.model import config, db_transaction, notification, user
 from data.model.organization import is_org_admin
+from data.readreplica import ReadOnlyModeException
 from oauth import utils
 from oauth.provider import AuthorizationProvider
 from util import get_app_url
@@ -635,6 +637,34 @@ def create_application(org, name, application_uri, redirect_uri, **kwargs):
     )
 
 
+def update_oauth_token_last_accessed(token: OAuthAccessToken) -> None:
+    """Update OAuth token last_accessed using OAuth-specific debounce config."""
+    now = datetime.now()
+    threshold = timedelta(
+        seconds=config.app_config.get("OAUTH_TOKEN_LAST_ACCESSED_UPDATE_THRESHOLD_S", 60)
+    )
+    if token.last_accessed is not None and now - token.last_accessed < threshold:
+        return
+
+    try:
+        (
+            OAuthAccessToken.update(last_accessed=now)
+            .where(OAuthAccessToken.id == token.id)
+            .execute()
+        )
+        token.last_accessed = now
+    except ReadOnlyModeException:
+        pass
+    except PeeweeException:
+        strict_logging_disabled = config.app_config.get(
+            "ALLOW_WITHOUT_STRICT_LOGGING"
+        ) or config.app_config.get("ALLOW_PULLS_WITHOUT_STRICT_LOGGING")
+        if strict_logging_disabled:
+            logger.exception("update last_accessed for OAuth token failed")
+        else:
+            raise
+
+
 def validate_access_token(access_token):
     assert isinstance(access_token, str)
     token_name = access_token[:ACCESS_TOKEN_PREFIX_LENGTH]
@@ -655,6 +685,9 @@ def validate_access_token(access_token):
 
         if found.token_code is None or not found.token_code.matches(token_code):
             return None
+
+        if found.expires_at > datetime.now():
+            update_oauth_token_last_accessed(found)
 
         return found
     except OAuthAccessToken.DoesNotExist:

--- a/data/model/test/test_oauth.py
+++ b/data/model/test/test_oauth.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from auth.scopes import READ_REPO
@@ -23,6 +23,25 @@ def setup(num_assignments=0):
         application, user, REDIRECT_URI, READ_REPO.scope, "token"
     )
     return (application, token_assignment, user, org)
+
+
+def create_access_token_for_last_accessed_test(application_name, expires_at):
+    owner = model.user.get_user("devtable")
+    application = model.oauth.create_application(owner, application_name, "", "")
+    token, access_token = model.oauth.create_user_access_token_for_application(
+        owner,
+        application,
+        READ_REPO.scope,
+        "Bearer",
+        3600,
+    )
+    (
+        OAuthAccessToken.update(expires_at=expires_at)
+        .where(OAuthAccessToken.id == token.id)
+        .execute()
+    )
+    token.expires_at = expires_at
+    return token, access_token
 
 
 def test_oauth_access_token_metadata_fields_are_nullable():
@@ -59,6 +78,101 @@ def test_oauth_access_token_created_defaults_to_now(initialized_db):
 
     assert token.last_accessed is None
     assert before <= token.created <= after
+
+
+def test_validate_access_token_updates_last_accessed_for_active_token(initialized_db):
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    token, access_token = create_access_token_for_last_accessed_test(
+        "last-accessed-active",
+        now + timedelta(hours=1),
+    )
+
+    with patch("data.model.oauth.datetime") as mock_datetime:
+        mock_datetime.now.return_value = now
+        found = model.oauth.validate_access_token(access_token)
+
+    assert found.id == token.id
+    assert found.last_accessed == now
+    assert OAuthAccessToken.get_by_id(token.id).last_accessed == now
+
+
+def test_validate_access_token_does_not_update_expired_token(initialized_db):
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    token, access_token = create_access_token_for_last_accessed_test(
+        "last-accessed-expired",
+        now - timedelta(seconds=1),
+    )
+
+    with patch("data.model.oauth.datetime") as mock_datetime:
+        mock_datetime.now.return_value = now
+        found = model.oauth.validate_access_token(access_token)
+
+    assert found.id == token.id
+    assert found.last_accessed is None
+    assert OAuthAccessToken.get_by_id(token.id).last_accessed is None
+
+
+def test_validate_access_token_does_not_update_invalid_suffix(initialized_db):
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    token, access_token = create_access_token_for_last_accessed_test(
+        "last-accessed-invalid-suffix",
+        now + timedelta(hours=1),
+    )
+    prefix_length = model.oauth.ACCESS_TOKEN_PREFIX_LENGTH
+    replacement = "x" if access_token[prefix_length] != "x" else "y"
+    invalid_access_token = (
+        access_token[:prefix_length] + replacement + access_token[prefix_length + 1 :]
+    )
+
+    assert model.oauth.validate_access_token(invalid_access_token) is None
+    assert OAuthAccessToken.get_by_id(token.id).last_accessed is None
+
+
+def test_validate_access_token_honors_oauth_last_accessed_debounce(initialized_db):
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    previous = now - timedelta(seconds=30)
+    token, access_token = create_access_token_for_last_accessed_test(
+        "last-accessed-debounce",
+        now + timedelta(hours=1),
+    )
+    (
+        OAuthAccessToken.update(last_accessed=previous)
+        .where(OAuthAccessToken.id == token.id)
+        .execute()
+    )
+    token.last_accessed = previous
+
+    with patch.dict(
+        model.oauth.config.app_config,
+        {"OAUTH_TOKEN_LAST_ACCESSED_UPDATE_THRESHOLD_S": 60},
+        clear=False,
+    ):
+        with patch("data.model.oauth.datetime") as mock_datetime:
+            mock_datetime.now.return_value = now
+            found = model.oauth.validate_access_token(access_token)
+
+    assert found.last_accessed == previous
+    assert OAuthAccessToken.get_by_id(token.id).last_accessed == previous
+
+
+def test_validate_access_token_ignores_user_last_accessed_feature_flag(initialized_db):
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    token, access_token = create_access_token_for_last_accessed_test(
+        "last-accessed-user-feature-disabled",
+        now + timedelta(hours=1),
+    )
+
+    with patch.dict(
+        model.oauth.config.app_config,
+        {"FEATURE_USER_LAST_ACCESSED": False},
+        clear=False,
+    ):
+        with patch("data.model.oauth.datetime") as mock_datetime:
+            mock_datetime.now.return_value = now
+            found = model.oauth.validate_access_token(access_token)
+
+    assert found.last_accessed == now
+    assert OAuthAccessToken.get_by_id(token.id).last_accessed == now
 
 
 def test_get_token_response_with_assignment_id(initialized_db):

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -74,6 +74,7 @@ INTERNAL_ONLY_PROPERTIES = {
     "USE_CDN",
     "ANALYTICS_TYPE",
     "LAST_ACCESSED_UPDATE_THRESHOLD_S",
+    "OAUTH_TOKEN_LAST_ACCESSED_UPDATE_THRESHOLD_S",
     "GREENLET_TRACING",
     "EXCEPTION_LOG_TYPE",
     "SENTRY_DSN",
@@ -2368,6 +2369,14 @@ CONFIG_SCHEMA = {
     "LAST_ACCESSED_UPDATE_THRESHOLD_S": {
         "type": "number",
         "description": "Update the LAST_ACCESSED database column. Defaults to 60 in seconds",
+        "x-example": 60,
+        "x-reference": None,
+    },
+    "OAUTH_TOKEN_LAST_ACCESSED_UPDATE_THRESHOLD_S": {
+        "type": "number",
+        "description": (
+            "Update the OAuth token LAST_ACCESSED database column. Defaults to 60 seconds"
+        ),
         "x-example": 60,
         "x-reference": None,
     },


### PR DESCRIPTION
- Update OAuth token `last_accessed` after successful non-expired validation
- Use OAuth-specific debounce config independent of user `last-accessed` tracking
- Preserve expired-token return behavior while skipping `last_accessed` writes