### PR TITLE
QUAYIO-2047: fix(cache): add null-safety guards and fix typo in referrers serialization

### DIFF
--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -284,9 +284,7 @@ class OCIModel(RegistryDataInterface):
         self, model_cache, repository_ref, manifest, artifact_type=None
     ):
         def load_referrers():
-            referrers = self.lookup_referrers_for_manifest(
-                repository_ref, manifest, artifact_type
-            )
+            referrers = self.lookup_referrers_for_manifest(repository_ref, manifest, artifact_type)
             serializable = []
             for r in referrers:
                 d = r.asdict()

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -284,7 +284,21 @@ class OCIModel(RegistryDataInterface):
         self, model_cache, repository_ref, manifest, artifact_type=None
     ):
         def load_referrers():
-            return self.lookup_referrers_for_manifest(repository_ref, manifest, artifact_type)
+            referrers = self.lookup_referrers_for_manifest(
+                repository_ref, manifest, artifact_type
+            )
+            serializable = []
+            for r in referrers:
+                d = r.asdict()
+                if d["internal_manifest_bytes"] is not None:
+                    d["internal_manifest_bytes"] = d["internal_manifest_bytes"].as_unicode()
+                if d.get("inputs") and d["inputs"].get("repository") is not None:
+                    d["inputs"]["repository"] = d["inputs"]["repository"].asdict()
+                if d.get("inputs"):
+                    d["inputs"]["legacy_id_handler"] = None
+                    d["inputs"]["legacy_image_row"] = None
+                serializable.append(d)
+            return serializable
 
         referrers_cache_key = cache_key.for_manifest_referrers(
             repository_ref, manifest.digest, model_cache.cache_config

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -305,6 +305,11 @@ class OCIModel(RegistryDataInterface):
         )
         result = model_cache.retrieve(referrers_cache_key, load_referrers)
         try:
+            for referrer_dict in result:
+                if referrer_dict.get("internal_manifest_bytes") is not None:
+                    referrer_dict["internal_manifest_bytes"] = Bytes.for_string_or_unicode(
+                        referrer_dict["internal_manifest_bytes"]
+                    )
             return [Manifest.from_dict(referrer_dict) for referrer_dict in result]
         except FromDictionaryException:
             return self.lookup_referrers_for_manifest(repository_ref, manifest, artifact_type)

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -289,14 +289,15 @@ class OCIModel(RegistryDataInterface):
                 repository_ref, manifest, artifact_type
             ):
                 referrer_dict = referrer.asdict()
-                referrer_dict["internal_manifest_bytes"] = referrer_dict[
-                    "internal_manifest_bytes"
-                ].as_unicode()
+                if referrer_dict["internal_manifest_bytes"] is not None:
+                    referrer_dict["internal_manifest_bytes"] = referrer_dict[
+                        "internal_manifest_bytes"
+                    ].as_unicode()
                 referrer_dict["inputs"]["repository"] = referrer_dict["inputs"][
                     "repository"
                 ].asdict()
                 referrer_dict["inputs"]["legacy_id_handler"] = None
-                referrer_dict["inputs"]["legacy_image_handler"] = None
+                referrer_dict["inputs"]["legacy_image_row"] = None
                 cacheable_referrers.append(referrer_dict)
             return cacheable_referrers
 
@@ -309,9 +310,10 @@ class OCIModel(RegistryDataInterface):
         result = model_cache.retrieve(referrers_cache_key, load_referrers)
         try:
             for referrer_dict in result:
-                referrer_dict["internal_manifest_bytes"] = Bytes.for_string_or_unicode(
-                    referrer_dict["internal_manifest_bytes"]
-                )
+                if referrer_dict.get("internal_manifest_bytes") is not None:
+                    referrer_dict["internal_manifest_bytes"] = Bytes.for_string_or_unicode(
+                        referrer_dict["internal_manifest_bytes"]
+                    )
             return [Manifest.from_dict(referrer_dict) for referrer_dict in result]
         except FromDictionaryException:
             return self.lookup_referrers_for_manifest(repository_ref, manifest, artifact_type)

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -1619,3 +1619,10 @@ def test_lookup_cached_referrers_serialization_roundtrip(oci_model):
         assert from_cache.digest == orig.digest
         assert from_cache.media_type == orig.media_type
         assert from_cache._db_id == orig._db_id
+
+        # Verify internal_manifest_bytes survived the roundtrip as a Bytes object
+        assert from_cache.internal_manifest_bytes is not None
+        assert from_cache.internal_manifest_bytes.as_encoded_str() == (
+            orig.internal_manifest_bytes.as_encoded_str()
+        )
+        assert from_cache.get_parsed_manifest() is not None

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -1475,3 +1475,147 @@ def test_lookup_repository_cache_stale_after_delete_without_invalidation(
 
     assert repo_ref_stale._db_id == old_repo_id  # Points to a deleted repo
     assert repo_ref_stale._db_id != new_repo.id
+
+
+def _create_oci_manifest_with_subject(oci_model, repository_ref, subject_manifest):
+    """Helper to create an OCI manifest that references another manifest as its subject."""
+    from image.oci.manifest import OCIManifestBuilder
+
+    config = json.dumps(
+        {
+            "os": "linux",
+            "architecture": "amd64",
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "history": [],
+        }
+    )
+    config_bytes = config.encode("utf-8")
+    config_digest = sha256_digest(config_bytes)
+
+    layer_data = os.urandom(32)
+    layer_digest = sha256_digest(layer_data)
+
+    builder = OCIManifestBuilder()
+    builder.set_config_digest(config_digest, len(config_bytes))
+    builder.add_layer(layer_digest, len(layer_data))
+
+    subject_bytes = subject_manifest.internal_manifest_bytes.as_encoded_str()
+    builder.set_subject(
+        subject_manifest.digest,
+        len(subject_bytes),
+        subject_manifest.media_type,
+    )
+
+    oci_manifest = builder.build()
+
+    repo_obj = Repository.get(Repository.id == repository_ref._db_id)
+    location = ImageStorageLocation.get(name="local_us")
+    blob = store_blob_record_and_temp_link(
+        repo_obj.namespace_user.username,
+        repo_obj.name,
+        config_digest,
+        location,
+        len(config_bytes),
+        120,
+    )
+    storage.put_content(["local_us"], get_layer_path(blob), config_bytes)
+
+    blob2 = store_blob_record_and_temp_link(
+        repo_obj.namespace_user.username,
+        repo_obj.name,
+        layer_digest,
+        location,
+        len(layer_data),
+        120,
+    )
+    storage.put_content(["local_us"], get_layer_path(blob2), layer_data)
+
+    created, _ = oci_model.create_manifest_and_retarget_tag(
+        repository_ref, oci_manifest, "referrer-" + os.urandom(4).hex(), storage
+    )
+    return created
+
+
+def test_lookup_cached_referrers_for_manifest(oci_model):
+    """Test that referrers can be cached and retrieved from cache correctly."""
+    model_cache = InMemoryDataModelCache(TEST_CACHE_CONFIG)
+    repository_ref = oci_model.lookup_repository("devtable", "simple")
+    latest_tag = oci_model.get_repo_tag(repository_ref, "latest")
+    subject = oci_model.get_manifest_for_tag(latest_tag)
+    assert subject is not None
+
+    referrer = _create_oci_manifest_with_subject(oci_model, repository_ref, subject)
+    assert referrer is not None
+
+    referrers = oci_model.lookup_cached_referrers_for_manifest(
+        model_cache, repository_ref, subject
+    )
+    assert len(referrers) >= 1
+
+    referrer_digests = {r.digest for r in referrers}
+    assert referrer.digest in referrer_digests
+
+    for r in referrers:
+        assert r.digest is not None
+        assert r.media_type is not None
+
+    # Call again — this time the result should come from cache.
+    # Patch the DB lookup to verify the cache is actually being used.
+    with patch(
+        "data.registry_model.registry_oci_model.oci.manifest.lookup_manifest_referrers",
+    ) as mock_db:
+        mock_db.side_effect = AssertionError("DB should not be called when cache is warm")
+        cached_referrers = oci_model.lookup_cached_referrers_for_manifest(
+            model_cache, repository_ref, subject
+        )
+
+    assert len(cached_referrers) == len(referrers)
+    cached_digests = {r.digest for r in cached_referrers}
+    assert cached_digests == referrer_digests
+
+
+def test_lookup_cached_referrers_for_manifest_empty(oci_model):
+    """Test cached referrers returns empty list when no referrers exist."""
+    model_cache = InMemoryDataModelCache(TEST_CACHE_CONFIG)
+    repository_ref = oci_model.lookup_repository("devtable", "simple")
+    latest_tag = oci_model.get_repo_tag(repository_ref, "latest")
+    subject = oci_model.get_manifest_for_tag(latest_tag)
+    assert subject is not None
+
+    referrers = oci_model.lookup_cached_referrers_for_manifest(
+        model_cache, repository_ref, subject
+    )
+    assert referrers == []
+
+
+def test_lookup_cached_referrers_serialization_roundtrip(oci_model):
+    """Test that Manifest objects survive the serialize->cache->deserialize roundtrip."""
+    model_cache = InMemoryDataModelCache(TEST_CACHE_CONFIG)
+    repository_ref = oci_model.lookup_repository("devtable", "simple")
+    latest_tag = oci_model.get_repo_tag(repository_ref, "latest")
+    subject = oci_model.get_manifest_for_tag(latest_tag)
+
+    ref1 = _create_oci_manifest_with_subject(oci_model, repository_ref, subject)
+    ref2 = _create_oci_manifest_with_subject(oci_model, repository_ref, subject)
+
+    referrers = oci_model.lookup_cached_referrers_for_manifest(
+        model_cache, repository_ref, subject
+    )
+    assert len(referrers) >= 2
+
+    digests_from_db = {r.digest for r in referrers}
+    assert ref1.digest in digests_from_db
+    assert ref2.digest in digests_from_db
+
+    # Fetch from cache and verify all fields survived roundtrip
+    cached = oci_model.lookup_cached_referrers_for_manifest(
+        model_cache, repository_ref, subject
+    )
+
+    for orig, from_cache in zip(
+        sorted(referrers, key=lambda m: m.digest),
+        sorted(cached, key=lambda m: m.digest),
+    ):
+        assert from_cache.digest == orig.digest
+        assert from_cache.media_type == orig.media_type
+        assert from_cache._db_id == orig._db_id

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -1547,9 +1547,7 @@ def test_lookup_cached_referrers_for_manifest(oci_model):
     referrer = _create_oci_manifest_with_subject(oci_model, repository_ref, subject)
     assert referrer is not None
 
-    referrers = oci_model.lookup_cached_referrers_for_manifest(
-        model_cache, repository_ref, subject
-    )
+    referrers = oci_model.lookup_cached_referrers_for_manifest(model_cache, repository_ref, subject)
     assert len(referrers) >= 1
 
     referrer_digests = {r.digest for r in referrers}
@@ -1582,9 +1580,7 @@ def test_lookup_cached_referrers_for_manifest_empty(oci_model):
     subject = oci_model.get_manifest_for_tag(latest_tag)
     assert subject is not None
 
-    referrers = oci_model.lookup_cached_referrers_for_manifest(
-        model_cache, repository_ref, subject
-    )
+    referrers = oci_model.lookup_cached_referrers_for_manifest(model_cache, repository_ref, subject)
     assert referrers == []
 
 
@@ -1598,9 +1594,7 @@ def test_lookup_cached_referrers_serialization_roundtrip(oci_model):
     ref1 = _create_oci_manifest_with_subject(oci_model, repository_ref, subject)
     ref2 = _create_oci_manifest_with_subject(oci_model, repository_ref, subject)
 
-    referrers = oci_model.lookup_cached_referrers_for_manifest(
-        model_cache, repository_ref, subject
-    )
+    referrers = oci_model.lookup_cached_referrers_for_manifest(model_cache, repository_ref, subject)
     assert len(referrers) >= 2
 
     digests_from_db = {r.digest for r in referrers}
@@ -1608,9 +1602,7 @@ def test_lookup_cached_referrers_serialization_roundtrip(oci_model):
     assert ref2.digest in digests_from_db
 
     # Fetch from cache and verify all fields survived roundtrip
-    cached = oci_model.lookup_cached_referrers_for_manifest(
-        model_cache, repository_ref, subject
-    )
+    cached = oci_model.lookup_cached_referrers_for_manifest(model_cache, repository_ref, subject)
 
     for orig, from_cache in zip(
         sorted(referrers, key=lambda m: m.digest),

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -1633,3 +1633,69 @@ def test_referrers_cache_artifact_type_isolation(initialized_db, registry_model)
         test_cache, repository_ref, created_a
     )
     assert len(unfiltered_again) == 1
+
+
+def test_referrers_cache_serialization_roundtrip(initialized_db, registry_model):
+    """
+    Verify that referrer Manifest objects survive the cache serialization
+    roundtrip: internal_manifest_bytes must be restored as a Bytes instance
+    so that get_parsed_manifest() works on cached results.
+    """
+    test_cache = InMemoryDataModelCache(TEST_CACHE_CONFIG)
+    repository_ref = registry_model.lookup_repository("devtable", "simple")
+
+    builder_a = _create_oci_manifest_with_blobs("devtable", "simple")
+    manifest_a = builder_a.build()
+
+    created_a, _ = registry_model.create_manifest_and_retarget_tag(
+        repository_ref, manifest_a, "roundtrip-subject", storage, raise_on_error=True
+    )
+    assert created_a is not None
+
+    builder_b = _create_oci_manifest_with_blobs(
+        "devtable",
+        "simple",
+        config_content=json.dumps(
+            {
+                "config": {"kind": "roundtrip-ref"},
+                "rootfs": {"type": "layers", "diff_ids": []},
+                "history": [],
+            }
+        ),
+    )
+    builder_b.set_subject(
+        manifest_a.digest,
+        len(manifest_a.bytes.as_encoded_str()),
+        manifest_a.media_type,
+    )
+    manifest_b = builder_b.build()
+
+    registry_model.create_manifest_with_temp_tag(
+        repository_ref, manifest_b, 300, storage, model_cache=test_cache
+    )
+
+    referrers = registry_model.lookup_cached_referrers_for_manifest(
+        test_cache, repository_ref, created_a
+    )
+    assert len(referrers) == 1
+
+    cached = registry_model.lookup_cached_referrers_for_manifest(
+        test_cache, repository_ref, created_a
+    )
+    assert len(cached) == 1
+
+    for orig, from_cache in zip(
+        sorted(referrers, key=lambda m: m.digest),
+        sorted(cached, key=lambda m: m.digest),
+        strict=True,
+    ):
+        assert from_cache.digest == orig.digest
+        assert from_cache.media_type == orig.media_type
+        assert from_cache._db_id == orig._db_id
+
+        assert from_cache.internal_manifest_bytes is not None
+        assert isinstance(from_cache.internal_manifest_bytes, Bytes)
+        assert from_cache.internal_manifest_bytes.as_encoded_str() == (
+            orig.internal_manifest_bytes.as_encoded_str()
+        )
+        assert from_cache.get_parsed_manifest() is not None

--- a/web/playwright/e2e/repository/referrers-api.spec.ts
+++ b/web/playwright/e2e/repository/referrers-api.spec.ts
@@ -1,9 +1,12 @@
 /**
- * OCI Referrers API Response Tests
+ * OCI Referrers API — Mocked Smoke Tests
  *
- * Verifies that the /v2/.../referrers/<digest> endpoint returns a valid
- * OCI image index response. Uses Playwright's API request context with
- * route mocking to validate the response shape.
+ * These tests validate the expected OCI referrers response shape using
+ * mocked routes. They do NOT hit the real backend.
+ *
+ * For real end-to-end referrers tests (pushing images, attaching via
+ * oras, fetching the live endpoint), see api-v2.spec.ts which covers
+ * the full "list referrers for manifest" flow with actual data.
  *
  * Related fix: serialization of Manifest objects in the referrers Redis
  * cache (lookup_cached_referrers_for_manifest).
@@ -38,139 +41,135 @@ const MOCK_REFERRERS_INDEX = {
   ],
 };
 
-const EMPTY_REFERRERS_INDEX = {
-  schemaVersion: 2,
-  mediaType: 'application/vnd.oci.image.index.v1+json',
-  manifests: [],
-};
+test.describe(
+  'OCI Referrers API (mocked)',
+  {tag: ['@repository']},
+  () => {
+    test('returns a valid OCI index with referrers', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const repo = await api.repository();
 
-test.describe('OCI Referrers API', {tag: ['@repository']}, () => {
-  test('returns a valid OCI index with referrers for a manifest', async ({
-    authenticatedPage,
-    api,
-  }) => {
-    const repo = await api.repository();
+      await authenticatedPage.route(
+        `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}`,
+        async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/vnd.oci.image.index.v1+json',
+            body: JSON.stringify(MOCK_REFERRERS_INDEX),
+          });
+        },
+      );
 
-    await authenticatedPage.route(
-      `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}`,
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/vnd.oci.image.index.v1+json',
-          body: JSON.stringify(MOCK_REFERRERS_INDEX),
-        });
-      },
-    );
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
-    // Navigate to the repo page so the page has a valid origin for fetch
-    await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      const response = await authenticatedPage.evaluate(
+        async ({ns, name, digest}) => {
+          const res = await fetch(`/v2/${ns}/${name}/referrers/${digest}`);
+          return {
+            status: res.status,
+            contentType: res.headers.get('content-type'),
+            body: await res.json(),
+          };
+        },
+        {ns: repo.namespace, name: repo.name, digest: SUBJECT_DIGEST},
+      );
 
-    const response = await authenticatedPage.evaluate(
-      async ({ns, name, digest}) => {
-        const res = await fetch(`/v2/${ns}/${name}/referrers/${digest}`);
-        return {
-          status: res.status,
-          contentType: res.headers.get('content-type'),
-          body: await res.json(),
-        };
-      },
-      {ns: repo.namespace, name: repo.name, digest: SUBJECT_DIGEST},
-    );
+      expect(response.status).toBe(200);
+      expect(response.contentType).toContain(
+        'application/vnd.oci.image.index.v1+json',
+      );
+      expect(response.body.schemaVersion).toBe(2);
+      expect(response.body.manifests).toHaveLength(2);
+      expect(response.body.manifests[0].artifactType).toBe(
+        'application/vnd.example.sbom.v1',
+      );
+      expect(response.body.manifests[1].artifactType).toBe(
+        'application/vnd.example.signature.v1',
+      );
+    });
 
-    expect(response.status).toBe(200);
-    expect(response.contentType).toContain(
-      'application/vnd.oci.image.index.v1+json',
-    );
-    expect(response.body.schemaVersion).toBe(2);
-    expect(response.body.manifests).toHaveLength(2);
-    expect(response.body.manifests[0].artifactType).toBe(
-      'application/vnd.example.sbom.v1',
-    );
-    expect(response.body.manifests[1].artifactType).toBe(
-      'application/vnd.example.signature.v1',
-    );
-  });
+    test('returns an empty OCI index when no referrers exist', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const repo = await api.repository();
 
-  test('returns an empty OCI index when no referrers exist', async ({
-    authenticatedPage,
-    api,
-  }) => {
-    const repo = await api.repository();
+      await authenticatedPage.route(
+        `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}`,
+        async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/vnd.oci.image.index.v1+json',
+            body: JSON.stringify({
+              schemaVersion: 2,
+              mediaType: 'application/vnd.oci.image.index.v1+json',
+              manifests: [],
+            }),
+          });
+        },
+      );
 
-    await authenticatedPage.route(
-      `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}`,
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/vnd.oci.image.index.v1+json',
-          body: JSON.stringify(EMPTY_REFERRERS_INDEX),
-        });
-      },
-    );
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
-    await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      const response = await authenticatedPage.evaluate(
+        async ({ns, name, digest}) => {
+          const res = await fetch(`/v2/${ns}/${name}/referrers/${digest}`);
+          return {status: res.status, body: await res.json()};
+        },
+        {ns: repo.namespace, name: repo.name, digest: SUBJECT_DIGEST},
+      );
 
-    const response = await authenticatedPage.evaluate(
-      async ({ns, name, digest}) => {
-        const res = await fetch(`/v2/${ns}/${name}/referrers/${digest}`);
-        return {
-          status: res.status,
-          body: await res.json(),
-        };
-      },
-      {ns: repo.namespace, name: repo.name, digest: SUBJECT_DIGEST},
-    );
+      expect(response.status).toBe(200);
+      expect(response.body.schemaVersion).toBe(2);
+      expect(response.body.manifests).toHaveLength(0);
+    });
 
-    expect(response.status).toBe(200);
-    expect(response.body.schemaVersion).toBe(2);
-    expect(response.body.manifests).toHaveLength(0);
-  });
+    test('supports artifactType filtering via query parameter', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const repo = await api.repository();
+      const filteredIndex = {
+        ...MOCK_REFERRERS_INDEX,
+        manifests: [MOCK_REFERRERS_INDEX.manifests[0]],
+      };
 
-  test('supports artifactType filtering via query parameter', async ({
-    authenticatedPage,
-    api,
-  }) => {
-    const repo = await api.repository();
-    const filteredIndex = {
-      ...MOCK_REFERRERS_INDEX,
-      manifests: [MOCK_REFERRERS_INDEX.manifests[0]],
-    };
+      await authenticatedPage.route(
+        `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}?**`,
+        async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/vnd.oci.image.index.v1+json',
+            headers: {'OCI-Filters-Applied': 'artifactType'},
+            body: JSON.stringify(filteredIndex),
+          });
+        },
+      );
 
-    await authenticatedPage.route(
-      `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}?**`,
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/vnd.oci.image.index.v1+json',
-          headers: {
-            'OCI-Filters-Applied': 'artifactType',
-          },
-          body: JSON.stringify(filteredIndex),
-        });
-      },
-    );
+      await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
-    await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+      const response = await authenticatedPage.evaluate(
+        async ({ns, name, digest}) => {
+          const res = await fetch(
+            `/v2/${ns}/${name}/referrers/${digest}?artifactType=application/vnd.example.sbom.v1`,
+          );
+          return {
+            status: res.status,
+            filtersApplied: res.headers.get('oci-filters-applied'),
+            body: await res.json(),
+          };
+        },
+        {ns: repo.namespace, name: repo.name, digest: SUBJECT_DIGEST},
+      );
 
-    const response = await authenticatedPage.evaluate(
-      async ({ns, name, digest}) => {
-        const res = await fetch(
-          `/v2/${ns}/${name}/referrers/${digest}?artifactType=application/vnd.example.sbom.v1`,
-        );
-        return {
-          status: res.status,
-          filtersApplied: res.headers.get('oci-filters-applied'),
-          body: await res.json(),
-        };
-      },
-      {ns: repo.namespace, name: repo.name, digest: SUBJECT_DIGEST},
-    );
-
-    expect(response.status).toBe(200);
-    expect(response.filtersApplied).toBe('artifactType');
-    expect(response.body.manifests).toHaveLength(1);
-    expect(response.body.manifests[0].artifactType).toBe(
-      'application/vnd.example.sbom.v1',
-    );
-  });
-});
+      expect(response.status).toBe(200);
+      expect(response.filtersApplied).toBe('artifactType');
+      expect(response.body.manifests).toHaveLength(1);
+      expect(response.body.manifests[0].artifactType).toBe(
+        'application/vnd.example.sbom.v1',
+      );
+    });
+  },
+);

--- a/web/playwright/e2e/repository/referrers-api.spec.ts
+++ b/web/playwright/e2e/repository/referrers-api.spec.ts
@@ -1,9 +1,9 @@
 /**
- * OCI Referrers API Tests
+ * OCI Referrers API Response Tests
  *
  * Verifies that the /v2/.../referrers/<digest> endpoint returns a valid
- * OCI image index response. Uses API route mocking to simulate the
- * referrers listing returned by the backend cache layer.
+ * OCI image index response. Uses Playwright's API request context with
+ * route mocking to validate the response shape.
  *
  * Related fix: serialization of Manifest objects in the referrers Redis
  * cache (lookup_cached_referrers_for_manifest).
@@ -62,6 +62,9 @@ test.describe('OCI Referrers API', {tag: ['@repository']}, () => {
       },
     );
 
+    // Navigate to the repo page so the page has a valid origin for fetch
+    await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+
     const response = await authenticatedPage.evaluate(
       async ({ns, name, digest}) => {
         const res = await fetch(`/v2/${ns}/${name}/referrers/${digest}`);
@@ -105,6 +108,8 @@ test.describe('OCI Referrers API', {tag: ['@repository']}, () => {
       },
     );
 
+    await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
+
     const response = await authenticatedPage.evaluate(
       async ({ns, name, digest}) => {
         const res = await fetch(`/v2/${ns}/${name}/referrers/${digest}`);
@@ -132,7 +137,7 @@ test.describe('OCI Referrers API', {tag: ['@repository']}, () => {
     };
 
     await authenticatedPage.route(
-      `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}?artifactType=*`,
+      `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}?**`,
       async (route) => {
         await route.fulfill({
           status: 200,
@@ -144,6 +149,8 @@ test.describe('OCI Referrers API', {tag: ['@repository']}, () => {
         });
       },
     );
+
+    await authenticatedPage.goto(`/repository/${repo.fullName}?tab=tags`);
 
     const response = await authenticatedPage.evaluate(
       async ({ns, name, digest}) => {

--- a/web/playwright/e2e/repository/referrers-api.spec.ts
+++ b/web/playwright/e2e/repository/referrers-api.spec.ts
@@ -64,9 +64,7 @@ test.describe('OCI Referrers API', {tag: ['@repository']}, () => {
 
     const response = await authenticatedPage.evaluate(
       async ({ns, name, digest}) => {
-        const res = await fetch(
-          `/v2/${ns}/${name}/referrers/${digest}`,
-        );
+        const res = await fetch(`/v2/${ns}/${name}/referrers/${digest}`);
         return {
           status: res.status,
           contentType: res.headers.get('content-type'),
@@ -109,9 +107,7 @@ test.describe('OCI Referrers API', {tag: ['@repository']}, () => {
 
     const response = await authenticatedPage.evaluate(
       async ({ns, name, digest}) => {
-        const res = await fetch(
-          `/v2/${ns}/${name}/referrers/${digest}`,
-        );
+        const res = await fetch(`/v2/${ns}/${name}/referrers/${digest}`);
         return {
           status: res.status,
           body: await res.json(),

--- a/web/playwright/e2e/repository/referrers-api.spec.ts
+++ b/web/playwright/e2e/repository/referrers-api.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * OCI Referrers API Tests
+ *
+ * Verifies that the /v2/.../referrers/<digest> endpoint returns a valid
+ * OCI image index response. Uses API route mocking to simulate the
+ * referrers listing returned by the backend cache layer.
+ *
+ * Related fix: serialization of Manifest objects in the referrers Redis
+ * cache (lookup_cached_referrers_for_manifest).
+ */
+
+import {test, expect} from '../../fixtures';
+
+const SUBJECT_DIGEST =
+  'sha256:aaaa111122223333444455556666777788889999aaaabbbbccccddddeeeeffff';
+
+const MOCK_REFERRERS_INDEX = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.oci.image.index.v1+json',
+  manifests: [
+    {
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      digest:
+        'sha256:bbbb111122223333444455556666777788889999aaaabbbbccccddddeeeeffff',
+      size: 512,
+      artifactType: 'application/vnd.example.sbom.v1',
+      annotations: {
+        'org.opencontainers.image.created': '2026-01-01T00:00:00Z',
+      },
+    },
+    {
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      digest:
+        'sha256:cccc111122223333444455556666777788889999aaaabbbbccccddddeeeeffff',
+      size: 256,
+      artifactType: 'application/vnd.example.signature.v1',
+    },
+  ],
+};
+
+const EMPTY_REFERRERS_INDEX = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.oci.image.index.v1+json',
+  manifests: [],
+};
+
+test.describe('OCI Referrers API', {tag: ['@repository']}, () => {
+  test('returns a valid OCI index with referrers for a manifest', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const repo = await api.repository();
+
+    await authenticatedPage.route(
+      `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/vnd.oci.image.index.v1+json',
+          body: JSON.stringify(MOCK_REFERRERS_INDEX),
+        });
+      },
+    );
+
+    const response = await authenticatedPage.evaluate(
+      async ({ns, name, digest}) => {
+        const res = await fetch(
+          `/v2/${ns}/${name}/referrers/${digest}`,
+        );
+        return {
+          status: res.status,
+          contentType: res.headers.get('content-type'),
+          body: await res.json(),
+        };
+      },
+      {ns: repo.namespace, name: repo.name, digest: SUBJECT_DIGEST},
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.contentType).toContain(
+      'application/vnd.oci.image.index.v1+json',
+    );
+    expect(response.body.schemaVersion).toBe(2);
+    expect(response.body.manifests).toHaveLength(2);
+    expect(response.body.manifests[0].artifactType).toBe(
+      'application/vnd.example.sbom.v1',
+    );
+    expect(response.body.manifests[1].artifactType).toBe(
+      'application/vnd.example.signature.v1',
+    );
+  });
+
+  test('returns an empty OCI index when no referrers exist', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const repo = await api.repository();
+
+    await authenticatedPage.route(
+      `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/vnd.oci.image.index.v1+json',
+          body: JSON.stringify(EMPTY_REFERRERS_INDEX),
+        });
+      },
+    );
+
+    const response = await authenticatedPage.evaluate(
+      async ({ns, name, digest}) => {
+        const res = await fetch(
+          `/v2/${ns}/${name}/referrers/${digest}`,
+        );
+        return {
+          status: res.status,
+          body: await res.json(),
+        };
+      },
+      {ns: repo.namespace, name: repo.name, digest: SUBJECT_DIGEST},
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body.schemaVersion).toBe(2);
+    expect(response.body.manifests).toHaveLength(0);
+  });
+
+  test('supports artifactType filtering via query parameter', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const repo = await api.repository();
+    const filteredIndex = {
+      ...MOCK_REFERRERS_INDEX,
+      manifests: [MOCK_REFERRERS_INDEX.manifests[0]],
+    };
+
+    await authenticatedPage.route(
+      `**/v2/${repo.namespace}/${repo.name}/referrers/${SUBJECT_DIGEST}?artifactType=*`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/vnd.oci.image.index.v1+json',
+          headers: {
+            'OCI-Filters-Applied': 'artifactType',
+          },
+          body: JSON.stringify(filteredIndex),
+        });
+      },
+    );
+
+    const response = await authenticatedPage.evaluate(
+      async ({ns, name, digest}) => {
+        const res = await fetch(
+          `/v2/${ns}/${name}/referrers/${digest}?artifactType=application/vnd.example.sbom.v1`,
+        );
+        return {
+          status: res.status,
+          filtersApplied: res.headers.get('oci-filters-applied'),
+          body: await res.json(),
+        };
+      },
+      {ns: repo.namespace, name: repo.name, digest: SUBJECT_DIGEST},
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.filtersApplied).toBe('artifactType');
+    expect(response.body.manifests).toHaveLength(1);
+    expect(response.body.manifests[0].artifactType).toBe(
+      'application/vnd.example.sbom.v1',
+    );
+  });
+});

--- a/web/playwright/e2e/repository/referrers-cache.spec.ts
+++ b/web/playwright/e2e/repository/referrers-cache.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * OCI Referrers cache serialization e2e test.
+ *
+ * Validates that the referrers endpoint returns consistent results across
+ * repeated calls (exercising the cache serialization/deserialization path).
+ */
+
+import path from 'path';
+import {test, expect, uniqueName} from '../../fixtures';
+import {TEST_USERS} from '../../global-setup';
+import {ApiClient} from '../../utils/api';
+import {getV2Token} from '../../utils/api/auth';
+import {pushImage, orasAttach, isOrasAvailable} from '../../utils/container';
+import {API_URL} from '../../utils/config';
+
+test.describe(
+  'OCI Referrers Cache',
+  {tag: ['@repository', '@container', '@auth:Database']},
+  () => {
+    test.describe.configure({mode: 'serial'});
+
+    const username = TEST_USERS.user.username;
+    const password = TEST_USERS.user.password;
+
+    let orgName: string;
+    let repoName: string;
+    let manifestDigest: string;
+
+    test.beforeAll(async ({userContext, cachedContainerAvailable}) => {
+      if (!cachedContainerAvailable) return;
+
+      const api = new ApiClient(userContext.request);
+
+      orgName = uniqueName('refcache');
+      repoName = uniqueName('repo');
+
+      await api.createOrganization(orgName, `${orgName}@example.com`);
+      await api.createRepository(orgName, repoName, 'public');
+      await pushImage(orgName, repoName, 'latest', username, password);
+
+      const scope = `repository:${orgName}/${repoName}:pull,push`;
+      const v2Token = await getV2Token(
+        userContext.request,
+        API_URL,
+        username,
+        password,
+        scope,
+      );
+      const r = await userContext.request.get(
+        `${API_URL}/v2/${orgName}/${repoName}/manifests/latest`,
+        {
+          headers: {
+            authorization: `Bearer ${v2Token}`,
+            Accept: 'application/vnd.docker.distribution.manifest.v2+json',
+          },
+        },
+      );
+      expect(r.status()).toBe(200);
+      manifestDigest = r.headers()['docker-content-digest'];
+      expect(manifestDigest).toBeTruthy();
+    });
+
+    test.afterAll(async ({userContext, cachedContainerAvailable}) => {
+      if (!cachedContainerAvailable || !orgName) return;
+
+      const api = new ApiClient(userContext.request);
+      try {
+        await api.deleteRepository(orgName, repoName);
+      } catch {
+        /* ignore */
+      }
+      try {
+        await api.deleteOrganization(orgName);
+      } catch {
+        /* ignore */
+      }
+    });
+
+    test('referrers endpoint returns consistent results across repeated calls', async ({
+      playwright,
+    }) => {
+      const orasAvailable = await isOrasAvailable();
+      test.skip(!orasAvailable, 'oras CLI required for referrer tests');
+
+      const fixturesDir = path.resolve(__dirname, '../../fixtures/oras');
+
+      orasAttach(
+        orgName,
+        repoName,
+        'latest',
+        username,
+        password,
+        'application/spdx+json',
+        'producer=test',
+        path.join(fixturesDir, 'referrer.spdx.json'),
+      );
+
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+      try {
+        const scope = `repository:${orgName}/${repoName}:pull,push`;
+        const v2Token = await getV2Token(
+          request,
+          API_URL,
+          username,
+          password,
+          scope,
+        );
+
+        const url = `${API_URL}/v2/${orgName}/${repoName}/referrers/${manifestDigest}`;
+        const headers = {authorization: `Bearer ${v2Token}`};
+
+        // Wait for the referrer to appear
+        await expect
+          .poll(
+            async () => {
+              const r = await request.get(url, {headers});
+              expect(r.status()).toBe(200);
+              const body = await r.json();
+              return body.manifests.length;
+            },
+            {
+              message: 'Waiting for referrer to appear in index',
+              timeout: 10_000,
+              intervals: [500, 1_000, 2_000],
+            },
+          )
+          .toBe(1);
+
+        // Second call exercises the cache hit path; response must be identical
+        const cached = await request.get(url, {headers});
+        expect(cached.status()).toBe(200);
+        const cachedBody = await cached.json();
+        expect(cachedBody.manifests).toHaveLength(1);
+        expect(cachedBody.manifests[0].artifactType).toBe(
+          'application/spdx+json',
+        );
+      } finally {
+        await request.dispose();
+      }
+    });
+  },
+);


### PR DESCRIPTION
[QUAYIO-2047](https://redhat.atlassian.net/browse/QUAYIO-2047)

## Context

Follow-up to [#6511](https://github.com/quay/quay/pull/6511) which introduced referrers cache serialization. That PR resolved the core serialization issue but introduced two bugs that still cause the original Sentry error in production:

```
TypeError: Object of type Manifest is not JSON serializable
at data/cache/impl.py:333 (RedisDataModelCache.retrieve)
transaction: v2.list_manifest_referrers
```

Confirmed still firing in production as of 2026-08-05 (Sentry event ac86c75c).

## Bugs Fixed

### 1. Missing null guard on `internal_manifest_bytes`

When `Manifest.select()` omits the `manifest_bytes` column (documented in `datatypes.py`), `internal_manifest_bytes` is `None`. PR #6511 unconditionally calls `.as_unicode()` on it during serialization and `Bytes.for_string_or_unicode()` during deserialization, which would raise `AttributeError`.

**Fix:** Add null checks on both serialization and deserialization paths.

### 2. Wrong key name: `legacy_image_handler` → `legacy_image_row`

The `inputs` dict has a key `legacy_image_row` (set by the `Manifest` datatype constructor), but #6511 nullifies the non-existent key `legacy_image_handler`. This leaves the real non-serializable `legacy_image_row` object in the dict, which causes `json.dumps()` to fail with `TypeError: Object of type Manifest is not JSON serializable`.

**Fix:** Use the correct key name `legacy_image_row`.

## Test

Adds `test_referrers_cache_serialization_roundtrip` to verify:
- `internal_manifest_bytes` survives the cache roundtrip as a `Bytes` instance
- `get_parsed_manifest()` succeeds on cached referrer objects

Jira: https://issues.redhat.com/browse/QUAYIO-2047
