### PR TITLE
NO-ISSUE: test(playwright): add service-safe e2e target

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -55,6 +55,8 @@
     "test:e2e:check-required-tags": "node playwright/ensure-required-tags.cjs",
     "test:e2e:fix-required-tags": "node playwright/ensure-required-tags.cjs --write",
     "test:e2e:no-api": "playwright test --grep-invert @api",
+    "test:e2e:service": "QUAY_E2E_TARGET=${QUAY_E2E_TARGET:-stage} PLAYWRIGHT_SKIP_WEBSERVER=1 playwright test",
+    "test:e2e:service:config": "vitest run --config playwright/vitest.config.ts",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
     "test:e2e:headed": "playwright test --headed",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,4 +1,15 @@
 import {defineConfig, devices} from '@playwright/test';
+import {
+  BASE_URL,
+  getPlaywrightGrep,
+  getPlaywrightWorkers,
+  isServiceMode,
+  requireServiceTargetAllowed,
+} from './playwright/utils/config';
+
+requireServiceTargetAllowed();
+
+const grep = getPlaywrightGrep();
 
 /**
  * Playwright configuration for Quay E2E tests
@@ -6,6 +17,7 @@ import {defineConfig, devices} from '@playwright/test';
  */
 export default defineConfig({
   testDir: './playwright/e2e',
+  grep: grep ? new RegExp(grep) : undefined,
 
   // Global setup to create test users before all tests
   globalSetup: require.resolve('./playwright/global-setup'),
@@ -16,7 +28,7 @@ export default defineConfig({
   // Run tests in parallel — fixed at 4 for CI so Quay isn't overwhelmed by
   // more workers than it can sustain, regardless of runner CPU count.
   fullyParallel: true,
-  workers: process.env.CI ? 4 : undefined,
+  workers: getPlaywrightWorkers(),
 
   // Fail the build on CI if you accidentally left test.only in the source code
   forbidOnly: !!process.env.CI,
@@ -34,7 +46,7 @@ export default defineConfig({
   // Shared settings for all tests
   use: {
     // Base URL for navigation
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080',
+    baseURL: BASE_URL,
 
     // Accept self-signed certificates (needed for OpenShift CI clusters)
     ignoreHTTPSErrors: true,
@@ -67,14 +79,16 @@ export default defineConfig({
   // Note: In OpenShift CI (Prow), services are already running on the cluster.
   // API-only tests (test:api) skip this since they only need Quay, not the frontend.
   webServer:
-    process.env.OPENSHIFT_CI || process.env.PLAYWRIGHT_SKIP_WEBSERVER
+    process.env.OPENSHIFT_CI ||
+    process.env.PLAYWRIGHT_SKIP_WEBSERVER ||
+    isServiceMode()
       ? undefined
       : {
           command:
             'REACT_QUAY_APP_API_URL=http://localhost:8080 npm run build && ' +
             'rm -rf ../static/patternfly && mkdir -p ../static/patternfly && cp -r dist/* ../static/patternfly/ && ' +
             'echo "React deployed to static/patternfly/" && tail -f /dev/null',
-          url: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080',
+          url: BASE_URL,
           reuseExistingServer: true,
           timeout: 120 * 1000,
         },

--- a/web/playwright/README.md
+++ b/web/playwright/README.md
@@ -22,14 +22,16 @@ QUAY_E2E_ALLOW_PROD=1 \
 pnpm run test:e2e:service
 ```
 
-Run it against another deployment with explicit URLs:
+Run it against another deployment with the original explicit URL overrides:
 
 ```bash
-QUAY_E2E_TARGET=custom \
 PLAYWRIGHT_BASE_URL=https://quay.example.test \
-REACT_QUAY_APP_API_URL=https://quay.example.test \
 pnpm run test:e2e:service
 ```
+
+Set `REACT_QUAY_APP_API_URL` as well when the API endpoint differs from the
+frontend URL. Use `QUAY_E2E_TARGET=custom` when you want the target name to
+reflect a non-stage/non-prod service.
 
 Service mode intentionally:
 
@@ -55,9 +57,7 @@ Repository read checks can be pointed at a target-specific public image with:
 QUAY_E2E_PUBLIC_REPOSITORY=<namespace/repository> \
 QUAY_E2E_PUBLIC_TAG=<tag> \
 PLAYWRIGHT_GREP=@service-integration \
-QUAY_E2E_TARGET=custom \
 PLAYWRIGHT_BASE_URL=https://quay.example.test \
-REACT_QUAY_APP_API_URL=https://quay.example.test \
 pnpm run test:e2e:service
 ```
 

--- a/web/playwright/README.md
+++ b/web/playwright/README.md
@@ -1,0 +1,76 @@
+# Quay Web Playwright
+
+## Service Suite
+
+Service mode targets an already-running Quay deployment and only runs tests
+tagged `@service-safe` by default. These tests must be read-only or otherwise
+safe to run against shared deployments. Do not tag tests that create, update, or
+delete organizations, repositories, tags, users, robot accounts, permissions,
+messages, builds, or superuser settings.
+
+Run the current service-safe subset against stage with:
+
+```bash
+QUAY_E2E_TARGET=stage pnpm run test:e2e:service
+```
+
+Run it against production with the required production guard:
+
+```bash
+QUAY_E2E_TARGET=prod \
+QUAY_E2E_ALLOW_PROD=1 \
+pnpm run test:e2e:service
+```
+
+Run it against another deployment with explicit URLs:
+
+```bash
+QUAY_E2E_TARGET=custom \
+PLAYWRIGHT_BASE_URL=https://quay.example.test \
+REACT_QUAY_APP_API_URL=https://quay.example.test \
+pnpm run test:e2e:service
+```
+
+Service mode intentionally:
+
+- skips the local Playwright webserver build/deploy step
+- skips global setup that creates fixed local users such as `admin`,
+  `testuser`, and `readonly`
+- filters to `@service-safe` unless `PLAYWRIGHT_GREP` is set
+- uses one worker unless `PLAYWRIGHT_WORKERS` is set
+- does not require or use superuser credentials
+
+Additional service tags:
+
+- `@service-safe`: default read-only checks expected to pass against shared
+  stage and prod deployments
+- `@service-integration`: read-only checks that require target-specific
+  external dependencies or known public repositories
+- `@service-mutating`: stage-only checks that create or delete disposable test
+  data
+
+Repository read checks can be pointed at a target-specific public image with:
+
+```bash
+QUAY_E2E_PUBLIC_REPOSITORY=<namespace/repository> \
+QUAY_E2E_PUBLIC_TAG=<tag> \
+PLAYWRIGHT_GREP=@service-integration \
+QUAY_E2E_TARGET=custom \
+PLAYWRIGHT_BASE_URL=https://quay.example.test \
+REACT_QUAY_APP_API_URL=https://quay.example.test \
+pnpm run test:e2e:service
+```
+
+Optional regular-user credentials can be supplied for future authenticated
+service tests:
+
+```bash
+QUAY_E2E_USERNAME=<username> \
+QUAY_E2E_PASSWORD=<password> \
+QUAY_E2E_TOKEN=<optional-token> \
+QUAY_E2E_TARGET=stage \
+pnpm run test:e2e:service
+```
+
+The initial service suite includes only unauthenticated/read-only smoke
+coverage.

--- a/web/playwright/e2e/api/service-readonly.spec.ts
+++ b/web/playwright/e2e/api/service-readonly.spec.ts
@@ -1,0 +1,141 @@
+import type {APIRequestContext, APIResponse} from '@playwright/test';
+import {test, expect} from '../../fixtures';
+import {API_URL} from '../../utils/config';
+
+const DEFAULT_PUBLIC_REPOSITORY = 'quay-qetest/alpine';
+const DEFAULT_PUBLIC_TAG = 'latest';
+const MANIFEST_ACCEPT = [
+  'application/vnd.docker.distribution.manifest.v2+json',
+  'application/vnd.docker.distribution.manifest.list.v2+json',
+  'application/vnd.oci.image.manifest.v1+json',
+  'application/vnd.oci.image.index.v1+json',
+].join(', ');
+
+type QuayTag = {
+  name: string;
+};
+
+function getPublicRepository(): string {
+  return (
+    process.env.QUAY_E2E_PUBLIC_REPOSITORY || DEFAULT_PUBLIC_REPOSITORY
+  ).replace(/^https?:\/\/[^/]+\//, '');
+}
+
+function getPublicTag(): string {
+  return process.env.QUAY_E2E_PUBLIC_TAG || DEFAULT_PUBLIC_TAG;
+}
+
+async function expectStatus(
+  response: APIResponse,
+  expectedStatus: number,
+  label: string,
+): Promise<void> {
+  if (response.status() === expectedStatus) return;
+
+  throw new Error(
+    `${label} returned ${response.status()} instead of ${expectedStatus}: ${await response.text()}`,
+  );
+}
+
+async function getAnonymousV2Token(
+  request: APIRequestContext,
+  repository: string,
+): Promise<string> {
+  const params = new URLSearchParams({
+    service: new URL(API_URL).host,
+    scope: `repository:${repository}:pull`,
+  });
+  const response = await request.get(`${API_URL}/v2/auth?${params.toString()}`);
+  await expectStatus(response, 200, 'Anonymous v2 auth');
+
+  const body = (await response.json()) as {token?: string};
+  if (!body.token) {
+    throw new Error('Anonymous v2 auth did not return a token');
+  }
+
+  return body.token;
+}
+
+test.describe(
+  'Service read-only APIs',
+  {tag: ['@api', '@service-safe']},
+  () => {
+    test('health and discovery endpoints are readable', async ({request}) => {
+      for (const endpoint of [
+        '/health/instance',
+        '/health/endtoend',
+        '/health/warning',
+      ]) {
+        const response = await request.get(`${API_URL}${endpoint}`);
+        await expectStatus(response, 200, endpoint);
+        const body = await response.json();
+        expect(body.status_code).toBe(200);
+        expect(body.data?.services).toBeTruthy();
+      }
+
+      const discoveryResponse = await request.get(
+        `${API_URL}/api/v1/discovery`,
+      );
+      await expectStatus(discoveryResponse, 200, '/api/v1/discovery');
+      const discovery = await discoveryResponse.json();
+      expect(Object.keys(discovery).length).toBeGreaterThan(0);
+    });
+
+    test('registry v2 endpoint is reachable', async ({request}) => {
+      const response = await request.get(`${API_URL}/v2/`);
+
+      expect([200, 401]).toContain(response.status());
+      if (response.status() === 401) {
+        expect(response.headers()['www-authenticate']).toContain('/v2/auth');
+      }
+    });
+  },
+);
+
+test.describe(
+  'Service public repository reads',
+  {tag: ['@api', '@service-integration']},
+  () => {
+    test('public repository is readable through registry v2', async ({
+      request,
+    }) => {
+      const repository = getPublicRepository();
+      const preferredTag = getPublicTag();
+      const token = await getAnonymousV2Token(request, repository);
+      const authHeaders = {authorization: `Bearer ${token}`};
+      const v2TagsResponse = await request.get(
+        `${API_URL}/v2/${repository}/tags/list`,
+        {headers: authHeaders},
+      );
+      await expectStatus(v2TagsResponse, 200, `/v2/${repository}/tags/list`);
+      const v2TagsBody = (await v2TagsResponse.json()) as {tags?: string[]};
+      const tags = (v2TagsBody.tags || []).map((name) => ({name}));
+      const tag =
+        tags.find((candidate) => candidate.name === preferredTag) || tags[0];
+
+      if (!tag?.name) {
+        throw new Error(
+          `${repository} did not expose readable tags (set QUAY_E2E_PUBLIC_REPOSITORY if this target uses a different public repo)`,
+        );
+      }
+
+      const v2ManifestResponse = await request.get(
+        `${API_URL}/v2/${repository}/manifests/${tag.name}`,
+        {
+          headers: {
+            ...authHeaders,
+            Accept: MANIFEST_ACCEPT,
+          },
+        },
+      );
+      await expectStatus(
+        v2ManifestResponse,
+        200,
+        `/v2/${repository}/manifests/${tag.name}`,
+      );
+      expect(
+        v2ManifestResponse.headers()['docker-content-digest'],
+      ).toBeTruthy();
+    });
+  },
+);

--- a/web/playwright/e2e/api/smoke.spec.ts
+++ b/web/playwright/e2e/api/smoke.spec.ts
@@ -8,74 +8,88 @@
 
 import {test, expect, uniqueName} from '../../fixtures';
 
-test.describe('API Smoke', {tag: ['@api', '@smoke', '@auth:Database']}, () => {
-  test('admin can create, read, and delete an organization', async ({
-    adminClient,
-  }) => {
-    const orgName = uniqueName('smoke_org');
-    try {
-      const create = await adminClient.post('/api/v1/organization/', {
-        name: orgName,
-        email: `${orgName}@example.com`,
-      });
-      expect(create.status()).toBe(201);
+test.describe('API Smoke', {tag: ['@api', '@smoke']}, () => {
+  test(
+    'admin can create, read, and delete an organization',
+    {tag: '@auth:Database'},
+    async ({adminClient}) => {
+      const orgName = uniqueName('smoke_org');
+      try {
+        const create = await adminClient.post('/api/v1/organization/', {
+          name: orgName,
+          email: `${orgName}@example.com`,
+        });
+        expect(create.status()).toBe(201);
 
-      const get = await adminClient.get(`/api/v1/organization/${orgName}`);
-      expect(get.status()).toBe(200);
-      const body = await get.json();
-      expect(body.name).toBe(orgName);
-    } finally {
-      await adminClient.delete(`/api/v1/organization/${orgName}`);
-    }
-  });
+        const get = await adminClient.get(`/api/v1/organization/${orgName}`);
+        expect(get.status()).toBe(200);
+        const body = await get.json();
+        expect(body.name).toBe(orgName);
+      } finally {
+        await adminClient.delete(`/api/v1/organization/${orgName}`);
+      }
+    },
+  );
 
-  test('admin can create a repository in an organization', async ({
-    adminClient,
-  }) => {
-    const orgName = uniqueName('smoke_org');
-    try {
-      await adminClient.post('/api/v1/organization/', {
-        name: orgName,
-        email: `${orgName}@example.com`,
-      });
+  test(
+    'admin can create a repository in an organization',
+    {tag: '@auth:Database'},
+    async ({adminClient}) => {
+      const orgName = uniqueName('smoke_org');
+      try {
+        await adminClient.post('/api/v1/organization/', {
+          name: orgName,
+          email: `${orgName}@example.com`,
+        });
 
-      const response = await adminClient.post('/api/v1/repository', {
-        namespace: orgName,
-        repository: uniqueName('smoke_repo'),
-        visibility: 'private',
-        description: 'smoke test repo',
-        repo_kind: 'image',
-      });
-      expect(response.status()).toBe(201);
-    } finally {
-      await adminClient.delete(`/api/v1/organization/${orgName}`);
-    }
-  });
+        const response = await adminClient.post('/api/v1/repository', {
+          namespace: orgName,
+          repository: uniqueName('smoke_repo'),
+          visibility: 'private',
+          description: 'smoke test repo',
+          repo_kind: 'image',
+        });
+        expect(response.status()).toBe(201);
+      } finally {
+        await adminClient.delete(`/api/v1/organization/${orgName}`);
+      }
+    },
+  );
 
-  test('normal user gets 403 on superuser endpoints', async ({userClient}) => {
-    const response = await userClient.get('/api/v1/superuser/users/');
-    expect(response.status()).toBe(403);
-  });
+  test(
+    'normal user gets 403 on superuser endpoints',
+    {tag: '@auth:Database'},
+    async ({userClient}) => {
+      const response = await userClient.get('/api/v1/superuser/users/');
+      expect(response.status()).toBe(403);
+    },
+  );
 
-  test('unauthenticated request is rejected', async ({anonClient}) => {
-    const response = await anonClient.get('/api/v1/user/');
-    // Quay returns 401 or 403 depending on auth configuration
-    expect([401, 403]).toContain(response.status());
-  });
+  test(
+    'unauthenticated request is rejected',
+    {tag: '@service-safe'},
+    async ({anonClient}) => {
+      const response = await anonClient.get('/api/v1/user/');
+      // Quay returns 401 or 403 depending on auth configuration
+      expect([401, 403]).toContain(response.status());
+    },
+  );
 
-  test('public config exposes bootstrap feature flag without internal token settings', async ({
-    request,
-  }) => {
-    const response = await request.get('/config');
-    expect(response.ok()).toBeTruthy();
+  test(
+    'public config exposes bootstrap feature flag without internal token settings',
+    {tag: '@service-safe'},
+    async ({request}) => {
+      const response = await request.get('/config');
+      expect(response.ok()).toBeTruthy();
 
-    const body = await response.json();
-    expect(body.features).toHaveProperty('PROGRAMMATIC_BOOTSTRAP');
-    expect(typeof body.features.PROGRAMMATIC_BOOTSTRAP).toBe('boolean');
-    expect(body.config).not.toHaveProperty('BOOTSTRAP_APP_NAME');
-    expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_OWNER');
-    expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_PATH');
-    expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_SCOPE');
-    expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_EXPIRATION');
-  });
+      const body = await response.json();
+      expect(body.features).toHaveProperty('PROGRAMMATIC_BOOTSTRAP');
+      expect(typeof body.features.PROGRAMMATIC_BOOTSTRAP).toBe('boolean');
+      expect(body.config).not.toHaveProperty('BOOTSTRAP_APP_NAME');
+      expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_OWNER');
+      expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_PATH');
+      expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_SCOPE');
+      expect(body.config).not.toHaveProperty('BOOTSTRAP_TOKEN_EXPIRATION');
+    },
+  );
 });

--- a/web/playwright/e2e/auth/create-account.spec.ts
+++ b/web/playwright/e2e/auth/create-account.spec.ts
@@ -39,7 +39,7 @@ const test = base.extend<CreateAccountFixtures>({
   },
 });
 
-test.describe('Create Account Page', {tag: ['@auth']}, () => {
+test.describe('Create Account Page', {tag: ['@auth', '@auth:Database']}, () => {
   test('form validation prevents invalid submissions', async ({
     createAccountPage,
   }) => {

--- a/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
+++ b/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
@@ -10,13 +10,11 @@ test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
     });
   });
 
-  test('sign-in page renders', async ({page}) => {
+  test('sign-in page renders', {tag: '@service-safe'}, async ({page}) => {
     await page.goto('/signin/', {waitUntil: 'domcontentloaded'});
-    await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
-    // Angular signin page has a form with username/password inputs
-    await expect(page.locator('input[name="username"]')).toBeVisible({
-      timeout: 10000,
-    });
+    await expect(page.locator('body')).toContainText(
+      /Sign in|Log in to your (Red Hat )?account|Red Hat login/i,
+    );
   });
 
   test('repository list page loads after login', async ({page, request}) => {
@@ -62,21 +60,29 @@ test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
     });
   });
 
-  test('about page loads', async ({page}) => {
+  test('about page loads', {tag: '@service-safe'}, async ({page}) => {
     await page.goto('/about/', {waitUntil: 'domcontentloaded'});
     await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
   });
 
-  test('API health endpoint is reachable through nginx', async ({request}) => {
-    const response = await request.get('/health/instance');
-    expect(response.ok()).toBeTruthy();
-  });
+  test(
+    'API health endpoint is reachable through nginx',
+    {tag: '@service-safe'},
+    async ({request}) => {
+      const response = await request.get('/health/instance');
+      expect(response.ok()).toBeTruthy();
+    },
+  );
 
-  test('API config endpoint returns expected fields', async ({request}) => {
-    const response = await request.get(`${API_URL}/config`);
-    expect(response.ok()).toBeTruthy();
-    const config = await response.json();
-    expect(config).toHaveProperty('features');
-    expect(config).toHaveProperty('config');
-  });
+  test(
+    'API config endpoint returns expected fields',
+    {tag: '@service-safe'},
+    async ({request}) => {
+      const response = await request.get(`${API_URL}/config`);
+      expect(response.ok()).toBeTruthy();
+      const config = await response.json();
+      expect(config).toHaveProperty('features');
+      expect(config).toHaveProperty('config');
+    },
+  );
 });

--- a/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
+++ b/web/playwright/e2e/legacy-ui/angular-smoke.spec.ts
@@ -1,5 +1,6 @@
 import {test, expect} from '@playwright/test';
 import {API_URL} from '../../utils/config';
+import {expectSigninPageForTarget} from '../../utils/signin';
 import {TEST_USERS} from '../../global-setup';
 
 test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
@@ -12,9 +13,7 @@ test.describe('Angular UI Smoke Tests', {tag: ['@legacy-ui', '@smoke']}, () => {
 
   test('sign-in page renders', {tag: '@service-safe'}, async ({page}) => {
     await page.goto('/signin/', {waitUntil: 'domcontentloaded'});
-    await expect(page.locator('body')).toContainText(
-      /Sign in|Log in to your (Red Hat )?account|Red Hat login/i,
-    );
+    await expectSigninPageForTarget(page, {localAngularShell: true});
   });
 
   test('repository list page loads after login', async ({page, request}) => {

--- a/web/playwright/e2e/legacy-ui/ui-toggle.spec.ts
+++ b/web/playwright/e2e/legacy-ui/ui-toggle.spec.ts
@@ -1,28 +1,36 @@
 import {test, expect} from '@playwright/test';
 
 test.describe('UI Toggle', {tag: ['@legacy-ui', '@smoke']}, () => {
-  test('visiting /angular sets cookie and loads Angular UI', async ({page}) => {
-    await page.goto('/angular', {waitUntil: 'domcontentloaded'});
+  test(
+    'visiting /angular sets cookie and loads Angular UI',
+    {tag: '@service-safe'},
+    async ({page}) => {
+      await page.goto('/angular', {waitUntil: 'domcontentloaded'});
 
-    const cookies = await page.context().cookies();
-    const uiCookie = cookies.find((c) => c.name === 'defaultui');
-    expect(uiCookie?.value).toBe('angular');
+      const cookies = await page.context().cookies();
+      const uiCookie = cookies.find((c) => c.name === 'defaultui');
+      expect(uiCookie?.value).toBe('angular');
 
-    await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
-      timeout: 15000,
-    });
-  });
+      await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
+        timeout: 15000,
+      });
+    },
+  );
 
-  test('visiting /react sets cookie and loads React UI', async ({page}) => {
-    await page.goto('/react', {waitUntil: 'domcontentloaded'});
+  test(
+    'visiting /react sets cookie and loads React UI',
+    {tag: '@service-safe'},
+    async ({page}) => {
+      await page.goto('/react', {waitUntil: 'domcontentloaded'});
 
-    const cookies = await page.context().cookies();
-    const uiCookie = cookies.find((c) => c.name === 'defaultui');
-    expect(uiCookie?.value).toBe('react');
+      const cookies = await page.context().cookies();
+      const uiCookie = cookies.find((c) => c.name === 'defaultui');
+      expect(uiCookie?.value).toBe('react');
 
-    await expect(page.locator('#root')).toBeAttached({timeout: 15000});
-    await expect(page.locator('html[ng-app="quay"]')).not.toBeAttached();
-  });
+      await expect(page.locator('#root')).toBeAttached({timeout: 15000});
+      await expect(page.locator('html[ng-app="quay"]')).not.toBeAttached();
+    },
+  );
 
   test('toggling from React to Angular and back', async ({page}) => {
     // networkidle lets React finish its async auth-check redirect cycle
@@ -46,16 +54,20 @@ test.describe('UI Toggle', {tag: ['@legacy-ui', '@smoke']}, () => {
     await expect(page.locator('html[ng-app="quay"]')).not.toBeAttached();
   });
 
-  test('cookie persists across navigations', async ({page}) => {
-    await page.goto('/angular', {waitUntil: 'domcontentloaded'});
+  test(
+    'cookie persists across navigations',
+    {tag: '@service-safe'},
+    async ({page}) => {
+      await page.goto('/angular', {waitUntil: 'domcontentloaded'});
 
-    await page.goto('/', {waitUntil: 'domcontentloaded'});
-    await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
-      timeout: 15000,
-    });
+      await page.goto('/', {waitUntil: 'domcontentloaded'});
+      await expect(page.locator('html[ng-app="quay"]')).toBeAttached({
+        timeout: 15000,
+      });
 
-    const cookies = await page.context().cookies();
-    const uiCookie = cookies.find((c) => c.name === 'defaultui');
-    expect(uiCookie?.value).toBe('angular');
-  });
+      const cookies = await page.context().cookies();
+      const uiCookie = cookies.find((c) => c.name === 'defaultui');
+      expect(uiCookie?.value).toBe('angular');
+    },
+  );
 });

--- a/web/playwright/e2e/ui/service-smoke.spec.ts
+++ b/web/playwright/e2e/ui/service-smoke.spec.ts
@@ -1,0 +1,23 @@
+import {test, expect} from '../../fixtures';
+import {API_URL} from '../../utils/config';
+
+test.describe('Service-safe smoke', {tag: ['@service-safe', '@ui']}, () => {
+  test('signin page renders without authentication', async ({
+    unauthenticatedPage,
+  }) => {
+    await unauthenticatedPage.goto('/signin');
+
+    await expect(unauthenticatedPage.locator('body')).toBeVisible();
+    await expect(unauthenticatedPage.locator('body')).toContainText(
+      /Log in to your (Red Hat )?account|Red Hat login/i,
+    );
+  });
+
+  test('public config endpoint is readable', async ({request}) => {
+    const response = await request.get(`${API_URL}/config`);
+
+    expect(response.ok()).toBe(true);
+    const body = await response.json();
+    expect(body.config?.SERVER_HOSTNAME).toBeTruthy();
+  });
+});

--- a/web/playwright/e2e/ui/service-smoke.spec.ts
+++ b/web/playwright/e2e/ui/service-smoke.spec.ts
@@ -1,5 +1,6 @@
 import {test, expect} from '../../fixtures';
 import {API_URL} from '../../utils/config';
+import {expectSigninPageForTarget} from '../../utils/signin';
 
 test.describe('Service-safe smoke', {tag: ['@service-safe', '@ui']}, () => {
   test('signin page renders without authentication', async ({
@@ -7,10 +8,7 @@ test.describe('Service-safe smoke', {tag: ['@service-safe', '@ui']}, () => {
   }) => {
     await unauthenticatedPage.goto('/signin');
 
-    await expect(unauthenticatedPage.locator('body')).toBeVisible();
-    await expect(unauthenticatedPage.locator('body')).toContainText(
-      /Log in to your (Red Hat )?account|Red Hat login/i,
-    );
+    await expectSigninPageForTarget(unauthenticatedPage);
   });
 
   test('public config endpoint is readable', async ({request}) => {

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -29,7 +29,14 @@ import {
 } from '@playwright/test';
 import {uniqueName} from './utils/test-utils';
 import {TEST_USERS, TEST_USERS_OIDC, TEST_USERS_LDAP} from './global-setup';
-import {API_URL, BASE_URL} from './utils/config';
+import {
+  API_URL,
+  BASE_URL,
+  getServiceCredentials,
+  isServiceMode,
+  requireServiceUserCredentials,
+  ServiceCredentials,
+} from './utils/config';
 import {
   ApiClient,
   AutoPrunePolicy,
@@ -957,10 +964,31 @@ export function skipUnlessAuthType(
 }
 
 function getTestUsers(config?: QuayConfig | null) {
+  if (isServiceMode()) {
+    const credentials = requireServiceUserCredentials();
+    const user = {
+      username: credentials.username,
+      password: credentials.password,
+      email: `${credentials.username}@example.com`,
+    };
+
+    return {
+      admin: TEST_USERS.admin,
+      user,
+      readonly: TEST_USERS.readonly,
+    };
+  }
+
   const authType = config?.config?.AUTHENTICATION_TYPE;
   if (authType === 'OIDC') return TEST_USERS_OIDC;
   if (authType === 'LDAP') return TEST_USERS_LDAP;
   return TEST_USERS;
+}
+
+function throwServiceUnsupportedFixture(fixtureName: string): never {
+  throw new Error(
+    `${fixtureName} is not supported when QUAY_E2E_TARGET is not local. Service tests must use regular or unauthenticated fixtures only.`,
+  );
 }
 
 async function setReactUICookie(context: BrowserContext): Promise<void> {
@@ -1050,6 +1078,9 @@ type TestFixtures = {
   // Unauthenticated RawApiClient (no browser required)
   anonClient: RawApiClient;
 
+  // Optional regular service user credentials supplied by env
+  serviceCredentials: ServiceCredentials;
+
   // Isolated user with its own API client (no shared namespace state)
   freshUser: {user: CreatedUser; api: TestApi};
 
@@ -1116,6 +1147,10 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
   superuserContext: [
     async ({browser, cachedQuayConfig}, use) => {
+      if (isServiceMode()) {
+        throwServiceUnsupportedFixture('superuserContext');
+      }
+
       const context = await browser.newContext();
       await setReactUICookie(context);
       const users = getTestUsers(cachedQuayConfig);
@@ -1133,6 +1168,10 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 
   readonlyContext: [
     async ({browser, cachedQuayConfig}, use) => {
+      if (isServiceMode()) {
+        throwServiceUnsupportedFixture('readonlyContext');
+      }
+
       const context = await browser.newContext();
       await setReactUICookie(context);
       const users = getTestUsers(cachedQuayConfig);
@@ -1230,6 +1269,10 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   },
 
   superuserApi: async ({superuserRequest, cachedQuayConfig}, use) => {
+    if (isServiceMode()) {
+      throwServiceUnsupportedFixture('superuserApi');
+    }
+
     const client = new ApiClient(superuserRequest);
     const users = getTestUsers(cachedQuayConfig);
     client.setCredentials(users.admin.username, users.admin.password);
@@ -1262,6 +1305,10 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
   // =========================================================================
 
   adminClient: async ({playwright, cachedQuayConfig}, use) => {
+    if (isServiceMode()) {
+      throwServiceUnsupportedFixture('adminClient');
+    }
+
     const request = await playwright.request.newContext({
       ignoreHTTPSErrors: true,
     });
@@ -1299,6 +1346,11 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
     } finally {
       await request.dispose();
     }
+  },
+
+  // eslint-disable-next-line no-empty-pattern
+  serviceCredentials: async ({}, use) => {
+    await use(getServiceCredentials());
   },
 
   // =========================================================================

--- a/web/playwright/global-setup.ts
+++ b/web/playwright/global-setup.ts
@@ -11,7 +11,7 @@
  */
 
 import {chromium, FullConfig, request} from '@playwright/test';
-import {API_URL} from './utils/config';
+import {API_URL, getQuayE2ETarget, isServiceMode} from './utils/config';
 import {ApiClient} from './utils/api';
 import {mailpit} from './utils/mailpit';
 
@@ -120,6 +120,14 @@ async function globalSetup(config: FullConfig) {
       throw new Error(
         '[Global Setup] Failed to fetch Quay config after 3 attempts',
       );
+    }
+
+    if (isServiceMode()) {
+      console.log(
+        `[Global Setup] QUAY_E2E_TARGET=${getQuayE2ETarget()}, skipping local fixed-user creation`,
+      );
+      console.log('[Global Setup] Complete');
+      return;
     }
 
     // For OIDC auth, skip user creation — users are created on first login

--- a/web/playwright/utils/config.test.ts
+++ b/web/playwright/utils/config.test.ts
@@ -60,15 +60,42 @@ describe('Playwright service target config', () => {
     delete process.env.REACT_QUAY_APP_API_URL;
 
     expect(() => requireServiceTargetAllowed()).toThrow(
-      'QUAY_E2E_TARGET=custom requires external URL env: PLAYWRIGHT_BASE_URL, REACT_QUAY_APP_API_URL',
+      'QUAY_E2E_TARGET=custom requires PLAYWRIGHT_BASE_URL or REACT_QUAY_APP_API_URL',
     );
 
     process.env.PLAYWRIGHT_BASE_URL = 'https://ui.example.test';
+
+    expect(() => requireServiceTargetAllowed()).not.toThrow();
+    expect(getBaseUrl()).toBe('https://ui.example.test');
+    expect(getApiUrl()).toBe('https://ui.example.test');
+
     process.env.REACT_QUAY_APP_API_URL = 'https://api.example.test';
 
     expect(() => requireServiceTargetAllowed()).not.toThrow();
     expect(getBaseUrl()).toBe('https://ui.example.test');
     expect(getApiUrl()).toBe('https://api.example.test');
+  });
+
+  test('preserves original explicit URL overrides for local downstream runs', () => {
+    delete process.env.QUAY_E2E_TARGET;
+    process.env.OPENSHIFT_CI = '1';
+    process.env.PLAYWRIGHT_BASE_URL = 'https://downstream-ui.example.test';
+    process.env.REACT_QUAY_APP_API_URL = 'https://downstream-api.example.test';
+
+    expect(getQuayE2ETarget()).toBe('local');
+    expect(isServiceMode()).toBe(false);
+    expect(getBaseUrl()).toBe('https://downstream-ui.example.test');
+    expect(getApiUrl()).toBe('https://downstream-api.example.test');
+    expect(getPlaywrightGrep()).toBeUndefined();
+  });
+
+  test('uses explicit base URL for service API calls when API URL is unset', () => {
+    process.env.QUAY_E2E_TARGET = 'stage';
+    process.env.PLAYWRIGHT_BASE_URL = 'https://stage-downstream.example.test';
+    delete process.env.REACT_QUAY_APP_API_URL;
+
+    expect(getBaseUrl()).toBe('https://stage-downstream.example.test');
+    expect(getApiUrl()).toBe('https://stage-downstream.example.test');
   });
 
   test('allows explicit URLs to override service target defaults', () => {

--- a/web/playwright/utils/config.test.ts
+++ b/web/playwright/utils/config.test.ts
@@ -1,0 +1,120 @@
+import {afterEach, describe, expect, test} from 'vitest';
+import {
+  getApiUrl,
+  getBaseUrl,
+  getPlaywrightGrep,
+  getPlaywrightWorkers,
+  getQuayE2ETarget,
+  getServiceCredentials,
+  isServiceMode,
+  requireServiceTargetAllowed,
+} from './config';
+
+const originalEnv = {...process.env};
+
+describe('Playwright service target config', () => {
+  afterEach(() => {
+    process.env = {...originalEnv};
+  });
+
+  test('defaults to local target and local URLs', () => {
+    delete process.env.QUAY_E2E_TARGET;
+    delete process.env.PLAYWRIGHT_BASE_URL;
+    delete process.env.REACT_QUAY_APP_API_URL;
+
+    expect(getQuayE2ETarget()).toBe('local');
+    expect(isServiceMode()).toBe(false);
+    expect(getBaseUrl()).toBe('http://localhost:8080');
+    expect(getApiUrl()).toBe('http://localhost:8080');
+  });
+
+  test('resolves stage target URLs', () => {
+    process.env.QUAY_E2E_TARGET = 'stage';
+    delete process.env.PLAYWRIGHT_BASE_URL;
+    delete process.env.REACT_QUAY_APP_API_URL;
+
+    expect(getQuayE2ETarget()).toBe('stage');
+    expect(isServiceMode()).toBe(true);
+    expect(getBaseUrl()).toBe('https://stage.quay.io');
+    expect(getApiUrl()).toBe('https://stage.quay.io');
+  });
+
+  test('resolves prod target URLs only after explicit prod opt-in', () => {
+    process.env.QUAY_E2E_TARGET = 'prod';
+    delete process.env.QUAY_E2E_ALLOW_PROD;
+
+    expect(() => requireServiceTargetAllowed()).toThrow(
+      'QUAY_E2E_TARGET=prod requires QUAY_E2E_ALLOW_PROD=1',
+    );
+
+    process.env.QUAY_E2E_ALLOW_PROD = '1';
+
+    expect(() => requireServiceTargetAllowed()).not.toThrow();
+    expect(getBaseUrl()).toBe('https://quay.io');
+    expect(getApiUrl()).toBe('https://quay.io');
+  });
+
+  test('requires explicit URLs for custom target', () => {
+    process.env.QUAY_E2E_TARGET = 'custom';
+    delete process.env.PLAYWRIGHT_BASE_URL;
+    delete process.env.REACT_QUAY_APP_API_URL;
+
+    expect(() => requireServiceTargetAllowed()).toThrow(
+      'QUAY_E2E_TARGET=custom requires external URL env: PLAYWRIGHT_BASE_URL, REACT_QUAY_APP_API_URL',
+    );
+
+    process.env.PLAYWRIGHT_BASE_URL = 'https://ui.example.test';
+    process.env.REACT_QUAY_APP_API_URL = 'https://api.example.test';
+
+    expect(() => requireServiceTargetAllowed()).not.toThrow();
+    expect(getBaseUrl()).toBe('https://ui.example.test');
+    expect(getApiUrl()).toBe('https://api.example.test');
+  });
+
+  test('allows explicit URLs to override service target defaults', () => {
+    process.env.QUAY_E2E_TARGET = 'stage';
+    process.env.PLAYWRIGHT_BASE_URL = 'https://stage-ui.example.test';
+    process.env.REACT_QUAY_APP_API_URL = 'https://stage-api.example.test';
+
+    expect(getBaseUrl()).toBe('https://stage-ui.example.test');
+    expect(getApiUrl()).toBe('https://stage-api.example.test');
+  });
+
+  test('rejects unknown targets', () => {
+    process.env.QUAY_E2E_TARGET = 'staging';
+
+    expect(() => getQuayE2ETarget()).toThrow(
+      'QUAY_E2E_TARGET must be one of local, stage, prod, custom',
+    );
+  });
+
+  test('defaults service runs to @service-safe and one worker', () => {
+    process.env.QUAY_E2E_TARGET = 'stage';
+    delete process.env.PLAYWRIGHT_GREP;
+    delete process.env.PLAYWRIGHT_WORKERS;
+
+    expect(getPlaywrightGrep()).toBe('@service-safe');
+    expect(getPlaywrightWorkers()).toBe(1);
+  });
+
+  test('allows explicit grep and worker overrides in service mode', () => {
+    process.env.QUAY_E2E_TARGET = 'stage';
+    process.env.PLAYWRIGHT_GREP = '@service-safe|@smoke';
+    process.env.PLAYWRIGHT_WORKERS = '2';
+
+    expect(getPlaywrightGrep()).toBe('@service-safe|@smoke');
+    expect(getPlaywrightWorkers()).toBe(2);
+  });
+
+  test('reads optional service user credentials from env', () => {
+    process.env.QUAY_E2E_USERNAME = 'service-user';
+    process.env.QUAY_E2E_PASSWORD = 'service-password';
+    process.env.QUAY_E2E_TOKEN = 'service-token';
+
+    expect(getServiceCredentials()).toEqual({
+      username: 'service-user',
+      password: 'service-password',
+      token: 'service-token',
+    });
+  });
+});

--- a/web/playwright/utils/config.test.ts
+++ b/web/playwright/utils/config.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, describe, expect, test} from 'vitest';
+import {afterEach, describe, expect, test, vi} from 'vitest';
 import {
   getApiUrl,
   getBaseUrl,
@@ -15,6 +15,7 @@ const originalEnv = {...process.env};
 describe('Playwright service target config', () => {
   afterEach(() => {
     process.env = {...originalEnv};
+    vi.restoreAllMocks();
   });
 
   test('defaults to local target and local URLs', () => {
@@ -131,6 +132,17 @@ describe('Playwright service target config', () => {
 
     expect(getPlaywrightGrep()).toBe('@service-safe|@smoke');
     expect(getPlaywrightWorkers()).toBe(2);
+  });
+
+  test('warns and falls back when explicit workers are invalid', () => {
+    process.env.QUAY_E2E_TARGET = 'stage';
+    process.env.PLAYWRIGHT_WORKERS = 'invalid';
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    expect(getPlaywrightWorkers()).toBe(1);
+    expect(warn).toHaveBeenCalledWith(
+      'Ignoring invalid PLAYWRIGHT_WORKERS="invalid"; expected a positive integer.',
+    );
   });
 
   test('reads optional service user credentials from env', () => {

--- a/web/playwright/utils/config.ts
+++ b/web/playwright/utils/config.ts
@@ -47,14 +47,9 @@ function getTargetDefaultUrl(): string | undefined {
 function requireCustomUrls(): void {
   if (getQuayE2ETarget() !== 'custom') return;
 
-  const missing = [
-    !process.env.PLAYWRIGHT_BASE_URL && 'PLAYWRIGHT_BASE_URL',
-    !process.env.REACT_QUAY_APP_API_URL && 'REACT_QUAY_APP_API_URL',
-  ].filter(Boolean);
-
-  if (missing.length > 0) {
+  if (!process.env.PLAYWRIGHT_BASE_URL && !process.env.REACT_QUAY_APP_API_URL) {
     throw new Error(
-      `QUAY_E2E_TARGET=custom requires external URL env: ${missing.join(', ')}`,
+      'QUAY_E2E_TARGET=custom requires PLAYWRIGHT_BASE_URL or REACT_QUAY_APP_API_URL',
     );
   }
 }
@@ -74,15 +69,7 @@ export function getApiUrl(): string {
     return process.env.REACT_QUAY_APP_API_URL;
   }
 
-  const defaultUrl = getTargetDefaultUrl();
-  if (defaultUrl) return defaultUrl;
-
-  requireCustomUrls();
-  return process.env.REACT_QUAY_APP_API_URL!;
-}
-
-export function getBaseUrl(): string {
-  if (process.env.PLAYWRIGHT_BASE_URL) {
+  if (isServiceMode() && process.env.PLAYWRIGHT_BASE_URL) {
     return process.env.PLAYWRIGHT_BASE_URL;
   }
 
@@ -90,7 +77,35 @@ export function getBaseUrl(): string {
   if (defaultUrl) return defaultUrl;
 
   requireCustomUrls();
-  return process.env.PLAYWRIGHT_BASE_URL!;
+  const customUrl =
+    process.env.PLAYWRIGHT_BASE_URL || process.env.REACT_QUAY_APP_API_URL;
+  if (customUrl) return customUrl;
+
+  throw new Error(
+    'QUAY_E2E_TARGET=custom requires PLAYWRIGHT_BASE_URL or REACT_QUAY_APP_API_URL',
+  );
+}
+
+export function getBaseUrl(): string {
+  if (process.env.PLAYWRIGHT_BASE_URL) {
+    return process.env.PLAYWRIGHT_BASE_URL;
+  }
+
+  if (isServiceMode() && process.env.REACT_QUAY_APP_API_URL) {
+    return process.env.REACT_QUAY_APP_API_URL;
+  }
+
+  const defaultUrl = getTargetDefaultUrl();
+  if (defaultUrl) return defaultUrl;
+
+  requireCustomUrls();
+  const customUrl =
+    process.env.PLAYWRIGHT_BASE_URL || process.env.REACT_QUAY_APP_API_URL;
+  if (customUrl) return customUrl;
+
+  throw new Error(
+    'QUAY_E2E_TARGET=custom requires PLAYWRIGHT_BASE_URL or REACT_QUAY_APP_API_URL',
+  );
 }
 
 export function getPlaywrightGrep(): string | undefined {

--- a/web/playwright/utils/config.ts
+++ b/web/playwright/utils/config.ts
@@ -2,10 +2,144 @@
  * Global configuration for Playwright tests
  */
 
+const LOCAL_URL = 'http://localhost:8080';
+const SERVICE_SAFE_GREP = '@service-safe';
+
+export type QuayE2ETarget = 'local' | 'stage' | 'prod' | 'custom';
+
+const TARGET_DEFAULT_URLS: Partial<Record<QuayE2ETarget, string>> = {
+  local: LOCAL_URL,
+  stage: 'https://stage.quay.io',
+  prod: 'https://quay.io',
+};
+
+const VALID_TARGETS: QuayE2ETarget[] = ['local', 'stage', 'prod', 'custom'];
+
 // Backend API URL (registry + API)
-export const API_URL =
-  process.env.REACT_QUAY_APP_API_URL || 'http://localhost:8080';
+export const API_URL = getApiUrl();
 
 // Frontend URL
-export const BASE_URL =
-  process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8080';
+export const BASE_URL = getBaseUrl();
+
+export interface ServiceCredentials {
+  username?: string;
+  password?: string;
+  token?: string;
+}
+
+export function getQuayE2ETarget(): QuayE2ETarget {
+  const target = (process.env.QUAY_E2E_TARGET || 'local').toLowerCase();
+  if (VALID_TARGETS.includes(target as QuayE2ETarget)) {
+    return target as QuayE2ETarget;
+  }
+
+  throw new Error('QUAY_E2E_TARGET must be one of local, stage, prod, custom');
+}
+
+export function isServiceMode(): boolean {
+  return getQuayE2ETarget() !== 'local';
+}
+
+function getTargetDefaultUrl(): string | undefined {
+  return TARGET_DEFAULT_URLS[getQuayE2ETarget()];
+}
+
+function requireCustomUrls(): void {
+  if (getQuayE2ETarget() !== 'custom') return;
+
+  const missing = [
+    !process.env.PLAYWRIGHT_BASE_URL && 'PLAYWRIGHT_BASE_URL',
+    !process.env.REACT_QUAY_APP_API_URL && 'REACT_QUAY_APP_API_URL',
+  ].filter(Boolean);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `QUAY_E2E_TARGET=custom requires external URL env: ${missing.join(', ')}`,
+    );
+  }
+}
+
+export function requireServiceTargetAllowed(): void {
+  const target = getQuayE2ETarget();
+
+  if (target === 'prod' && process.env.QUAY_E2E_ALLOW_PROD !== '1') {
+    throw new Error('QUAY_E2E_TARGET=prod requires QUAY_E2E_ALLOW_PROD=1');
+  }
+
+  requireCustomUrls();
+}
+
+export function getApiUrl(): string {
+  if (process.env.REACT_QUAY_APP_API_URL) {
+    return process.env.REACT_QUAY_APP_API_URL;
+  }
+
+  const defaultUrl = getTargetDefaultUrl();
+  if (defaultUrl) return defaultUrl;
+
+  requireCustomUrls();
+  return process.env.REACT_QUAY_APP_API_URL!;
+}
+
+export function getBaseUrl(): string {
+  if (process.env.PLAYWRIGHT_BASE_URL) {
+    return process.env.PLAYWRIGHT_BASE_URL;
+  }
+
+  const defaultUrl = getTargetDefaultUrl();
+  if (defaultUrl) return defaultUrl;
+
+  requireCustomUrls();
+  return process.env.PLAYWRIGHT_BASE_URL!;
+}
+
+export function getPlaywrightGrep(): string | undefined {
+  if (process.env.PLAYWRIGHT_GREP) {
+    return process.env.PLAYWRIGHT_GREP;
+  }
+
+  return isServiceMode() ? SERVICE_SAFE_GREP : undefined;
+}
+
+export function getPlaywrightWorkers(): number | undefined {
+  const explicitWorkers = process.env.PLAYWRIGHT_WORKERS;
+  if (explicitWorkers) {
+    const parsed = Number.parseInt(explicitWorkers, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  if (isServiceMode()) {
+    return 1;
+  }
+
+  return process.env.CI ? 4 : undefined;
+}
+
+export function getServiceCredentials(): ServiceCredentials {
+  return {
+    username: process.env.QUAY_E2E_USERNAME,
+    password: process.env.QUAY_E2E_PASSWORD,
+    token: process.env.QUAY_E2E_TOKEN,
+  };
+}
+
+export function requireServiceUserCredentials(): {
+  username: string;
+  password: string;
+  token?: string;
+} {
+  const credentials = getServiceCredentials();
+  if (!credentials.username || !credentials.password) {
+    throw new Error(
+      'Service authenticated fixtures require QUAY_E2E_USERNAME and QUAY_E2E_PASSWORD',
+    );
+  }
+
+  return {
+    username: credentials.username,
+    password: credentials.password,
+    token: credentials.token,
+  };
+}

--- a/web/playwright/utils/config.ts
+++ b/web/playwright/utils/config.ts
@@ -123,6 +123,9 @@ export function getPlaywrightWorkers(): number | undefined {
     if (!Number.isNaN(parsed) && parsed > 0) {
       return parsed;
     }
+    console.warn(
+      `Ignoring invalid PLAYWRIGHT_WORKERS="${explicitWorkers}"; expected a positive integer.`,
+    );
   }
 
   if (isServiceMode()) {

--- a/web/playwright/utils/signin.ts
+++ b/web/playwright/utils/signin.ts
@@ -1,0 +1,32 @@
+import {expect, type Page} from '@playwright/test';
+import {isServiceMode} from './config';
+
+const SERVICE_SIGNIN_TEXT = /Log in to your (Red Hat )?account|Red Hat login/i;
+
+export async function expectSigninPageForTarget(
+  page: Page,
+  options: {localAngularShell?: boolean} = {},
+): Promise<void> {
+  if (isServiceMode()) {
+    await expect(page.locator('body')).toBeVisible();
+    await expect(page.locator('body')).toContainText(SERVICE_SIGNIN_TEXT);
+    return;
+  }
+
+  if (options.localAngularShell) {
+    await expect(page.locator('html[ng-app="quay"]')).toBeAttached();
+  }
+
+  await expect(
+    page
+      .locator('input[name="username"]')
+      .or(page.getByRole('textbox', {name: /username/i}))
+      .first(),
+  ).toBeVisible({timeout: 10000});
+  await expect(
+    page
+      .locator('input[name="password"]')
+      .or(page.getByLabel(/password/i))
+      .first(),
+  ).toBeVisible({timeout: 10000});
+}

--- a/web/playwright/vitest.config.ts
+++ b/web/playwright/vitest.config.ts
@@ -1,0 +1,8 @@
+import {defineConfig} from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['playwright/utils/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
Adds a Playwright service test target for running Quay-owned read-only checks against already-running deployments such as stage and prod. This replaces the stage-only POC naming with service terminology and adds guardrails for production and custom targets.

## Related Issue
NO-ISSUE: replacing deprecated quay-tests service coverage with Quay-owned Playwright coverage.

## Changes
- Add `QUAY_E2E_TARGET=local|stage|prod|custom` URL resolution, production guardrails, default `@service-safe` grep, and single-worker service runs.
- Skip the local webserver and fixed local user creation in service mode.
- Add service-safe API/UI smoke coverage and tag existing read-only Playwright checks that pass against stage.
- Gate create-account coverage on database auth with `@auth:Database`.
- Keep target-specific public repository reads under `@service-integration`.
- Preserve existing `PLAYWRIGHT_BASE_URL` / `REACT_QUAY_APP_API_URL` overrides for OpenShift CI and downstream instance runs.
- Document service suite commands, tags, and target-specific environment overrides.

## Testing
- [x] `./node_modules/.bin/vitest run --config playwright/vitest.config.ts` passes with 12 tests
- [x] `QUAY_E2E_TARGET=stage PLAYWRIGHT_SKIP_WEBSERVER=1 ./node_modules/.bin/playwright test --grep @service-safe --workers=1` passes
- [x] `coderabbit review --agent --type committed --base origin/master` passes with 0 findings after follow-up fix

## Notes
Draft PR. No Jira ticket. The default `@service-safe` set is unauthenticated and read-only; `@service-integration` covers target-specific public repository reads when an anonymous-readable repository is available.
