### PR TITLE
NO-ISSUE: fix(go): update dockerfile and certs gen

### DIFF
--- a/Dockerfile.mirror
+++ b/Dockerfile.mirror
@@ -1,8 +1,10 @@
-FROM golang:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:9.8 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
-COPY . .
+COPY cmd/ cmd/
+COPY internal/ internal/
+USER 0
 RUN CGO_ENABLED=0 go build -o /quay ./cmd/quay
 
 FROM registry.access.redhat.com/ubi9/ubi-micro:latest

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -25,11 +25,13 @@ func GenerateSelfSigned(hostname, certPath, keyPath string) error {
 	}
 
 	template := x509.Certificate{
-		Subject:     pkix.Name{CommonName: hostname},
-		NotBefore:   time.Now(),
-		NotAfter:    time.Now().Add(10 * 365 * 24 * time.Hour),
-		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Subject:               pkix.Name{CommonName: hostname},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
 	}
 
 	if ip := net.ParseIP(hostname); ip != nil {

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -63,6 +63,24 @@ func TestGenerateSelfSigned_KeyPermissions(t *testing.T) {
 	}
 }
 
+func TestGenerateSelfSigned_IsCertificateAuthority(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+
+	if err := GenerateSelfSigned("registry.example.com", certPath, keyPath); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	cert := loadCert(t, certPath, keyPath)
+	if !cert.Leaf.IsCA || !cert.Leaf.BasicConstraintsValid {
+		t.Error("expected a valid CA certificate")
+	}
+	if cert.Leaf.KeyUsage&x509.KeyUsageCertSign == 0 {
+		t.Error("expected certificate signing key usage")
+	}
+}
+
 func TestFilesExist(t *testing.T) {
 	dir := t.TempDir()
 	certPath := filepath.Join(dir, "cert.pem")


### PR DESCRIPTION
Update dockerfile to build from go-toolset, copy only needed files, and the CA generation to be an authority for self signed certs (required for the OCP provisioning)