### PR TITLE
PROJQUAY-XXXX: docs(agents): Add 'revert' type to PR conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ make types-test                      # Type checking (mypy)
 
 - **PR title:** `PROJQUAY-XXXXX: type(scope): lowercase description`
   - Use `NO-ISSUE:` when there is no associated Jira ticket
-  - Types: `fix`, `feat`, `test`, `refactor`, `docs`, `chore`
+  - Types: `fix`, `feat`, `test`, `refactor`, `docs`, `chore`, `revert`
   - `PROJQUAY-10983: fix(mirroring): add isRequired to robot user field`
   - `NO-ISSUE: docs(agents): add contributing guide`
 - **Branch naming:** `<type>/projquay-XXXXX-short-description` where `<type>` matches the PR type


### PR DESCRIPTION
## What happened
The `feat` type is incorrect for a revert.
## What changed
Added `revert` type to documented PR conventions.
## How to test
Verify the updated PR conventions in AGENTS.md.

---
_Opened by autonomous agent. Human review required before merge._