### PR TITLE
NO-ISSUE: ci: exclude agent config from CodeRabbit review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,6 +25,8 @@ reviews:
       - "[do not merge]"
 
   path_filters:
+    - "!.agents/**"
+    - "!.claude/**"
     - "!static/js/**"
     - "!static/lib/**"
     - "!**/*.min.js"


### PR DESCRIPTION
## Summary

Exclude `.agents/` and `.claude/` from CodeRabbit review using the existing `path_filters` configuration.

These directories contain agent configuration rather than application code. Reviewing them has produced unrelated false-positive feedback, as described in #6500.

## Changes

- exclude `.agents/**` from CodeRabbit review
- exclude `.claude/**` from CodeRabbit review

## Validation

- confirmed `.coderabbit.yaml` remains valid YAML
- confirmed the change is limited to the two requested path filters

The end-to-end behavior will be confirmed by CodeRabbit's file-selection output on a future change touching these directories.

Closes #6500