### PR TITLE
NO-ISSUE: exclude .agents/ and .claude/ from CodeRabbit review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -33,6 +33,8 @@ reviews:
     - "!**/*_generated*"
     - "!**/node_modules/**"
     - "!web/dist/**"
+    - "!.agents/**"
+    - "!.claude/**"
 
   path_instructions:
     - path: "data/migrations/versions/**/*.py"


### PR DESCRIPTION
## What

Adds `!.agents/**` and `!.claude/**` to the `path_filters` list in `.coderabbit.yaml`, alongside the existing exclusions for `static/js`, `vendor`, `node_modules`, `web/dist`, etc.

Closes #6500.

## Why

The `.agents/` directory holds agent skill definitions (`SKILL.md` instruction files and helper shell scripts) and `.claude/` holds Claude config — both are AI-agent tooling, not application source. CodeRabbit's code-quality checks produce false positives when applied to these files.

This was observed on #6496, where a pure directory rename under `.agents/skills/` drew 8 'actionable' review comments, all false positives about pre-existing patterns unrelated to the change. Excluding these non-application paths removes that noise and keeps unresolved-comment signal meaningful (relevant to #6427).

## Validation

On the next PR that touches files under `.agents/` (or `.claude/`), CodeRabbit's 'Files selected for processing' section should exclude those paths and post no review comments on their content.

The change mirrors the form of the existing root-relative filters (e.g. `!static/js/**`).