### PR TITLE
PROJQUAY-9330: fix(ui): correct same repo name tag breadcrumb paths

### DIFF
--- a/web/playwright/e2e/ui/breadcrumbs.spec.ts
+++ b/web/playwright/e2e/ui/breadcrumbs.spec.ts
@@ -164,6 +164,62 @@ test.describe('Breadcrumbs', {tag: ['@ui', '@breadcrumbs']}, () => {
         `/repository/${org.name}/${repo.name}/tag/${tagName}`,
       );
     });
+
+    test(
+      'tag names containing the repository name use canonical breadcrumbs',
+      {tag: '@PROJQUAY-9330'},
+      async ({authenticatedPage, api}) => {
+        const org = await api.organization('breadcrumborg');
+        const repo = await api.repositoryWithName(org.name, 'alpine');
+        const tagNames = [repo.name, `${repo.name}1`];
+
+        for (const tagName of tagNames) {
+          await pushImage(
+            org.name,
+            repo.name,
+            tagName,
+            TEST_USERS.user.username,
+            TEST_USERS.user.password,
+          );
+
+          const tagPath = `/repository/${org.name}/${repo.name}/tag/${tagName}`;
+          await authenticatedPage.goto(tagPath);
+
+          const items = authenticatedPage
+            .getByTestId('page-breadcrumbs-list')
+            .locator('li');
+          await expect(items).toHaveCount(4);
+          await expect(items).toHaveText([
+            'Repository',
+            org.name,
+            repo.name,
+            tagName,
+          ]);
+          await expect(items.nth(2).locator('a')).toHaveAttribute(
+            'href',
+            `/repository/${org.name}/${repo.name}`,
+          );
+          await expect(items.nth(3).locator('a')).toHaveClass(/disabled-link/);
+          await expect(items.nth(3).locator('a')).toHaveAttribute(
+            'href',
+            tagPath,
+          );
+        }
+
+        await authenticatedPage
+          .getByTestId('page-breadcrumbs-list')
+          .locator('li')
+          .nth(2)
+          .locator('a')
+          .click();
+        await expect(authenticatedPage).toHaveURL(
+          `/repository/${org.name}/${repo.name}`,
+        );
+        await expect(
+          authenticatedPage.getByText('Unable to complete request'),
+        ).not.toBeVisible();
+      },
+    );
   });
 
   test.describe('Team breadcrumbs', () => {

--- a/web/src/components/breadcrumb/Breadcrumb.tsx
+++ b/web/src/components/breadcrumb/Breadcrumb.tsx
@@ -36,11 +36,6 @@ export function QuayBreadcrumb() {
     setBreadcrumbItems([]);
   };
 
-  const lastOccurrenceOfSubstring = (substring: string): string => {
-    const lastIndex = location.pathname.lastIndexOf(substring);
-    return location.pathname.slice(0, lastIndex);
-  };
-
   const fetchBreadcrumb = (
     existingBreadcrumbs,
     nextBreadcrumb,
@@ -68,13 +63,19 @@ export function QuayBreadcrumb() {
         case NavigationPath.repositoryDetail:
           nextBreadcrumb['title'] = parseRepoNameFromUrl(location.pathname);
           nextBreadcrumb['pathname'] =
-            lastOccurrenceOfSubstring(nextBreadcrumb['title']) +
+            existingBreadcrumbs[0]['pathname'] +
+            '/' +
+            parseOrgNameFromUrl(location.pathname) +
+            '/' +
             nextBreadcrumb['title'];
           break;
         case NavigationPath.teamMember:
           nextBreadcrumb['title'] = parseTeamNameFromUrl(location.pathname);
           nextBreadcrumb['pathname'] =
-            lastOccurrenceOfSubstring(nextBreadcrumb['title']) +
+            existingBreadcrumbs[0]['pathname'] +
+            '/' +
+            parseOrgNameFromUrl(location.pathname) +
+            '/teams/' +
             nextBreadcrumb['title'];
           break;
       }


### PR DESCRIPTION
Example fix:

<img width="2880" height="1520" alt="[PROJQUAY-9330](https://redhat.atlassian.net/browse/PROJQUAY-9330)-repository-and-tag-same-name" src="https://github.com/user-attachments/assets/7dd7c620-6b4a-4e1e-b79e-20a078b62879" />

<img width="2880" height="1520" alt="[PROJQUAY-9330](https://redhat.atlassian.net/browse/PROJQUAY-9330)-tag-contains-repository-name" src="https://github.com/user-attachments/assets/81f263a4-a1df-4d5f-b152-23763d738625" />
