### PR TITLE
PROJQUAY-12229: fix(ui): prevent column header truncation in namespace notifications table

### DIFF
--- a/web/playwright/e2e/organization/namespace-notifications.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect} from '../../fixtures';
+import {test, expect, uniqueName} from '../../fixtures';
 
 test.describe(
   'Namespace Notifications',
@@ -366,6 +366,39 @@ test.describe(
       // Flowdock and HipChat should NOT be listed
       await expect(authenticatedPage.getByText('Flowdock')).not.toBeVisible();
       await expect(authenticatedPage.getByText('HipChat')).not.toBeVisible();
+    });
+
+    test('table column headers are not truncated', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const orgName = uniqueName('nsnotifcol');
+      const org = await api.organization(orgName);
+      const title = uniqueName('col-test');
+
+      await api.namespaceNotification(
+        org.name,
+        'quota_warning',
+        'webhook',
+        {url: 'https://example.com/hook'},
+        {},
+        title,
+      );
+
+      await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
+      await authenticatedPage.getByTestId('Notifications').click();
+
+      const table = authenticatedPage.getByTestId('ns-notifications-table');
+      await expect(table).toBeVisible();
+
+      const headers = table.locator('thead th');
+      await expect(headers.filter({hasText: 'Title'})).toBeVisible();
+      await expect(headers.filter({hasText: 'Event'})).toBeVisible();
+      await expect(headers.filter({hasText: 'Method'})).toBeVisible();
+      await expect(headers.filter({hasText: 'Status'})).toBeVisible();
+
+      await expect(headers.filter({hasText: /^Ti\.\.\.$/})).toHaveCount(0);
+      await expect(headers.filter({hasText: /^S\.\.\.$/})).toHaveCount(0);
     });
 
     test('form validation — submit disabled without required fields', async ({

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/NamespaceNotifications.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/NamespaceNotifications.tsx
@@ -221,10 +221,18 @@ export default function NamespaceNotifications({
         <Thead>
           <Tr>
             <Th />
-            <Th sort={getSortableSort(0)}>Title</Th>
-            <Th sort={getSortableSort(1)}>Event</Th>
-            <Th sort={getSortableSort(2)}>Method</Th>
-            <Th sort={getSortableSort(3)}>Status</Th>
+            <Th modifier="nowrap" sort={getSortableSort(0)}>
+              Title
+            </Th>
+            <Th modifier="nowrap" sort={getSortableSort(1)}>
+              Event
+            </Th>
+            <Th modifier="nowrap" sort={getSortableSort(2)}>
+              Method
+            </Th>
+            <Th modifier="nowrap" sort={getSortableSort(3)}>
+              Status
+            </Th>
             <Th />
           </Tr>
         </Thead>


### PR DESCRIPTION
## Summary
- The namespace notifications table (Organization > Settings > Notifications) truncates the "Title" and "Status" column headers to "Ti..." and "S..." due to missing width constraints on PatternFly `<Th>` elements
- Fixed by adding `modifier="nowrap"` to all sortable `<Th>` headers, which is the idiomatic PatternFly approach to prevent header text truncation

## Test plan
- [ ] Navigate to Organization > Settings > Notifications tab
- [ ] Create a namespace notification (e.g. Webhook POST for Quota Warning)
- [ ] Verify all column headers (Title, Event, Method, Status) display fully without truncation
- [ ] Verify table layout remains correct at various browser widths

JIRA: https://redhat.atlassian.net/browse/PROJQUAY-12229

🤖 Generated with [Claude Code](https://claude.ai/code)