### PR TITLE
PROJQUAY-12230: fix(quota): cast limit_bytes to int to prevent JSON serialization failure

### DIFF
--- a/data/model/namespacequota.py
+++ b/data/model/namespacequota.py
@@ -237,7 +237,7 @@ def check_limits(namespace_name, size):
         "limit_bytes": limit_bytes,
         "severity_level": severity_level,
         "usage_bytes": size,
-        "quota_limit_bytes": quota.limit_bytes,
+        "quota_limit_bytes": int(quota.limit_bytes),
         "threshold_percent": threshold_percent,
     }
 

--- a/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
@@ -68,6 +68,11 @@ test.describe(
           const webhook = await receiver.waitForWebhook(undefined, 60_000);
           expect(webhook).not.toBeNull();
           expect(webhook?.body).toHaveProperty('event_data');
+
+          // PROJQUAY-12230: verify numeric fields are serialized correctly
+          // (Decimal from PostgreSQL must be cast to int before json.dumps)
+          expect(typeof webhook?.body?.limit_bytes).toBe('number');
+          expect(typeof webhook?.body?.usage_bytes).toBe('number');
         } finally {
           await receiver.stop();
         }


### PR DESCRIPTION
## Summary
- Quota notifications (warning/error) silently fail when a push exceeds the namespace quota because `quota.limit_bytes` is a `Decimal` (from PostgreSQL `BigIntegerField`) that `json.dumps()` cannot serialize
- Fixed by casting `quota.limit_bytes` to `int` when building the quota result dict in `data/model/namespacequota.py:240`

## Test plan
- [ ] Set a storage quota on a namespace (e.g. 100MB)
- [ ] Configure a Quota Warning and Quota Error namespace notification with Webhook POST
- [ ] Push an image that exceeds the quota
- [ ] Verify the webhook receives the notification payload
- [ ] Verify no `TypeError: Object of type Decimal is not JSON serializable` in Quay pod logs

JIRA: https://redhat.atlassian.net/browse/PROJQUAY-12230

🤖 Generated with [Claude Code](https://claude.ai/code)