### PR TITLE
PROJQUAY-12324: fix(quadlet): add :U flag to volume mount for Podman 5.x UID remapping

### DIFF
--- a/internal/system/quadlet.go
+++ b/internal/system/quadlet.go
@@ -52,7 +52,7 @@ After=network-online.target
 
 [Container]
 Image=%s
-Volume=%s:/data:Z
+Volume=%s:/data:Z,U
 PublishPort=%s:%s
 Exec=%s
 

--- a/internal/system/quadlet_test.go
+++ b/internal/system/quadlet_test.go
@@ -94,6 +94,26 @@ func TestQuadletInstallDoesNotPersistBootstrapCredentials(t *testing.T) {
 	}
 }
 
+func TestQuadletInstallVolumeHasUFlag(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+
+	err := manager.Install("quay", &QuadletSpec{
+		Image:    "localhost/quay:test",
+		DataDir:  "/var/lib/quay",
+		Hostname: "localhost",
+		Port:     "8443",
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	content := readQuadletTestFile(t, env.QuadletPath("quay"))
+	if !strings.Contains(content, "Volume=/var/lib/quay:/data:Z,U") {
+		t.Fatalf("quadlet volume missing :U flag for UID remapping:\n%s", content)
+	}
+}
+
 func TestQuadletHostname(t *testing.T) {
 	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
 	manager := NewQuadletManager(OSFS{}, env)


### PR DESCRIPTION
## Summary
- Add `:U` flag to the Quadlet volume mount (`Volume=%s:/data:Z,U`)
- The Containerfile sets `USER 1001`; without `:U`, Podman 5.x cannot remap host UIDs to match the in-container user, causing permission denied errors on `/data`
- Same fix applied to OMR 2.0.x in [PROJQUAY-9329](https://redhat.atlassian.net/browse/PROJQUAY-9329)

## Test plan
- [ ] Verify `TestQuadletInstallVolumeHasUFlag` passes
- [ ] Deploy on a Podman 5.x host and confirm the container starts without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)