### PR TITLE
PROJQUAY-12324: feat(install): add custom TLS certificate support

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -15,6 +15,9 @@ func newInstallCmd() *Command {
 	hostname := fs.String("hostname", "", "server hostname for TLS and config (required)")
 	dataDir := fs.String("data-dir", "/var/lib/quay", "directory for database, storage, and certs")
 	port := fs.String("port", "", "HTTPS port for the registry (default 8443; an existing port is preserved on upgrade)")
+	sslCert := fs.String("ssl-cert", "", "path to TLS certificate (PEM)")
+	sslKey := fs.String("ssl-key", "", "path to TLS private key (PEM)")
+	sslCheckSkip := fs.Bool("ssl-check-skip", false, "skip hostname verification on TLS certificate")
 	imageArchive := fs.String("image-archive", "", "path to container image tar (offline mode)")
 	image := fs.String("image", installer.DefaultImage, "container image to use")
 
@@ -28,13 +31,27 @@ func newInstallCmd() *Command {
 				cmd.Usage(os.Stderr)
 				return 1
 			}
-			return runInstall(ctx, *hostname, *dataDir, *port, *imageArchive, *image)
+			if err := installer.ValidateSSLFlags(*sslCert, *sslKey); err != nil {
+				fmt.Fprintln(os.Stderr, "error:", err)
+				cmd.Usage(os.Stderr)
+				return 1
+			}
+			return runInstall(ctx, &installer.Config{
+				Hostname:     *hostname,
+				DataDir:      *dataDir,
+				Port:         *port,
+				SSLCert:      *sslCert,
+				SSLKey:       *sslKey,
+				SSLCheckSkip: *sslCheckSkip,
+				ImageArchive: *imageArchive,
+				Image:        *image,
+			})
 		},
 	}
 }
 
-func runInstall(ctx context.Context, hostname, dataDir, port, imageArchive, image string) int {
-	if err := installer.ValidateHostname(hostname); err != nil {
+func runInstall(ctx context.Context, cfg *installer.Config) int {
+	if err := installer.ValidateHostname(cfg.Hostname); err != nil {
 		slog.Error("invalid hostname", "err", err)
 		return 1
 	}
@@ -45,13 +62,7 @@ func runInstall(ctx context.Context, hostname, dataDir, port, imageArchive, imag
 		return 1
 	}
 
-	if err := inst.Run(ctx, &installer.Config{
-		Hostname:     hostname,
-		DataDir:      dataDir,
-		Port:         port,
-		ImageArchive: imageArchive,
-		Image:        image,
-	}); err != nil {
+	if err := inst.Run(ctx, cfg); err != nil {
 		slog.Error("install failed", "err", err)
 		return 1
 	}

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -17,7 +17,7 @@ func newInstallCmd() *Command {
 	port := fs.String("port", "", "HTTPS port for the registry (default 8443; an existing port is preserved on upgrade)")
 	sslCert := fs.String("ssl-cert", "", "path to TLS certificate (PEM)")
 	sslKey := fs.String("ssl-key", "", "path to TLS private key (PEM)")
-	sslCheckSkip := fs.Bool("ssl-check-skip", false, "skip hostname verification on TLS certificate")
+	sslSkipHostnameVerification := fs.Bool("ssl-skip-hostname-verification", false, "allow TLS certificate hostname to differ from -hostname")
 	imageArchive := fs.String("image-archive", "", "path to container image tar (offline mode)")
 	image := fs.String("image", installer.DefaultImage, "container image to use")
 
@@ -37,14 +37,14 @@ func newInstallCmd() *Command {
 				return 1
 			}
 			return runInstall(ctx, &installer.Config{
-				Hostname:     *hostname,
-				DataDir:      *dataDir,
-				Port:         *port,
-				SSLCert:      *sslCert,
-				SSLKey:       *sslKey,
-				SSLCheckSkip: *sslCheckSkip,
-				ImageArchive: *imageArchive,
-				Image:        *image,
+				Hostname:                    *hostname,
+				DataDir:                     *dataDir,
+				Port:                        *port,
+				SSLCert:                     *sslCert,
+				SSLKey:                      *sslKey,
+				SSLSkipHostnameVerification: *sslSkipHostnameVerification,
+				ImageArchive:                *imageArchive,
+				Image:                       *image,
 			})
 		},
 	}

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/quay/quay/internal/certs"
@@ -31,15 +32,15 @@ const (
 
 // Config holds the parameters for an install or upgrade operation.
 type Config struct {
-	Hostname     string
-	DataDir      string
-	ImageArchive string
-	Image        string
-	ConfigPath   string
-	Port         string
-	SSLCert      string
-	SSLKey       string
-	SSLCheckSkip bool
+	Hostname                    string
+	DataDir                     string
+	ImageArchive                string
+	Image                       string
+	ConfigPath                  string
+	Port                        string
+	SSLCert                     string
+	SSLKey                      string
+	SSLSkipHostnameVerification bool
 }
 
 // Installer orchestrates fresh installs and upgrades of the registry
@@ -107,7 +108,7 @@ func (inst *Installer) Run(ctx context.Context, cfg *Config) error {
 	healthURL := fmt.Sprintf("https://%s:%s/healthz", resolvedCfg.Hostname, port)
 	certPath := filepath.Join(resolvedCfg.DataDir, "ssl.cert")
 	slog.Info("waiting for registry to start")
-	if err := inst.waitForHealth(ctx, healthURL, certPath, resolvedCfg.SSLCheckSkip, 30*time.Second); err != nil {
+	if err := inst.waitForHealth(ctx, healthURL, certPath, resolvedCfg.SSLSkipHostnameVerification, 30*time.Second); err != nil {
 		inst.dumpContainerLogs(ctx)
 		return fmt.Errorf("health check: %w", err)
 	}
@@ -261,34 +262,40 @@ func healthTLSConfig(caCert []byte, skipHostname bool) (*tls.Config, error) {
 
 	tlsCfg := certs.SecureTLSConfig()
 	tlsCfg.RootCAs = pool
-	if !skipHostname {
-		return tlsCfg, nil
-	}
-
-	// Disable the standard verifier only so hostname matching can be omitted.
-	// VerifyConnection still validates the presented chain against the supplied
-	// certificate pool and for server-auth usage.
-	tlsCfg.InsecureSkipVerify = true //nolint:gosec // custom verification below preserves certificate trust
-	tlsCfg.VerifyConnection = func(state tls.ConnectionState) error {
-		if len(state.PeerCertificates) == 0 {
-			return fmt.Errorf("server did not provide a certificate")
-		}
-
-		intermediates := x509.NewCertPool()
-		for _, cert := range state.PeerCertificates[1:] {
-			intermediates.AddCert(cert)
-		}
-		_, err := state.PeerCertificates[0].Verify(x509.VerifyOptions{
-			Roots:         pool,
-			Intermediates: intermediates,
-			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		})
+	if skipHostname {
+		cert, err := parseCertPEM(caCert)
 		if err != nil {
-			return fmt.Errorf("verify server certificate: %w", err)
+			return nil, err
 		}
-		return nil
+		serverName, err := healthServerName(cert)
+		if err != nil {
+			return nil, err
+		}
+		// A non-empty ServerName prevents net/http from substituting the URL
+		// hostname. Standard TLS verification remains enabled against an identity
+		// declared by the installed certificate and the pinned certificate pool.
+		tlsCfg.ServerName = serverName
 	}
 	return tlsCfg, nil
+}
+
+func healthServerName(cert *x509.Certificate) (string, error) {
+	for _, dnsName := range cert.DNSNames {
+		candidate := dnsName
+		if strings.HasPrefix(candidate, "*.") {
+			candidate = "health-check." + strings.TrimPrefix(candidate, "*.")
+		}
+		if err := cert.VerifyHostname(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	for _, ip := range cert.IPAddresses {
+		candidate := ip.String()
+		if err := cert.VerifyHostname(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("certificate has no usable DNS or IP subject alternative name")
 }
 
 func (inst *Installer) dumpContainerLogs(ctx context.Context) {
@@ -322,13 +329,13 @@ func (inst *Installer) copyUserTLS(cfg *Config) error {
 		return fmt.Errorf("certificate/key pair invalid: %w", err)
 	}
 
-	if !cfg.SSLCheckSkip {
+	if !cfg.SSLSkipHostnameVerification {
 		cert, err := parseCertPEM(certData)
 		if err != nil {
 			return fmt.Errorf("parse certificate: %w", err)
 		}
 		if err := verifyCertHostname(cert, cfg.Hostname); err != nil {
-			return fmt.Errorf("certificate hostname check failed (use -ssl-check-skip to override): %w", err)
+			return fmt.Errorf("certificate hostname check failed (use -ssl-skip-hostname-verification to override): %w", err)
 		}
 	}
 

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -7,11 +7,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -93,7 +95,7 @@ func (inst *Installer) Run(ctx context.Context, cfg *Config) error {
 	}
 
 	if upgrading {
-		if err := inst.upgrade(ctx, imageRef, port); err != nil {
+		if err := inst.upgrade(ctx, &resolvedCfg, imageRef, port); err != nil {
 			return fmt.Errorf("upgrade: %w", err)
 		}
 	} else {
@@ -105,7 +107,7 @@ func (inst *Installer) Run(ctx context.Context, cfg *Config) error {
 	healthURL := fmt.Sprintf("https://%s:%s/healthz", resolvedCfg.Hostname, port)
 	certPath := filepath.Join(resolvedCfg.DataDir, "ssl.cert")
 	slog.Info("waiting for registry to start")
-	if err := inst.waitForHealth(ctx, healthURL, certPath, 30*time.Second); err != nil {
+	if err := inst.waitForHealth(ctx, healthURL, certPath, resolvedCfg.SSLCheckSkip, 30*time.Second); err != nil {
 		inst.dumpContainerLogs(ctx)
 		return fmt.Errorf("health check: %w", err)
 	}
@@ -151,8 +153,16 @@ func (inst *Installer) resolveImage(ctx context.Context, archive, image string) 
 	return image, nil
 }
 
-func (inst *Installer) upgrade(ctx context.Context, imageRef, port string) error {
+func (inst *Installer) upgrade(ctx context.Context, cfg *Config, imageRef, port string) error {
 	slog.Info("existing installation detected, upgrading")
+
+	// Validate and install replacement TLS material before stopping the running
+	// service. The process keeps its currently loaded pair until it is restarted.
+	if cfg.SSLCert != "" {
+		if err := inst.copyUserTLS(cfg); err != nil {
+			return fmt.Errorf("TLS certificate setup: %w", err)
+		}
+	}
 
 	slog.Info("stopping registry")
 	if err := inst.systemd.Stop(ctx, quadletServiceName); err != nil {
@@ -211,7 +221,7 @@ func (inst *Installer) freshInstall(ctx context.Context, cfg *Config, imageRef s
 	return nil
 }
 
-func (inst *Installer) waitForHealth(ctx context.Context, url, certPath string, timeout time.Duration) error {
+func (inst *Installer) waitForHealth(ctx context.Context, url, certPath string, skipHostname bool, timeout time.Duration) error {
 	deadline := time.After(timeout)
 
 	// Wait for the container to generate the TLS certificate.
@@ -232,17 +242,53 @@ func (inst *Installer) waitForHealth(ctx context.Context, url, certPath string, 
 	if err != nil {
 		return fmt.Errorf("read TLS certificate: %w", err)
 	}
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(caCert) {
-		return fmt.Errorf("parse TLS certificate: %s", certPath)
+	tlsCfg, err := healthTLSConfig(caCert, skipHostname)
+	if err != nil {
+		return fmt.Errorf("parse TLS certificate %s: %w", certPath, err)
 	}
-	tlsCfg := certs.SecureTLSConfig()
-	tlsCfg.RootCAs = pool
 	client := &http.Client{
 		Timeout:   2 * time.Second,
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},
 	}
 	return system.WaitForHealth(ctx, client, url, timeout)
+}
+
+func healthTLSConfig(caCert []byte, skipHostname bool) (*tls.Config, error) {
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("no certificates found")
+	}
+
+	tlsCfg := certs.SecureTLSConfig()
+	tlsCfg.RootCAs = pool
+	if !skipHostname {
+		return tlsCfg, nil
+	}
+
+	// Disable the standard verifier only so hostname matching can be omitted.
+	// VerifyConnection still validates the presented chain against the supplied
+	// certificate pool and for server-auth usage.
+	tlsCfg.InsecureSkipVerify = true //nolint:gosec // custom verification below preserves certificate trust
+	tlsCfg.VerifyConnection = func(state tls.ConnectionState) error {
+		if len(state.PeerCertificates) == 0 {
+			return fmt.Errorf("server did not provide a certificate")
+		}
+
+		intermediates := x509.NewCertPool()
+		for _, cert := range state.PeerCertificates[1:] {
+			intermediates.AddCert(cert)
+		}
+		_, err := state.PeerCertificates[0].Verify(x509.VerifyOptions{
+			Roots:         pool,
+			Intermediates: intermediates,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		})
+		if err != nil {
+			return fmt.Errorf("verify server certificate: %w", err)
+		}
+		return nil
+	}
+	return tlsCfg, nil
 }
 
 func (inst *Installer) dumpContainerLogs(ctx context.Context) {
@@ -286,16 +332,179 @@ func (inst *Installer) copyUserTLS(cfg *Config) error {
 		}
 	}
 
-	certDst := filepath.Join(cfg.DataDir, "ssl.cert")
-	if err := inst.fs.WriteFile(certDst, certData, 0o600); err != nil {
-		return fmt.Errorf("write certificate: %w", err)
-	}
-	keyDst := filepath.Join(cfg.DataDir, "ssl.key")
-	if err := inst.fs.WriteFile(keyDst, keyData, 0o600); err != nil {
-		return fmt.Errorf("write key: %w", err)
+	if err := inst.replaceTLSFiles(cfg.DataDir, certData, keyData); err != nil {
+		return err
 	}
 
+	certDst := filepath.Join(cfg.DataDir, "ssl.cert")
+	keyDst := filepath.Join(cfg.DataDir, "ssl.key")
 	slog.Info("user-provided TLS certificate installed", "cert", certDst, "key", keyDst)
+	return nil
+}
+
+type tlsDestination struct {
+	path       string
+	backupPath string
+	info       os.FileInfo
+}
+
+func (inst *Installer) replaceTLSFiles(dataDir string, certData, keyData []byte) (retErr error) {
+	destinations := []tlsDestination{
+		{path: filepath.Join(dataDir, "ssl.cert")},
+		{path: filepath.Join(dataDir, "ssl.key")},
+	}
+	if err := inst.inspectTLSDestinations(destinations); err != nil {
+		return err
+	}
+
+	stagingDir, err := inst.fs.MkdirTemp(dataDir, ".tls-update-")
+	if err != nil {
+		return fmt.Errorf("create TLS staging directory: %w", err)
+	}
+
+	stagedPaths := []string{
+		filepath.Join(stagingDir, "ssl.cert"),
+		filepath.Join(stagingDir, "ssl.key"),
+	}
+	cleanupPaths := append([]string(nil), stagedPaths...)
+	defer func() {
+		retErr = errors.Join(retErr, inst.cleanupTLSStaging(stagingDir, cleanupPaths))
+	}()
+
+	if err := inst.stageTLSFiles(stagedPaths, destinations, [][]byte{certData, keyData}); err != nil {
+		return err
+	}
+
+	for i := range destinations {
+		if destinations[i].info == nil {
+			continue
+		}
+		destinations[i].backupPath = filepath.Join(stagingDir, filepath.Base(destinations[i].path)+".rollback")
+		cleanupPaths = append(cleanupPaths, destinations[i].backupPath)
+	}
+
+	if err := inst.preserveTLSDestinations(destinations); err != nil {
+		return err
+	}
+	return inst.commitTLSFiles(stagedPaths, destinations)
+}
+
+func (inst *Installer) inspectTLSDestinations(destinations []tlsDestination) error {
+	for i := range destinations {
+		info, _, err := inst.regularDestination(destinations[i].path)
+		if err != nil {
+			return err
+		}
+		destinations[i].info = info
+	}
+	return nil
+}
+
+func (inst *Installer) stageTLSFiles(stagedPaths []string, destinations []tlsDestination, contents [][]byte) error {
+	for i, data := range contents {
+		if err := inst.fs.WriteFile(stagedPaths[i], data, 0o600); err != nil {
+			return fmt.Errorf("stage %s: %w", filepath.Base(destinations[i].path), err)
+		}
+		if err := inst.fs.Chmod(stagedPaths[i], 0o600); err != nil {
+			return fmt.Errorf("secure staged %s: %w", filepath.Base(destinations[i].path), err)
+		}
+	}
+	return nil
+}
+
+func (inst *Installer) preserveTLSDestinations(destinations []tlsDestination) error {
+	for _, destination := range destinations {
+		if destination.info == nil {
+			continue
+		}
+		if err := inst.ensureDestinationUnchanged(destination); err != nil {
+			return err
+		}
+		if err := inst.fs.Link(destination.path, destination.backupPath); err != nil {
+			return fmt.Errorf("preserve existing %s: %w", filepath.Base(destination.path), err)
+		}
+	}
+	return nil
+}
+
+func (inst *Installer) commitTLSFiles(stagedPaths []string, destinations []tlsDestination) error {
+	replaced := false
+	for i := range destinations {
+		if err := inst.ensureDestinationUnchanged(destinations[i]); err != nil {
+			if replaced {
+				return errors.Join(err, inst.restoreTLSDestinations(destinations))
+			}
+			return err
+		}
+		if err := inst.fs.Rename(stagedPaths[i], destinations[i].path); err != nil {
+			rollbackErr := inst.restoreTLSDestinations(destinations)
+			return errors.Join(fmt.Errorf("replace %s: %w", filepath.Base(destinations[i].path), err), rollbackErr)
+		}
+		replaced = true
+	}
+	return nil
+}
+
+func (inst *Installer) cleanupTLSStaging(stagingDir string, paths []string) error {
+	var cleanupErr error
+	for _, path := range paths {
+		if err := inst.fs.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove staged TLS file %s: %w", path, err))
+		}
+	}
+	if err := inst.fs.Remove(stagingDir); err != nil && !errors.Is(err, os.ErrNotExist) {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove TLS staging directory: %w", err))
+	}
+	return cleanupErr
+}
+
+func (inst *Installer) regularDestination(path string) (info os.FileInfo, exists bool, err error) {
+	info, err = inst.fs.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect TLS destination %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, false, fmt.Errorf("TLS destination %s is not a regular file", path)
+	}
+	return info, true, nil
+}
+
+func (inst *Installer) ensureDestinationUnchanged(destination tlsDestination) error {
+	info, exists, err := inst.regularDestination(destination.path)
+	if err != nil {
+		return err
+	}
+	if destination.info == nil {
+		if exists {
+			return fmt.Errorf("TLS destination %s appeared during replacement", destination.path)
+		}
+		return nil
+	}
+	if !exists || !os.SameFile(destination.info, info) {
+		return fmt.Errorf("TLS destination %s changed during replacement", destination.path)
+	}
+	return nil
+}
+
+func (inst *Installer) restoreTLSDestinations(destinations []tlsDestination) error {
+	var rollbackErr error
+	for _, destination := range destinations {
+		if destination.info == nil {
+			if err := inst.fs.Remove(destination.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				rollbackErr = errors.Join(rollbackErr, fmt.Errorf("remove partial %s: %w", destination.path, err))
+			}
+			continue
+		}
+		if err := inst.fs.Rename(destination.backupPath, destination.path); err != nil {
+			rollbackErr = errors.Join(rollbackErr, fmt.Errorf("restore %s: %w", destination.path, err))
+		}
+	}
+	if rollbackErr != nil {
+		return fmt.Errorf("rollback TLS replacement: %w", rollbackErr)
+	}
 	return nil
 }
 

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -4,10 +4,13 @@ package installer
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -32,6 +35,9 @@ type Config struct {
 	Image        string
 	ConfigPath   string
 	Port         string
+	SSLCert      string
+	SSLKey       string
+	SSLCheckSkip bool
 }
 
 // Installer orchestrates fresh installs and upgrades of the registry
@@ -174,6 +180,12 @@ func (inst *Installer) freshInstall(ctx context.Context, cfg *Config, imageRef s
 		}
 	}
 
+	if cfg.SSLCert != "" {
+		if err := inst.copyUserTLS(cfg); err != nil {
+			return fmt.Errorf("TLS certificate setup: %w", err)
+		}
+	}
+
 	spec := system.QuadletSpec{
 		Image:      imageRef,
 		DataDir:    cfg.DataDir,
@@ -237,4 +249,82 @@ func (inst *Installer) dumpContainerLogs(ctx context.Context) {
 	slog.Info("dumping container logs for diagnostics")
 	_ = inst.runner.Run(ctx, "podman", "logs", quadletServiceName)
 	_ = inst.runner.Run(ctx, "systemctl", "status", quadletServiceName)
+}
+
+// ValidateSSLFlags checks that -ssl-cert and -ssl-key are either both provided
+// or both absent. Returns an error if only one is set.
+func ValidateSSLFlags(sslCert, sslKey string) error {
+	if (sslCert == "") != (sslKey == "") {
+		return fmt.Errorf("-ssl-cert and -ssl-key must both be provided")
+	}
+	return nil
+}
+
+// copyUserTLS validates and copies user-provided TLS cert/key into the data
+// directory so the serve process uses them instead of auto-generating.
+func (inst *Installer) copyUserTLS(cfg *Config) error {
+	certData, err := inst.fs.ReadFile(cfg.SSLCert)
+	if err != nil {
+		return fmt.Errorf("read certificate: %w", err)
+	}
+	keyData, err := inst.fs.ReadFile(cfg.SSLKey)
+	if err != nil {
+		return fmt.Errorf("read key: %w", err)
+	}
+
+	if _, err := tls.X509KeyPair(certData, keyData); err != nil {
+		return fmt.Errorf("certificate/key pair invalid: %w", err)
+	}
+
+	if !cfg.SSLCheckSkip {
+		cert, err := parseCertPEM(certData)
+		if err != nil {
+			return fmt.Errorf("parse certificate: %w", err)
+		}
+		if err := verifyCertHostname(cert, cfg.Hostname); err != nil {
+			return fmt.Errorf("certificate hostname check failed (use -ssl-check-skip to override): %w", err)
+		}
+	}
+
+	certDst := filepath.Join(cfg.DataDir, "ssl.cert")
+	if err := inst.fs.WriteFile(certDst, certData, 0o600); err != nil {
+		return fmt.Errorf("write certificate: %w", err)
+	}
+	keyDst := filepath.Join(cfg.DataDir, "ssl.key")
+	if err := inst.fs.WriteFile(keyDst, keyData, 0o600); err != nil {
+		return fmt.Errorf("write key: %w", err)
+	}
+
+	slog.Info("user-provided TLS certificate installed", "cert", certDst, "key", keyDst)
+	return nil
+}
+
+func parseCertPEM(data []byte) (*x509.Certificate, error) {
+	var block *pem.Block
+	rest := data
+	for {
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			return nil, fmt.Errorf("no CERTIFICATE block found in PEM data")
+		}
+		if block.Type == "CERTIFICATE" {
+			break
+		}
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+func verifyCertHostname(cert *x509.Certificate, hostname string) error {
+	if ip := net.ParseIP(hostname); ip != nil {
+		for _, certIP := range cert.IPAddresses {
+			if certIP.Equal(ip) {
+				return nil
+			}
+		}
+		return fmt.Errorf("certificate does not contain IP SAN for %s", hostname)
+	}
+	if err := cert.VerifyHostname(hostname); err != nil {
+		return fmt.Errorf("hostname %q not in certificate SANs: %w", hostname, err)
+	}
+	return nil
 }

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -2,6 +2,9 @@ package installer
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,7 +53,7 @@ func TestUpgradeUsesEffectivePort(t *testing.T) {
 			port, err := inst.resolvePort(tt.requestedPort, true)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantPort, port)
-			require.NoError(t, inst.upgrade(t.Context(), "localhost/quay:new", port))
+			require.NoError(t, inst.upgrade(t.Context(), &Config{}, "localhost/quay:new", port))
 
 			content, err := os.ReadFile(env.QuadletPath(quadletServiceName))
 			require.NoError(t, err)
@@ -59,6 +62,52 @@ func TestUpgradeUsesEffectivePort(t *testing.T) {
 			assert.Equal(t, []string{"stop:quay", "daemon-reload", "start:quay"}, services.calls)
 		})
 	}
+}
+
+func TestUpgradeInstallsReplacementTLS(t *testing.T) {
+	dataDir := t.TempDir()
+	oldCert, oldKey := generateTLSFiles(t, dataDir)
+	oldCertData, err := os.ReadFile(oldCert)
+	require.NoError(t, err)
+	oldKeyData, err := os.ReadFile(oldKey)
+	require.NoError(t, err)
+
+	sourceDir := t.TempDir()
+	newCert, newKey := generateTLSFiles(t, sourceDir)
+	newCertData, err := os.ReadFile(newCert)
+	require.NoError(t, err)
+	newKeyData, err := os.ReadFile(newKey)
+	require.NoError(t, err)
+	require.NotEqual(t, oldCertData, newCertData)
+	require.NotEqual(t, oldKeyData, newKeyData)
+
+	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir()}
+	quadlet := system.NewQuadletManager(system.OSFS{}, env)
+	require.NoError(t, quadlet.Install(quadletServiceName, &system.QuadletSpec{
+		Image:    "localhost/quay:old",
+		DataDir:  dataDir,
+		Hostname: "registry.example.com",
+		Port:     "8443",
+	}))
+	services := &recordingServiceManager{}
+	inst := &Installer{
+		systemd: services,
+		quadlet: quadlet,
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	err = inst.upgrade(t.Context(), &Config{
+		Hostname: "registry.example.com",
+		DataDir:  dataDir,
+		SSLCert:  newCert,
+		SSLKey:   newKey,
+	}, "localhost/quay:new", "8443")
+
+	require.NoError(t, err)
+	assert.Equal(t, newCertData, mustReadFile(t, filepath.Join(dataDir, "ssl.cert")))
+	assert.Equal(t, newKeyData, mustReadFile(t, filepath.Join(dataDir, "ssl.key")))
+	assert.Equal(t, []string{"stop:quay", "daemon-reload", "start:quay"}, services.calls)
 }
 
 func TestResolvePortDefaultsFreshInstall(t *testing.T) {
@@ -216,4 +265,166 @@ func TestParseCertPEM_Invalid(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for invalid PEM")
 	}
+}
+
+func TestHealthTLSConfigSkipsOnlyHostnameVerification(t *testing.T) {
+	serverDir := t.TempDir()
+	serverCertPath, _ := generateTLSFiles(t, serverDir)
+	serverCert, err := parseCertPEM(mustReadFile(t, serverCertPath))
+	require.NoError(t, err)
+
+	strictConfig, err := healthTLSConfig(mustReadFile(t, serverCertPath), false)
+	require.NoError(t, err)
+	assert.False(t, strictConfig.InsecureSkipVerify)
+	assert.Nil(t, strictConfig.VerifyConnection)
+	assert.Error(t, serverCert.VerifyHostname("127.0.0.1"))
+
+	skipConfig, err := healthTLSConfig(mustReadFile(t, serverCertPath), true)
+	require.NoError(t, err)
+	assert.True(t, skipConfig.InsecureSkipVerify)
+	require.NotNil(t, skipConfig.VerifyConnection)
+	require.NoError(t, skipConfig.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{serverCert},
+	}))
+
+	untrustedDir := t.TempDir()
+	untrustedCertPath, _ := generateTLSFiles(t, untrustedDir)
+	untrustedConfig, err := healthTLSConfig(mustReadFile(t, untrustedCertPath), true)
+	require.NoError(t, err)
+	require.Error(t, untrustedConfig.VerifyConnection(tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{serverCert},
+	}))
+}
+
+func TestCopyUserTLSReplacesPermissiveKeyWithSecureMode(t *testing.T) {
+	dataDir := t.TempDir()
+	generateTLSFiles(t, dataDir)
+	require.NoError(t, os.Chmod(filepath.Join(dataDir, "ssl.key"), 0o644))
+
+	sourceDir := t.TempDir()
+	certPath, keyPath := generateTLSFiles(t, sourceDir)
+	inst := &Installer{fs: system.OSFS{}}
+
+	require.NoError(t, inst.copyUserTLS(&Config{
+		Hostname: "registry.example.com",
+		DataDir:  dataDir,
+		SSLCert:  certPath,
+		SSLKey:   keyPath,
+	}))
+
+	keyInfo, err := os.Stat(filepath.Join(dataDir, "ssl.key"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), keyInfo.Mode().Perm())
+	assert.Equal(t, mustReadFile(t, keyPath), mustReadFile(t, filepath.Join(dataDir, "ssl.key")))
+}
+
+func TestCopyUserTLSRejectsUnsafeDestinations(t *testing.T) {
+	tests := []struct {
+		name        string
+		destination string
+		setup       func(t *testing.T, path string)
+	}{
+		{
+			name:        "certificate symlink",
+			destination: "ssl.cert",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				target := filepath.Join(t.TempDir(), "target")
+				require.NoError(t, os.WriteFile(target, []byte("unchanged"), 0o600))
+				require.NoError(t, os.Symlink(target, path))
+				t.Cleanup(func() {
+					assert.Equal(t, []byte("unchanged"), mustReadFile(t, target))
+				})
+			},
+		},
+		{
+			name:        "key directory",
+			destination: "ssl.key",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				require.NoError(t, os.Mkdir(path, 0o700))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			test.setup(t, filepath.Join(dataDir, test.destination))
+			sourceDir := t.TempDir()
+			certPath, keyPath := generateTLSFiles(t, sourceDir)
+			inst := &Installer{fs: system.OSFS{}}
+
+			err := inst.copyUserTLS(&Config{
+				Hostname: "registry.example.com",
+				DataDir:  dataDir,
+				SSLCert:  certPath,
+				SSLKey:   keyPath,
+			})
+
+			require.ErrorContains(t, err, "is not a regular file")
+			info, statErr := os.Lstat(filepath.Join(dataDir, test.destination))
+			require.NoError(t, statErr)
+			if test.destination == "ssl.cert" {
+				assert.NotZero(t, info.Mode()&os.ModeSymlink)
+			} else {
+				assert.True(t, info.IsDir())
+			}
+		})
+	}
+}
+
+func TestCopyUserTLSRollsBackPairWhenKeyReplacementFails(t *testing.T) {
+	dataDir := t.TempDir()
+	oldCertPath, oldKeyPath := generateTLSFiles(t, dataDir)
+	oldCert := mustReadFile(t, oldCertPath)
+	oldKey := mustReadFile(t, oldKeyPath)
+
+	sourceDir := t.TempDir()
+	newCertPath, newKeyPath := generateTLSFiles(t, sourceDir)
+	failingFS := &failKeyRenameFS{OSFS: system.OSFS{}, keyDestination: oldKeyPath}
+	inst := &Installer{fs: failingFS}
+
+	err := inst.copyUserTLS(&Config{
+		Hostname: "registry.example.com",
+		DataDir:  dataDir,
+		SSLCert:  newCertPath,
+		SSLKey:   newKeyPath,
+	})
+
+	require.ErrorContains(t, err, "replace ssl.key")
+	assert.Equal(t, oldCert, mustReadFile(t, oldCertPath))
+	assert.Equal(t, oldKey, mustReadFile(t, oldKeyPath))
+	_, err = tls.X509KeyPair(mustReadFile(t, oldCertPath), mustReadFile(t, oldKeyPath))
+	require.NoError(t, err)
+	entries, err := os.ReadDir(dataDir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+}
+
+type failKeyRenameFS struct {
+	system.OSFS
+	keyDestination string
+}
+
+func (fs *failKeyRenameFS) Rename(oldPath, newPath string) error {
+	if newPath == fs.keyDestination && filepath.Base(oldPath) == "ssl.key" {
+		return errors.New("injected key replacement failure")
+	}
+	return fs.OSFS.Rename(oldPath, newPath)
+}
+
+func generateTLSFiles(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	certPath = filepath.Join(dir, "ssl.cert")
+	keyPath = filepath.Join(dir, "ssl.key")
+	require.NoError(t, certs.GenerateSelfSigned("registry.example.com", certPath, keyPath))
+	return certPath, keyPath
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return data
 }

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -107,6 +107,9 @@ func TestUpgradeInstallsReplacementTLS(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, newCertData, mustReadFile(t, filepath.Join(dataDir, "ssl.cert")))
 	assert.Equal(t, newKeyData, mustReadFile(t, filepath.Join(dataDir, "ssl.key")))
+	keyInfo, err := os.Stat(filepath.Join(dataDir, "ssl.key"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), keyInfo.Mode().Perm())
 	assert.Equal(t, []string{"stop:quay", "daemon-reload", "start:quay"}, services.calls)
 }
 

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/quay/quay/internal/certs"
 	"github.com/quay/quay/internal/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -107,3 +108,112 @@ func (r *recordingServiceManager) EnableLinger(context.Context) error {
 }
 
 var _ system.ServiceManager = (*recordingServiceManager)(nil)
+
+func TestValidateSSLFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		cert    string
+		key     string
+		wantErr bool
+	}{
+		{"both empty", "", "", false},
+		{"both set", "/tmp/ssl.cert", "/tmp/ssl.key", false},
+		{"cert only", "/tmp/ssl.cert", "", true},
+		{"key only", "", "/tmp/ssl.key", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSSLFlags(tt.cert, tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSSLFlags(%q, %q) error = %v, wantErr %v", tt.cert, tt.key, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyCertHostname(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ssl.cert")
+	keyPath := filepath.Join(dir, "ssl.key")
+
+	if err := certs.GenerateSelfSigned("myhost.example.com", certPath, keyPath); err != nil {
+		t.Fatalf("generate cert: %v", err)
+	}
+
+	certData, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+
+	cert, err := parseCertPEM(certData)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+
+	if err := verifyCertHostname(cert, "myhost.example.com"); err != nil {
+		t.Errorf("expected hostname to match: %v", err)
+	}
+
+	if err := verifyCertHostname(cert, "wrong.example.com"); err == nil {
+		t.Error("expected hostname mismatch error")
+	}
+}
+
+func TestVerifyCertHostnameIP(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ssl.cert")
+	keyPath := filepath.Join(dir, "ssl.key")
+
+	if err := certs.GenerateSelfSigned("192.168.1.100", certPath, keyPath); err != nil {
+		t.Fatalf("generate cert: %v", err)
+	}
+
+	certData, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+
+	cert, err := parseCertPEM(certData)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+
+	if err := verifyCertHostname(cert, "192.168.1.100"); err != nil {
+		t.Errorf("expected IP to match: %v", err)
+	}
+
+	if err := verifyCertHostname(cert, "10.0.0.1"); err == nil {
+		t.Error("expected IP mismatch error")
+	}
+}
+
+func TestParseCertPEM(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ssl.cert")
+	keyPath := filepath.Join(dir, "ssl.key")
+
+	if err := certs.GenerateSelfSigned("test.example.com", certPath, keyPath); err != nil {
+		t.Fatalf("generate cert: %v", err)
+	}
+
+	certData, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+
+	cert, err := parseCertPEM(certData)
+	if err != nil {
+		t.Fatalf("parseCertPEM: %v", err)
+	}
+
+	if cert.Subject.CommonName != "test.example.com" {
+		t.Errorf("CN = %q, want %q", cert.Subject.CommonName, "test.example.com")
+	}
+}
+
+func TestParseCertPEM_Invalid(t *testing.T) {
+	_, err := parseCertPEM([]byte("not a cert"))
+	if err == nil {
+		t.Error("expected error for invalid PEM")
+	}
+}

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -281,19 +281,25 @@ func TestHealthTLSConfigSkipsOnlyHostnameVerification(t *testing.T) {
 
 	skipConfig, err := healthTLSConfig(mustReadFile(t, serverCertPath), true)
 	require.NoError(t, err)
-	assert.True(t, skipConfig.InsecureSkipVerify)
-	require.NotNil(t, skipConfig.VerifyConnection)
-	require.NoError(t, skipConfig.VerifyConnection(tls.ConnectionState{
-		PeerCertificates: []*x509.Certificate{serverCert},
-	}))
+	assert.False(t, skipConfig.InsecureSkipVerify)
+	assert.Equal(t, "registry.example.com", skipConfig.ServerName)
+	_, err = serverCert.Verify(x509.VerifyOptions{
+		Roots:     skipConfig.RootCAs,
+		DNSName:   skipConfig.ServerName,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	require.NoError(t, err)
 
 	untrustedDir := t.TempDir()
 	untrustedCertPath, _ := generateTLSFiles(t, untrustedDir)
 	untrustedConfig, err := healthTLSConfig(mustReadFile(t, untrustedCertPath), true)
 	require.NoError(t, err)
-	require.Error(t, untrustedConfig.VerifyConnection(tls.ConnectionState{
-		PeerCertificates: []*x509.Certificate{serverCert},
-	}))
+	_, err = serverCert.Verify(x509.VerifyOptions{
+		Roots:     untrustedConfig.RootCAs,
+		DNSName:   untrustedConfig.ServerName,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	require.Error(t, err)
 }
 
 func TestCopyUserTLSReplacesPermissiveKeyWithSecureMode(t *testing.T) {

--- a/internal/system/fs.go
+++ b/internal/system/fs.go
@@ -7,7 +7,13 @@ type FileSystem interface {
 	ReadFile(path string) ([]byte, error)
 	WriteFile(path string, data []byte, perm os.FileMode) error
 	MkdirAll(path string, perm os.FileMode) error
+	MkdirTemp(dir, pattern string) (string, error)
 	Stat(path string) (os.FileInfo, error)
+	Lstat(path string) (os.FileInfo, error)
+	Chmod(path string, mode os.FileMode) error
+	Link(oldPath, newPath string) error
+	Rename(oldPath, newPath string) error
+	Remove(path string) error
 }
 
 // OSFS implements FileSystem using the real filesystem.
@@ -24,5 +30,23 @@ func (OSFS) WriteFile(path string, data []byte, perm os.FileMode) error {
 // MkdirAll delegates to os.MkdirAll.
 func (OSFS) MkdirAll(path string, perm os.FileMode) error { return os.MkdirAll(path, perm) }
 
+// MkdirTemp delegates to os.MkdirTemp.
+func (OSFS) MkdirTemp(dir, pattern string) (string, error) { return os.MkdirTemp(dir, pattern) }
+
 // Stat delegates to os.Stat.
 func (OSFS) Stat(path string) (os.FileInfo, error) { return os.Stat(path) }
+
+// Lstat delegates to os.Lstat.
+func (OSFS) Lstat(path string) (os.FileInfo, error) { return os.Lstat(path) }
+
+// Chmod delegates to os.Chmod.
+func (OSFS) Chmod(path string, mode os.FileMode) error { return os.Chmod(path, mode) }
+
+// Link delegates to os.Link.
+func (OSFS) Link(oldPath, newPath string) error { return os.Link(oldPath, newPath) }
+
+// Rename delegates to os.Rename.
+func (OSFS) Rename(oldPath, newPath string) error { return os.Rename(oldPath, newPath) }
+
+// Remove delegates to os.Remove.
+func (OSFS) Remove(path string) error { return os.Remove(path) }

--- a/internal/system/fs.go
+++ b/internal/system/fs.go
@@ -19,6 +19,8 @@ type FileSystem interface {
 // OSFS implements FileSystem using the real filesystem.
 type OSFS struct{}
 
+var _ FileSystem = OSFS{}
+
 // ReadFile delegates to os.ReadFile.
 func (OSFS) ReadFile(path string) ([]byte, error) { return os.ReadFile(path) } //nolint:gosec // paths from known locations
 


### PR DESCRIPTION
## Summary
- Add `-ssl-cert`, `-ssl-key`, and `-ssl-skip-hostname-verification` flags to the install command
- Validate the certificate/key pair and verify its SAN against `-hostname` unless hostname verification is explicitly skipped
- Install custom TLS material securely for fresh installs and upgrades with rollback-safe replacement
- Keep certificate trust verification enabled for the post-start health check when hostname verification is skipped
- Hard-fail if only one of certificate/key is provided, matching OMR 2.0.x behavior

## Testing
- [x] `go test -count=1 ./internal/...`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=5m ./...`
- [x] Pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
