### PR TITLE
PROJQUAY-12324: feat(install): add explicit registry initialization

### DIFF
--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -3,13 +3,9 @@ package bootstrap
 
 import (
 	"context"
-	"crypto/rand"
 	"database/sql"
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
@@ -17,28 +13,46 @@ import (
 	"github.com/quay/quay/internal/dal/daldb"
 )
 
-// AdminUser creates the initial admin user if no users exist in the database.
-// It returns true if a user was created, false if users already exist.
-// authDir is the directory where the admin-password file is stored.
-func AdminUser(ctx context.Context, db *sql.DB, username, authDir string) (bool, error) {
+// HasUsers reports whether the database already contains a login user.
+func HasUsers(ctx context.Context, db *sql.DB) (bool, error) {
 	q := daldb.New(db)
-
 	count, err := q.CountUsers(ctx)
 	if err != nil {
 		return false, fmt.Errorf("count users: %w", err)
 	}
-	if count > 0 {
-		return false, nil
-	}
+	return count > 0, nil
+}
 
-	if err := os.MkdirAll(authDir, 0o750); err != nil {
-		return false, fmt.Errorf("create auth dir: %w", err)
-	}
-
-	passFile := filepath.Join(authDir, "admin-password")
-	password, err := readOrGeneratePassword(passFile)
+// RequireAdminUser verifies that install-time provisioning has created a user
+// and returns the first login username for standalone default authorization.
+func RequireAdminUser(ctx context.Context, db *sql.DB) (string, error) {
+	var username string
+	err := db.QueryRowContext(ctx, `
+		SELECT username FROM "user"
+		WHERE organization = 0 AND robot = 0
+		ORDER BY id LIMIT 1
+	`).Scan(&username)
 	if err != nil {
-		return false, fmt.Errorf("password: %w", err)
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("database has no users; run `quay init` or `quay install` to provision the initial administrator")
+		}
+		return "", fmt.Errorf("find initial administrator: %w", err)
+	}
+	return username, nil
+}
+
+// AdminUser creates the initial admin user if no users exist in the database.
+// It returns true if a user was created, false if users already exist. Password
+// generation and persistence belong to the one-shot installer, not the server.
+func AdminUser(ctx context.Context, db *sql.DB, username, password string) (bool, error) {
+	q := daldb.New(db)
+
+	hasUsers, err := HasUsers(ctx, db)
+	if err != nil {
+		return false, err
+	}
+	if hasUsers {
+		return false, nil
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
@@ -57,24 +71,5 @@ func AdminUser(ctx context.Context, db *sql.DB, username, authDir string) (bool,
 	}
 
 	slog.Info("admin user created", "username", username)
-	slog.Info("password saved", "path", passFile)
 	return true, nil
-}
-
-func readOrGeneratePassword(passFile string) (string, error) {
-	data, err := os.ReadFile(passFile) //nolint:gosec // known path in data dir
-	if err == nil {
-		pass := strings.TrimSpace(string(data))
-		if pass != "" {
-			return pass, nil
-		}
-	}
-
-	pass := rand.Text()
-
-	if err := os.WriteFile(passFile, []byte(pass), 0o600); err != nil {
-		return "", fmt.Errorf("write credentials file: %w", err)
-	}
-
-	return pass, nil
 }

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -68,7 +68,9 @@ func AdminUser(ctx context.Context, db *sql.DB, username, password string) (bool
 		PasswordHash: sql.NullString{String: string(hash), Valid: true},
 		Email:        email,
 	}); err != nil {
-		return false, fmt.Errorf("create user: %w", err)
+		// Driver errors can include bound values, so do not propagate the
+		// password-derived hash to command-level logs.
+		return false, errors.New("create initial administrator")
 	}
 
 	slog.Info("admin user created", "username", username)

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -4,6 +4,7 @@ package bootstrap
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -57,7 +58,7 @@ func AdminUser(ctx context.Context, db *sql.DB, username, password string) (bool
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
-		return false, fmt.Errorf("hash password: %w", err)
+		return false, errors.New("hash initial administrator password")
 	}
 
 	email := fmt.Sprintf("%s@localhost", username)

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -2,12 +2,12 @@ package bootstrap
 
 import (
 	"io"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/quay/quay/internal/dal/daldb"
 	"github.com/quay/quay/internal/dal/dbcore"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestAdminUser_CreatesUser(t *testing.T) {
@@ -24,8 +24,7 @@ func TestAdminUser_CreatesUser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	authDir := filepath.Join(dir, "auth")
-	created, err := AdminUser(ctx, db, "admin", authDir)
+	created, err := AdminUser(ctx, db, "admin", "my-chosen-password")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,19 +40,8 @@ func TestAdminUser_CreatesUser(t *testing.T) {
 	if !user.Enabled {
 		t.Error("user should be enabled")
 	}
-
-	passFile := filepath.Join(authDir, "admin-password")
-	data, err := os.ReadFile(passFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(data) == 0 {
-		t.Error("credentials file is empty")
-	}
-
-	info, _ := os.Stat(passFile)
-	if info.Mode().Perm() != 0o600 {
-		t.Errorf("permissions = %o, want 0600", info.Mode().Perm())
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash.String), []byte("my-chosen-password")); err != nil {
+		t.Errorf("password does not match stored hash: %v", err)
 	}
 }
 
@@ -71,11 +59,10 @@ func TestAdminUser_SkipsExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	authDir := filepath.Join(dir, "auth")
-	if _, err := AdminUser(ctx, db, "admin", authDir); err != nil {
+	if _, err := AdminUser(ctx, db, "admin", "first-password"); err != nil {
 		t.Fatal(err)
 	}
-	created, err := AdminUser(ctx, db, "admin", authDir)
+	created, err := AdminUser(ctx, db, "other", "second-password")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +71,7 @@ func TestAdminUser_SkipsExisting(t *testing.T) {
 	}
 }
 
-func TestAdminUser_ReadsPreSeededPassword(t *testing.T) {
+func TestRequireAdminUser(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
 	db, err := dbcore.OpenSQLite(dbPath)
@@ -98,11 +85,11 @@ func TestAdminUser_ReadsPreSeededPassword(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	authDir := filepath.Join(dir, "auth")
-	os.MkdirAll(authDir, 0o750)
-	os.WriteFile(filepath.Join(authDir, "admin-password"), []byte("my-chosen-password"), 0o600)
+	if _, err := RequireAdminUser(ctx, db); err == nil {
+		t.Fatal("expected an uninitialized database error")
+	}
 
-	created, err := AdminUser(ctx, db, "admin", authDir)
+	created, err := AdminUser(ctx, db, "custom-admin", "my-chosen-password")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,12 +97,11 @@ func TestAdminUser_ReadsPreSeededPassword(t *testing.T) {
 		t.Error("expected user to be created")
 	}
 
-	q := daldb.New(db)
-	user, err := q.GetUserByUsername(ctx, "admin")
+	username, err := RequireAdminUser(ctx, db)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !user.PasswordHash.Valid {
-		t.Error("password hash should be valid")
+	if username != "custom-admin" {
+		t.Errorf("username = %q, want custom-admin", username)
 	}
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -24,6 +24,7 @@ func Run(args []string) int {
 		Flags:    fs,
 		Subcommands: []*Command{
 			newInstallCmd(),
+			newInitCmd(),
 			newConfigCmd(),
 			newServeCmd(),
 			newMigrateCmd(),

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/quay/quay/internal/installer"
+)
+
+func newInitCmd() *Command {
+	return newInitCmdWithDeps(os.Stdin, runInitialize)
+}
+
+func newInitCmdWithDeps(stdin io.Reader, initialize func(context.Context, *installer.Config) int) *Command {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	configPath := fs.String("config", "", "path to config.yaml (optional, overrides flags)")
+	dataDir := fs.String("data-dir", ".", "root directory for DB, storage, certs")
+	hostname := fs.String("hostname", "localhost", "server hostname for generated configuration")
+	initUser := fs.String("init-user", "admin", "admin username for initial setup")
+	initPasswordStdin := fs.Bool("init-password-stdin", false, "read the initial admin password from stdin")
+
+	return &Command{
+		Name:     "init",
+		Synopsis: "Initialize the registry database and administrator",
+		Flags:    fs,
+		Run: func(ctx context.Context, _ *Command, _ []string) int {
+			var password string
+			if *initPasswordStdin {
+				var err error
+				password, err = readInitPassword(stdin)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "error: read initial password:", err)
+					return 1
+				}
+			}
+			return initialize(ctx, &installer.Config{
+				ConfigPath:      *configPath,
+				DataDir:         *dataDir,
+				Hostname:        *hostname,
+				InitUser:        *initUser,
+				InitPassword:    password,
+				InitPasswordSet: *initPasswordStdin,
+			})
+		},
+	}
+}
+
+func runInitialize(ctx context.Context, cfg *installer.Config) int {
+	if err := installer.Initialize(ctx, cfg); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return 1
+	}
+	return 0
+}

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/quay/quay/internal/installer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadInitPassword(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{name: "pipe newline", input: "secret-password\n", want: "secret-password"},
+		{name: "pipe CRLF", input: "secret-password\r\n", want: "secret-password"},
+		{name: "no newline", input: "secret-password", want: "secret-password"},
+		{name: "surrounding spaces preserved", input: "  secret password  \n", want: "  secret password  "},
+		{name: "only one newline removed", input: "secret-password\n\n", want: "secret-password\n"},
+		{name: "72 bytes plus CRLF", input: strings.Repeat("x", 72) + "\r\n", want: strings.Repeat("x", 72)},
+		{name: "empty", input: "\n", wantErr: "must not be empty"},
+		{name: "too long", input: strings.Repeat("x", 73), wantErr: "must not exceed 72 bytes"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := readInitPassword(strings.NewReader(test.input))
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestInitCommandReadsPasswordFromStdin(t *testing.T) {
+	var got *installer.Config
+	cmd := newInitCmdWithDeps(strings.NewReader("  chosen secret  \n"), func(_ context.Context, cfg *installer.Config) int {
+		got = cfg
+		return 0
+	})
+
+	require.Nil(t, cmd.Flags.Lookup("init-password"))
+	require.NotNil(t, cmd.Flags.Lookup("init-password-stdin"))
+	require.Equal(t, 0, cmd.Execute(t.Context(), []string{
+		"-data-dir", "/tmp/quay-test",
+		"-init-user", "custom-admin",
+		"-init-password-stdin",
+	}))
+	require.NotNil(t, got)
+	assert.Equal(t, "custom-admin", got.InitUser)
+	assert.Equal(t, "  chosen secret  ", got.InitPassword)
+	assert.True(t, got.InitPasswordSet)
+}
+
+func TestInstallCommandReadsPasswordFromStdin(t *testing.T) {
+	var got *installer.Config
+	cmd := newInstallCmdWithDeps(strings.NewReader("chosen-secret\n"), func(_ context.Context, cfg *installer.Config) int {
+		got = cfg
+		return 0
+	})
+
+	require.Nil(t, cmd.Flags.Lookup("init-password"))
+	require.Equal(t, 0, cmd.Execute(t.Context(), []string{
+		"-hostname", "registry.example.com",
+		"-init-user", "custom-admin",
+		"-init-password-stdin",
+	}))
+	require.NotNil(t, got)
+	assert.Equal(t, "chosen-secret", got.InitPassword)
+	assert.True(t, got.InitPasswordSet)
+}

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/quay/quay/internal/installer"
 )
 
 func newInstallCmd() *Command {
+	return newInstallCmdWithDeps(os.Stdin, runInstall)
+}
+
+func newInstallCmdWithDeps(stdin io.Reader, install func(context.Context, *installer.Config) int) *Command {
 	fs := flag.NewFlagSet("install", flag.ContinueOnError)
 	hostname := fs.String("hostname", "", "server hostname for TLS and config (required)")
 	dataDir := fs.String("data-dir", "/var/lib/quay", "directory for database, storage, and certs")
@@ -19,7 +25,7 @@ func newInstallCmd() *Command {
 	sslKey := fs.String("ssl-key", "", "path to TLS private key (PEM)")
 	sslSkipHostnameVerification := fs.Bool("ssl-skip-hostname-verification", false, "allow TLS certificate hostname to differ from -hostname")
 	initUser := fs.String("init-user", "admin", "admin username for initial setup")
-	initPassword := fs.String("init-password", "", "admin password (auto-generated if not set)")
+	initPasswordStdin := fs.Bool("init-password-stdin", false, "read the initial admin password from stdin")
 	imageArchive := fs.String("image-archive", "", "path to container image tar (offline mode)")
 	image := fs.String("image", installer.DefaultImage, "container image to use")
 
@@ -38,7 +44,16 @@ func newInstallCmd() *Command {
 				cmd.Usage(os.Stderr)
 				return 1
 			}
-			return runInstall(ctx, &installer.Config{
+			var initPassword string
+			if *initPasswordStdin {
+				var err error
+				initPassword, err = readInitPassword(stdin)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "error: read initial password:", err)
+					return 1
+				}
+			}
+			return install(ctx, &installer.Config{
 				Hostname:                    *hostname,
 				DataDir:                     *dataDir,
 				Port:                        *port,
@@ -46,12 +61,33 @@ func newInstallCmd() *Command {
 				SSLKey:                      *sslKey,
 				SSLSkipHostnameVerification: *sslSkipHostnameVerification,
 				InitUser:                    *initUser,
-				InitPassword:                *initPassword,
+				InitPassword:                initPassword,
+				InitPasswordSet:             *initPasswordStdin,
 				ImageArchive:                *imageArchive,
 				Image:                       *image,
 			})
 		},
 	}
+}
+
+// readInitPassword follows the Podman password-stdin convention: consume the
+// secret from stdin and remove one final LF (or CRLF) produced by a typical
+// shell pipe. All other bytes, including surrounding spaces, are preserved.
+func readInitPassword(r io.Reader) (string, error) {
+	data, err := io.ReadAll(io.LimitReader(r, installer.MaxInitPasswordBytes+3))
+	if err != nil {
+		return "", err
+	}
+	password := string(data)
+	if strings.HasSuffix(password, "\r\n") {
+		password = strings.TrimSuffix(password, "\r\n")
+	} else {
+		password = strings.TrimSuffix(password, "\n")
+	}
+	if err := installer.ValidateInitPassword(password); err != nil {
+		return "", err
+	}
+	return password, nil
 }
 
 func runInstall(ctx context.Context, cfg *installer.Config) int {

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -18,6 +18,8 @@ func newInstallCmd() *Command {
 	sslCert := fs.String("ssl-cert", "", "path to TLS certificate (PEM)")
 	sslKey := fs.String("ssl-key", "", "path to TLS private key (PEM)")
 	sslSkipHostnameVerification := fs.Bool("ssl-skip-hostname-verification", false, "allow TLS certificate hostname to differ from -hostname")
+	initUser := fs.String("init-user", "admin", "admin username for initial setup")
+	initPassword := fs.String("init-password", "", "admin password (auto-generated if not set)")
 	imageArchive := fs.String("image-archive", "", "path to container image tar (offline mode)")
 	image := fs.String("image", installer.DefaultImage, "container image to use")
 
@@ -43,6 +45,8 @@ func newInstallCmd() *Command {
 				SSLCert:                     *sslCert,
 				SSLKey:                      *sslKey,
 				SSLSkipHostnameVerification: *sslSkipHostnameVerification,
+				InitUser:                    *initUser,
+				InitPassword:                *initPassword,
 				ImageArchive:                *imageArchive,
 				Image:                       *image,
 			})

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"log/slog"
 	"net/http"
-	"path/filepath"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -36,19 +35,18 @@ func newServeCmd() *Command {
 	dataDir := fs.String("data-dir", ".", "root directory for DB, storage, certs")
 	hostname := fs.String("hostname", "localhost", "server hostname for TLS SANs")
 	addr := fs.String("addr", ":8443", "listen address")
-	adminUsername := fs.String("admin-username", "admin", "admin username (first run only)")
 
 	return &Command{
 		Name:     "serve",
 		Synopsis: "Start the OCI container registry",
 		Flags:    fs,
 		Run: func(ctx context.Context, _ *Command, _ []string) int {
-			return runServe(ctx, *configPath, *dataDir, *hostname, *addr, *adminUsername)
+			return runServe(ctx, *configPath, *dataDir, *hostname, *addr)
 		},
 	}
 }
 
-func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUsername string) int {
+func runServe(ctx context.Context, configPath, dataDir, hostname, addr string) int {
 	resolved, err := config.Resolve(configPath, dataDir, hostname)
 	if err != nil {
 		slog.Error("config error", "err", err)
@@ -69,11 +67,12 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUse
 	}
 	blobLocks := oci.NewBlobLockSet()
 
-	authDir := filepath.Join(resolved.DataDir, "auth")
-	if _, err := bootstrap.AdminUser(ctx, db, adminUsername, authDir); err != nil {
-		slog.Error("bootstrap admin user error", "err", err)
+	adminUsername, err := bootstrap.RequireAdminUser(ctx, db)
+	if err != nil {
+		slog.Error("registry is not initialized", "err", err)
 		return 1
 	}
+	configureStandaloneSuperuser(resolved, adminUsername)
 
 	featureUserLastAccessed := featureEnabled(resolved.Config.FeatureUserLastAccessed)
 	lastAccessedUpdateThresholdSeconds := resolved.Config.LastAccessedUpdateThresholdS
@@ -187,6 +186,12 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr, adminUse
 	)
 
 	return srv.ListenAndServe(ctx)
+}
+
+func configureStandaloneSuperuser(resolved *config.Resolved, username string) {
+	if !resolved.FromFile {
+		resolved.Config.SuperUsers = []string{username}
+	}
 }
 
 func healthHandler(db *sql.DB) http.Handler {

--- a/internal/cmd/serve_test.go
+++ b/internal/cmd/serve_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/quay/quay/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigureStandaloneSuperuser(t *testing.T) {
+	t.Run("defaults follow initialized user", func(t *testing.T) {
+		resolved := &config.Resolved{Config: config.NewDefault("localhost", "/data/storage")}
+
+		configureStandaloneSuperuser(resolved, "custom-admin")
+
+		assert.Equal(t, []string{"custom-admin"}, resolved.Config.SuperUsers)
+	})
+
+	t.Run("explicit config remains authoritative", func(t *testing.T) {
+		resolved := &config.Resolved{
+			Config:   config.NewDefault("localhost", "/data/storage"),
+			FromFile: true,
+		}
+		resolved.Config.SuperUsers = []string{"configured-admin"}
+
+		configureStandaloneSuperuser(resolved, "database-user")
+
+		assert.Equal(t, []string{"configured-admin"}, resolved.Config.SuperUsers)
+	})
+}
+
+func TestServeHasNoBootstrapCredentialFlags(t *testing.T) {
+	cmd := newServeCmd()
+	assert.Nil(t, cmd.Flags.Lookup("admin-username"))
+	assert.Nil(t, cmd.Flags.Lookup("init-password"))
+	assert.Nil(t, cmd.Flags.Lookup("init-password-stdin"))
+}

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -14,6 +14,7 @@ type Resolved struct {
 	DataDir     string
 	StoragePath string
 	DBPath      string
+	FromFile    bool
 }
 
 // Resolve loads and resolves a complete configuration. If configPath is
@@ -44,7 +45,7 @@ func resolveFromFile(configPath string) (*Resolved, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Resolved{Config: cfg, DataDir: filepath.Dir(dbPath), StoragePath: storagePath, DBPath: dbPath}, nil
+	return &Resolved{Config: cfg, DataDir: filepath.Dir(dbPath), StoragePath: storagePath, DBPath: dbPath, FromFile: true}, nil
 }
 
 func resolveFromDefaults(dataDir, hostname string) (*Resolved, error) {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -465,7 +465,6 @@ func (inst *Installer) prepareInitialPassword(cfg *Config) (string, error) {
 	if err := inst.atomicWriteCredential(authDir, passwordPath, []byte(password)); err != nil {
 		return "", err
 	}
-	slog.Info("admin password saved", "path", passwordPath)
 	return password, nil
 }
 

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -4,6 +4,7 @@ package installer
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -15,10 +16,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/quay/quay/internal/bootstrap"
 	"github.com/quay/quay/internal/certs"
+	"github.com/quay/quay/internal/config"
+	"github.com/quay/quay/internal/dal/dbcore"
 	"github.com/quay/quay/internal/system"
 )
 
@@ -26,8 +31,9 @@ const (
 	// DefaultImage is the default container image for the registry.
 	DefaultImage = "quay.io/quay/quay-mirror:latest"
 
-	defaultPort        = "8443"
-	quadletServiceName = "quay"
+	defaultPort         = "8443"
+	defaultInitUsername = "admin"
+	quadletServiceName  = "quay"
 )
 
 // Config holds the parameters for an install or upgrade operation.
@@ -43,6 +49,7 @@ type Config struct {
 	SSLSkipHostnameVerification bool
 	InitUser                    string
 	InitPassword                string
+	InitPasswordSet             bool
 }
 
 // Installer orchestrates fresh installs and upgrades of the registry
@@ -77,6 +84,23 @@ func New(stderr io.Writer) (*Installer, error) {
 	}, nil
 }
 
+// Initialize performs the one-shot initialization used by both `quay init`
+// and `quay install`, without starting a long-running server or container.
+func Initialize(ctx context.Context, cfg *Config) error {
+	if cfg == nil {
+		return fmt.Errorf("nil installer config")
+	}
+	resolvedCfg := *cfg
+	if resolvedCfg.InitUser == "" {
+		resolvedCfg.InitUser = defaultInitUsername
+	}
+	if err := validateInitConfig(&resolvedCfg); err != nil {
+		return fmt.Errorf("initial administrator: %w", err)
+	}
+	inst := &Installer{fs: system.OSFS{}}
+	return inst.initialize(ctx, &resolvedCfg)
+}
+
 // Run performs an install or upgrade based on whether a Quadlet unit already
 // exists.
 func (inst *Installer) Run(ctx context.Context, cfg *Config) error {
@@ -84,13 +108,24 @@ func (inst *Installer) Run(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("nil installer config")
 	}
 
+	resolvedCfg := *cfg
+	if resolvedCfg.InitUser == "" {
+		resolvedCfg.InitUser = defaultInitUsername
+	}
+	if err := validateInitConfig(&resolvedCfg); err != nil {
+		return fmt.Errorf("initial administrator: %w", err)
+	}
+
 	upgrading := inst.quadlet.Exists(quadletServiceName)
 	port, err := inst.resolvePort(cfg.Port, upgrading)
 	if err != nil {
 		return fmt.Errorf("resolve port: %w", err)
 	}
-	resolvedCfg := *cfg
 	resolvedCfg.Port = port
+
+	if err := inst.initialize(ctx, &resolvedCfg); err != nil {
+		return fmt.Errorf("initialize registry: %w", err)
+	}
 
 	imageRef, err := inst.resolveImage(ctx, resolvedCfg.ImageArchive, resolvedCfg.Image)
 	if err != nil {
@@ -115,7 +150,7 @@ func (inst *Installer) Run(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("health check: %w", err)
 	}
 
-	credPath := filepath.Join(resolvedCfg.DataDir, "credentials")
+	credPath := filepath.Join(resolvedCfg.DataDir, "auth", "admin-password")
 	slog.Info("registry running", "url", fmt.Sprintf("https://%s:%s", resolvedCfg.Hostname, port), "credentials", credPath)
 	return nil
 }
@@ -187,31 +222,18 @@ func (inst *Installer) upgrade(ctx context.Context, cfg *Config, imageRef, port 
 }
 
 func (inst *Installer) freshInstall(ctx context.Context, cfg *Config, imageRef string) error {
-	for _, dir := range []string{cfg.DataDir, filepath.Join(cfg.DataDir, "storage")} {
-		if err := inst.fs.MkdirAll(dir, 0o750); err != nil {
-			return fmt.Errorf("create directory %s: %w", dir, err)
-		}
-	}
-
 	if cfg.SSLCert != "" {
 		if err := inst.copyUserTLS(cfg); err != nil {
 			return fmt.Errorf("TLS certificate setup: %w", err)
 		}
 	}
 
-	if cfg.InitPassword != "" {
-		if err := inst.writeInitPassword(cfg.DataDir, cfg.InitPassword); err != nil {
-			return fmt.Errorf("write init password: %w", err)
-		}
-	}
-
 	spec := system.QuadletSpec{
-		Image:         imageRef,
-		DataDir:       cfg.DataDir,
-		Hostname:      cfg.Hostname,
-		Port:          cfg.Port,
-		ConfigPath:    cfg.ConfigPath,
-		AdminUsername: cfg.InitUser,
+		Image:      imageRef,
+		DataDir:    cfg.DataDir,
+		Hostname:   cfg.Hostname,
+		Port:       cfg.Port,
+		ConfigPath: cfg.ConfigPath,
 	}
 	if err := inst.quadlet.Install(quadletServiceName, &spec); err != nil {
 		return fmt.Errorf("install quadlet: %w", err)
@@ -307,16 +329,190 @@ func healthServerName(cert *x509.Certificate) (string, error) {
 	return "", fmt.Errorf("certificate has no usable DNS or IP subject alternative name")
 }
 
-func (inst *Installer) writeInitPassword(dataDir, password string) error {
-	authDir := filepath.Join(dataDir, "auth")
-	if err := inst.fs.MkdirAll(authDir, 0o750); err != nil {
-		return fmt.Errorf("create auth directory: %w", err)
+func validateInitConfig(cfg *Config) error {
+	if err := ValidateInitUsername(cfg.InitUser); err != nil {
+		return fmt.Errorf("invalid username %q: %w", cfg.InitUser, err)
 	}
-	passPath := filepath.Join(authDir, "admin-password")
-	if err := inst.fs.WriteFile(passPath, []byte(password), 0o600); err != nil {
-		return fmt.Errorf("write password file: %w", err)
+	if cfg.InitPasswordSet || cfg.InitPassword != "" {
+		if err := ValidateInitPassword(cfg.InitPassword); err != nil {
+			return fmt.Errorf("invalid password: %w", err)
+		}
 	}
-	slog.Info("admin password set", "path", passPath)
+	return nil
+}
+
+func (inst *Installer) initialize(ctx context.Context, cfg *Config) error {
+	for _, dir := range []string{cfg.DataDir, filepath.Join(cfg.DataDir, "storage")} {
+		if err := inst.fs.MkdirAll(dir, 0o750); err != nil {
+			return fmt.Errorf("create directory %s: %w", dir, err)
+		}
+	}
+
+	dbPath, runtimeCfg, err := resolveInitDatabase(cfg)
+	if err != nil {
+		return err
+	}
+
+	db, err := dbcore.Setup(ctx, dbPath)
+	if err != nil {
+		return fmt.Errorf("database setup: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	hasUsers, err := bootstrap.HasUsers(ctx, db)
+	if err != nil {
+		return err
+	}
+	if hasUsers {
+		if cfg.InitPasswordSet || cfg.InitPassword != "" {
+			return fmt.Errorf("registry is already initialized; supplied password was not applied and existing credentials are unchanged")
+		}
+		slog.Info("initial administrator already provisioned")
+		return nil
+	}
+
+	if runtimeCfg != nil && !slices.Contains(runtimeCfg.SuperUsers, cfg.InitUser) {
+		return fmt.Errorf("initial username %q is not listed in SUPER_USERS", cfg.InitUser)
+	}
+
+	password, err := inst.prepareInitialPassword(cfg)
+	if err != nil {
+		return err
+	}
+	created, err := bootstrap.AdminUser(ctx, db, cfg.InitUser, password)
+	if err != nil {
+		return fmt.Errorf("create initial administrator: %w", err)
+	}
+	if !created {
+		return fmt.Errorf("initial administrator was created concurrently; credentials were not changed")
+	}
+	return nil
+}
+
+func resolveInitDatabase(cfg *Config) (string, *config.Config, error) {
+	dbPath := filepath.Join(cfg.DataDir, "quay.db")
+	if cfg.ConfigPath == "" {
+		return dbPath, nil, nil
+	}
+
+	hostConfigPath, err := hostDataPath(cfg.DataDir, cfg.ConfigPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve config path: %w", err)
+	}
+	resolved, err := config.Resolve(hostConfigPath, cfg.DataDir, cfg.Hostname)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve config: %w", err)
+	}
+	dbPath, err = hostDataPath(cfg.DataDir, resolved.DBPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve database path: %w", err)
+	}
+	return dbPath, resolved.Config, nil
+}
+
+func hostDataPath(dataDir, path string) (string, error) {
+	if path == "/data" {
+		return dataDir, nil
+	}
+	if relative, ok := strings.CutPrefix(path, "/data/"); ok {
+		cleaned := filepath.Clean(relative)
+		if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+			return "", fmt.Errorf("path %q escapes /data", path)
+		}
+		return filepath.Join(dataDir, cleaned), nil
+	}
+	return path, nil
+}
+
+func (inst *Installer) prepareInitialPassword(cfg *Config) (string, error) {
+	authDir := filepath.Join(cfg.DataDir, "auth")
+	if err := inst.secureAuthDir(authDir); err != nil {
+		return "", err
+	}
+
+	passwordPath := filepath.Join(authDir, "admin-password")
+	info, err := inst.fs.Lstat(passwordPath)
+	switch {
+	case err == nil && !info.Mode().IsRegular():
+		return "", fmt.Errorf("credential destination %s is not a regular file", passwordPath)
+	case err != nil && !errors.Is(err, os.ErrNotExist):
+		return "", fmt.Errorf("inspect credential destination: %w", err)
+	}
+
+	provided := cfg.InitPasswordSet || cfg.InitPassword != ""
+	if err == nil && !provided {
+		if info.Mode().Perm() != 0o600 {
+			return "", fmt.Errorf("existing credential file %s has unsafe permissions %04o", passwordPath, info.Mode().Perm())
+		}
+		data, readErr := inst.fs.ReadFile(passwordPath)
+		if readErr != nil {
+			return "", fmt.Errorf("read existing credential file: %w", readErr)
+		}
+		password := string(data)
+		if validateErr := ValidateInitPassword(password); validateErr != nil {
+			return "", fmt.Errorf("existing credential file is invalid; retry with -init-password-stdin: %w", validateErr)
+		}
+		return password, nil
+	}
+
+	password := cfg.InitPassword
+	if !provided {
+		password = rand.Text()
+	}
+	if err := ValidateInitPassword(password); err != nil {
+		return "", fmt.Errorf("invalid password: %w", err)
+	}
+	if err := inst.atomicWriteCredential(authDir, passwordPath, []byte(password)); err != nil {
+		return "", err
+	}
+	slog.Info("admin password saved", "path", passwordPath)
+	return password, nil
+}
+
+func (inst *Installer) secureAuthDir(authDir string) error {
+	info, err := inst.fs.Lstat(authDir)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		if err := inst.fs.MkdirAll(authDir, 0o700); err != nil {
+			return fmt.Errorf("create auth directory: %w", err)
+		}
+	case err != nil:
+		return fmt.Errorf("inspect auth directory: %w", err)
+	case !info.IsDir():
+		return fmt.Errorf("auth destination %s is not a directory", authDir)
+	}
+	if err := inst.fs.Chmod(authDir, 0o700); err != nil {
+		return fmt.Errorf("secure auth directory: %w", err)
+	}
+	return nil
+}
+
+func (inst *Installer) atomicWriteCredential(dir, destination string, data []byte) (retErr error) {
+	stagingDir, err := inst.fs.MkdirTemp(dir, ".credential-")
+	if err != nil {
+		return fmt.Errorf("create credential staging directory: %w", err)
+	}
+	stagedPath := filepath.Join(stagingDir, "admin-password")
+	defer func() {
+		if err := inst.fs.Remove(stagedPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			retErr = errors.Join(retErr, fmt.Errorf("remove staged credential: %w", err))
+		}
+		if err := inst.fs.Remove(stagingDir); err != nil && !errors.Is(err, os.ErrNotExist) {
+			retErr = errors.Join(retErr, fmt.Errorf("remove credential staging directory: %w", err))
+		}
+	}()
+	if err := inst.fs.Chmod(stagingDir, 0o700); err != nil {
+		return fmt.Errorf("secure credential staging directory: %w", err)
+	}
+	if err := inst.fs.WriteFile(stagedPath, data, 0o600); err != nil {
+		return fmt.Errorf("stage credential: %w", err)
+	}
+	if err := inst.fs.Chmod(stagedPath, 0o600); err != nil {
+		return fmt.Errorf("secure staged credential: %w", err)
+	}
+	if err := inst.fs.Rename(stagedPath, destination); err != nil {
+		return fmt.Errorf("install credential: %w", err)
+	}
 	return nil
 }
 

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -41,6 +41,8 @@ type Config struct {
 	SSLCert                     string
 	SSLKey                      string
 	SSLSkipHostnameVerification bool
+	InitUser                    string
+	InitPassword                string
 }
 
 // Installer orchestrates fresh installs and upgrades of the registry
@@ -197,12 +199,19 @@ func (inst *Installer) freshInstall(ctx context.Context, cfg *Config, imageRef s
 		}
 	}
 
+	if cfg.InitPassword != "" {
+		if err := inst.writeInitPassword(cfg.DataDir, cfg.InitPassword); err != nil {
+			return fmt.Errorf("write init password: %w", err)
+		}
+	}
+
 	spec := system.QuadletSpec{
-		Image:      imageRef,
-		DataDir:    cfg.DataDir,
-		Hostname:   cfg.Hostname,
-		Port:       cfg.Port,
-		ConfigPath: cfg.ConfigPath,
+		Image:         imageRef,
+		DataDir:       cfg.DataDir,
+		Hostname:      cfg.Hostname,
+		Port:          cfg.Port,
+		ConfigPath:    cfg.ConfigPath,
+		AdminUsername: cfg.InitUser,
 	}
 	if err := inst.quadlet.Install(quadletServiceName, &spec); err != nil {
 		return fmt.Errorf("install quadlet: %w", err)
@@ -296,6 +305,19 @@ func healthServerName(cert *x509.Certificate) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("certificate has no usable DNS or IP subject alternative name")
+}
+
+func (inst *Installer) writeInitPassword(dataDir, password string) error {
+	authDir := filepath.Join(dataDir, "auth")
+	if err := inst.fs.MkdirAll(authDir, 0o750); err != nil {
+		return fmt.Errorf("create auth directory: %w", err)
+	}
+	passPath := filepath.Join(authDir, "admin-password")
+	if err := inst.fs.WriteFile(passPath, []byte(password), 0o600); err != nil {
+		return fmt.Errorf("write password file: %w", err)
+	}
+	slog.Info("admin password set", "path", passPath)
+	return nil
 }
 
 func (inst *Installer) dumpContainerLogs(ctx context.Context) {

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -10,10 +10,246 @@ import (
 	"testing"
 
 	"github.com/quay/quay/internal/certs"
+	"github.com/quay/quay/internal/dal/daldb"
+	"github.com/quay/quay/internal/dal/dbcore"
 	"github.com/quay/quay/internal/system"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
+
+func TestInitializeCreatesCustomAdminSecurely(t *testing.T) {
+	dataDir := t.TempDir()
+	require.NoError(t, Initialize(t.Context(), &Config{
+		DataDir:         dataDir,
+		Hostname:        "registry.example.com",
+		InitUser:        "custom-admin",
+		InitPassword:    "  chosen password  ",
+		InitPasswordSet: true,
+	}))
+
+	db, err := dbcore.OpenSQLite(filepath.Join(dataDir, "quay.db"))
+	require.NoError(t, err)
+	defer db.Close()
+	user, err := daldb.New(db).GetUserByUsername(t.Context(), "custom-admin")
+	require.NoError(t, err)
+	require.NoError(t, bcrypt.CompareHashAndPassword(
+		[]byte(user.PasswordHash.String),
+		[]byte("  chosen password  "),
+	))
+
+	passwordPath := filepath.Join(dataDir, "auth", "admin-password")
+	assert.Equal(t, []byte("  chosen password  "), mustReadFile(t, passwordPath))
+	passwordInfo, err := os.Stat(passwordPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), passwordInfo.Mode().Perm())
+	authInfo, err := os.Stat(filepath.Dir(passwordPath))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), authInfo.Mode().Perm())
+}
+
+func TestInitializeIsIdempotentForExistingDatabase(t *testing.T) {
+	dataDir := t.TempDir()
+	first := &Config{
+		DataDir:         dataDir,
+		InitUser:        "first-admin",
+		InitPassword:    "first-password",
+		InitPasswordSet: true,
+	}
+	require.NoError(t, Initialize(t.Context(), first))
+	passwordPath := filepath.Join(dataDir, "auth", "admin-password")
+	originalCredential := mustReadFile(t, passwordPath)
+
+	require.NoError(t, Initialize(t.Context(), &Config{
+		DataDir:  dataDir,
+		InitUser: "second-admin",
+	}))
+	assert.Equal(t, originalCredential, mustReadFile(t, passwordPath))
+
+	err := Initialize(t.Context(), &Config{
+		DataDir:         dataDir,
+		InitUser:        "first-admin",
+		InitPassword:    "replacement-password",
+		InitPasswordSet: true,
+	})
+	require.ErrorContains(t, err, "registry is already initialized")
+	require.ErrorContains(t, err, "supplied password was not applied")
+	assert.Equal(t, originalCredential, mustReadFile(t, passwordPath))
+
+	db, err := dbcore.OpenSQLite(filepath.Join(dataDir, "quay.db"))
+	require.NoError(t, err)
+	defer db.Close()
+	queries := daldb.New(db)
+	_, err = queries.GetUserByUsername(t.Context(), "first-admin")
+	require.NoError(t, err)
+	_, err = queries.GetUserByUsername(t.Context(), "second-admin")
+	require.Error(t, err)
+}
+
+func TestUpgradePreservesConfigBasedServeCommand(t *testing.T) {
+	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir()}
+	quadlet := system.NewQuadletManager(system.OSFS{}, env)
+	require.NoError(t, quadlet.Install(quadletServiceName, &system.QuadletSpec{
+		Image:      "localhost/quay:old",
+		DataDir:    "/var/lib/quay",
+		Hostname:   "registry.example.com",
+		Port:       "8443",
+		ConfigPath: "/data/config.yaml",
+	}))
+	services := &recordingServiceManager{}
+	inst := &Installer{
+		systemd: services,
+		quadlet: quadlet,
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	require.NoError(t, inst.upgrade(t.Context(), &Config{}, "localhost/quay:new", "9443"))
+
+	content := string(mustReadFile(t, env.QuadletPath(quadletServiceName)))
+	assert.Contains(t, content, "Exec=serve --config /data/config.yaml")
+	assert.Contains(t, content, "Image=localhost/quay:new")
+	assert.Contains(t, content, "PublishPort=9443:8443")
+}
+
+func TestInitializeValidatesBeforeFilesystemChanges(t *testing.T) {
+	root := t.TempDir()
+	tests := []struct {
+		name     string
+		username string
+		password string
+		wantErr  string
+	}{
+		{name: "username", username: "bad user", password: "valid-password", wantErr: "invalid username"},
+		{name: "password length", username: "admin", password: string(make([]byte, 73)), wantErr: "must not exceed 72 bytes"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dataDir := filepath.Join(root, test.name)
+			err := Initialize(t.Context(), &Config{
+				DataDir:         dataDir,
+				InitUser:        test.username,
+				InitPassword:    test.password,
+				InitPasswordSet: true,
+			})
+			require.ErrorContains(t, err, test.wantErr)
+			_, statErr := os.Stat(dataDir)
+			assert.ErrorIs(t, statErr, os.ErrNotExist)
+		})
+	}
+}
+
+func TestInitializeCredentialDestinationSafety(t *testing.T) {
+	t.Run("rejects symlink", func(t *testing.T) {
+		dataDir := initializedEmptyDataDir(t)
+		authDir := filepath.Join(dataDir, "auth")
+		require.NoError(t, os.Mkdir(authDir, 0o700))
+		target := filepath.Join(t.TempDir(), "target")
+		require.NoError(t, os.WriteFile(target, []byte("unchanged"), 0o600))
+		require.NoError(t, os.Symlink(target, filepath.Join(authDir, "admin-password")))
+
+		err := Initialize(t.Context(), &Config{
+			DataDir: dataDir, InitUser: "admin",
+			InitPassword: "replacement-password", InitPasswordSet: true,
+		})
+		require.ErrorContains(t, err, "is not a regular file")
+		assert.Equal(t, []byte("unchanged"), mustReadFile(t, target))
+	})
+
+	t.Run("rejects unsafe existing generated credential", func(t *testing.T) {
+		dataDir := initializedEmptyDataDir(t)
+		authDir := filepath.Join(dataDir, "auth")
+		require.NoError(t, os.Mkdir(authDir, 0o700))
+		passwordPath := filepath.Join(authDir, "admin-password")
+		require.NoError(t, os.WriteFile(passwordPath, []byte("existing-password"), 0o644))
+
+		err := Initialize(t.Context(), &Config{DataDir: dataDir, InitUser: "admin"})
+		require.ErrorContains(t, err, "unsafe permissions")
+		assert.Equal(t, []byte("existing-password"), mustReadFile(t, passwordPath))
+	})
+
+	t.Run("atomically replaces failed bootstrap password", func(t *testing.T) {
+		dataDir := initializedEmptyDataDir(t)
+		authDir := filepath.Join(dataDir, "auth")
+		require.NoError(t, os.Mkdir(authDir, 0o750))
+		passwordPath := filepath.Join(authDir, "admin-password")
+		require.NoError(t, os.WriteFile(passwordPath, []byte(string(make([]byte, 73))), 0o644))
+
+		require.NoError(t, Initialize(t.Context(), &Config{
+			DataDir: dataDir, InitUser: "admin",
+			InitPassword: "corrected-password", InitPasswordSet: true,
+		}))
+		assert.Equal(t, []byte("corrected-password"), mustReadFile(t, passwordPath))
+		info, err := os.Stat(passwordPath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	})
+}
+
+func TestInitializeUsesMountedConfigDatabase(t *testing.T) {
+	dataDir := t.TempDir()
+	configPath := filepath.Join(dataDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+SERVER_HOSTNAME: registry.example.com
+PREFERRED_URL_SCHEME: https
+DB_URI: sqlite:////data/custom.db
+DISTRIBUTED_STORAGE_CONFIG:
+  default:
+    - LocalStorage
+    - storage_path: /data/storage
+SUPER_USERS:
+  - custom-admin
+`), 0o600))
+
+	require.NoError(t, Initialize(t.Context(), &Config{
+		DataDir:         dataDir,
+		ConfigPath:      "/data/config.yaml",
+		InitUser:        "custom-admin",
+		InitPassword:    "chosen-password",
+		InitPasswordSet: true,
+	}))
+	_, err := os.Stat(filepath.Join(dataDir, "custom.db"))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dataDir, "quay.db"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestInitializeRequiresConfiguredSuperuserForExplicitConfig(t *testing.T) {
+	dataDir := t.TempDir()
+	configPath := filepath.Join(dataDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+SERVER_HOSTNAME: registry.example.com
+PREFERRED_URL_SCHEME: https
+DB_URI: sqlite:////data/quay.db
+DISTRIBUTED_STORAGE_CONFIG:
+  default:
+    - LocalStorage
+    - storage_path: /data/storage
+SUPER_USERS:
+  - configured-admin
+`), 0o600))
+
+	err := Initialize(t.Context(), &Config{
+		DataDir:         dataDir,
+		ConfigPath:      "/data/config.yaml",
+		InitUser:        "different-admin",
+		InitPassword:    "chosen-password",
+		InitPasswordSet: true,
+	})
+	require.ErrorContains(t, err, `initial username "different-admin" is not listed in SUPER_USERS`)
+	_, statErr := os.Stat(filepath.Join(dataDir, "auth", "admin-password"))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func initializedEmptyDataDir(t *testing.T) string {
+	t.Helper()
+	dataDir := t.TempDir()
+	db, err := dbcore.Setup(t.Context(), filepath.Join(dataDir, "quay.db"))
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	return dataDir
+}
 
 func TestUpgradeUsesEffectivePort(t *testing.T) {
 	tests := []struct {

--- a/internal/installer/validate.go
+++ b/internal/installer/validate.go
@@ -3,9 +3,15 @@ package installer
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+// MaxInitPasswordBytes is bcrypt's maximum accepted password length.
+const MaxInitPasswordBytes int64 = 72
+
+var usernamePattern = regexp.MustCompile(`^[a-z0-9]+(?:[._-][a-z0-9]+)*$`)
 
 // ValidateHostname checks that hostname is a valid DNS name or IP address.
 func ValidateHostname(hostname string) error {
@@ -51,6 +57,29 @@ func ValidatePort(port string) error {
 	}
 	if n < 1 || n > 65535 {
 		return fmt.Errorf("out of range (1-65535): %d", n)
+	}
+	return nil
+}
+
+// ValidateInitUsername applies Quay's product username contract.
+func ValidateInitUsername(username string) error {
+	if len(username) < 2 || len(username) > 255 {
+		return fmt.Errorf("must be between 2 and 255 characters")
+	}
+	if !usernamePattern.MatchString(username) {
+		return fmt.Errorf("must match %s", usernamePattern.String())
+	}
+	return nil
+}
+
+// ValidateInitPassword enforces bcrypt's input limit without normalizing any
+// caller-supplied bytes.
+func ValidateInitPassword(password string) error {
+	if password == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if len([]byte(password)) > int(MaxInitPasswordBytes) {
+		return fmt.Errorf("must not exceed %d bytes", MaxInitPasswordBytes)
 	}
 	return nil
 }

--- a/internal/installer/validate_test.go
+++ b/internal/installer/validate_test.go
@@ -31,3 +31,40 @@ func TestValidatePort(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateInitUsername(t *testing.T) {
+	tests := []struct {
+		username string
+		wantErr  bool
+	}{
+		{"admin", false},
+		{"custom-admin", false},
+		{"custom_admin.example", false},
+		{"a", true},
+		{"Admin", true},
+		{"bad user", true},
+		{"bad\nuser", true},
+		{"-admin", true},
+		{"admin-", true},
+	}
+	for _, test := range tests {
+		t.Run(test.username, func(t *testing.T) {
+			err := ValidateInitUsername(test.username)
+			if (err != nil) != test.wantErr {
+				t.Errorf("ValidateInitUsername(%q) error = %v, wantErr %v", test.username, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateInitPassword(t *testing.T) {
+	if err := ValidateInitPassword(" leading and trailing "); err != nil {
+		t.Fatalf("whitespace should be preserved and accepted: %v", err)
+	}
+	if err := ValidateInitPassword(""); err == nil {
+		t.Fatal("empty password should be rejected")
+	}
+	if err := ValidateInitPassword(string(make([]byte, 73))); err == nil {
+		t.Fatal("password over bcrypt limit should be rejected")
+	}
+}

--- a/internal/system/quadlet.go
+++ b/internal/system/quadlet.go
@@ -10,12 +10,11 @@ const registryContainerPort = "8443"
 
 // QuadletSpec describes a Quadlet container unit.
 type QuadletSpec struct {
-	Image         string
-	DataDir       string
-	Hostname      string
-	Port          string
-	ConfigPath    string
-	AdminUsername string
+	Image      string
+	DataDir    string
+	Hostname   string
+	Port       string
+	ConfigPath string
 }
 
 // QuadletManager handles Quadlet .container files.
@@ -45,13 +44,7 @@ func (q *QuadletManager) Install(service string, spec *QuadletSpec) error {
 		return fmt.Errorf("nil quadlet spec")
 	}
 
-	serveCommand := fmt.Sprintf("serve --data-dir /data --hostname %s", spec.Hostname)
-	if spec.ConfigPath != "" {
-		serveCommand = fmt.Sprintf("serve --config %s", spec.ConfigPath)
-	}
-	if spec.AdminUsername != "" && spec.AdminUsername != "admin" {
-		serveCommand += fmt.Sprintf(" --admin-username %s", spec.AdminUsername)
-	}
+	serveCommand := quadletServeCommand(spec)
 
 	content := fmt.Sprintf(`[Unit]
 Description=Quay OCI Registry
@@ -72,6 +65,13 @@ WantedBy=default.target
 		return fmt.Errorf("write quadlet: %w", err)
 	}
 	return nil
+}
+
+func quadletServeCommand(spec *QuadletSpec) string {
+	if spec.ConfigPath != "" {
+		return fmt.Sprintf("serve --config %s", spec.ConfigPath)
+	}
+	return fmt.Sprintf("serve --data-dir /data --hostname %s", spec.Hostname)
 }
 
 // HostPort returns the host port published by an existing Quadlet file.
@@ -143,6 +143,5 @@ func (q *QuadletManager) UpdateImageAndPort(service, newImage, hostPort string) 
 	if !foundPort {
 		return fmt.Errorf("no PublishPort= directive found in %s", path)
 	}
-
 	return q.fs.WriteFile(path, []byte(strings.Join(updated, "\n")+"\n"), 0o600)
 }

--- a/internal/system/quadlet.go
+++ b/internal/system/quadlet.go
@@ -10,11 +10,12 @@ const registryContainerPort = "8443"
 
 // QuadletSpec describes a Quadlet container unit.
 type QuadletSpec struct {
-	Image      string
-	DataDir    string
-	Hostname   string
-	Port       string
-	ConfigPath string
+	Image         string
+	DataDir       string
+	Hostname      string
+	Port          string
+	ConfigPath    string
+	AdminUsername string
 }
 
 // QuadletManager handles Quadlet .container files.
@@ -47,6 +48,9 @@ func (q *QuadletManager) Install(service string, spec *QuadletSpec) error {
 	serveCommand := fmt.Sprintf("serve --data-dir /data --hostname %s", spec.Hostname)
 	if spec.ConfigPath != "" {
 		serveCommand = fmt.Sprintf("serve --config %s", spec.ConfigPath)
+	}
+	if spec.AdminUsername != "" && spec.AdminUsername != "admin" {
+		serveCommand += fmt.Sprintf(" --admin-username %s", spec.AdminUsername)
 	}
 
 	content := fmt.Sprintf(`[Unit]

--- a/internal/system/quadlet_test.go
+++ b/internal/system/quadlet_test.go
@@ -71,67 +71,23 @@ func TestQuadletInstallMapsCustomHostPortToRegistryPort(t *testing.T) {
 	}
 }
 
-func TestQuadletInstallAdminUsername(t *testing.T) {
+func TestQuadletInstallDoesNotPersistBootstrapCredentials(t *testing.T) {
 	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
 	manager := NewQuadletManager(OSFS{}, env)
 
 	err := manager.Install("quay", &QuadletSpec{
-		Image:         "localhost/quay:test",
-		DataDir:       "/var/lib/quay",
-		Hostname:      "localhost",
-		Port:          "8443",
-		AdminUsername: "myuser",
+		Image:    "localhost/quay:test",
+		DataDir:  "/var/lib/quay",
+		Hostname: "localhost",
+		Port:     "8443",
 	})
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 
 	content := readQuadletTestFile(t, env.QuadletPath("quay"))
-	if !strings.Contains(content, "--admin-username myuser") {
-		t.Fatalf("quadlet does not include admin-username:\n%s", content)
-	}
-}
-
-func TestQuadletInstallAdminUsernameDefaultOmitted(t *testing.T) {
-	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
-	manager := NewQuadletManager(OSFS{}, env)
-
-	err := manager.Install("quay", &QuadletSpec{
-		Image:         "localhost/quay:test",
-		DataDir:       "/var/lib/quay",
-		Hostname:      "localhost",
-		Port:          "8443",
-		AdminUsername: "admin",
-	})
-	if err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-
-	content := readQuadletTestFile(t, env.QuadletPath("quay"))
-	if strings.Contains(content, "--admin-username") {
-		t.Fatalf("quadlet should not include --admin-username when set to default:\n%s", content)
-	}
-}
-
-func TestQuadletInstallConfigPathWithAdminUsername(t *testing.T) {
-	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
-	manager := NewQuadletManager(OSFS{}, env)
-
-	err := manager.Install("quay", &QuadletSpec{
-		Image:         "localhost/quay:test",
-		DataDir:       "/var/lib/quay",
-		Hostname:      "localhost",
-		Port:          "8443",
-		ConfigPath:    "/data/config.yaml",
-		AdminUsername: "custom",
-	})
-	if err != nil {
-		t.Fatalf("Install: %v", err)
-	}
-
-	content := readQuadletTestFile(t, env.QuadletPath("quay"))
-	if !strings.Contains(content, "Exec=serve --config /data/config.yaml --admin-username custom") {
-		t.Fatalf("quadlet should combine config path and admin-username:\n%s", content)
+	if strings.Contains(content, "admin-username") || strings.Contains(content, "admin-password") {
+		t.Fatalf("quadlet should not contain bootstrap credentials:\n%s", content)
 	}
 }
 

--- a/internal/system/quadlet_test.go
+++ b/internal/system/quadlet_test.go
@@ -71,6 +71,70 @@ func TestQuadletInstallMapsCustomHostPortToRegistryPort(t *testing.T) {
 	}
 }
 
+func TestQuadletInstallAdminUsername(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+
+	err := manager.Install("quay", &QuadletSpec{
+		Image:         "localhost/quay:test",
+		DataDir:       "/var/lib/quay",
+		Hostname:      "localhost",
+		Port:          "8443",
+		AdminUsername: "myuser",
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	content := readQuadletTestFile(t, env.QuadletPath("quay"))
+	if !strings.Contains(content, "--admin-username myuser") {
+		t.Fatalf("quadlet does not include admin-username:\n%s", content)
+	}
+}
+
+func TestQuadletInstallAdminUsernameDefaultOmitted(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+
+	err := manager.Install("quay", &QuadletSpec{
+		Image:         "localhost/quay:test",
+		DataDir:       "/var/lib/quay",
+		Hostname:      "localhost",
+		Port:          "8443",
+		AdminUsername: "admin",
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	content := readQuadletTestFile(t, env.QuadletPath("quay"))
+	if strings.Contains(content, "--admin-username") {
+		t.Fatalf("quadlet should not include --admin-username when set to default:\n%s", content)
+	}
+}
+
+func TestQuadletInstallConfigPathWithAdminUsername(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+
+	err := manager.Install("quay", &QuadletSpec{
+		Image:         "localhost/quay:test",
+		DataDir:       "/var/lib/quay",
+		Hostname:      "localhost",
+		Port:          "8443",
+		ConfigPath:    "/data/config.yaml",
+		AdminUsername: "custom",
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	content := readQuadletTestFile(t, env.QuadletPath("quay"))
+	if !strings.Contains(content, "Exec=serve --config /data/config.yaml --admin-username custom") {
+		t.Fatalf("quadlet should combine config path and admin-username:\n%s", content)
+	}
+}
+
 func readQuadletTestFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Clean(path))


### PR DESCRIPTION
## Summary

Introduce an explicit registry initialization phase shared by standalone and managed workflows. Users can run `quay init` followed by `quay serve`, while `quay install` invokes the same initialization logic before installing and starting the service.

Initialization owns administrator provisioning and credential handling; `serve` now requires an initialized database and Quadlet units contain no bootstrap credentials.

## Related Issue

[PROJQUAY-12324](https://redhat.atlassian.net/browse/PROJQUAY-12324)

## Changes

- Add a public `quay init` command and reuse its provisioning path from `quay install`.
- Read explicit initial passwords through `-init-password-stdin`, following Podman-style stdin handling instead of exposing secrets in process arguments.
- Validate initial usernames and bcrypt password length before filesystem or database mutations.
- Configure a custom initial user as the standalone superuser; explicit config files remain authoritative through `SUPER_USERS`.
- Make initialization idempotent from actual database state and reject password changes once the registry is initialized.
- Persist generated credentials with atomic replacement, symlink checks, and `0700`/`0600` directory and file permissions.
- Remove bootstrap username/password handling from `serve` and generated Quadlet commands.
- Preserve explicit config/database path behavior for `/data`-mounted configurations.

## Testing

- [x] `go fmt ./internal/...`
- [x] `go vet ./internal/...`
- [x] `golangci-lint run ./internal/...`
- [x] `go test ./internal/...`
- [x] `go test -race ./internal/cmd ./internal/installer ./internal/bootstrap ./internal/system ./internal/config`
- [x] `pre-commit run`

## Notes

- Intended command flow: `quay init` → `quay serve`; `quay install` performs both provisioning and managed service installation.
- No live Podman/systemd end-to-end install was run locally.
