### PR TITLE
PROJQUAY-12324: fix(install): increase health check timeout to 2 minutes

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -89,7 +89,7 @@ func (inst *Installer) Run(ctx context.Context, cfg *Config) error {
 	healthURL := fmt.Sprintf("https://%s:8443/healthz", cfg.Hostname)
 	certPath := filepath.Join(cfg.DataDir, "ssl.cert")
 	slog.Info("waiting for registry to start")
-	if err := inst.waitForHealth(ctx, healthURL, certPath, 30*time.Second); err != nil {
+	if err := inst.waitForHealth(ctx, healthURL, certPath, 2*time.Minute); err != nil {
 		inst.dumpContainerLogs(ctx)
 		return fmt.Errorf("health check: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Increase health check timeout from 30 seconds to 2 minutes
- 30s is too short for slow machines or large image loads; OMR 2.0.x used 5 minutes

## Test plan
- [ ] Verify existing tests pass
- [ ] Install on a slow machine and confirm the health check waits long enough

🤖 Generated with [Claude Code](https://claude.com/claude-code)