### PR TITLE
PROJQUAY-12324: fix(install): add journalctl output to failure diagnostics

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -208,4 +208,5 @@ func (inst *Installer) dumpContainerLogs(ctx context.Context) {
 	slog.Info("dumping container logs for diagnostics")
 	_ = inst.runner.Run(ctx, "podman", "logs", quadletServiceName)
 	_ = inst.runner.Run(ctx, "systemctl", "status", quadletServiceName)
+	_ = inst.runner.Run(ctx, "journalctl", "--no-pager", "-n", "100", "CONTAINER_NAME="+quadletServiceName)
 }


### PR DESCRIPTION
## Summary
- Add \`journalctl --no-pager -n 100 CONTAINER_NAME=quay\` to \`dumpContainerLogs()\`
- Podman 5.x Quadlet-managed containers log to journald; without this, failure diagnostics miss container-level errors

## Test plan
- [ ] Verify existing tests pass
- [ ] Trigger a health check failure and confirm journalctl output appears in diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)