### PR TITLE
NO-ISSUE: chore(playwright): add OpenShift CI runner Dockerfile

### DIFF
--- a/.github/workflows/sentinel.yaml
+++ b/.github/workflows/sentinel.yaml
@@ -53,6 +53,7 @@ jobs:
               - '**'
               - '!**/*.md'
               - '!docs/**'
+              - '!web/playwright/Dockerfile'
               - '!.agent/**'
               - '!.claude/**'
               - '!agent_docs/**'

--- a/web/playwright/Dockerfile
+++ b/web/playwright/Dockerfile
@@ -1,0 +1,12 @@
+FROM src
+RUN dnf module enable -y nodejs:20 && \
+    dnf install -y nodejs \
+    alsa-lib atk at-spi2-atk cups-libs libdrm libXcomposite \
+    libXdamage libXrandr mesa-libgbm pango nss nss-util nspr \
+    libxkbcommon libXfixes libXcursor libXext libXi libXtst \
+    libwayland-client && \
+    dnf clean all
+WORKDIR /go/src/github.com/quay/quay/web
+RUN npm ci
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
+RUN npx playwright install chromium


### PR DESCRIPTION
## Summary
Move the OpenShift CI Playwright runner recipe from an inline ci-operator definition into the Quay source tree. This gives the runner a stable repository path so merge jobs can build and promote it for cross-repository consumers.

## Related Issue
NO-ISSUE: CI infrastructure maintenance; no product behavior changes.

## Changes
- Add web/playwright/Dockerfile with the existing Node.js 20, Chromium runtime, npm dependency, and Playwright browser installation recipe.
- Preserve the current /go/src/github.com/quay/quay/web working directory and /opt/playwright browser path.
- Exclude the runner Dockerfile from the sentinel web path filter so image-only changes do not run the frontend suite.

## Testing
- [x] pre-commit run --files .github/workflows/sentinel.yaml web/playwright/Dockerfile
- [x] Compared the Dockerfile byte-for-byte with the prior inline recipe after removing YAML indentation.
- [x] Verified FROM src and from: src semantics against the official OpenShift CI ci-operator image-build documentation.
- [ ] Image build not run locally: FROM src is a ci-operator pipeline image alias. The dependent openshift/release PR regenerates /test images against this path.

## Notes
Depends on openshift/release#82052 for build and promotion configuration. This Quay PR must merge first so the release postsubmit never references a missing Dockerfile. No backport is required.