### PR TITLE
NO-ISSUE: feat(registry): add Go bearer token authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/distribution/distribution/v3 v3.0.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.48.1
 )

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -22,6 +23,7 @@ import (
 	"github.com/quay/quay/internal/oci"
 	"github.com/quay/quay/internal/oci/storage/local"
 	"github.com/quay/quay/internal/registry"
+	registryauth "github.com/quay/quay/internal/registry/auth"
 	"github.com/quay/quay/internal/registry/distribution"
 	registrymw "github.com/quay/quay/internal/registry/distribution/middleware"
 	"github.com/quay/quay/internal/repository"
@@ -33,7 +35,7 @@ func newServeCmd() *Command {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	configPath := fs.String("config", "", "path to config.yaml (optional, overrides flags)")
 	dataDir := fs.String("data-dir", ".", "root directory for DB, storage, certs")
-	hostname := fs.String("hostname", "localhost", "server hostname for TLS SANs")
+	hostname := fs.String("hostname", "localhost", "public registry hostname, including a non-default port")
 	addr := fs.String("addr", ":8443", "listen address")
 
 	return &Command{
@@ -83,24 +85,62 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr string) i
 		FeatureUserLastAccessed:        featureUserLastAccessed,
 		LastAccessedUpdateThresholdSec: lastAccessedUpdateThresholdSeconds,
 	}
+	credentialVerifier := auth.NewDatabaseVerifier(db, databaseVerifierConfig)
 	superUsersFullAccess := featureEnabled(resolved.Config.FeatureSuperUsers) && featureEnabled(resolved.Config.FeatureSuperUsersFullAccess)
+	anonymousAccess := resolved.Config.FeatureAnonymousAccess == nil || *resolved.Config.FeatureAnonymousAccess
+
+	grantResolver, err := distribution.NewGrantResolver(db, distribution.GrantResolverConfig{
+		LibraryNamespace: resolved.Config.LibraryNamespace, SuperUsers: resolved.Config.SuperUsers,
+		SuperUsersFullAccess: superUsersFullAccess,
+	})
+	if err != nil {
+		slog.Error("registry grant resolver setup error", "err", err)
+		return 1
+	}
+	maxFresh := time.Duration(resolved.Config.RegistryJWTAuthMaxFreshS) * time.Second
+	tokenLifetime := min(5*time.Minute, maxFresh)
+	signer, verifier, err := registryauth.NewES256Pair(registryauth.ES256Config{
+		Issuer: registryauth.Issuer, Audience: resolved.Config.ServerHostname,
+		MaxFresh: maxFresh, ClockSkew: 5 * time.Second,
+	})
+	if err != nil {
+		slog.Error("registry token key setup error", "err", err)
+		return 1
+	}
+	realm := (&url.URL{
+		Scheme: resolved.Config.PreferredURLScheme,
+		Host:   resolved.Config.ServerHostname,
+		Path:   "/v2/auth",
+	}).String()
+	accessController, err := registryauth.NewController(registryauth.ControllerConfig{
+		Realm: realm, Service: resolved.Config.ServerHostname,
+		LibraryNamespace: resolved.Config.LibraryNamespace, Verifier: verifier,
+	})
+	if err != nil {
+		slog.Error("registry access controller setup error", "err", err)
+		return 1
+	}
+	tokenHandler, err := registryauth.NewHandler(registryauth.HandlerConfig{
+		Service: resolved.Config.ServerHostname, LibraryNamespace: resolved.Config.LibraryNamespace,
+		AnonymousAccess: anonymousAccess, Lifetime: tokenLifetime, Signer: signer,
+		Authenticate: func(ctx context.Context, username, secret string) (registryauth.Identity, bool) {
+			result := credentialVerifier.Verify(ctx, auth.Credentials{Username: username, Secret: secret})
+			if !result.Authenticated {
+				return registryauth.Identity{}, false
+			}
+			principal := result.Principal
+			return registryauth.Identity{Subject: principal.Username, Principal: &principal}, true
+		},
+		ResolveGrants: grantResolver.Resolve,
+	})
+	if err != nil {
+		slog.Error("registry token handler setup error", "err", err)
+		return 1
+	}
 
 	reg, err := distribution.NewRegistry(ctx, &distribution.Config{
-		StoragePath:                        resolved.StoragePath,
-		Hostname:                           resolved.Config.ServerHostname,
-		ListenAddr:                         addr,
-		DB:                                 db,
-		Store:                              store,
-		BlobLocker:                         blobLocks,
-		LibraryNamespace:                   resolved.Config.LibraryNamespace,
-		AnonymousAccess:                    resolved.Config.FeatureAnonymousAccess,
-		DatabaseSecretKey:                  resolved.Config.DatabaseSecretKey,
-		RobotsDisallow:                     resolved.Config.RobotsDisallow,
-		RobotsWhitelist:                    resolved.Config.RobotsWhitelist,
-		FeatureUserLastAccessed:            featureUserLastAccessed,
-		LastAccessedUpdateThresholdSeconds: lastAccessedUpdateThresholdSeconds,
-		SuperUsers:                         resolved.Config.SuperUsers,
-		SuperUsersFullAccess:               superUsersFullAccess,
+		StoragePath: resolved.StoragePath, ListenAddr: addr, Store: store, BlobLocker: blobLocks,
+		LibraryNamespace: resolved.Config.LibraryNamespace, AccessController: accessController,
 	})
 	if err != nil {
 		slog.Error("registry setup error", "err", err)
@@ -121,7 +161,7 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr string) i
 	}
 
 	api, err := apiv1.New(apiv1.Config{
-		Authenticator: auth.NewBasicAuthenticator(auth.NewDatabaseVerifier(db, databaseVerifierConfig)),
+		Authenticator: auth.NewBasicAuthenticator(credentialVerifier),
 		Realm:         resolved.Config.ServerHostname,
 	},
 		repositoryapi.NewModule(repositoryService),
@@ -136,17 +176,9 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr string) i
 	referrersEnabled := resolved.Config.FeatureReferrersAPI == nil || *resolved.Config.FeatureReferrersAPI
 	v2Handler := distHandler
 	if referrersEnabled {
-		referrersHandler := registry.NewReferrersHandler(db, store, &registry.ReferrersConfig{
-			LibraryNamespace:                   resolved.Config.LibraryNamespace,
-			AnonymousAccess:                    resolved.Config.FeatureAnonymousAccess == nil || *resolved.Config.FeatureAnonymousAccess,
-			LibrarySupport:                     resolved.Config.FeatureLibrarySupport == nil || *resolved.Config.FeatureLibrarySupport,
-			DatabaseSecretKey:                  databaseVerifierConfig.DatabaseSecretKey,
-			RobotsDisallow:                     databaseVerifierConfig.RobotsDisallow,
-			RobotsWhitelist:                    databaseVerifierConfig.RobotsWhitelist,
-			FeatureUserLastAccessed:            databaseVerifierConfig.FeatureUserLastAccessed,
-			LastAccessedUpdateThresholdSeconds: databaseVerifierConfig.LastAccessedUpdateThresholdSec,
-			SuperUsers:                         resolved.Config.SuperUsers,
-			SuperUsersFullAccess:               superUsersFullAccess,
+		referrersHandler := registry.NewReferrersHandler(store, accessController, &registry.ReferrersConfig{
+			LibraryNamespace: resolved.Config.LibraryNamespace,
+			LibrarySupport:   resolved.Config.FeatureLibrarySupport == nil || *resolved.Config.FeatureLibrarySupport,
 		})
 		v2Handler = registry.WrapWithReferrers(referrersHandler, distHandler)
 	}
@@ -155,6 +187,7 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr string) i
 	mux.Handle("/healthz", healthHandler(db))
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.Handle("/api/", api)
+	mux.Handle("/v2/auth", tokenHandler)
 	mux.Handle("/", v2Handler)
 
 	srv, err := server.New(ctx, mux, &server.Config{

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -23,7 +22,6 @@ import (
 	"github.com/quay/quay/internal/oci"
 	"github.com/quay/quay/internal/oci/storage/local"
 	"github.com/quay/quay/internal/registry"
-	registryauth "github.com/quay/quay/internal/registry/auth"
 	"github.com/quay/quay/internal/registry/distribution"
 	registrymw "github.com/quay/quay/internal/registry/distribution/middleware"
 	"github.com/quay/quay/internal/repository"
@@ -87,60 +85,22 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr string) i
 	}
 	credentialVerifier := auth.NewDatabaseVerifier(db, databaseVerifierConfig)
 	superUsersFullAccess := featureEnabled(resolved.Config.FeatureSuperUsers) && featureEnabled(resolved.Config.FeatureSuperUsersFullAccess)
-	anonymousAccess := resolved.Config.FeatureAnonymousAccess == nil || *resolved.Config.FeatureAnonymousAccess
-
-	grantResolver, err := distribution.NewGrantResolver(db, distribution.GrantResolverConfig{
-		LibraryNamespace: resolved.Config.LibraryNamespace, SuperUsers: resolved.Config.SuperUsers,
+	registryAuthentication, err := distribution.NewAuthentication(db, credentialVerifier, &distribution.AuthenticationConfig{
+		Scheme: resolved.Config.PreferredURLScheme, Service: resolved.Config.ServerHostname,
+		LibraryNamespace:     resolved.Config.LibraryNamespace,
+		AnonymousAccess:      featureEnabledByDefault(resolved.Config.FeatureAnonymousAccess),
+		MaxTokenFreshness:    time.Duration(resolved.Config.RegistryJWTAuthMaxFreshS) * time.Second,
+		SuperUsers:           resolved.Config.SuperUsers,
 		SuperUsersFullAccess: superUsersFullAccess,
 	})
 	if err != nil {
-		slog.Error("registry grant resolver setup error", "err", err)
-		return 1
-	}
-	maxFresh := time.Duration(resolved.Config.RegistryJWTAuthMaxFreshS) * time.Second
-	tokenLifetime := min(5*time.Minute, maxFresh)
-	signer, verifier, err := registryauth.NewES256Pair(registryauth.ES256Config{
-		Issuer: registryauth.Issuer, Audience: resolved.Config.ServerHostname,
-		MaxFresh: maxFresh, ClockSkew: 5 * time.Second,
-	})
-	if err != nil {
-		slog.Error("registry token key setup error", "err", err)
-		return 1
-	}
-	realm := (&url.URL{
-		Scheme: resolved.Config.PreferredURLScheme,
-		Host:   resolved.Config.ServerHostname,
-		Path:   "/v2/auth",
-	}).String()
-	accessController, err := registryauth.NewController(registryauth.ControllerConfig{
-		Realm: realm, Service: resolved.Config.ServerHostname,
-		LibraryNamespace: resolved.Config.LibraryNamespace, Verifier: verifier,
-	})
-	if err != nil {
-		slog.Error("registry access controller setup error", "err", err)
-		return 1
-	}
-	tokenHandler, err := registryauth.NewHandler(registryauth.HandlerConfig{
-		Service: resolved.Config.ServerHostname, LibraryNamespace: resolved.Config.LibraryNamespace,
-		AnonymousAccess: anonymousAccess, Lifetime: tokenLifetime, Signer: signer,
-		Authenticate: func(ctx context.Context, username, secret string) (registryauth.Identity, bool) {
-			result := credentialVerifier.Verify(ctx, auth.Credentials{Username: username, Secret: secret})
-			if !result.Authenticated {
-				return registryauth.Identity{}, false
-			}
-			principal := result.Principal
-			return registryauth.Identity{Subject: principal.Username, Principal: &principal}, true
-		},
-		ResolveGrants: grantResolver.Resolve,
-	})
-	if err != nil {
-		slog.Error("registry token handler setup error", "err", err)
+		slog.Error("registry authentication setup error", "err", err)
 		return 1
 	}
 
 	reg, err := distribution.NewRegistry(ctx, &distribution.Config{
 		StoragePath: resolved.StoragePath, ListenAddr: addr, Store: store, BlobLocker: blobLocks,
-		LibraryNamespace: resolved.Config.LibraryNamespace, AccessController: accessController,
+		LibraryNamespace: resolved.Config.LibraryNamespace, AccessController: registryAuthentication.Controller,
 	})
 	if err != nil {
 		slog.Error("registry setup error", "err", err)
@@ -173,12 +133,12 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr string) i
 
 	distHandler := registrymw.SubjectHeaderMiddleware(reg.Handler())
 
-	referrersEnabled := resolved.Config.FeatureReferrersAPI == nil || *resolved.Config.FeatureReferrersAPI
+	referrersEnabled := featureEnabledByDefault(resolved.Config.FeatureReferrersAPI)
 	v2Handler := distHandler
 	if referrersEnabled {
-		referrersHandler := registry.NewReferrersHandler(store, accessController, &registry.ReferrersConfig{
+		referrersHandler := registry.NewReferrersHandler(store, registryAuthentication.Controller, &registry.ReferrersConfig{
 			LibraryNamespace: resolved.Config.LibraryNamespace,
-			LibrarySupport:   resolved.Config.FeatureLibrarySupport == nil || *resolved.Config.FeatureLibrarySupport,
+			LibrarySupport:   featureEnabledByDefault(resolved.Config.FeatureLibrarySupport),
 		})
 		v2Handler = registry.WrapWithReferrers(referrersHandler, distHandler)
 	}
@@ -187,7 +147,7 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr string) i
 	mux.Handle("/healthz", healthHandler(db))
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.Handle("/api/", api)
-	mux.Handle("/v2/auth", tokenHandler)
+	mux.Handle("/v2/auth", registryAuthentication.TokenHandler)
 	mux.Handle("/", v2Handler)
 
 	srv, err := server.New(ctx, mux, &server.Config{
@@ -251,4 +211,8 @@ func healthHandler(db *sql.DB) http.Handler {
 
 func featureEnabled(configured *bool) bool {
 	return configured != nil && *configured
+}
+
+func featureEnabledByDefault(configured *bool) bool {
+	return configured == nil || *configured
 }

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -2,10 +2,11 @@ package config
 
 // Auth holds authentication and authorization settings.
 type Auth struct {
-	AuthenticationType string   `yaml:"AUTHENTICATION_TYPE"`
-	SuperUsers         []string `yaml:"SUPER_USERS"`
-	RobotsDisallow     bool     `yaml:"ROBOTS_DISALLOW"`
-	RobotsWhitelist    []string `yaml:"ROBOTS_WHITELIST"`
+	AuthenticationType       string   `yaml:"AUTHENTICATION_TYPE"`
+	SuperUsers               []string `yaml:"SUPER_USERS"`
+	RobotsDisallow           bool     `yaml:"ROBOTS_DISALLOW"`
+	RobotsWhitelist          []string `yaml:"ROBOTS_WHITELIST"`
+	RegistryJWTAuthMaxFreshS int      `yaml:"REGISTRY_JWT_AUTH_MAX_FRESH_S"`
 }
 
 // validateAuth checks authentication enum values.
@@ -19,6 +20,12 @@ func validateAuth(cfg *Config, _ ValidateOptions) []ValidationError {
 		errs = append(errs, ValidationError{
 			Field: "AUTHENTICATION_TYPE", Severity: SeverityError,
 			Message: `must be one of: "Database", "LDAP", "JWT", "Keystone", "OIDC", "AppToken"`,
+		})
+	}
+	if cfg.RegistryJWTAuthMaxFreshS < 60 {
+		errs = append(errs, ValidationError{
+			Field: "REGISTRY_JWT_AUTH_MAX_FRESH_S", Severity: SeverityError,
+			Message: "must be at least 60 seconds",
 		})
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,8 +54,15 @@ func TestParseDefaults(t *testing.T) {
 	assert.Equal(t, "http", cfg.PreferredURLScheme)
 	assert.Equal(t, "Red Hat Quay", cfg.RegistryTitle)
 	assert.Equal(t, "Database", cfg.AuthenticationType)
+	assert.Equal(t, DefaultRegistryJWTAuthMaxFreshS, cfg.RegistryJWTAuthMaxFreshS)
 	require.NotNil(t, cfg.FeatureDirectLogin)
 	assert.True(t, *cfg.FeatureDirectLogin)
+}
+
+func TestParseRegistryJWTAuthMaxFreshOverride(t *testing.T) {
+	cfg, err := Parse([]byte("SERVER_HOSTNAME: test\nREGISTRY_JWT_AUTH_MAX_FRESH_S: 120\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 120, cfg.RegistryJWTAuthMaxFreshS)
 }
 
 func TestParseRobotAuthConfig(t *testing.T) {
@@ -89,10 +96,13 @@ func TestParseRobotAuthDefaults(t *testing.T) {
 }
 
 func TestNewDefaultConfiguresStandaloneAdminFullAccess(t *testing.T) {
-	cfg := NewDefault("localhost", "/data/storage")
+	cfg := NewDefault("localhost:8443", "/data/storage")
 
+	assert.Equal(t, "localhost:8443", cfg.ServerHostname)
 	assert.Equal(t, "Database", cfg.AuthenticationType)
+	assert.Equal(t, DefaultLibraryNamespace, cfg.LibraryNamespace)
 	assert.Equal(t, []string{"admin"}, cfg.SuperUsers)
+	assert.Equal(t, DefaultRegistryJWTAuthMaxFreshS, cfg.RegistryJWTAuthMaxFreshS)
 	require.NotNil(t, cfg.FeatureSuperUsers)
 	assert.True(t, *cfg.FeatureSuperUsers)
 	require.NotNil(t, cfg.FeatureSuperUsersFullAccess)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -8,6 +8,7 @@ const (
 	DefaultTagExpiration                = "2w"
 	DefaultLibraryNamespace             = "library"
 	DefaultLastAccessedUpdateThresholdS = 60
+	DefaultRegistryJWTAuthMaxFreshS     = 3660
 )
 
 // newDefaultConfig returns a Config pre-populated with Quay's documented
@@ -22,7 +23,8 @@ func newDefaultConfig() Config {
 			LibraryNamespace:   DefaultLibraryNamespace,
 		},
 		Auth: Auth{
-			AuthenticationType: DefaultAuthenticationType,
+			AuthenticationType:       DefaultAuthenticationType,
+			RegistryJWTAuthMaxFreshS: DefaultRegistryJWTAuthMaxFreshS,
 		},
 		Storage: Storage{
 			DefaultTagExpiration: DefaultTagExpiration,

--- a/internal/config/resolve.go
+++ b/internal/config/resolve.go
@@ -118,10 +118,12 @@ func NewDefault(hostname, storagePath string) *Config {
 		Server: Server{
 			ServerHostname:     hostname,
 			PreferredURLScheme: "https",
+			LibraryNamespace:   DefaultLibraryNamespace,
 		},
 		Auth: Auth{
-			AuthenticationType: "Database",
-			SuperUsers:         []string{"admin"},
+			AuthenticationType:       "Database",
+			SuperUsers:               []string{"admin"},
+			RegistryJWTAuthMaxFreshS: DefaultRegistryJWTAuthMaxFreshS,
 		},
 		Features: Features{
 			FeatureSuperUsers:           boolPtr(true),

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -262,6 +262,7 @@ var goOnlyFields = map[string]bool{
 	"LAST_ACCESSED_UPDATE_THRESHOLD_S": true,
 	"SECRET_KEY":                       true,
 	"LIBRARY_NAMESPACE":                true, // QUAY.IO-only in Python schema but needed by Go middleware
+	"REGISTRY_JWT_AUTH_MAX_FRESH_S":    true, // Python runtime setting is not exposed in CONFIG_SCHEMA
 }
 
 // TestSchemaFieldCoverage compares the Python schema keys against the Go struct

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -93,6 +93,15 @@ func TestValidateInvalidAuthenticationType(t *testing.T) {
 	assert.True(t, hasFieldError(errs, "AUTHENTICATION_TYPE"), "expected error for invalid AUTHENTICATION_TYPE")
 }
 
+func TestValidateRegistryJWTAuthMaxFreshMinimum(t *testing.T) {
+	yaml := minimalValidYAML + "\nREGISTRY_JWT_AUTH_MAX_FRESH_S: 59\n"
+	cfg, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+
+	errs := Validate(t.Context(), cfg, ValidateOptions{Mode: "offline"})
+	assert.True(t, hasFieldError(errs, "REGISTRY_JWT_AUTH_MAX_FRESH_S"))
+}
+
 func TestValidateInvalidTagExpiration(t *testing.T) {
 	yaml := strings.Replace(minimalValidYAML, "DEFAULT_TAG_EXPIRATION: 2w", "DEFAULT_TAG_EXPIRATION: forever", 1)
 	cfg, err := Parse([]byte(yaml))

--- a/internal/registry/auth/controller.go
+++ b/internal/registry/auth/controller.go
@@ -51,7 +51,7 @@ func NewController(cfg ControllerConfig) (*Controller, error) {
 // Authorized verifies the bearer token and checks exact requested resources
 // and actions. A granted wildcard action satisfies every requested action.
 func (c *Controller) Authorized(req *http.Request, requested ...distauth.Access) (*distauth.Grant, error) {
-	challenge := &bearerChallenge{
+	challenge := &bearerChallengeError{
 		realm: c.realm, service: c.service, scopes: challengeScopes(requested), err: errTokenRequired,
 	}
 
@@ -91,7 +91,7 @@ func (c *Controller) Authorized(req *http.Request, requested ...distauth.Access)
 		resource.Name = c.normalizeResourceName(resource.Type, resource.Name)
 		actions := granted[resource]
 		_, exact := actions[item.Action]
-		_, wildcard := actions["*"]
+		_, wildcard := actions[wildcardAction]
 		if !exact && !wildcard {
 			challenge.err = errInsufficientScope
 			return nil, challenge
@@ -117,6 +117,16 @@ func (c *Controller) Authorized(req *http.Request, requested ...distauth.Access)
 	}, nil
 }
 
+// AuthorizeRepository checks one repository action without exposing
+// Distribution auth types to protocol handlers.
+func (c *Controller) AuthorizeRepository(req *http.Request, name, action string) error {
+	_, err := c.Authorized(req, distauth.Access{
+		Resource: distauth.Resource{Type: repositoryResourceType, Name: name},
+		Action:   action,
+	})
+	return err
+}
+
 func (c *Controller) normalizeResourceName(resourceType, name string) string {
 	if resourceType == repositoryResourceType && !strings.Contains(name, "/") {
 		return c.libraryNamespace + "/" + name
@@ -124,26 +134,26 @@ func (c *Controller) normalizeResourceName(resourceType, name string) string {
 	return name
 }
 
-type bearerChallenge struct {
+type bearerChallengeError struct {
 	realm   string
 	service string
 	scopes  string
 	err     error
 }
 
-var _ distauth.Challenge = (*bearerChallenge)(nil)
+var _ distauth.Challenge = (*bearerChallengeError)(nil)
 
-func (c *bearerChallenge) Error() string { return c.err.Error() }
+func (c *bearerChallengeError) Error() string { return c.err.Error() }
 
-func (c *bearerChallenge) SetHeaders(_ *http.Request, response http.ResponseWriter) {
+func (c *bearerChallengeError) SetHeaders(_ *http.Request, response http.ResponseWriter) {
 	value := "Bearer realm=" + strconv.Quote(c.realm) + ",service=" + strconv.Quote(c.service)
 	if c.scopes != "" {
 		value += ",scope=" + strconv.Quote(c.scopes)
 	}
-	switch c.err {
-	case ErrInvalidToken:
+	switch {
+	case errors.Is(c.err, ErrInvalidToken):
 		value += `,error="invalid_token"`
-	case errInsufficientScope:
+	case errors.Is(c.err, errInsufficientScope):
 		value += `,error="insufficient_scope"`
 	}
 	response.Header().Set("WWW-Authenticate", value)

--- a/internal/registry/auth/controller.go
+++ b/internal/registry/auth/controller.go
@@ -1,0 +1,184 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	distauth "github.com/distribution/distribution/v3/registry/auth"
+)
+
+var (
+	errTokenRequired     = errors.New("authorization token required")
+	errInsufficientScope = errors.New("insufficient scope")
+)
+
+// ControllerConfig configures the shared Distribution access controller.
+type ControllerConfig struct {
+	Realm            string
+	Service          string
+	LibraryNamespace string
+	Verifier         TokenVerifier
+}
+
+// Controller validates bearer tokens for Distribution and custom registry
+// endpoints. It is immutable after construction and safe for concurrent use.
+type Controller struct {
+	realm            string
+	service          string
+	libraryNamespace string
+	verifier         TokenVerifier
+}
+
+var _ distauth.AccessController = (*Controller)(nil)
+
+// NewController creates a bearer-only access controller.
+func NewController(cfg ControllerConfig) (*Controller, error) {
+	if cfg.Realm == "" || cfg.Service == "" || cfg.LibraryNamespace == "" || cfg.Verifier == nil {
+		return nil, fmt.Errorf("realm, service, library namespace, and verifier are required")
+	}
+	return &Controller{
+		realm:            cfg.Realm,
+		service:          cfg.Service,
+		libraryNamespace: cfg.LibraryNamespace,
+		verifier:         cfg.Verifier,
+	}, nil
+}
+
+// Authorized verifies the bearer token and checks exact requested resources
+// and actions. A granted wildcard action satisfies every requested action.
+func (c *Controller) Authorized(req *http.Request, requested ...distauth.Access) (*distauth.Grant, error) {
+	challenge := &bearerChallenge{
+		realm: c.realm, service: c.service, scopes: challengeScopes(requested), err: errTokenRequired,
+	}
+
+	header := strings.TrimSpace(req.Header.Get("Authorization"))
+	fields := strings.Fields(header)
+	if len(fields) == 0 || !strings.EqualFold(fields[0], "Bearer") {
+		return nil, challenge
+	}
+	if len(fields) != 2 || fields[1] == "" {
+		challenge.err = ErrInvalidToken
+		return nil, challenge
+	}
+
+	claims, err := c.verifier.Verify(fields[1])
+	if err != nil {
+		challenge.err = ErrInvalidToken
+		return nil, challenge
+	}
+
+	granted := make(map[distauth.Resource]map[string]struct{}, len(claims.Access))
+	resources := make(map[distauth.Resource]struct{}, len(claims.Access))
+	for _, item := range claims.Access {
+		resource := distauth.Resource{Type: item.Type, Class: item.Class, Name: item.Name}
+		actions := granted[resource]
+		if actions == nil {
+			actions = make(map[string]struct{})
+			granted[resource] = actions
+		}
+		resources[resource] = struct{}{}
+		for _, action := range item.Actions {
+			actions[action] = struct{}{}
+		}
+	}
+
+	for _, item := range requested {
+		resource := item.Resource
+		resource.Name = c.normalizeResourceName(resource.Type, resource.Name)
+		actions := granted[resource]
+		_, exact := actions[item.Action]
+		_, wildcard := actions["*"]
+		if !exact && !wildcard {
+			challenge.err = errInsufficientScope
+			return nil, challenge
+		}
+	}
+
+	resourceList := make([]distauth.Resource, 0, len(resources))
+	for resource := range resources {
+		resourceList = append(resourceList, resource)
+	}
+	sort.Slice(resourceList, func(i, j int) bool {
+		if resourceList[i].Type != resourceList[j].Type {
+			return resourceList[i].Type < resourceList[j].Type
+		}
+		if resourceList[i].Name != resourceList[j].Name {
+			return resourceList[i].Name < resourceList[j].Name
+		}
+		return resourceList[i].Class < resourceList[j].Class
+	})
+
+	return &distauth.Grant{
+		User: distauth.UserInfo{Name: claims.Subject}, Resources: resourceList,
+	}, nil
+}
+
+func (c *Controller) normalizeResourceName(resourceType, name string) string {
+	if resourceType == repositoryResourceType && !strings.Contains(name, "/") {
+		return c.libraryNamespace + "/" + name
+	}
+	return name
+}
+
+type bearerChallenge struct {
+	realm   string
+	service string
+	scopes  string
+	err     error
+}
+
+var _ distauth.Challenge = (*bearerChallenge)(nil)
+
+func (c *bearerChallenge) Error() string { return c.err.Error() }
+
+func (c *bearerChallenge) SetHeaders(_ *http.Request, response http.ResponseWriter) {
+	value := "Bearer realm=" + strconv.Quote(c.realm) + ",service=" + strconv.Quote(c.service)
+	if c.scopes != "" {
+		value += ",scope=" + strconv.Quote(c.scopes)
+	}
+	switch c.err {
+	case ErrInvalidToken:
+		value += `,error="invalid_token"`
+	case errInsufficientScope:
+		value += `,error="insufficient_scope"`
+	}
+	response.Header().Set("WWW-Authenticate", value)
+}
+
+func challengeScopes(requested []distauth.Access) string {
+	type resourceKey struct{ resourceType, name string }
+	byResource := make(map[resourceKey]map[string]struct{})
+	for _, item := range requested {
+		key := resourceKey{resourceType: item.Type, name: item.Name}
+		actions := byResource[key]
+		if actions == nil {
+			actions = make(map[string]struct{})
+			byResource[key] = actions
+		}
+		actions[item.Action] = struct{}{}
+	}
+	keys := make([]resourceKey, 0, len(byResource))
+	for key := range byResource {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].resourceType != keys[j].resourceType {
+			return keys[i].resourceType < keys[j].resourceType
+		}
+		return keys[i].name < keys[j].name
+	})
+	scopes := make([]string, 0, len(keys))
+	for _, key := range keys {
+		actions := make([]string, 0, len(byResource[key]))
+		for action := range byResource[key] {
+			actions = append(actions, action)
+		}
+		sort.Strings(actions)
+		scopes = append(scopes, fmt.Sprintf("%s:%s:%s", key.resourceType, key.name, strings.Join(actions, ",")))
+	}
+	return strings.Join(scopes, " ")
+}

--- a/internal/registry/auth/controller_test.go
+++ b/internal/registry/auth/controller_test.go
@@ -11,7 +11,7 @@ import (
 	distauth "github.com/distribution/distribution/v3/registry/auth"
 )
 
-func newTestController(t *testing.T, access []ResourceActions) (*Controller, string) {
+func newTestController(t *testing.T, access []ResourceActions) (controller *Controller, raw string) {
 	t.Helper()
 	signer, verifier := newTestPair(t)
 	claims := validTestClaims()
@@ -20,7 +20,7 @@ func newTestController(t *testing.T, access []ResourceActions) (*Controller, str
 	if err != nil {
 		t.Fatal(err)
 	}
-	controller, err := NewController(ControllerConfig{
+	controller, err = NewController(ControllerConfig{
 		Realm: "https://registry.example.com:8443/v2/auth", Service: "registry.example.com:8443",
 		LibraryNamespace: "library", Verifier: verifier,
 	})
@@ -36,7 +36,7 @@ func repositoryAccess(name, action string) distauth.Access {
 
 func TestControllerChallengesAreDeterministic(t *testing.T) {
 	controller, _ := newTestController(t, []ResourceActions{})
-	req := httptest.NewRequest(http.MethodGet, "/v2/acme/image/manifests/latest", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/acme/image/manifests/latest", http.NoBody)
 	_, err := controller.Authorized(req,
 		repositoryAccess("z/repo", "push"), repositoryAccess("a/repo", "pull"), repositoryAccess("z/repo", "pull"),
 	)
@@ -81,7 +81,7 @@ func TestControllerInvalidAndInsufficientScope(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/", http.NoBody)
 			req.Header.Set("Authorization", "Bearer "+tt.token)
 			_, err := controller.Authorized(req, tt.access)
 			var challenge distauth.Challenge
@@ -102,7 +102,7 @@ func TestControllerExactWildcardAndLibraryGrants(t *testing.T) {
 		{Type: "repository", Name: "acme/image", Actions: []string{"*"}},
 		{Type: "repository", Name: "library/busybox", Actions: []string{"pull"}},
 	})
-	req := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/", http.NoBody)
 	req.Header.Set("Authorization", "Bearer "+raw)
 	grant, err := controller.Authorized(req,
 		repositoryAccess("acme/image", "delete"), repositoryAccess("busybox", "pull"),
@@ -118,13 +118,14 @@ func TestControllerExactWildcardAndLibraryGrants(t *testing.T) {
 func TestControllerConcurrentAuthorization(t *testing.T) {
 	controller, raw := newTestController(t, []ResourceActions{{Type: "repository", Name: "acme/image", Actions: []string{"pull"}}})
 	const workers = 64
+	ctx := t.Context()
 	var wg sync.WaitGroup
 	errs := make(chan error, workers)
 	for range workers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			req := httptest.NewRequest(http.MethodGet, "/v2/acme/image/manifests/latest", http.NoBody)
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v2/acme/image/manifests/latest", http.NoBody)
 			req.Header.Set("Authorization", "Bearer "+raw)
 			_, err := controller.Authorized(req, repositoryAccess("acme/image", "pull"))
 			errs <- err

--- a/internal/registry/auth/controller_test.go
+++ b/internal/registry/auth/controller_test.go
@@ -1,0 +1,140 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	distauth "github.com/distribution/distribution/v3/registry/auth"
+)
+
+func newTestController(t *testing.T, access []ResourceActions) (*Controller, string) {
+	t.Helper()
+	signer, verifier := newTestPair(t)
+	claims := validTestClaims()
+	claims.Access = access
+	raw, err := signer.Sign(claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller, err := NewController(ControllerConfig{
+		Realm: "https://registry.example.com:8443/v2/auth", Service: "registry.example.com:8443",
+		LibraryNamespace: "library", Verifier: verifier,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return controller, raw
+}
+
+func repositoryAccess(name, action string) distauth.Access {
+	return distauth.Access{Resource: distauth.Resource{Type: "repository", Name: name}, Action: action}
+}
+
+func TestControllerChallengesAreDeterministic(t *testing.T) {
+	controller, _ := newTestController(t, []ResourceActions{})
+	req := httptest.NewRequest(http.MethodGet, "/v2/acme/image/manifests/latest", http.NoBody)
+	_, err := controller.Authorized(req,
+		repositoryAccess("z/repo", "push"), repositoryAccess("a/repo", "pull"), repositoryAccess("z/repo", "pull"),
+	)
+	if err == nil {
+		t.Fatal("expected challenge")
+	}
+	var challenge distauth.Challenge
+	if !errors.As(err, &challenge) {
+		t.Fatalf("error is %T, want auth.Challenge", err)
+	}
+	w := httptest.NewRecorder()
+	challenge.SetHeaders(req, w)
+	want := `Bearer realm="https://registry.example.com:8443/v2/auth",service="registry.example.com:8443",scope="repository:a/repo:pull repository:z/repo:pull,push"`
+	if got := w.Header().Get("WWW-Authenticate"); got != want {
+		t.Fatalf("challenge = %q, want %q", got, want)
+	}
+
+	req.SetBasicAuth("user", "password")
+	_, err = controller.Authorized(req, repositoryAccess("a/repo", "pull"))
+	challenge = nil
+	if !errors.As(err, &challenge) {
+		t.Fatalf("Basic request error is %T, want auth.Challenge", err)
+	}
+	w = httptest.NewRecorder()
+	challenge.SetHeaders(req, w)
+	if strings.Contains(w.Header().Get("WWW-Authenticate"), "error=") {
+		t.Fatalf("mismatched auth scheme should be token-required: %s", w.Header().Get("WWW-Authenticate"))
+	}
+}
+
+func TestControllerInvalidAndInsufficientScope(t *testing.T) {
+	controller, raw := newTestController(t, []ResourceActions{{Type: "repository", Name: "acme/image", Actions: []string{"pull"}}})
+	tests := []struct {
+		name   string
+		token  string
+		access distauth.Access
+		error  string
+	}{
+		{"malformed", "bad", repositoryAccess("acme/image", "pull"), `error="invalid_token"`},
+		{"wrong action", raw, repositoryAccess("acme/image", "push"), `error="insufficient_scope"`},
+		{"wrong resource", raw, repositoryAccess("acme/other", "pull"), `error="insufficient_scope"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+			req.Header.Set("Authorization", "Bearer "+tt.token)
+			_, err := controller.Authorized(req, tt.access)
+			var challenge distauth.Challenge
+			if !errors.As(err, &challenge) {
+				t.Fatalf("error = %v", err)
+			}
+			w := httptest.NewRecorder()
+			challenge.SetHeaders(req, w)
+			if !strings.Contains(w.Header().Get("WWW-Authenticate"), tt.error) {
+				t.Fatalf("challenge = %q", w.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
+}
+
+func TestControllerExactWildcardAndLibraryGrants(t *testing.T) {
+	controller, raw := newTestController(t, []ResourceActions{
+		{Type: "repository", Name: "acme/image", Actions: []string{"*"}},
+		{Type: "repository", Name: "library/busybox", Actions: []string{"pull"}},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	grant, err := controller.Authorized(req,
+		repositoryAccess("acme/image", "delete"), repositoryAccess("busybox", "pull"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grant.User.Name != "acme+robot" || len(grant.Resources) != 2 {
+		t.Fatalf("grant = %#v", grant)
+	}
+}
+
+func TestControllerConcurrentAuthorization(t *testing.T) {
+	controller, raw := newTestController(t, []ResourceActions{{Type: "repository", Name: "acme/image", Actions: []string{"pull"}}})
+	const workers = 64
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/v2/acme/image/manifests/latest", http.NoBody)
+			req.Header.Set("Authorization", "Bearer "+raw)
+			_, err := controller.Authorized(req, repositoryAccess("acme/image", "pull"))
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/registry/auth/handler.go
+++ b/internal/registry/auth/handler.go
@@ -1,0 +1,172 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const maximumTokenQueryBytes = 64 << 10
+
+// HandlerConfig configures GET /v2/auth.
+type HandlerConfig struct {
+	Service          string
+	LibraryNamespace string
+	AnonymousAccess  bool
+	Lifetime         time.Duration
+	Signer           TokenSigner
+	Authenticate     AuthenticateFunc
+	ResolveGrants    GrantResolver
+	Now              func() time.Time
+}
+
+// Handler exchanges Quay Basic credentials for short-lived scoped tokens.
+type Handler struct {
+	service          string
+	libraryNamespace string
+	anonymousAccess  bool
+	lifetime         time.Duration
+	signer           TokenSigner
+	authenticate     AuthenticateFunc
+	resolveGrants    GrantResolver
+	now              func() time.Time
+}
+
+// NewHandler constructs a token exchange handler.
+func NewHandler(cfg HandlerConfig) (*Handler, error) {
+	if cfg.Service == "" || cfg.LibraryNamespace == "" || cfg.Signer == nil || cfg.ResolveGrants == nil {
+		return nil, fmt.Errorf("service, library namespace, signer, and grant resolver are required")
+	}
+	if cfg.Lifetime < minimumTokenLifetime {
+		return nil, fmt.Errorf("token lifetime must be at least %s", minimumTokenLifetime)
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &Handler{
+		service:          cfg.Service,
+		libraryNamespace: cfg.LibraryNamespace,
+		anonymousAccess:  cfg.AnonymousAccess,
+		lifetime:         cfg.Lifetime,
+		signer:           cfg.Signer,
+		authenticate:     cfg.Authenticate,
+		resolveGrants:    cfg.ResolveGrants,
+		now:              cfg.Now,
+	}, nil
+}
+
+func (h *Handler) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	setNoCacheHeaders(response)
+	if request.Method != http.MethodGet {
+		response.Header().Set("Allow", http.MethodGet)
+		writeTokenError(response, http.StatusMethodNotAllowed, "method_not_allowed")
+		return
+	}
+	if len(request.URL.RawQuery) > maximumTokenQueryBytes {
+		writeTokenError(response, http.StatusBadRequest, "invalid_scope")
+		return
+	}
+
+	query := request.URL.Query()
+	services := query["service"]
+	if len(services) != 1 || services[0] != h.service {
+		writeTokenError(response, http.StatusBadRequest, "invalid_service")
+		return
+	}
+	requested, err := ParseScopes(query["scope"], h.service, h.libraryNamespace)
+	if err != nil {
+		writeTokenError(response, http.StatusBadRequest, "invalid_scope")
+		return
+	}
+
+	identity, ok := h.authenticateRequest(request)
+	if !ok {
+		response.Header().Set("WWW-Authenticate", `Basic realm=`+quoteHeader(h.service))
+		writeTokenError(response, http.StatusUnauthorized, "invalid_client")
+		return
+	}
+
+	access, err := h.resolveGrants(request.Context(), identity, requested)
+	if err != nil {
+		writeTokenError(response, http.StatusInternalServerError, "server_error")
+		return
+	}
+	if access == nil {
+		access = []ResourceActions{}
+	}
+
+	now := h.now().UTC().Truncate(time.Second)
+	jti, err := randomTokenID()
+	if err != nil {
+		writeTokenError(response, http.StatusInternalServerError, "server_error")
+		return
+	}
+	claims := &Claims{
+		Issuer: Issuer, Subject: identity.Subject, Audience: h.service,
+		IssuedAt: now.Unix(), NotBefore: now.Unix(), Expiration: now.Add(h.lifetime).Unix(),
+		JWTID: jti, Access: access,
+	}
+	token, err := h.signer.Sign(claims)
+	if err != nil {
+		writeTokenError(response, http.StatusInternalServerError, "server_error")
+		return
+	}
+
+	response.Header().Set("Content-Type", "application/json")
+	response.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(response).Encode(map[string]any{
+		"token": token, "access_token": token, "expires_in": int64(h.lifetime / time.Second),
+		"issued_at": now.Format(time.RFC3339),
+	})
+}
+
+func (h *Handler) authenticateRequest(request *http.Request) (Identity, bool) {
+	header := strings.TrimSpace(request.Header.Get("Authorization"))
+	if header == "" {
+		if !h.anonymousAccess {
+			return Identity{}, false
+		}
+		return Identity{Subject: AnonymousSubject, Anonymous: true}, true
+	}
+	fields := strings.Fields(header)
+	if len(fields) != 2 || !strings.EqualFold(fields[0], "Basic") {
+		return Identity{}, false
+	}
+	username, secret, ok := request.BasicAuth()
+	if !ok || h.authenticate == nil {
+		return Identity{}, false
+	}
+	identity, ok := h.authenticate(request.Context(), username, secret)
+	if !ok || identity.Subject == "" || identity.Anonymous {
+		return Identity{}, false
+	}
+	return identity, true
+}
+
+func setNoCacheHeaders(response http.ResponseWriter) {
+	response.Header().Set("Cache-Control", "no-store")
+	response.Header().Set("Pragma", "no-cache")
+}
+
+func writeTokenError(response http.ResponseWriter, status int, code string) {
+	response.Header().Set("Content-Type", "application/json")
+	response.WriteHeader(status)
+	_ = json.NewEncoder(response).Encode(map[string]string{"error": code})
+}
+
+func randomTokenID() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
+}
+
+func quoteHeader(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/internal/registry/auth/handler.go
+++ b/internal/registry/auth/handler.go
@@ -37,7 +37,10 @@ type Handler struct {
 }
 
 // NewHandler constructs a token exchange handler.
-func NewHandler(cfg HandlerConfig) (*Handler, error) {
+func NewHandler(cfg *HandlerConfig) (*Handler, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("nil handler config")
+	}
 	if cfg.Service == "" || cfg.LibraryNamespace == "" || cfg.Signer == nil || cfg.ResolveGrants == nil {
 		return nil, fmt.Errorf("service, library namespace, signer, and grant resolver are required")
 	}

--- a/internal/registry/auth/handler.go
+++ b/internal/registry/auth/handler.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 const maximumTokenQueryBytes = 64 << 10
@@ -109,9 +111,12 @@ func (h *Handler) ServeHTTP(response http.ResponseWriter, request *http.Request)
 		return
 	}
 	claims := &Claims{
-		Issuer: Issuer, Subject: identity.Subject, Audience: h.service,
-		IssuedAt: now.Unix(), NotBefore: now.Unix(), Expiration: now.Add(h.lifetime).Unix(),
-		JWTID: jti, Access: access,
+		Claims: jwt.Claims{
+			Issuer: Issuer, Subject: identity.Subject, Audience: jwt.Audience{h.service},
+			IssuedAt: jwt.NewNumericDate(now), NotBefore: jwt.NewNumericDate(now),
+			Expiry: jwt.NewNumericDate(now.Add(h.lifetime)), ID: jti,
+		},
+		Access: access,
 	}
 	token, err := h.signer.Sign(claims)
 	if err != nil {

--- a/internal/registry/auth/handler_test.go
+++ b/internal/registry/auth/handler_test.go
@@ -24,7 +24,7 @@ type tokenResponse struct {
 func newTestHandler(t *testing.T, anonymous bool, authenticate AuthenticateFunc, resolver GrantResolver) (*Handler, TokenVerifier) {
 	t.Helper()
 	signer, verifier := newTestPair(t)
-	handler, err := NewHandler(HandlerConfig{
+	handler, err := NewHandler(&HandlerConfig{
 		Service: "registry.example.com:8443", LibraryNamespace: "library", AnonymousAccess: anonymous,
 		Lifetime: 5 * time.Minute, Signer: signer, Authenticate: authenticate, ResolveGrants: resolver,
 		Now: func() time.Time { return testNow },
@@ -56,7 +56,7 @@ func TestHandlerIssuesDownscopedToken(t *testing.T) {
 		"scope":         {"repository:acme/image:pull,push", "repository:acme/image:pull"},
 		"offline_token": {"true"},
 	}
-	req := httptest.NewRequest(http.MethodGet, "/v2/auth?"+query.Encode(), http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/auth?"+query.Encode(), http.NoBody)
 	req.SetBasicAuth("user", "password")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
@@ -94,7 +94,7 @@ func TestHandlerInvalidCredentialsNeverBecomeAnonymous(t *testing.T) {
 		return nil, nil
 	}
 	handler, _ := newTestHandler(t, true, authenticate, resolver)
-	req := httptest.NewRequest(http.MethodGet, "/v2/auth?service=registry.example.com%3A8443&scope=repository%3Apublic%2Frepo%3Apull", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/auth?service=registry.example.com%3A8443&scope=repository%3Apublic%2Frepo%3Apull", http.NoBody)
 	req.SetBasicAuth("user", "wrong")
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
@@ -124,7 +124,7 @@ func TestHandlerAnonymousEmptyAndPublicScopes(t *testing.T) {
 		"/v2/auth?service=registry.example.com%3A8443&scope=repository%3Apublic%2Frepo%3Apull",
 		"/v2/auth?service=registry.example.com%3A8443&scope=repository%3Aprivate%2Frepo%3Apull",
 	} {
-		req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, http.NoBody)
 		w := httptest.NewRecorder()
 		handler.ServeHTTP(w, req)
 		if w.Code != http.StatusOK {
@@ -160,7 +160,7 @@ func TestHandlerRejectsProtocolErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(tt.method, tt.path, http.NoBody)
+			req := httptest.NewRequestWithContext(t.Context(), tt.method, tt.path, http.NoBody)
 			if tt.name != "missing credentials" {
 				req.SetBasicAuth("user", "password")
 			}
@@ -188,7 +188,7 @@ func TestHandlerRejectsExcessiveScopesBeforeResolution(t *testing.T) {
 	for i := 0; i <= maximumScopeCount; i++ {
 		query.Add("scope", "repository:acme/repo"+strconv.Itoa(i)+":pull")
 	}
-	request := httptest.NewRequest(http.MethodGet, "/v2/auth?"+query.Encode(), http.NoBody)
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/auth?"+query.Encode(), http.NoBody)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 
@@ -206,7 +206,7 @@ func TestHandlerRejectsOversizedQueryBeforeResolution(t *testing.T) {
 		},
 	)
 	path := "/v2/auth?service=registry.example.com%3A8443&padding=" + strings.Repeat("x", maximumTokenQueryBytes)
-	request := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, http.NoBody)
 	response := httptest.NewRecorder()
 	handler.ServeHTTP(response, request)
 
@@ -221,7 +221,7 @@ func TestHandlerResolverFailure(t *testing.T) {
 			return nil, errors.New("database failed")
 		},
 	)
-	req := httptest.NewRequest(http.MethodGet, "/v2/auth?service=registry.example.com%3A8443", http.NoBody)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/auth?service=registry.example.com%3A8443", http.NoBody)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	if w.Code != http.StatusInternalServerError {

--- a/internal/registry/auth/handler_test.go
+++ b/internal/registry/auth/handler_test.go
@@ -1,0 +1,230 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+type tokenResponse struct {
+	Token       string `json:"token"`
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int64  `json:"expires_in"`
+	IssuedAt    string `json:"issued_at"`
+}
+
+func newTestHandler(t *testing.T, anonymous bool, authenticate AuthenticateFunc, resolver GrantResolver) (*Handler, TokenVerifier) {
+	t.Helper()
+	signer, verifier := newTestPair(t)
+	handler, err := NewHandler(HandlerConfig{
+		Service: "registry.example.com:8443", LibraryNamespace: "library", AnonymousAccess: anonymous,
+		Lifetime: 5 * time.Minute, Signer: signer, Authenticate: authenticate, ResolveGrants: resolver,
+		Now: func() time.Time { return testNow },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handler, verifier
+}
+
+func TestHandlerIssuesDownscopedToken(t *testing.T) {
+	var requested []Scope
+	authenticate := func(_ context.Context, username, secret string) (Identity, bool) {
+		if username != "user" || secret != "password" {
+			return Identity{}, false
+		}
+		return Identity{Subject: username, Principal: int64(42)}, true
+	}
+	resolver := func(_ context.Context, identity Identity, scopes []Scope) ([]ResourceActions, error) {
+		if identity.Principal != int64(42) {
+			t.Fatalf("principal = %#v", identity.Principal)
+		}
+		requested = scopes
+		return []ResourceActions{{Type: "repository", Name: "acme/image", Actions: []string{"pull"}}}, nil
+	}
+	handler, verifier := newTestHandler(t, false, authenticate, resolver)
+	query := url.Values{
+		"service":       {"registry.example.com:8443"},
+		"scope":         {"repository:acme/image:pull,push", "repository:acme/image:pull"},
+		"offline_token": {"true"},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v2/auth?"+query.Encode(), http.NoBody)
+	req.SetBasicAuth("user", "password")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if w.Header().Get("Cache-Control") != "no-store" || w.Header().Get("Pragma") != "no-cache" {
+		t.Fatalf("cache headers = %#v", w.Header())
+	}
+	wantScopes := []Scope{{Type: "repository", Name: "acme/image", Actions: []string{"pull", "push"}}}
+	if !reflect.DeepEqual(requested, wantScopes) {
+		t.Fatalf("scopes = %#v, want %#v", requested, wantScopes)
+	}
+	var response tokenResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Token == "" || response.Token != response.AccessToken || response.ExpiresIn != 300 || response.IssuedAt != testNow.Format(time.RFC3339) {
+		t.Fatalf("response = %#v", response)
+	}
+	claims, err := verifier.Verify(response.Token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.Subject != "user" || !reflect.DeepEqual(claims.Access[0].Actions, []string{"pull"}) {
+		t.Fatalf("claims = %#v", claims)
+	}
+}
+
+func TestHandlerInvalidCredentialsNeverBecomeAnonymous(t *testing.T) {
+	authenticate := func(context.Context, string, string) (Identity, bool) { return Identity{}, false }
+	resolverCalled := false
+	resolver := func(context.Context, Identity, []Scope) ([]ResourceActions, error) {
+		resolverCalled = true
+		return nil, nil
+	}
+	handler, _ := newTestHandler(t, true, authenticate, resolver)
+	req := httptest.NewRequest(http.MethodGet, "/v2/auth?service=registry.example.com%3A8443&scope=repository%3Apublic%2Frepo%3Apull", http.NoBody)
+	req.SetBasicAuth("user", "wrong")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized || resolverCalled {
+		t.Fatalf("status = %d, resolverCalled = %v", w.Code, resolverCalled)
+	}
+}
+
+func TestHandlerAnonymousEmptyAndPublicScopes(t *testing.T) {
+	resolver := func(_ context.Context, identity Identity, scopes []Scope) ([]ResourceActions, error) {
+		if !identity.Anonymous || identity.Subject != AnonymousSubject {
+			t.Fatalf("identity = %#v", identity)
+		}
+		access := make([]ResourceActions, 0, len(scopes))
+		for _, scope := range scopes {
+			actions := []string{}
+			if scope.Name == "public/repo" {
+				actions = []string{"pull"}
+			}
+			access = append(access, ResourceActions{Type: scope.Type, Name: scope.Name, Actions: actions})
+		}
+		return access, nil
+	}
+	handler, verifier := newTestHandler(t, true, nil, resolver)
+	for _, path := range []string{
+		"/v2/auth?service=registry.example.com%3A8443",
+		"/v2/auth?service=registry.example.com%3A8443&scope=repository%3Apublic%2Frepo%3Apull",
+		"/v2/auth?service=registry.example.com%3A8443&scope=repository%3Aprivate%2Frepo%3Apull",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s status = %d", path, w.Code)
+		}
+		var response tokenResponse
+		_ = json.NewDecoder(w.Body).Decode(&response)
+		claims, err := verifier.Verify(response.Token)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if claims.Subject != AnonymousSubject {
+			t.Fatalf("subject = %q", claims.Subject)
+		}
+	}
+}
+
+func TestHandlerRejectsProtocolErrors(t *testing.T) {
+	handler, _ := newTestHandler(t, false,
+		func(context.Context, string, string) (Identity, bool) { return Identity{Subject: "user"}, true },
+		func(context.Context, Identity, []Scope) ([]ResourceActions, error) { return []ResourceActions{}, nil },
+	)
+	tests := []struct {
+		name, method, path string
+		status             int
+	}{
+		{"method", http.MethodPost, "/v2/auth?service=registry.example.com%3A8443", http.StatusMethodNotAllowed},
+		{"missing service", http.MethodGet, "/v2/auth", http.StatusBadRequest},
+		{"wrong service", http.MethodGet, "/v2/auth?service=attacker.example", http.StatusBadRequest},
+		{"repeated service", http.MethodGet, "/v2/auth?service=registry.example.com%3A8443&service=registry.example.com%3A8443", http.StatusBadRequest},
+		{"invalid scope", http.MethodGet, "/v2/auth?service=registry.example.com%3A8443&scope=repository%3Aacme%2Frepo%3Ascan", http.StatusBadRequest},
+		{"missing credentials", http.MethodGet, "/v2/auth?service=registry.example.com%3A8443", http.StatusUnauthorized},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, http.NoBody)
+			if tt.name != "missing credentials" {
+				req.SetBasicAuth("user", "password")
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			if w.Code != tt.status {
+				t.Fatalf("status = %d, want %d", w.Code, tt.status)
+			}
+			if w.Header().Get("Cache-Control") != "no-store" || w.Header().Get("Pragma") != "no-cache" {
+				t.Fatal("missing no-cache headers")
+			}
+		})
+	}
+}
+
+func TestHandlerRejectsExcessiveScopesBeforeResolution(t *testing.T) {
+	resolverCalled := false
+	handler, _ := newTestHandler(t, true, nil,
+		func(context.Context, Identity, []Scope) ([]ResourceActions, error) {
+			resolverCalled = true
+			return nil, nil
+		},
+	)
+	query := url.Values{"service": {"registry.example.com:8443"}}
+	for i := 0; i <= maximumScopeCount; i++ {
+		query.Add("scope", "repository:acme/repo"+strconv.Itoa(i)+":pull")
+	}
+	request := httptest.NewRequest(http.MethodGet, "/v2/auth?"+query.Encode(), http.NoBody)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest || resolverCalled {
+		t.Fatalf("status = %d, resolverCalled = %v", response.Code, resolverCalled)
+	}
+}
+
+func TestHandlerRejectsOversizedQueryBeforeResolution(t *testing.T) {
+	resolverCalled := false
+	handler, _ := newTestHandler(t, true, nil,
+		func(context.Context, Identity, []Scope) ([]ResourceActions, error) {
+			resolverCalled = true
+			return nil, nil
+		},
+	)
+	path := "/v2/auth?service=registry.example.com%3A8443&padding=" + strings.Repeat("x", maximumTokenQueryBytes)
+	request := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusBadRequest || resolverCalled {
+		t.Fatalf("status = %d, resolverCalled = %v", response.Code, resolverCalled)
+	}
+}
+
+func TestHandlerResolverFailure(t *testing.T) {
+	handler, _ := newTestHandler(t, true, nil,
+		func(context.Context, Identity, []Scope) ([]ResourceActions, error) {
+			return nil, errors.New("database failed")
+		},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/v2/auth?service=registry.example.com%3A8443", http.NoBody)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d", w.Code)
+	}
+}

--- a/internal/registry/auth/register.go
+++ b/internal/registry/auth/register.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"fmt"
+	"sync"
+
+	distauth "github.com/distribution/distribution/v3/registry/auth"
+)
+
+const (
+	// DistributionBackendName is the registered upstream auth backend name.
+	DistributionBackendName = "quaytoken"
+	// DistributionControllerOption carries the prebuilt controller through
+	// Distribution's weakly typed plugin options.
+	DistributionControllerOption = "controller"
+)
+
+// Distribution exposes custom access controllers only through a process-wide
+// plugin registry. This once/error pair is the constrained exception to Go
+// OMR's no-global-state rule: it registers a stateless adapter and never stores
+// a controller, key, database handle, or other runtime dependency globally.
+var (
+	registerOnce sync.Once
+	registerErr  error
+)
+
+// RegisterDistributionAdapter registers the stateless quaytoken adapter once.
+func RegisterDistributionAdapter() error {
+	registerOnce.Do(func() {
+		registerErr = distauth.Register(DistributionBackendName, distauth.InitFunc(func(options map[string]interface{}) (distauth.AccessController, error) {
+			controller, ok := options[DistributionControllerOption].(*Controller)
+			if !ok || controller == nil {
+				return nil, fmt.Errorf("%q must be set to *auth.Controller", DistributionControllerOption)
+			}
+			return controller, nil
+		}))
+	})
+	return registerErr
+}

--- a/internal/registry/auth/register.go
+++ b/internal/registry/auth/register.go
@@ -21,13 +21,13 @@ const (
 // a controller, key, database handle, or other runtime dependency globally.
 var (
 	registerOnce sync.Once
-	registerErr  error
+	errRegister  error
 )
 
 // RegisterDistributionAdapter registers the stateless quaytoken adapter once.
 func RegisterDistributionAdapter() error {
 	registerOnce.Do(func() {
-		registerErr = distauth.Register(DistributionBackendName, distauth.InitFunc(func(options map[string]interface{}) (distauth.AccessController, error) {
+		errRegister = distauth.Register(DistributionBackendName, distauth.InitFunc(func(options map[string]interface{}) (distauth.AccessController, error) {
 			controller, ok := options[DistributionControllerOption].(*Controller)
 			if !ok || controller == nil {
 				return nil, fmt.Errorf("%q must be set to *auth.Controller", DistributionControllerOption)
@@ -35,5 +35,5 @@ func RegisterDistributionAdapter() error {
 			return controller, nil
 		}))
 	})
-	return registerErr
+	return errRegister
 }

--- a/internal/registry/auth/scope.go
+++ b/internal/registry/auth/scope.go
@@ -1,0 +1,171 @@
+package auth
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	repositoryResourceType = "repository"
+	registryResourceType   = "registry"
+	maximumScopeCount      = 100
+)
+
+// ParseScopes parses repeated and whitespace-separated scope parameters,
+// normalizes repository names, and returns a deterministic de-duplicated list.
+func ParseScopes(values []string, service, libraryNamespace string) ([]Scope, error) {
+	if service == "" {
+		return nil, fmt.Errorf("service must not be empty")
+	}
+	if libraryNamespace == "" {
+		return nil, fmt.Errorf("library namespace must not be empty")
+	}
+
+	type scopeKey struct {
+		resourceType string
+		name         string
+	}
+	actionsByScope := make(map[scopeKey]map[string]struct{})
+
+	for _, value := range values {
+		for _, raw := range strings.Fields(value) {
+			scope, err := parseScope(raw, service, libraryNamespace)
+			if err != nil {
+				return nil, err
+			}
+			key := scopeKey{resourceType: scope.Type, name: scope.Name}
+			actions := actionsByScope[key]
+			if actions == nil {
+				actions = make(map[string]struct{})
+				actionsByScope[key] = actions
+				if len(actionsByScope) > maximumScopeCount {
+					return nil, fmt.Errorf("too many scopes: maximum is %d", maximumScopeCount)
+				}
+			}
+			for _, action := range scope.Actions {
+				actions[action] = struct{}{}
+			}
+		}
+	}
+
+	keys := make([]scopeKey, 0, len(actionsByScope))
+	for key := range actionsByScope {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].resourceType != keys[j].resourceType {
+			return keys[i].resourceType < keys[j].resourceType
+		}
+		return keys[i].name < keys[j].name
+	})
+
+	result := make([]Scope, 0, len(keys))
+	for _, key := range keys {
+		actions := make([]string, 0, len(actionsByScope[key]))
+		for action := range actionsByScope[key] {
+			actions = append(actions, action)
+		}
+		sort.Strings(actions)
+		result = append(result, Scope{Type: key.resourceType, Name: key.name, Actions: actions})
+	}
+	return result, nil
+}
+
+func parseScope(raw, service, libraryNamespace string) (Scope, error) {
+	firstColon := strings.IndexByte(raw, ':')
+	lastColon := strings.LastIndexByte(raw, ':')
+	if firstColon <= 0 || lastColon <= firstColon+1 || lastColon == len(raw)-1 {
+		return Scope{}, fmt.Errorf("invalid scope %q", raw)
+	}
+
+	resourceType := raw[:firstColon]
+	name := raw[firstColon+1 : lastColon]
+	actionList := raw[lastColon+1:]
+	if !validToken(resourceType) || name == "" {
+		return Scope{}, fmt.Errorf("invalid scope %q", raw)
+	}
+
+	switch resourceType {
+	case repositoryResourceType:
+		name = strings.TrimPrefix(name, service+"/")
+		if !strings.Contains(name, "/") {
+			name = libraryNamespace + "/" + name
+		}
+		if !validRepositoryName(name) {
+			return Scope{}, fmt.Errorf("invalid repository scope name %q", name)
+		}
+	case registryResourceType:
+		if !validToken(name) {
+			return Scope{}, fmt.Errorf("invalid registry scope name %q", name)
+		}
+	default:
+		return Scope{}, fmt.Errorf("unsupported scope resource type %q", resourceType)
+	}
+
+	actions := strings.Split(actionList, ",")
+	seen := make(map[string]struct{}, len(actions))
+	parsedActions := make([]string, 0, len(actions))
+	for _, action := range actions {
+		if !validScopeAction(action) {
+			return Scope{}, fmt.Errorf("invalid scope action %q", action)
+		}
+		if resourceType == registryResourceType && action != "*" {
+			return Scope{}, fmt.Errorf("invalid registry scope action %q", action)
+		}
+		if _, ok := seen[action]; ok {
+			continue
+		}
+		seen[action] = struct{}{}
+		parsedActions = append(parsedActions, action)
+	}
+	sort.Strings(parsedActions)
+
+	return Scope{Type: resourceType, Name: name, Actions: parsedActions}, nil
+}
+
+func validScopeAction(action string) bool {
+	switch action {
+	case "pull", "push", "delete", "*":
+		return true
+	default:
+		return false
+	}
+}
+
+func validRepositoryName(name string) bool {
+	if strings.Contains(name, ":") {
+		return false
+	}
+	parts := strings.Split(name, "/")
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if !isAlphaNumeric(r) && r != '.' && r != '_' && r != '-' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func validToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if !isAlphaNumeric(r) && r != '.' && r != '_' && r != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func isAlphaNumeric(r rune) bool {
+	return r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9'
+}

--- a/internal/registry/auth/scope.go
+++ b/internal/registry/auth/scope.go
@@ -10,6 +10,10 @@ const (
 	repositoryResourceType = "repository"
 	registryResourceType   = "registry"
 	maximumScopeCount      = 100
+	repositoryPullAction   = "pull"
+	repositoryPushAction   = "push"
+	repositoryDeleteAction = "delete"
+	wildcardAction         = "*"
 )
 
 // ParseScopes parses repeated and whitespace-separated scope parameters,
@@ -86,6 +90,18 @@ func parseScope(raw, service, libraryNamespace string) (Scope, error) {
 		return Scope{}, fmt.Errorf("invalid scope %q", raw)
 	}
 
+	name, err := normalizeScopeName(resourceType, name, service, libraryNamespace)
+	if err != nil {
+		return Scope{}, err
+	}
+	parsedActions, err := parseScopeActions(resourceType, actionList)
+	if err != nil {
+		return Scope{}, err
+	}
+	return Scope{Type: resourceType, Name: name, Actions: parsedActions}, nil
+}
+
+func normalizeScopeName(resourceType, name, service, libraryNamespace string) (string, error) {
 	switch resourceType {
 	case repositoryResourceType:
 		name = strings.TrimPrefix(name, service+"/")
@@ -93,25 +109,29 @@ func parseScope(raw, service, libraryNamespace string) (Scope, error) {
 			name = libraryNamespace + "/" + name
 		}
 		if !validRepositoryName(name) {
-			return Scope{}, fmt.Errorf("invalid repository scope name %q", name)
+			return "", fmt.Errorf("invalid repository scope name %q", name)
 		}
+		return name, nil
 	case registryResourceType:
 		if !validToken(name) {
-			return Scope{}, fmt.Errorf("invalid registry scope name %q", name)
+			return "", fmt.Errorf("invalid registry scope name %q", name)
 		}
+		return name, nil
 	default:
-		return Scope{}, fmt.Errorf("unsupported scope resource type %q", resourceType)
+		return "", fmt.Errorf("unsupported scope resource type %q", resourceType)
 	}
+}
 
+func parseScopeActions(resourceType, actionList string) ([]string, error) {
 	actions := strings.Split(actionList, ",")
 	seen := make(map[string]struct{}, len(actions))
 	parsedActions := make([]string, 0, len(actions))
 	for _, action := range actions {
 		if !validScopeAction(action) {
-			return Scope{}, fmt.Errorf("invalid scope action %q", action)
+			return nil, fmt.Errorf("invalid scope action %q", action)
 		}
-		if resourceType == registryResourceType && action != "*" {
-			return Scope{}, fmt.Errorf("invalid registry scope action %q", action)
+		if resourceType == registryResourceType && action != wildcardAction {
+			return nil, fmt.Errorf("invalid registry scope action %q", action)
 		}
 		if _, ok := seen[action]; ok {
 			continue
@@ -121,12 +141,12 @@ func parseScope(raw, service, libraryNamespace string) (Scope, error) {
 	}
 	sort.Strings(parsedActions)
 
-	return Scope{Type: resourceType, Name: name, Actions: parsedActions}, nil
+	return parsedActions, nil
 }
 
 func validScopeAction(action string) bool {
 	switch action {
-	case "pull", "push", "delete", "*":
+	case repositoryPullAction, repositoryPushAction, repositoryDeleteAction, wildcardAction:
 		return true
 	default:
 		return false
@@ -146,6 +166,9 @@ func validRepositoryName(name string) bool {
 			return false
 		}
 		for _, r := range part {
+			if r >= 'A' && r <= 'Z' {
+				return false
+			}
 			if !isAlphaNumeric(r) && r != '.' && r != '_' && r != '-' {
 				return false
 			}

--- a/internal/registry/auth/scope_test.go
+++ b/internal/registry/auth/scope_test.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseScopesNormalizesAndDeduplicates(t *testing.T) {
+	got, err := ParseScopes([]string{
+		"repository:registry.example.com:8443/acme/team/image:push,pull,pull",
+		"repository:acme/team/image:delete repository:busybox:pull",
+		"repository:acme/team/image:push",
+	}, "registry.example.com:8443", "library")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Scope{
+		{Type: "repository", Name: "acme/team/image", Actions: []string{"delete", "pull", "push"}},
+		{Type: "repository", Name: "library/busybox", Actions: []string{"pull"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("scopes = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseScopesAcceptsCatalog(t *testing.T) {
+	got, err := ParseScopes([]string{"registry:catalog:*"}, "registry.example.com", "library")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Type != "registry" || got[0].Name != "catalog" {
+		t.Fatalf("unexpected scopes: %#v", got)
+	}
+}
+
+func TestParseScopesRejectsMalformedValues(t *testing.T) {
+	tests := []string{
+		"repository", "repository::pull", "repository:acme/repo:",
+		"repository:acme//repo:pull", "repository:other.example:8443/acme/repo:pull",
+		"repository:acme/repo:scan", "repository:acme/repo:pull,",
+		"registry:catalog:pull", "artifact:acme/repo:pull",
+	}
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := ParseScopes([]string{raw}, "registry.example.com:8443", "library"); err == nil {
+				t.Fatalf("expected %q to fail", raw)
+			}
+		})
+	}
+}
+
+func TestParseScopesEmpty(t *testing.T) {
+	got, err := ParseScopes(nil, "registry.example.com", "library")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Fatalf("scopes = %#v, want non-nil empty slice", got)
+	}
+}

--- a/internal/registry/auth/scope_test.go
+++ b/internal/registry/auth/scope_test.go
@@ -37,6 +37,7 @@ func TestParseScopesRejectsMalformedValues(t *testing.T) {
 	tests := []string{
 		"repository", "repository::pull", "repository:acme/repo:",
 		"repository:acme//repo:pull", "repository:other.example:8443/acme/repo:pull",
+		"repository:acme/Repo:pull",
 		"repository:acme/repo:scan", "repository:acme/repo:pull,",
 		"registry:catalog:pull", "artifact:acme/repo:pull",
 	}

--- a/internal/registry/auth/token.go
+++ b/internal/registry/auth/token.go
@@ -2,23 +2,23 @@ package auth
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"math/big"
+	"strings"
 	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 const (
-	es256Algorithm       = "ES256"
-	algorithmHeader      = "alg"
-	keyIDHeader          = "kid"
 	maximumClockSkew     = 5 * time.Second
 	minimumTokenLifetime = 60 * time.Second
 )
@@ -36,8 +36,9 @@ type ES256Config struct {
 }
 
 type es256Signer struct {
-	key   *ecdsa.PrivateKey
-	keyID string
+	key        *ecdsa.PrivateKey
+	keyID      string
+	joseSigner jose.Signer
 }
 
 type es256Verifier struct {
@@ -70,13 +71,28 @@ func NewES256Pair(cfg ES256Config) (TokenSigner, TokenVerifier, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate ES256 key: %w", err)
 	}
-	keyID := rfc7638Thumbprint(&privateKey.PublicKey)
+	thumbprint, err := (&jose.JSONWebKey{Key: &privateKey.PublicKey}).Thumbprint(crypto.SHA256)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate ES256 key ID: %w", err)
+	}
+	keyID := base64.RawURLEncoding.EncodeToString(thumbprint)
 	if keyID == "" {
-		return nil, nil, fmt.Errorf("generate ES256 key ID")
+		return nil, nil, fmt.Errorf("generate ES256 key ID: empty thumbprint")
+	}
+	joseSigner, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.ES256,
+		Key: jose.JSONWebKey{
+			Key:       privateKey,
+			KeyID:     keyID,
+			Algorithm: string(jose.ES256),
+		},
+	}, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create ES256 signer: %w", err)
 	}
 	publicKey := privateKey.PublicKey
 
-	return &es256Signer{key: privateKey, keyID: keyID}, &es256Verifier{
+	return &es256Signer{key: privateKey, keyID: keyID, joseSigner: joseSigner}, &es256Verifier{
 		key:       &publicKey,
 		keyID:     keyID,
 		issuer:    cfg.Issuer,
@@ -90,37 +106,28 @@ func NewES256Pair(cfg ES256Config) (TokenSigner, TokenVerifier, error) {
 func (s *es256Signer) KeyID() string { return s.keyID }
 
 func (s *es256Signer) Sign(claims *Claims) (string, error) {
-	if s == nil || s.key == nil || claims == nil {
+	if s == nil || s.key == nil || s.joseSigner == nil || claims == nil {
 		return "", fmt.Errorf("invalid signer or claims")
 	}
-	header, err := json.Marshal(map[string]string{algorithmHeader: es256Algorithm, keyIDHeader: s.keyID})
-	if err != nil {
-		return "", fmt.Errorf("marshal registry token header: %w", err)
-	}
-	payload, err := json.Marshal(claims)
-	if err != nil {
-		return "", fmt.Errorf("marshal registry claims: %w", err)
-	}
-	encodedHeader := base64.RawURLEncoding.EncodeToString(header)
-	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
-	signingInput := encodedHeader + "." + encodedPayload
-	digest := sha256.Sum256([]byte(signingInput))
-	r, signatureS, err := ecdsa.Sign(rand.Reader, s.key, digest[:])
+	raw, err := jwt.Signed(s.joseSigner).Claims(claims).Serialize()
 	if err != nil {
 		return "", fmt.Errorf("sign registry claims: %w", err)
 	}
-	coordinateSize := (s.key.Curve.Params().BitSize + 7) / 8
-	signature := make([]byte, coordinateSize*2)
-	r.FillBytes(signature[:coordinateSize])
-	signatureS.FillBytes(signature[coordinateSize:])
-	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+	return raw, nil
 }
 
 func (v *es256Verifier) KeyID() string { return v.keyID }
 
 func (v *es256Verifier) Verify(raw string) (*Claims, error) {
-	payload, ok := v.verifySignedPayload(raw)
-	if !ok {
+	if v == nil || v.key == nil {
+		return nil, ErrInvalidToken
+	}
+	token, err := jwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.ES256})
+	if err != nil || len(token.Headers) != 1 || !validProtectedHeader(raw, token.Headers[0], v.keyID) {
+		return nil, ErrInvalidToken
+	}
+	var payload json.RawMessage
+	if err := token.Claims(v.key, &payload); err != nil {
 		return nil, ErrInvalidToken
 	}
 	claims, ok := decodeClaims(payload)
@@ -128,29 +135,6 @@ func (v *es256Verifier) Verify(raw string) (*Claims, error) {
 		return nil, ErrInvalidToken
 	}
 	return claims, nil
-}
-
-func (v *es256Verifier) verifySignedPayload(raw string) ([]byte, bool) {
-	if v == nil || v.key == nil || !validProtectedHeader(raw, v.keyID) {
-		return nil, false
-	}
-	parts := splitCompactToken(raw)
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
-	if err != nil {
-		return nil, false
-	}
-	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
-	coordinateSize := (v.key.Curve.Params().BitSize + 7) / 8
-	if err != nil || len(signature) != coordinateSize*2 {
-		return nil, false
-	}
-	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
-	r := new(big.Int).SetBytes(signature[:coordinateSize])
-	signatureS := new(big.Int).SetBytes(signature[coordinateSize:])
-	if !ecdsa.Verify(v.key, digest[:], r, signatureS) {
-		return nil, false
-	}
-	return payload, true
 }
 
 func decodeClaims(payload []byte) (*Claims, bool) {
@@ -229,60 +213,28 @@ func (v *es256Verifier) validClaimTimes(claims *Claims) bool {
 	return now.Sub(issuedAt) <= v.maxFresh+v.clockSkew
 }
 
-func validProtectedHeader(raw, expectedKeyID string) bool {
-	parts := splitCompactToken(raw)
-	if parts == nil {
+func validProtectedHeader(raw string, header jose.Header, expectedKeyID string) bool {
+	if header.Algorithm != string(jose.ES256) || header.KeyID != expectedKeyID {
 		return false
 	}
-	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	// go-jose intentionally hides the raw x5c field after parsing. Inspect the
+	// protected object so even empty attacker-selectable key headers are rejected.
+	encodedHeader, _, ok := strings.Cut(raw, ".")
+	if !ok {
+		return false
+	}
+	headerBytes, err := base64.RawURLEncoding.DecodeString(encodedHeader)
 	if err != nil {
 		return false
 	}
-	var header map[string]json.RawMessage
-	if err := json.Unmarshal(headerBytes, &header); err != nil {
-		return false
-	}
-	var algorithm, keyID string
-	if err := json.Unmarshal(header[algorithmHeader], &algorithm); err != nil || algorithm != es256Algorithm {
-		return false
-	}
-	if err := json.Unmarshal(header[keyIDHeader], &keyID); err != nil || keyID != expectedKeyID {
+	var protected map[string]json.RawMessage
+	if err := json.Unmarshal(headerBytes, &protected); err != nil {
 		return false
 	}
 	for _, attackerSelectable := range []string{"jwk", "x5c", "x5u", "jku", "crit"} {
-		if _, ok := header[attackerSelectable]; ok {
+		if _, ok := protected[attackerSelectable]; ok {
 			return false
 		}
 	}
 	return true
-}
-
-func splitCompactToken(raw string) []string {
-	parts := make([]string, 0, 3)
-	start := 0
-	for i := 0; i < len(raw); i++ {
-		if raw[i] != '.' {
-			continue
-		}
-		parts = append(parts, raw[start:i])
-		start = i + 1
-	}
-	parts = append(parts, raw[start:])
-	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
-		return nil
-	}
-	return parts
-}
-
-func rfc7638Thumbprint(key *ecdsa.PublicKey) string {
-	if key == nil || key.Curve != elliptic.P256() || key.X == nil || key.Y == nil {
-		return ""
-	}
-	coordinateSize := (key.Curve.Params().BitSize + 7) / 8
-	x := key.X.FillBytes(make([]byte, coordinateSize))
-	y := key.Y.FillBytes(make([]byte, coordinateSize))
-	canonical := fmt.Sprintf(`{"crv":"P-256","kty":"EC","x":%q,"y":%q}`,
-		base64.RawURLEncoding.EncodeToString(x), base64.RawURLEncoding.EncodeToString(y))
-	digest := sha256.Sum256([]byte(canonical))
-	return base64.RawURLEncoding.EncodeToString(digest[:])
 }

--- a/internal/registry/auth/token.go
+++ b/internal/registry/auth/token.go
@@ -148,6 +148,15 @@ func decodeClaims(payload []byte) (*Claims, bool) {
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		return nil, false
 	}
+	// jwt.Audience accepts both RFC 7519 forms. Registry tokens are emitted and
+	// accepted with exactly one string audience, so preserve that wire contract.
+	var wire struct {
+		Audience json.RawMessage `json:"aud"`
+	}
+	var audience string
+	if err := json.Unmarshal(payload, &wire); err != nil || json.Unmarshal(wire.Audience, &audience) != nil {
+		return nil, false
+	}
 	return &claims, true
 }
 
@@ -181,17 +190,22 @@ func validAccessActions(item ResourceActions) bool {
 }
 
 func (v *es256Verifier) validClaims(claims *Claims) bool {
-	if !v.validRequiredClaims(claims) {
+	if !v.validRequiredClaims(claims) || claims.ValidateWithLeeway(jwt.Expected{
+		Issuer:      v.issuer,
+		AnyAudience: jwt.Audience{v.audience},
+		Time:        v.now().UTC(),
+	}, v.clockSkew) != nil {
 		return false
 	}
 	return v.validClaimTimes(claims)
 }
 
 func (v *es256Verifier) validRequiredClaims(claims *Claims) bool {
-	if claims.Issuer != v.issuer || claims.Audience != v.audience || claims.Subject == "" || claims.JWTID == "" {
+	if claims.Subject == "" || claims.ID == "" || len(claims.Audience) != 1 {
 		return false
 	}
-	if claims.IssuedAt <= 0 || claims.NotBefore <= 0 || claims.Expiration <= 0 {
+	if claims.IssuedAt == nil || claims.NotBefore == nil || claims.Expiry == nil ||
+		*claims.IssuedAt <= 0 || *claims.NotBefore <= 0 || *claims.Expiry <= 0 {
 		return false
 	}
 	return true
@@ -199,12 +213,9 @@ func (v *es256Verifier) validRequiredClaims(claims *Claims) bool {
 
 func (v *es256Verifier) validClaimTimes(claims *Claims) bool {
 	now := v.now().UTC()
-	issuedAt := time.Unix(claims.IssuedAt, 0)
-	notBefore := time.Unix(claims.NotBefore, 0)
-	expires := time.Unix(claims.Expiration, 0)
-	if issuedAt.After(now.Add(v.clockSkew)) || now.Before(notBefore.Add(-v.clockSkew)) || now.After(expires.Add(v.clockSkew)) {
-		return false
-	}
+	issuedAt := claims.IssuedAt.Time()
+	notBefore := claims.NotBefore.Time()
+	expires := claims.Expiry.Time()
 	if expires.Before(issuedAt) || expires.Equal(issuedAt) || expires.Sub(issuedAt) > v.maxFresh {
 		return false
 	}

--- a/internal/registry/auth/token.go
+++ b/internal/registry/auth/token.go
@@ -17,6 +17,8 @@ import (
 
 const (
 	es256Algorithm       = "ES256"
+	algorithmHeader      = "alg"
+	keyIDHeader          = "kid"
 	maximumClockSkew     = 5 * time.Second
 	minimumTokenLifetime = 60 * time.Second
 )
@@ -91,7 +93,7 @@ func (s *es256Signer) Sign(claims *Claims) (string, error) {
 	if s == nil || s.key == nil || claims == nil {
 		return "", fmt.Errorf("invalid signer or claims")
 	}
-	header, err := json.Marshal(map[string]string{"alg": es256Algorithm, "kid": s.keyID})
+	header, err := json.Marshal(map[string]string{algorithmHeader: es256Algorithm, keyIDHeader: s.keyID})
 	if err != nil {
 		return "", fmt.Errorf("marshal registry token header: %w", err)
 	}
@@ -117,71 +119,100 @@ func (s *es256Signer) Sign(claims *Claims) (string, error) {
 func (v *es256Verifier) KeyID() string { return v.keyID }
 
 func (v *es256Verifier) Verify(raw string) (*Claims, error) {
-	if v == nil || v.key == nil || !validProtectedHeader(raw, v.keyID) {
+	payload, ok := v.verifySignedPayload(raw)
+	if !ok {
 		return nil, ErrInvalidToken
+	}
+	claims, ok := decodeClaims(payload)
+	if !ok || !validAccess(claims.Access) || !v.validClaims(claims) {
+		return nil, ErrInvalidToken
+	}
+	return claims, nil
+}
+
+func (v *es256Verifier) verifySignedPayload(raw string) ([]byte, bool) {
+	if v == nil || v.key == nil || !validProtectedHeader(raw, v.keyID) {
+		return nil, false
 	}
 	parts := splitCompactToken(raw)
 	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
-		return nil, ErrInvalidToken
+		return nil, false
 	}
 	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
 	coordinateSize := (v.key.Curve.Params().BitSize + 7) / 8
 	if err != nil || len(signature) != coordinateSize*2 {
-		return nil, ErrInvalidToken
+		return nil, false
 	}
 	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
 	r := new(big.Int).SetBytes(signature[:coordinateSize])
 	signatureS := new(big.Int).SetBytes(signature[coordinateSize:])
 	if !ecdsa.Verify(v.key, digest[:], r, signatureS) {
-		return nil, ErrInvalidToken
+		return nil, false
 	}
+	return payload, true
+}
 
+func decodeClaims(payload []byte) (*Claims, bool) {
 	var claims Claims
 	decoder := json.NewDecoder(bytes.NewReader(payload))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&claims); err != nil || claims.Access == nil {
-		return nil, ErrInvalidToken
+		return nil, false
 	}
 	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		return nil, ErrInvalidToken
+		return nil, false
 	}
-	for _, item := range claims.Access {
-		if item.Type == "" || item.Name == "" || item.Actions == nil {
-			return nil, ErrInvalidToken
-		}
-		switch item.Type {
-		case repositoryResourceType:
-			if !validRepositoryName(item.Name) {
-				return nil, ErrInvalidToken
-			}
-		case registryResourceType:
-			if !validToken(item.Name) {
-				return nil, ErrInvalidToken
-			}
-		default:
-			return nil, ErrInvalidToken
-		}
-		for _, action := range item.Actions {
-			if !validScopeAction(action) || item.Type == registryResourceType && action != "*" {
-				return nil, ErrInvalidToken
-			}
+	return &claims, true
+}
+
+func validAccess(access []ResourceActions) bool {
+	for _, item := range access {
+		if item.Type == "" || item.Name == "" || item.Actions == nil || !validAccessResource(item) || !validAccessActions(item) {
+			return false
 		}
 	}
-	if !v.validClaims(&claims) {
-		return nil, ErrInvalidToken
+	return true
+}
+
+func validAccessResource(item ResourceActions) bool {
+	switch item.Type {
+	case repositoryResourceType:
+		return validRepositoryName(item.Name)
+	case registryResourceType:
+		return validToken(item.Name)
+	default:
+		return false
 	}
-	return &claims, nil
+}
+
+func validAccessActions(item ResourceActions) bool {
+	for _, action := range item.Actions {
+		if !validScopeAction(action) || item.Type == registryResourceType && action != wildcardAction {
+			return false
+		}
+	}
+	return true
 }
 
 func (v *es256Verifier) validClaims(claims *Claims) bool {
+	if !v.validRequiredClaims(claims) {
+		return false
+	}
+	return v.validClaimTimes(claims)
+}
+
+func (v *es256Verifier) validRequiredClaims(claims *Claims) bool {
 	if claims.Issuer != v.issuer || claims.Audience != v.audience || claims.Subject == "" || claims.JWTID == "" {
 		return false
 	}
 	if claims.IssuedAt <= 0 || claims.NotBefore <= 0 || claims.Expiration <= 0 {
 		return false
 	}
+	return true
+}
 
+func (v *es256Verifier) validClaimTimes(claims *Claims) bool {
 	now := v.now().UTC()
 	issuedAt := time.Unix(claims.IssuedAt, 0)
 	notBefore := time.Unix(claims.NotBefore, 0)
@@ -212,10 +243,10 @@ func validProtectedHeader(raw, expectedKeyID string) bool {
 		return false
 	}
 	var algorithm, keyID string
-	if err := json.Unmarshal(header["alg"], &algorithm); err != nil || algorithm != es256Algorithm {
+	if err := json.Unmarshal(header[algorithmHeader], &algorithm); err != nil || algorithm != es256Algorithm {
 		return false
 	}
-	if err := json.Unmarshal(header["kid"], &keyID); err != nil || keyID != expectedKeyID {
+	if err := json.Unmarshal(header[keyIDHeader], &keyID); err != nil || keyID != expectedKeyID {
 		return false
 	}
 	for _, attackerSelectable := range []string{"jwk", "x5c", "x5u", "jku", "crit"} {
@@ -250,7 +281,7 @@ func rfc7638Thumbprint(key *ecdsa.PublicKey) string {
 	coordinateSize := (key.Curve.Params().BitSize + 7) / 8
 	x := key.X.FillBytes(make([]byte, coordinateSize))
 	y := key.Y.FillBytes(make([]byte, coordinateSize))
-	canonical := fmt.Sprintf(`{"crv":"P-256","kty":"EC","x":"%s","y":"%s"}`,
+	canonical := fmt.Sprintf(`{"crv":"P-256","kty":"EC","x":%q,"y":%q}`,
 		base64.RawURLEncoding.EncodeToString(x), base64.RawURLEncoding.EncodeToString(y))
 	digest := sha256.Sum256([]byte(canonical))
 	return base64.RawURLEncoding.EncodeToString(digest[:])

--- a/internal/registry/auth/token.go
+++ b/internal/registry/auth/token.go
@@ -21,6 +21,7 @@ import (
 const (
 	maximumClockSkew     = 5 * time.Second
 	minimumTokenLifetime = 60 * time.Second
+	jsonWebKeyHeader     = "jwk"
 )
 
 // ErrInvalidToken is returned for every malformed or invalid bearer token.
@@ -123,7 +124,7 @@ func (v *es256Verifier) Verify(raw string) (*Claims, error) {
 		return nil, ErrInvalidToken
 	}
 	token, err := jwt.ParseSigned(raw, []jose.SignatureAlgorithm{jose.ES256})
-	if err != nil || len(token.Headers) != 1 || !validProtectedHeader(raw, token.Headers[0], v.keyID) {
+	if err != nil || len(token.Headers) != 1 || !validProtectedHeader(raw, &token.Headers[0], v.keyID) {
 		return nil, ErrInvalidToken
 	}
 	var payload json.RawMessage
@@ -213,8 +214,8 @@ func (v *es256Verifier) validClaimTimes(claims *Claims) bool {
 	return now.Sub(issuedAt) <= v.maxFresh+v.clockSkew
 }
 
-func validProtectedHeader(raw string, header jose.Header, expectedKeyID string) bool {
-	if header.Algorithm != string(jose.ES256) || header.KeyID != expectedKeyID {
+func validProtectedHeader(raw string, header *jose.Header, expectedKeyID string) bool {
+	if header == nil || header.Algorithm != string(jose.ES256) || header.KeyID != expectedKeyID {
 		return false
 	}
 	// go-jose intentionally hides the raw x5c field after parsing. Inspect the
@@ -231,7 +232,7 @@ func validProtectedHeader(raw string, header jose.Header, expectedKeyID string) 
 	if err := json.Unmarshal(headerBytes, &protected); err != nil {
 		return false
 	}
-	for _, attackerSelectable := range []string{"jwk", "x5c", "x5u", "jku", "crit"} {
+	for _, attackerSelectable := range []string{jsonWebKeyHeader, "x5c", "x5u", "jku", "crit"} {
 		if _, ok := protected[attackerSelectable]; ok {
 			return false
 		}

--- a/internal/registry/auth/token.go
+++ b/internal/registry/auth/token.go
@@ -1,0 +1,257 @@
+package auth
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"time"
+)
+
+const (
+	es256Algorithm       = "ES256"
+	maximumClockSkew     = 5 * time.Second
+	minimumTokenLifetime = 60 * time.Second
+)
+
+// ErrInvalidToken is returned for every malformed or invalid bearer token.
+var ErrInvalidToken = errors.New("invalid registry bearer token")
+
+// ES256Config configures an ephemeral ES256 signer/verifier pair.
+type ES256Config struct {
+	Issuer    string
+	Audience  string
+	MaxFresh  time.Duration
+	ClockSkew time.Duration
+	Now       func() time.Time
+}
+
+type es256Signer struct {
+	key   *ecdsa.PrivateKey
+	keyID string
+}
+
+type es256Verifier struct {
+	key       *ecdsa.PublicKey
+	keyID     string
+	issuer    string
+	audience  string
+	maxFresh  time.Duration
+	clockSkew time.Duration
+	now       func() time.Time
+}
+
+// NewES256Pair generates a process-ephemeral P-256 key and returns a signer
+// that owns the private key and a verifier that retains only the public key.
+func NewES256Pair(cfg ES256Config) (TokenSigner, TokenVerifier, error) {
+	if cfg.Issuer == "" || cfg.Audience == "" {
+		return nil, nil, fmt.Errorf("issuer and audience must not be empty")
+	}
+	if cfg.MaxFresh < minimumTokenLifetime {
+		return nil, nil, fmt.Errorf("maximum token freshness must be at least %s", minimumTokenLifetime)
+	}
+	if cfg.ClockSkew < 0 || cfg.ClockSkew > maximumClockSkew {
+		return nil, nil, fmt.Errorf("clock skew must be between zero and %s", maximumClockSkew)
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate ES256 key: %w", err)
+	}
+	keyID := rfc7638Thumbprint(&privateKey.PublicKey)
+	if keyID == "" {
+		return nil, nil, fmt.Errorf("generate ES256 key ID")
+	}
+	publicKey := privateKey.PublicKey
+
+	return &es256Signer{key: privateKey, keyID: keyID}, &es256Verifier{
+		key:       &publicKey,
+		keyID:     keyID,
+		issuer:    cfg.Issuer,
+		audience:  cfg.Audience,
+		maxFresh:  cfg.MaxFresh,
+		clockSkew: cfg.ClockSkew,
+		now:       cfg.Now,
+	}, nil
+}
+
+func (s *es256Signer) KeyID() string { return s.keyID }
+
+func (s *es256Signer) Sign(claims *Claims) (string, error) {
+	if s == nil || s.key == nil || claims == nil {
+		return "", fmt.Errorf("invalid signer or claims")
+	}
+	header, err := json.Marshal(map[string]string{"alg": es256Algorithm, "kid": s.keyID})
+	if err != nil {
+		return "", fmt.Errorf("marshal registry token header: %w", err)
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal registry claims: %w", err)
+	}
+	encodedHeader := base64.RawURLEncoding.EncodeToString(header)
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	signingInput := encodedHeader + "." + encodedPayload
+	digest := sha256.Sum256([]byte(signingInput))
+	r, signatureS, err := ecdsa.Sign(rand.Reader, s.key, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign registry claims: %w", err)
+	}
+	coordinateSize := (s.key.Curve.Params().BitSize + 7) / 8
+	signature := make([]byte, coordinateSize*2)
+	r.FillBytes(signature[:coordinateSize])
+	signatureS.FillBytes(signature[coordinateSize:])
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func (v *es256Verifier) KeyID() string { return v.keyID }
+
+func (v *es256Verifier) Verify(raw string) (*Claims, error) {
+	if v == nil || v.key == nil || !validProtectedHeader(raw, v.keyID) {
+		return nil, ErrInvalidToken
+	}
+	parts := splitCompactToken(raw)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	coordinateSize := (v.key.Curve.Params().BitSize + 7) / 8
+	if err != nil || len(signature) != coordinateSize*2 {
+		return nil, ErrInvalidToken
+	}
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	r := new(big.Int).SetBytes(signature[:coordinateSize])
+	signatureS := new(big.Int).SetBytes(signature[coordinateSize:])
+	if !ecdsa.Verify(v.key, digest[:], r, signatureS) {
+		return nil, ErrInvalidToken
+	}
+
+	var claims Claims
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&claims); err != nil || claims.Access == nil {
+		return nil, ErrInvalidToken
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, ErrInvalidToken
+	}
+	for _, item := range claims.Access {
+		if item.Type == "" || item.Name == "" || item.Actions == nil {
+			return nil, ErrInvalidToken
+		}
+		switch item.Type {
+		case repositoryResourceType:
+			if !validRepositoryName(item.Name) {
+				return nil, ErrInvalidToken
+			}
+		case registryResourceType:
+			if !validToken(item.Name) {
+				return nil, ErrInvalidToken
+			}
+		default:
+			return nil, ErrInvalidToken
+		}
+		for _, action := range item.Actions {
+			if !validScopeAction(action) || item.Type == registryResourceType && action != "*" {
+				return nil, ErrInvalidToken
+			}
+		}
+	}
+	if !v.validClaims(&claims) {
+		return nil, ErrInvalidToken
+	}
+	return &claims, nil
+}
+
+func (v *es256Verifier) validClaims(claims *Claims) bool {
+	if claims.Issuer != v.issuer || claims.Audience != v.audience || claims.Subject == "" || claims.JWTID == "" {
+		return false
+	}
+	if claims.IssuedAt <= 0 || claims.NotBefore <= 0 || claims.Expiration <= 0 {
+		return false
+	}
+
+	now := v.now().UTC()
+	issuedAt := time.Unix(claims.IssuedAt, 0)
+	notBefore := time.Unix(claims.NotBefore, 0)
+	expires := time.Unix(claims.Expiration, 0)
+	if issuedAt.After(now.Add(v.clockSkew)) || now.Before(notBefore.Add(-v.clockSkew)) || now.After(expires.Add(v.clockSkew)) {
+		return false
+	}
+	if expires.Before(issuedAt) || expires.Equal(issuedAt) || expires.Sub(issuedAt) > v.maxFresh {
+		return false
+	}
+	if notBefore.Before(issuedAt.Add(-v.clockSkew)) || notBefore.After(issuedAt.Add(v.clockSkew)) {
+		return false
+	}
+	return now.Sub(issuedAt) <= v.maxFresh+v.clockSkew
+}
+
+func validProtectedHeader(raw, expectedKeyID string) bool {
+	parts := splitCompactToken(raw)
+	if parts == nil {
+		return false
+	}
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	var header map[string]json.RawMessage
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return false
+	}
+	var algorithm, keyID string
+	if err := json.Unmarshal(header["alg"], &algorithm); err != nil || algorithm != es256Algorithm {
+		return false
+	}
+	if err := json.Unmarshal(header["kid"], &keyID); err != nil || keyID != expectedKeyID {
+		return false
+	}
+	for _, attackerSelectable := range []string{"jwk", "x5c", "x5u", "jku", "crit"} {
+		if _, ok := header[attackerSelectable]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+func splitCompactToken(raw string) []string {
+	parts := make([]string, 0, 3)
+	start := 0
+	for i := 0; i < len(raw); i++ {
+		if raw[i] != '.' {
+			continue
+		}
+		parts = append(parts, raw[start:i])
+		start = i + 1
+	}
+	parts = append(parts, raw[start:])
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return nil
+	}
+	return parts
+}
+
+func rfc7638Thumbprint(key *ecdsa.PublicKey) string {
+	if key == nil || key.Curve != elliptic.P256() || key.X == nil || key.Y == nil {
+		return ""
+	}
+	coordinateSize := (key.Curve.Params().BitSize + 7) / 8
+	x := key.X.FillBytes(make([]byte, coordinateSize))
+	y := key.Y.FillBytes(make([]byte, coordinateSize))
+	canonical := fmt.Sprintf(`{"crv":"P-256","kty":"EC","x":"%s","y":"%s"}`,
+		base64.RawURLEncoding.EncodeToString(x), base64.RawURLEncoding.EncodeToString(y))
+	digest := sha256.Sum256([]byte(canonical))
+	return base64.RawURLEncoding.EncodeToString(digest[:])
+}

--- a/internal/registry/auth/token_test.go
+++ b/internal/registry/auth/token_test.go
@@ -99,7 +99,7 @@ func TestVerifierRejectsWrongKeyAndMalformedAlgorithms(t *testing.T) {
 		compactUnsigned(t, map[string]any{"alg": "RS256", "kid": signer.KeyID()}, validTestClaims()),
 		compactUnsigned(t, map[string]any{"alg": "ES256"}, validTestClaims()),
 		compactUnsigned(t, map[string]any{"alg": "ES256", "kid": "unknown"}, validTestClaims()),
-		compactUnsigned(t, map[string]any{"alg": "ES256", "kid": signer.KeyID(), "jwk": map[string]string{"kty": "EC"}}, validTestClaims()),
+		compactUnsigned(t, map[string]any{"alg": "ES256", "kid": signer.KeyID(), jsonWebKeyHeader: map[string]string{"kty": "EC"}}, validTestClaims()),
 	}
 	for _, token := range malformed {
 		if _, err := verifier.Verify(token); err == nil {
@@ -112,11 +112,11 @@ func TestVerifierRejectsSignedAttackerSelectableHeaders(t *testing.T) {
 	signer, verifier := newTestPair(t)
 	concrete := signer.(*es256Signer)
 	tests := map[string]any{
-		"jwk":  jose.JSONWebKey{Key: &concrete.key.PublicKey},
-		"x5c":  []string{},
-		"x5u":  "https://attacker.example/cert.pem",
-		"jku":  "https://attacker.example/jwks.json",
-		"crit": []string{},
+		jsonWebKeyHeader: jose.JSONWebKey{Key: &concrete.key.PublicKey},
+		"x5c":            []string{},
+		"x5u":            "https://attacker.example/cert.pem",
+		"jku":            "https://attacker.example/jwks.json",
+		"crit":           []string{},
 	}
 	for name, value := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/registry/auth/token_test.go
+++ b/internal/registry/auth/token_test.go
@@ -1,0 +1,160 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+var testNow = time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+
+func newTestPair(t *testing.T) (TokenSigner, TokenVerifier) {
+	t.Helper()
+	signer, verifier, err := NewES256Pair(ES256Config{
+		Issuer: Issuer, Audience: "registry.example.com:8443", MaxFresh: 10 * time.Minute,
+		ClockSkew: 5 * time.Second, Now: func() time.Time { return testNow },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer, verifier
+}
+
+func validTestClaims() *Claims {
+	return &Claims{
+		Issuer: Issuer, Subject: "acme+robot", Audience: "registry.example.com:8443",
+		IssuedAt: testNow.Unix(), NotBefore: testNow.Unix(), Expiration: testNow.Add(5 * time.Minute).Unix(),
+		JWTID: "test-jti", Access: []ResourceActions{{Type: "repository", Name: "acme/image", Actions: []string{"pull"}}},
+	}
+}
+
+func TestES256SignVerifyAndRFC7638KeyID(t *testing.T) {
+	signer, verifier := newTestPair(t)
+	raw, err := signer.Sign(validTestClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+	claims, err := verifier.Verify(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.Subject != "acme+robot" {
+		t.Fatalf("subject = %q", claims.Subject)
+	}
+
+	concrete := signer.(*es256Signer)
+	size := (concrete.key.Curve.Params().BitSize + 7) / 8
+	canonical := fmt.Sprintf(`{"crv":"P-256","kty":"EC","x":"%s","y":"%s"}`,
+		base64.RawURLEncoding.EncodeToString(concrete.key.X.FillBytes(make([]byte, size))),
+		base64.RawURLEncoding.EncodeToString(concrete.key.Y.FillBytes(make([]byte, size))))
+	digest := sha256.Sum256([]byte(canonical))
+	wantKeyID := base64.RawURLEncoding.EncodeToString(digest[:])
+	if signer.KeyID() != wantKeyID || verifier.KeyID() != wantKeyID {
+		t.Fatalf("kid = %q, want RFC 7638 thumbprint %q", signer.KeyID(), wantKeyID)
+	}
+
+	parts := strings.Split(raw, ".")
+	headerJSON, _ := base64.RawURLEncoding.DecodeString(parts[0])
+	var header map[string]any
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		t.Fatal(err)
+	}
+	if header["alg"] != "ES256" || header["kid"] != wantKeyID {
+		t.Fatalf("header = %#v", header)
+	}
+	if len(header) != 2 {
+		t.Fatalf("unexpected protected headers: %#v", header)
+	}
+}
+
+func TestES256KeyIDsDifferAcrossProcessKeys(t *testing.T) {
+	first, _ := newTestPair(t)
+	second, _ := newTestPair(t)
+	if first.KeyID() == second.KeyID() {
+		t.Fatal("independent process keys must have distinct thumbprints")
+	}
+}
+
+func TestVerifierRejectsWrongKeyAndMalformedAlgorithms(t *testing.T) {
+	signer, _ := newTestPair(t)
+	_, otherVerifier := newTestPair(t)
+	raw, err := signer.Sign(validTestClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := otherVerifier.Verify(raw); err == nil {
+		t.Fatal("expected token signed by old process key to fail")
+	}
+
+	malformed := []string{
+		"not-a-token",
+		compactUnsigned(t, map[string]any{"alg": "none", "kid": signer.KeyID()}, validTestClaims()),
+		compactUnsigned(t, map[string]any{"alg": "RS256", "kid": signer.KeyID()}, validTestClaims()),
+		compactUnsigned(t, map[string]any{"alg": "ES256"}, validTestClaims()),
+		compactUnsigned(t, map[string]any{"alg": "ES256", "kid": "unknown"}, validTestClaims()),
+		compactUnsigned(t, map[string]any{"alg": "ES256", "kid": signer.KeyID(), "jwk": map[string]string{"kty": "EC"}}, validTestClaims()),
+	}
+	_, verifier := newTestPair(t)
+	for _, token := range malformed {
+		if _, err := verifier.Verify(token); err == nil {
+			t.Fatalf("expected malformed token %q to fail", token)
+		}
+	}
+}
+
+func TestVerifierRejectsInvalidClaims(t *testing.T) {
+	tests := map[string]func(*Claims){
+		"issuer":        func(c *Claims) { c.Issuer = "other" },
+		"audience":      func(c *Claims) { c.Audience = "other" },
+		"subject":       func(c *Claims) { c.Subject = "" },
+		"jti":           func(c *Claims) { c.JWTID = "" },
+		"issued at":     func(c *Claims) { c.IssuedAt = 0 },
+		"not before":    func(c *Claims) { c.NotBefore = 0 },
+		"expiration":    func(c *Claims) { c.Expiration = 0 },
+		"expired":       func(c *Claims) { c.Expiration = testNow.Add(-6 * time.Second).Unix() },
+		"future issued": func(c *Claims) { c.IssuedAt = testNow.Add(6 * time.Second).Unix(); c.NotBefore = c.IssuedAt },
+		"not yet valid": func(c *Claims) { c.NotBefore = testNow.Add(6 * time.Second).Unix() },
+		"overlong":      func(c *Claims) { c.Expiration = testNow.Add(11 * time.Minute).Unix() },
+		"stale": func(c *Claims) {
+			c.IssuedAt = testNow.Add(-11 * time.Minute).Unix()
+			c.NotBefore = c.IssuedAt
+			c.Expiration = testNow.Add(time.Minute).Unix()
+		},
+		"missing access":  func(c *Claims) { c.Access = nil },
+		"bad access type": func(c *Claims) { c.Access[0].Type = "" },
+		"bad access name": func(c *Claims) { c.Access[0].Name = "" },
+		"missing actions": func(c *Claims) { c.Access[0].Actions = nil },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			signer, verifier := newTestPair(t)
+			claims := validTestClaims()
+			mutate(claims)
+			raw, err := signer.Sign(claims)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := verifier.Verify(raw); err == nil {
+				t.Fatal("expected invalid claims to fail")
+			}
+		})
+	}
+}
+
+func compactUnsigned(t *testing.T, header any, claims any) string {
+	t.Helper()
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(claimsJSON) + "." + base64.RawURLEncoding.EncodeToString(make([]byte, 64))
+}

--- a/internal/registry/auth/token_test.go
+++ b/internal/registry/auth/token_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 var testNow = time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
@@ -80,7 +83,7 @@ func TestES256KeyIDsDifferAcrossProcessKeys(t *testing.T) {
 }
 
 func TestVerifierRejectsWrongKeyAndMalformedAlgorithms(t *testing.T) {
-	signer, _ := newTestPair(t)
+	signer, verifier := newTestPair(t)
 	_, otherVerifier := newTestPair(t)
 	raw, err := signer.Sign(validTestClaims())
 	if err != nil {
@@ -98,11 +101,44 @@ func TestVerifierRejectsWrongKeyAndMalformedAlgorithms(t *testing.T) {
 		compactUnsigned(t, map[string]any{"alg": "ES256", "kid": "unknown"}, validTestClaims()),
 		compactUnsigned(t, map[string]any{"alg": "ES256", "kid": signer.KeyID(), "jwk": map[string]string{"kty": "EC"}}, validTestClaims()),
 	}
-	_, verifier := newTestPair(t)
 	for _, token := range malformed {
 		if _, err := verifier.Verify(token); err == nil {
 			t.Fatalf("expected malformed token %q to fail", token)
 		}
+	}
+}
+
+func TestVerifierRejectsSignedAttackerSelectableHeaders(t *testing.T) {
+	signer, verifier := newTestPair(t)
+	concrete := signer.(*es256Signer)
+	tests := map[string]any{
+		"jwk":  jose.JSONWebKey{Key: &concrete.key.PublicKey},
+		"x5c":  []string{},
+		"x5u":  "https://attacker.example/cert.pem",
+		"jku":  "https://attacker.example/jwks.json",
+		"crit": []string{},
+	}
+	for name, value := range tests {
+		t.Run(name, func(t *testing.T) {
+			raw := signTestClaims(t, concrete, validTestClaims(), map[jose.HeaderKey]any{
+				jose.HeaderKey(name): value,
+			})
+			if _, err := verifier.Verify(raw); err == nil {
+				t.Fatal("expected attacker-selectable header to fail")
+			}
+		})
+	}
+}
+
+func TestVerifierRejectsUnknownClaims(t *testing.T) {
+	signer, verifier := newTestPair(t)
+	claims := struct {
+		*Claims
+		Unexpected bool `json:"unexpected"`
+	}{Claims: validTestClaims(), Unexpected: true}
+	raw := signTestClaims(t, signer.(*es256Signer), claims, nil)
+	if _, err := verifier.Verify(raw); err == nil {
+		t.Fatal("expected unknown claim to fail")
 	}
 }
 
@@ -157,4 +193,22 @@ func compactUnsigned(t *testing.T, header, claims any) string {
 	}
 	return base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
 		base64.RawURLEncoding.EncodeToString(claimsJSON) + "." + base64.RawURLEncoding.EncodeToString(make([]byte, 64))
+}
+
+func signTestClaims(t *testing.T, signer *es256Signer, claims any, headers map[jose.HeaderKey]any) string {
+	t.Helper()
+	options := &jose.SignerOptions{}
+	options.WithHeader(jose.HeaderKey("kid"), signer.keyID)
+	for name, value := range headers {
+		options.WithHeader(name, value)
+	}
+	joseSigner, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES256, Key: signer.key}, options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := jwt.Signed(joseSigner).Claims(claims).Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
 }

--- a/internal/registry/auth/token_test.go
+++ b/internal/registry/auth/token_test.go
@@ -29,9 +29,12 @@ func newTestPair(t *testing.T) (TokenSigner, TokenVerifier) {
 
 func validTestClaims() *Claims {
 	return &Claims{
-		Issuer: Issuer, Subject: "acme+robot", Audience: "registry.example.com:8443",
-		IssuedAt: testNow.Unix(), NotBefore: testNow.Unix(), Expiration: testNow.Add(5 * time.Minute).Unix(),
-		JWTID: "test-jti", Access: []ResourceActions{{Type: "repository", Name: "acme/image", Actions: []string{"pull"}}},
+		Claims: jwt.Claims{
+			Issuer: Issuer, Subject: "acme+robot", Audience: jwt.Audience{"registry.example.com:8443"},
+			IssuedAt: jwt.NewNumericDate(testNow), NotBefore: jwt.NewNumericDate(testNow),
+			Expiry: jwt.NewNumericDate(testNow.Add(5 * time.Minute)), ID: "test-jti",
+		},
+		Access: []ResourceActions{{Type: "repository", Name: "acme/image", Actions: []string{"pull"}}},
 	}
 }
 
@@ -71,6 +74,14 @@ func TestES256SignVerifyAndRFC7638KeyID(t *testing.T) {
 	}
 	if len(header) != 2 {
 		t.Fatalf("unexpected protected headers: %#v", header)
+	}
+	payloadJSON, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var payload map[string]any
+	if err := json.Unmarshal(payloadJSON, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if audience, ok := payload["aud"].(string); !ok || audience != "registry.example.com:8443" {
+		t.Fatalf("audience = %#v, want a single JSON string", payload["aud"])
 	}
 }
 
@@ -142,23 +153,55 @@ func TestVerifierRejectsUnknownClaims(t *testing.T) {
 	}
 }
 
+func TestVerifierRejectsAudienceArray(t *testing.T) {
+	signer, verifier := newTestPair(t)
+	payload, err := json.Marshal(validTestClaims())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatal(err)
+	}
+	claims["aud"] = []string{"registry.example.com:8443"}
+	raw := signTestClaims(t, signer.(*es256Signer), claims, nil)
+	if _, err := verifier.Verify(raw); err == nil {
+		t.Fatal("expected array audience to fail")
+	}
+}
+
 func TestVerifierRejectsInvalidClaims(t *testing.T) {
 	tests := map[string]func(*Claims){
-		"issuer":        func(c *Claims) { c.Issuer = "other" },
-		"audience":      func(c *Claims) { c.Audience = "other" },
-		"subject":       func(c *Claims) { c.Subject = "" },
-		"jti":           func(c *Claims) { c.JWTID = "" },
-		"issued at":     func(c *Claims) { c.IssuedAt = 0 },
-		"not before":    func(c *Claims) { c.NotBefore = 0 },
-		"expiration":    func(c *Claims) { c.Expiration = 0 },
-		"expired":       func(c *Claims) { c.Expiration = testNow.Add(-6 * time.Second).Unix() },
-		"future issued": func(c *Claims) { c.IssuedAt = testNow.Add(6 * time.Second).Unix(); c.NotBefore = c.IssuedAt },
-		"not yet valid": func(c *Claims) { c.NotBefore = testNow.Add(6 * time.Second).Unix() },
-		"overlong":      func(c *Claims) { c.Expiration = testNow.Add(11 * time.Minute).Unix() },
-		"stale": func(c *Claims) {
-			c.IssuedAt = testNow.Add(-11 * time.Minute).Unix()
+		"issuer":   func(c *Claims) { c.Issuer = "other" },
+		"audience": func(c *Claims) { c.Audience = jwt.Audience{"other"} },
+		"extra audience": func(c *Claims) {
+			c.Audience = jwt.Audience{"registry.example.com:8443", "other"}
+		},
+		"subject": func(c *Claims) { c.Subject = "" },
+		"jti":     func(c *Claims) { c.ID = "" },
+		"missing issued at": func(c *Claims) {
+			c.IssuedAt = nil
+		},
+		"missing not before": func(c *Claims) {
+			c.NotBefore = nil
+		},
+		"missing expiration": func(c *Claims) {
+			c.Expiry = nil
+		},
+		"issued at":  func(c *Claims) { c.IssuedAt = numericDate(0) },
+		"not before": func(c *Claims) { c.NotBefore = numericDate(0) },
+		"expiration": func(c *Claims) { c.Expiry = numericDate(0) },
+		"expired":    func(c *Claims) { c.Expiry = jwt.NewNumericDate(testNow.Add(-6 * time.Second)) },
+		"future issued": func(c *Claims) {
+			c.IssuedAt = jwt.NewNumericDate(testNow.Add(6 * time.Second))
 			c.NotBefore = c.IssuedAt
-			c.Expiration = testNow.Add(time.Minute).Unix()
+		},
+		"not yet valid": func(c *Claims) { c.NotBefore = jwt.NewNumericDate(testNow.Add(6 * time.Second)) },
+		"overlong":      func(c *Claims) { c.Expiry = jwt.NewNumericDate(testNow.Add(11 * time.Minute)) },
+		"stale": func(c *Claims) {
+			c.IssuedAt = jwt.NewNumericDate(testNow.Add(-11 * time.Minute))
+			c.NotBefore = c.IssuedAt
+			c.Expiry = jwt.NewNumericDate(testNow.Add(time.Minute))
 		},
 		"missing access":  func(c *Claims) { c.Access = nil },
 		"bad access type": func(c *Claims) { c.Access[0].Type = "" },
@@ -179,6 +222,43 @@ func TestVerifierRejectsInvalidClaims(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVerifierAcceptsConfiguredClockSkew(t *testing.T) {
+	tests := map[string]func(*Claims){
+		"recently expired": func(c *Claims) {
+			c.IssuedAt = jwt.NewNumericDate(testNow.Add(-5 * time.Minute))
+			c.NotBefore = c.IssuedAt
+			c.Expiry = jwt.NewNumericDate(testNow.Add(-5 * time.Second))
+		},
+		"future issued": func(c *Claims) {
+			c.IssuedAt = jwt.NewNumericDate(testNow.Add(5 * time.Second))
+			c.NotBefore = c.IssuedAt
+			c.Expiry = jwt.NewNumericDate(testNow.Add(5 * time.Minute))
+		},
+		"not yet valid": func(c *Claims) {
+			c.NotBefore = jwt.NewNumericDate(testNow.Add(5 * time.Second))
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			signer, verifier := newTestPair(t)
+			claims := validTestClaims()
+			mutate(claims)
+			raw, err := signer.Sign(claims)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := verifier.Verify(raw); err != nil {
+				t.Fatalf("expected token within configured skew to pass: %v", err)
+			}
+		})
+	}
+}
+
+func numericDate(seconds int64) *jwt.NumericDate {
+	value := jwt.NumericDate(seconds)
+	return &value
 }
 
 func compactUnsigned(t *testing.T, header, claims any) string {

--- a/internal/registry/auth/token_test.go
+++ b/internal/registry/auth/token_test.go
@@ -48,7 +48,7 @@ func TestES256SignVerifyAndRFC7638KeyID(t *testing.T) {
 
 	concrete := signer.(*es256Signer)
 	size := (concrete.key.Curve.Params().BitSize + 7) / 8
-	canonical := fmt.Sprintf(`{"crv":"P-256","kty":"EC","x":"%s","y":"%s"}`,
+	canonical := fmt.Sprintf(`{"crv":"P-256","kty":"EC","x":%q,"y":%q}`,
 		base64.RawURLEncoding.EncodeToString(concrete.key.X.FillBytes(make([]byte, size))),
 		base64.RawURLEncoding.EncodeToString(concrete.key.Y.FillBytes(make([]byte, size))))
 	digest := sha256.Sum256([]byte(canonical))
@@ -145,7 +145,7 @@ func TestVerifierRejectsInvalidClaims(t *testing.T) {
 	}
 }
 
-func compactUnsigned(t *testing.T, header any, claims any) string {
+func compactUnsigned(t *testing.T, header, claims any) string {
 	t.Helper()
 	headerJSON, err := json.Marshal(header)
 	if err != nil {

--- a/internal/registry/auth/types.go
+++ b/internal/registry/auth/types.go
@@ -4,7 +4,11 @@
 // and repository authorization through the function types defined here.
 package auth
 
-import "context"
+import (
+	"context"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+)
 
 const (
 	// AnonymousSubject matches the subject used by Python Quay registry tokens.
@@ -47,16 +51,11 @@ type ResourceActions struct {
 	Actions []string `json:"actions"`
 }
 
-// Claims is the complete JWT claim set issued by Go OMR.
+// Claims is the complete JWT claim set issued by Go OMR. Standard claims use
+// go-jose's types and validation; Access is the Docker Distribution extension.
 type Claims struct {
-	Issuer     string            `json:"iss"`
-	Subject    string            `json:"sub"`
-	Audience   string            `json:"aud"`
-	Expiration int64             `json:"exp"`
-	NotBefore  int64             `json:"nbf"`
-	IssuedAt   int64             `json:"iat"`
-	JWTID      string            `json:"jti"`
-	Access     []ResourceActions `json:"access"`
+	jwt.Claims
+	Access []ResourceActions `json:"access"`
 }
 
 // TokenSigner signs algorithm-neutral registry claims.

--- a/internal/registry/auth/types.go
+++ b/internal/registry/auth/types.go
@@ -1,0 +1,72 @@
+// Package auth implements the Docker Registry v2 bearer-token flow.
+//
+// It is intentionally a leaf package: callers adapt credential verification
+// and repository authorization through the function types defined here.
+package auth
+
+import "context"
+
+const (
+	// AnonymousSubject matches the subject used by Python Quay registry tokens.
+	AnonymousSubject = "(anonymous)"
+	// Issuer is the issuer used for Go OMR registry tokens.
+	Issuer = "quay"
+)
+
+// Identity is the authenticated identity presented to a GrantResolver.
+// Principal is opaque to this leaf package and lets the composition root carry
+// its authorization-domain identity without coupling packages.
+type Identity struct {
+	Subject   string
+	Principal any
+	Anonymous bool
+}
+
+// AuthenticateFunc validates a username and secret.
+// Invalid credentials return ok=false; transport and authorization remain
+// separate from credential validation.
+type AuthenticateFunc func(ctx context.Context, username, secret string) (identity Identity, ok bool)
+
+// GrantResolver downscopes requested scopes to the actions the identity may
+// perform. Permission denial is represented by omitted actions, not an error.
+type GrantResolver func(ctx context.Context, identity Identity, requested []Scope) ([]ResourceActions, error)
+
+// Scope is a parsed registry token scope.
+type Scope struct {
+	Type    string
+	Name    string
+	Actions []string
+}
+
+// ResourceActions is the access claim shape defined by the Distribution token
+// specification.
+type ResourceActions struct {
+	Type    string   `json:"type"`
+	Class   string   `json:"class,omitempty"`
+	Name    string   `json:"name"`
+	Actions []string `json:"actions"`
+}
+
+// Claims is the complete JWT claim set issued by Go OMR.
+type Claims struct {
+	Issuer     string            `json:"iss"`
+	Subject    string            `json:"sub"`
+	Audience   string            `json:"aud"`
+	Expiration int64             `json:"exp"`
+	NotBefore  int64             `json:"nbf"`
+	IssuedAt   int64             `json:"iat"`
+	JWTID      string            `json:"jti"`
+	Access     []ResourceActions `json:"access"`
+}
+
+// TokenSigner signs algorithm-neutral registry claims.
+type TokenSigner interface {
+	Sign(*Claims) (string, error)
+	KeyID() string
+}
+
+// TokenVerifier verifies a compact JWT and returns validated claims.
+type TokenVerifier interface {
+	Verify(string) (*Claims, error)
+	KeyID() string
+}

--- a/internal/registry/distribution/app.go
+++ b/internal/registry/distribution/app.go
@@ -65,7 +65,7 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 			"quay": configuration.Parameters{
 				"rootdirectory": cfg.StoragePath,
 			},
-			"delete": configuration.Parameters{
+			repositoryDeleteAction: configuration.Parameters{
 				"enabled": true,
 			},
 		},

--- a/internal/registry/distribution/app.go
+++ b/internal/registry/distribution/app.go
@@ -3,7 +3,6 @@ package distribution
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"net/http"
 
@@ -12,32 +11,23 @@ import (
 
 	"github.com/quay/quay/internal/oci"
 	"github.com/quay/quay/internal/oci/storage/local"
+	registryauth "github.com/quay/quay/internal/registry/auth"
 	registrymw "github.com/quay/quay/internal/registry/distribution/middleware"
 )
 
 // Config holds the parameters needed to construct the distribution registry.
 type Config struct {
-	StoragePath                        string
-	Hostname                           string
-	ListenAddr                         string
-	DB                                 *sql.DB
-	Store                              oci.MetadataStore
-	BlobLocker                         oci.BlobLocker
-	LibraryNamespace                   string
-	AnonymousAccess                    *bool
-	DatabaseSecretKey                  string
-	RobotsDisallow                     bool
-	RobotsWhitelist                    []string
-	FeatureUserLastAccessed            bool
-	LastAccessedUpdateThresholdSeconds int
-	SuperUsers                         []string
-	SuperUsersFullAccess               bool
+	StoragePath      string
+	ListenAddr       string
+	Store            oci.MetadataStore
+	BlobLocker       oci.BlobLocker
+	LibraryNamespace string
+	AccessController *registryauth.Controller
 }
 
 // Registry wraps the distribution registry handler.
 type Registry struct {
 	handler http.Handler
-	db      *sql.DB
 }
 
 // NewRegistry creates the distribution registry with metadata middleware.
@@ -51,8 +41,8 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 	if cfg.Store == nil {
 		return nil, fmt.Errorf("nil metastore store")
 	}
-	if cfg.DB == nil {
-		return nil, fmt.Errorf("nil database")
+	if cfg.AccessController == nil {
+		return nil, fmt.Errorf("nil access controller")
 	}
 
 	libraryNamespace := cfg.LibraryNamespace
@@ -64,6 +54,9 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 
 	if err := registrymw.Register(cfg.Store, cfg.BlobLocker, libraryNamespace); err != nil {
 		return nil, fmt.Errorf("register middleware: %w", err)
+	}
+	if err := registryauth.RegisterDistributionAdapter(); err != nil {
+		return nil, fmt.Errorf("register token access controller: %w", err)
 	}
 
 	distCfg := &configuration.Configuration{
@@ -77,18 +70,8 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 			},
 		},
 		Auth: configuration.Auth{
-			"quaydb": configuration.Parameters{
-				authOptionRealm:                      cfg.Hostname,
-				"db":                                 cfg.DB,
-				"libraryNamespace":                   libraryNamespace,
-				authOptionAnonAccess:                 anonymousAccessEnabled(cfg.AnonymousAccess),
-				"databaseSecretKey":                  cfg.DatabaseSecretKey,
-				"robotsDisallow":                     cfg.RobotsDisallow,
-				"robotsWhitelist":                    cfg.RobotsWhitelist,
-				"featureUserLastAccessed":            cfg.FeatureUserLastAccessed,
-				"lastAccessedUpdateThresholdSeconds": cfg.LastAccessedUpdateThresholdSeconds,
-				"superUsers":                         cfg.SuperUsers,
-				"superUsersFullAccess":               cfg.SuperUsersFullAccess,
+			registryauth.DistributionBackendName: configuration.Parameters{
+				registryauth.DistributionControllerOption: cfg.AccessController,
 			},
 		},
 	}
@@ -97,10 +80,7 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 	}
 
 	distCfg.HTTP.Addr = cfg.ListenAddr
-	return &Registry{
-		handler: handlers.NewApp(ctx, distCfg),
-		db:      cfg.DB,
-	}, nil
+	return &Registry{handler: handlers.NewApp(ctx, distCfg)}, nil
 }
 
 // Handler returns the HTTP handler for the registry.
@@ -111,11 +91,4 @@ func (a *Registry) Handler() http.Handler {
 // Close releases resources held by the registry.
 func (a *Registry) Close() error {
 	return nil
-}
-
-func anonymousAccessEnabled(configured *bool) bool {
-	if configured == nil {
-		return true
-	}
-	return *configured
 }

--- a/internal/registry/distribution/app_test.go
+++ b/internal/registry/distribution/app_test.go
@@ -54,7 +54,7 @@ func TestRegistryBearerChallengeExchangeAndRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tokenHandler, err := registryauth.NewHandler(registryauth.HandlerConfig{
+	tokenHandler, err := registryauth.NewHandler(&registryauth.HandlerConfig{
 		Service: "registry.example.com:8443", LibraryNamespace: "library", AnonymousAccess: true,
 		Lifetime: 5 * time.Minute, Signer: signer,
 		ResolveGrants: func(_ context.Context, _ registryauth.Identity, scopes []registryauth.Scope) ([]registryauth.ResourceActions, error) {
@@ -80,7 +80,7 @@ func TestRegistryBearerChallengeExchangeAndRetry(t *testing.T) {
 	mux.Handle("/v2/auth", tokenHandler)
 	mux.Handle("/", registry.Handler())
 
-	challengeRequest := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+	challengeRequest := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/", http.NoBody)
 	challengeResponse := httptest.NewRecorder()
 	mux.ServeHTTP(challengeResponse, challengeRequest)
 	if challengeResponse.Code != http.StatusUnauthorized {
@@ -91,7 +91,7 @@ func TestRegistryBearerChallengeExchangeAndRetry(t *testing.T) {
 		t.Fatalf("challenge = %q", challenge)
 	}
 
-	directBasic := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+	directBasic := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/", http.NoBody)
 	directBasic.SetBasicAuth("user", "password")
 	directBasicResponse := httptest.NewRecorder()
 	mux.ServeHTTP(directBasicResponse, directBasic)
@@ -101,7 +101,7 @@ func TestRegistryBearerChallengeExchangeAndRetry(t *testing.T) {
 
 	exchangeURL := "/v2/auth?service=" + url.QueryEscape("registry.example.com:8443") +
 		"&scope=" + url.QueryEscape("repository:public/repo:pull")
-	exchangeRequest := httptest.NewRequest(http.MethodGet, exchangeURL, http.NoBody)
+	exchangeRequest := httptest.NewRequestWithContext(t.Context(), http.MethodGet, exchangeURL, http.NoBody)
 	exchangeResponse := httptest.NewRecorder()
 	mux.ServeHTTP(exchangeResponse, exchangeRequest)
 	if exchangeResponse.Code != http.StatusOK {
@@ -114,7 +114,7 @@ func TestRegistryBearerChallengeExchangeAndRetry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	retryRequest := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+	retryRequest := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/", http.NoBody)
 	retryRequest.Header.Set("Authorization", "Bearer "+tokenBody.Token)
 	retryResponse := httptest.NewRecorder()
 	mux.ServeHTTP(retryResponse, retryRequest)
@@ -128,7 +128,7 @@ func TestRegistryBearerChallengeExchangeAndRetry(t *testing.T) {
 	referrers := registryhandler.NewReferrersHandler(store, controller, &registryhandler.ReferrersConfig{
 		LibraryNamespace: "library", LibrarySupport: true,
 	})
-	referrersRequest := httptest.NewRequest(http.MethodGet,
+	referrersRequest := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
 		"/v2/public/repo/referrers/"+digest.FromString("subject").String(), http.NoBody)
 	referrersRequest.Header.Set("Authorization", "Bearer "+tokenBody.Token)
 	referrersResponse := httptest.NewRecorder()

--- a/internal/registry/distribution/app_test.go
+++ b/internal/registry/distribution/app_test.go
@@ -1,8 +1,23 @@
 package distribution
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+
+	"github.com/quay/quay/internal/dal/dbcore"
+	"github.com/quay/quay/internal/dal/metastore"
+	"github.com/quay/quay/internal/oci"
+	registryhandler "github.com/quay/quay/internal/registry"
+	registryauth "github.com/quay/quay/internal/registry/auth"
 )
 
 func TestNewRegistryRejectsNilBlobLocker(t *testing.T) {
@@ -12,5 +27,113 @@ func TestNewRegistryRejectsNilBlobLocker(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "nil blob locker") {
 		t.Fatalf("expected nil blob locker error, got %v", err)
+	}
+}
+
+func TestRegistryBearerChallengeExchangeAndRetry(t *testing.T) {
+	db, err := dbcore.Setup(t.Context(), filepath.Join(t.TempDir(), "quay.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	store, err := metastore.NewSQLiteStore(t.Context(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, verifier, err := registryauth.NewES256Pair(registryauth.ES256Config{
+		Issuer: registryauth.Issuer, Audience: "registry.example.com:8443",
+		MaxFresh: 10 * time.Minute, ClockSkew: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller, err := registryauth.NewController(registryauth.ControllerConfig{
+		Realm: "https://registry.example.com:8443/v2/auth", Service: "registry.example.com:8443",
+		LibraryNamespace: "library", Verifier: verifier,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenHandler, err := registryauth.NewHandler(registryauth.HandlerConfig{
+		Service: "registry.example.com:8443", LibraryNamespace: "library", AnonymousAccess: true,
+		Lifetime: 5 * time.Minute, Signer: signer,
+		ResolveGrants: func(_ context.Context, _ registryauth.Identity, scopes []registryauth.Scope) ([]registryauth.ResourceActions, error) {
+			grants := make([]registryauth.ResourceActions, 0, len(scopes))
+			for _, scope := range scopes {
+				grants = append(grants, registryauth.ResourceActions{Type: scope.Type, Name: scope.Name, Actions: scope.Actions})
+			}
+			return grants, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry, err := NewRegistry(t.Context(), &Config{
+		StoragePath: filepath.Join(t.TempDir(), "storage"), ListenAddr: ":0", Store: store,
+		BlobLocker: oci.NewBlobLockSet(), LibraryNamespace: "library", AccessController: controller,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer registry.Close()
+	mux := http.NewServeMux()
+	mux.Handle("/v2/auth", tokenHandler)
+	mux.Handle("/", registry.Handler())
+
+	challengeRequest := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+	challengeResponse := httptest.NewRecorder()
+	mux.ServeHTTP(challengeResponse, challengeRequest)
+	if challengeResponse.Code != http.StatusUnauthorized {
+		t.Fatalf("challenge status = %d, body = %s", challengeResponse.Code, challengeResponse.Body.String())
+	}
+	challenge := challengeResponse.Header().Get("WWW-Authenticate")
+	if !strings.Contains(challenge, `Bearer realm="https://registry.example.com:8443/v2/auth",service="registry.example.com:8443"`) {
+		t.Fatalf("challenge = %q", challenge)
+	}
+
+	directBasic := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+	directBasic.SetBasicAuth("user", "password")
+	directBasicResponse := httptest.NewRecorder()
+	mux.ServeHTTP(directBasicResponse, directBasic)
+	if directBasicResponse.Code != http.StatusUnauthorized || strings.HasPrefix(directBasicResponse.Header().Get("WWW-Authenticate"), "Basic") {
+		t.Fatalf("direct Basic response = %d, challenge = %q", directBasicResponse.Code, directBasicResponse.Header().Get("WWW-Authenticate"))
+	}
+
+	exchangeURL := "/v2/auth?service=" + url.QueryEscape("registry.example.com:8443") +
+		"&scope=" + url.QueryEscape("repository:public/repo:pull")
+	exchangeRequest := httptest.NewRequest(http.MethodGet, exchangeURL, http.NoBody)
+	exchangeResponse := httptest.NewRecorder()
+	mux.ServeHTTP(exchangeResponse, exchangeRequest)
+	if exchangeResponse.Code != http.StatusOK {
+		t.Fatalf("exchange status = %d, body = %s", exchangeResponse.Code, exchangeResponse.Body.String())
+	}
+	var tokenBody struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(exchangeResponse.Body).Decode(&tokenBody); err != nil {
+		t.Fatal(err)
+	}
+
+	retryRequest := httptest.NewRequest(http.MethodGet, "/v2/", http.NoBody)
+	retryRequest.Header.Set("Authorization", "Bearer "+tokenBody.Token)
+	retryResponse := httptest.NewRecorder()
+	mux.ServeHTTP(retryResponse, retryRequest)
+	if retryResponse.Code != http.StatusOK {
+		t.Fatalf("retry status = %d, body = %s", retryResponse.Code, retryResponse.Body.String())
+	}
+
+	if _, err := store.EnsureRepository(t.Context(), oci.RepositoryName{Namespace: "public", Name: "repo"}); err != nil {
+		t.Fatal(err)
+	}
+	referrers := registryhandler.NewReferrersHandler(store, controller, &registryhandler.ReferrersConfig{
+		LibraryNamespace: "library", LibrarySupport: true,
+	})
+	referrersRequest := httptest.NewRequest(http.MethodGet,
+		"/v2/public/repo/referrers/"+digest.FromString("subject").String(), http.NoBody)
+	referrersRequest.Header.Set("Authorization", "Bearer "+tokenBody.Token)
+	referrersResponse := httptest.NewRecorder()
+	referrers.ServeHTTP(referrersResponse, referrersRequest)
+	if referrersResponse.Code != http.StatusOK {
+		t.Fatalf("referrers status = %d, body = %s", referrersResponse.Code, referrersResponse.Body.String())
 	}
 }

--- a/internal/registry/distribution/auth.go
+++ b/internal/registry/distribution/auth.go
@@ -1,340 +1,193 @@
 package distribution
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
-	"log/slog"
-	"net/http"
+	"slices"
+	"sort"
 	"strings"
 
-	distauth "github.com/distribution/distribution/v3/registry/auth"
-	"github.com/quay/quay/internal/auth"
+	quayauth "github.com/quay/quay/internal/auth"
 	"github.com/quay/quay/internal/dal/daldb"
-	"github.com/quay/quay/internal/oci"
+	registryauth "github.com/quay/quay/internal/registry/auth"
 	repo "github.com/quay/quay/internal/repository"
 	repositorydal "github.com/quay/quay/internal/repository/dal"
-)
-
-func init() {
-	if err := distauth.Register("quaydb", distauth.InitFunc(newAccessController)); err != nil {
-		slog.Error("failed to register quaydb auth", "err", err)
-	}
-}
-
-type accessController struct {
-	authenticator    *auth.BasicAuthenticator
-	authorizer       *repositorydal.Authorizer
-	queries          *daldb.Queries
-	realm            string
-	libraryNamespace string
-	anonymousAccess  bool
-}
-
-var (
-	_ distauth.AccessController = &accessController{}
-	_ oci.Authenticator         = &accessController{}
 )
 
 const (
 	repositoryPushAction   = "push"
 	repositoryDeleteAction = "delete"
-	registryResourceType   = "registry"
-	registryCatalogName    = "catalog"
-	registryCatalogAction  = "*"
-	authOptionRealm        = "realm"
-	authOptionAnonAccess   = "anonymousAccess"
+	repositoryAdminAction  = "*"
 )
 
-func newAccessController(options map[string]interface{}) (distauth.AccessController, error) {
-	realm, ok := options[authOptionRealm].(string)
-	if !ok || realm == "" {
-		return nil, fmt.Errorf("%q must be set for quaydb access controller", authOptionRealm)
-	}
+// GrantResolverConfig configures Quay repository authorization for registry
+// token issuance.
+type GrantResolverConfig struct {
+	LibraryNamespace     string
+	SuperUsers           []string
+	SuperUsersFullAccess bool
+}
 
-	db, ok := options["db"].(*sql.DB)
-	if !ok || db == nil {
-		return nil, fmt.Errorf(`"db" must be set to *sql.DB for quaydb access controller`)
-	}
+// GrantResolver maps Quay repository RBAC to downscoped registry token grants.
+// It performs no credential or JWT work.
+type GrantResolver struct {
+	authorizer       *repositorydal.Authorizer
+	queries          *daldb.Queries
+	libraryNamespace string
+}
 
-	libraryNamespace, _ := options["libraryNamespace"].(string)
+// NewGrantResolver constructs a DB-backed registry grant resolver.
+func NewGrantResolver(db *sql.DB, cfg GrantResolverConfig) (*GrantResolver, error) {
+	if db == nil {
+		return nil, fmt.Errorf("nil database")
+	}
+	libraryNamespace := cfg.LibraryNamespace
 	if libraryNamespace == "" {
 		libraryNamespace = defaultLibraryNamespace
 	}
-
-	anonymousAccess, ok := options[authOptionAnonAccess].(bool)
-	if !ok {
-		anonymousAccess = true
-	}
-
-	databaseSecretKey, _ := options["databaseSecretKey"].(string)
-	robotsDisallow, _ := options["robotsDisallow"].(bool)
-	robotsWhitelist, _ := options["robotsWhitelist"].([]string)
-	featureUserLastAccessed, _ := options["featureUserLastAccessed"].(bool)
-	lastAccessedUpdateThresholdSeconds, _ := options["lastAccessedUpdateThresholdSeconds"].(int)
-	superUsers, _ := options["superUsers"].([]string)
-	superUsersFullAccess, _ := options["superUsersFullAccess"].(bool)
-
-	verifier := auth.NewDatabaseVerifier(db, auth.DatabaseVerifierConfig{
-		DatabaseSecretKey:              databaseSecretKey,
-		RobotsDisallow:                 robotsDisallow,
-		RobotsWhitelist:                robotsWhitelist,
-		FeatureUserLastAccessed:        featureUserLastAccessed,
-		LastAccessedUpdateThresholdSec: lastAccessedUpdateThresholdSeconds,
-	})
-
-	return &accessController{
-		authenticator: auth.NewBasicAuthenticator(verifier),
+	return &GrantResolver{
 		authorizer: repositorydal.NewAuthorizer(db, repositorydal.AuthorizerConfig{
-			SuperUsers:           superUsers,
-			SuperUsersFullAccess: superUsersFullAccess,
+			SuperUsers: cfg.SuperUsers, SuperUsersFullAccess: cfg.SuperUsersFullAccess,
 		}),
 		queries:          daldb.New(db),
-		realm:            realm,
 		libraryNamespace: libraryNamespace,
-		anonymousAccess:  anonymousAccess,
 	}, nil
 }
 
-func (ac *accessController) Authorized(req *http.Request, access ...distauth.Access) (*distauth.Grant, error) {
-	result := ac.authenticator.Authenticate(req)
-	// Only missing credentials may fall back to anonymous public pulls. Invalid
-	// credentials must fail instead of silently becoming anonymous.
-	if !result.Authenticated && !result.Presented && ac.canAnonymousPull(req, access) {
-		return &distauth.Grant{User: distauth.UserInfo{Name: auth.AnonymousPrincipal().Username}}, nil
+// Resolve returns the requested/allowed action intersection. Permission denial
+// produces an empty action list; only lookup failures are returned as errors.
+func (r *GrantResolver) Resolve(ctx context.Context, identity registryauth.Identity, scopes []registryauth.Scope) ([]registryauth.ResourceActions, error) {
+	principal, err := r.principal(identity)
+	if err != nil {
+		return nil, err
 	}
 
-	if !result.Authenticated && !result.Presented {
-		return nil, &challenge{
-			realm: ac.realm,
-			err:   distauth.ErrInvalidCredential,
+	grants := make([]registryauth.ResourceActions, 0, len(scopes))
+	for _, scope := range scopes {
+		grant := registryauth.ResourceActions{Type: scope.Type, Name: scope.Name, Actions: []string{}}
+		if scope.Type == repositoryResourceType {
+			grant.Actions, err = r.resolveRepositoryActions(ctx, principal, scope)
+			if err != nil {
+				return nil, err
+			}
 		}
+		grants = append(grants, grant)
 	}
-	if !result.Authenticated {
-		return nil, &challenge{
-			realm: ac.realm,
-			err:   distauth.ErrAuthenticationFailure,
-		}
-	}
-
-	if err := ac.authorizeDistributionAccess(req, &result.Principal, access); err != nil {
-		return nil, &challenge{
-			realm: ac.realm,
-			err:   distauth.ErrAuthenticationFailure,
-		}
-	}
-
-	return &distauth.Grant{User: distauth.UserInfo{Name: result.Principal.Username}}, nil
+	return grants, nil
 }
 
-func (ac *accessController) Authenticate(r *http.Request, access ...oci.Access) (*oci.Grant, error) {
-	result := ac.authenticator.Authenticate(r)
-	// Only missing credentials may fall back to anonymous public pulls. Invalid
-	// credentials must fail instead of silently becoming anonymous.
-	if !result.Authenticated && !result.Presented && ac.canAnonymousOCIPull(r, access) {
-		return &oci.Grant{User: oci.User{Name: auth.AnonymousPrincipal().Username}}, nil
+func (r *GrantResolver) principal(identity registryauth.Identity) (*quayauth.Principal, error) {
+	if identity.Anonymous {
+		return quayauth.AnonymousPrincipal(), nil
 	}
-
-	if !result.Authenticated {
-		return nil, &challenge{
-			realm: ac.realm,
-			err:   oci.ErrUnauthorized,
-		}
+	principal, ok := identity.Principal.(*quayauth.Principal)
+	if !ok || principal == nil || principal.IsAnonymous() || principal.Username != identity.Subject {
+		return nil, fmt.Errorf("invalid authenticated principal")
 	}
-
-	if err := ac.authorizeOCIAccess(r, &result.Principal, access); err != nil {
-		return nil, &challenge{
-			realm: ac.realm,
-			err:   oci.ErrUnauthorized,
-		}
-	}
-
-	return &oci.Grant{User: oci.User{Name: result.Principal.Username}}, nil
+	return principal, nil
 }
 
-func (ac *accessController) canAnonymousPull(req *http.Request, access []distauth.Access) bool {
-	if !ac.anonymousAccess || len(access) == 0 {
-		return false
+func (r *GrantResolver) resolveRepositoryActions(ctx context.Context, principal *quayauth.Principal, scope registryauth.Scope) ([]string, error) {
+	repositoryRecord, err := r.resolveRepository(ctx, scope.Name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			exists, existsErr := r.repositoryExists(ctx, scope.Name)
+			if existsErr != nil {
+				return nil, existsErr
+			}
+			if exists {
+				return []string{}, nil
+			}
+			return r.resolveMissingRepositoryActions(ctx, principal, scope)
+		}
+		return nil, err
+	}
+	if repositoryRecord.KindID != repo.KindImage {
+		return []string{}, nil
 	}
 
-	for _, item := range access {
-		if item.Type != repositoryResourceType || item.Action != repositoryPullAction {
-			return false
+	allowedActions := make([]string, 0, len(scope.Actions))
+	for _, action := range scope.Actions {
+		var allowed bool
+		switch action {
+		case repositoryPullAction:
+			allowed, err = r.authorizer.CanPullRepository(ctx, principal, &repositoryRecord)
+		case repositoryPushAction, repositoryDeleteAction:
+			allowed, err = r.authorizer.CanPushRepository(ctx, principal, &repositoryRecord)
+		case repositoryAdminAction:
+			if repositoryRecord.State != repo.StateNormal || !repositoryRecord.NamespaceEnabled {
+				continue
+			}
+			allowed, err = r.authorizer.CanAdminRepository(ctx, principal, &repositoryRecord)
+		default:
+			return nil, fmt.Errorf("unsupported repository action %q", action)
 		}
-		if !ac.repositoryIsPublic(req, item.Name) {
-			return false
+		if err != nil {
+			return nil, err
+		}
+		if allowed {
+			allowedActions = append(allowedActions, action)
 		}
 	}
-	return true
+	sort.Strings(allowedActions)
+	return allowedActions, nil
 }
 
-func (ac *accessController) canAnonymousOCIPull(req *http.Request, access []oci.Access) bool {
-	if !ac.anonymousAccess || len(access) == 0 {
-		return false
-	}
-
-	for _, item := range access {
-		resourceType, resourceName, ok := strings.Cut(item.Resource, ":")
-		if !ok || resourceType != repositoryResourceType || item.Action != repositoryPullAction {
-			return false
-		}
-		if !ac.repositoryIsPublic(req, resourceName) {
-			return false
-		}
-	}
-	return true
-}
-
-func (ac *accessController) repositoryIsPublic(req *http.Request, name string) bool {
-	namespace, repository, ok := ac.repositoryParts(name)
+func (r *GrantResolver) repositoryExists(ctx context.Context, name string) (bool, error) {
+	namespace, repository, ok := r.repositoryParts(name)
 	if !ok {
-		return false
+		return false, fmt.Errorf("invalid repository name %q", name)
 	}
-
-	isPublic, err := ac.queries.RepositoryIsPublicByNamespaceName(req.Context(), daldb.RepositoryIsPublicByNamespaceNameParams{
+	_, err := r.queries.GetRepositoryByNamespaceName(ctx, daldb.GetRepositoryByNamespaceNameParams{
 		Username: namespace,
 		Name:     repository,
 	})
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (r *GrantResolver) resolveMissingRepositoryActions(ctx context.Context, principal *quayauth.Principal, scope registryauth.Scope) ([]string, error) {
+	namespace, _, ok := r.repositoryParts(scope.Name)
+	if !ok {
+		return nil, fmt.Errorf("invalid repository name %q", scope.Name)
+	}
+	requestedPull := slices.Contains(scope.Actions, repositoryPullAction)
+	requestedPush := slices.Contains(scope.Actions, repositoryPushAction)
+	if !requestedPull && !requestedPush {
+		return []string{}, nil
+	}
+	canCreate, err := r.authorizer.CanCreateRepository(ctx, principal, namespace)
 	if err != nil {
-		slog.Debug("anonymous repository visibility lookup failed", "repository", name, "err", err)
-		return false
+		return nil, err
+	}
+	if !canCreate {
+		return []string{}, nil
 	}
 
-	return isPublic != 0
+	allowedActions := make([]string, 0, 2)
+	for _, action := range scope.Actions {
+		if action == repositoryPullAction || action == repositoryPushAction {
+			allowedActions = append(allowedActions, action)
+		}
+	}
+	sort.Strings(allowedActions)
+	return allowedActions, nil
 }
 
-func (ac *accessController) authorizeDistributionAccess(req *http.Request, principal *auth.Principal, access []distauth.Access) error {
-	if len(access) == 0 {
-		return nil
-	}
-
-	for _, item := range access {
-		switch item.Type {
-		case repositoryResourceType:
-			if err := ac.authorizeRepositoryAccess(req, principal, item, access); err != nil {
-				return err
-			}
-		case registryResourceType:
-			if item.Name == registryCatalogName && item.Action == registryCatalogAction {
-				return fmt.Errorf("registry catalog is not supported by quaydb auth")
-			}
-			return fmt.Errorf("unsupported access resource type %q", item.Type)
-		default:
-			return fmt.Errorf("unsupported access resource type %q", item.Type)
-		}
-	}
-
-	return nil
-}
-
-func (ac *accessController) authorizeOCIAccess(req *http.Request, principal *auth.Principal, access []oci.Access) error {
-	if len(access) == 0 {
-		return nil
-	}
-
-	distributionAccess := make([]distauth.Access, 0, len(access))
-	for _, item := range access {
-		resourceType, resourceName, ok := strings.Cut(item.Resource, ":")
-		if !ok {
-			return fmt.Errorf("invalid OCI access resource %q", item.Resource)
-		}
-		distributionAccess = append(distributionAccess, distauth.Access{
-			Resource: distauth.Resource{
-				Type: resourceType,
-				Name: resourceName,
-			},
-			Action: item.Action,
-		})
-	}
-
-	return ac.authorizeDistributionAccess(req, principal, distributionAccess)
-}
-
-func (ac *accessController) authorizeRepositoryAccess(req *http.Request, principal *auth.Principal, item distauth.Access, access []distauth.Access) error {
-	repositoryRecord, err := ac.resolveRepository(req, item.Name)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return ac.authorizeMissingRepositoryAccess(req, principal, item, access)
-		}
-		return err
-	}
-	if repositoryRecord.KindID != repo.KindImage {
-		return fmt.Errorf("repository %q is not an image repository", item.Name)
-	}
-
-	var allowed bool
-	switch item.Action {
-	case repositoryPullAction:
-		allowed, err = ac.authorizer.CanPullRepository(req.Context(), principal, &repositoryRecord)
-	case repositoryPushAction, repositoryDeleteAction:
-		allowed, err = ac.authorizer.CanPushRepository(req.Context(), principal, &repositoryRecord)
-	default:
-		return fmt.Errorf("unsupported repository action %q", item.Action)
-	}
-	if err != nil {
-		return err
-	}
-	if !allowed {
-		return fmt.Errorf("repository action %q denied for %s", item.Action, principal.Username)
-	}
-
-	return nil
-}
-
-func (ac *accessController) authorizeMissingRepositoryAccess(req *http.Request, principal *auth.Principal, item distauth.Access, access []distauth.Access) error {
-	switch item.Action {
-	case repositoryPullAction:
-		if accessIncludesRepositoryAction(access, item.Name, repositoryPushAction) {
-			return nil
-		}
-		namespace, _, ok := ac.repositoryParts(item.Name)
-		if !ok {
-			return fmt.Errorf("invalid repository name %q", item.Name)
-		}
-		allowed, err := ac.authorizer.CanCreateRepository(req.Context(), principal, namespace)
-		if err != nil {
-			return err
-		}
-		if allowed {
-			return nil
-		}
-		return sql.ErrNoRows
-	case repositoryPushAction:
-		namespace, _, ok := ac.repositoryParts(item.Name)
-		if !ok {
-			return fmt.Errorf("invalid repository name %q", item.Name)
-		}
-		allowed, err := ac.authorizer.CanCreateRepository(req.Context(), principal, namespace)
-		if err != nil {
-			return err
-		}
-		if !allowed {
-			return fmt.Errorf("repository create denied for %s", principal.Username)
-		}
-		return nil
-	case repositoryDeleteAction:
-		return sql.ErrNoRows
-	default:
-		return fmt.Errorf("unsupported repository action %q", item.Action)
-	}
-}
-
-func accessIncludesRepositoryAction(access []distauth.Access, name, action string) bool {
-	for _, item := range access {
-		if item.Type == repositoryResourceType && item.Name == name && item.Action == action {
-			return true
-		}
-	}
-	return false
-}
-
-func (ac *accessController) resolveRepository(req *http.Request, name string) (repo.Repository, error) {
-	namespace, repository, ok := ac.repositoryParts(name)
+func (r *GrantResolver) resolveRepository(ctx context.Context, name string) (repo.Repository, error) {
+	namespace, repository, ok := r.repositoryParts(name)
 	if !ok {
 		return repo.Repository{}, fmt.Errorf("invalid repository name %q", name)
 	}
 
-	row, err := ac.queries.GetRepositoryAccessByNamespaceName(req.Context(), daldb.GetRepositoryAccessByNamespaceNameParams{
+	row, err := r.queries.GetRepositoryAccessByNamespaceName(ctx, daldb.GetRepositoryAccessByNamespaceNameParams{
 		Username: namespace,
 		Name:     repository,
 	})
@@ -355,30 +208,14 @@ func (ac *accessController) resolveRepository(req *http.Request, name string) (r
 	}, nil
 }
 
-func (ac *accessController) repositoryParts(name string) (namespace, repository string, ok bool) {
+func (r *GrantResolver) repositoryParts(name string) (namespace, repository string, ok bool) {
 	namespace, repository, ok = strings.Cut(name, "/")
 	if !ok {
-		namespace = ac.libraryNamespace
+		namespace = r.libraryNamespace
 		repository = name
 	}
 	if namespace == "" || repository == "" {
 		return "", "", false
 	}
 	return namespace, repository, true
-}
-
-// challenge implements auth.Challenge for Basic auth 401 responses.
-type challenge struct {
-	realm string
-	err   error
-}
-
-var _ distauth.Challenge = challenge{}
-
-func (ch challenge) SetHeaders(_ *http.Request, w http.ResponseWriter) {
-	w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", ch.realm))
-}
-
-func (ch challenge) Error() string {
-	return fmt.Sprintf("basic authentication challenge for realm %q: %s", ch.realm, ch.err)
 }

--- a/internal/registry/distribution/auth_test.go
+++ b/internal/registry/distribution/auth_test.go
@@ -240,7 +240,7 @@ func TestTokenHandlerAcceptsExistingHumanAndMigratedRobotCredentials(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler, err := registryauth.NewHandler(registryauth.HandlerConfig{
+	handler, err := registryauth.NewHandler(&registryauth.HandlerConfig{
 		Service: "registry.example.com", LibraryNamespace: "library", AnonymousAccess: true,
 		Lifetime: 5 * time.Minute, Signer: signer, ResolveGrants: resolver.Resolve,
 		Authenticate: func(ctx context.Context, username, secret string) (registryauth.Identity, bool) {
@@ -266,7 +266,7 @@ func TestTokenHandlerAcceptsExistingHumanAndMigratedRobotCredentials(t *testing.
 		{"invalid robot", "acme+writer", "wrong", "", http.StatusUnauthorized},
 	} {
 		t.Run(credentials.name, func(t *testing.T) {
-			request := httptest.NewRequest(http.MethodGet,
+			request := httptest.NewRequestWithContext(t.Context(), http.MethodGet,
 				"/v2/auth?service="+url.QueryEscape("registry.example.com"), http.NoBody)
 			request.SetBasicAuth(credentials.username, credentials.password)
 			response := httptest.NewRecorder()

--- a/internal/registry/distribution/auth_test.go
+++ b/internal/registry/distribution/auth_test.go
@@ -1,16 +1,20 @@
 package distribution
 
 import (
+	"context"
 	"database/sql"
-	"errors"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"reflect"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/distribution/distribution/v3/registry/auth"
-	"github.com/quay/quay/internal/oci"
+	quayauth "github.com/quay/quay/internal/auth"
+	registryauth "github.com/quay/quay/internal/registry/auth"
 	_ "modernc.org/sqlite"
 )
 
@@ -18,925 +22,274 @@ func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
-		t.Fatalf("open db: %v", err)
+		t.Fatal(err)
 	}
 	db.SetMaxOpenConns(1)
-
-	ctx := t.Context()
-
-	// Create minimal user table matching Quay schema.
-	_, err = db.ExecContext(ctx, `CREATE TABLE "user" (
-		id INTEGER PRIMARY KEY,
-		uuid VARCHAR(36),
-		username VARCHAR(255) NOT NULL,
-		password_hash VARCHAR(255),
-		email VARCHAR(255) NOT NULL,
-		verified INTEGER NOT NULL DEFAULT 0,
-		organization INTEGER NOT NULL DEFAULT 0,
-		robot INTEGER NOT NULL DEFAULT 0,
-		enabled INTEGER NOT NULL DEFAULT 1,
-		last_accessed DATETIME
-	)`)
-	if err != nil {
-		t.Fatalf("create table: %v", err)
+	statements := []string{
+		`CREATE TABLE "user" (id INTEGER PRIMARY KEY, uuid TEXT, username TEXT NOT NULL, password_hash TEXT, email TEXT NOT NULL, verified INTEGER NOT NULL DEFAULT 0, organization INTEGER NOT NULL DEFAULT 0, robot INTEGER NOT NULL DEFAULT 0, enabled INTEGER NOT NULL DEFAULT 1, last_accessed DATETIME)`,
+		`CREATE TABLE visibility (id INTEGER PRIMARY KEY, name TEXT NOT NULL)`,
+		`CREATE TABLE repository (id INTEGER PRIMARY KEY, namespace_user_id INTEGER, name TEXT NOT NULL, visibility_id INTEGER NOT NULL, kind_id INTEGER NOT NULL DEFAULT 1, state INTEGER NOT NULL DEFAULT 0)`,
+		`CREATE TABLE role (id INTEGER PRIMARY KEY, name TEXT NOT NULL)`,
+		`CREATE TABLE teamrole (id INTEGER PRIMARY KEY, name TEXT NOT NULL)`,
+		`CREATE TABLE team (id INTEGER PRIMARY KEY, name TEXT NOT NULL, organization_id INTEGER NOT NULL, role_id INTEGER NOT NULL, description TEXT NOT NULL)`,
+		`CREATE TABLE teammember (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, team_id INTEGER NOT NULL)`,
+		`CREATE TABLE repositorypermission (id INTEGER PRIMARY KEY, team_id INTEGER, user_id INTEGER, repository_id INTEGER NOT NULL, role_id INTEGER NOT NULL)`,
+		`CREATE TABLE repomirrorconfig (id INTEGER PRIMARY KEY, repository_id INTEGER NOT NULL, internal_robot_id INTEGER)`,
+		`CREATE TABLE orgmirrorconfig (id INTEGER PRIMARY KEY, organization_id INTEGER NOT NULL, internal_robot_id INTEGER)`,
+		`CREATE TABLE orgmirrorrepository (id INTEGER PRIMARY KEY, org_mirror_config_id INTEGER NOT NULL, repository_id INTEGER)`,
+		`CREATE TABLE robotaccounttoken (id INTEGER PRIMARY KEY, robot_account_id INTEGER NOT NULL, token TEXT NOT NULL, fully_migrated BOOLEAN DEFAULT 0 NOT NULL)`,
+		`INSERT INTO visibility VALUES (1, 'public'), (2, 'private')`,
+		`INSERT INTO role VALUES (1, 'read'), (2, 'write'), (3, 'admin')`,
+		`INSERT INTO teamrole VALUES (1, 'admin'), (2, 'creator'), (3, 'member')`,
+		`INSERT INTO "user" (id, uuid, username, email, organization, robot, enabled) VALUES
+			(1, 'u-admin', 'admin', 'admin@example.com', 0, 0, 1),
+			(2, 'org-acme', 'acme', 'acme@example.com', 1, 0, 1),
+			(3, 'robot-reader', 'acme+reader', 'robot@example.com', 0, 1, 1),
+			(4, 'robot-writer', 'acme+writer', 'robot@example.com', 0, 1, 1),
+			(5, 'u-public', 'public', 'public@example.com', 0, 0, 1),
+			(6, 'org-disabled', 'disabled', 'disabled@example.com', 1, 0, 0),
+			(7, 'u-library', 'library', 'library@example.com', 0, 0, 1),
+			(8, 'org-create', 'createorg', 'create@example.com', 1, 0, 1)`,
+		`INSERT INTO repository (id, namespace_user_id, name, visibility_id, kind_id, state) VALUES
+			(1, 5, 'publicrepo', 1, 1, 0),
+			(2, 2, 'private', 2, 1, 0),
+			(3, 5, 'deleted', 1, 1, 3),
+			(4, 2, 'readonly', 2, 1, 1),
+			(5, 2, 'application', 2, 2, 0),
+			(6, 6, 'publicrepo', 1, 1, 0),
+			(7, 7, 'busybox', 1, 1, 0),
+			(8, 2, 'mirror', 2, 1, 2),
+			(9, 2, 'orgmirror', 2, 1, 4)`,
+		`INSERT INTO repositorypermission (id, user_id, repository_id, role_id) VALUES
+			(1, 3, 2, 1), (2, 4, 2, 2), (3, 4, 4, 2), (4, 4, 5, 3),
+			(5, 4, 8, 2), (6, 4, 9, 2)`,
+		`INSERT INTO team (id, name, organization_id, role_id, description) VALUES
+			(1, 'creators', 2, 2, ''), (2, 'createorg-creators', 8, 2, '')`,
+		`INSERT INTO teammember (id, user_id, team_id) VALUES (1, 4, 1), (2, 4, 2)`,
+		`INSERT INTO repomirrorconfig (id, repository_id, internal_robot_id) VALUES (1, 8, 4)`,
+		`INSERT INTO orgmirrorconfig (id, organization_id, internal_robot_id) VALUES (1, 2, 4)`,
+		`INSERT INTO orgmirrorrepository (id, org_mirror_config_id, repository_id) VALUES (1, 1, 9)`,
+		`INSERT INTO robotaccounttoken (id, robot_account_id, token, fully_migrated) VALUES
+			(1, 4, 'v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==', 1)`,
 	}
-
-	_, err = db.ExecContext(ctx, `CREATE TABLE visibility (
-		id INTEGER PRIMARY KEY,
-		name VARCHAR(255) NOT NULL
-	)`)
-	if err != nil {
-		t.Fatalf("create visibility table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE repository (
-		id INTEGER PRIMARY KEY,
-		namespace_user_id INTEGER,
-		name VARCHAR(255) NOT NULL,
-		visibility_id INTEGER NOT NULL,
-		kind_id INTEGER NOT NULL DEFAULT 1,
-		state INTEGER NOT NULL DEFAULT 0
-	)`)
-	if err != nil {
-		t.Fatalf("create repository table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE role (
-		id INTEGER PRIMARY KEY,
-		name VARCHAR(255) NOT NULL
-	)`)
-	if err != nil {
-		t.Fatalf("create role table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE teamrole (
-		id INTEGER PRIMARY KEY,
-		name VARCHAR(255) NOT NULL
-	)`)
-	if err != nil {
-		t.Fatalf("create teamrole table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE team (
-		id INTEGER PRIMARY KEY,
-		name VARCHAR(255) NOT NULL,
-		organization_id INTEGER NOT NULL,
-		role_id INTEGER NOT NULL,
-		description TEXT NOT NULL
-	)`)
-	if err != nil {
-		t.Fatalf("create team table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE teammember (
-		id INTEGER PRIMARY KEY,
-		user_id INTEGER NOT NULL,
-		team_id INTEGER NOT NULL
-	)`)
-	if err != nil {
-		t.Fatalf("create teammember table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE repositorypermission (
-		id INTEGER PRIMARY KEY,
-		team_id INTEGER,
-		user_id INTEGER,
-		repository_id INTEGER NOT NULL,
-		role_id INTEGER NOT NULL
-	)`)
-	if err != nil {
-		t.Fatalf("create repositorypermission table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE repomirrorconfig (
-		id INTEGER PRIMARY KEY,
-		repository_id INTEGER NOT NULL,
-		internal_robot_id INTEGER
-	)`)
-	if err != nil {
-		t.Fatalf("create repomirrorconfig table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE orgmirrorconfig (
-		id INTEGER PRIMARY KEY,
-		organization_id INTEGER NOT NULL,
-		internal_robot_id INTEGER
-	)`)
-	if err != nil {
-		t.Fatalf("create orgmirrorconfig table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE orgmirrorrepository (
-		id INTEGER PRIMARY KEY,
-		org_mirror_config_id INTEGER NOT NULL,
-		repository_id INTEGER
-	)`)
-	if err != nil {
-		t.Fatalf("create orgmirrorrepository table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `CREATE TABLE robotaccounttoken (
-		id INTEGER PRIMARY KEY,
-		robot_account_id INTEGER NOT NULL,
-		token VARCHAR(255) NOT NULL,
-		fully_migrated BOOLEAN DEFAULT 0 NOT NULL
-	)`)
-	if err != nil {
-		t.Fatalf("create robotaccounttoken table: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO visibility (id, name) VALUES (1, 'public'), (2, 'private')`)
-	if err != nil {
-		t.Fatalf("insert visibility: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO role (id, name) VALUES (1, 'read'), (2, 'write'), (3, 'admin')`)
-	if err != nil {
-		t.Fatalf("insert roles: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO teamrole (id, name) VALUES (1, 'admin'), (2, 'creator'), (3, 'member')`)
-	if err != nil {
-		t.Fatalf("insert teamroles: %v", err)
-	}
-
-	hash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
-	if err != nil {
-		t.Fatalf("bcrypt: %v", err)
-	}
-
-	// Active user.
-	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
-		VALUES ('u1', 'admin', ?, 'admin@test.com', 1, 0, 0, 1)`, string(hash))
-	if err != nil {
-		t.Fatalf("insert admin: %v", err)
-	}
-
-	// Disabled user.
-	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
-		VALUES ('u2', 'disabled', ?, 'disabled@test.com', 1, 0, 0, 0)`, string(hash))
-	if err != nil {
-		t.Fatalf("insert disabled: %v", err)
-	}
-
-	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
-		VALUES ('org-1', 'acme', NULL, 'acme@example.com', 1, 1, 0, 1)`)
-	if err != nil {
-		t.Fatalf("insert acme org: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
-		VALUES ('robot-read', 'acme+reader', NULL, 'robot@example.com', 1, 0, 1, 1)`)
-	if err != nil {
-		t.Fatalf("insert reader robot: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
-		VALUES ('robot-write', 'acme+writer', NULL, 'robot@example.com', 1, 0, 1, 1)`)
-	if err != nil {
-		t.Fatalf("insert writer robot: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
-		VALUES ('disabled-org', 'disabled-org', NULL, 'disabled-org@example.com', 1, 1, 0, 0)`)
-	if err != nil {
-		t.Fatalf("insert disabled org: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
-		VALUES ('disabled-creator', 'disabled-org+creator', NULL, 'robot@example.com', 1, 0, 1, 1)`)
-	if err != nil {
-		t.Fatalf("insert disabled org creator robot: %v", err)
-	}
-
-	for _, username := range []string{"public", "devtable", "library"} {
-		_, err = db.ExecContext(ctx, `INSERT INTO "user" (uuid, username, password_hash, email, verified, organization, robot, enabled)
-			VALUES (?, ?, NULL, ?, 1, 0, 0, 1)`, "u-"+username, username, username+"@test.com")
-		if err != nil {
-			t.Fatalf("insert namespace %s: %v", username, err)
+	for _, statement := range statements {
+		if _, err := db.ExecContext(t.Context(), statement); err != nil {
+			t.Fatalf("exec %q: %v", statement, err)
 		}
 	}
-
-	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
-		SELECT id, 'publicrepo', 1, 1, 0 FROM "user" WHERE username = 'public'`)
+	passwordHash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
 	if err != nil {
-		t.Fatalf("insert public repo: %v", err)
+		t.Fatal(err)
 	}
-	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
-		SELECT id, 'simple', 2, 1, 0 FROM "user" WHERE username = 'devtable'`)
-	if err != nil {
-		t.Fatalf("insert private repo: %v", err)
+	if _, err := db.ExecContext(t.Context(), `UPDATE "user" SET password_hash = ? WHERE username = 'admin'`, string(passwordHash)); err != nil {
+		t.Fatal(err)
 	}
-	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
-		SELECT id, 'deleted', 1, 1, 3 FROM "user" WHERE username = 'public'`)
-	if err != nil {
-		t.Fatalf("insert deleted repo: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
-		SELECT id, 'nginx', 1, 1, 0 FROM "user" WHERE username = 'library'`)
-	if err != nil {
-		t.Fatalf("insert library repo: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
-		SELECT id, 'private', 2, 1, 0 FROM "user" WHERE username = 'acme'`)
-	if err != nil {
-		t.Fatalf("insert acme private repo: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO repository (namespace_user_id, name, visibility_id, kind_id, state)
-		SELECT id, 'publicrepo', 1, 1, 0 FROM "user" WHERE username = 'disabled-org'`)
-	if err != nil {
-		t.Fatalf("insert disabled org public repo: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO robotaccounttoken (robot_account_id, token, fully_migrated)
-		SELECT id, 'v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==', 1 FROM "user" WHERE username = 'acme+reader'`)
-	if err != nil {
-		t.Fatalf("insert reader robot token: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO robotaccounttoken (robot_account_id, token, fully_migrated)
-		SELECT id, 'v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==', 1 FROM "user" WHERE username = 'acme+writer'`)
-	if err != nil {
-		t.Fatalf("insert writer robot token: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO robotaccounttoken (robot_account_id, token, fully_migrated)
-		SELECT id, 'v0$$XTxqlz/Kw8s9WKw+GaSvXFEKgpO/a2cGNhvnozzkaUh4C+FgHqZqnA==', 1 FROM "user" WHERE username = 'disabled-org+creator'`)
-	if err != nil {
-		t.Fatalf("insert disabled org creator token: %v", err)
-	}
-
 	return db
 }
 
-func newTestController(t *testing.T, db *sql.DB) auth.AccessController {
-	t.Helper()
-	return newTestControllerWithAnonymousAccess(t, db, true)
+func identity(principal *quayauth.Principal) registryauth.Identity {
+	return registryauth.Identity{Subject: principal.Username, Principal: principal}
 }
 
-func newTestControllerWithAnonymousAccess(t *testing.T, db *sql.DB, anonymousAccess bool) auth.AccessController {
+func userPrincipal(id int64, username string) *quayauth.Principal {
+	return &quayauth.Principal{ID: id, Username: username, Kind: quayauth.PrincipalUser}
+}
+
+func robotPrincipal(id int64, username string) *quayauth.Principal {
+	return &quayauth.Principal{ID: id, Username: username, Kind: quayauth.PrincipalRobot}
+}
+
+func resolveOne(t *testing.T, resolver *GrantResolver, principal registryauth.Identity, name string, actions ...string) []string {
 	t.Helper()
-	ac, err := newAccessController(map[string]interface{}{
-		authOptionRealm:      "test-realm",
-		"db":                 db,
-		authOptionAnonAccess: anonymousAccess,
+	grants, err := resolver.Resolve(t.Context(), principal, []registryauth.Scope{{Type: "repository", Name: name, Actions: actions}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(grants) != 1 {
+		t.Fatalf("grants = %#v", grants)
+	}
+	return grants[0].Actions
+}
+
+func TestGrantResolverDownscopesRepositoryActions(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	resolver, err := NewGrantResolver(db, GrantResolverConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		identity   registryauth.Identity
+		repository string
+		requested  []string
+		want       []string
+	}{
+		{"anonymous public pull", registryauth.Identity{Subject: registryauth.AnonymousSubject, Anonymous: true}, "public/publicrepo", []string{"pull", "push"}, []string{"pull"}},
+		{"anonymous private pull", registryauth.Identity{Subject: registryauth.AnonymousSubject, Anonymous: true}, "acme/private", []string{"pull"}, []string{}},
+		{"reader pull", identity(robotPrincipal(3, "acme+reader")), "acme/private", []string{"pull", "push", "delete", "*"}, []string{"pull"}},
+		{"writer pull push delete", identity(robotPrincipal(4, "acme+writer")), "acme/private", []string{"pull", "push", "delete"}, []string{"delete", "pull", "push"}},
+		{"owner admin wildcard", identity(userPrincipal(2, "acme")), "acme/private", []string{"*"}, []string{"*"}},
+		{"normal user denied", identity(userPrincipal(1, "admin")), "acme/private", []string{"pull", "push"}, []string{}},
+		{"deleted denied", identity(userPrincipal(5, "public")), "public/deleted", []string{"pull", "push", "delete", "*"}, []string{}},
+		{"disabled namespace denied", identity(userPrincipal(6, "disabled")), "disabled/publicrepo", []string{"pull", "push", "*"}, []string{}},
+		{"application denied", identity(robotPrincipal(4, "acme+writer")), "acme/application", []string{"pull", "push", "*"}, []string{}},
+		{"readonly push and admin denied", identity(robotPrincipal(4, "acme+writer")), "acme/readonly", []string{"push", "delete", "*"}, []string{}},
+		{"library normalized", registryauth.Identity{Subject: registryauth.AnonymousSubject, Anonymous: true}, "library/busybox", []string{"pull"}, []string{"pull"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveOne(t, resolver, tt.identity, tt.repository, tt.requested...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("actions = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGrantResolverMissingRepositoryIsSideEffectFree(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	resolver, err := NewGrantResolver(db, GrantResolverConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	creator := identity(robotPrincipal(4, "acme+writer"))
+	got := resolveOne(t, resolver, creator, "createorg/newrepo", "pull", "push", "delete", "*")
+	if want := []string{"pull", "push"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("actions = %#v, want %#v", got, want)
+	}
+	var count int
+	if err := db.QueryRowContext(t.Context(), `SELECT COUNT(*) FROM repository WHERE name = 'newrepo'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("token issuance created %d repositories", count)
+	}
+	pullOnly := resolveOne(t, resolver, creator, "createorg/pullprobe", "pull")
+	if want := []string{"pull"}; !reflect.DeepEqual(pullOnly, want) {
+		t.Fatalf("pull-only actions = %#v, want %#v", pullOnly, want)
+	}
+
+	denied := resolveOne(t, resolver, identity(userPrincipal(1, "admin")), "createorg/other", "pull", "push")
+	if len(denied) != 0 {
+		t.Fatalf("denied actions = %#v", denied)
+	}
+}
+
+func TestGrantResolverPreservesMirrorRobotRules(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	resolver, err := NewGrantResolver(db, GrantResolverConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := identity(robotPrincipal(4, "acme+writer"))
+	for _, repository := range []string{"acme/mirror", "acme/orgmirror"} {
+		if got := resolveOne(t, resolver, writer, repository, "push"); !reflect.DeepEqual(got, []string{"push"}) {
+			t.Fatalf("%s actions = %#v", repository, got)
+		}
+		if got := resolveOne(t, resolver, identity(userPrincipal(2, "acme")), repository, "push"); len(got) != 0 {
+			t.Fatalf("%s owner actions = %#v", repository, got)
+		}
+	}
+}
+
+func TestGrantResolverCatalogGetsNoAccess(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	resolver, err := NewGrantResolver(db, GrantResolverConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	grants, err := resolver.Resolve(t.Context(), identity(userPrincipal(1, "admin")), []registryauth.Scope{{Type: "registry", Name: "catalog", Actions: []string{"*"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(grants) != 1 || len(grants[0].Actions) != 0 {
+		t.Fatalf("grants = %#v", grants)
+	}
+}
+
+func TestGrantResolverRejectsInvalidIdentity(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	resolver, err := NewGrantResolver(db, GrantResolverConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(context.Background(), registryauth.Identity{Subject: "admin", Principal: "not-a-principal"}, nil)
+	if err == nil {
+		t.Fatal("expected invalid principal error")
+	}
+}
+
+func TestTokenHandlerAcceptsExistingHumanAndMigratedRobotCredentials(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	resolver, err := NewGrantResolver(db, GrantResolverConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier := quayauth.NewDatabaseVerifier(db, quayauth.DatabaseVerifierConfig{DatabaseSecretKey: "test1234"})
+	signer, tokenVerifier, err := registryauth.NewES256Pair(registryauth.ES256Config{
+		Issuer: registryauth.Issuer, Audience: "registry.example.com",
+		MaxFresh: 10 * time.Minute, ClockSkew: 5 * time.Second,
 	})
 	if err != nil {
-		t.Fatalf("new access controller: %v", err)
-	}
-	return ac
-}
-
-func newTestControllerWithRobotAuth(t *testing.T, db *sql.DB) auth.AccessController {
-	t.Helper()
-	ac, err := newAccessController(map[string]interface{}{
-		authOptionRealm:                      "test-realm",
-		"db":                                 db,
-		authOptionAnonAccess:                 true,
-		"databaseSecretKey":                  "test1234",
-		"featureUserLastAccessed":            true,
-		"lastAccessedUpdateThresholdSeconds": 0,
-	})
-	if err != nil {
-		t.Fatalf("new access controller: %v", err)
-	}
-	return ac
-}
-
-func newTestControllerWithSuperUserFullAccess(t *testing.T, db *sql.DB) auth.AccessController {
-	t.Helper()
-	ac, err := newAccessController(map[string]interface{}{
-		authOptionRealm:        "test-realm",
-		"db":                   db,
-		authOptionAnonAccess:   true,
-		"superUsers":           []string{"admin"},
-		"superUsersFullAccess": true,
-	})
-	if err != nil {
-		t.Fatalf("new access controller: %v", err)
-	}
-	return ac
-}
-
-func seedRobotPermission(t *testing.T, db *sql.DB, robotUsername, roleName string) {
-	t.Helper()
-	ctx := t.Context()
-
-	var userID int64
-	err := db.QueryRowContext(ctx, `SELECT id FROM "user" WHERE username = ?`, robotUsername).Scan(&userID)
-	if err != nil {
-		t.Fatalf("find robot user %s: %v", robotUsername, err)
-	}
-
-	var repoID int64
-	err = db.QueryRowContext(ctx, `SELECT r.id
-		FROM repository r
-		JOIN "user" u ON r.namespace_user_id = u.id
-		WHERE u.username = 'acme' AND r.name = 'private'`).Scan(&repoID)
-	if err != nil {
-		t.Fatalf("find repository acme/private: %v", err)
-	}
-
-	var roleID int64
-	err = db.QueryRowContext(ctx, `SELECT id FROM role WHERE name = ?`, roleName).Scan(&roleID)
-	if err != nil {
-		t.Fatalf("find role %s: %v", roleName, err)
-	}
-
-	_, err = db.ExecContext(ctx, `INSERT INTO repositorypermission (team_id, user_id, repository_id, role_id)
-		VALUES (NULL, ?, ?, ?)`, userID, repoID, roleID)
-	if err != nil {
-		t.Fatalf("insert robot permission: %v", err)
-	}
-}
-
-func seedNamespaceTeamMembership(t *testing.T, db *sql.DB, username, namespace, teamRole string) {
-	t.Helper()
-	ctx := t.Context()
-
-	var userID int64
-	err := db.QueryRowContext(ctx, `SELECT id FROM "user" WHERE username = ?`, username).Scan(&userID)
-	if err != nil {
-		t.Fatalf("find user %s: %v", username, err)
-	}
-
-	var namespaceID int64
-	err = db.QueryRowContext(ctx, `SELECT id FROM "user" WHERE username = ?`, namespace).Scan(&namespaceID)
-	if err != nil {
-		t.Fatalf("find namespace %s: %v", namespace, err)
-	}
-
-	var roleID int64
-	err = db.QueryRowContext(ctx, `SELECT id FROM teamrole WHERE name = ?`, teamRole).Scan(&roleID)
-	if err != nil {
-		t.Fatalf("find team role %s: %v", teamRole, err)
-	}
-
-	result, err := db.ExecContext(ctx, `INSERT INTO team (name, organization_id, role_id, description)
-		VALUES (?, ?, ?, '')`, username+"-"+teamRole, namespaceID, roleID)
-	if err != nil {
-		t.Fatalf("insert team: %v", err)
-	}
-
-	teamID, err := result.LastInsertId()
-	if err != nil {
-		t.Fatalf("team id: %v", err)
-	}
-	_, err = db.ExecContext(ctx, `INSERT INTO teammember (user_id, team_id) VALUES (?, ?)`, userID, teamID)
-	if err != nil {
-		t.Fatalf("insert team member: %v", err)
-	}
-}
-
-func TestAuthorized_ValidCredentials(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/", http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
-
-	grant, err := ac.Authorized(req)
-	if err != nil {
-		t.Fatalf("expected success, got: %v", err)
-	}
-	if grant.User.Name != "admin" {
-		t.Errorf("expected user 'admin', got %q", grant.User.Name)
-	}
-}
-
-func TestAuthorized_WrongPassword(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/", http.NoBody)
-	req.SetBasicAuth("admin", "wrong-password")
-
-	_, err := ac.Authorized(req)
-	if err == nil {
-		t.Fatal("expected error for wrong password")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_UnknownUser(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/", http.NoBody)
-	req.SetBasicAuth("nobody", "password")
-
-	_, err := ac.Authorized(req)
-	if err == nil {
-		t.Fatal("expected error for unknown user")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_DisabledUser(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/", http.NoBody)
-	req.SetBasicAuth("disabled", "correct-password")
-
-	_, err := ac.Authorized(req)
-	if err == nil {
-		t.Fatal("expected error for disabled user")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_NoAuthHeader(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/", http.NoBody)
-	// No BasicAuth set.
-
-	_, err := ac.Authorized(req)
-	if err == nil {
-		t.Fatal("expected error for missing auth")
-	}
-	var ch auth.Challenge
-	if !errors.As(err, &ch) {
-		t.Fatalf("expected Challenge error, got %T", err)
-	}
-	// Verify the challenge sets WWW-Authenticate header.
-	w := httptest.NewRecorder()
-	ch.SetHeaders(req, w)
-	if got := w.Header().Get("WWW-Authenticate"); got == "" {
-		t.Error("expected WWW-Authenticate header")
-	}
-}
-
-func TestAuthorized_AnonymousPullPublicRepository(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
-
-	grant, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
-	if err != nil {
-		t.Fatalf("expected anonymous pull to public repo to succeed, got: %v", err)
-	}
-	if grant.User.Name != "anonymous" {
-		t.Errorf("expected anonymous user, got %q", grant.User.Name)
-	}
-}
-
-func TestAuthorized_AnonymousPullDisabledByFeatureFlag(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestControllerWithAnonymousAccess(t, db, false)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
-
-	_, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
-	if err == nil {
-		t.Fatal("expected missing auth challenge when anonymous access is disabled")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_AnonymousPullPrivateRepository(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/devtable/simple/manifests/latest", http.NoBody)
-
-	_, err := ac.Authorized(req, repositoryAccess("devtable/simple", "pull"))
-	if err == nil {
-		t.Fatal("expected missing auth challenge for private repo")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_AnonymousPullDeletedPublicRepository(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/deleted/manifests/latest", http.NoBody)
-
-	_, err := ac.Authorized(req, repositoryAccess("public/deleted", "pull"))
-	if err == nil {
-		t.Fatal("expected missing auth challenge for deleted public repo")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_AnonymousPushPublicRepository(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/public/publicrepo/manifests/latest", http.NoBody)
-
-	_, err := ac.Authorized(
-		req,
-		repositoryAccess("public/publicrepo", "pull"),
-		repositoryAccess("public/publicrepo", "push"),
-	)
-	if err == nil {
-		t.Fatal("expected missing auth challenge for anonymous push")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_InvalidBasicAuthDoesNotFallBackToAnonymous(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
-	req.SetBasicAuth("admin", "wrong-password")
-
-	_, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
-	if err == nil {
-		t.Fatal("expected auth failure for invalid basic credentials")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_AuthenticatedUserCanPullPublicRepository(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
-
-	grant, err := ac.Authorized(req, repositoryAccess("public/publicrepo", "pull"))
-	if err != nil {
-		t.Fatalf("expected authenticated public pull to succeed, got: %v", err)
-	}
-	if grant.User.Name != "admin" {
-		t.Errorf("expected grant user 'admin', got %q", grant.User.Name)
-	}
-}
-
-func TestAuthorized_AnonymousPullLibraryRepository(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/nginx/manifests/latest", http.NoBody)
-
-	grant, err := ac.Authorized(req, repositoryAccess("nginx", "pull"))
-	if err != nil {
-		t.Fatalf("expected anonymous pull to library repo to succeed, got: %v", err)
-	}
-	if grant.User.Name != "anonymous" {
-		t.Errorf("expected anonymous user, got %q", grant.User.Name)
-	}
-}
-
-func TestAuthorized_RobotCreatorCanPushNewRepository(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	seedNamespaceTeamMembership(t, db, "acme+writer", "acme", "creator")
-	ac := newTestControllerWithRobotAuth(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/newrepo/manifests/latest", http.NoBody)
-	req.SetBasicAuth("acme+writer", "hello world")
-
-	grant, err := ac.Authorized(
-		req,
-		repositoryAccess("acme/newrepo", "pull"),
-		repositoryAccess("acme/newrepo", "push"),
-	)
-	if err != nil {
-		t.Fatalf("expected creator robot push to new repository to succeed, got: %v", err)
-	}
-	if grant.User.Name != "acme+writer" {
-		t.Errorf("expected grant user 'acme+writer', got %q", grant.User.Name)
-	}
-}
-
-func TestAuthorized_NamespaceOwnerCanCheckMissingRepositoryBlobBeforePush(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "HEAD", "/v2/admin/newrepo/blobs/sha256:abc", http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
-
-	grant, err := ac.Authorized(req, repositoryAccess("admin/newrepo", "pull"))
-	if err != nil {
-		t.Fatalf("expected namespace owner missing repository blob check to succeed, got: %v", err)
-	}
-	if grant.User.Name != "admin" {
-		t.Errorf("expected grant user 'admin', got %q", grant.User.Name)
-	}
-}
-
-func TestAuthorized_RepositoryDeleteRequiresWrite(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	seedRobotPermission(t, db, "acme+reader", "read")
-	seedRobotPermission(t, db, "acme+writer", "write")
-	ac := newTestControllerWithRobotAuth(t, db)
-
-	readerReq := httptest.NewRequestWithContext(t.Context(), "DELETE", "/v2/acme/private/manifests/latest", http.NoBody)
-	readerReq.SetBasicAuth("acme+reader", "hello world")
-	_, err := ac.Authorized(readerReq, repositoryAccess("acme/private", "delete"))
-	if err == nil {
-		t.Fatal("expected read robot delete to fail")
-	}
-	assertChallenge(t, err)
-
-	writerReq := httptest.NewRequestWithContext(t.Context(), "DELETE", "/v2/acme/private/manifests/latest", http.NoBody)
-	writerReq.SetBasicAuth("acme+writer", "hello world")
-	grant, err := ac.Authorized(writerReq, repositoryAccess("acme/private", "delete"))
-	if err != nil {
-		t.Fatalf("expected write robot delete to succeed, got: %v", err)
-	}
-	if grant.User.Name != "acme+writer" {
-		t.Errorf("expected grant user 'acme+writer', got %q", grant.User.Name)
-	}
-}
-
-func TestAuthorized_CatalogIsDeniedUntilQuayFilteredCatalogExists(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/_catalog", http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
-
-	_, err := ac.Authorized(req, auth.Access{
-		Resource: auth.Resource{Type: "registry", Name: "catalog"},
-		Action:   "*",
-	})
-	if err == nil {
-		t.Fatal("expected unfiltered distribution catalog to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_WriteRobotCannotPushReadOnlyRepository(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	seedRobotPermission(t, db, "acme+writer", "write")
-	if _, err := db.ExecContext(t.Context(), `UPDATE repository SET state = 1 WHERE name = 'private' AND namespace_user_id = (SELECT id FROM "user" WHERE username = 'acme')`); err != nil {
-		t.Fatalf("mark repo read-only: %v", err)
-	}
-	ac := newTestControllerWithRobotAuth(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
-	req.SetBasicAuth("acme+writer", "hello world")
-	_, err := ac.Authorized(req, repositoryAccess("acme/private", "push"))
-	if err == nil {
-		t.Fatal("expected read-only repository push to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_WriteRobotCannotPushApplicationRepository(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	seedRobotPermission(t, db, "acme+writer", "write")
-	if _, err := db.ExecContext(t.Context(), `UPDATE repository SET kind_id = 2 WHERE name = 'private' AND namespace_user_id = (SELECT id FROM "user" WHERE username = 'acme')`); err != nil {
-		t.Fatalf("mark repo application kind: %v", err)
-	}
-	ac := newTestControllerWithRobotAuth(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
-	req.SetBasicAuth("acme+writer", "hello world")
-	_, err := ac.Authorized(req, repositoryAccess("acme/private", "push"))
-	if err == nil {
-		t.Fatal("expected application repository push to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_DisabledNamespacePublicPullDenied(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestController(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/disabled-org/publicrepo/manifests/latest", http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
-	_, err := ac.Authorized(req, repositoryAccess("disabled-org/publicrepo", "pull"))
-	if err == nil {
-		t.Fatal("expected disabled namespace public pull to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_DisabledNamespaceCreateDenied(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	seedNamespaceTeamMembership(t, db, "disabled-org+creator", "disabled-org", "creator")
-	ac := newTestControllerWithRobotAuth(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/disabled-org/newrepo/manifests/latest", http.NoBody)
-	req.SetBasicAuth("disabled-org+creator", "hello world")
-	_, err := ac.Authorized(
-		req,
-		repositoryAccess("disabled-org/newrepo", "pull"),
-		repositoryAccess("disabled-org/newrepo", "push"),
-	)
-	if err == nil {
-		t.Fatal("expected disabled namespace create to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_SuperUserCannotCreateInDisabledNamespace(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac := newTestControllerWithSuperUserFullAccess(t, db)
-
-	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/disabled-org/newrepo/manifests/latest", http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
-	_, err := ac.Authorized(
-		req,
-		repositoryAccess("disabled-org/newrepo", "pull"),
-		repositoryAccess("disabled-org/newrepo", "push"),
-	)
-	if err == nil {
-		t.Fatal("expected superuser disabled namespace create to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_RobotReadCanPullNotPush(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	seedRobotPermission(t, db, "acme+reader", "read")
-	ac := newTestControllerWithRobotAuth(t, db)
-
-	pullReq := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/acme/private/manifests/latest", http.NoBody)
-	pullReq.SetBasicAuth("acme+reader", "hello world")
-
-	grant, err := ac.Authorized(pullReq, repositoryAccess("acme/private", "pull"))
-	if err != nil {
-		t.Fatalf("expected robot pull to succeed, got: %v", err)
-	}
-	if grant.User.Name != "acme+reader" {
-		t.Errorf("expected grant user 'acme+reader', got %q", grant.User.Name)
-	}
-
-	pushReq := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
-	pushReq.SetBasicAuth("acme+reader", "hello world")
-
-	_, err = ac.Authorized(pushReq, repositoryAccess("acme/private", "push"))
-	if err == nil {
-		t.Fatal("expected read robot push to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthorized_RobotWriteCanPullAndPush(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	seedRobotPermission(t, db, "acme+writer", "write")
-	ac := newTestControllerWithRobotAuth(t, db)
-
-	pullReq := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/acme/private/manifests/latest", http.NoBody)
-	pullReq.SetBasicAuth("acme+writer", "hello world")
-
-	pullGrant, err := ac.Authorized(pullReq, repositoryAccess("acme/private", "pull"))
-	if err != nil {
-		t.Fatalf("expected robot pull to succeed, got: %v", err)
-	}
-	if pullGrant.User.Name != "acme+writer" {
-		t.Errorf("expected pull grant user 'acme+writer', got %q", pullGrant.User.Name)
-	}
-
-	pushReq := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
-	pushReq.SetBasicAuth("acme+writer", "hello world")
-
-	pushGrant, err := ac.Authorized(pushReq, repositoryAccess("acme/private", "push"))
-	if err != nil {
-		t.Fatalf("expected robot push to succeed, got: %v", err)
-	}
-	if pushGrant.User.Name != "acme+writer" {
-		t.Errorf("expected push grant user 'acme+writer', got %q", pushGrant.User.Name)
-	}
-}
-
-func TestAuthenticate_InvalidRobotCredentialsDoNotFallBackToAnonymous(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac, ok := newTestControllerWithRobotAuth(t, db).(*accessController)
-	if !ok {
-		t.Fatal("expected concrete accessController")
-	}
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/public/publicrepo/manifests/latest", http.NoBody)
-	req.SetBasicAuth("acme+reader", "wrong")
-
-	_, err := ac.Authenticate(req, oci.Access{Resource: "repository:public/publicrepo", Action: "pull"})
-	if err == nil {
-		t.Fatal("expected auth failure for invalid robot credentials")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthenticate_ValidUserCannotPullPrivateRepositoryWithoutPermission(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac, ok := newTestController(t, db).(*accessController)
-	if !ok {
-		t.Fatal("expected concrete accessController")
-	}
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/devtable/simple/manifests/latest", http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
-
-	_, err := ac.Authenticate(req, ociRepositoryAccess("devtable/simple", repositoryPullAction))
-	if err == nil {
-		t.Fatal("expected valid user without pull permission to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthenticate_ValidUserCannotPushRepositoryWithoutPermission(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac, ok := newTestController(t, db).(*accessController)
-	if !ok {
-		t.Fatal("expected concrete accessController")
-	}
-
-	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/public/publicrepo/manifests/latest", http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
-
-	_, err := ac.Authenticate(req, ociRepositoryAccess("public/publicrepo", repositoryPushAction))
-	if err == nil {
-		t.Fatal("expected valid user without push permission to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthenticate_ValidRobotCannotPullPrivateRepositoryWithoutPermission(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	ac, ok := newTestControllerWithRobotAuth(t, db).(*accessController)
-	if !ok {
-		t.Fatal("expected concrete accessController")
-	}
-
-	req := httptest.NewRequestWithContext(t.Context(), "GET", "/v2/acme/private/manifests/latest", http.NoBody)
-	req.SetBasicAuth("acme+reader", "hello world")
-
-	_, err := ac.Authenticate(req, ociRepositoryAccess("acme/private", repositoryPullAction))
-	if err == nil {
-		t.Fatal("expected valid robot without pull permission to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthenticate_ValidRobotCannotPushPrivateRepositoryWithReadOnlyPermission(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	seedRobotPermission(t, db, "acme+reader", "read")
-	ac, ok := newTestControllerWithRobotAuth(t, db).(*accessController)
-	if !ok {
-		t.Fatal("expected concrete accessController")
-	}
-
-	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
-	req.SetBasicAuth("acme+reader", "hello world")
-
-	_, err := ac.Authenticate(req, ociRepositoryAccess("acme/private", repositoryPushAction))
-	if err == nil {
-		t.Fatal("expected valid read robot push to fail")
-	}
-	assertChallenge(t, err)
-}
-
-func TestAuthenticate_ValidRobotCanPushPrivateRepositoryWithWritePermission(t *testing.T) {
-	db := setupTestDB(t)
-	defer db.Close()
-	seedRobotPermission(t, db, "acme+writer", "write")
-	ac, ok := newTestControllerWithRobotAuth(t, db).(*accessController)
-	if !ok {
-		t.Fatal("expected concrete accessController")
-	}
-
-	req := httptest.NewRequestWithContext(t.Context(), "PUT", "/v2/acme/private/manifests/latest", http.NoBody)
-	req.SetBasicAuth("acme+writer", "hello world")
-
-	grant, err := ac.Authenticate(req, ociRepositoryAccess("acme/private", repositoryPushAction))
-	if err != nil {
-		t.Fatalf("expected write robot push to succeed, got: %v", err)
-	}
-	if grant.User.Name != "acme+writer" {
-		t.Errorf("expected grant user 'acme+writer', got %q", grant.User.Name)
-	}
-}
-
-func assertChallenge(t *testing.T, err error) {
-	t.Helper()
-	var ch auth.Challenge
-	if !errors.As(err, &ch) {
-		t.Errorf("expected Challenge error, got %T: %v", err, err)
-	}
-}
-
-func repositoryAccess(name, action string) auth.Access {
-	return auth.Access{
-		Resource: auth.Resource{
-			Type: "repository",
-			Name: name,
+		t.Fatal(err)
+	}
+	handler, err := registryauth.NewHandler(registryauth.HandlerConfig{
+		Service: "registry.example.com", LibraryNamespace: "library", AnonymousAccess: true,
+		Lifetime: 5 * time.Minute, Signer: signer, ResolveGrants: resolver.Resolve,
+		Authenticate: func(ctx context.Context, username, secret string) (registryauth.Identity, bool) {
+			result := verifier.Verify(ctx, quayauth.Credentials{Username: username, Secret: secret})
+			if !result.Authenticated {
+				return registryauth.Identity{}, false
+			}
+			principal := result.Principal
+			return registryauth.Identity{Subject: principal.Username, Principal: &principal}, true
 		},
-		Action: action,
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-}
 
-func ociRepositoryAccess(name, action string) oci.Access {
-	return oci.Access{
-		Resource: "repository:" + name,
-		Action:   action,
+	for _, credentials := range []struct {
+		name, username, password, subject string
+		status                            int
+	}{
+		{"human", "admin", "correct-password", "admin", http.StatusOK},
+		{"migrated robot", "acme+writer", "hello world", "acme+writer", http.StatusOK},
+		{"invalid human", "admin", "wrong", "", http.StatusUnauthorized},
+		{"invalid robot", "acme+writer", "wrong", "", http.StatusUnauthorized},
+	} {
+		t.Run(credentials.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet,
+				"/v2/auth?service="+url.QueryEscape("registry.example.com"), http.NoBody)
+			request.SetBasicAuth(credentials.username, credentials.password)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != credentials.status {
+				t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+			}
+			if credentials.status != http.StatusOK {
+				return
+			}
+			var body struct {
+				Token string `json:"token"`
+			}
+			if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			claims, err := tokenVerifier.Verify(body.Token)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if claims.Subject != credentials.subject {
+				t.Fatalf("subject = %q, want %q", claims.Subject, credentials.subject)
+			}
+		})
 	}
 }

--- a/internal/registry/distribution/authentication.go
+++ b/internal/registry/distribution/authentication.go
@@ -1,0 +1,88 @@
+package distribution
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	quayauth "github.com/quay/quay/internal/auth"
+	registryauth "github.com/quay/quay/internal/registry/auth"
+)
+
+const (
+	registryTokenLifetime  = 5 * time.Minute
+	registryTokenClockSkew = 5 * time.Second
+)
+
+// AuthenticationConfig configures registry token issuance and authorization.
+type AuthenticationConfig struct {
+	Scheme               string
+	Service              string
+	LibraryNamespace     string
+	AnonymousAccess      bool
+	MaxTokenFreshness    time.Duration
+	SuperUsers           []string
+	SuperUsersFullAccess bool
+}
+
+// Authentication holds the shared registry access controller and token endpoint.
+type Authentication struct {
+	Controller   *registryauth.Controller
+	TokenHandler http.Handler
+}
+
+// NewAuthentication constructs the complete registry bearer-token flow.
+func NewAuthentication(db *sql.DB, credentialVerifier quayauth.Verifier, cfg *AuthenticationConfig) (*Authentication, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("nil authentication config")
+	}
+	if credentialVerifier == nil {
+		return nil, fmt.Errorf("nil credential verifier")
+	}
+
+	grantResolver, err := NewGrantResolver(db, GrantResolverConfig{
+		LibraryNamespace: cfg.LibraryNamespace, SuperUsers: cfg.SuperUsers,
+		SuperUsersFullAccess: cfg.SuperUsersFullAccess,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create registry grant resolver: %w", err)
+	}
+
+	signer, verifier, err := registryauth.NewES256Pair(registryauth.ES256Config{
+		Issuer: registryauth.Issuer, Audience: cfg.Service,
+		MaxFresh: cfg.MaxTokenFreshness, ClockSkew: registryTokenClockSkew,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create registry token keys: %w", err)
+	}
+	realm := (&url.URL{Scheme: cfg.Scheme, Host: cfg.Service, Path: "/v2/auth"}).String()
+	controller, err := registryauth.NewController(registryauth.ControllerConfig{
+		Realm: realm, Service: cfg.Service, LibraryNamespace: cfg.LibraryNamespace, Verifier: verifier,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create registry access controller: %w", err)
+	}
+
+	tokenLifetime := min(registryTokenLifetime, cfg.MaxTokenFreshness)
+	tokenHandler, err := registryauth.NewHandler(&registryauth.HandlerConfig{
+		Service: cfg.Service, LibraryNamespace: cfg.LibraryNamespace,
+		AnonymousAccess: cfg.AnonymousAccess, Lifetime: tokenLifetime, Signer: signer,
+		Authenticate: func(ctx context.Context, username, secret string) (registryauth.Identity, bool) {
+			result := credentialVerifier.Verify(ctx, quayauth.Credentials{Username: username, Secret: secret})
+			if !result.Authenticated {
+				return registryauth.Identity{}, false
+			}
+			principal := result.Principal
+			return registryauth.Identity{Subject: principal.Username, Principal: &principal}, true
+		},
+		ResolveGrants: grantResolver.Resolve,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create registry token handler: %w", err)
+	}
+
+	return &Authentication{Controller: controller, TokenHandler: tokenHandler}, nil
+}

--- a/internal/registry/distribution/authentication_test.go
+++ b/internal/registry/distribution/authentication_test.go
@@ -1,0 +1,63 @@
+package distribution
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	distauth "github.com/distribution/distribution/v3/registry/auth"
+	quayauth "github.com/quay/quay/internal/auth"
+	_ "modernc.org/sqlite"
+)
+
+type authenticationVerifierStub struct{}
+
+func (authenticationVerifierStub) Verify(_ context.Context, credentials quayauth.Credentials) quayauth.Result {
+	return quayauth.Result{Username: credentials.Username, Presented: true}
+}
+
+func TestNewAuthenticationComposesRegistryTokenFlow(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	authentication, err := NewAuthentication(db, authenticationVerifierStub{}, &AuthenticationConfig{
+		Scheme: "https", Service: "registry.example.com:8443", LibraryNamespace: "library",
+		AnonymousAccess: true, MaxTokenFreshness: 10 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authentication.Controller == nil || authentication.TokenHandler == nil {
+		t.Fatalf("authentication = %#v", authentication)
+	}
+
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/", http.NoBody)
+	_, err = authentication.Controller.Authorized(request)
+	var challenge distauth.Challenge
+	if !errors.As(err, &challenge) {
+		t.Fatalf("challenge error = %v", err)
+	}
+	response := httptest.NewRecorder()
+	challenge.SetHeaders(request, response)
+	if header := response.Header().Get("WWW-Authenticate"); !strings.Contains(header, `realm="https://registry.example.com:8443/v2/auth"`) ||
+		!strings.Contains(header, `service="registry.example.com:8443"`) {
+		t.Fatalf("WWW-Authenticate = %q", header)
+	}
+}
+
+func TestNewAuthenticationRejectsMissingDependencies(t *testing.T) {
+	if _, err := NewAuthentication(nil, authenticationVerifierStub{}, nil); err == nil {
+		t.Fatal("expected nil config error")
+	}
+	if _, err := NewAuthentication(nil, nil, &AuthenticationConfig{}); err == nil {
+		t.Fatal("expected nil verifier error")
+	}
+}

--- a/internal/registry/referrers.go
+++ b/internal/registry/referrers.go
@@ -2,21 +2,18 @@
 package registry
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"regexp"
 	"strings"
 
+	distauth "github.com/distribution/distribution/v3/registry/auth"
 	"github.com/opencontainers/go-digest"
 
-	"github.com/quay/quay/internal/auth"
-	"github.com/quay/quay/internal/dal/daldb"
 	"github.com/quay/quay/internal/oci"
-	"github.com/quay/quay/internal/repository"
-	repositorydal "github.com/quay/quay/internal/repository/dal"
 )
 
 const (
@@ -31,29 +28,19 @@ var (
 
 // ReferrersConfig holds the configuration for the referrers handler.
 type ReferrersConfig struct {
-	LibraryNamespace                   string
-	AnonymousAccess                    bool
-	LibrarySupport                     bool
-	DatabaseSecretKey                  string
-	RobotsDisallow                     bool
-	RobotsWhitelist                    []string
-	FeatureUserLastAccessed            bool
-	LastAccessedUpdateThresholdSeconds int
-	SuperUsers                         []string
-	SuperUsersFullAccess               bool
+	LibraryNamespace string
+	LibrarySupport   bool
 }
 
 // ReferrersHandler serves the OCI referrers API.
 type ReferrersHandler struct {
-	store         oci.MetadataStore
-	authenticator *auth.BasicAuthenticator
-	authorizer    *repositorydal.Authorizer
-	queries       *daldb.Queries
-	config        ReferrersConfig
+	store      oci.MetadataStore
+	controller distauth.AccessController
+	config     ReferrersConfig
 }
 
 // NewReferrersHandler creates a handler for GET /v2/{name}/referrers/{digest}.
-func NewReferrersHandler(db *sql.DB, store oci.MetadataStore, cfg *ReferrersConfig) *ReferrersHandler {
+func NewReferrersHandler(store oci.MetadataStore, controller distauth.AccessController, cfg *ReferrersConfig) *ReferrersHandler {
 	config := ReferrersConfig{}
 	if cfg != nil {
 		config = *cfg
@@ -62,20 +49,7 @@ func NewReferrersHandler(db *sql.DB, store oci.MetadataStore, cfg *ReferrersConf
 		config.LibraryNamespace = defaultLibraryNamespace
 	}
 	return &ReferrersHandler{
-		store: store,
-		authenticator: auth.NewBasicAuthenticator(auth.NewDatabaseVerifier(db, auth.DatabaseVerifierConfig{
-			DatabaseSecretKey:              config.DatabaseSecretKey,
-			RobotsDisallow:                 config.RobotsDisallow,
-			RobotsWhitelist:                config.RobotsWhitelist,
-			FeatureUserLastAccessed:        config.FeatureUserLastAccessed,
-			LastAccessedUpdateThresholdSec: config.LastAccessedUpdateThresholdSeconds,
-		})),
-		authorizer: repositorydal.NewAuthorizer(db, repositorydal.AuthorizerConfig{
-			SuperUsers:           config.SuperUsers,
-			SuperUsersFullAccess: config.SuperUsersFullAccess,
-		}),
-		queries: daldb.New(db),
-		config:  config,
+		store: store, controller: controller, config: config,
 	}
 }
 
@@ -106,9 +80,15 @@ func (h *ReferrersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.authorize(r, namespace, repo) {
-		w.Header().Set("WWW-Authenticate", `Basic realm="quay"`)
-		writeOCIError(w, http.StatusUnauthorized, "UNAUTHORIZED", "authentication required")
+	if err := h.authorize(r, namespace, repo); err != nil {
+		var challenge distauth.Challenge
+		if errors.As(err, &challenge) {
+			challenge.SetHeaders(r, w)
+			writeOCIError(w, http.StatusUnauthorized, "UNAUTHORIZED", "authentication required")
+			return
+		}
+		slog.Error("referrers authorization failed", "repository", name, "err", err) //nolint:gosec // structured logging, not injection
+		writeOCIError(w, http.StatusInternalServerError, "UNKNOWN", "internal error")
 		return
 	}
 
@@ -173,60 +153,15 @@ func (h *ReferrersHandler) splitName(name string) (namespace, repo string) {
 	return name[:i], name[i+1:]
 }
 
-func (h *ReferrersHandler) authorize(r *http.Request, namespace, repo string) bool {
-	if h.authenticator == nil {
-		return h.config.AnonymousAccess
+func (h *ReferrersHandler) authorize(r *http.Request, namespace, repo string) error {
+	if h.controller == nil {
+		return fmt.Errorf("nil access controller")
 	}
-	result := h.authenticator.Authenticate(r)
-	if result.Authenticated {
-		return h.canPullRepository(r, &result.Principal, namespace, repo)
-	}
-	if result.Presented {
-		return false
-	}
-	if h.config.AnonymousAccess && h.queries != nil {
-		isPublic, err := h.queries.RepositoryIsPublicByNamespaceName(r.Context(), daldb.RepositoryIsPublicByNamespaceNameParams{
-			Username: namespace,
-			Name:     repo,
-		})
-		if err == nil && isPublic != 0 {
-			return true
-		}
-	}
-	return false
-}
-
-func (h *ReferrersHandler) canPullRepository(r *http.Request, principal *auth.Principal, namespace, repoName string) bool {
-	if h.queries == nil || h.authorizer == nil {
-		return false
-	}
-
-	row, err := h.queries.GetRepositoryAccessByNamespaceName(r.Context(), daldb.GetRepositoryAccessByNamespaceNameParams{
-		Username: namespace,
-		Name:     repoName,
+	_, err := h.controller.Authorized(r, distauth.Access{
+		Resource: distauth.Resource{Type: "repository", Name: namespace + "/" + repo},
+		Action:   "pull",
 	})
-	if err != nil {
-		slog.Debug("referrers repository lookup failed", "namespace", namespace, "repository", repoName, "err", err)
-		return false
-	}
-
-	repo := repository.Repository{
-		ID: row.ID,
-		Ref: repository.Ref{
-			Namespace: row.Namespace,
-			Name:      row.Name,
-		},
-		Visibility:       repository.Visibility(row.Visibility),
-		State:            row.State,
-		KindID:           row.KindID,
-		NamespaceEnabled: row.NamespaceEnabled,
-	}
-	allowed, err := h.authorizer.CanPullRepository(r.Context(), principal, &repo)
-	if err != nil {
-		slog.Debug("referrers pull authorization failed", "namespace", namespace, "repository", repoName, "err", err)
-		return false
-	}
-	return allowed
+	return err
 }
 
 type ociIndex struct {

--- a/internal/registry/referrers.go
+++ b/internal/registry/referrers.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 
-	distauth "github.com/distribution/distribution/v3/registry/auth"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/quay/quay/internal/oci"
@@ -35,12 +34,17 @@ type ReferrersConfig struct {
 // ReferrersHandler serves the OCI referrers API.
 type ReferrersHandler struct {
 	store      oci.MetadataStore
-	controller distauth.AccessController
+	controller RepositoryAccessController
 	config     ReferrersConfig
 }
 
+// RepositoryAccessController authorizes one action against a repository.
+type RepositoryAccessController interface {
+	AuthorizeRepository(req *http.Request, name, action string) error
+}
+
 // NewReferrersHandler creates a handler for GET /v2/{name}/referrers/{digest}.
-func NewReferrersHandler(store oci.MetadataStore, controller distauth.AccessController, cfg *ReferrersConfig) *ReferrersHandler {
+func NewReferrersHandler(store oci.MetadataStore, controller RepositoryAccessController, cfg *ReferrersConfig) *ReferrersHandler {
 	config := ReferrersConfig{}
 	if cfg != nil {
 		config = *cfg
@@ -81,7 +85,7 @@ func (h *ReferrersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.authorize(r, namespace, repo); err != nil {
-		var challenge distauth.Challenge
+		var challenge authenticationChallenge
 		if errors.As(err, &challenge) {
 			challenge.SetHeaders(r, w)
 			writeOCIError(w, http.StatusUnauthorized, "UNAUTHORIZED", "authentication required")
@@ -157,11 +161,12 @@ func (h *ReferrersHandler) authorize(r *http.Request, namespace, repo string) er
 	if h.controller == nil {
 		return fmt.Errorf("nil access controller")
 	}
-	_, err := h.controller.Authorized(r, distauth.Access{
-		Resource: distauth.Resource{Type: "repository", Name: namespace + "/" + repo},
-		Action:   "pull",
-	})
-	return err
+	return h.controller.AuthorizeRepository(r, namespace+"/"+repo, "pull")
+}
+
+type authenticationChallenge interface {
+	error
+	SetHeaders(*http.Request, http.ResponseWriter)
 }
 
 type ociIndex struct {

--- a/internal/registry/referrers_test.go
+++ b/internal/registry/referrers_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	distauth "github.com/distribution/distribution/v3/registry/auth"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/quay/quay/internal/oci"
@@ -76,22 +75,21 @@ func (m *mockStore) CleanExpiredUploadedBlobs(context.Context) error { return ni
 // --- tests ---
 
 type accessControllerStub struct {
-	err        error
-	lastAccess []distauth.Access
+	err            error
+	lastRepository string
+	lastAction     string
 }
 
-func (s *accessControllerStub) Authorized(_ *http.Request, access ...distauth.Access) (*distauth.Grant, error) {
-	s.lastAccess = access
-	if s.err != nil {
-		return nil, s.err
-	}
-	return &distauth.Grant{User: distauth.UserInfo{Name: "test-user"}}, nil
+func (s *accessControllerStub) AuthorizeRepository(_ *http.Request, name, action string) error {
+	s.lastRepository = name
+	s.lastAction = action
+	return s.err
 }
 
-type challengeStub struct{}
+type challengeStubError struct{}
 
-func (challengeStub) Error() string { return "authorization required" }
-func (challengeStub) SetHeaders(_ *http.Request, w http.ResponseWriter) {
+func (challengeStubError) Error() string { return "authorization required" }
+func (challengeStubError) SetHeaders(_ *http.Request, w http.ResponseWriter) {
 	w.Header().Set("WWW-Authenticate", `Bearer realm="https://registry.example/v2/auth",service="registry.example"`)
 }
 
@@ -118,7 +116,7 @@ func TestNewReferrersHandlerUsesSharedController(t *testing.T) {
 }
 
 func TestReferrersAuthorizationChallengeSetsBearerHeader(t *testing.T) {
-	controller := &accessControllerStub{err: challengeStub{}}
+	controller := &accessControllerStub{err: challengeStubError{}}
 	handler := NewReferrersHandler(&mockStore{repoID: 10}, controller, &ReferrersConfig{LibrarySupport: true})
 	subjectDgst := digest.FromString("subject")
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/acme/private/referrers/"+subjectDgst.String(), http.NoBody)
@@ -132,9 +130,8 @@ func TestReferrersAuthorizationChallengeSetsBearerHeader(t *testing.T) {
 	if got := w.Header().Get("WWW-Authenticate"); got != `Bearer realm="https://registry.example/v2/auth",service="registry.example"` {
 		t.Fatalf("challenge = %q", got)
 	}
-	if len(controller.lastAccess) != 1 || controller.lastAccess[0].Type != "repository" ||
-		controller.lastAccess[0].Name != "acme/private" || controller.lastAccess[0].Action != "pull" {
-		t.Fatalf("access = %#v", controller.lastAccess)
+	if controller.lastRepository != "acme/private" || controller.lastAction != "pull" {
+		t.Fatalf("repository = %q, action = %q", controller.lastRepository, controller.lastAction)
 	}
 }
 

--- a/internal/registry/referrers_test.go
+++ b/internal/registry/referrers_test.go
@@ -2,18 +2,16 @@ package registry
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	distauth "github.com/distribution/distribution/v3/registry/auth"
 	"github.com/opencontainers/go-digest"
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/quay/quay/internal/oci"
-	_ "modernc.org/sqlite"
 )
 
 // --- mock store ---
@@ -77,97 +75,53 @@ func (m *mockStore) CleanExpiredUploadedBlobs(context.Context) error { return ni
 
 // --- tests ---
 
+type accessControllerStub struct {
+	err        error
+	lastAccess []distauth.Access
+}
+
+func (s *accessControllerStub) Authorized(_ *http.Request, access ...distauth.Access) (*distauth.Grant, error) {
+	s.lastAccess = access
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &distauth.Grant{User: distauth.UserInfo{Name: "test-user"}}, nil
+}
+
+type challengeStub struct{}
+
+func (challengeStub) Error() string { return "authorization required" }
+func (challengeStub) SetHeaders(_ *http.Request, w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Bearer realm="https://registry.example/v2/auth",service="registry.example"`)
+}
+
 func newTestHandler(store oci.MetadataStore) *ReferrersHandler {
 	return &ReferrersHandler{
-		store:  store,
-		config: ReferrersConfig{LibraryNamespace: "library", AnonymousAccess: true, LibrarySupport: true},
+		store:      store,
+		controller: &accessControllerStub{},
+		config:     ReferrersConfig{LibraryNamespace: "library", LibrarySupport: true},
 	}
 }
 
-func TestNewReferrersHandlerConstructsDatabaseVerifier(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
-	defer db.Close()
-
-	handler := NewReferrersHandler(db, &mockStore{}, &ReferrersConfig{
-		AnonymousAccess:                    true,
-		LibrarySupport:                     true,
-		DatabaseSecretKey:                  "test1234",
-		RobotsDisallow:                     true,
-		RobotsWhitelist:                    []string{"acme+deploy"},
-		FeatureUserLastAccessed:            true,
-		LastAccessedUpdateThresholdSeconds: 60,
-	})
-
+func TestNewReferrersHandlerUsesSharedController(t *testing.T) {
+	controller := &accessControllerStub{}
+	handler := NewReferrersHandler(&mockStore{}, controller, &ReferrersConfig{LibrarySupport: true})
 	if handler == nil {
 		t.Fatal("expected handler")
 	}
-	if handler.authenticator == nil {
-		t.Fatal("expected database-backed authenticator")
-	}
-	if handler.queries == nil {
-		t.Fatal("expected database queries")
+	if handler.controller != controller {
+		t.Fatal("handler did not retain the shared controller")
 	}
 	if handler.config.LibraryNamespace != defaultLibraryNamespace {
 		t.Fatalf("library namespace = %q, want default %q", handler.config.LibraryNamespace, defaultLibraryNamespace)
 	}
 }
 
-func setupReferrersAuthDB(t *testing.T) *sql.DB {
-	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
-	db.SetMaxOpenConns(1)
-
-	statements := []string{
-		`CREATE TABLE "user" (id INTEGER PRIMARY KEY, uuid VARCHAR(36), username VARCHAR(255) NOT NULL, password_hash VARCHAR(255), email VARCHAR(255) NOT NULL, verified INTEGER NOT NULL DEFAULT 0, organization INTEGER NOT NULL DEFAULT 0, robot INTEGER NOT NULL DEFAULT 0, enabled INTEGER NOT NULL DEFAULT 1, last_accessed DATETIME)`,
-		`CREATE TABLE visibility (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
-		`CREATE TABLE repository (id INTEGER PRIMARY KEY, namespace_user_id INTEGER, name VARCHAR(255) NOT NULL, visibility_id INTEGER NOT NULL, kind_id INTEGER NOT NULL DEFAULT 1, state INTEGER NOT NULL DEFAULT 0)`,
-		`CREATE TABLE role (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
-		`CREATE TABLE teamrole (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL)`,
-		`CREATE TABLE team (id INTEGER PRIMARY KEY, name VARCHAR(255) NOT NULL, organization_id INTEGER NOT NULL, role_id INTEGER NOT NULL, description TEXT NOT NULL)`,
-		`CREATE TABLE teammember (id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, team_id INTEGER NOT NULL)`,
-		`CREATE TABLE repositorypermission (id INTEGER PRIMARY KEY, team_id INTEGER, user_id INTEGER, repository_id INTEGER NOT NULL, role_id INTEGER NOT NULL)`,
-		`CREATE TABLE repomirrorconfig (id INTEGER PRIMARY KEY, repository_id INTEGER NOT NULL, internal_robot_id INTEGER)`,
-		`CREATE TABLE orgmirrorconfig (id INTEGER PRIMARY KEY, organization_id INTEGER NOT NULL, internal_robot_id INTEGER)`,
-		`CREATE TABLE orgmirrorrepository (id INTEGER PRIMARY KEY, org_mirror_config_id INTEGER NOT NULL, repository_id INTEGER)`,
-		`INSERT INTO visibility (id, name) VALUES (1, 'public'), (2, 'private')`,
-		`INSERT INTO role (id, name) VALUES (1, 'read'), (2, 'write'), (3, 'admin')`,
-		`INSERT INTO teamrole (id, name) VALUES (1, 'admin'), (2, 'creator'), (3, 'member')`,
-		`INSERT INTO "user" (id, uuid, username, password_hash, email, verified, organization, robot, enabled) VALUES (2, 'org-acme', 'acme', NULL, 'acme@example.com', 1, 1, 0, 1)`,
-		`INSERT INTO repository (id, namespace_user_id, name, visibility_id, kind_id, state) VALUES (10, 2, 'private', 2, 1, 0)`,
-	}
-	for _, stmt := range statements {
-		if _, err := db.ExecContext(t.Context(), stmt); err != nil {
-			t.Fatalf("exec %q: %v", stmt, err)
-		}
-	}
-
-	hash, err := bcrypt.GenerateFromPassword([]byte("correct-password"), bcrypt.MinCost)
-	if err != nil {
-		t.Fatalf("bcrypt: %v", err)
-	}
-	if _, err := db.ExecContext(t.Context(), `INSERT INTO "user" (id, uuid, username, password_hash, email, verified, organization, robot, enabled) VALUES (1, 'user-admin', 'admin', ?, 'admin@example.com', 1, 0, 0, 1)`, string(hash)); err != nil {
-		t.Fatalf("insert admin: %v", err)
-	}
-	return db
-}
-
-func TestReferrers_AuthenticatedUserRequiresPullPermission(t *testing.T) {
-	db := setupReferrersAuthDB(t)
-	defer db.Close()
-
-	handler := NewReferrersHandler(db, &mockStore{repoID: 10}, &ReferrersConfig{
-		AnonymousAccess: false,
-		LibrarySupport:  true,
-	})
+func TestReferrersAuthorizationChallengeSetsBearerHeader(t *testing.T) {
+	controller := &accessControllerStub{err: challengeStub{}}
+	handler := NewReferrersHandler(&mockStore{repoID: 10}, controller, &ReferrersConfig{LibrarySupport: true})
 	subjectDgst := digest.FromString("subject")
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/acme/private/referrers/"+subjectDgst.String(), http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -175,22 +129,21 @@ func TestReferrers_AuthenticatedUserRequiresPullPermission(t *testing.T) {
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
 	}
+	if got := w.Header().Get("WWW-Authenticate"); got != `Bearer realm="https://registry.example/v2/auth",service="registry.example"` {
+		t.Fatalf("challenge = %q", got)
+	}
+	if len(controller.lastAccess) != 1 || controller.lastAccess[0].Type != "repository" ||
+		controller.lastAccess[0].Name != "acme/private" || controller.lastAccess[0].Action != "pull" {
+		t.Fatalf("access = %#v", controller.lastAccess)
+	}
 }
 
-func TestReferrers_AuthenticatedUserWithPullPermissionAllowed(t *testing.T) {
-	db := setupReferrersAuthDB(t)
-	defer db.Close()
-	if _, err := db.ExecContext(t.Context(), `INSERT INTO repositorypermission (id, user_id, repository_id, role_id) VALUES (1, 1, 10, 1)`); err != nil {
-		t.Fatalf("insert permission: %v", err)
-	}
-
-	handler := NewReferrersHandler(db, &mockStore{repoID: 10}, &ReferrersConfig{
-		AnonymousAccess: false,
-		LibrarySupport:  true,
-	})
+func TestReferrersSharedControllerGrantAllowed(t *testing.T) {
+	controller := &accessControllerStub{}
+	handler := NewReferrersHandler(&mockStore{repoID: 10}, controller, &ReferrersConfig{LibrarySupport: true})
 	subjectDgst := digest.FromString("subject")
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v2/acme/private/referrers/"+subjectDgst.String(), http.NoBody)
-	req.SetBasicAuth("admin", "correct-password")
+	req.Header.Set("Authorization", "Bearer shared-token")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)

--- a/internal/server/tls.go
+++ b/internal/server/tls.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"path/filepath"
 
@@ -12,6 +13,7 @@ import (
 const defaultHostname = "localhost"
 
 func ensureTLS(hostname, certDir string, srv *http.Server) (certPath, keyPath string, err error) {
+	hostname = certificateHostname(hostname)
 	certPath = filepath.Join(certDir, "ssl.cert")
 	keyPath = filepath.Join(certDir, "ssl.key")
 
@@ -27,4 +29,11 @@ func ensureTLS(hostname, certDir string, srv *http.Server) (certPath, keyPath st
 
 	srv.TLSConfig = certs.SecureTLSConfig()
 	return certPath, keyPath, nil
+}
+
+func certificateHostname(serverHostname string) string {
+	if host, _, err := net.SplitHostPort(serverHostname); err == nil {
+		return host
+	}
+	return serverHostname
 }

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -1,0 +1,18 @@
+package server
+
+import "testing"
+
+func TestCertificateHostnameStripsPublishedPort(t *testing.T) {
+	tests := map[string]string{
+		"registry.example.com":      "registry.example.com",
+		"registry.example.com:8443": "registry.example.com",
+		"192.0.2.1:9443":            "192.0.2.1",
+		"[2001:db8::1]:8443":        "2001:db8::1",
+		"2001:db8::1":               "2001:db8::1",
+	}
+	for input, want := range tests {
+		if got := certificateHostname(input); got != want {
+			t.Errorf("certificateHostname(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/internal/system/quadlet.go
+++ b/internal/system/quadlet.go
@@ -3,6 +3,7 @@ package system
 import (
 	"bufio"
 	"fmt"
+	"net"
 	"strings"
 )
 
@@ -71,7 +72,7 @@ func quadletServeCommand(spec *QuadletSpec) string {
 	if spec.ConfigPath != "" {
 		return fmt.Sprintf("serve --config %s --hostname %s", spec.ConfigPath, spec.Hostname)
 	}
-	return fmt.Sprintf("serve --data-dir /data --hostname %s", spec.Hostname)
+	return fmt.Sprintf("serve --data-dir /data --hostname %s", net.JoinHostPort(spec.Hostname, spec.Port))
 }
 
 // HostPort returns the host port published by an existing Quadlet file.
@@ -122,7 +123,11 @@ func (q *QuadletManager) Hostname(service string) (string, error) {
 			if i+1 >= len(fields) || fields[i+1] == "" {
 				return "", fmt.Errorf("invalid hostname flag in Exec= directive in %s", path)
 			}
-			return fields[i+1], nil
+			hostname := fields[i+1]
+			if host, _, err := net.SplitHostPort(hostname); err == nil {
+				return host, nil
+			}
+			return hostname, nil
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -161,6 +166,8 @@ func (q *QuadletManager) UpdateImageAndPort(service, newImage, hostPort string) 
 		case strings.HasPrefix(line, "PublishPort="):
 			updated = append(updated, "PublishPort="+hostPort+":"+registryContainerPort)
 			foundPort = true
+		case strings.HasPrefix(line, "Exec="):
+			updated = append(updated, updatePublishedPort(line, hostPort))
 		default:
 			updated = append(updated, line)
 		}
@@ -175,4 +182,20 @@ func (q *QuadletManager) UpdateImageAndPort(service, newImage, hostPort string) 
 		return fmt.Errorf("no PublishPort= directive found in %s", path)
 	}
 	return q.fs.WriteFile(path, []byte(strings.Join(updated, "\n")+"\n"), 0o600)
+}
+
+func updatePublishedPort(line, hostPort string) string {
+	fields := strings.Fields(strings.TrimPrefix(line, "Exec="))
+	for i := 0; i+1 < len(fields); i++ {
+		if fields[i] != "--hostname" {
+			continue
+		}
+		hostname := fields[i+1]
+		if host, _, err := net.SplitHostPort(hostname); err == nil {
+			hostname = host
+		}
+		fields[i+1] = net.JoinHostPort(hostname, hostPort)
+		break
+	}
+	return "Exec=" + strings.Join(fields, " ")
 }

--- a/internal/system/quadlet_test.go
+++ b/internal/system/quadlet_test.go
@@ -49,7 +49,7 @@ func TestQuadletInstallUsesDefaultServeArgsWithoutConfigPath(t *testing.T) {
 	}
 
 	content := readQuadletTestFile(t, env.QuadletPath("quay"))
-	if !strings.Contains(content, "Exec=serve --data-dir /data --hostname localhost") {
+	if !strings.Contains(content, "Exec=serve --data-dir /data --hostname localhost:8443") {
 		t.Fatalf("quadlet does not use default serve args:\n%s", content)
 	}
 }
@@ -71,6 +71,55 @@ func TestQuadletInstallMapsCustomHostPortToRegistryPort(t *testing.T) {
 	content := readQuadletTestFile(t, env.QuadletPath("quay"))
 	if !strings.Contains(content, "PublishPort=9443:8443") {
 		t.Fatalf("quadlet does not map the custom host port to the registry port:\n%s", content)
+	}
+	if !strings.Contains(content, "--hostname localhost:9443") {
+		t.Fatalf("quadlet does not advertise the custom host port:\n%s", content)
+	}
+}
+
+func TestQuadletUpdateKeepsServerHostnameInSyncWithPublishedPort(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+
+	err := manager.Install("quay", &QuadletSpec{
+		Image:    "localhost/quay:old",
+		DataDir:  "/var/lib/quay",
+		Hostname: "registry.example.com",
+		Port:     "8443",
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if err := manager.UpdateImageAndPort("quay", "localhost/quay:new", "9443"); err != nil {
+		t.Fatalf("UpdateImageAndPort: %v", err)
+	}
+
+	content := readQuadletTestFile(t, env.QuadletPath("quay"))
+	if !strings.Contains(content, "Image=localhost/quay:new") ||
+		!strings.Contains(content, "PublishPort=9443:8443") ||
+		!strings.Contains(content, "--hostname registry.example.com:9443") {
+		t.Fatalf("quadlet update did not keep public endpoint in sync:\n%s", content)
+	}
+}
+
+func TestQuadletUpdateAddsPublishedPortToLegacyDefaultCommand(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+	path := env.QuadletPath("quay")
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	legacy := "[Container]\nImage=localhost/quay:old\nPublishPort=8443:8443\nExec=serve --data-dir /data --hostname registry.example.com\n"
+	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := manager.UpdateImageAndPort("quay", "localhost/quay:new", "9443"); err != nil {
+		t.Fatalf("UpdateImageAndPort: %v", err)
+	}
+	content := readQuadletTestFile(t, path)
+	if !strings.Contains(content, "--hostname registry.example.com:9443") {
+		t.Fatalf("legacy command was not upgraded with public endpoint:\n%s", content)
 	}
 }
 


### PR DESCRIPTION
## Summary
Add Docker Registry v2 bearer-token authentication to the Go OMR registry, replacing direct Basic authentication on registry data paths. Tokens are short-lived, ES256-signed, and downscoped through Quay repository permissions.

## Related Issue
NO-ISSUE: completes the Go OMR registry authentication flow described by the implementation handoff.

## Changes
- Add `/v2/auth` exchanges for human, robot, and anonymous identities.
- Share strict bearer-token authorization across Distribution and the referrers endpoint.
- Generate process-ephemeral ES256 keys and validate token headers, claims, audience, freshness, and access grants.
- Preserve Quay repository creation, mirror, read-only, deletion, and superuser authorization semantics.
- Keep `SERVER_HOSTNAME` as the canonical public registry authority, including its published port.
- Bound token scope query size and unique scope count before database authorization.
- Add `REGISTRY_JWT_AUTH_MAX_FRESH_S` configuration with validation and defaults.

## Testing
- [x] `GOCACHE=/tmp/quay-go-cache go test -count=1 ./internal/...`
- [x] `GOCACHE=/tmp/quay-go-cache go test -race -count=1 ./internal/registry/auth ./internal/registry/distribution ./internal/system ./internal/server`
- [x] `GOCACHE=/tmp/quay-go-cache go vet ./internal/...`
- [x] Commit-time pre-commit hooks pass.

## Notes
No database migrations or new dependencies. Issued tokens are capped at five minutes and are intentionally invalidated when the process restarts.
