### PR TITLE
PROJQUAY-12230: fix(quota): cast usage_bytes to int to prevent Decimal JSON serialization failure

### DIFF
--- a/data/model/repository.py
+++ b/data/model/repository.py
@@ -751,4 +751,4 @@ def get_size_during_upload(repo_id: int):
         )
     ).get()
 
-    return query.size_bytes if query.size_bytes is not None else 0
+    return int(query.size_bytes) if query.size_bytes is not None else 0

--- a/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
@@ -70,9 +70,10 @@ test.describe(
           expect(webhook?.body).toHaveProperty('event_data');
 
           // PROJQUAY-12230: verify numeric fields are serialized correctly
-          // (Decimal from PostgreSQL must be cast to int before json.dumps)
+          // (Decimal from PostgreSQL SUM()/BigIntegerField must be cast to int before json.dumps)
           expect(typeof webhook?.body?.limit_bytes).toBe('number');
           expect(typeof webhook?.body?.usage_bytes).toBe('number');
+          expect(typeof webhook?.body?.usage_percent).toBe('number');
         } finally {
           await receiver.stop();
         }


### PR DESCRIPTION
## Summary
- PR #6523 fixed `quota.limit_bytes` Decimal serialization but missed `usage_bytes`
- `get_size_during_upload()` uses `fn.Sum(BlobUpload.byte_count)` which returns `Decimal` from PostgreSQL's `SUM()`
- This `Decimal` propagates into the quota notification payload and causes `json.dumps()` to fail with `TypeError: Object of type Decimal is not JSON serializable`
- Fixed by casting the return value of `get_size_during_upload()` to `int`

## Root cause
```
gunicorn-registry | ERROR | Failed to trigger quota notification for namespace quayqe
  File "data/model/namespacequota.py", line 342, in _do_trigger_quota_notification
    enqueued = spawn_namespace_notification(
  File "notifications/__init__.py", line 159, in spawn_namespace_notification
    notification_queue.put(path, json.dumps(notification_data))
TypeError: Object of type Decimal is not JSON serializable
```

## Validation testing is passed via Webhook and Email:
<img width="2343" height="1186" alt="image" src="https://github.com/user-attachments/assets/f8ee81b6-5d63-4949-af08-ee2971179236" />
<img width="2082" height="512" alt="image" src="https://github.com/user-attachments/assets/a4863f98-0a41-4dc4-9642-34045061593d" />



## Test plan
- [x] Set a storage quota on a namespace (e.g. 100MB)
- [x] Configure a Quota Warning and Quota Error namespace notification
- [x] Push an image that exceeds the quota
- [x] Verify no `TypeError: Object of type Decimal is not JSON serializable` in Quay pod logs
- [x] Verify the notification is delivered successfully

JIRA: https://redhat.atlassian.net/browse/PROJQUAY-12230

🤖 Generated with [Claude Code](https://claude.ai/code)