### PR TITLE
[redhat-3.18] PROJQUAY-12346: chore(deps): upgrade pyasn1 from 0.6.3 to 0.6.4 to address CVE-2026-59886

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
     -   id: requirements-pinned
         name: Check requirements.txt is pinned
-        entry: bash -euo pipefail -c 'while IFS= read -r i; do case "$i" in ""|\\#*|-r*|--*) continue;; esac; if [[ "$i" != *"=="* && "$i" != *"@"* ]]; then echo "$i is not pinned"; exit 1; fi; done < requirements.txt'
+        entry: bash -euo pipefail -c 'while IFS= read -r i; do case "$i" in ""|"#"*|-r*|--*) continue;; esac; if [[ "$i" != *"=="* && "$i" != *"@"* ]]; then echo "$i is not pinned"; exit 1; fi; done < requirements.txt'
         language: system
         files: requirements.txt
         pass_filenames: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ prometheus_client==0.7.1
 protobuf==5.29.5
 psutil==5.9.0
 psycopg2==2.9.9
-pyasn1==0.6.3
+pyasn1==0.6.4
 pyasn1_modules==0.4.2
 py-bitbucket @ git+https://github.com/quay/py-bitbucket.git@3ba167408d92eb4ba2cae78c0047b8f1e8821c67
 PyGithub==2.1.1

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -20,8 +20,7 @@ const execFileAsync = promisify(execFile);
 // Extract registry host from API_URL (e.g., 'localhost:8080')
 const REGISTRY_HOST = new URL(API_URL).host;
 
-const BUSYBOX_IMAGE =
-  'quay.io/prometheus/busybox@sha256:467c84e76e5bd720ffd3cb86c11e421e2489ef20868114ba58cd0a9e02e70a9d';
+const BUSYBOX_IMAGE = 'quay.io/prometheus/busybox:latest';
 
 type ToolAvailability = {
   skopeo: boolean;


### PR DESCRIPTION
1. chore(deps): upgrade pyasn1 from 0.6.3 to 0.6.4 to address CVE-2026-59885,CVE-2026-59886
2. Fix requirements-pinned hook to correctly skip comment lines by replacing broken \#* case pattern with "#"*
3. use busybox :latest tag instead of pinned digest
https://redhat.atlassian.net/browse/PROJQUAY-12346