### PR TITLE
PROJQUAY-11202: fix(ui): match domainRoute keywords as path segments

### DIFF
--- a/web/playwright/e2e/organization/teams-and-membership.spec.ts
+++ b/web/playwright/e2e/organization/teams-and-membership.spec.ts
@@ -272,4 +272,72 @@ test.describe('Teams and Membership', {tag: ['@organization']}, () => {
       team.name,
     );
   });
+
+  // Org-name keyword cases that break getTeamMemberPath when domainRoute's
+  // organization branch is active (current path is /organization/...).
+  // overview/repository/signin substrings on this path do not exercise those
+  // regex branches — see repository-list coverage for the repository branch.
+  const keywordOrgPrefixes = [
+    'testorganization',
+    'organization',
+    'organizationtest2',
+  ] as const;
+
+  for (const orgPrefix of keywordOrgPrefixes) {
+    test(
+      `team and members links stay correct for org name prefix "${orgPrefix}"`,
+      {tag: ['@PROJQUAY-11202']},
+      async ({authenticatedPage, api}) => {
+        const org = await api.organization(orgPrefix);
+        const team = await api.team(org.name, 'keywordnav');
+        await api.teamMember(org.name, team.name, TEST_USERS.user.username);
+
+        const expectedTeamPath = `/organization/${org.name}/teams/${team.name}`;
+
+        async function clickTeamLinkAndAssertPath(
+          link: ReturnType<typeof authenticatedPage.getByRole>,
+        ) {
+          const href = await link.getAttribute('href');
+          expect(href, `malformed team link href: ${href}`).toContain(
+            expectedTeamPath,
+          );
+          expect(href).not.toContain(`/organization/${org.name}/organization/`);
+
+          await link.click();
+
+          await expect(authenticatedPage).toHaveURL(
+            (url) => url.pathname === expectedTeamPath,
+          );
+          await expect(
+            authenticatedPage.getByTestId('teamname-title'),
+          ).toContainText(team.name);
+        }
+
+        // Teams view
+        await navigateToTeamsTab(authenticatedPage, org.name);
+        await searchForTeam(authenticatedPage, team.name);
+        await clickTeamLinkAndAssertPath(
+          authenticatedPage.getByRole('link', {name: team.name}),
+        );
+
+        // Members view
+        await authenticatedPage.goto(
+          `/organization/${org.name}?tab=Teamsandmembership`,
+        );
+        await authenticatedPage
+          .getByRole('button', {name: 'Members View'})
+          .click();
+        await authenticatedPage
+          .getByTestId('members-view-search')
+          .fill(TEST_USERS.user.username);
+        await expect(
+          authenticatedPage.locator('.pf-v6-c-pagination__total-items').first(),
+        ).toContainText('1 - 1 of 1', {timeout: 15000});
+
+        await clickTeamLinkAndAssertPath(
+          authenticatedPage.getByRole('link', {name: team.name}),
+        );
+      },
+    );
+  }
 });

--- a/web/playwright/e2e/repository/repositories-list.spec.ts
+++ b/web/playwright/e2e/repository/repositories-list.spec.ts
@@ -1,6 +1,7 @@
 import {test, expect, uniqueName} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
 import {API_URL} from '../../utils/config';
+import {pushImage} from '../../utils/container';
 
 /**
  * Helper to get the search input inside the PatternFly SearchInput component
@@ -530,4 +531,48 @@ test.describe('Repositories List', {tag: ['@repository']}, () => {
       await expect(reposPanel.getByText('exists-repo')).toBeVisible();
     });
   });
+
+  // domainRoute's repository branch only runs when the current path is under
+  // /repository/...; org-page team links cannot exercise it.
+  test.describe(
+    'domainRoute repository keyword',
+    {tag: ['@PROJQUAY-11202', '@container']},
+    () => {
+      test('tag link stays correct from /repository/.../testrepository... path', async ({
+        authenticatedPage,
+        api,
+      }) => {
+        const org = await api.organization('kwrepo');
+        const repo = await api.repository(org.name, 'testrepository');
+        await pushImage(
+          org.name,
+          repo.name,
+          'latest',
+          TEST_USERS.user.username,
+          TEST_USERS.user.password,
+        );
+
+        const repoPath = `/repository/${org.name}/${repo.name}`;
+        const expectedTagPath = `${repoPath}/tag/latest`;
+
+        // Current path includes /repository and a later "repository" substring.
+        await authenticatedPage.goto(`${repoPath}?tab=tags`);
+        await expect(authenticatedPage.getByTestId('repo-title')).toContainText(
+          repo.name,
+        );
+
+        const tagLink = authenticatedPage.getByRole('link', {name: 'latest'});
+        const href = await tagLink.getAttribute('href');
+        expect(href, `malformed tag link href: ${href}`).toContain(
+          expectedTagPath,
+        );
+        expect(href).not.toContain(`${repoPath}/repository/`);
+
+        await tagLink.click();
+        await expect(authenticatedPage).toHaveURL(
+          (url) => url.pathname === expectedTagPath,
+        );
+      });
+    },
+  );
 });

--- a/web/src/routes/NavigationPath.tsx
+++ b/web/src/routes/NavigationPath.tsx
@@ -153,7 +153,7 @@ function domainRoute(currentRoute, definedRoute) {
    ***/
   return (
     currentRoute.replace(
-      /\/(overview|organization|repository|signin)(?!.*\1).*/,
+      /\/(overview|organization|repository|signin)(?=\/|$).*/,
       '',
     ) + definedRoute
   );


### PR DESCRIPTION
## Summary
- Fix regular expression  in domainRoute() in the React UI so route keywords 
(`overview`, `organization`, `repository`, `signin`) are matched as full path segments instead of sub-strings.
- This stops malformed in-app links when an organization contains those keywords (`test-organization` or `testorganization`).
- Previously, `getTeamMemberPath` could prepend the current pathname, producing duplicated paths and failed API calls (e.g. team member navigation showing "Unable to get repository").

## Test plan
- Create (or use) an org whose name contains `organization` (e.g. `test-organization` or `testorganization`)
- Open **Teams and Membership**, click a team name, and confirm navigation to `/organization/<org>/teams/<team>` (no duplicated `/organization/...` segment)
-  Confirm the team members page loads without "Unable to get repository" / 404 API calls to `/api/v1/repository/organization/...`