### PR TITLE
PROJQUAY-XXXXX: fix(ui): marketplace subscription hook bugs

### DIFF
--- a/web/src/hooks/UseMarketplaceSubscriptions.ts
+++ b/web/src/hooks/UseMarketplaceSubscriptions.ts
@@ -20,7 +20,7 @@ export function useMarketplaceSubscriptions(
     ['subscriptions', {type: 'user'}],
     () => fetchMarketplaceSubscriptions(),
     {
-      enabled: config?.features?.RH_MARKETPLACE,
+      enabled: !!config?.features?.RH_MARKETPLACE,
     },
   );
 
@@ -29,10 +29,11 @@ export function useMarketplaceSubscriptions(
     error: errorFetchingOrgSubs,
     data: orgSubscriptions,
   } = useQuery(
-    ['subscriptions', {type: 'org'}],
+    ['subscriptions', {type: 'org', org: organizationName}],
     () => fetchMarketplaceSubscriptions(organizationName),
     {
-      enabled: config?.features?.RH_MARKETPLACE && organizationName != userName,
+      enabled:
+        !!config?.features?.RH_MARKETPLACE && organizationName != userName,
     },
   );
 
@@ -42,8 +43,8 @@ export function useMarketplaceSubscriptions(
       : loadingUserSubs;
 
   return {
-    userSubscriptions: userSubscriptions,
-    orgSubscriptions: orgSubscriptions,
+    userSubscriptions: userSubscriptions ?? [],
+    orgSubscriptions: orgSubscriptions ?? [],
     loading: loading,
     error: errorFetchingUserSubs,
   };
@@ -78,9 +79,9 @@ export function useManageOrgSubscriptions(org: string, {onSuccess, onError}) {
       }
       reqBody.push(subscriptionObj);
       if (manageType === 'attach') {
-        setMarketplaceOrgAttachment(org, reqBody);
+        await setMarketplaceOrgAttachment(org, reqBody);
       } else {
-        setMarketplaceOrgRemoval(org, reqBody);
+        await setMarketplaceOrgRemoval(org, reqBody);
       }
     },
     {

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/MarketplaceDetails.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/MarketplaceDetails.tsx
@@ -49,7 +49,7 @@ export default function MarketplaceDetails(props: MarketplaceDetailsProps) {
       }
     }
     props.updateTotalPrivate(marketplaceTotalPrivate);
-  });
+  }, [loading, error, orgSubscriptions, userSubscriptions]);
 
   const handleModalToggle = (modalType: string) => {
     setModalType(modalType);


### PR DESCRIPTION
## Summary

Fixes three bugs in the marketplace subscription UI that affect organization subscription management:

**Major:**
- **Stale org subscription cache**: The org subscription query key `['subscriptions', {type: 'org'}]` did not include `organizationName`, causing React Query to serve stale cached data from a previously viewed org when navigating between organizations.
- **Null safety crash**: When `RH_MARKETPLACE` feature flag is disabled (or config hasn't loaded), subscription queries are disabled and `data` is `undefined`. Calling `.map()` or `.filter()` on undefined crashes the page. Now defaults to `[]`.

**Minor:**
- **Silent mutation failures**: `setMarketplaceOrgAttachment` and `setMarketplaceOrgRemoval` were not awaited in the mutation handler, causing the mutation to resolve "successfully" before the HTTP request completed and silently swallowing API errors.
- **useEffect without deps**: The `useEffect` in `MarketplaceDetails` had no dependency array, causing it to run on every render. Added proper deps.

## Jira

- PROJQUAY-XXXXX (placeholder — Jira tickets to be created for stale cache + null safety)

## Test plan

- [ ] Navigate to Org A settings → Billing → verify subscriptions load
- [ ] Navigate to Org B settings → Billing → verify Org B subscriptions (not Org A's cached data)
- [ ] With `RH_MARKETPLACE` feature disabled, verify Billing tab doesn't crash
- [ ] Attach a subscription → verify error toast appears if API fails
- [ ] Existing cypress test `marketplace.cy.ts` passes


Made with [Cursor](https://cursor.com)