### PR TITLE
QUAYIO-1708: feat(deploy): add PDBs and dedicated node pool support

### DIFF
--- a/.github/workflows/sentinel.yaml
+++ b/.github/workflows/sentinel.yaml
@@ -113,6 +113,8 @@ jobs:
         with:
           allowed-skips: >-
             ${{
+              needs.lint-ci.result == 'skipped' && 'lint-ci,' || ''
+            }}${{
               needs.go-ci.result == 'skipped' && 'go-ci,' || ''
             }}${{
               needs.config-tool-ci.result == 'skipped' && 'config-tool-ci,' || ''

--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -139,6 +139,10 @@ objects:
       app: quay-rls
   spec:
     ports:
+    - name: healthcheck
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
     - name: grpc
       protocol: TCP
       port: 8081
@@ -184,10 +188,26 @@ objects:
           image: ${RLS_IMAGE}:${RLS_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           ports:
+          - containerPort: 8080
+            name: healthcheck
           - containerPort: 8081
             name: grpc
           - containerPort: 9090
             name: metrics
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
           env:
           - name: USE_STATSD
             value: "false"

--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -59,7 +59,11 @@ objects:
           app: quay-envoy
       spec:
         nodeSelector:
-          part-of: quay
+          workload: envoy
+        tolerations:
+        - key: workload
+          value: envoy
+          effect: NoSchedule
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -118,6 +122,15 @@ objects:
               path: ssl.cert
             - key: ssl.key
               path: ssl.key
+- apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    name: quay-envoy-pdb
+  spec:
+    maxUnavailable: 1
+    selector:
+      matchLabels:
+        app: quay-envoy
 - apiVersion: v1
   kind: Service
   metadata:
@@ -161,7 +174,11 @@ objects:
           app: quay-rls
       spec:
         nodeSelector:
-          part-of: quay
+          workload: envoy
+        tolerations:
+        - key: workload
+          value: envoy
+          effect: NoSchedule
         containers:
         - name: quay-rls
           image: ${RLS_IMAGE}:${RLS_IMAGE_TAG}
@@ -214,6 +231,15 @@ objects:
         - name: config
           configMap:
             name: ${{RLS_CONFIG_CONFIGMAP}}
+- apiVersion: policy/v1
+  kind: PodDisruptionBudget
+  metadata:
+    name: quay-rls-pdb
+  spec:
+    maxUnavailable: 1
+    selector:
+      matchLabels:
+        app: quay-rls
 parameters:
 - name: ENVOY_IMAGE
   value: "docker.io/envoyproxy/envoy"
@@ -222,7 +248,7 @@ parameters:
   value: "v1.35-latest"
   displayName: Envoy image tag
 - name: ENVOY_REPLICAS
-  value: "1"
+  value: "2"
   displayName: Number of Envoy replicas
 - name: ENVOY_CPU_REQUEST
   value: "500m"
@@ -249,7 +275,7 @@ parameters:
   value: "latest"
   displayName: Rate limit service image tag
 - name: RLS_REPLICAS
-  value: "1"
+  value: "2"
   displayName: Number of RLS replicas
 - name: RLS_CPU_REQUEST
   value: "100m"


### PR DESCRIPTION
## Summary

- Add PodDisruptionBudgets (`maxUnavailable: 1`) for Envoy and RLS — prevents node drains from evicting all pods simultaneously
- Change `nodeSelector` from `part-of: quay` to `workload: envoy` — pins Envoy/RLS pods to dedicated nodes
- Add toleration for `workload=envoy:NoSchedule` taint — allows Envoy pods onto tainted nodes while blocking Quay app pods
- Bump default replicas from 1 to 2 — PDB requires 2+ replicas to be effective

## Why

Envoy sits on the critical path for all quay.io traffic. Dedicated nodes isolate Envoy resource usage from Quay app pods and allow independent scaling. PDBs ensure availability during cluster upgrades and node maintenance.

## How it works

Dedicated envoy nodes are labeled `part-of: quay` (ALB can see them) + `workload: envoy` (nodeSelector target) and tainted `workload=envoy:NoSchedule`. This means:
- ALB registers envoy nodes (they have `part-of: quay`)
- Quay app pods can't schedule on envoy nodes (taint blocks them)
- Envoy/RLS pods only schedule on envoy nodes (nodeSelector)

## Depends on

App-interface MR to add the dedicated node pools to the cluster config (machine pools with labels + taints).

## Test plan

- [ ] Verify envoy nodes have both labels (`part-of=quay`, `workload=envoy`)
- [ ] Verify Envoy/RLS pods schedule on envoy nodes only
- [ ] Verify Quay app pods do NOT schedule on envoy nodes
- [ ] Verify PDB prevents full eviction during node drain

🤖 Generated with [Claude Code](https://claude.com/claude-code)