### PR TITLE
PROJQUAY-12347: fix(ui): include org name in subscription query key

### DIFF
--- a/web/src/hooks/UseMarketplaceSubscriptions.test.tsx
+++ b/web/src/hooks/UseMarketplaceSubscriptions.test.tsx
@@ -1,0 +1,141 @@
+import React, {ReactNode} from 'react';
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {useMarketplaceSubscriptions} from './UseMarketplaceSubscriptions';
+import * as BillingResource from 'src/resources/BillingResource';
+
+jest.mock('src/resources/BillingResource', () => ({
+  ...jest.requireActual('src/resources/BillingResource'),
+  fetchMarketplaceSubscriptions: jest.fn(),
+}));
+
+jest.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: jest.fn(() => ({features: {RH_MARKETPLACE: true}})),
+}));
+
+jest.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: jest.fn(() => ({user: {username: 'testuser'}})),
+}));
+
+import {useQuayConfig} from 'src/hooks/UseQuayConfig';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        cacheTime: 0,
+      },
+    },
+  });
+
+  const Wrapper = ({children}: {children: ReactNode}) => {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+  return Wrapper;
+};
+
+describe('useMarketplaceSubscriptions', () => {
+  const mockFetchMarketplaceSubscriptions =
+    BillingResource.fetchMarketplaceSubscriptions as jest.Mock;
+  const mockUseQuayConfig = useQuayConfig as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseQuayConfig.mockReturnValue({features: {RH_MARKETPLACE: true}});
+  });
+
+  it('should include organizationName in org query key (fetches different data per org)', async () => {
+    const orgAData = {subscriptions: [{id: '1', org: 'orgA'}]};
+    const orgBData = {subscriptions: [{id: '2', org: 'orgB'}]};
+
+    mockFetchMarketplaceSubscriptions.mockImplementation((org?: string) => {
+      if (org === 'orgA') return Promise.resolve(orgAData);
+      if (org === 'orgB') return Promise.resolve(orgBData);
+      return Promise.resolve({subscriptions: []});
+    });
+
+    const {result: resultA} = renderHook(
+      () => useMarketplaceSubscriptions('orgA', 'testuser'),
+      {wrapper: createWrapper()},
+    );
+
+    await waitFor(() => {
+      expect(resultA.current.loading).toBe(false);
+    });
+
+    expect(mockFetchMarketplaceSubscriptions).toHaveBeenCalledWith('orgA');
+    expect(resultA.current.orgSubscriptions).toEqual(orgAData);
+
+    const {result: resultB} = renderHook(
+      () => useMarketplaceSubscriptions('orgB', 'testuser'),
+      {wrapper: createWrapper()},
+    );
+
+    await waitFor(() => {
+      expect(resultB.current.loading).toBe(false);
+    });
+
+    expect(mockFetchMarketplaceSubscriptions).toHaveBeenCalledWith('orgB');
+    expect(resultB.current.orgSubscriptions).toEqual(orgBData);
+  });
+
+  it('should not fetch org subscriptions when org equals user', async () => {
+    mockFetchMarketplaceSubscriptions.mockResolvedValue({subscriptions: []});
+
+    const {result} = renderHook(
+      () => useMarketplaceSubscriptions('testuser', 'testuser'),
+      {wrapper: createWrapper()},
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    const orgCalls = mockFetchMarketplaceSubscriptions.mock.calls.filter(
+      (call) => call[0] === 'testuser',
+    );
+    expect(orgCalls).toHaveLength(0);
+    expect(result.current.orgSubscriptions).toBeUndefined();
+  });
+
+  it('should not fetch when RH_MARKETPLACE is disabled', async () => {
+    mockUseQuayConfig.mockReturnValue({features: {RH_MARKETPLACE: false}});
+    mockFetchMarketplaceSubscriptions.mockResolvedValue({subscriptions: []});
+
+    renderHook(
+      () => useMarketplaceSubscriptions('orgA', 'testuser'),
+      {wrapper: createWrapper()},
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mockFetchMarketplaceSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it('should return user and org subscriptions on success', async () => {
+    const userSubs = {subscriptions: [{id: 'u1', plan: 'pro'}]};
+    const orgSubs = {subscriptions: [{id: 'o1', plan: 'team'}]};
+
+    mockFetchMarketplaceSubscriptions.mockImplementation((org?: string) => {
+      if (org) return Promise.resolve(orgSubs);
+      return Promise.resolve(userSubs);
+    });
+
+    const {result} = renderHook(
+      () => useMarketplaceSubscriptions('myorg', 'testuser'),
+      {wrapper: createWrapper()},
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.userSubscriptions).toEqual(userSubs);
+    expect(result.current.orgSubscriptions).toEqual(orgSubs);
+    expect(result.current.error).toBeFalsy();
+  });
+});

--- a/web/src/hooks/UseMarketplaceSubscriptions.ts
+++ b/web/src/hooks/UseMarketplaceSubscriptions.ts
@@ -20,7 +20,7 @@ export function useMarketplaceSubscriptions(
     ['subscriptions', {type: 'user'}],
     () => fetchMarketplaceSubscriptions(),
     {
-      enabled: config?.features?.RH_MARKETPLACE,
+      enabled: !!config?.features?.RH_MARKETPLACE,
     },
   );
 
@@ -29,10 +29,11 @@ export function useMarketplaceSubscriptions(
     error: errorFetchingOrgSubs,
     data: orgSubscriptions,
   } = useQuery(
-    ['subscriptions', {type: 'org'}],
+    ['subscriptions', {type: 'org', org: organizationName}],
     () => fetchMarketplaceSubscriptions(organizationName),
     {
-      enabled: config?.features?.RH_MARKETPLACE && organizationName != userName,
+      enabled:
+        !!config?.features?.RH_MARKETPLACE && organizationName != userName,
     },
   );
 


### PR DESCRIPTION
## Summary

- Fixed stale org subscription cache bug in `UseMarketplaceSubscriptions` hook
- The org subscription query key did not include `organizationName`, causing React Query to serve stale cached data from a previously viewed org when navigating between organizations
- Changed query key from `['subscriptions', {type: 'org'}]` to `['subscriptions', {type: 'org', org: organizationName}]`
- Changed `enabled` from `config?.features?.RH_MARKETPLACE` to `!!config?.features?.RH_MARKETPLACE` for proper boolean coercion on both user and org queries

## Test plan

- [x] Added unit tests in `UseMarketplaceSubscriptions.test.tsx` covering:
  - Query key includes org name (different data fetched per org, no stale cache)
  - Org query is disabled when org equals current user
  - No API calls made when RH_MARKETPLACE feature is disabled
  - Both user and org subscriptions returned correctly on success
- [x] All 4 tests pass via `react-scripts test`


Made with [Cursor](https://cursor.com)