### PR TITLE
PROJQUAY-9998: feat(secscan): add retry limiting via metadata_json for v1 and v2 scanners

### DIFF
--- a/config.py
+++ b/config.py
@@ -553,7 +553,7 @@ class DefaultConfig(ImmutableConfig):
     SECURITY_SCANNER_V4_REINDEX_THRESHOLD = 300
 
     # Maximum number of scan retries per indexer hash before a manifest is skipped.
-    SECURITY_SCANNER_MAX_SCAN_RETRIES = 3
+    SECURITY_SCANNER_MAX_SCAN_RETRIES = 5
 
     # Security scanner V2 worker (lock-free, uses FOR UPDATE SKIP LOCKED)
     FEATURE_SECURITY_SCANNER_V2 = False

--- a/config.py
+++ b/config.py
@@ -552,6 +552,9 @@ class DefaultConfig(ImmutableConfig):
     # Minimum number of seconds before re-indexing a manifest with the security scanner.
     SECURITY_SCANNER_V4_REINDEX_THRESHOLD = 300
 
+    # Maximum number of scan retries per indexer hash before a manifest is skipped.
+    SECURITY_SCANNER_MAX_SCAN_RETRIES = 3
+
     # Security scanner V2 worker (lock-free, uses FOR UPDATE SKIP LOCKED)
     FEATURE_SECURITY_SCANNER_V2 = False
     SECURITY_SCANNER_V2_INDEXING_INTERVAL = 30

--- a/data/database.py
+++ b/data/database.py
@@ -2181,6 +2181,7 @@ class IndexStatus(IntEnum):
     Possible statuses of manifest security scan progress.
     """
 
+    SCAN_RETRIES_EXHAUSTED = -4
     MANIFEST_LAYER_TOO_LARGE = -3
     MANIFEST_UNSUPPORTED = -2
     FAILED = -1

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -505,6 +505,7 @@ class V4SecurityScanner(SecurityScannerInterface):
 
             if exhausted_manifest_ids:
                 ManifestSecurityStatus.update(
+                    index_status=IndexStatus.SCAN_RETRIES_EXHAUSTED,
                     last_indexed=datetime.utcnow(),
                 ).where(
                     ManifestSecurityStatus.manifest_id.in_(exhausted_manifest_ids),

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -52,6 +52,7 @@ from util.secscan.v4.api import (
     ClairSecurityScannerAPI,
     InvalidContentSent,
     LayerTooLargeException,
+    Non200ResponseException,
 )
 from util.secscan.validator import V4SecurityConfigValidator
 
@@ -638,6 +639,36 @@ class V4SecurityScanner(SecurityScannerInterface):
             except InvalidContentSent as ex:
                 mark_manifest_unsupported(manifest)
                 logger.exception("Failed to perform indexing, invalid content sent")
+                continue
+            except Non200ResponseException as ex:
+                try:
+                    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
+                    metadata = mss.metadata_json or {}
+                    if metadata.get("last_failed_hash") != current_indexer_hash:
+                        metadata["retry_count"] = 1
+                    else:
+                        metadata["retry_count"] = metadata.get("retry_count", 0) + 1
+                except ManifestSecurityStatus.DoesNotExist:
+                    metadata = {"retry_count": 1}
+                metadata["last_failed_hash"] = current_indexer_hash
+
+                ManifestSecurityStatus.update(
+                    index_status=IndexStatus.FAILED,
+                    indexer_hash="server_error",
+                    error_json={
+                        "error": "non-200 response",
+                        "status_code": ex.response.status_code,
+                    },
+                    metadata_json=metadata,
+                    last_indexed=datetime.utcnow(),
+                ).where(
+                    ManifestSecurityStatus.manifest == candidate,
+                    ManifestSecurityStatus.index_status == IndexStatus.IN_PROGRESS,
+                ).execute()
+                logger.exception(
+                    "Failed to perform indexing, security scanner returned %s",
+                    ex.response.status_code,
+                )
                 continue
             except APIRequestFailure as ex:
                 ManifestSecurityStatus.update(

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -374,7 +374,7 @@ class V4SecurityScanner(SecurityScannerInterface):
             reindex_threshold=reindex_threshold,
         )
 
-        self._index(iterator, reindex_threshold)
+        self._index(iterator, reindex_threshold, indexer_state.get("state", ""))
 
     def perform_indexing(self, start_token=None, batch_size=None):
         try:
@@ -408,13 +408,13 @@ class V4SecurityScanner(SecurityScannerInterface):
             reindex_threshold=reindex_threshold,
         )
 
-        self._index(iterator, reindex_threshold)
+        self._index(iterator, reindex_threshold, indexer_state.get("state", ""))
 
         return ScanToken(max_id + 1)
 
-    def _index(self, iterator, reindex_threshold):
+    def _index(self, iterator, reindex_threshold, current_indexer_hash):
         max_retries = self.app.config.get(
-            "SECURITY_SCANNER_V4_MAX_SCAN_RETRIES", DEFAULT_MAX_SCAN_RETRIES
+            "SECURITY_SCANNER_MAX_SCAN_RETRIES", DEFAULT_MAX_SCAN_RETRIES
         )
 
         def mark_manifest_unsupported(manifest):
@@ -496,7 +496,10 @@ class V4SecurityScanner(SecurityScannerInterface):
             exhausted_manifest_ids = []
             for row in retry_exhausted_query:
                 metadata = row.metadata_json or {}
-                if metadata.get("retry_count", 0) >= max_retries:
+                retry_count = metadata.get("retry_count", 0)
+                if metadata.get("last_failed_hash") != current_indexer_hash:
+                    retry_count = 0
+                if retry_count >= max_retries:
                     preempted_ids.add(row.manifest_id)
                     exhausted_manifest_ids.append(row.manifest_id)
 
@@ -542,6 +545,11 @@ class V4SecurityScanner(SecurityScannerInterface):
         for candidate, abt, num_remaining, should_skip in batched_iterator_with_preemption_check(
             iterator
         ):
+            if should_skip:
+                logger.debug("Manifest %d preempted by another worker (batch check)", candidate.id)
+                abt.set()
+                continue
+
             manifest = ManifestDataType.for_manifest(candidate, None)
             if manifest.is_manifest_list:
                 mark_manifest_unsupported(manifest)
@@ -561,8 +569,6 @@ class V4SecurityScanner(SecurityScannerInterface):
                 mark_manifest_unsupported(manifest)
                 continue
 
-            # We need to verify that the image layers are actual container images. Since Docker v2 schema 1 images
-            # cannot be anything other than container images, for them specifically we should skip the layer check.
             if manifest.media_type not in DOCKER_SCHEMA1_CONTENT_TYPES:
                 if not _has_container_layers(layers):
                     logger.info(
@@ -575,12 +581,6 @@ class V4SecurityScanner(SecurityScannerInterface):
                     )
                     mark_manifest_unsupported(manifest)
                     continue
-
-            # Check preemption status (computed via bulk query in batch)
-            if should_skip:
-                logger.debug("Manifest %d preempted by another worker (batch check)", candidate.id)
-                abt.set()
-                continue
 
             logger.debug(
                 "Indexing manifest [%d] %s/%s@%s"
@@ -639,18 +639,10 @@ class V4SecurityScanner(SecurityScannerInterface):
                 logger.exception("Failed to perform indexing, invalid content sent")
                 continue
             except APIRequestFailure as ex:
-                try:
-                    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
-                    metadata = mss.metadata_json or {}
-                except ManifestSecurityStatus.DoesNotExist:
-                    metadata = {}
-                metadata["retry_count"] = metadata.get("retry_count", 0) + 1
-
                 ManifestSecurityStatus.update(
                     index_status=IndexStatus.FAILED,
                     indexer_hash="api_failure",
                     error_json={"error": str(ex)},
-                    metadata_json=metadata,
                     last_indexed=datetime.utcnow(),
                 ).where(
                     ManifestSecurityStatus.manifest == candidate,
@@ -756,9 +748,13 @@ class V4SecurityScanner(SecurityScannerInterface):
                 try:
                     mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
                     metadata = mss.metadata_json or {}
+                    if metadata.get("last_failed_hash") != current_indexer_hash:
+                        metadata["retry_count"] = 1
+                    else:
+                        metadata["retry_count"] = metadata.get("retry_count", 0) + 1
                 except ManifestSecurityStatus.DoesNotExist:
-                    metadata = {}
-                metadata["retry_count"] = metadata.get("retry_count", 0) + 1
+                    metadata = {"retry_count": 1}
+                metadata["last_failed_hash"] = current_indexer_hash
 
                 ManifestSecurityStatus.update(
                     index_status=IndexStatus.FAILED,
@@ -782,9 +778,13 @@ class V4SecurityScanner(SecurityScannerInterface):
                 try:
                     mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
                     old_metadata = mss.metadata_json or {}
-                    metadata["retry_count"] = old_metadata.get("retry_count", 0) + 1
+                    if old_metadata.get("last_failed_hash") != current_indexer_hash:
+                        metadata["retry_count"] = 1
+                    else:
+                        metadata["retry_count"] = old_metadata.get("retry_count", 0) + 1
                 except ManifestSecurityStatus.DoesNotExist:
                     metadata["retry_count"] = 1
+                metadata["last_failed_hash"] = current_indexer_hash
 
             with db_transaction():
                 ManifestSecurityStatus.delete().where(

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_SECURITY_SCANNER_V4_REINDEX_THRESHOLD = 86400  # 1 day
-DEFAULT_MAX_SCAN_RETRIES = 3
+DEFAULT_MAX_SCAN_RETRIES = 5
 STALE_IN_PROGRESS_HOURS = 6  # Hours before an IN_PROGRESS manifest is considered stale
 TAG_LIMIT = 100
 

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -223,7 +223,7 @@ class V4SecurityScanner(SecurityScannerInterface):
         except ManifestSecurityStatus.DoesNotExist:
             return SecurityInformationLookupResult.with_status(ScanLookupStatus.NOT_YET_INDEXED)
 
-        if status.index_status == IndexStatus.FAILED:
+        if status.index_status in (IndexStatus.FAILED, IndexStatus.SCAN_RETRIES_EXHAUSTED):
             return SecurityInformationLookupResult.with_status(ScanLookupStatus.FAILED_TO_INDEX)
 
         if status.index_status == IndexStatus.MANIFEST_UNSUPPORTED:

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -59,6 +59,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_SECURITY_SCANNER_V4_REINDEX_THRESHOLD = 86400  # 1 day
+DEFAULT_MAX_SCAN_RETRIES = 3
 STALE_IN_PROGRESS_HOURS = 6  # Hours before an IN_PROGRESS manifest is considered stale
 TAG_LIMIT = 100
 
@@ -412,6 +413,10 @@ class V4SecurityScanner(SecurityScannerInterface):
         return ScanToken(max_id + 1)
 
     def _index(self, iterator, reindex_threshold):
+        max_retries = self.app.config.get(
+            "SECURITY_SCANNER_V4_MAX_SCAN_RETRIES", DEFAULT_MAX_SCAN_RETRIES
+        )
+
         def mark_manifest_unsupported(manifest):
             with db_transaction():
                 ManifestSecurityStatus.delete().where(
@@ -479,7 +484,21 @@ class V4SecurityScanner(SecurityScannerInterface):
                 ),
             )
 
-            return {row.manifest_id for row in preempted_query}
+            preempted_ids = {row.manifest_id for row in preempted_query}
+
+            retry_exhausted_query = ManifestSecurityStatus.select(
+                ManifestSecurityStatus.manifest_id,
+                ManifestSecurityStatus.metadata_json,
+            ).where(
+                ManifestSecurityStatus.manifest_id.in_(candidate_ids),
+                ManifestSecurityStatus.index_status == IndexStatus.FAILED,
+            )
+            for row in retry_exhausted_query:
+                metadata = row.metadata_json or {}
+                if metadata.get("retry_count", 0) >= max_retries:
+                    preempted_ids.add(row.manifest_id)
+
+            return preempted_ids
 
         def batched_iterator_with_preemption_check(iterator, batch_size=20):
             """
@@ -611,11 +630,18 @@ class V4SecurityScanner(SecurityScannerInterface):
                 logger.exception("Failed to perform indexing, invalid content sent")
                 continue
             except APIRequestFailure as ex:
-                # Mark as FAILED instead of deleting to preserve scan history
+                try:
+                    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
+                    metadata = mss.metadata_json or {}
+                except ManifestSecurityStatus.DoesNotExist:
+                    metadata = {}
+                metadata["retry_count"] = metadata.get("retry_count", 0) + 1
+
                 ManifestSecurityStatus.update(
                     index_status=IndexStatus.FAILED,
                     indexer_hash="api_failure",
                     error_json={"error": str(ex)},
+                    metadata_json=metadata,
                     last_indexed=datetime.utcnow(),
                 ).where(
                     ManifestSecurityStatus.manifest == candidate,
@@ -718,11 +744,18 @@ class V4SecurityScanner(SecurityScannerInterface):
             elif report["state"] == IndexReportState.Index_Error:
                 index_status = IndexStatus.FAILED
             else:
-                # Unknown state - mark as FAILED instead of deleting to preserve scan history
+                try:
+                    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
+                    metadata = mss.metadata_json or {}
+                except ManifestSecurityStatus.DoesNotExist:
+                    metadata = {}
+                metadata["retry_count"] = metadata.get("retry_count", 0) + 1
+
                 ManifestSecurityStatus.update(
                     index_status=IndexStatus.FAILED,
                     indexer_hash="unknown_state",
                     error_json={"error": "unknown_state", "state": report.get("state")},
+                    metadata_json=metadata,
                     last_indexed=datetime.utcnow(),
                 ).where(
                     ManifestSecurityStatus.manifest == candidate,
@@ -735,6 +768,15 @@ class V4SecurityScanner(SecurityScannerInterface):
                 )
                 continue
 
+            metadata = {}
+            if index_status == IndexStatus.FAILED:
+                try:
+                    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
+                    old_metadata = mss.metadata_json or {}
+                    metadata["retry_count"] = old_metadata.get("retry_count", 0) + 1
+                except ManifestSecurityStatus.DoesNotExist:
+                    metadata["retry_count"] = 1
+
             with db_transaction():
                 ManifestSecurityStatus.delete().where(
                     ManifestSecurityStatus.manifest == candidate
@@ -746,7 +788,7 @@ class V4SecurityScanner(SecurityScannerInterface):
                     index_status=index_status,
                     indexer_hash=state,
                     indexer_version=IndexerVersion.V4,
-                    metadata_json={},
+                    metadata_json=metadata,
                 )
 
     def lookup_notification_page(self, notification_id, page_index=None):

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -493,10 +493,19 @@ class V4SecurityScanner(SecurityScannerInterface):
                 ManifestSecurityStatus.manifest_id.in_(candidate_ids),
                 ManifestSecurityStatus.index_status == IndexStatus.FAILED,
             )
+            exhausted_manifest_ids = []
             for row in retry_exhausted_query:
                 metadata = row.metadata_json or {}
                 if metadata.get("retry_count", 0) >= max_retries:
                     preempted_ids.add(row.manifest_id)
+                    exhausted_manifest_ids.append(row.manifest_id)
+
+            if exhausted_manifest_ids:
+                ManifestSecurityStatus.update(
+                    last_indexed=datetime.utcnow(),
+                ).where(
+                    ManifestSecurityStatus.manifest_id.in_(exhausted_manifest_ids),
+                ).execute()
 
             return preempted_ids
 

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -40,6 +40,7 @@ from util.secscan.validator import V4SecurityConfigValidator
 logger = logging.getLogger(__name__)
 
 DEFAULT_REINDEX_THRESHOLD = 86400
+DEFAULT_MAX_SCAN_RETRIES = 3
 STALE_IN_PROGRESS_HOURS = 6
 TAG_LIMIT = 100
 
@@ -118,6 +119,10 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
         )
 
     def _find_and_claim_batch(self, batch_size, reindex_threshold, stale_threshold, indexer_hash):
+        max_retries = self.app.config.get(
+            "SECURITY_SCANNER_V2_MAX_SCAN_RETRIES", DEFAULT_MAX_SCAN_RETRIES
+        )
+
         with db_transaction():
             query = (
                 ManifestSecurityStatus.select()
@@ -150,6 +155,16 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             )
 
             rows = list(db_for_update(query, skip_locked=True))
+
+            if not rows:
+                return []
+
+            rows = [
+                r
+                for r in rows
+                if r.index_status != IndexStatus.FAILED
+                or (r.metadata_json or {}).get("retry_count", 0) < max_retries
+            ]
 
             if not rows:
                 return []
@@ -282,6 +297,15 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             )
             return
 
+        metadata = {}
+        if index_status == IndexStatus.FAILED:
+            try:
+                mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
+                old_metadata = mss.metadata_json or {}
+                metadata["retry_count"] = old_metadata.get("retry_count", 0) + 1
+            except ManifestSecurityStatus.DoesNotExist:
+                metadata["retry_count"] = 1
+
         with db_transaction():
             ManifestSecurityStatus.delete().where(
                 ManifestSecurityStatus.manifest == candidate
@@ -293,7 +317,7 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
                 index_status=index_status,
                 indexer_hash=state,
                 indexer_version=IndexerVersion.V4,
-                metadata_json={},
+                metadata_json=metadata,
             )
 
         result_label = "completed" if index_status == IndexStatus.COMPLETED else "failed"
@@ -387,10 +411,18 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             )
 
     def _mark_failed(self, manifest_id, indexer_hash, error_json):
+        try:
+            mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == manifest_id)
+            metadata = mss.metadata_json or {}
+            metadata["retry_count"] = metadata.get("retry_count", 0) + 1
+        except ManifestSecurityStatus.DoesNotExist:
+            metadata = {"retry_count": 1}
+
         ManifestSecurityStatus.update(
             index_status=IndexStatus.FAILED,
             indexer_hash=indexer_hash,
             error_json=error_json,
+            metadata_json=metadata,
             last_indexed=datetime.utcnow(),
         ).where(
             ManifestSecurityStatus.manifest == manifest_id,

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -159,25 +159,35 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             if not rows:
                 return []
 
-            rows = [
-                r
-                for r in rows
-                if r.index_status != IndexStatus.FAILED
-                or (r.metadata_json or {}).get("retry_count", 0) < max_retries
-            ]
+            now = datetime.utcnow()
 
-            if not rows:
+            eligible = []
+            exhausted_ids = []
+            for r in rows:
+                if (
+                    r.index_status == IndexStatus.FAILED
+                    and (r.metadata_json or {}).get("retry_count", 0) >= max_retries
+                ):
+                    exhausted_ids.append(r.id)
+                else:
+                    eligible.append(r)
+
+            if exhausted_ids:
+                ManifestSecurityStatus.update(
+                    last_indexed=now,
+                ).where(ManifestSecurityStatus.id.in_(exhausted_ids)).execute()
+
+            if not eligible:
                 return []
 
-            row_ids = [r.id for r in rows]
-            now = datetime.utcnow()
+            row_ids = [r.id for r in eligible]
             ManifestSecurityStatus.update(
                 index_status=IndexStatus.IN_PROGRESS,
                 indexer_hash="in_progress_v2",
                 last_indexed=now,
             ).where(ManifestSecurityStatus.id.in_(row_ids)).execute()
 
-            return rows
+            return eligible
 
     def _claim_unindexed_manifests(self, batch_size):
         candidates = list(

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -40,7 +40,7 @@ from util.secscan.validator import V4SecurityConfigValidator
 logger = logging.getLogger(__name__)
 
 DEFAULT_REINDEX_THRESHOLD = 86400
-DEFAULT_MAX_SCAN_RETRIES = 3
+DEFAULT_MAX_SCAN_RETRIES = 5
 STALE_IN_PROGRESS_HOURS = 6
 TAG_LIMIT = 100
 

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -34,6 +34,7 @@ from util.secscan.v4.api import (
     ClairSecurityScannerAPI,
     InvalidContentSent,
     LayerTooLargeException,
+    Non200ResponseException,
 )
 from util.secscan.validator import V4SecurityConfigValidator
 
@@ -280,6 +281,18 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             self._mark_unsupported(manifest)
             secscan_v2_scan_result.labels(result="unsupported").inc()
             logger.exception("Failed to index: invalid content sent")
+            return
+        except Non200ResponseException as ex:
+            self._mark_failed(
+                candidate.id,
+                "server_error",
+                {"error": "non-200 response", "status_code": ex.response.status_code},
+                current_indexer_hash,
+            )
+            secscan_v2_scan_result.labels(result="api_error").inc()
+            logger.exception(
+                "Failed to index: security scanner returned %s", ex.response.status_code
+            )
             return
         except APIRequestFailure as ex:
             ManifestSecurityStatus.update(

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -107,10 +107,10 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             return
 
         for candidate in claimed_new:
-            self._index_manifest_by_id(candidate.id, candidate.repository_id)
+            self._index_manifest_by_id(candidate.id, candidate.repository_id, indexer_hash)
 
         for mss_row in claimed_mss:
-            self._index_manifest_by_id(mss_row.manifest_id, mss_row.repository_id)
+            self._index_manifest_by_id(mss_row.manifest_id, mss_row.repository_id, indexer_hash)
 
         cycle_duration = time.monotonic() - cycle_start
         secscan_v2_cycle_duration.observe(cycle_duration)
@@ -120,7 +120,7 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
 
     def _find_and_claim_batch(self, batch_size, reindex_threshold, stale_threshold, indexer_hash):
         max_retries = self.app.config.get(
-            "SECURITY_SCANNER_V2_MAX_SCAN_RETRIES", DEFAULT_MAX_SCAN_RETRIES
+            "SECURITY_SCANNER_MAX_SCAN_RETRIES", DEFAULT_MAX_SCAN_RETRIES
         )
 
         with db_transaction():
@@ -164,10 +164,11 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             eligible = []
             exhausted_ids = []
             for r in rows:
-                if (
-                    r.index_status == IndexStatus.FAILED
-                    and (r.metadata_json or {}).get("retry_count", 0) >= max_retries
-                ):
+                metadata = r.metadata_json or {}
+                retry_count = metadata.get("retry_count", 0)
+                if metadata.get("last_failed_hash") != indexer_hash:
+                    retry_count = 0
+                if r.index_status == IndexStatus.FAILED and retry_count >= max_retries:
                     exhausted_ids.append(r.id)
                 else:
                     eligible.append(r)
@@ -226,12 +227,17 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
 
         return claimed
 
-    def _index_manifest_by_id(self, manifest_id, repository_id):
+    def _index_manifest_by_id(self, manifest_id, repository_id, current_indexer_hash):
         try:
             candidate = Manifest.get(Manifest.id == manifest_id)
         except Manifest.DoesNotExist:
             logger.warning("Manifest %d no longer exists, skipping", manifest_id)
-            self._mark_failed(manifest_id, "manifest_deleted", {"error": "manifest not found"})
+            self._mark_failed(
+                manifest_id,
+                "manifest_deleted",
+                {"error": "manifest not found"},
+                current_indexer_hash,
+            )
             return
 
         manifest = ManifestDataType.for_manifest(candidate, None)
@@ -275,7 +281,15 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             logger.exception("Failed to index: invalid content sent")
             return
         except APIRequestFailure as ex:
-            self._mark_failed(candidate.id, "api_failure", {"error": str(ex)})
+            ManifestSecurityStatus.update(
+                index_status=IndexStatus.FAILED,
+                indexer_hash="api_failure",
+                error_json={"error": str(ex)},
+                last_indexed=datetime.utcnow(),
+            ).where(
+                ManifestSecurityStatus.manifest == candidate.id,
+                ManifestSecurityStatus.index_status == IndexStatus.IN_PROGRESS,
+            ).execute()
             secscan_v2_scan_result.labels(result="api_error").inc()
             logger.exception("Failed to index: security scanner API error")
             return
@@ -298,6 +312,7 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
                 candidate.id,
                 "unknown_state",
                 {"error": "unknown_state", "state": report.get("state")},
+                current_indexer_hash,
             )
             secscan_v2_scan_result.labels(result="failed").inc()
             logger.warning(
@@ -312,9 +327,13 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             try:
                 mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
                 old_metadata = mss.metadata_json or {}
-                metadata["retry_count"] = old_metadata.get("retry_count", 0) + 1
+                if old_metadata.get("last_failed_hash") != current_indexer_hash:
+                    metadata["retry_count"] = 1
+                else:
+                    metadata["retry_count"] = old_metadata.get("retry_count", 0) + 1
             except ManifestSecurityStatus.DoesNotExist:
                 metadata["retry_count"] = 1
+            metadata["last_failed_hash"] = current_indexer_hash
 
         with db_transaction():
             ManifestSecurityStatus.delete().where(
@@ -420,13 +439,17 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
                 metadata_json={},
             )
 
-    def _mark_failed(self, manifest_id, indexer_hash, error_json):
+    def _mark_failed(self, manifest_id, indexer_hash, error_json, current_indexer_hash):
         try:
             mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == manifest_id)
             metadata = mss.metadata_json or {}
-            metadata["retry_count"] = metadata.get("retry_count", 0) + 1
+            if metadata.get("last_failed_hash") != current_indexer_hash:
+                metadata["retry_count"] = 1
+            else:
+                metadata["retry_count"] = metadata.get("retry_count", 0) + 1
         except ManifestSecurityStatus.DoesNotExist:
             metadata = {"retry_count": 1}
+        metadata["last_failed_hash"] = current_indexer_hash
 
         ManifestSecurityStatus.update(
             index_status=IndexStatus.FAILED,

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -175,6 +175,7 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
 
             if exhausted_ids:
                 ManifestSecurityStatus.update(
+                    index_status=IndexStatus.SCAN_RETRIES_EXHAUSTED,
                     last_indexed=now,
                 ).where(ManifestSecurityStatus.id.in_(exhausted_ids)).execute()
 

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -1423,6 +1423,134 @@ def test_deduplicate_recent_vs_full_catalog(initialized_db, set_secscan_config):
         )
 
 
+def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_config):
+    """
+    Test that manifests with retry_count >= max_retries are skipped during indexing.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    reindex_threshold = datetime.utcnow() - timedelta(
+        seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"]
+    )
+
+    manifests = list(Manifest.select().limit(6))
+    assert len(manifests) >= 6
+
+    for i in range(3):
+        ManifestSecurityStatus.create(
+            manifest=manifests[i],
+            repository=manifests[i].repository,
+            error_json={},
+            index_status=IndexStatus.FAILED,
+            indexer_hash="abc",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=reindex_threshold - timedelta(seconds=100),
+            metadata_json={"retry_count": 3},
+        )
+
+    for i in range(3, 6):
+        ManifestSecurityStatus.create(
+            manifest=manifests[i],
+            repository=manifests[i].repository,
+            error_json={},
+            index_status=IndexStatus.FAILED,
+            indexer_hash="abc",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=reindex_threshold - timedelta(seconds=100),
+            metadata_json={"retry_count": 1},
+        )
+
+    from threading import Event
+
+    def test_iterator():
+        for m in manifests:
+            yield m, Event(), len(manifests)
+
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+    secscan._secscan_api.index.return_value = (
+        {"err": None, "state": IndexReportState.Index_Finished},
+        "abc",
+    )
+
+    secscan._index(test_iterator(), reindex_threshold)
+
+    exhausted_ids = {manifests[i].id for i in range(3)}
+    for mss in ManifestSecurityStatus.select().where(
+        ManifestSecurityStatus.manifest_id.in_(list(exhausted_ids))
+    ):
+        assert mss.index_status == IndexStatus.FAILED
+        assert mss.metadata_json.get("retry_count") == 3
+
+
+def test_api_failure_increments_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that APIRequestFailure increments retry_count in metadata_json.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.index.side_effect = APIRequestFailure("connection refused")
+
+    secscan.perform_indexing(batch_size=100)
+
+    for mss in ManifestSecurityStatus.select():
+        assert mss.index_status == IndexStatus.FAILED
+        assert mss.metadata_json.get("retry_count") == 1
+
+
+def test_index_error_increments_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that Index_Error response increments retry_count in metadata_json.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.index.return_value = (
+        {"err": "something went wrong", "state": IndexReportState.Index_Error},
+        "abc",
+    )
+
+    secscan.perform_indexing(batch_size=100)
+
+    for mss in ManifestSecurityStatus.select():
+        if mss.index_status == IndexStatus.FAILED:
+            assert mss.metadata_json.get("retry_count") == 1
+
+
+def test_successful_indexing_resets_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that successful indexing resets metadata_json (clears retry_count).
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+    secscan._secscan_api.index.return_value = (
+        {"err": None, "state": IndexReportState.Index_Finished},
+        "abc",
+    )
+
+    for manifest in Manifest.select():
+        ManifestSecurityStatus.create(
+            manifest=manifest,
+            repository=manifest.repository,
+            error_json={},
+            index_status=IndexStatus.FAILED,
+            indexer_hash="abc",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=datetime.utcnow()
+            - timedelta(seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"] + 60),
+            metadata_json={"retry_count": 2},
+        )
+
+    secscan.perform_indexing(batch_size=100)
+
+    for mss in ManifestSecurityStatus.select():
+        if mss.index_status == IndexStatus.COMPLETED:
+            assert mss.metadata_json == {}
+
+
 def test_batch_preemption_reduces_queries(initialized_db, set_secscan_config):
     """
     Integration test verifying that batch preemption checking actually reduces

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -23,6 +23,7 @@ from data.database import (
     db_transaction,
 )
 from data.registry_model import registry_model
+from data.registry_model.datatypes import Manifest as ManifestDataType
 from data.registry_model.datatypes import ManifestLayer, RepositoryReference
 from data.secscan_model.datatypes import (
     NVD,
@@ -1649,3 +1650,101 @@ def test_batch_preemption_reduces_queries(initialized_db, set_secscan_config):
 
     # Most of the 25 recently indexed should still have "test" hash (they were skipped)
     assert still_test_hash >= 20, f"Expected at least 20 skipped manifests, got {still_test_hash}"
+
+
+def test_unknown_state_increments_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that an unknown report state increments retry_count in metadata_json.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.index.return_value = (
+        {"err": None, "state": "SomeUnknownState"},
+        "abc",
+    )
+
+    secscan.perform_indexing(batch_size=100)
+
+    failed_count = 0
+    for mss in ManifestSecurityStatus.select():
+        if mss.index_status == IndexStatus.FAILED:
+            assert mss.metadata_json.get("retry_count") == 1
+            assert mss.metadata_json.get("last_failed_hash") == "abc"
+            failed_count += 1
+    assert failed_count > 0, "Expected at least one FAILED manifest"
+
+
+def test_last_failed_hash_resets_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that retry_count resets to 1 when the indexer hash changes, allowing
+    manifests to get a fresh set of retries after a Clair update.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+
+    manifest = Manifest.select().first()
+
+    # Mark all manifests as COMPLETED so only our target is picked up
+    for m in Manifest.select():
+        ManifestSecurityStatus.create(
+            manifest=m,
+            repository=m.repository,
+            error_json={},
+            index_status=IndexStatus.COMPLETED,
+            indexer_hash="old_hash",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=datetime.utcnow(),
+            metadata_json={},
+        )
+
+    # Override the target: COMPLETED with stale hash so it only matches
+    # needs_reindexing_query (not index_error_query which also picks up FAILED)
+    ManifestSecurityStatus.delete().where(ManifestSecurityStatus.manifest == manifest).execute()
+    ManifestSecurityStatus.create(
+        manifest=manifest,
+        repository=manifest.repository,
+        error_json={},
+        index_status=IndexStatus.COMPLETED,
+        indexer_hash="old_hash",
+        indexer_version=IndexerVersion.V4,
+        last_indexed=datetime.utcnow()
+        - timedelta(seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"] + 60),
+        metadata_json={"retry_count": 4, "last_failed_hash": "old_hash"},
+    )
+
+    secscan._secscan_api.state.return_value = {"state": "new_hash"}
+    secscan._secscan_api.index.return_value = (
+        {"err": "still broken", "state": IndexReportState.Index_Error},
+        "new_hash",
+    )
+
+    secscan.perform_indexing(batch_size=100)
+
+    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == manifest)
+    assert mss.metadata_json.get("retry_count") == 1
+    assert mss.metadata_json.get("last_failed_hash") == "new_hash"
+
+
+def test_load_security_information_scan_retries_exhausted(initialized_db, set_secscan_config):
+    """
+    Test that load_security_information returns FAILED_TO_INDEX for manifests
+    with SCAN_RETRIES_EXHAUSTED status.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+
+    manifest = ManifestDataType.for_manifest(Manifest.select().first(), None)
+    ManifestSecurityStatus.create(
+        manifest=manifest._db_id,
+        repository=manifest.repository._db_id,
+        error_json={},
+        index_status=IndexStatus.SCAN_RETRIES_EXHAUSTED,
+        indexer_hash="abc",
+        indexer_version=IndexerVersion.V4,
+        metadata_json={"retry_count": 5, "last_failed_hash": "abc"},
+    )
+
+    result = secscan.load_security_information(manifest)
+    assert result.status == ScanLookupStatus.FAILED_TO_INDEX

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -1444,7 +1444,7 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
             indexer_hash="abc",
             indexer_version=IndexerVersion.V4,
             last_indexed=reindex_threshold - timedelta(seconds=100),
-            metadata_json={"retry_count": 3, "last_failed_hash": "abc"},
+            metadata_json={"retry_count": 5, "last_failed_hash": "abc"},
         )
 
     for i in range(3, 6):
@@ -1479,7 +1479,7 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
         ManifestSecurityStatus.manifest_id.in_(list(exhausted_ids))
     ):
         assert mss.index_status == IndexStatus.FAILED
-        assert mss.metadata_json.get("retry_count") == 3
+        assert mss.metadata_json.get("retry_count") == 5
 
     under_limit_ids = {manifests[i].id for i in range(3, 6)}
     for mss in ManifestSecurityStatus.select().where(
@@ -1490,13 +1490,14 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
 
 def test_api_failure_does_not_increment_retry_count(initialized_db, set_secscan_config):
     """
-    Test that APIRequestFailure does not increment retry_count since transport
-    failures are transient and should not count against the retry limit.
+    Test that APIRequestFailure does not increment retry_count since Clair 5xx
+    and connection errors are not a definitive verdict on the manifest. Only
+    Index_Error and unknown_state report states count toward the retry limit.
     """
     secscan = V4SecurityScanner(application, instance_keys, storage)
     secscan._secscan_api = mock.Mock()
     secscan._secscan_api.state.return_value = {"state": "abc"}
-    secscan._secscan_api.index.side_effect = APIRequestFailure("connection refused")
+    secscan._secscan_api.index.side_effect = APIRequestFailure("500 internal server error")
 
     secscan.perform_indexing(batch_size=100)
 

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -1482,6 +1482,12 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
         assert mss.index_status == IndexStatus.FAILED
         assert mss.metadata_json.get("retry_count") == 3
 
+    under_limit_ids = {manifests[i].id for i in range(3, 6)}
+    for mss in ManifestSecurityStatus.select().where(
+        ManifestSecurityStatus.manifest_id.in_(list(under_limit_ids))
+    ):
+        assert mss.index_status == IndexStatus.COMPLETED
+
 
 def test_api_failure_increments_retry_count(initialized_db, set_secscan_config):
     """
@@ -1513,9 +1519,12 @@ def test_index_error_increments_retry_count(initialized_db, set_secscan_config):
 
     secscan.perform_indexing(batch_size=100)
 
+    failed_count = 0
     for mss in ManifestSecurityStatus.select():
         if mss.index_status == IndexStatus.FAILED:
             assert mss.metadata_json.get("retry_count") == 1
+            failed_count += 1
+    assert failed_count > 0, "Expected at least one FAILED manifest"
 
 
 def test_successful_indexing_resets_retry_count(initialized_db, set_secscan_config):
@@ -1546,9 +1555,12 @@ def test_successful_indexing_resets_retry_count(initialized_db, set_secscan_conf
 
     secscan.perform_indexing(batch_size=100)
 
+    completed_count = 0
     for mss in ManifestSecurityStatus.select():
         if mss.index_status == IndexStatus.COMPLETED:
             assert mss.metadata_json == {}
+            completed_count += 1
+    assert completed_count > 0, "Expected at least one COMPLETED manifest"
 
 
 def test_batch_preemption_reduces_queries(initialized_db, set_secscan_config):

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -1478,8 +1478,7 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
     for mss in ManifestSecurityStatus.select().where(
         ManifestSecurityStatus.manifest_id.in_(list(exhausted_ids))
     ):
-        assert mss.index_status == IndexStatus.FAILED
-        assert mss.metadata_json.get("retry_count") == 5
+        assert mss.index_status == IndexStatus.SCAN_RETRIES_EXHAUSTED
 
     under_limit_ids = {manifests[i].id for i in range(3, 6)}
     for mss in ManifestSecurityStatus.select().where(

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -1243,7 +1243,7 @@ def test_batch_preemption_check(initialized_db, set_secscan_config):
     secscan._secscan_api.index = count_index
 
     # Run indexing
-    secscan._index(simple_iterator(), reindex_threshold)
+    secscan._index(simple_iterator(), reindex_threshold, "abc")
 
     # Verify that recently indexed manifests were skipped
     # We expect: 3 skipped (recently indexed), rest processed
@@ -1316,7 +1316,7 @@ def test_batched_iterator_with_preemption_check(initialized_db, set_secscan_conf
     secscan._secscan_api.index = counting_index
 
     # Run indexing
-    secscan._index(test_iterator(), reindex_threshold)
+    secscan._index(test_iterator(), reindex_threshold, "test")
 
     # Verify that batching worked - some manifests were skipped
     # We marked 10 as recently indexed, so they should be skipped
@@ -1346,7 +1346,7 @@ def test_batch_preemption_empty_and_edge_cases(initialized_db, set_secscan_confi
     secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
 
     # Should not crash with empty iterator
-    secscan._index(empty_iterator(), reindex_threshold)
+    secscan._index(empty_iterator(), reindex_threshold, "test")
 
     # Test 2: Single manifest
     manifests = list(Manifest.select().limit(1))
@@ -1359,7 +1359,7 @@ def test_batch_preemption_empty_and_edge_cases(initialized_db, set_secscan_confi
             {"err": None, "state": IndexReportState.Index_Finished},
             "test",
         )
-        secscan._index(single_iterator(), reindex_threshold)
+        secscan._index(single_iterator(), reindex_threshold, "test")
 
         # Verify it was processed (may be marked as unsupported if it's a manifest list)
         assert (
@@ -1444,7 +1444,7 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
             indexer_hash="abc",
             indexer_version=IndexerVersion.V4,
             last_indexed=reindex_threshold - timedelta(seconds=100),
-            metadata_json={"retry_count": 3},
+            metadata_json={"retry_count": 3, "last_failed_hash": "abc"},
         )
 
     for i in range(3, 6):
@@ -1456,7 +1456,7 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
             indexer_hash="abc",
             indexer_version=IndexerVersion.V4,
             last_indexed=reindex_threshold - timedelta(seconds=100),
-            metadata_json={"retry_count": 1},
+            metadata_json={"retry_count": 1, "last_failed_hash": "abc"},
         )
 
     from threading import Event
@@ -1472,8 +1472,7 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
         {"err": None, "state": IndexReportState.Index_Finished},
         "abc",
     )
-
-    secscan._index(test_iterator(), reindex_threshold)
+    secscan._index(test_iterator(), reindex_threshold, "abc")
 
     exhausted_ids = {manifests[i].id for i in range(3)}
     for mss in ManifestSecurityStatus.select().where(
@@ -1489,9 +1488,10 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
         assert mss.index_status == IndexStatus.COMPLETED
 
 
-def test_api_failure_increments_retry_count(initialized_db, set_secscan_config):
+def test_api_failure_does_not_increment_retry_count(initialized_db, set_secscan_config):
     """
-    Test that APIRequestFailure increments retry_count in metadata_json.
+    Test that APIRequestFailure does not increment retry_count since transport
+    failures are transient and should not count against the retry limit.
     """
     secscan = V4SecurityScanner(application, instance_keys, storage)
     secscan._secscan_api = mock.Mock()
@@ -1502,7 +1502,7 @@ def test_api_failure_increments_retry_count(initialized_db, set_secscan_config):
 
     for mss in ManifestSecurityStatus.select():
         assert mss.index_status == IndexStatus.FAILED
-        assert mss.metadata_json.get("retry_count") == 1
+        assert mss.metadata_json.get("retry_count") is None
 
 
 def test_index_error_increments_retry_count(initialized_db, set_secscan_config):
@@ -1610,7 +1610,7 @@ def test_batch_preemption_reduces_queries(initialized_db, set_secscan_config):
         "test",
     )
 
-    secscan._index(test_iterator(), reindex_threshold)
+    secscan._index(test_iterator(), reindex_threshold, "test")
 
     # Verify that recently indexed manifests still have original hash
     # (they were skipped, so hash wasn't updated)

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -56,7 +56,7 @@ from image.oci import (
 )
 from initdb import create_schema2_or_oci_manifest_for_testing
 from test.fixtures import *
-from util.secscan.v4.api import APIRequestFailure
+from util.secscan.v4.api import APIRequestFailure, Non200ResponseException
 
 logger = logging.getLogger(__name__)
 
@@ -1487,22 +1487,46 @@ def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_confi
         assert mss.index_status == IndexStatus.COMPLETED
 
 
-def test_api_failure_does_not_increment_retry_count(initialized_db, set_secscan_config):
+def test_connection_failure_does_not_increment_retry_count(initialized_db, set_secscan_config):
     """
-    Test that APIRequestFailure does not increment retry_count since Clair 5xx
-    and connection errors are not a definitive verdict on the manifest. Only
-    Index_Error and unknown_state report states count toward the retry limit.
+    Test that APIRequestFailure (connection errors, timeouts) does not increment
+    retry_count. These are transient infrastructure errors, not a verdict on the
+    manifest itself.
     """
     secscan = V4SecurityScanner(application, instance_keys, storage)
     secscan._secscan_api = mock.Mock()
     secscan._secscan_api.state.return_value = {"state": "abc"}
-    secscan._secscan_api.index.side_effect = APIRequestFailure("500 internal server error")
+    secscan._secscan_api.index.side_effect = APIRequestFailure("connection refused")
 
     secscan.perform_indexing(batch_size=100)
 
     for mss in ManifestSecurityStatus.select():
         assert mss.index_status == IndexStatus.FAILED
         assert mss.metadata_json.get("retry_count") is None
+
+
+def test_non200_response_increments_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that Non200ResponseException (e.g. Clair 500 for corrupt layers)
+    increments retry_count, since the server processed the request and rejected
+    it — retrying the same manifest will produce the same result.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    mock_response = mock.Mock()
+    mock_response.status_code = 500
+    secscan._secscan_api.index.side_effect = Non200ResponseException(mock_response)
+
+    secscan.perform_indexing(batch_size=100)
+
+    failed_count = 0
+    for mss in ManifestSecurityStatus.select():
+        if mss.index_status == IndexStatus.FAILED:
+            assert mss.metadata_json.get("retry_count") == 1
+            assert mss.metadata_json.get("last_failed_hash") == "abc"
+            failed_count += 1
+    assert failed_count > 0, "Expected at least one FAILED manifest"
 
 
 def test_index_error_increments_retry_count(initialized_db, set_secscan_config):

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -203,6 +203,47 @@ class TestFindAndClaimBatch:
         claimed = scanner._find_and_claim_batch(50, reindex_threshold, stale_threshold, "abc")
         assert len(claimed) == 0
 
+    def test_skips_failed_with_exhausted_retries(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        for m in Manifest.select():
+            ManifestSecurityStatus.create(
+                manifest=m,
+                repository=m.repository,
+                error_json={},
+                index_status=IndexStatus.FAILED,
+                indexer_hash="abc",
+                indexer_version=IndexerVersion.V4,
+                last_indexed=datetime.utcnow() - timedelta(seconds=600),
+                metadata_json={"retry_count": 3},
+            )
+
+        claimed = scanner._find_and_claim_batch(50, reindex_threshold, stale_threshold, "abc")
+        assert len(claimed) == 0
+
+    def test_claims_failed_under_retry_limit(self, initialized_db, scanner):
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        for m in Manifest.select():
+            ManifestSecurityStatus.create(
+                manifest=m,
+                repository=m.repository,
+                error_json={},
+                index_status=IndexStatus.FAILED,
+                indexer_hash="abc",
+                indexer_version=IndexerVersion.V4,
+                last_indexed=datetime.utcnow() - timedelta(seconds=600),
+                metadata_json={"retry_count": 2},
+            )
+
+        manifest_count = Manifest.select().count()
+        claimed = scanner._find_and_claim_batch(
+            manifest_count, reindex_threshold, stale_threshold, "abc"
+        )
+        assert len(claimed) == manifest_count
+
     @pytest.mark.parametrize(
         "status",
         [IndexStatus.MANIFEST_UNSUPPORTED, IndexStatus.MANIFEST_LAYER_TOO_LARGE],
@@ -231,6 +272,98 @@ class TestFindAndClaimBatch:
 
         claimed = scanner._find_and_claim_batch(2, reindex_threshold, stale_threshold, "abc")
         assert len(claimed) == 2
+
+
+class TestRetryCountTracking:
+    def test_mark_failed_increments_retry_count(self, initialized_db, scanner):
+        m = Manifest.select().first()
+        ManifestSecurityStatus.create(
+            manifest=m,
+            repository=m.repository,
+            error_json={},
+            index_status=IndexStatus.IN_PROGRESS,
+            indexer_hash="in_progress_v2",
+            indexer_version=IndexerVersion.V4,
+            metadata_json={},
+        )
+
+        scanner._mark_failed(m.id, "api_failure", {"error": "timeout"})
+
+        mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == m)
+        assert mss.index_status == IndexStatus.FAILED
+        assert mss.metadata_json["retry_count"] == 1
+
+        ManifestSecurityStatus.update(
+            index_status=IndexStatus.IN_PROGRESS,
+        ).where(ManifestSecurityStatus.manifest == m).execute()
+
+        scanner._mark_failed(m.id, "api_failure", {"error": "timeout"})
+
+        mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == m)
+        assert mss.metadata_json["retry_count"] == 2
+
+    def test_index_error_increments_retry_count(self, initialized_db, scanner):
+        scanner._secscan_api.index.return_value = (
+            {"err": "something went wrong", "state": IndexReportState.Index_Error},
+            "abc",
+        )
+
+        scanner.perform_indexing(batch_size=1)
+
+        mss = ManifestSecurityStatus.select().first()
+        assert mss.index_status == IndexStatus.FAILED
+        assert mss.metadata_json.get("retry_count", 0) == 1
+
+    def test_successful_indexing_resets_retry_count(self, initialized_db, scanner):
+        m = Manifest.select().first()
+        ManifestSecurityStatus.create(
+            manifest=m,
+            repository=m.repository,
+            error_json={},
+            index_status=IndexStatus.FAILED,
+            indexer_hash="abc",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=datetime.utcnow() - timedelta(days=2),
+            metadata_json={"retry_count": 2},
+        )
+
+        scanner.perform_indexing(batch_size=100)
+
+        for mss in ManifestSecurityStatus.select():
+            if mss.index_status == IndexStatus.COMPLETED:
+                assert mss.metadata_json == {} or mss.metadata_json.get("retry_count", 0) == 0
+
+    def test_configurable_max_retries(self, initialized_db, scanner):
+        application.config["SECURITY_SCANNER_V2_MAX_SCAN_RETRIES"] = 5
+
+        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+
+        m = Manifest.select().first()
+        ManifestSecurityStatus.create(
+            manifest=m,
+            repository=m.repository,
+            error_json={},
+            index_status=IndexStatus.FAILED,
+            indexer_hash="abc",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=datetime.utcnow() - timedelta(seconds=600),
+            metadata_json={"retry_count": 4},
+        )
+
+        claimed = scanner._find_and_claim_batch(10, reindex_threshold, stale_threshold, "abc")
+        assert len(claimed) == 1
+
+        ManifestSecurityStatus.update(
+            index_status=IndexStatus.FAILED,
+            last_indexed=datetime.utcnow() - timedelta(seconds=600),
+            metadata_json={"retry_count": 5},
+        ).where(ManifestSecurityStatus.manifest == m).execute()
+
+        claimed = scanner._find_and_claim_batch(10, reindex_threshold, stale_threshold, "abc")
+        assert len(claimed) == 0
+
+        del application.config["SECURITY_SCANNER_V2_MAX_SCAN_RETRIES"]
 
 
 class TestPerformIndexingCycle:

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -329,41 +329,44 @@ class TestRetryCountTracking:
 
         scanner.perform_indexing(batch_size=100)
 
+        completed_count = 0
         for mss in ManifestSecurityStatus.select():
             if mss.index_status == IndexStatus.COMPLETED:
                 assert mss.metadata_json == {} or mss.metadata_json.get("retry_count", 0) == 0
+                completed_count += 1
+        assert completed_count > 0, "Expected at least one COMPLETED manifest"
 
     def test_configurable_max_retries(self, initialized_db, scanner):
         application.config["SECURITY_SCANNER_V2_MAX_SCAN_RETRIES"] = 5
+        try:
+            reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
+            stale_threshold = datetime.utcnow() - timedelta(hours=6)
 
-        reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
-        stale_threshold = datetime.utcnow() - timedelta(hours=6)
+            m = Manifest.select().first()
+            ManifestSecurityStatus.create(
+                manifest=m,
+                repository=m.repository,
+                error_json={},
+                index_status=IndexStatus.FAILED,
+                indexer_hash="abc",
+                indexer_version=IndexerVersion.V4,
+                last_indexed=datetime.utcnow() - timedelta(seconds=600),
+                metadata_json={"retry_count": 4},
+            )
 
-        m = Manifest.select().first()
-        ManifestSecurityStatus.create(
-            manifest=m,
-            repository=m.repository,
-            error_json={},
-            index_status=IndexStatus.FAILED,
-            indexer_hash="abc",
-            indexer_version=IndexerVersion.V4,
-            last_indexed=datetime.utcnow() - timedelta(seconds=600),
-            metadata_json={"retry_count": 4},
-        )
+            claimed = scanner._find_and_claim_batch(10, reindex_threshold, stale_threshold, "abc")
+            assert len(claimed) == 1
 
-        claimed = scanner._find_and_claim_batch(10, reindex_threshold, stale_threshold, "abc")
-        assert len(claimed) == 1
+            ManifestSecurityStatus.update(
+                index_status=IndexStatus.FAILED,
+                last_indexed=datetime.utcnow() - timedelta(seconds=600),
+                metadata_json={"retry_count": 5},
+            ).where(ManifestSecurityStatus.manifest == m).execute()
 
-        ManifestSecurityStatus.update(
-            index_status=IndexStatus.FAILED,
-            last_indexed=datetime.utcnow() - timedelta(seconds=600),
-            metadata_json={"retry_count": 5},
-        ).where(ManifestSecurityStatus.manifest == m).execute()
-
-        claimed = scanner._find_and_claim_batch(10, reindex_threshold, stale_threshold, "abc")
-        assert len(claimed) == 0
-
-        del application.config["SECURITY_SCANNER_V2_MAX_SCAN_RETRIES"]
+            claimed = scanner._find_and_claim_batch(10, reindex_threshold, stale_threshold, "abc")
+            assert len(claimed) == 0
+        finally:
+            application.config.pop("SECURITY_SCANNER_V2_MAX_SCAN_RETRIES", None)
 
 
 class TestPerformIndexingCycle:

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -216,7 +216,7 @@ class TestFindAndClaimBatch:
                 indexer_hash="abc",
                 indexer_version=IndexerVersion.V4,
                 last_indexed=datetime.utcnow() - timedelta(seconds=600),
-                metadata_json={"retry_count": 3},
+                metadata_json={"retry_count": 3, "last_failed_hash": "abc"},
             )
 
         claimed = scanner._find_and_claim_batch(50, reindex_threshold, stale_threshold, "abc")
@@ -287,17 +287,18 @@ class TestRetryCountTracking:
             metadata_json={},
         )
 
-        scanner._mark_failed(m.id, "api_failure", {"error": "timeout"})
+        scanner._mark_failed(m.id, "api_failure", {"error": "timeout"}, "abc")
 
         mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == m)
         assert mss.index_status == IndexStatus.FAILED
         assert mss.metadata_json["retry_count"] == 1
+        assert mss.metadata_json["last_failed_hash"] == "abc"
 
         ManifestSecurityStatus.update(
             index_status=IndexStatus.IN_PROGRESS,
         ).where(ManifestSecurityStatus.manifest == m).execute()
 
-        scanner._mark_failed(m.id, "api_failure", {"error": "timeout"})
+        scanner._mark_failed(m.id, "api_failure", {"error": "timeout"}, "abc")
 
         mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == m)
         assert mss.metadata_json["retry_count"] == 2
@@ -337,7 +338,7 @@ class TestRetryCountTracking:
         assert completed_count > 0, "Expected at least one COMPLETED manifest"
 
     def test_configurable_max_retries(self, initialized_db, scanner):
-        application.config["SECURITY_SCANNER_V2_MAX_SCAN_RETRIES"] = 5
+        application.config["SECURITY_SCANNER_MAX_SCAN_RETRIES"] = 5
         try:
             reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
             stale_threshold = datetime.utcnow() - timedelta(hours=6)
@@ -351,7 +352,7 @@ class TestRetryCountTracking:
                 indexer_hash="abc",
                 indexer_version=IndexerVersion.V4,
                 last_indexed=datetime.utcnow() - timedelta(seconds=600),
-                metadata_json={"retry_count": 4},
+                metadata_json={"retry_count": 4, "last_failed_hash": "abc"},
             )
 
             claimed = scanner._find_and_claim_batch(10, reindex_threshold, stale_threshold, "abc")
@@ -360,13 +361,13 @@ class TestRetryCountTracking:
             ManifestSecurityStatus.update(
                 index_status=IndexStatus.FAILED,
                 last_indexed=datetime.utcnow() - timedelta(seconds=600),
-                metadata_json={"retry_count": 5},
+                metadata_json={"retry_count": 5, "last_failed_hash": "abc"},
             ).where(ManifestSecurityStatus.manifest == m).execute()
 
             claimed = scanner._find_and_claim_batch(10, reindex_threshold, stale_threshold, "abc")
             assert len(claimed) == 0
         finally:
-            application.config.pop("SECURITY_SCANNER_V2_MAX_SCAN_RETRIES", None)
+            application.config.pop("SECURITY_SCANNER_MAX_SCAN_RETRIES", None)
 
 
 class TestPerformIndexingCycle:

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -216,7 +216,7 @@ class TestFindAndClaimBatch:
                 indexer_hash="abc",
                 indexer_version=IndexerVersion.V4,
                 last_indexed=datetime.utcnow() - timedelta(seconds=600),
-                metadata_json={"retry_count": 3, "last_failed_hash": "abc"},
+                metadata_json={"retry_count": 5, "last_failed_hash": "abc"},
             )
 
         claimed = scanner._find_and_claim_batch(50, reindex_threshold, stale_threshold, "abc")

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -12,6 +12,7 @@ from data.registry_model import registry_model
 from data.secscan_model.secscan_v4_model import IndexReportState
 from data.secscan_model.secscan_v4_model_v2 import V4SecurityScannerV2
 from test.fixtures import *
+from util.secscan.v4.api import Non200ResponseException
 
 logger = logging.getLogger(__name__)
 
@@ -320,6 +321,18 @@ class TestRetryCountTracking:
         mss = ManifestSecurityStatus.select().first()
         assert mss.index_status == IndexStatus.FAILED
         assert mss.metadata_json.get("retry_count", 0) == 1
+
+    def test_non200_response_increments_retry_count(self, initialized_db, scanner):
+        mock_response = mock.Mock()
+        mock_response.status_code = 500
+        scanner._secscan_api.index.side_effect = Non200ResponseException(mock_response)
+
+        scanner.perform_indexing(batch_size=1)
+
+        mss = ManifestSecurityStatus.select().first()
+        assert mss.index_status == IndexStatus.FAILED
+        assert mss.metadata_json.get("retry_count") == 1
+        assert mss.metadata_json.get("last_failed_hash") == "abc"
 
     def test_successful_indexing_resets_retry_count(self, initialized_db, scanner):
         m = Manifest.select().first()

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -219,8 +219,14 @@ class TestFindAndClaimBatch:
                 metadata_json={"retry_count": 5, "last_failed_hash": "abc"},
             )
 
-        claimed = scanner._find_and_claim_batch(50, reindex_threshold, stale_threshold, "abc")
+        manifest_count = Manifest.select().count()
+        claimed = scanner._find_and_claim_batch(
+            manifest_count, reindex_threshold, stale_threshold, "abc"
+        )
         assert len(claimed) == 0
+
+        for mss in ManifestSecurityStatus.select():
+            assert mss.index_status == IndexStatus.SCAN_RETRIES_EXHAUSTED
 
     def test_claims_failed_under_retry_limit(self, initialized_db, scanner):
         reindex_threshold = datetime.utcnow() - timedelta(seconds=300)
@@ -366,6 +372,9 @@ class TestRetryCountTracking:
 
             claimed = scanner._find_and_claim_batch(10, reindex_threshold, stale_threshold, "abc")
             assert len(claimed) == 0
+
+            mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == m)
+            assert mss.index_status == IndexStatus.SCAN_RETRIES_EXHAUSTED
         finally:
             application.config.pop("SECURITY_SCANNER_MAX_SCAN_RETRIES", None)
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -100,6 +100,7 @@ var knownUnmapped = map[string]bool{
 	"FEATURE_SECURITY_SCANNER_V2":             true,
 	"SECURITY_SCANNER_V2_BATCH_SIZE":          true,
 	"SECURITY_SCANNER_V2_INDEXING_INTERVAL":   true,
+	"SECURITY_SCANNER_MAX_SCAN_RETRIES":       true,
 
 	// Feature flags not yet mapped
 	"FEATURE_ADVERTISE_V2":                          true,

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -858,6 +858,11 @@ CONFIG_SCHEMA = {
             "description": "The number of seconds between indexing cycles in the V2 security scanner. Defaults to 30.",
             "x-example": 30,
         },
+        "SECURITY_SCANNER_MAX_SCAN_RETRIES": {
+            "type": "number",
+            "description": "The maximum number of scan retries per indexer hash before a manifest is skipped. Defaults to 3.",
+            "x-example": 3,
+        },
         # Repository mirroring
         "REPO_MIRROR_INTERVAL": {
             "type": "number",

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -859,9 +859,10 @@ CONFIG_SCHEMA = {
             "x-example": 30,
         },
         "SECURITY_SCANNER_MAX_SCAN_RETRIES": {
-            "type": "number",
-            "description": "The maximum number of scan retries per indexer hash before a manifest is skipped. Defaults to 3.",
-            "x-example": 3,
+            "type": "integer",
+            "minimum": 0,
+            "description": "The maximum number of scan retries per indexer hash before a manifest is skipped. Defaults to 5.",
+            "x-example": 5,
         },
         # Repository mirroring
         "REPO_MIRROR_INTERVAL": {

--- a/util/secscan/v4/api.py
+++ b/util/secscan/v4/api.py
@@ -259,7 +259,7 @@ class ClairSecurityScannerAPI(SecurityScannerAPIInterface):
             resp = self._perform(actions["Index"](body))
         except BadRequestResponseException as ex:
             raise InvalidContentSent(ex)
-        except (Non200ResponseException, IncompatibleAPIResponse) as ex:
+        except IncompatibleAPIResponse as ex:
             raise APIRequestFailure(ex)
 
         # Required clair indexer hash.

--- a/web/playwright/e2e/tags/security-scan.spec.ts
+++ b/web/playwright/e2e/tags/security-scan.spec.ts
@@ -153,6 +153,29 @@ test.describe(
       await expect(vulnRows.first()).toBeVisible();
     });
 
+    test('security status API returns valid scan status', async ({
+      userContext,
+    }) => {
+      const api = new ApiClient(userContext.request);
+      const tags = await api.getTags(testRepo.namespace, testRepo.name);
+      const digest = tags.tags[0].manifest_digest;
+
+      const sec = await api.getManifestSecurity(
+        testRepo.namespace,
+        testRepo.name,
+        digest,
+      );
+
+      expect(sec.status).toBeDefined();
+      expect(['queued', 'scanned', 'failed', 'unsupported']).toContain(
+        sec.status,
+      );
+
+      if (sec.status === 'scanned') {
+        expect(sec.data).toBeDefined();
+      }
+    });
+
     test('packages tab supports filtering', async ({authenticatedPage}) => {
       await authenticatedPage.goto(
         `/repository/${testRepo.fullName}/tag/latest?tab=packages`,

--- a/web/playwright/e2e/tags/security-scan.spec.ts
+++ b/web/playwright/e2e/tags/security-scan.spec.ts
@@ -153,29 +153,6 @@ test.describe(
       await expect(vulnRows.first()).toBeVisible();
     });
 
-    test('security status API returns valid scan status', async ({
-      userContext,
-    }) => {
-      const api = new ApiClient(userContext.request);
-      const tags = await api.getTags(testRepo.namespace, testRepo.name);
-      const digest = tags.tags[0].manifest_digest;
-
-      const sec = await api.getManifestSecurity(
-        testRepo.namespace,
-        testRepo.name,
-        digest,
-      );
-
-      expect(sec.status).toBeDefined();
-      expect(['queued', 'scanned', 'failed', 'unsupported']).toContain(
-        sec.status,
-      );
-
-      if (sec.status === 'scanned') {
-        expect(sec.data).toBeDefined();
-      }
-    });
-
     test('packages tab supports filtering', async ({authenticatedPage}) => {
       await authenticatedPage.goto(
         `/repository/${testRepo.fullName}/tag/latest?tab=packages`,


### PR DESCRIPTION
Track scan retry count in metadata_json to prevent permanently-failing manifests from consuming indexing cycles indefinitely. After exceeding the configurable max retries (default 3), failed manifests are skipped. No migration required, uses the existing metadata_json JSONField.

Rollout https://github.com/quay/quay/pull/6633 first to canary