### PR TITLE
NO-ISSUE: fix(playwright): update BUSYBOX_IMAGE to valid manifest list digest

### DIFF
--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -21,7 +21,7 @@ const execFileAsync = promisify(execFile);
 const REGISTRY_HOST = new URL(API_URL).host;
 
 const BUSYBOX_IMAGE =
-  'quay.io/prometheus/busybox@sha256:467c84e76e5bd720ffd3cb86c11e421e2489ef20868114ba58cd0a9e02e70a9d';
+  'quay.io/prometheus/busybox@sha256:065fa27af988710200f7a9ceb7a09ae2fa6604074898c650bd89459e36edd6cf';
 
 type ToolAvailability = {
   skopeo: boolean;


### PR DESCRIPTION
## Summary
- The pinned `quay.io/prometheus/busybox` digest (`467c84...`) was deleted upstream again, breaking all Playwright E2E tests that push images via skopeo
- Updated to the current manifest list digest (`065fa27...`) which resolves correctly for both single-platform (`--override-os/arch`) and multi-arch (`--all`) skopeo copies
- This is the same root cause as #6549 — the upstream image keeps getting garbage-collected

## JIRA
NO-ISSUE

## Test Plan
- [ ] CI Playwright E2E tests pass with the new digest
- [ ] Cherry-pick to `redhat-3.18` to unblock #6537
