### PR TITLE
PROJQUAY-12361: fix(nginx): support TLS 1.3 ciphersuites and conditional ssl_ciphers

### DIFF
--- a/conf/init/nginx_conf_create.py
+++ b/conf/init/nginx_conf_create.py
@@ -74,6 +74,7 @@ def generate_nginx_config(config):
     enable_rate_limits = config.get("FEATURE_RATE_LIMITS", False)
     ssl_protocols = config.get("SSL_PROTOCOLS", SSL_PROTOCOL_DEFAULTS)
     ssl_ciphers = config.get("SSL_CIPHERS", SSL_CIPHER_DEFAULTS)
+    ssl_ciphersuites = config.get("SSL_CIPHERSUITES", [])
 
     # Enable IPv4 and/or IPv6. Valid values are IPv4, IPv6 or dual-stack.
     ip_version = config.get("FEATURE_LISTEN_IP_VERSION", "IPv4")
@@ -94,6 +95,7 @@ def generate_nginx_config(config):
         v1_only_domain=v1_only_domain,
         ssl_protocols=ssl_protocols,
         ssl_ciphers=":".join(ssl_ciphers),
+        ssl_ciphersuites=":".join(ssl_ciphersuites),
         use_ipv4=use_ipv4,
         use_ipv6=use_ipv6,
         preferred_scheme=preferred_scheme,

--- a/conf/nginx/nginx.conf.jnj
+++ b/conf/nginx/nginx.conf.jnj
@@ -16,7 +16,8 @@ http {
 
     resolver 127.0.0.1:8053 valid=10s;
 
-    ssl_ciphers '{{ ssl_ciphers }}';
+    {% if ssl_ciphers %}ssl_ciphers '{{ ssl_ciphers }}';{% endif %}
+    {% if ssl_ciphersuites %}ssl_conf_command Ciphersuites {{ ssl_ciphersuites }};{% endif %}
     ssl_protocols {% for ssl_protocol in ssl_protocols %}{{ ssl_protocol }} {% endfor %};
     ssl_session_cache shared:SSL:60m;
     ssl_session_timeout 2h;


### PR DESCRIPTION
## Summary
- Add `SSL_CIPHERSUITES` support to nginx config generation via `ssl_conf_command Ciphersuites` directive
- Make `ssl_ciphers` conditional so it is omitted when empty (e.g., Modern/TLS 1.3-only profile)
- Fix: When cluster TLS profile is set to "Modern" (TLS 1.3 only), nginx config incorrectly falls back to hardcoded TLS 1.2 cipher defaults because `SSL_CIPHERS` is absent in config.yaml

## Root Cause
1. `conf/init/nginx_conf_create.py:76`: `config.get("SSL_CIPHERS", SSL_CIPHER_DEFAULTS)` falls back to TLS 1.2 ciphers when `SSL_CIPHERS` is absent
2. `conf/nginx/nginx.conf.jnj`: No support for `ssl_ciphersuites` directive, so `SSL_CIPHERSUITES` from operator config is ignored

## Test plan
- [ ] Deploy Quay with cluster TLS profile set to "Modern" — verify nginx config has no `ssl_ciphers` line and has `ssl_conf_command Ciphersuites` with TLS 1.3 ciphers
- [ ] Deploy Quay with cluster TLS profile set to "Intermediate" — verify nginx config has both `ssl_ciphers` (TLS 1.2) and `ssl_conf_command Ciphersuites` (TLS 1.3)
- [ ] Deploy Quay without operator (standalone) — verify fallback to `SSL_CIPHER_DEFAULTS` still works
- [ ] Verify TLS 1.3 connections succeed under Modern profile
- [ ] Verify TLS 1.2 connections are rejected under Modern profile

Fixes: https://redhat.atlassian.net/browse/PROJQUAY-12361
Related: https://redhat.atlassian.net/browse/PROJQUAY-10442

🤖 Generated with [Claude Code](https://claude.ai/code)