### PR TITLE
[redhat-3.16] PROJQUAY-12275: chore(deps): upgrade pyasn1 from 0.6.3 to 0.6.4 to address CVE-2026-59885

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ prometheus_client==0.7.1
 protobuf==5.29.5
 psutil==5.9.0
 psycopg2==2.9.9
-pyasn1==0.6.3
+pyasn1==0.6.4
 pyasn1_modules==0.4.2
 py-bitbucket @ git+https://github.com/quay/py-bitbucket.git@3ba167408d92eb4ba2cae78c0047b8f1e8821c67
 PyGithub==2.1.1


### PR DESCRIPTION
[PROJQUAY-12319](https://redhat.atlassian.net/browse/PROJQUAY-12319):  chore(deps): upgrade pyasn1 from 0.6.3 to 0.6.4 to address CVE-2026-59885, CVE-2026-59886
https://redhat.atlassian.net/browse/PROJQUAY-12319 - CVE-2026-59886
https://redhat.atlassian.net/browse/PROJQUAY-12275 - CVE-2026-59885