### PR TITLE
[redhat-3.18] NO-ISSUE: fix(quota): backport retroactive notification payload serialization

### DIFF
--- a/data/model/namespacequota.py
+++ b/data/model/namespacequota.py
@@ -383,7 +383,7 @@ def maybe_trigger_retroactive_notification(
             return
 
         usage_bytes = get_namespace_size(namespace_name)
-        quota_limit_bytes = quota.limit_bytes
+        quota_limit_bytes = int(quota.limit_bytes)
         bytes_allowed = int(quota_limit_bytes * threshold_percent / 100)
 
         if usage_bytes <= bytes_allowed:

--- a/data/model/test/test_quota_retroactive.py
+++ b/data/model/test/test_quota_retroactive.py
@@ -1,3 +1,5 @@
+import json
+from decimal import Decimal
 from unittest.mock import call, patch
 
 import pytest
@@ -11,6 +13,7 @@ from data.model.namespacequota import (
     maybe_trigger_retroactive_notification,
     maybe_trigger_retroactive_notifications_for_quota,
 )
+from data.model.notification import create_namespace_notification
 from data.model.user import get_user
 from test.fixtures import *
 
@@ -153,3 +156,31 @@ class TestMaybeTriggerRetroactiveNotification:
         maybe_trigger_retroactive_notifications_for_quota("buynlarge", quota)
 
         mock_trigger.assert_not_called()
+
+    @patch("features.QUOTA_NOTIFICATIONS", True)
+    @patch("notifications.spawn_namespace_notification")
+    def test_retroactive_notification_json_serializable(self, mock_spawn, initialized_db):
+        """quota_limit_bytes passed through the full notification path is an int,
+        not a Decimal, so json.dumps() in spawn_namespace_notification succeeds."""
+        limit_bytes = 1000
+        self._set_namespace_size(self.org, 850)
+        quota, _ = self._create_quota_with_limit(self.org, limit_bytes, 80, "Warning")
+        create_namespace_notification(
+            self.org,
+            "quota_warning",
+            "quay_notification",
+            {"target": {"kind": "user", "name": "public"}},
+            {},
+        )
+
+        maybe_trigger_retroactive_notification("buynlarge", quota, 80, "Warning")
+
+        mock_spawn.assert_called_once()
+        extra = mock_spawn.call_args[1]["extra_data"]
+        # All numeric values must be int, not Decimal, for JSON serialization
+        assert isinstance(extra["limit_bytes"], int)
+        assert isinstance(extra["usage_bytes"], int)
+        assert isinstance(extra["usage_percent"], int)
+        assert isinstance(extra["threshold_percent"], int)
+        # The full extra_data dict must be JSON-serializable without TypeError
+        json.dumps(extra)

--- a/data/model/test/test_quota_retroactive.py
+++ b/data/model/test/test_quota_retroactive.py
@@ -1,5 +1,4 @@
 import json
-from decimal import Decimal
 from unittest.mock import call, patch
 
 import pytest

--- a/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
@@ -74,6 +74,7 @@ test.describe(
           expect(typeof webhook?.body?.limit_bytes).toBe('number');
           expect(typeof webhook?.body?.usage_bytes).toBe('number');
           expect(typeof webhook?.body?.usage_percent).toBe('number');
+          expect(typeof webhook?.body?.threshold_percent).toBe('number');
         } finally {
           await receiver.stop();
         }


### PR DESCRIPTION
## Summary
Backport the retroactive quota notification serialization fix from PR #6534 to `redhat-3.18`.

## Root Cause / Rationale
Quota notification payload fields can contain PostgreSQL `Decimal`/big-integer values that are not safely JSON serializable. The backport ensures `limit_bytes` is cast to an integer and adds regression coverage for the numeric payload fields.

## Changes
- Cast `limit_bytes` to `int` in the retroactive quota notification path.
- Add unit coverage for the retroactive notification payload.
- Add Playwright coverage for `threshold_percent` while preserving the newer `usage_percent` assertion already present on `redhat-3.18`.
- Resolve the test-file conflict by retaining both the target branch's newer serialization coverage and PR #6534's threshold coverage.

## Test Plan
- Pre-commit checks passed for the changed files except ESLint and Playwright tag validation, which could not run because frontend dependencies are not installed in the temporary worktree.
- `git diff --check` passed.
- CI should run the backend unit tests and Playwright checks.

## JIRA Link
No Jira issue — backport of https://github.com/quay/quay/pull/6534.

## Backport
This PR targets `redhat-3.18` and backports PR #6534.