### PR TITLE
PROJQUAY-12414: feat(mirror): prepare DefaultImage for release build overrides

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -27,7 +27,6 @@ func newInstallCmdWithDeps(stdin io.Reader, install func(context.Context, *insta
 	initUser := fs.String("init-user", "admin", "admin username for initial setup")
 	initPasswordStdin := fs.Bool("init-password-stdin", false, "read the initial admin password from stdin")
 	imageArchive := fs.String("image-archive", "", "path to container image tar (offline mode)")
-	image := fs.String("image", installer.DefaultImage, "container image to use")
 
 	return &Command{
 		Name:     "install",
@@ -59,7 +58,7 @@ func newInstallCmdWithDeps(stdin io.Reader, install func(context.Context, *insta
 				InitPassword:                initPassword,
 				InitPasswordSet:             *initPasswordStdin,
 				ImageArchive:                *imageArchive,
-				Image:                       *image,
+				Image:                       installer.DefaultImage,
 			})
 		},
 	}

--- a/internal/cmd/migrate.go
+++ b/internal/cmd/migrate.go
@@ -15,7 +15,6 @@ func newMigrateCmd() *Command {
 	fs := flag.NewFlagSet("migrate", flag.ContinueOnError)
 	dataDir := fs.String("data-dir", "/var/lib/quay", "target directory for new installation")
 	hostname := fs.String("hostname", "", "server hostname (auto-detected from old config)")
-	image := fs.String("image", installer.DefaultImage, "container image reference")
 	imageArchive := fs.String("image-archive", "", "path to container image tar (auto-detected)")
 
 	sourceRoot := fs.String("source-root", "", "old quay-install directory")
@@ -35,7 +34,7 @@ func newMigrateCmd() *Command {
 			return runMigrate(ctx, &migrate.Migrator{
 				DataDir:       *dataDir,
 				Hostname:      *hostname,
-				Image:         *image,
+				Image:         installer.DefaultImage,
 				ImageArchive:  *imageArchive,
 				SourceRoot:    *sourceRoot,
 				SourceDB:      *sourceDB,

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -27,13 +27,14 @@ import (
 	"github.com/quay/quay/internal/system"
 )
 
-const (
-	// DefaultImage is the default container image for the registry.
-	DefaultImage = "quay.io/quay/quay-mirror:latest"
+// DefaultImage is the default container image for the registry.
+// Overridden at build time via ldflags for release builds.
+var DefaultImage = "quay.io/quay/quay-mirror:latest"
 
-	defaultPort         = "8443"
+const (
+	defaultPort        = "8443"
 	defaultInitUsername = "admin"
-	quadletServiceName  = "quay"
+	quadletServiceName = "quay"
 )
 
 // Config holds the parameters for an install or upgrade operation.

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -32,9 +32,9 @@ import (
 var DefaultImage = "quay.io/quay/quay-mirror:latest"
 
 const (
-	defaultPort        = "8443"
+	defaultPort         = "8443"
 	defaultInitUsername = "admin"
-	quadletServiceName = "quay"
+	quadletServiceName  = "quay"
 )
 
 // Config holds the parameters for an install or upgrade operation.


### PR DESCRIPTION
## Summary

Prepares the OMR 3.0 binary for Konflux release builds by making `DefaultImage` overridable and removing the `--image` flag.

**Why**: OMR 3.0 will ship offline bundles containing a host binary + an oci-archive container image tar. The binary needs to know which container image to pull for online installs. Release builds override `DefaultImage` via ldflags to point to `registry.redhat.io/openshift/omr-mirror-rhel9:v3.0.0`. The `--image` flag is removed to prevent users from accidentally using a mismatched image version.

**What changed**:

- `internal/installer/installer.go`: `DefaultImage` changed from `const` to `var` so release builds can override it via `-ldflags "-X '...DefaultImage=registry.redhat.io/openshift/omr-mirror-rhel9:v3.0.0'"`. The default (`quay.io/quay/quay-mirror:latest`) remains for local development.
- `internal/cmd/install.go`, `internal/cmd/migrate.go`: Removed `--image` flag. The binary always uses its built-in `DefaultImage` for online installs, or `--image-archive` for offline installs.

No changes to `image.go` — `podman load` is preserved as-is. The offline bundle uses proper oci-archive tars (exported via skopeo in the Konflux pipeline), which are directly compatible with `podman load`.

**User flows**:
```bash
# Online install (binary pulls its built-in DefaultImage):
./quay install --hostname myhost

# Offline install (user provides the oci-archive tar from the offline bundle):
./quay install --hostname myhost --image-archive omr-mirror.tar

# Migration (same two modes):
./quay migrate --source-root /opt/quay-install
./quay migrate --source-root /opt/quay-install --image-archive omr-mirror.tar
```

## Test plan

- [x] `go test ./internal/system/ ./internal/installer/ ./internal/cmd/` — all pass
- [x] `go build ./internal/system/ ./internal/installer/ ./internal/cmd/` — compiles clean
- [ ] Verify `DefaultImage` is overridable: `go build -ldflags "-X 'github.com/quay/quay/internal/installer.DefaultImage=test'" ./cmd/quay && ./quay version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)