### PR TITLE
PROJQUAY-10587: fix(mirroring): prevent SSRF in repository sources

### DIFF
--- a/config.py
+++ b/config.py
@@ -574,9 +574,9 @@ class DefaultConfig(ImmutableConfig):
     # Organization-level repository mirror
     FEATURE_ORG_MIRROR = False
 
-    # Hostnames or CIDR ranges allowed to bypass SSRF blocklist for organization mirrors
-    # and export log callbacks. Use for enterprise deployments where endpoints run on
-    # private networks.
+    # Hostnames or CIDR ranges allowed to bypass SSRF blocklist for repository mirrors,
+    # organization mirrors, proxy cache registries, and export log callbacks. Use for
+    # enterprise deployments where endpoints run on private networks.
     SSRF_ALLOWED_HOSTS: List[str] = []
 
     # The number of seconds between organization mirror worker iterations

--- a/data/model/repo_mirror.py
+++ b/data/model/repo_mirror.py
@@ -18,6 +18,7 @@ from data.database import (
 from data.fields import DecryptedValue
 from data.model import DataModelException
 from util.names import parse_robot_username
+from util.security.ssrf import validate_external_registry_reference
 
 # TODO: Move these to the configuration
 MAX_SYNC_RETRIES = 3
@@ -228,10 +229,20 @@ def enable_mirroring_for_repository(
     external_registry_config=None,
     is_enabled=True,
     sync_start_date=None,
+    allowed_hosts=None,
 ):
     """
     Create a RepoMirrorConfig and set the Repository to the MIRROR state.
     """
+    try:
+        validate_external_registry_reference(
+            external_reference,
+            resolve_dns=False,
+            allowed_hosts=allowed_hosts,
+        )
+    except ValueError as e:
+        raise DataModelException(str(e))
+
     assert internal_robot.robot
 
     namespace, _ = parse_robot_username(internal_robot.username)
@@ -449,10 +460,19 @@ def delete_mirror(repository):
     raise NotImplementedError("TODO: Not Implemented")
 
 
-def change_remote(repository, remote_repository):
+def change_remote(repository, remote_repository, allowed_hosts=None):
     """
     Update the external repository for Repository Mirroring.
     """
+    try:
+        validate_external_registry_reference(
+            remote_repository,
+            resolve_dns=False,
+            allowed_hosts=allowed_hosts,
+        )
+    except ValueError as e:
+        raise DataModelException(str(e))
+
     mirror = get_mirror(repository)
     updates = {"external_reference": remote_repository}
     return bool(update_with_transaction(mirror, **updates))

--- a/data/model/test/test_repo_mirroring.py
+++ b/data/model/test/test_repo_mirroring.py
@@ -269,6 +269,60 @@ def test_repo_mirror_robot(initialized_db):
     assert model.repo_mirror.robot_has_mirror(mirror.internal_robot)
 
 
+class TestRepoMirrorSSRFProtection:
+    """Data-model validation prevents bypassing the repository mirror API."""
+
+    def _create_args(self):
+        repo = model.repository.get_repository("devtable", "simple")
+        robot = model.user.lookup_robot("devtable+dtrobot")
+        rule = model.repo_mirror.create_rule(repo, ["latest"])
+        return {
+            "repository": repo,
+            "root_rule": rule,
+            "internal_robot": robot,
+            "external_reference": "registry.example.com/team/repository",
+            "sync_interval": 3600,
+            "skopeo_timeout_interval": 300,
+        }
+
+    def test_create_rejects_private_registry(self, initialized_db):
+        args = self._create_args()
+        args["external_reference"] = "169.254.169.254/latest/meta-data"
+
+        with pytest.raises(model.DataModelException, match="private or reserved"):
+            model.repo_mirror.enable_mirroring_for_repository(**args)
+
+        assert model.repo_mirror.get_mirror(args["repository"]) is None
+
+    def test_change_remote_rejects_private_registry(self, initialized_db):
+        mirror, repo = create_mirror_repo_robot(["latest"], repo_name="ssrf_update")
+
+        with pytest.raises(model.DataModelException, match="private or reserved"):
+            model.repo_mirror.change_remote(repo, "10.0.0.1/team/repository")
+
+        updated = model.repo_mirror.get_mirror(repo)
+        assert updated.external_reference == mirror.external_reference
+
+    def test_create_allows_configured_private_registry(self, initialized_db):
+        args = self._create_args()
+        args["external_reference"] = "10.0.0.1/team/repository"
+        args["allowed_hosts"] = ["10.0.0.0/8"]
+
+        mirror = model.repo_mirror.enable_mirroring_for_repository(**args)
+
+        assert mirror.external_reference == "10.0.0.1/team/repository"
+
+    def test_change_remote_allows_configured_private_registry(self, initialized_db):
+        _, repo = create_mirror_repo_robot(["latest"], repo_name="ssrf_allowed_update")
+
+        assert model.repo_mirror.change_remote(
+            repo,
+            "10.0.0.1/team/repository",
+            allowed_hosts=["10.0.0.0/8"],
+        )
+        assert model.repo_mirror.get_mirror(repo).external_reference == ("10.0.0.1/team/repository")
+
+
 class TestArchitectureFilter:
     """Tests for architecture_filter functionality."""
 

--- a/endpoints/api/mirror.py
+++ b/endpoints/api/mirror.py
@@ -359,7 +359,10 @@ class RepoMirrorResource(RepositoryParamResource):
                 400,
             )
 
-        data["sync_start_date"] = self._string_to_dt(data["sync_start_date"])
+        try:
+            data["sync_start_date"] = self._string_to_dt(data["sync_start_date"])
+        except ValueError:
+            return {"detail": "Incorrect DateTime format for sync_start_date."}, 400
 
         rule = model.repo_mirror.create_rule(repo, data["root_rule"]["rule_value"])
         del data["root_rule"]

--- a/endpoints/api/mirror.py
+++ b/endpoints/api/mirror.py
@@ -25,6 +25,27 @@ from endpoints.api import (
 from endpoints.exception import InvalidRequest, NotFound
 from util.audit import track_and_log, wrap_repository
 from util.names import parse_robot_username
+from util.security.ssrf import SSRFBlockedError, validate_external_registry_reference
+
+SSRF_GENERIC_ERROR = "The provided registry location is not allowed"
+
+
+def _get_ssrf_allowed_hosts():
+    return app.config.get("SSRF_ALLOWED_HOSTS", [])
+
+
+def _validate_external_reference(reference):
+    """Validate a repository mirror source and normalize SSRF errors."""
+    try:
+        validate_external_registry_reference(
+            reference,
+            allowed_hosts=_get_ssrf_allowed_hosts(),
+        )
+    except SSRFBlockedError:
+        raise InvalidRequest(SSRF_GENERIC_ERROR)
+    except ValueError as e:
+        raise InvalidRequest(str(e))
+
 
 common_properties = {
     "is_enabled": {
@@ -319,6 +340,19 @@ class RepoMirrorResource(RepositoryParamResource):
 
         data = request.get_json()
 
+        # Validate the complete request before creating rules or changing permissions.
+        _validate_external_reference(data["external_reference"])
+
+        arch_filter = data.get("architecture_filter")
+        if arch_filter and not app.config.get("FEATURE_SPARSE_INDEX", False):
+            return {
+                "detail": "Architecture filtering requires FEATURE_SPARSE_INDEX to be enabled."
+            }, 400
+        try:
+            model.repo_mirror.validate_architecture_filter(arch_filter)
+        except ValidationError as e:
+            return {"detail": str(e)}, 400
+
         if data["skopeo_timeout_interval"] < 300:
             return (
                 {"detail": "Skopeo timeout interval cannot be less than 300 seconds"},
@@ -340,20 +374,15 @@ class RepoMirrorResource(RepositoryParamResource):
         arch_filter = data.pop("architecture_filter", None)
 
         mirror = model.repo_mirror.enable_mirroring_for_repository(
-            repo, root_rule=rule, internal_robot=robot, **data
+            repo,
+            root_rule=rule,
+            internal_robot=robot,
+            allowed_hosts=_get_ssrf_allowed_hosts(),
+            **data,
         )
         if mirror:
-            # Set architecture filter if provided
             if arch_filter is not None:
-                if arch_filter and not app.config.get("FEATURE_SPARSE_INDEX", False):
-                    return {
-                        "detail": "Architecture filtering requires FEATURE_SPARSE_INDEX to be enabled."
-                    }, 400
-                try:
-                    model.repo_mirror.validate_architecture_filter(arch_filter)
-                    model.repo_mirror.set_architecture_filter(repo, arch_filter)
-                except ValidationError as e:
-                    return {"detail": str(e)}, 400
+                model.repo_mirror.set_architecture_filter(repo, arch_filter)
 
             track_and_log(
                 "repo_mirror_config_changed",
@@ -385,6 +414,55 @@ class RepoMirrorResource(RepositoryParamResource):
         if not mirror:
             raise NotFound()
 
+        # Validate and normalize every requested change before applying any update.
+        if "external_reference" in values:
+            _validate_external_reference(values["external_reference"])
+
+        if "sync_start_date" in values:
+            try:
+                values["sync_start_date"] = self._string_to_dt(values["sync_start_date"])
+            except ValueError:
+                return {"detail": "Incorrect DateTime format for sync_start_date."}, 400
+
+        if "skopeo_timeout_interval" in values and values["skopeo_timeout_interval"] < 300:
+            return ({"detail": "Skopeo timeout interval cannot be less than 300 seconds."}, 400)
+
+        if "architecture_filter" in values:
+            arch_filter = values["architecture_filter"]
+            if arch_filter and not app.config.get("FEATURE_SPARSE_INDEX", False):
+                return {
+                    "detail": "Architecture filtering requires FEATURE_SPARSE_INDEX to be enabled."
+                }, 400
+            try:
+                model.repo_mirror.validate_architecture_filter(arch_filter)
+            except ValidationError as e:
+                return {"detail": str(e)}, 400
+
+        if "external_registry_password" in values and "external_registry_username" not in values:
+            return (
+                {"detail": "Unable to set a new password without also specifying a username."},
+                400,
+            )
+        if (
+            "external_registry_username" in values
+            and "external_registry_password" in values
+            and values["external_registry_username"] is None
+            and values["external_registry_password"] is not None
+        ):
+            return {"detail": "Unable to delete username while setting a password."}, 400
+
+        if "root_rule" in values:
+            model.repo_mirror.validate_rule(
+                RepoMirrorRuleType.TAG_GLOB_CSV,
+                values["root_rule"]["rule_value"],
+            )
+
+        validated_robot = None
+        if "robot_username" in values:
+            validated_robot = self._validate_robot_for_mirroring(
+                namespace_name, values["robot_username"]
+            )
+
         if "is_enabled" in values:
             if values["is_enabled"] == True:
                 if model.repo_mirror.enable_mirror(repo):
@@ -404,9 +482,11 @@ class RepoMirrorResource(RepositoryParamResource):
                     )
 
         if "external_reference" in values:
-            if values["external_reference"] == "":
-                return {"detail": "Empty string is an invalid repository location."}, 400
-            if model.repo_mirror.change_remote(repo, values["external_reference"]):
+            if model.repo_mirror.change_remote(
+                repo,
+                values["external_reference"],
+                allowed_hosts=_get_ssrf_allowed_hosts(),
+            ):
                 track_and_log(
                     "repo_mirror_config_changed",
                     wrap_repository(repo),
@@ -416,7 +496,12 @@ class RepoMirrorResource(RepositoryParamResource):
 
         if "robot_username" in values:
             robot_username = values["robot_username"]
-            robot = self._setup_robot_for_mirroring(namespace_name, repository_name, robot_username)
+            robot = self._setup_robot_for_mirroring(
+                namespace_name,
+                repository_name,
+                robot_username,
+                validated_robot=validated_robot,
+            )
             if model.repo_mirror.set_mirroring_robot(repo, robot):
                 track_and_log(
                     "repo_mirror_config_changed",
@@ -426,16 +511,12 @@ class RepoMirrorResource(RepositoryParamResource):
                 )
 
         if "sync_start_date" in values:
-            try:
-                sync_start_date = self._string_to_dt(values["sync_start_date"])
-            except ValueError as e:
-                return {"detail": "Incorrect DateTime format for sync_start_date."}, 400
-            if model.repo_mirror.change_sync_start_date(repo, sync_start_date):
+            if model.repo_mirror.change_sync_start_date(repo, values["sync_start_date"]):
                 track_and_log(
                     "repo_mirror_config_changed",
                     wrap_repository(repo),
                     changed="sync_start_date",
-                    to=sync_start_date,
+                    to=values["sync_start_date"],
                 )
 
         if "sync_interval" in values:
@@ -448,9 +529,6 @@ class RepoMirrorResource(RepositoryParamResource):
                 )
 
         if "skopeo_timeout_interval" in values:
-            if values["skopeo_timeout_interval"] < 300:
-                return ({"detail": "Skopeo timeout interval cannot be less than 300 seconds."}, 400)
-
             if model.repo_mirror.change_skopeo_timeout_interval(
                 repo, values["skopeo_timeout_interval"]
             ):
@@ -463,15 +541,6 @@ class RepoMirrorResource(RepositoryParamResource):
 
         if "architecture_filter" in values:
             arch_filter = values["architecture_filter"]
-            if arch_filter and not app.config.get("FEATURE_SPARSE_INDEX", False):
-                return {
-                    "detail": "Architecture filtering requires FEATURE_SPARSE_INDEX to be enabled."
-                }, 400
-            try:
-                model.repo_mirror.validate_architecture_filter(arch_filter)
-            except ValidationError as e:
-                return {"detail": str(e)}, 400
-
             if model.repo_mirror.set_architecture_filter(repo, arch_filter or []):
                 track_and_log(
                     "repo_mirror_config_changed",
@@ -483,8 +552,6 @@ class RepoMirrorResource(RepositoryParamResource):
         if "external_registry_username" in values and "external_registry_password" in values:
             username = values["external_registry_username"]
             password = values["external_registry_password"]
-            if username is None and password is not None:
-                return {"detail": "Unable to delete username while setting a password."}, 400
             if model.repo_mirror.change_credentials(repo, username, password):
                 track_and_log(
                     "repo_mirror_config_changed",
@@ -516,13 +583,6 @@ class RepoMirrorResource(RepositoryParamResource):
                     changed="external_registry_username",
                     to=username,
                 )
-
-        # Do not allow specifying a password without setting a username
-        if "external_registry_password" in values and "external_registry_username" not in values:
-            return (
-                {"detail": "Unable to set a new password without also specifying a username."},
-                400,
-            )
 
         if "external_registry_config" in values:
             external_registry_config = values.get("external_registry_config", {})
@@ -581,10 +641,6 @@ class RepoMirrorResource(RepositoryParamResource):
                         )
 
         if "root_rule" in values:
-
-            if values["root_rule"]["rule_kind"] != "tag_glob_csv":
-                raise ValidationError('validation failed: rule_kind must be "tag_glob_csv"')
-
             if model.repo_mirror.change_rule(
                 repo, RepoMirrorRuleType.TAG_GLOB_CSV, values["root_rule"]["rule_value"]
             ):
@@ -607,16 +663,26 @@ class RepoMirrorResource(RepositoryParamResource):
                     "organization-level mirroring is configured"
                 )
 
-    def _setup_robot_for_mirroring(self, namespace_name, repo_name, robot_username):
-        """
-        Validate robot exists and give write permissions.
-        """
+    def _validate_robot_for_mirroring(self, namespace_name, robot_username):
         robot = model.user.lookup_robot(robot_username)
         assert robot.robot
 
-        namespace, _ = parse_robot_username(robot_username)
+        parsed_username = parse_robot_username(robot_username)
+        if parsed_username is None:
+            raise model.DataModelException("Invalid robot")
+
+        namespace, _ = parsed_username
         if namespace != namespace_name:
             raise model.DataModelException("Invalid robot")
+        return robot
+
+    def _setup_robot_for_mirroring(
+        self, namespace_name, repo_name, robot_username, validated_robot=None
+    ):
+        """Validate the robot and grant write permission when required."""
+        robot = validated_robot or self._validate_robot_for_mirroring(
+            namespace_name, robot_username
+        )
 
         # Ensure the robot specified has access to the repository. If not, grant it.
         permissions = model.permission.get_user_repository_permissions(

--- a/endpoints/api/test/test_mirror.py
+++ b/endpoints/api/test/test_mirror.py
@@ -102,6 +102,24 @@ def test_create_mirror_sets_permissions(existing_robot_permission, expected_perm
     assert config.root_rule.rule_value == ["latest", "foo", "bar"]
 
 
+def test_create_mirror_with_invalid_sync_start_date(app):
+    robot, _ = model.user.create_robot("invaliddatebot", model.user.get_namespace_user("devtable"))
+
+    with client_with_identity("devtable", app) as cl:
+        params = {"repository": "devtable/simple"}
+        request_body = {
+            "external_reference": "quay.io/foobar/barbaz",
+            "sync_interval": 100,
+            "skopeo_timeout_interval": 300,
+            "sync_start_date": "not-a-date",
+            "root_rule": {"rule_kind": "tag_glob_csv", "rule_value": ["latest"]},
+            "robot_username": robot.username,
+        }
+        resp = conduct_api_call(cl, RepoMirrorResource, "POST", params, request_body, 400)
+
+    assert resp.json["detail"] == "Incorrect DateTime format for sync_start_date."
+
+
 def test_get_mirror_does_not_exist(app):
     with client_with_identity("devtable", app) as cl:
         params = {"repository": "devtable/simple"}
@@ -371,9 +389,7 @@ class TestRepoMirrorSSRFProtection:
         assert model.repo_mirror.get_mirror(repo) is None
         rules = RepoMirrorRule.select().where(RepoMirrorRule.repository == repo)
         assert list(rules) == []
-        permissions = model.permission.get_user_repository_permissions(
-            robot, "devtable", "simple"
-        )
+        permissions = model.permission.get_user_repository_permissions(robot, "devtable", "simple")
         assert next(iter(permissions), None) is None
 
     def test_create_with_hostname_resolving_private_rejected(self, app):

--- a/endpoints/api/test/test_mirror.py
+++ b/endpoints/api/test/test_mirror.py
@@ -8,13 +8,26 @@ from data import model
 from data.database import (
     OrgMirrorConfig,
     OrgMirrorStatus,
+    RepoMirrorRule,
     SourceRegistryType,
     Visibility,
 )
-from endpoints.api.mirror import RepoMirrorResource, RepoMirrorSyncCancelResource
+from endpoints.api.mirror import (
+    RepoMirrorResource,
+    RepoMirrorSyncCancelResource,
+    _validate_external_reference,
+)
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
 from test.fixtures import *
+
+
+@pytest.fixture(autouse=True)
+def _mock_dns_for_ssrf_validation():
+    """Keep mirror endpoint tests independent of external DNS."""
+    with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+        mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        yield mock_dns
 
 
 def _setup_mirror():
@@ -136,7 +149,7 @@ def test_get_mirror(app):
         ("is_enabled", "foo", 400),
         ("external_reference", "example.com/foo/bar", 201),
         ("external_reference", "example.com/foo", 201),
-        ("external_reference", "example.com", 201),
+        ("external_reference", "example.com", 400),
         ("external_registry_username", "newTestUsername", 201),
         ("external_registry_username", None, 201),
         ("external_registry_username", 123, 400),
@@ -253,6 +266,44 @@ def test_change_config(key, value, expected_status, app):
             assert resp.json[key] != value
 
 
+def test_update_robot_is_looked_up_once(app):
+    _setup_mirror()
+    lookup_robot = model.user.lookup_robot
+
+    with patch("endpoints.api.mirror.model.user.lookup_robot", wraps=lookup_robot) as mock_lookup:
+        with client_with_identity("devtable", app) as cl:
+            params = {"repository": "devtable/simple"}
+            conduct_api_call(
+                cl,
+                RepoMirrorResource,
+                "PUT",
+                params,
+                {"robot_username": "devtable+dtrobot"},
+                201,
+            )
+
+    mock_lookup.assert_called_once_with("devtable+dtrobot")
+
+
+def test_update_robot_without_namespace_separator_is_invalid(app):
+    _setup_mirror()
+    robot = model.user.lookup_robot("devtable+dtrobot")
+
+    with patch("endpoints.api.mirror.model.user.lookup_robot", return_value=robot):
+        with client_with_identity("devtable", app) as cl:
+            params = {"repository": "devtable/simple"}
+            response = conduct_api_call(
+                cl,
+                RepoMirrorResource,
+                "PUT",
+                params,
+                {"robot_username": "dtrobot"},
+                400,
+            )
+
+    assert response.json["message"] == "Invalid robot"
+
+
 @pytest.mark.parametrize(
     "request_body, expected_status",
     [
@@ -287,6 +338,174 @@ def test_change_credentials(request_body, expected_status, app):
     with client_with_identity("devtable", app) as cl:
         params = {"repository": "devtable/simple"}
         conduct_api_call(cl, RepoMirrorResource, "PUT", params, request_body, expected_status)
+
+
+class TestRepoMirrorSSRFProtection:
+    """Repository mirror API rejects internal source registries."""
+
+    def _create_body(self, external_reference, robot_username):
+        return {
+            "external_reference": external_reference,
+            "sync_interval": 100,
+            "skopeo_timeout_interval": 300,
+            "sync_start_date": "2019-08-20T17:51:00Z",
+            "root_rule": {"rule_kind": "tag_glob_csv", "rule_value": ["latest"]},
+            "robot_username": robot_username,
+        }
+
+    def test_create_with_metadata_ip_rejected_before_persistence(self, app):
+        robot, _ = model.user.create_robot(
+            "ssrfcreatebot", model.user.get_namespace_user("devtable")
+        )
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"repository": "devtable/simple"}
+            body = self._create_body(
+                "169.254.169.254/latest/meta-data",
+                robot.username,
+            )
+            resp = conduct_api_call(cl, RepoMirrorResource, "POST", params, body, 400)
+
+        assert resp.json["error_message"] == "The provided registry location is not allowed"
+        repo = model.repository.get_repository("devtable", "simple")
+        assert model.repo_mirror.get_mirror(repo) is None
+        rules = RepoMirrorRule.select().where(RepoMirrorRule.repository == repo)
+        assert list(rules) == []
+        permissions = model.permission.get_user_repository_permissions(
+            robot, "devtable", "simple"
+        )
+        assert next(iter(permissions), None) is None
+
+    def test_create_with_hostname_resolving_private_rejected(self, app):
+        robot, _ = model.user.create_robot("ssrfdnsbot", model.user.get_namespace_user("devtable"))
+
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(2, 1, 6, "", ("10.0.0.1", 0))]
+            with client_with_identity("devtable", app) as cl:
+                params = {"repository": "devtable/simple"}
+                body = self._create_body("registry.example.com/team/repo", robot.username)
+                resp = conduct_api_call(cl, RepoMirrorResource, "POST", params, body, 400)
+
+        assert resp.json["error_message"] == "The provided registry location is not allowed"
+
+    def test_create_with_allowlisted_private_registry_succeeds(self, app):
+        robot, _ = model.user.create_robot(
+            "ssrfallowlistbot", model.user.get_namespace_user("devtable")
+        )
+
+        with patch.dict(quay_app.config, {"SSRF_ALLOWED_HOSTS": ["10.0.0.0/8"]}):
+            with client_with_identity("devtable", app) as cl:
+                params = {"repository": "devtable/simple"}
+                body = self._create_body("10.0.0.1/team/repo", robot.username)
+                conduct_api_call(cl, RepoMirrorResource, "POST", params, body, 201)
+
+        mirror = model.repo_mirror.get_mirror(model.repository.get_repository("devtable", "simple"))
+        assert mirror.external_reference == "10.0.0.1/team/repo"
+
+    def test_create_validates_external_reference_before_mutation(self, app):
+        robot, _ = model.user.create_robot(
+            "ssrfmutationbot", model.user.get_namespace_user("devtable")
+        )
+        validated = False
+        create_rule = model.repo_mirror.create_rule
+
+        def validate_before_mutation(reference):
+            nonlocal validated
+            _validate_external_reference(reference)
+            validated = True
+
+        def create_rule_after_validation(*args, **kwargs):
+            assert validated
+            return create_rule(*args, **kwargs)
+
+        with patch(
+            "endpoints.api.mirror._validate_external_reference",
+            side_effect=validate_before_mutation,
+        ) as validate:
+            with patch(
+                "endpoints.api.mirror.model.repo_mirror.create_rule",
+                side_effect=create_rule_after_validation,
+            ) as mutation:
+                with client_with_identity("devtable", app) as cl:
+                    params = {"repository": "devtable/simple"}
+                    body = self._create_body("quay.io/team/repo", robot.username)
+                    conduct_api_call(cl, RepoMirrorResource, "POST", params, body, 201)
+
+        validate.assert_called_once_with("quay.io/team/repo")
+        mutation.assert_called_once()
+
+    def test_update_validates_external_reference_before_mutation(self, app):
+        _setup_mirror()
+        validated = False
+        change_remote = model.repo_mirror.change_remote
+
+        def validate_before_mutation(reference):
+            nonlocal validated
+            _validate_external_reference(reference)
+            validated = True
+
+        def change_remote_after_validation(*args, **kwargs):
+            assert validated
+            return change_remote(*args, **kwargs)
+
+        with patch(
+            "endpoints.api.mirror._validate_external_reference",
+            side_effect=validate_before_mutation,
+        ) as validate:
+            with patch(
+                "endpoints.api.mirror.model.repo_mirror.change_remote",
+                side_effect=change_remote_after_validation,
+            ) as mutation:
+                with client_with_identity("devtable", app) as cl:
+                    params = {"repository": "devtable/simple"}
+                    body = {"external_reference": "quay.io/team/repo"}
+                    conduct_api_call(cl, RepoMirrorResource, "PUT", params, body, 201)
+
+        validate.assert_called_once_with("quay.io/team/repo")
+        mutation.assert_called_once()
+
+    def test_update_with_private_ip_rejected_without_partial_updates(self, app):
+        mirror = _setup_mirror()
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"repository": "devtable/simple"}
+            body = {
+                "external_reference": "10.0.0.1/team/repo",
+                "sync_interval": mirror.sync_interval + 100,
+            }
+            resp = conduct_api_call(cl, RepoMirrorResource, "PUT", params, body, 400)
+
+        assert resp.json["error_message"] == "The provided registry location is not allowed"
+        updated = model.repo_mirror.get_mirror(mirror.repository)
+        assert updated.external_reference == "quay.io/redhat/quay"
+        assert updated.sync_interval == mirror.sync_interval
+
+    def test_update_invalid_date_rejected_before_source_update(self, app):
+        mirror = _setup_mirror()
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"repository": "devtable/simple"}
+            body = {
+                "external_reference": "registry.example.com/team/repo",
+                "sync_start_date": "not-a-date",
+            }
+            conduct_api_call(cl, RepoMirrorResource, "PUT", params, body, 400)
+
+        updated = model.repo_mirror.get_mirror(mirror.repository)
+        assert updated.external_reference == "quay.io/redhat/quay"
+        assert updated.sync_start_date == mirror.sync_start_date
+
+    def test_update_with_allowlisted_private_registry_succeeds(self, app):
+        mirror = _setup_mirror()
+
+        with patch.dict(quay_app.config, {"SSRF_ALLOWED_HOSTS": ["10.0.0.0/8"]}):
+            with client_with_identity("devtable", app) as cl:
+                params = {"repository": "devtable/simple"}
+                body = {"external_reference": "10.0.0.1/team/repo"}
+                conduct_api_call(cl, RepoMirrorResource, "PUT", params, body, 201)
+
+        updated = model.repo_mirror.get_mirror(mirror.repository)
+        assert updated.external_reference == "10.0.0.1/team/repo"
 
 
 def test_cancel_repo_mirroring(app):

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1142,7 +1142,7 @@ CONFIG_SCHEMA = {
         },
         "SSRF_ALLOWED_HOSTS": {
             "type": "array",
-            "description": "List of hostnames or CIDR ranges allowed to bypass SSRF protection for organization mirror source registries and export log callback URLs. Use for enterprise deployments where endpoints are on private networks.",
+            "description": "List of hostnames or CIDR ranges allowed to bypass SSRF protection for repository and organization mirror source registries, proxy cache registries, and export log callback URLs. Use for enterprise deployments where endpoints are on private networks.",
             "uniqueItems": True,
             "items": {"type": "string"},
             "x-example": ["internal-harbor.corp.example.com", "10.0.0.0/8"],

--- a/util/security/ssrf.py
+++ b/util/security/ssrf.py
@@ -5,6 +5,7 @@ SSRF prevention utilities for validating user-supplied URLs.
 
 import ipaddress
 import logging
+import re
 from socket import AF_UNSPEC, SOCK_STREAM
 from socket import gaierror as _gaierror
 from socket import getaddrinfo as _getaddrinfo
@@ -65,23 +66,31 @@ BLOCKED_HOSTNAMES = {
 
 ALLOWED_SCHEMES = {"http", "https"}
 
+_REGISTRY_HOSTNAME_RE = re.compile(
+    r"^(?=.{1,253}$)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$"
+)
+
 
 def _is_ip_blocked(ip_str: str) -> bool:
     """
-    Check if an IP address falls within any blocked network.
+    Check whether an IP address is unsafe for a user-controlled destination.
 
-    Args:
-        ip_str: IP address as string
-
-    Returns:
-        True if the IP is in a blocked network, False otherwise
+    Only globally routable unicast addresses are allowed by default. The explicit
+    network list remains necessary for globally classified translation ranges such
+    as NAT64 and IPv4-mapped IPv6.
     """
     try:
         ip = ipaddress.ip_address(ip_str)
     except ValueError:
         return True  # Unparseable IPs are treated as blocked
 
-    return any(ip in network for network in BLOCKED_NETWORKS)
+    return (
+        any(ip in network for network in BLOCKED_NETWORKS)
+        or not ip.is_global
+        or ip.is_multicast
+        or getattr(ip, "is_site_local", False)
+    )
 
 
 def _is_allowed(hostname: str, ip_str: Optional[str], allowed_hosts: List[str]) -> bool:
@@ -126,6 +135,86 @@ def _is_allowed(hostname: str, ip_str: Optional[str], allowed_hosts: List[str]) 
             return True
 
     return False
+
+
+def validate_external_registry_reference(
+    reference: str,
+    resolve_dns: bool = True,
+    allowed_hosts: Optional[List[str]] = None,
+) -> None:
+    """
+    Validate a scheme-less container registry reference used by repository mirroring.
+
+    Repository mirror references have the form ``registry[:port]/namespace/repository``.
+    Only the registry authority determines the network destination, so it is normalized
+    to an HTTPS URL before applying the shared SSRF checks.
+
+    Args:
+        reference: Scheme-less external repository reference
+        resolve_dns: Whether to resolve and validate the registry hostname
+        allowed_hosts: Optional hostnames/CIDRs that bypass the blocklist
+
+    Raises:
+        SSRFBlockedError: If the registry destination is blocked
+        ValueError: If the reference is empty or malformed
+    """
+    if not reference or not isinstance(reference, str):
+        raise ValueError("External registry reference is required")
+
+    if not reference.strip():
+        raise ValueError("External registry reference is required")
+
+    if reference != reference.strip() or any(char.isspace() for char in reference):
+        raise ValueError("External registry reference must not include whitespace")
+
+    if "://" in reference:
+        raise ValueError("External registry reference must not include a URL scheme")
+
+    if any(char in reference for char in ("?", "#", "\\", "%")):
+        raise ValueError("External registry reference contains an invalid character")
+
+    reference_parts = reference.split("/", 1)
+    if len(reference_parts) != 2 or not all(reference_parts):
+        raise ValueError("External registry reference must include a repository path")
+
+    registry = reference_parts[0]
+    if registry.startswith("["):
+        bracket_end = registry.find("]")
+        suffix = registry[bracket_end + 1 :] if bracket_end >= 0 else None
+        if bracket_end < 0 or (suffix and not suffix.startswith(":")):
+            raise ValueError("External registry reference contains an invalid registry authority")
+        if suffix == ":":
+            raise ValueError("External registry reference contains an invalid registry port")
+    else:
+        if registry.count(":") > 1:
+            raise ValueError("External registry reference contains an invalid registry authority")
+        if registry.endswith(":"):
+            raise ValueError("External registry reference contains an invalid registry port")
+
+    try:
+        parsed_registry = urlparse(f"https://{registry}")
+        hostname = parsed_registry.hostname
+        port = parsed_registry.port
+    except ValueError:
+        raise ValueError("External registry reference contains an invalid registry authority")
+
+    if parsed_registry.username or parsed_registry.password or not hostname:
+        raise ValueError("External registry reference must include a valid registry hostname")
+
+    if port == 0:
+        raise ValueError("External registry reference contains an invalid registry port")
+
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        if hostname.endswith(".") or not _REGISTRY_HOSTNAME_RE.fullmatch(hostname):
+            raise ValueError("External registry reference must include a valid registry hostname")
+
+    validate_external_registry_url(
+        f"https://{registry}",
+        resolve_dns=resolve_dns,
+        allowed_hosts=allowed_hosts,
+    )
 
 
 def validate_external_registry_url(

--- a/util/security/test/test_ssrf.py
+++ b/util/security/test/test_ssrf.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 
 import pytest
 
-from util.security.ssrf import SSRFBlockedError, validate_external_registry_url
+from util.security.ssrf import (
+    SSRFBlockedError,
+    validate_external_registry_reference,
+    validate_external_registry_url,
+)
 
 
 class TestSSRFBlockedError:
@@ -148,10 +152,13 @@ class TestValidateExternalRegistryUrl:
     @pytest.mark.parametrize(
         "ip",
         [
+            "[::]",  # Unspecified; routes to loopback on Linux
             "[::1]",  # Loopback
             "[fc00::1]",  # Unique local
             "[fd00::1]",  # Unique local
             "[fe80::1]",  # Link-local
+            "[fec0::1]",  # Deprecated site-local
+            "[ff02::1]",  # Multicast
         ],
     )
     def test_private_ipv6_rejected(self, ip):
@@ -269,6 +276,88 @@ class TestValidateExternalRegistryUrl:
     def test_resolve_dns_false_skips_dns_check(self):
         """With resolve_dns=False, hostnames pass without DNS resolution."""
         validate_external_registry_url("https://registry.example.com", resolve_dns=False)
+
+    def test_dns_resolving_to_unspecified_ipv6_rejected(self):
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(10, 1, 6, "", ("::", 0, 0, 0))]
+            with pytest.raises(SSRFBlockedError, match="private or reserved"):
+                validate_external_registry_url("https://registry.example.com")
+
+
+class TestValidateExternalRegistryReference:
+    """Tests for scheme-less repository mirror references."""
+
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            "quay.io/projectquay/quay",
+            "quay.io/Team/Nested.Repository:Tag",
+            "quay.io/team/repository@sha256:abc",
+            "registry.example.com:5000/team/repository",
+            "93.184.216.34/team/repository",
+            "[2606:2800:220:1:248:1893:25c8:1946]/team/repository",
+            "[2606:2800:220:1:248:1893:25c8:1946]:5000/team/repository",
+        ],
+    )
+    def test_valid_references_pass(self, reference):
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+            validate_external_registry_reference(reference)
+
+    @pytest.mark.parametrize("reference", [None, "", "   "])
+    def test_empty_reference_rejected(self, reference):
+        with pytest.raises(ValueError, match="required"):
+            validate_external_registry_reference(reference)
+
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            "https://quay.io/project/repository",
+            "quay.io/project repo",
+            "/project/repository",
+            "quay.io?#/project/repository",
+            "quay.io:bad/repository",
+            "quay.io:/repository",
+            "quay.io:70000/repository",
+            "quay.io:0/repository",
+            "[2606:2800:220:1:248:1893:25c8:1946]:/repository",
+            "quay.io/repository?query=value",
+            "quay.io/repository#fragment",
+            "quay.io",
+            "quay.io/",
+            "quay.io\\repository",
+            "quay.io/%2e%2e",
+        ],
+    )
+    def test_malformed_reference_rejected(self, reference):
+        with pytest.raises(ValueError, match="reference"):
+            validate_external_registry_reference(reference, resolve_dns=False)
+
+    @pytest.mark.parametrize(
+        "reference",
+        [
+            "localhost/project/repository",
+            "127.0.0.1/project/repository",
+            "169.254.169.254/latest/meta-data",
+            "10.0.0.1/project/repository",
+            "[::1]:5000/project/repository",
+        ],
+    )
+    def test_blocked_registry_rejected(self, reference):
+        with pytest.raises(SSRFBlockedError):
+            validate_external_registry_reference(reference, resolve_dns=False)
+
+    def test_dns_resolving_to_private_ip_rejected(self):
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(2, 1, 6, "", ("10.0.0.1", 0))]
+            with pytest.raises(SSRFBlockedError, match="private or reserved"):
+                validate_external_registry_reference("registry.example.com/team/repository")
+
+    def test_allowlisted_private_registry_passes(self):
+        validate_external_registry_reference(
+            "10.0.0.1/team/repository",
+            allowed_hosts=["10.0.0.0/8"],
+        )
 
 
 class TestSSRFAllowlist:

--- a/web/playwright/e2e/api/api-v1-advanced-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-advanced-features.spec.ts
@@ -34,7 +34,7 @@ test.describe(
 
         // Create mirror config
         await client.createMirrorConfig(org.name, repo.name, {
-          external_reference: 'registry.example.io/library/alpine',
+          external_reference: 'quay.io/quay/busybox',
           sync_interval: 3600,
           sync_start_date: '2023-07-10T06:24:00Z',
           root_rule: {

--- a/web/playwright/e2e/usage-logs.spec.ts
+++ b/web/playwright/e2e/usage-logs.spec.ts
@@ -329,7 +329,7 @@ test.describe('Usage Logs', {tag: ['@logs']}, () => {
         const syncStartDate = new Date();
         syncStartDate.setMinutes(syncStartDate.getMinutes() + 5);
         await api.raw.createMirrorConfig(org.name, repo.name, {
-          external_reference: 'nonexistent.invalid/nope',
+          external_reference: `quay.io/${org.name}/${repo.name}`,
           sync_interval: 86400,
           sync_start_date: syncStartDate
             .toISOString()

--- a/workers/repomirrorworker/__init__.py
+++ b/workers/repomirrorworker/__init__.py
@@ -52,6 +52,7 @@ from notifications import spawn_notification
 from util.audit import wrap_repository
 from util.orgmirror import get_registry_adapter
 from util.repomirror.skopeomirror import SkopeoMirror, SkopeoResults
+from util.security.ssrf import validate_external_registry_reference
 from workers.repomirrorworker.manifest_utils import (
     ManifestSizeLimitExceeded,
     filter_manifests_by_architecture,
@@ -253,6 +254,38 @@ def perform_mirror(skopeo: SkopeoMirror, mirror: RepoMirrorConfig):
     sync_start_time = time.time()
     namespace = mirror.repository.namespace_user.username
     repository_name = mirror.repository.name
+
+    # Re-resolve the source immediately before use to catch persisted blocked
+    # configurations and DNS changes observed before the Skopeo invocation.
+    try:
+        validate_external_registry_reference(
+            mirror.external_reference,
+            resolve_dns=True,
+            allowed_hosts=app.config.get("SSRF_ALLOWED_HOSTS", []),
+        )
+    except ValueError:
+        logger.warning(
+            "Repository mirror source validation failed for repository %s/%s",
+            namespace,
+            repository_name,
+        )
+        emit_log(
+            mirror,
+            "repo_mirror_sync_failed",
+            "end",
+            "Source registry location is not allowed",
+            tags="",
+            stdout="Not applicable",
+            stderr="Not applicable",
+        )
+        _update_mirror_metrics_on_failure(
+            namespace,
+            repository_name,
+            "invalid_source_registry",
+            sync_start_time,
+        )
+        release_mirror(mirror, RepoMirrorStatus.FAIL)
+        return RepoMirrorStatus.FAIL
 
     # Set sync status to in_progress (2)
     repo_mirror_last_sync_status.labels(

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -32,6 +32,14 @@ from workers.repomirrorworker import (
 from workers.repomirrorworker.repomirrorworker import RepoMirrorWorker
 
 
+@pytest.fixture(autouse=True)
+def _mock_dns_for_ssrf_validation():
+    """Keep repository mirror worker tests independent of external DNS."""
+    with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+        mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+        yield mock_dns
+
+
 def _assert_skopeo_args(actual_args, expected_args):
     """Assert skopeo args match, stripping transient authfile and legacy inline --*-creds pairs."""
     auth_flags = (
@@ -174,6 +182,60 @@ def test_successful_mirror(run_skopeo_mock, initialized_db, app):
     worker._process_mirrors()
 
     assert [] == skopeo_calls
+
+
+@disable_existing_mirrors
+@mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
+def test_blocked_mirror_source_never_invokes_skopeo(run_skopeo_mock, initialized_db, app):
+    """Persisted legacy configurations are revalidated before network access."""
+    mirror, _ = create_mirror_repo_robot(["latest"], repo_name="blocked_source")
+    mirror.external_reference = "169.254.169.254/latest/meta-data"
+    mirror.save()
+
+    result = perform_mirror(SkopeoMirror(), mirror)
+
+    assert result == RepoMirrorStatus.FAIL
+    run_skopeo_mock.assert_not_called()
+    updated = RepoMirrorConfig.get_by_id(mirror.id)
+    assert updated.sync_status == RepoMirrorStatus.FAIL
+    assert updated.sync_expiration_date is None
+
+
+@disable_existing_mirrors
+@mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
+def test_worker_reresolves_source_before_skopeo(
+    run_skopeo_mock, initialized_db, app, _mock_dns_for_ssrf_validation
+):
+    mirror, _ = create_mirror_repo_robot(["latest"], repo_name="dns_revalidation")
+    _mock_dns_for_ssrf_validation.return_value = [(2, 1, 6, "", ("10.0.0.1", 0))]
+
+    result = perform_mirror(SkopeoMirror(), mirror)
+
+    assert result == RepoMirrorStatus.FAIL
+    run_skopeo_mock.assert_not_called()
+    updated = RepoMirrorConfig.get_by_id(mirror.id)
+    assert updated.sync_status == RepoMirrorStatus.FAIL
+    assert updated.sync_expiration_date is None
+
+
+@disable_existing_mirrors
+@mock.patch("util.repomirror.skopeomirror.SkopeoMirror.run_skopeo")
+def test_allowlisted_private_mirror_source_invokes_skopeo(run_skopeo_mock, initialized_db, app):
+    """The worker honors SSRF_ALLOWED_HOSTS for private enterprise registries."""
+    mirror, _ = create_mirror_repo_robot(["latest"], repo_name="allowed_source")
+    mirror.external_reference = "10.0.0.1/team/repository"
+    mirror.save()
+    run_skopeo_mock.return_value = SkopeoResults(True, [], '{"Tags": []}', "")
+
+    from workers.repomirrorworker import app as worker_app
+
+    with patch.dict(worker_app.config, {"SSRF_ALLOWED_HOSTS": ["10.0.0.0/8"]}):
+        result = perform_mirror(SkopeoMirror(), mirror)
+
+    assert result is None
+    run_skopeo_mock.assert_called_once()
+    updated = RepoMirrorConfig.get_by_id(mirror.id)
+    assert updated.sync_status == RepoMirrorStatus.SUCCESS
 
 
 @disable_existing_mirrors
@@ -580,7 +642,7 @@ def test_quote_params(run_skopeo_mock, initialized_db, app):
     """
 
     mirror, repo = create_mirror_repo_robot(["latest", "7.1"])
-    mirror.external_reference = "& rm -rf /;/namespace/repository"
+    mirror.external_reference = "registry.example.com/namespace/repository;rm-rf"
     mirror.external_registry_username = "`rm -rf /`"
     mirror.save()
 
@@ -592,7 +654,7 @@ def test_quote_params(run_skopeo_mock, initialized_db, app):
                 "--tls-verify=True",
                 "--creds",
                 "`rm -rf /`",
-                "docker://& rm -rf /;/namespace/repository",
+                "docker://registry.example.com/namespace/repository;rm-rf",
             ],
             "results": SkopeoResults(True, [], '{"Tags": ["latest"]}', ""),
         },
@@ -609,7 +671,7 @@ def test_quote_params(run_skopeo_mock, initialized_db, app):
                 % (mirror.internal_robot.username, retrieve_robot_token(mirror.internal_robot)),
                 "--src-creds",
                 "`rm -rf /`",
-                "'docker://& rm -rf /;/namespace/repository:latest'",
+                "'docker://registry.example.com/namespace/repository;rm-rf:latest'",
                 "docker://localhost:5000/mirror/repo:latest",
             ],
             "results": SkopeoResults(True, [], "stdout", "stderr"),
@@ -643,7 +705,7 @@ def test_quote_params_password(run_skopeo_mock, initialized_db, app):
     """
 
     mirror, repo = create_mirror_repo_robot(["latest", "7.1"])
-    mirror.external_reference = "& rm -rf /;/namespace/repository"
+    mirror.external_reference = "registry.example.com/namespace/repository;rm-rf"
     mirror.external_registry_username = "`rm -rf /`"
     mirror.external_registry_password = '""$PATH\\"'
     mirror.save()
@@ -656,7 +718,7 @@ def test_quote_params_password(run_skopeo_mock, initialized_db, app):
                 "--tls-verify=True",
                 "--creds",
                 '`rm -rf /`:""$PATH\\"',
-                "docker://& rm -rf /;/namespace/repository",
+                "docker://registry.example.com/namespace/repository;rm-rf",
             ],
             "results": SkopeoResults(True, [], '{"Tags": ["latest"]}', ""),
         },
@@ -673,7 +735,7 @@ def test_quote_params_password(run_skopeo_mock, initialized_db, app):
                 % (mirror.internal_robot.username, retrieve_robot_token(mirror.internal_robot)),
                 "--src-creds",
                 '`rm -rf /`:""$PATH\\"',
-                "'docker://& rm -rf /;/namespace/repository:latest'",
+                "'docker://registry.example.com/namespace/repository;rm-rf:latest'",
                 "docker://localhost:5000/mirror/repo:latest",
             ],
             "results": SkopeoResults(True, [], "stdout", "stderr"),


### PR DESCRIPTION
 - Prevent repository mirror sources from targeting private, reserved, or otherwise unsafe destinations unless allowed through `SSRF_ALLOWED_HOSTS`.
 - Validate sources when mirror configurations are created or updated and again immediately before Skopeo execution.
 - Return HTTP 400 for malformed `sync_start_date` values during mirror creation.

Existing mirrors using private or internal registries must add the source hostname or CIDR to `SSRF_ALLOWED_HOSTS` before upgrading. Otherwise, those mirrors will stop syncing. Public and already-allowlisted registries require no action.