### PR TITLE
PROJQUAY-12369: fix(notifications): fix Slack quota notification bold formatting and missing sample data

### DIFF
--- a/notifications/notificationevent.py
+++ b/notifications/notificationevent.py
@@ -505,6 +505,8 @@ class QuotaWarningEvent(NotificationEvent):
                 "usage_bytes": 858993459,
                 "limit_bytes": 1073741824,
                 "usage_percent": 80,
+                "usage_bytes_formatted": "819.20 MB",
+                "limit_bytes_formatted": "1.00 GB",
             },
         )
 
@@ -531,5 +533,7 @@ class QuotaErrorEvent(NotificationEvent):
                 "usage_bytes": 1127428915,
                 "limit_bytes": 1073741824,
                 "usage_percent": 105,
+                "usage_bytes_formatted": "1.05 GB",
+                "limit_bytes_formatted": "1.00 GB",
             },
         )

--- a/notifications/notificationmethod.py
+++ b/notifications/notificationmethod.py
@@ -496,7 +496,7 @@ class SlackMethod(NotificationMethod):
             raise CannotValidateNotificationMethodException("Missing Slack Callback URL")
 
     def format_for_slack(self, message):
-        message = message.replace("\n", "")
+        message = message.replace("\n", " ")
         message = re.sub(r"\s+", " ", message)
         message = message.replace("<br>", "\n")
         return adjust_tags(message)

--- a/notifications/test/test_notificationevent.py
+++ b/notifications/test/test_notificationevent.py
@@ -276,6 +276,14 @@ class TestQuotaWarningEvent:
         assert "usage_percent" in sample
         assert "homepage" in sample
 
+    def test_get_sample_data_includes_formatted_bytes(self):
+        event = QuotaWarningEvent()
+        sample = event.get_sample_data("testorg", "testrepo", {})
+        assert "usage_bytes_formatted" in sample
+        assert "limit_bytes_formatted" in sample
+        assert sample["usage_bytes_formatted"] == "819.20 MB"
+        assert sample["limit_bytes_formatted"] == "1.00 GB"
+
     def test_should_perform_default_true(self):
         event = QuotaWarningEvent()
         assert event.should_perform({}, {})
@@ -309,6 +317,14 @@ class TestQuotaErrorEvent:
         assert "usage_bytes" in sample
         assert "limit_bytes" in sample
         assert "homepage" in sample
+
+    def test_get_sample_data_includes_formatted_bytes(self):
+        event = QuotaErrorEvent()
+        sample = event.get_sample_data("testorg", "testrepo", {})
+        assert "usage_bytes_formatted" in sample
+        assert "limit_bytes_formatted" in sample
+        assert sample["usage_bytes_formatted"] == "1.05 GB"
+        assert sample["limit_bytes_formatted"] == "1.00 GB"
 
     def test_should_perform_default_true(self):
         event = QuotaErrorEvent()

--- a/notifications/test/test_notificationmethod.py
+++ b/notifications/test/test_notificationmethod.py
@@ -18,6 +18,39 @@ from notifications.notificationmethod import (
 )
 
 
+class TestSlackFormatting:
+    def test_bold_tags_have_surrounding_spaces(self):
+        method = SlackMethod()
+        html = (
+            "Namespace <b>quayqe</b> storage usage has\n"
+            "<b>exceeded</b> its quota limit (110%)."
+        )
+        result = method.format_for_slack(html)
+        assert "has *exceeded*" in result
+        assert "has*exceeded*" not in result
+
+    def test_bold_namespace_has_surrounding_spaces(self):
+        method = SlackMethod()
+        html = "Namespace <b>quayqe</b> storage usage has reached\n<b>70%</b> of its quota limit."
+        result = method.format_for_slack(html)
+        assert "*quayqe*" in result
+        assert "reached *70%*" in result
+        assert "reached*70%*" not in result
+
+    def test_br_tags_become_newlines(self):
+        method = SlackMethod()
+        html = "line one<br>line two"
+        result = method.format_for_slack(html)
+        assert result == "line one\nline two"
+
+    def test_existing_templates_unchanged(self):
+        method = SlackMethod()
+        html = '<a href="https://quay.io">link</a> and <i>italic</i>'
+        result = method.format_for_slack(html)
+        assert "<https://quay.io|link>" in result
+        assert "_italic_" in result
+
+
 def assert_validated(method, method_config, error_message, namespace_name, repo_name):
     if error_message is None:
         method.validate(namespace_name, repo_name, method_config)

--- a/notifications/test/test_notificationmethod.py
+++ b/notifications/test/test_notificationmethod.py
@@ -1,5 +1,3 @@
-from test.fixtures import *
-
 import pytest
 from httmock import HTTMock, urlmatch
 from mock import Mock, patch
@@ -16,6 +14,7 @@ from notifications.notificationmethod import (
     SlackMethod,
     WebhookMethod,
 )
+from test.fixtures import *
 
 
 class TestSlackFormatting:

--- a/notifications/test/test_notificationmethod.py
+++ b/notifications/test/test_notificationmethod.py
@@ -22,8 +22,7 @@ class TestSlackFormatting:
     def test_bold_tags_have_surrounding_spaces(self):
         method = SlackMethod()
         html = (
-            "Namespace <b>quayqe</b> storage usage has\n"
-            "<b>exceeded</b> its quota limit (110%)."
+            "Namespace <b>quayqe</b> storage usage has\n" "<b>exceeded</b> its quota limit (110%)."
         )
         result = method.format_for_slack(html)
         assert "has *exceeded*" in result

--- a/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
@@ -352,8 +352,12 @@ test.describe(
           expect(warnHook?.body?.event_data).toHaveProperty(
             'limit_bytes_formatted',
           );
-          expect(warnHook?.body?.event_data.usage_bytes_formatted).toBeTruthy();
-          expect(warnHook?.body?.event_data.limit_bytes_formatted).toBeTruthy();
+          expect(warnHook?.body?.event_data.usage_bytes_formatted).toBe(
+            '819.20 MB',
+          );
+          expect(warnHook?.body?.event_data.limit_bytes_formatted).toBe(
+            '1.00 GB',
+          );
         } finally {
           await receiver.stop();
         }

--- a/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
+++ b/web/playwright/e2e/organization/namespace-notifications-delivery.spec.ts
@@ -323,6 +323,44 @@ test.describe(
     );
 
     test(
+      'test notification payload includes formatted byte fields (PROJQUAY-12369)',
+      {tag: '@webhook'},
+      async ({api}) => {
+        test.setTimeout(60_000);
+
+        const org = await api.organization('nsdelivfmt');
+
+        const receiver = new WebhookReceiver();
+        await receiver.start();
+        try {
+          // Test quota_warning sample data
+          const warnNotif = await api.namespaceNotification(
+            org.name,
+            'quota_warning',
+            'webhook',
+            {url: receiver.getUrl()},
+            {},
+            'Format Check Warning',
+          );
+          await api.raw.testNamespaceNotification(org.name, warnNotif.uuid);
+
+          const warnHook = await receiver.waitForWebhook(undefined, 30_000);
+          expect(warnHook).not.toBeNull();
+          expect(warnHook?.body?.event_data).toHaveProperty(
+            'usage_bytes_formatted',
+          );
+          expect(warnHook?.body?.event_data).toHaveProperty(
+            'limit_bytes_formatted',
+          );
+          expect(warnHook?.body?.event_data.usage_bytes_formatted).toBeTruthy();
+          expect(warnHook?.body?.event_data.limit_bytes_formatted).toBeTruthy();
+        } finally {
+          await receiver.stop();
+        }
+      },
+    );
+
+    test(
       'retroactive webhook fires when quota limit is created while already exceeded',
       {
         tag: [


### PR DESCRIPTION
## Summary
- Fix broken bold formatting in Slack quota notifications — `has*exceeded*` rendered as literal asterisks instead of bold text due to `format_for_slack()` stripping newlines without preserving word boundaries
- Add missing `usage_bytes_formatted` and `limit_bytes_formatted` fields to `get_sample_data()` in both `QuotaWarningEvent` and `QuotaErrorEvent`, which caused test notifications to render `"Current usage: of ."` instead of actual sizes

## Root Cause
- `format_for_slack()` in `notifications/notificationmethod.py:499` used `replace("\n", "")` which joined `has` and `<b>exceeded</b>` without a space. After `SlackAdjuster` converts `<b>` to `*`, the result `has*exceeded*` lacks the whitespace Slack mrkdwn requires for bold rendering.
- `get_sample_data()` in `notifications/notificationevent.py` omitted the formatted byte fields that the HTML templates (`events/quota_error.html`, `events/quota_warning.html`) reference.

Both bugs were introduced by PR #6165 ([PROJQUAY-7306](https://redhat.atlassian.net/browse/PROJQUAY-7306)) and do not exist in redhat-3.17.

## Test plan
- [ ] Push an image exceeding quota threshold and verify Slack notification renders bold text correctly (`has *exceeded*` not `has*exceeded*`)
- [ ] Click "Test Notification" in Quay UI for a quota_warning Slack notification and verify usage data appears (e.g. `819.20 MB of 1.00 GB`)
- [ ] Click "Test Notification" for a quota_error Slack notification and verify same
- [ ] Verify email notifications still render correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)