### PR TITLE
NO-ISSUE: refactor(storage): inject distribution metastore

### DIFF
--- a/internal/oci/storage/local/register.go
+++ b/internal/oci/storage/local/register.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/distribution/distribution/v3/configuration"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/distribution/distribution/v3/registry/storage/driver/base"
 	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
@@ -12,41 +13,43 @@ import (
 	"github.com/quay/quay/internal/oci"
 )
 
-var (
-	metaMu         sync.RWMutex
-	registeredMeta oci.MetadataStore
+const (
+	driverName             = "quay"
+	rootDirectoryParameter = "rootdirectory"
+	metastoreParameter     = "metastore"
 )
 
-// RegisterMetadataStore sets the MetadataStore used when the factory creates
-// a DistDriver. Must be called before distribution creates the storage driver.
-func RegisterMetadataStore(meta oci.MetadataStore) {
-	if meta == nil {
-		panic("RegisterMetadataStore called with nil")
-	}
-	metaMu.Lock()
-	defer metaMu.Unlock()
-	if registeredMeta != nil {
-		panic("RegisterMetadataStore called twice")
-	}
-	registeredMeta = meta
+var registerFactory = sync.OnceFunc(func() {
+	factory.Register(driverName, &quayDriverFactory{})
+})
+
+// Register makes the stateless Quay storage factory available to distribution.
+// It is safe to call multiple times and concurrently.
+func Register() {
+	registerFactory()
 }
 
-func init() {
-	factory.Register("quay", &quayDriverFactory{})
+// Name returns the name used to register the storage driver with distribution.
+func Name() string { return driverName }
+
+// Parameters builds distribution parameters for the local Quay driver.
+func Parameters(rootDir string, meta oci.MetadataStore) configuration.Parameters {
+	return configuration.Parameters{
+		rootDirectoryParameter: rootDir,
+		metastoreParameter:     meta,
+	}
 }
 
 type quayDriverFactory struct{}
 
 func (f *quayDriverFactory) Create(ctx context.Context, params map[string]interface{}) (storagedriver.StorageDriver, error) {
-	rootDir, ok := params["rootdirectory"].(string)
+	rootDir, ok := params[rootDirectoryParameter].(string)
 	if !ok || rootDir == "" {
 		return nil, fmt.Errorf("quay storage driver: rootdirectory parameter required")
 	}
-	metaMu.RLock()
-	meta := registeredMeta
-	metaMu.RUnlock()
-	if meta == nil {
-		return nil, fmt.Errorf("quay storage driver: metastore not registered (call RegisterMetadataStore first)")
+	meta, ok := params[metastoreParameter].(oci.MetadataStore)
+	if !ok || meta == nil {
+		return nil, fmt.Errorf("quay storage driver: metastore parameter must implement oci.MetadataStore")
 	}
 	blobs, err := New(rootDir)
 	if err != nil {

--- a/internal/oci/storage/local/register_test.go
+++ b/internal/oci/storage/local/register_test.go
@@ -1,0 +1,56 @@
+package local
+
+import (
+	"testing"
+
+	"github.com/distribution/distribution/v3/registry/storage/driver/base"
+	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quay/quay/internal/oci"
+)
+
+type metadataStoreStub struct {
+	oci.MetadataStore
+}
+
+func TestQuayDriverFactoryRejectsInvalidMetastore(t *testing.T) {
+	for _, params := range []map[string]interface{}{
+		{
+			rootDirectoryParameter: t.TempDir(),
+		},
+		{
+			rootDirectoryParameter: t.TempDir(),
+			metastoreParameter:     "not a metastore",
+		},
+	} {
+		_, err := (&quayDriverFactory{}).Create(t.Context(), params)
+		require.ErrorContains(t, err, "metastore parameter must implement oci.MetadataStore")
+	}
+}
+
+func TestQuayDriverFactoryUsesStoreParameter(t *testing.T) {
+	Register()
+
+	firstStore := &metadataStoreStub{}
+	secondStore := &metadataStoreStub{}
+
+	first := createDistDriver(t, firstStore)
+	second := createDistDriver(t, secondStore)
+
+	require.Same(t, firstStore, first.meta)
+	require.Same(t, secondStore, second.meta)
+}
+
+func createDistDriver(t *testing.T, store oci.MetadataStore) *DistDriver {
+	t.Helper()
+
+	driver, err := factory.Create(t.Context(), Name(), Parameters(t.TempDir(), store))
+	require.NoError(t, err)
+
+	baseDriver, ok := driver.(*base.Base)
+	require.True(t, ok)
+	distDriver, ok := baseDriver.StorageDriver.(*DistDriver)
+	require.True(t, ok)
+	return distDriver
+}

--- a/internal/registry/distribution/app.go
+++ b/internal/registry/distribution/app.go
@@ -85,7 +85,7 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 		libraryNamespace = defaultLibraryNamespace
 	}
 
-	local.RegisterMetadataStore(cfg.Store)
+	local.Register()
 
 	if err := registrymw.Register(cfg.Store, cfg.BlobLocker, libraryNamespace); err != nil {
 		return nil, fmt.Errorf("register middleware: %w", err)
@@ -123,9 +123,7 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 	distCfg := &configuration.Configuration{
 		Catalog: configuration.Catalog{MaxEntries: 1000},
 		Storage: configuration.Storage{
-			"quay": configuration.Parameters{
-				"rootdirectory": cfg.StoragePath,
-			},
+			local.Name(): local.Parameters(cfg.StoragePath, cfg.Store),
 			"delete": configuration.Parameters{
 				"enabled": true,
 			},

--- a/internal/registry/distribution/app_test.go
+++ b/internal/registry/distribution/app_test.go
@@ -3,7 +3,20 @@ package distribution
 import (
 	"strings"
 	"testing"
+
+	"github.com/distribution/distribution/v3/registry/handlers"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quay/quay/internal/oci"
 )
+
+type metadataStoreStub struct {
+	oci.MetadataStore
+}
+
+type registryTokenServiceStub struct {
+	registryTokenService
+}
 
 func TestNewRegistryRejectsNilBlobLocker(t *testing.T) {
 	_, err := NewRegistry(t.Context(), &Config{})
@@ -13,4 +26,25 @@ func TestNewRegistryRejectsNilBlobLocker(t *testing.T) {
 	if !strings.Contains(err.Error(), "nil blob locker") {
 		t.Fatalf("expected nil blob locker error, got %v", err)
 	}
+}
+
+func TestNewRegistryPassesStoreToDistributionDriver(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	store := &metadataStoreStub{}
+
+	registry, err := NewRegistry(t.Context(), &Config{
+		StoragePath: t.TempDir(),
+		Hostname:    "registry.example.com",
+		TokenRealm:  "https://registry.example.com/v2/auth",
+		DB:          db,
+		Store:       store,
+		BlobLocker:  oci.NewBlobLockSet(),
+		JWTService:  &registryTokenServiceStub{},
+	})
+	require.NoError(t, err)
+
+	app, ok := registry.Handler().(*handlers.App)
+	require.True(t, ok)
+	require.Same(t, store, app.Config.Storage.Parameters()["metastore"])
 }


### PR DESCRIPTION
## Summary
Inject each registry metadata store through the Distribution storage parameters instead of retaining process-global state. This keeps storage factory registration stateless and idempotent while allowing independent driver instances to use different stores.

## Related Issue
NO-ISSUE: internal Go registry storage refactor with no associated Jira ticket.

## Changes
- replace the global registered metastore with a per-driver `metastore` parameter
- centralize the Quay storage driver name and parameter construction
- make factory registration safe to call repeatedly and concurrently
- test invalid metastore parameters and per-driver store isolation

## Testing
- [x] `go test ./internal/oci/storage/local ./internal/registry/distribution` passes
- [x] `go vet ./internal/oci/storage/local ./internal/registry/distribution` passes
- [x] `gofmt -d internal/oci/storage/local/register.go internal/oci/storage/local/register_test.go internal/registry/distribution/app.go` produces no diff
- [x] `git diff --check upstream/master...HEAD` passes

## Notes
No migration or backport is required.
