### PR TITLE
PROJQUAY-12368: fix(quota): cancel rejected blob uploads

### DIFF
--- a/endpoints/v2/blob.py
+++ b/endpoints/v2/blob.py
@@ -368,6 +368,12 @@ def upload_chunk(namespace_name, repo_name, upload_uuid):
     if repository_ref is None:
         raise NameUnknown("repository not found")
 
+    uploader = retrieve_blob_upload_manager(
+        repository_ref, upload_uuid, storage, _upload_settings()
+    )
+    if uploader is None:
+        raise BlobUploadUnknown()
+
     if app.config.get("FEATURE_QUOTA_MANAGEMENT", False) and app.config.get(
         "FEATURE_VERIFY_QUOTA", True
     ):
@@ -378,13 +384,8 @@ def upload_chunk(namespace_name, repo_name, upload_uuid):
             namespacequota.notify_organization_admins(
                 repository_ref, "quota_error", {"severity": "Reject"}
             )
+            uploader.cancel_upload()
             raise QuotaExceeded
-
-    uploader = retrieve_blob_upload_manager(
-        repository_ref, upload_uuid, storage, _upload_settings()
-    )
-    if uploader is None:
-        raise BlobUploadUnknown()
 
     # Upload the chunk for the blob.
     _upload_chunk(uploader)
@@ -419,6 +420,12 @@ def monolithic_upload_or_last_chunk(namespace_name, repo_name, upload_uuid):
     if repository_ref is None:
         raise NameUnknown("repository not found")
 
+    uploader = retrieve_blob_upload_manager(
+        repository_ref, upload_uuid, storage, _upload_settings()
+    )
+    if uploader is None:
+        raise BlobUploadUnknown()
+
     if app.config.get("FEATURE_QUOTA_MANAGEMENT", False) and app.config.get(
         "FEATURE_VERIFY_QUOTA", True
     ):
@@ -429,13 +436,8 @@ def monolithic_upload_or_last_chunk(namespace_name, repo_name, upload_uuid):
             namespacequota.notify_organization_admins(
                 repository_ref, "quota_error", {"severity": "Reject"}
             )
+            uploader.cancel_upload()
             raise QuotaExceeded
-
-    uploader = retrieve_blob_upload_manager(
-        repository_ref, upload_uuid, storage, _upload_settings()
-    )
-    if uploader is None:
-        raise BlobUploadUnknown()
 
     # Upload the chunk for the blob and commit it once complete.
     with complete_when_uploaded(uploader):

--- a/endpoints/v2/test/test_quota_enforcement.py
+++ b/endpoints/v2/test/test_quota_enforcement.py
@@ -483,6 +483,152 @@ class TestQuotaEnforcementV2:
                 raw_body=chunk3_large,
             )
 
+    @pytest.mark.parametrize(
+        ("rejection_endpoint", "rejection_method"),
+        [
+            ("v2.upload_chunk", "PATCH"),
+            ("v2.monolithic_upload_or_last_chunk", "PUT"),
+        ],
+    )
+    def test_small_upload_succeeds_after_quota_rejection(
+        self,
+        rejection_endpoint,
+        rejection_method,
+        client,
+        app,
+        initialized_db,
+    ):
+        with patch.dict(
+            app.config,
+            {
+                "FEATURE_QUOTA_MANAGEMENT": True,
+                "FEATURE_VERIFY_QUOTA": True,
+            },
+        ):
+            org_name = f"test-quota-cancel-{rejection_method.lower()}"
+            repo_name = "test-repo"
+            user = model.user.get_user("devtable")
+
+            org = model.organization.create_organization(org_name, f"{org_name}@test.com", user)
+            model.repository.create_repository(org_name, repo_name, user)
+
+            namespace_user = model.user.get_user_or_org(org_name)
+            quota = model.namespacequota.create_namespace_quota(namespace_user, 5 * 1024)
+            model.namespacequota.create_namespace_quota_limit(quota, "reject", 100)
+
+            from data.model.quota import run_backfill
+
+            run_backfill(org.id)
+
+            access = [
+                {
+                    "type": "repository",
+                    "name": f"{org_name}/{repo_name}",
+                    "actions": ["pull", "push"],
+                }
+            ]
+            context, subject = build_context_and_subject(ValidatedAuthContext(user=user))
+            token = generate_bearer_token(
+                realapp.config["SERVER_HOSTNAME"], subject, context, access, 600, instance_keys
+            )
+            auth_headers = {"Authorization": f"Bearer {token}"}
+            repository_params = {"repository": f"{org_name}/{repo_name}"}
+
+            init_response = conduct_call(
+                client,
+                "v2.start_blob_upload",
+                url_for,
+                "POST",
+                repository_params,
+                expected_code=202,
+                headers=auth_headers,
+            )
+            upload_params = {
+                **repository_params,
+                "upload_uuid": init_response.headers["Docker-Upload-UUID"],
+            }
+            oversized_blob = b"x" * (6 * 1024)
+            conduct_call(
+                client,
+                "v2.upload_chunk",
+                url_for,
+                "PATCH",
+                upload_params,
+                expected_code=202,
+                headers={
+                    **auth_headers,
+                    "Content-Range": "0-6143",
+                    "Content-Type": "application/octet-stream",
+                },
+                raw_body=oversized_blob,
+            )
+
+            rejection_params = dict(upload_params)
+            rejection_headers = dict(auth_headers)
+            rejection_body = None
+            if rejection_method == "PATCH":
+                rejection_headers.update(
+                    {
+                        "Content-Range": "6144-6144",
+                        "Content-Type": "application/octet-stream",
+                    }
+                )
+                rejection_body = b"y"
+            else:
+                rejection_params["digest"] = f"sha256:{hashlib.sha256(oversized_blob).hexdigest()}"
+                rejection_headers["Content-Length"] = "0"
+
+            conduct_call(
+                client,
+                rejection_endpoint,
+                url_for,
+                rejection_method,
+                rejection_params,
+                expected_code=403,
+                headers=rejection_headers,
+                raw_body=rejection_body,
+            )
+
+            tiny_blob = b"z"
+            tiny_digest = f"sha256:{hashlib.sha256(tiny_blob).hexdigest()}"
+            retry_response = conduct_call(
+                client,
+                "v2.start_blob_upload",
+                url_for,
+                "POST",
+                repository_params,
+                expected_code=202,
+                headers=auth_headers,
+            )
+            retry_params = {
+                **repository_params,
+                "upload_uuid": retry_response.headers["Docker-Upload-UUID"],
+            }
+            conduct_call(
+                client,
+                "v2.upload_chunk",
+                url_for,
+                "PATCH",
+                retry_params,
+                expected_code=202,
+                headers={
+                    **auth_headers,
+                    "Content-Range": "0-0",
+                    "Content-Type": "application/octet-stream",
+                },
+                raw_body=tiny_blob,
+            )
+            retry_params["digest"] = tiny_digest
+            conduct_call(
+                client,
+                "v2.monolithic_upload_or_last_chunk",
+                url_for,
+                "PUT",
+                retry_params,
+                expected_code=201,
+                headers={**auth_headers, "Content-Length": "0"},
+            )
+
     def test_shared_blob_deduplication_in_quota(self, client, app, initialized_db):
         """
         Verify shared blobs are counted once in quota calculations.

--- a/web/playwright/e2e/api/api-v2.spec.ts
+++ b/web/playwright/e2e/api/api-v2.spec.ts
@@ -14,6 +14,7 @@
  * authenticate via V2 bearer tokens.
  */
 
+import {createHash} from 'crypto';
 import path from 'path';
 import {test, expect, uniqueName} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
@@ -563,6 +564,115 @@ test.describe(
         }
       }
     });
+  },
+);
+
+// ============================================================================
+// V2 Blob Upload Quota Enforcement
+// ============================================================================
+
+test.describe(
+  'V2 Blob Upload Quota Enforcement',
+  {
+    tag: [
+      '@api',
+      '@v2',
+      '@superuser',
+      '@auth:Database',
+      '@feature:QUOTA_MANAGEMENT',
+      '@feature:EDIT_QUOTA',
+    ],
+  },
+  () => {
+    test(
+      'small upload succeeds after an oversized upload is rejected',
+      {tag: '@PROJQUAY-12368'},
+      async ({api, superuserApi, playwright}) => {
+        const username = TEST_USERS.user.username;
+        const password = TEST_USERS.user.password;
+        const org = await api.organization('v2quota');
+        const repo = await api.repository(org.name, 'repo');
+        const quota = await superuserApi.quota(org.name, 5 * 1024);
+        await superuserApi.raw.createQuotaLimit(
+          org.name,
+          quota.quotaId,
+          'Reject',
+          100,
+        );
+
+        const request = await playwright.request.newContext({
+          ignoreHTTPSErrors: true,
+        });
+        try {
+          const scope = `repository:${repo.fullName}:pull,push`;
+          const v2Token = await getV2Token(
+            request,
+            API_URL,
+            username,
+            password,
+            scope,
+          );
+          const headers = {authorization: `Bearer ${v2Token}`};
+          const uploadsUrl = `${API_URL}/v2/${repo.fullName}/blobs/uploads/`;
+
+          const oversizedBlob = Buffer.alloc(6 * 1024, 'x');
+          const oversizedDigest = `sha256:${createHash('sha256')
+            .update(oversizedBlob)
+            .digest('hex')}`;
+          const startResponse = await request.post(uploadsUrl, {headers});
+          expect(startResponse.status()).toBe(202);
+          const rejectedUploadUuid =
+            startResponse.headers()['docker-upload-uuid'];
+          expect(rejectedUploadUuid).toBeTruthy();
+
+          const rejectedUploadUrl = `${uploadsUrl}${rejectedUploadUuid}`;
+          const uploadResponse = await request.patch(rejectedUploadUrl, {
+            headers: {
+              ...headers,
+              'Content-Range': '0-6143',
+              'Content-Type': 'application/octet-stream',
+            },
+            data: oversizedBlob,
+          });
+          expect(uploadResponse.status()).toBe(202);
+
+          const rejectionResponse = await request.put(
+            `${rejectedUploadUrl}?digest=${encodeURIComponent(oversizedDigest)}`,
+            {headers},
+          );
+          expect(rejectionResponse.status()).toBe(403);
+
+          const tinyBlob = Buffer.from('z');
+          const tinyDigest = `sha256:${createHash('sha256')
+            .update(tinyBlob)
+            .digest('hex')}`;
+          const retryStartResponse = await request.post(uploadsUrl, {headers});
+          expect(retryStartResponse.status()).toBe(202);
+          const retryUploadUuid =
+            retryStartResponse.headers()['docker-upload-uuid'];
+          expect(retryUploadUuid).toBeTruthy();
+
+          const retryUploadUrl = `${uploadsUrl}${retryUploadUuid}`;
+          const retryPatchResponse = await request.patch(retryUploadUrl, {
+            headers: {
+              ...headers,
+              'Content-Range': '0-0',
+              'Content-Type': 'application/octet-stream',
+            },
+            data: tinyBlob,
+          });
+          expect(retryPatchResponse.status()).toBe(202);
+
+          const retryPutResponse = await request.put(
+            `${retryUploadUrl}?digest=${encodeURIComponent(tinyDigest)}`,
+            {headers},
+          );
+          expect(retryPutResponse.status()).toBe(201);
+        } finally {
+          await request.dispose();
+        }
+      },
+    );
   },
 );
 


### PR DESCRIPTION
## Summary

Fix quota-rejected blob uploads so they do not leave in-progress upload records that permanently inflate namespace quota usage.

## Root Cause / Rationale

The PATCH and final PUT blob-upload endpoints evaluated in-progress quota before retrieving the upload manager. When quota enforcement returned Reject, the request raised `QuotaExceeded` without canceling the current upload, leaving its `BlobUpload.byte_count` included in later quota checks.

## Changes

- Resolve the blob upload manager before during-upload quota enforcement for PATCH and final PUT requests.
- Cancel the active upload through the existing upload manager before returning the quota error.
- Add V2 regression coverage for both rejection paths and verify a subsequent small upload succeeds.

## Test Plan

- `TEST=true PYTHONPATH="." pytest endpoints/v2/test/test_quota_enforcement.py::TestQuotaEnforcementV2::test_small_upload_succeeds_after_quota_rejection -q --tb=short` — 2 passed.
- `TEST=true PYTHONPATH="." pytest endpoints/v2/test/test_blob.py endpoints/v2/test/test_quota_enforcement.py -q --tb=short` — 28 passed, 2 xfailed, 1 xpassed.
- Pre-commit hooks passed during commit.
- Makefile broad suites were attempted but exceeded local execution limits without reporting a test failure; `certs-test` requires the container-only `/quay-registry` path.

## JIRA

https://redhat.atlassian.net/browse/PROJQUAY-12368

## Backport

No backport is included in this PR. The reported issue affects 3.18, so a release-branch backport can be handled after the master fix merges.