### PR TITLE
PROJQUAY-12325: feat(cli): add quay uninstall command

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -466,6 +466,46 @@ jobs:
           podman pull "localhost:8443/projectquay/quay:3.13.2"
           echo "Successfully pulled mirrored image"
 
+      - name: Uninstall registry
+        run: |
+          sudo bin/quay uninstall -auto-approve -data-dir=/var/lib/quay
+
+      - name: Verify uninstall cleanup
+        run: |
+          set -euo pipefail
+
+          if sudo test -e /etc/containers/systemd/quay.container; then
+            echo "FAIL: quadlet file still exists"
+            exit 1
+          fi
+          echo "Quadlet file removed"
+
+          if sudo systemctl is-active quay.service 2>/dev/null; then
+            echo "FAIL: quay.service is still active"
+            exit 1
+          fi
+          echo "Service is not active"
+
+          if sudo test -d /var/lib/quay; then
+            echo "FAIL: data directory still exists"
+            exit 1
+          fi
+          echo "Data directory removed"
+
+          if ss -tlnp | grep -q ':8443 '; then
+            echo "FAIL: port 8443 is still listening"
+            exit 1
+          fi
+          echo "Port 8443 is not listening"
+
+          if sudo podman ps --format '{{.Names}}' | grep -q quay; then
+            echo "FAIL: quay container is still running"
+            exit 1
+          fi
+          echo "No quay container running"
+
+          echo "All uninstall assertions passed"
+
       - name: Collect diagnostics
         if: always()
         run: |

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -24,6 +24,7 @@ func Run(args []string) int {
 		Flags:    fs,
 		Subcommands: []*Command{
 			newInstallCmd(),
+			newUninstallCmd(),
 			newInitCmd(),
 			newConfigCmd(),
 			newServeCmd(),

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/quay/quay/internal/uninstaller"
+)
+
+func newUninstallCmd() *Command {
+	return newUninstallCmdWithDeps(os.Stdin, runUninstall)
+}
+
+func newUninstallCmdWithDeps(stdin io.Reader, uninstall func(context.Context, *uninstaller.Config) int) *Command {
+	fs := flag.NewFlagSet("uninstall", flag.ContinueOnError)
+	dataDir := fs.String("data-dir", "/var/lib/quay", "directory for database, storage, and certs")
+	autoApprove := fs.Bool("auto-approve", false, "skip confirmation prompt and remove data directory")
+
+	return &Command{
+		Name:     "uninstall",
+		Synopsis: "Remove the registry service and optionally its data",
+		Flags:    fs,
+		Run: func(ctx context.Context, cmd *Command, _ []string) int {
+			if !*autoApprove {
+				if !confirmUninstall(stdin) {
+					slog.Info("uninstall cancelled")
+					return 0
+				}
+			}
+			return uninstall(ctx, &uninstaller.Config{
+				DataDir:     *dataDir,
+				AutoApprove: *autoApprove,
+			})
+		},
+	}
+}
+
+func confirmUninstall(r io.Reader) bool {
+	fmt.Fprint(os.Stderr, "Are you sure you want to uninstall? [y/N]: ")
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		return false
+	}
+	answer := strings.TrimSpace(scanner.Text())
+	return strings.EqualFold(answer, "y") || strings.EqualFold(answer, "yes")
+}
+
+func runUninstall(ctx context.Context, cfg *uninstaller.Config) int {
+	u, err := uninstaller.New(os.Stderr)
+	if err != nil {
+		slog.Error("uninstaller setup failed", "err", err)
+		return 1
+	}
+
+	if err := u.Run(ctx, cfg); err != nil {
+		slog.Error("uninstall failed", "err", err)
+		return 1
+	}
+
+	return 0
+}

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -29,7 +29,7 @@ func newUninstallCmdWithDeps(stdin io.Reader, uninstall func(context.Context, *u
 		Run: func(ctx context.Context, cmd *Command, _ []string) int {
 			if !*autoApprove {
 				if !confirmUninstall(stdin) {
-					slog.Info("uninstall cancelled")
+					slog.Info("uninstall canceled")
 					return 0
 				}
 			}

--- a/internal/cmd/uninstall_test.go
+++ b/internal/cmd/uninstall_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/quay/quay/internal/uninstaller"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUninstallCmdDefaultFlags(t *testing.T) {
+	var captured *uninstaller.Config
+	cmd := newUninstallCmdWithDeps(strings.NewReader(""), func(_ context.Context, cfg *uninstaller.Config) int {
+		captured = cfg
+		return 0
+	})
+
+	code := cmd.Execute(t.Context(), []string{"-auto-approve"})
+
+	require.Equal(t, 0, code)
+	require.NotNil(t, captured)
+	assert.Equal(t, "/var/lib/quay", captured.DataDir)
+	assert.True(t, captured.AutoApprove)
+}
+
+func TestUninstallCmdCustomDataDir(t *testing.T) {
+	var captured *uninstaller.Config
+	cmd := newUninstallCmdWithDeps(strings.NewReader(""), func(_ context.Context, cfg *uninstaller.Config) int {
+		captured = cfg
+		return 0
+	})
+
+	code := cmd.Execute(t.Context(), []string{"-data-dir=/custom/path", "-auto-approve"})
+
+	require.Equal(t, 0, code)
+	require.NotNil(t, captured)
+	assert.Equal(t, "/custom/path", captured.DataDir)
+}
+
+func TestUninstallCmdPromptsForConfirmation(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantCode int
+		wantRun  bool
+	}{
+		{name: "y confirms", input: "y\n", wantCode: 0, wantRun: true},
+		{name: "Y confirms", input: "Y\n", wantCode: 0, wantRun: true},
+		{name: "yes confirms", input: "yes\n", wantCode: 0, wantRun: true},
+		{name: "n cancels", input: "n\n", wantCode: 0, wantRun: false},
+		{name: "empty cancels", input: "\n", wantCode: 0, wantRun: false},
+		{name: "random cancels", input: "maybe\n", wantCode: 0, wantRun: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ran := false
+			cmd := newUninstallCmdWithDeps(strings.NewReader(tt.input), func(_ context.Context, _ *uninstaller.Config) int {
+				ran = true
+				return 0
+			})
+
+			code := cmd.Execute(t.Context(), nil)
+
+			assert.Equal(t, tt.wantCode, code)
+			assert.Equal(t, tt.wantRun, ran)
+		})
+	}
+}
+
+func TestUninstallCmdAutoApproveSkipsPrompt(t *testing.T) {
+	ran := false
+	cmd := newUninstallCmdWithDeps(strings.NewReader(""), func(_ context.Context, _ *uninstaller.Config) int {
+		ran = true
+		return 0
+	})
+
+	code := cmd.Execute(t.Context(), []string{"-auto-approve"})
+
+	assert.Equal(t, 0, code)
+	assert.True(t, ran)
+}
+
+func TestUninstallCmdReturnsRunExitCode(t *testing.T) {
+	cmd := newUninstallCmdWithDeps(strings.NewReader(""), func(_ context.Context, _ *uninstaller.Config) int {
+		return 1
+	})
+
+	code := cmd.Execute(t.Context(), []string{"-auto-approve"})
+
+	assert.Equal(t, 1, code)
+}
+
+func TestUninstallCmdHelp(t *testing.T) {
+	cmd := newUninstallCmdWithDeps(strings.NewReader(""), func(_ context.Context, _ *uninstaller.Config) int {
+		return 0
+	})
+
+	var buf bytes.Buffer
+	cmd.Usage(&buf)
+
+	assert.Contains(t, buf.String(), "uninstall")
+	assert.Contains(t, buf.String(), "-data-dir")
+	assert.Contains(t, buf.String(), "-auto-approve")
+}

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -539,6 +539,10 @@ func (r *recordingServiceManager) EnableLinger(context.Context) error {
 	return nil
 }
 
+func (r *recordingServiceManager) DisableLinger(context.Context) error {
+	return nil
+}
+
 var _ system.ServiceManager = (*recordingServiceManager)(nil)
 
 func TestValidateSSLFlags(t *testing.T) {

--- a/internal/system/fs.go
+++ b/internal/system/fs.go
@@ -14,6 +14,7 @@ type FileSystem interface {
 	Link(oldPath, newPath string) error
 	Rename(oldPath, newPath string) error
 	Remove(path string) error
+	RemoveAll(path string) error
 }
 
 // OSFS implements FileSystem using the real filesystem.
@@ -52,3 +53,6 @@ func (OSFS) Rename(oldPath, newPath string) error { return os.Rename(oldPath, ne
 
 // Remove delegates to os.Remove.
 func (OSFS) Remove(path string) error { return os.Remove(path) }
+
+// RemoveAll delegates to os.RemoveAll.
+func (OSFS) RemoveAll(path string) error { return os.RemoveAll(path) } //nolint:gosec // paths from known locations

--- a/internal/system/quadlet.go
+++ b/internal/system/quadlet.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 )
 
@@ -33,6 +34,16 @@ func NewQuadletManager(fs FileSystem, env *Env) *QuadletManager {
 func (q *QuadletManager) Exists(service string) bool {
 	_, err := q.fs.Stat(q.env.QuadletPath(service))
 	return err == nil
+}
+
+// Remove deletes the Quadlet .container file for service. Returns nil
+// if the file does not exist.
+func (q *QuadletManager) Remove(service string) error {
+	err := q.fs.Remove(q.env.QuadletPath(service))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove quadlet: %w", err)
+	}
+	return nil
 }
 
 // Install writes a new Quadlet .container file.

--- a/internal/system/quadlet_test.go
+++ b/internal/system/quadlet_test.go
@@ -195,6 +195,32 @@ func TestUpdateServeHostnameRejectsMalformedHostname(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid hostname flag")
 }
 
+func TestQuadletRemoveDeletesContainerFile(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+	require.NoError(t, manager.Install("quay", &QuadletSpec{
+		Image:    "localhost/quay:test",
+		DataDir:  "/var/lib/quay",
+		Hostname: "localhost",
+		Port:     "8443",
+	}))
+	require.True(t, manager.Exists("quay"))
+
+	err := manager.Remove("quay")
+
+	require.NoError(t, err)
+	assert.False(t, manager.Exists("quay"))
+}
+
+func TestQuadletRemoveReturnsNilWhenFileAbsent(t *testing.T) {
+	env := &Env{Mode: UserMode, HomeDir: t.TempDir()}
+	manager := NewQuadletManager(OSFS{}, env)
+
+	err := manager.Remove("quay")
+
+	require.NoError(t, err)
+}
+
 func readQuadletTestFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Clean(path))

--- a/internal/system/systemd.go
+++ b/internal/system/systemd.go
@@ -8,6 +8,7 @@ type ServiceManager interface {
 	Start(ctx context.Context, service string) error
 	Stop(ctx context.Context, service string) error
 	EnableLinger(ctx context.Context) error
+	DisableLinger(ctx context.Context) error
 }
 
 // SystemdManager implements ServiceManager using systemctl.
@@ -42,4 +43,12 @@ func (s *SystemdManager) EnableLinger(ctx context.Context) error {
 		return nil
 	}
 	return s.runner.Run(ctx, "loginctl", "enable-linger", s.env.Username)
+}
+
+// DisableLinger disables lingering for the current user in user mode.
+func (s *SystemdManager) DisableLinger(ctx context.Context) error {
+	if s.env.Mode == RootMode || s.env.Username == "" {
+		return nil
+	}
+	return s.runner.Run(ctx, "loginctl", "disable-linger", s.env.Username)
 }

--- a/internal/system/systemd.go
+++ b/internal/system/systemd.go
@@ -1,6 +1,14 @@
 package system
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+// ErrUnitNotFound is returned when a systemd unit does not exist.
+var ErrUnitNotFound = errors.New("systemd unit not found")
 
 // ServiceManager abstracts systemd service operations.
 type ServiceManager interface {
@@ -32,9 +40,17 @@ func (s *SystemdManager) Start(ctx context.Context, service string) error {
 	return s.runner.Run(ctx, "systemctl", append(s.env.SystemctlArgs(), "start", service)...)
 }
 
-// Stop stops a systemd service.
+// Stop stops a systemd service. Returns ErrUnitNotFound if the unit does not
+// exist (systemctl exit code 5).
 func (s *SystemdManager) Stop(ctx context.Context, service string) error {
-	return s.runner.Run(ctx, "systemctl", append(s.env.SystemctlArgs(), "stop", service)...)
+	err := s.runner.Run(ctx, "systemctl", append(s.env.SystemctlArgs(), "stop", service)...)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 5 {
+			return fmt.Errorf("%w: %s", ErrUnitNotFound, service)
+		}
+	}
+	return err
 }
 
 // EnableLinger enables lingering for the current user in user mode.

--- a/internal/system/systemd_test.go
+++ b/internal/system/systemd_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 // a shell process that exits with that code.
 func exitError(t *testing.T, code int) *exec.ExitError {
 	t.Helper()
-	cmd := exec.Command("sh", "-c", "exit "+string(rune('0'+code)))
+	cmd := exec.CommandContext(t.Context(), "sh", "-c", fmt.Sprintf("exit %d", code))
 	err := cmd.Run()
 	require.Error(t, err)
 	var exitErr *exec.ExitError

--- a/internal/system/systemd_test.go
+++ b/internal/system/systemd_test.go
@@ -1,0 +1,107 @@
+package system
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// exitError returns a real *exec.ExitError with the given exit code by running
+// a shell process that exits with that code.
+func exitError(t *testing.T, code int) *exec.ExitError {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", "exit "+string(rune('0'+code)))
+	err := cmd.Run()
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.True(t, errors.As(err, &exitErr))
+	return exitErr
+}
+
+type recordingRunner struct {
+	calls []string
+	err   error
+}
+
+func (r *recordingRunner) Run(_ context.Context, name string, args ...string) error {
+	call := name
+	for _, a := range args {
+		call += " " + a
+	}
+	r.calls = append(r.calls, call)
+	return r.err
+}
+
+func (r *recordingRunner) Output(_ context.Context, name string, args ...string) (string, error) {
+	return "", r.err
+}
+
+var _ CommandRunner = (*recordingRunner)(nil)
+
+func TestStopWrapsExitCode5AsErrUnitNotFound(t *testing.T) {
+	runner := &recordingRunner{err: exitError(t, 5)}
+	mgr := NewSystemdManager(runner, &Env{Mode: UserMode, HomeDir: t.TempDir()})
+
+	err := mgr.Stop(t.Context(), "quay")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnitNotFound))
+	assert.Contains(t, runner.calls[0], "stop")
+}
+
+func TestStopPreservesNonExitCode5Errors(t *testing.T) {
+	runner := &recordingRunner{err: exitError(t, 1)}
+	mgr := NewSystemdManager(runner, &Env{Mode: UserMode, HomeDir: t.TempDir()})
+
+	err := mgr.Stop(t.Context(), "quay")
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrUnitNotFound))
+	var exitErr *exec.ExitError
+	assert.True(t, errors.As(err, &exitErr))
+}
+
+func TestStopReturnsNilOnSuccess(t *testing.T) {
+	runner := &recordingRunner{}
+	mgr := NewSystemdManager(runner, &Env{Mode: UserMode, HomeDir: t.TempDir()})
+
+	err := mgr.Stop(t.Context(), "quay")
+
+	require.NoError(t, err)
+	assert.Contains(t, runner.calls[0], "stop quay")
+}
+
+func TestDisableLingerCallsLoginctlInUserMode(t *testing.T) {
+	runner := &recordingRunner{}
+	mgr := NewSystemdManager(runner, &Env{Mode: UserMode, HomeDir: t.TempDir(), Username: "testuser"})
+
+	err := mgr.DisableLinger(t.Context())
+
+	require.NoError(t, err)
+	require.Len(t, runner.calls, 1)
+	assert.Equal(t, "loginctl disable-linger testuser", runner.calls[0])
+}
+
+func TestDisableLingerSkipsInRootMode(t *testing.T) {
+	runner := &recordingRunner{}
+	mgr := NewSystemdManager(runner, &Env{Mode: RootMode})
+
+	err := mgr.DisableLinger(t.Context())
+
+	require.NoError(t, err)
+	assert.Empty(t, runner.calls)
+}
+
+func TestDisableLingerSkipsWhenUsernameEmpty(t *testing.T) {
+	runner := &recordingRunner{}
+	mgr := NewSystemdManager(runner, &Env{Mode: UserMode, HomeDir: t.TempDir(), Username: ""})
+
+	err := mgr.DisableLinger(t.Context())
+
+	require.NoError(t, err)
+	assert.Empty(t, runner.calls)
+}

--- a/internal/uninstaller/uninstaller.go
+++ b/internal/uninstaller/uninstaller.go
@@ -1,8 +1,11 @@
+// Package uninstaller implements the removal workflow for the registry's
+// Quadlet-based systemd deployment.
 package uninstaller
 
 import (
 	"context"
 	"fmt"
+	"strings"
 	"io"
 	"log/slog"
 	"os"
@@ -48,7 +51,11 @@ func New(stderr io.Writer) (*Uninstaller, error) {
 // reload systemd, conditionally remove data, and disable linger.
 func (u *Uninstaller) Run(ctx context.Context, cfg *Config) error {
 	if err := u.systemd.Stop(ctx, serviceName); err != nil {
-		slog.Warn("failed to stop service (may already be stopped)", "err", err)
+		if isUnitNotFound(err) {
+			slog.Info("service not running, continuing")
+		} else {
+			return fmt.Errorf("stop service: %w", err)
+		}
 	}
 
 	if err := u.quadlet.Remove(serviceName); err != nil {
@@ -75,4 +82,9 @@ func (u *Uninstaller) Run(ctx context.Context, cfg *Config) error {
 
 	slog.Info("uninstall complete")
 	return nil
+}
+
+func isUnitNotFound(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "not loaded") || strings.Contains(msg, "not found")
 }

--- a/internal/uninstaller/uninstaller.go
+++ b/internal/uninstaller/uninstaller.go
@@ -1,0 +1,78 @@
+package uninstaller
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/quay/quay/internal/system"
+)
+
+const serviceName = "quay"
+
+// Config holds the parameters for an uninstall operation.
+type Config struct {
+	DataDir     string
+	AutoApprove bool
+}
+
+// Uninstaller removes the registry's Quadlet-based systemd deployment.
+type Uninstaller struct {
+	systemd system.ServiceManager
+	quadlet *system.QuadletManager
+	env     *system.Env
+	fs      system.FileSystem
+}
+
+// New detects the runtime environment and creates an Uninstaller.
+func New(stderr io.Writer) (*Uninstaller, error) {
+	env, err := system.NewEnv()
+	if err != nil {
+		return nil, fmt.Errorf("detect environment: %w", err)
+	}
+
+	runner := system.NewExecRunner(stderr)
+	fs := system.OSFS{}
+
+	return &Uninstaller{
+		systemd: system.NewSystemdManager(runner, env),
+		quadlet: system.NewQuadletManager(fs, env),
+		env:     env,
+		fs:      fs,
+	}, nil
+}
+
+// Run performs the uninstall sequence: stop service, remove Quadlet file,
+// reload systemd, conditionally remove data, and disable linger.
+func (u *Uninstaller) Run(ctx context.Context, cfg *Config) error {
+	if err := u.systemd.Stop(ctx, serviceName); err != nil {
+		slog.Warn("failed to stop service (may already be stopped)", "err", err)
+	}
+
+	if err := u.quadlet.Remove(serviceName); err != nil {
+		return fmt.Errorf("remove quadlet: %w", err)
+	}
+	slog.Info("removed quadlet unit", "path", u.env.QuadletPath(serviceName))
+
+	if err := u.systemd.DaemonReload(ctx); err != nil {
+		return fmt.Errorf("reload systemd: %w", err)
+	}
+
+	if cfg.AutoApprove {
+		if err := u.fs.RemoveAll(cfg.DataDir); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove data directory: %w", err)
+		}
+		slog.Info("removed data directory", "path", cfg.DataDir)
+	}
+
+	if u.env.Mode == system.UserMode {
+		if err := u.systemd.DisableLinger(ctx); err != nil {
+			slog.Warn("failed to disable linger", "err", err)
+		}
+	}
+
+	slog.Info("uninstall complete")
+	return nil
+}

--- a/internal/uninstaller/uninstaller.go
+++ b/internal/uninstaller/uninstaller.go
@@ -4,8 +4,8 @@ package uninstaller
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 	"io"
 	"log/slog"
 	"os"
@@ -51,7 +51,7 @@ func New(stderr io.Writer) (*Uninstaller, error) {
 // reload systemd, conditionally remove data, and disable linger.
 func (u *Uninstaller) Run(ctx context.Context, cfg *Config) error {
 	if err := u.systemd.Stop(ctx, serviceName); err != nil {
-		if isUnitNotFound(err) {
+		if errors.Is(err, system.ErrUnitNotFound) {
 			slog.Info("service not running, continuing")
 		} else {
 			return fmt.Errorf("stop service: %w", err)
@@ -82,9 +82,4 @@ func (u *Uninstaller) Run(ctx context.Context, cfg *Config) error {
 
 	slog.Info("uninstall complete")
 	return nil
-}
-
-func isUnitNotFound(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "not loaded") || strings.Contains(msg, "not found")
 }

--- a/internal/uninstaller/uninstaller_test.go
+++ b/internal/uninstaller/uninstaller_test.go
@@ -3,6 +3,7 @@ package uninstaller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -125,7 +126,7 @@ func TestRunSkipsLingerForRootMode(t *testing.T) {
 func TestRunContinuesWhenServiceNotRunning(t *testing.T) {
 	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir()}
 	services := &recordingServiceManager{
-		stopErr: errors.New("unit quay.service not loaded"),
+		stopErr: fmt.Errorf("%w: quay", system.ErrUnitNotFound),
 	}
 	u := &Uninstaller{
 		systemd: services,

--- a/internal/uninstaller/uninstaller_test.go
+++ b/internal/uninstaller/uninstaller_test.go
@@ -1,0 +1,188 @@
+package uninstaller
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/quay/quay/internal/system"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunStopsServiceRemovesQuadletAndReloads(t *testing.T) {
+	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir(), Username: "testuser"}
+	qm := system.NewQuadletManager(system.OSFS{}, env)
+	require.NoError(t, qm.Install("quay", &system.QuadletSpec{
+		Image: "localhost/quay:test", DataDir: "/var/lib/quay",
+		Hostname: "localhost", Port: "8443",
+	}))
+
+	services := &recordingServiceManager{}
+	u := &Uninstaller{
+		systemd: services,
+		quadlet: qm,
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	err := u.Run(t.Context(), &Config{DataDir: "/var/lib/quay"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"stop:quay", "daemon-reload", "disable-linger"}, services.calls)
+	assert.False(t, qm.Exists("quay"))
+}
+
+func TestRunRemovesDataDirWhenAutoApprove(t *testing.T) {
+	dataDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "quay.db"), []byte("data"), 0o600))
+
+	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir()}
+	qm := system.NewQuadletManager(system.OSFS{}, env)
+	require.NoError(t, qm.Install("quay", &system.QuadletSpec{
+		Image: "localhost/quay:test", DataDir: dataDir,
+		Hostname: "localhost", Port: "8443",
+	}))
+
+	services := &recordingServiceManager{}
+	u := &Uninstaller{
+		systemd: services,
+		quadlet: qm,
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	err := u.Run(t.Context(), &Config{DataDir: dataDir, AutoApprove: true})
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(dataDir)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestRunPreservesDataDirWithoutAutoApprove(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "quay.db")
+	require.NoError(t, os.WriteFile(dbPath, []byte("data"), 0o600))
+
+	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir()}
+	qm := system.NewQuadletManager(system.OSFS{}, env)
+	require.NoError(t, qm.Install("quay", &system.QuadletSpec{
+		Image: "localhost/quay:test", DataDir: dataDir,
+		Hostname: "localhost", Port: "8443",
+	}))
+
+	services := &recordingServiceManager{}
+	u := &Uninstaller{
+		systemd: services,
+		quadlet: qm,
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	err := u.Run(t.Context(), &Config{DataDir: dataDir})
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(dbPath)
+	assert.NoError(t, statErr)
+}
+
+func TestRunDisablesLingerForUserMode(t *testing.T) {
+	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir(), Username: "testuser"}
+	qm := system.NewQuadletManager(system.OSFS{}, env)
+
+	services := &recordingServiceManager{}
+	u := &Uninstaller{
+		systemd: services,
+		quadlet: qm,
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	err := u.Run(t.Context(), &Config{DataDir: "/var/lib/quay"})
+
+	require.NoError(t, err)
+	assert.Contains(t, services.calls, "disable-linger")
+}
+
+func TestRunSkipsLingerForRootMode(t *testing.T) {
+	env := &system.Env{Mode: system.RootMode}
+	services := &recordingServiceManager{}
+	u := &Uninstaller{
+		systemd: services,
+		quadlet: system.NewQuadletManager(system.OSFS{}, env),
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	err := u.Run(t.Context(), &Config{DataDir: "/var/lib/quay"})
+
+	require.NoError(t, err)
+	assert.NotContains(t, services.calls, "disable-linger")
+}
+
+func TestRunContinuesWhenServiceNotRunning(t *testing.T) {
+	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir()}
+	services := &recordingServiceManager{
+		stopErr: errors.New("unit quay.service not loaded"),
+	}
+	u := &Uninstaller{
+		systemd: services,
+		quadlet: system.NewQuadletManager(system.OSFS{}, env),
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	err := u.Run(t.Context(), &Config{DataDir: "/var/lib/quay"})
+
+	require.NoError(t, err)
+	assert.Contains(t, services.calls, "daemon-reload")
+}
+
+func TestRunIsIdempotent(t *testing.T) {
+	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir()}
+	services := &recordingServiceManager{}
+	u := &Uninstaller{
+		systemd: services,
+		quadlet: system.NewQuadletManager(system.OSFS{}, env),
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	require.NoError(t, u.Run(t.Context(), &Config{DataDir: "/var/lib/quay"}))
+	services.calls = nil
+	require.NoError(t, u.Run(t.Context(), &Config{DataDir: "/var/lib/quay"}))
+}
+
+type recordingServiceManager struct {
+	calls   []string
+	stopErr error
+}
+
+func (r *recordingServiceManager) DaemonReload(context.Context) error {
+	r.calls = append(r.calls, "daemon-reload")
+	return nil
+}
+
+func (r *recordingServiceManager) Start(_ context.Context, service string) error {
+	r.calls = append(r.calls, "start:"+service)
+	return nil
+}
+
+func (r *recordingServiceManager) Stop(_ context.Context, service string) error {
+	r.calls = append(r.calls, "stop:"+service)
+	return r.stopErr
+}
+
+func (r *recordingServiceManager) EnableLinger(context.Context) error {
+	r.calls = append(r.calls, "enable-linger")
+	return nil
+}
+
+func (r *recordingServiceManager) DisableLinger(context.Context) error {
+	r.calls = append(r.calls, "disable-linger")
+	return nil
+}
+
+var _ system.ServiceManager = (*recordingServiceManager)(nil)

--- a/internal/uninstaller/uninstaller_test.go
+++ b/internal/uninstaller/uninstaller_test.go
@@ -140,6 +140,35 @@ func TestRunContinuesWhenServiceNotRunning(t *testing.T) {
 	assert.Contains(t, services.calls, "daemon-reload")
 }
 
+func TestRunFailsOnUnexpectedStopError(t *testing.T) {
+	dataDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "quay.db"), []byte("data"), 0o600))
+
+	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir()}
+	qm := system.NewQuadletManager(system.OSFS{}, env)
+	require.NoError(t, qm.Install("quay", &system.QuadletSpec{
+		Image: "localhost/quay:test", DataDir: dataDir,
+		Hostname: "localhost", Port: "8443",
+	}))
+
+	services := &recordingServiceManager{
+		stopErr: errors.New("permission denied"),
+	}
+	u := &Uninstaller{
+		systemd: services,
+		quadlet: qm,
+		env:     env,
+		fs:      system.OSFS{},
+	}
+
+	err := u.Run(t.Context(), &Config{DataDir: dataDir, AutoApprove: true})
+
+	require.ErrorContains(t, err, "stop service")
+	assert.NotContains(t, services.calls, "daemon-reload")
+	_, statErr := os.Stat(filepath.Join(dataDir, "quay.db"))
+	assert.NoError(t, statErr)
+}
+
 func TestRunIsIdempotent(t *testing.T) {
 	env := &system.Env{Mode: system.UserMode, HomeDir: t.TempDir()}
 	services := &recordingServiceManager{}


### PR DESCRIPTION
## Summary

- Add `quay uninstall` command to cleanly remove the registry's Quadlet-based systemd deployment
- Supports interactive confirmation prompt (`-auto-approve` to skip) and conditional data directory removal
- Handles rootless installations by disabling `loginctl linger` on uninstall

## Root Cause / Rationale

OMR 3.0 has no uninstall command. OMR 2.0.x provides full uninstall with cleanup of services, volumes, secrets, and storage. This adds the equivalent for OMR 3.0's simpler single-Quadlet architecture.

## Changes

**New files:**
- `internal/cmd/uninstall.go` — CLI subcommand wiring (flags, interactive prompt, delegation)
- `internal/cmd/uninstall_test.go` — 8 tests covering flags, prompt variants, help output
- `internal/uninstaller/uninstaller.go` — Core uninstall logic (stop → remove quadlet → daemon-reload → optional data removal → disable linger)
- `internal/uninstaller/uninstaller_test.go` — 7 tests covering full sequence, data removal, linger, idempotency, error resilience

**Modified files:**
- `internal/cmd/cmd.go` — Register `newUninstallCmd()` in command tree
- `internal/system/systemd.go` — Add `DisableLinger` to `ServiceManager` interface + `SystemdManager` implementation
- `internal/system/fs.go` — Add `RemoveAll` to `FileSystem` interface + `OSFS` implementation
- `internal/system/quadlet.go` — Add `Remove` method to `QuadletManager`
- `internal/system/quadlet_test.go` — 2 tests for `QuadletManager.Remove`
- `internal/installer/installer_test.go` — Update mock to satisfy new `DisableLinger` interface method

## Uninstall Sequence

1. Stop systemd service (`systemctl [--user] stop quay`)
2. Remove Quadlet `.container` file
3. Daemon reload (`systemctl [--user] daemon-reload`)
4. Remove data directory (only with `--auto-approve`)
5. Disable linger (only for rootless/user-mode installs)

The command is idempotent — safe to run if the service is already stopped or the Quadlet file is already gone.

## Test Plan

- [x] 17 new unit tests covering all behaviors
- [x] All existing tests pass (25 packages, 0 failures)
- [x] Pre-commit hooks pass
- [x] Binary builds and `quay help` shows `uninstall` command
- [x] `quay uninstall --help` shows `-data-dir` and `-auto-approve` flags

## JIRA

https://redhat.atlassian.net/browse/PROJQUAY-12325

## Backport

Not required (no Target Version set).