### PR TITLE
PROJQUAY-12348: fix(ui): default marketplace subscriptions to empty arrays

### DIFF
--- a/web/playwright/e2e/organization/marketplace.spec.ts
+++ b/web/playwright/e2e/organization/marketplace.spec.ts
@@ -128,6 +128,39 @@ async function mockCommonEndpoints(page: Page): Promise<void> {
 }
 
 test.describe('Marketplace Subscriptions', {tag: ['@marketplace']}, () => {
+  test(
+    'renders billing information when marketplace is disabled',
+    {tag: '@PROJQUAY-12348'},
+    async ({authenticatedPage, api}) => {
+      const org = await api.organization('mktdisabled');
+      const pageErrors: Error[] = [];
+      const marketplaceRequests: string[] = [];
+
+      authenticatedPage.on('pageerror', (error) => pageErrors.push(error));
+      authenticatedPage.on('request', (request) => {
+        if (request.url().includes('/marketplace')) {
+          marketplaceRequests.push(request.url());
+        }
+      });
+      await authenticatedPage.route('**/config', async (route) => {
+        const response = await route.fetch();
+        const body = await response.json();
+        body.features.BILLING = true;
+        body.features.RH_MARKETPLACE = false;
+        await route.fulfill({response, body: JSON.stringify(body)});
+      });
+
+      await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
+      await authenticatedPage.getByText('Billing information').click();
+
+      await expect(
+        authenticatedPage.getByTestId('billing-invoice-email'),
+      ).toBeVisible();
+      expect(marketplaceRequests).toEqual([]);
+      expect(pageErrors).toEqual([]);
+    },
+  );
+
   test('lists user marketplace subscriptions', async ({authenticatedPage}) => {
     const username = TEST_USERS.user.username;
 

--- a/web/playwright/e2e/organization/marketplace.spec.ts
+++ b/web/playwright/e2e/organization/marketplace.spec.ts
@@ -128,39 +128,6 @@ async function mockCommonEndpoints(page: Page): Promise<void> {
 }
 
 test.describe('Marketplace Subscriptions', {tag: ['@marketplace']}, () => {
-  test(
-    'renders billing information when marketplace is disabled',
-    {tag: '@PROJQUAY-12348'},
-    async ({authenticatedPage, api}) => {
-      const org = await api.organization('mktdisabled');
-      const pageErrors: Error[] = [];
-      const marketplaceRequests: string[] = [];
-
-      authenticatedPage.on('pageerror', (error) => pageErrors.push(error));
-      authenticatedPage.on('request', (request) => {
-        if (request.url().includes('/marketplace')) {
-          marketplaceRequests.push(request.url());
-        }
-      });
-      await authenticatedPage.route('**/config', async (route) => {
-        const response = await route.fetch();
-        const body = await response.json();
-        body.features.BILLING = true;
-        body.features.RH_MARKETPLACE = false;
-        await route.fulfill({response, body: JSON.stringify(body)});
-      });
-
-      await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
-      await authenticatedPage.getByText('Billing information').click();
-
-      await expect(
-        authenticatedPage.getByTestId('billing-invoice-email'),
-      ).toBeVisible();
-      expect(marketplaceRequests).toEqual([]);
-      expect(pageErrors).toEqual([]);
-    },
-  );
-
   test('lists user marketplace subscriptions', async ({authenticatedPage}) => {
     const username = TEST_USERS.user.username;
 

--- a/web/playwright/e2e/organization/marketplace.spec.ts
+++ b/web/playwright/e2e/organization/marketplace.spec.ts
@@ -128,6 +128,37 @@ async function mockCommonEndpoints(page: Page): Promise<void> {
 }
 
 test.describe('Marketplace Subscriptions', {tag: ['@marketplace']}, () => {
+  test(
+    'renders billing information when marketplace is disabled',
+    {tag: ['@PROJQUAY-12348']},
+    async ({authenticatedPage, api, quayConfig}) => {
+      test.skip(
+        quayConfig?.features?.BILLING !== true ||
+          quayConfig?.features?.RH_MARKETPLACE !== false,
+        'Requires Billing enabled and RH Marketplace disabled',
+      );
+      const org = await api.organization('mktdisabled');
+      const pageErrors: Error[] = [];
+      const marketplaceRequests: string[] = [];
+
+      authenticatedPage.on('pageerror', (error) => pageErrors.push(error));
+      authenticatedPage.on('request', (request) => {
+        if (request.url().includes('/marketplace')) {
+          marketplaceRequests.push(request.url());
+        }
+      });
+
+      await authenticatedPage.goto(`/organization/${org.name}?tab=Settings`);
+      await authenticatedPage.getByText('Billing information').click();
+
+      await expect(
+        authenticatedPage.getByTestId('billing-invoice-email'),
+      ).toBeVisible();
+      expect(marketplaceRequests).toEqual([]);
+      expect(pageErrors).toEqual([]);
+    },
+  );
+
   test('lists user marketplace subscriptions', async ({authenticatedPage}) => {
     const username = TEST_USERS.user.username;
 

--- a/web/src/hooks/UseMarketplaceSubscriptions.test.ts
+++ b/web/src/hooks/UseMarketplaceSubscriptions.test.ts
@@ -1,7 +1,5 @@
 import {renderHook, act, waitFor} from '@testing-library/react';
-import React from 'react';
-import {QueryClientProvider} from '@tanstack/react-query';
-import {createTestQueryClient} from 'src/test-utils';
+import {TestWrapper} from 'src/test-utils';
 import {
   useMarketplaceSubscriptions,
   useManageOrgSubscriptions,
@@ -27,15 +25,6 @@ vi.mock('./UseQuayConfig', () => ({
   useQuayConfig: vi.fn(),
 }));
 
-function wrapper({children}: {children: React.ReactNode}) {
-  const [queryClient] = React.useState(() => createTestQueryClient());
-  return React.createElement(
-    QueryClientProvider,
-    {client: queryClient},
-    children,
-  );
-}
-
 describe('UseMarketplaceSubscriptions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -53,7 +42,7 @@ describe('UseMarketplaceSubscriptions', () => {
 
       const {result} = renderHook(
         () => useMarketplaceSubscriptions('testuser', 'testuser'),
-        {wrapper},
+        {wrapper: TestWrapper},
       );
 
       await waitFor(() => expect(result.current.loading).toBe(false));
@@ -65,13 +54,19 @@ describe('UseMarketplaceSubscriptions', () => {
         features: {RH_MARKETPLACE: false},
       } as ReturnType<typeof useQuayConfig>);
 
-      const {result} = renderHook(
+      const {result, rerender} = renderHook(
         () => useMarketplaceSubscriptions('myorg', 'testuser'),
-        {wrapper},
+        {wrapper: TestWrapper},
       );
+      const initialUserSubscriptions = result.current.userSubscriptions;
+      const initialOrgSubscriptions = result.current.orgSubscriptions;
+
+      rerender();
 
       expect(result.current.userSubscriptions).toEqual([]);
       expect(result.current.orgSubscriptions).toEqual([]);
+      expect(result.current.userSubscriptions).toBe(initialUserSubscriptions);
+      expect(result.current.orgSubscriptions).toBe(initialOrgSubscriptions);
       expect(fetchMarketplaceSubscriptions).not.toHaveBeenCalled();
     });
 
@@ -87,7 +82,7 @@ describe('UseMarketplaceSubscriptions', () => {
 
       const {result} = renderHook(
         () => useMarketplaceSubscriptions('myorg', 'testuser'),
-        {wrapper},
+        {wrapper: TestWrapper},
       );
 
       await waitFor(() => expect(result.current.loading).toBe(false));
@@ -102,7 +97,7 @@ describe('UseMarketplaceSubscriptions', () => {
       const onError = vi.fn();
       const {result} = renderHook(
         () => useManageOrgSubscriptions('myorg', {onSuccess, onError}),
-        {wrapper},
+        {wrapper: TestWrapper},
       );
 
       act(() => {
@@ -126,7 +121,7 @@ describe('UseMarketplaceSubscriptions', () => {
       const onError = vi.fn();
       const {result} = renderHook(
         () => useManageOrgSubscriptions('myorg', {onSuccess, onError}),
-        {wrapper},
+        {wrapper: TestWrapper},
       );
 
       act(() => {

--- a/web/src/hooks/UseMarketplaceSubscriptions.test.ts
+++ b/web/src/hooks/UseMarketplaceSubscriptions.test.ts
@@ -11,6 +11,7 @@ import {
   setMarketplaceOrgAttachment,
   setMarketplaceOrgRemoval,
 } from 'src/resources/BillingResource';
+import {useQuayConfig} from './UseQuayConfig';
 
 vi.mock('src/resources/BillingResource', () => ({
   fetchMarketplaceSubscriptions: vi.fn(),
@@ -23,9 +24,7 @@ vi.mock('./UseCurrentUser', () => ({
 }));
 
 vi.mock('./UseQuayConfig', () => ({
-  useQuayConfig: vi.fn(() => ({
-    features: {RH_MARKETPLACE: true},
-  })),
+  useQuayConfig: vi.fn(),
 }));
 
 function wrapper({children}: {children: React.ReactNode}) {
@@ -40,6 +39,9 @@ function wrapper({children}: {children: React.ReactNode}) {
 describe('UseMarketplaceSubscriptions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useQuayConfig).mockReturnValue({
+      features: {RH_MARKETPLACE: true},
+    } as ReturnType<typeof useQuayConfig>);
   });
 
   describe('useMarketplaceSubscriptions', () => {
@@ -56,6 +58,21 @@ describe('UseMarketplaceSubscriptions', () => {
 
       await waitFor(() => expect(result.current.loading).toBe(false));
       expect(result.current.userSubscriptions).toEqual(mockUserSubs);
+    });
+
+    it('returns empty subscription lists when marketplace is disabled', () => {
+      vi.mocked(useQuayConfig).mockReturnValue({
+        features: {RH_MARKETPLACE: false},
+      } as ReturnType<typeof useQuayConfig>);
+
+      const {result} = renderHook(
+        () => useMarketplaceSubscriptions('myorg', 'testuser'),
+        {wrapper},
+      );
+
+      expect(result.current.userSubscriptions).toEqual([]);
+      expect(result.current.orgSubscriptions).toEqual([]);
+      expect(fetchMarketplaceSubscriptions).not.toHaveBeenCalled();
     });
 
     it('fetches both user and org subscriptions when org differs from user', async () => {

--- a/web/src/hooks/UseMarketplaceSubscriptions.ts
+++ b/web/src/hooks/UseMarketplaceSubscriptions.ts
@@ -42,8 +42,8 @@ export function useMarketplaceSubscriptions(
       : loadingUserSubs;
 
   return {
-    userSubscriptions: userSubscriptions,
-    orgSubscriptions: orgSubscriptions,
+    userSubscriptions: userSubscriptions ?? [],
+    orgSubscriptions: orgSubscriptions ?? [],
     loading: loading,
     error: errorFetchingUserSubs,
   };

--- a/web/src/hooks/UseMarketplaceSubscriptions.ts
+++ b/web/src/hooks/UseMarketplaceSubscriptions.ts
@@ -7,10 +7,20 @@ import {
 import {useCurrentUser} from './UseCurrentUser';
 import {useQuayConfig} from './UseQuayConfig';
 
+const EMPTY_USER_SUBSCRIPTIONS: Array<Dict<string>> = [];
+const EMPTY_ORG_SUBSCRIPTIONS: Array<Dict<string>> = [];
+
+type MarketplaceSubscriptionsResult = {
+  userSubscriptions: Array<Dict<string>>;
+  orgSubscriptions: Array<Dict<string>>;
+  loading: boolean;
+  error: boolean;
+};
+
 export function useMarketplaceSubscriptions(
   organizationName: string = null,
   userName: string = null,
-) {
+): MarketplaceSubscriptionsResult {
   const config = useQuayConfig();
   const {
     isLoading: loadingUserSubs,
@@ -42,8 +52,8 @@ export function useMarketplaceSubscriptions(
       : loadingUserSubs;
 
   return {
-    userSubscriptions: userSubscriptions ?? [],
-    orgSubscriptions: orgSubscriptions ?? [],
+    userSubscriptions: userSubscriptions ?? EMPTY_USER_SUBSCRIPTIONS,
+    orgSubscriptions: orgSubscriptions ?? EMPTY_ORG_SUBSCRIPTIONS,
     loading: loading,
     error: errorFetchingUserSubs,
   };

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/BillingInformation.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/BillingInformation.test.tsx
@@ -1,0 +1,71 @@
+import {render, screen} from 'src/test-utils';
+import {BillingInformation} from './BillingInformation';
+import {fetchMarketplaceSubscriptions} from 'src/resources/BillingResource';
+
+vi.mock('src/hooks/UseCurrentUser', () => ({
+  useCurrentUser: vi.fn(() => ({
+    user: {
+      username: 'testuser',
+      invoice_email: false,
+      invoice_email_address: '',
+    },
+  })),
+  useUpdateUser: vi.fn(() => ({
+    updateUser: vi.fn(),
+    loading: false,
+    error: null,
+  })),
+}));
+
+vi.mock('src/hooks/UseOrganization', () => ({
+  useOrganization: vi.fn(() => ({
+    organization: {
+      invoice_email: false,
+      invoice_email_address: '',
+    },
+    isUserOrganization: false,
+    loading: false,
+  })),
+}));
+
+vi.mock('src/hooks/UseOrganizationSettings', () => ({
+  useOrganizationSettings: vi.fn(() => ({updateOrgSettings: vi.fn()})),
+}));
+
+vi.mock('src/hooks/UseUpgradePlan', () => ({
+  useUpgradePlan: vi.fn(() => ({
+    currentPlan: {plan: 'free', usedPrivateRepos: 0},
+    privateAllowed: false,
+    privateCount: 0,
+    upgrade: vi.fn(),
+  })),
+}));
+
+vi.mock('src/hooks/UseRepositories', () => ({
+  useRepositories: vi.fn(() => ({totalResults: 0})),
+}));
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: vi.fn(() => ({
+    features: {BILLING: true, RH_MARKETPLACE: false},
+  })),
+}));
+
+vi.mock('src/resources/BillingResource', () => ({
+  fetchMarketplaceSubscriptions: vi.fn(),
+  setMarketplaceOrgAttachment: vi.fn(),
+  setMarketplaceOrgRemoval: vi.fn(),
+}));
+
+describe('BillingInformation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders when billing is enabled and marketplace is disabled', () => {
+    render(<BillingInformation organizationName="testorg" />);
+
+    expect(screen.getByTestId('billing-invoice-email')).toBeVisible();
+    expect(fetchMarketplaceSubscriptions).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/test-utils.tsx
+++ b/web/src/test-utils.tsx
@@ -28,6 +28,27 @@ interface CustomRenderOptions extends Omit<RenderOptions, 'wrapper'> {
   queryClient?: QueryClient;
 }
 
+function TestWrapper({
+  children,
+  queryClient: providedQueryClient,
+}: {
+  children: React.ReactNode;
+  queryClient?: QueryClient;
+}): React.ReactElement {
+  const [queryClient] = React.useState(
+    () => providedQueryClient ?? createTestQueryClient(),
+  );
+  return (
+    <RecoilRoot>
+      <UIProvider>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </UIProvider>
+    </RecoilRoot>
+  );
+}
+
 function customRender(
   ui: ReactElement,
   options: CustomRenderOptions = {},
@@ -39,15 +60,7 @@ function customRender(
   }: {
     children: React.ReactNode;
   }): React.ReactElement {
-    return (
-      <RecoilRoot>
-        <UIProvider>
-          <QueryClientProvider client={queryClient}>
-            {children}
-          </QueryClientProvider>
-        </UIProvider>
-      </RecoilRoot>
-    );
+    return <TestWrapper queryClient={queryClient}>{children}</TestWrapper>;
   }
 
   return {
@@ -57,6 +70,6 @@ function customRender(
 }
 
 export {customRender as render};
-export {createTestQueryClient};
+export {createTestQueryClient, TestWrapper};
 export {screen, within, waitFor} from '@testing-library/react';
 export {default as userEvent} from '@testing-library/user-event';


### PR DESCRIPTION
## Summary

- prevent the organization Billing Information page from crashing when Billing is enabled but RH Marketplace is disabled
- default marketplace user and organization subscription query data to stable empty arrays at the hook boundary
- add hook and Billing Information component regression coverage for disabled marketplace behavior without subscription API calls

## Testing

- `NODE_OPTIONS="--localstorage-file=/tmp/quay-projquay-12348-localstorage" ../../quay-pqc/web/node_modules/.bin/vitest run src/hooks/UseMarketplaceSubscriptions.test.ts src/routes/OrganizationsList/Organization/Tabs/Settings/BillingInformation.test.tsx` — 6 tests passed
- commit-time pre-commit suite — passed, including ESLint and Playwright tag validation
- Prettier check for the changed files — passed
- `git diff --check` — passed
- `tsc --noEmit --pretty false` — not clean; the repository/shared worktree dependency baseline reports existing third-party and unrelated project type errors

## Risks and gaps

- This change prevents unsafe array operations but does not hide marketplace-specific headers or controls when RH Marketplace is disabled.

## Jira

https://redhat.atlassian.net/browse/PROJQUAY-12348
