### PR TITLE
PROJQUAY-12394: fix(ui): hide write-action buttons for global readonly superusers on org pages

### DIFF
--- a/web/playwright/e2e/organization/readonly-superuser-write-guards.spec.ts
+++ b/web/playwright/e2e/organization/readonly-superuser-write-guards.spec.ts
@@ -1,0 +1,52 @@
+import {test, expect} from '../../fixtures';
+
+test.describe(
+  'Global Readonly Superuser — Write Action Guards (PROJQUAY-12394)',
+  {tag: ['@organization', '@feature:GLOBAL_READONLY_SUPERUSER']},
+  () => {
+    test('org admin sees create buttons on OAuth Applications tab', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('roguardoauth');
+
+      await authenticatedPage.goto(
+        `/organization/${org.name}?tab=OauthApplications`,
+      );
+
+      await expect(
+        authenticatedPage.getByText('Create OAuth Application'),
+      ).toBeVisible();
+    });
+
+    test('org admin sees create button on Teams tab', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('roguardteams');
+
+      await authenticatedPage.goto(
+        `/organization/${org.name}?tab=TeamsAndMembership`,
+      );
+
+      await expect(
+        authenticatedPage.getByText('Create new team'),
+      ).toBeVisible();
+    });
+
+    test('org admin sees create button on Default Permissions tab', async ({
+      authenticatedPage,
+      api,
+    }) => {
+      const org = await api.organization('roguardperms');
+
+      await authenticatedPage.goto(
+        `/organization/${org.name}?tab=DefaultPermissions`,
+      );
+
+      await expect(
+        authenticatedPage.getByText('Create default permission'),
+      ).toBeVisible();
+    });
+  },
+);

--- a/web/playwright/e2e/organization/readonly-superuser-write-guards.spec.ts
+++ b/web/playwright/e2e/organization/readonly-superuser-write-guards.spec.ts
@@ -4,6 +4,7 @@ test.describe(
   'Global Readonly Superuser — Write Action Guards (PROJQUAY-12394)',
   {tag: ['@organization', '@feature:GLOBAL_READONLY_SUPERUSER']},
   () => {
+    // Positive tests: org admin sees write-action buttons
     test('org admin sees create buttons on OAuth Applications tab', async ({
       authenticatedPage,
       api,
@@ -47,6 +48,52 @@ test.describe(
       await expect(
         authenticatedPage.getByText('Create default permission'),
       ).toBeVisible();
+    });
+
+    // Negative tests: readonly superuser does NOT see write-action buttons
+    test('readonly superuser does not see create button on OAuth Applications tab', async ({
+      readonlyPage,
+      api,
+    }) => {
+      const org = await api.organization('roguardoauth');
+
+      await readonlyPage.goto(
+        `/organization/${org.name}?tab=OauthApplications`,
+      );
+
+      await expect(
+        readonlyPage.getByText('Create OAuth Application'),
+      ).not.toBeVisible();
+    });
+
+    test('readonly superuser does not see create button on Teams tab', async ({
+      readonlyPage,
+      api,
+    }) => {
+      const org = await api.organization('roguardteams');
+
+      await readonlyPage.goto(
+        `/organization/${org.name}?tab=TeamsAndMembership`,
+      );
+
+      await expect(
+        readonlyPage.getByText('Create new team'),
+      ).not.toBeVisible();
+    });
+
+    test('readonly superuser does not see create button on Default Permissions tab', async ({
+      readonlyPage,
+      api,
+    }) => {
+      const org = await api.organization('roguardperms');
+
+      await readonlyPage.goto(
+        `/organization/${org.name}?tab=DefaultPermissions`,
+      );
+
+      await expect(
+        readonlyPage.getByText('Create default permission'),
+      ).not.toBeVisible();
     });
   },
 );

--- a/web/playwright/e2e/organization/readonly-superuser-write-guards.spec.ts
+++ b/web/playwright/e2e/organization/readonly-superuser-write-guards.spec.ts
@@ -76,9 +76,7 @@ test.describe(
         `/organization/${org.name}?tab=TeamsAndMembership`,
       );
 
-      await expect(
-        readonlyPage.getByText('Create new team'),
-      ).not.toBeVisible();
+      await expect(readonlyPage.getByText('Create new team')).not.toBeVisible();
     });
 
     test('readonly superuser does not see create button on Default Permissions tab', async ({

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsDropDown.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsDropDown.test.tsx
@@ -1,0 +1,74 @@
+import {render, screen} from 'src/test-utils';
+import DefaultPermissionsDropDown from './DefaultPermissionsDropDown';
+import type {IDefaultPermission} from 'src/hooks/UseDefaultPermissions';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseDefaultPermissions', () => ({
+  useUpdateDefaultPermission: () => ({
+    setDefaultPermission: vi.fn(),
+    successSetDefaultPermission: false,
+    errorSetDefaultPermission: false,
+  }),
+}));
+
+const defaultPermission = {
+  id: 1,
+  createdBy: 'testuser',
+  appliedTo: 'org+robot',
+  permission: 'read',
+};
+
+describe('DefaultPermissionsDropDown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('renders dropdown toggle with permission level', () => {
+    render(
+      <DefaultPermissionsDropDown
+        orgName="myorg"
+        defaultPermission={defaultPermission as unknown as IDefaultPermission}
+      />,
+    );
+    expect(
+      screen.getByTestId(
+        `${defaultPermission.createdBy}-permission-dropdown-toggle`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('dropdown toggle is enabled for non-readonly user', () => {
+    render(
+      <DefaultPermissionsDropDown
+        orgName="myorg"
+        defaultPermission={defaultPermission as unknown as IDefaultPermission}
+      />,
+    );
+    const toggle = screen.getByTestId(
+      `${defaultPermission.createdBy}-permission-dropdown-toggle`,
+    );
+    expect(toggle).not.toBeDisabled();
+  });
+
+  it('dropdown toggle is disabled for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(
+      <DefaultPermissionsDropDown
+        orgName="myorg"
+        defaultPermission={defaultPermission as unknown as IDefaultPermission}
+      />,
+    );
+    const toggle = screen.getByTestId(
+      `${defaultPermission.createdBy}-permission-dropdown-toggle`,
+    );
+    expect(toggle).toBeDisabled();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsDropDown.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsDropDown.tsx
@@ -13,10 +13,12 @@ import {
 import {repoPermissions} from './DefaultPermissionsList';
 import {AlertVariant, useUI} from 'src/contexts/UIContext';
 import {titleCase} from 'src/libs/utils';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export default function DefaultPermissionsDropDown(
   props: DefaultPermissionsDropdownProps,
 ) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [isOpen, setIsOpen] = useState(false);
   const {addAlert} = useUI();
 
@@ -53,6 +55,7 @@ export default function DefaultPermissionsDropDown(
           ref={toggleRef}
           onClick={() => setIsOpen(!isOpen)}
           isExpanded={isOpen}
+          isDisabled={isReadOnlySuperUser}
           data-testid={`${props.defaultPermission.createdBy}-permission-dropdown-toggle`}
         >
           {titleCase(props.defaultPermission.permission)}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsToolbar.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsToolbar.test.tsx
@@ -1,0 +1,62 @@
+import {render, screen} from 'src/test-utils';
+import DefaultPermissionsToolbar from './DefaultPermissionsToolbar';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+const defaultProps = {
+  selectedItems: [],
+  deSelectAll: vi.fn(),
+  allItems: [],
+  paginatedItems: [],
+  onItemSelect: vi.fn(),
+  page: 1,
+  setPage: vi.fn(),
+  perPage: 10,
+  setPerPage: vi.fn(),
+  searchOptions: ['Creator'],
+  search: {field: 'Creator', query: ''},
+  setSearch: vi.fn(),
+  setDrawerContent: vi.fn(),
+  handleBulkDeleteModalToggle: vi.fn(),
+};
+
+describe('DefaultPermissionsToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('shows create button for non-readonly user', () => {
+    render(<DefaultPermissionsToolbar {...defaultProps} />);
+    expect(
+      screen.getByTestId('create-default-permissions-btn'),
+    ).toBeInTheDocument();
+  });
+
+  it('hides create button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<DefaultPermissionsToolbar {...defaultProps} />);
+    expect(
+      screen.queryByTestId('create-default-permissions-btn'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides bulk delete for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(
+      <DefaultPermissionsToolbar
+        {...defaultProps}
+        selectedItems={[{id: 1} as never]}
+      />,
+    );
+    expect(
+      screen.queryByTestId('default-perm-bulk-delete-icon'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DefaultPermissionsToolbar.tsx
@@ -17,10 +17,13 @@ import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import {IDefaultPermission} from 'src/hooks/UseDefaultPermissions';
 import {TrashIcon} from '@patternfly/react-icons';
 import {OrganizationDrawerContentType} from 'src/routes/OrganizationsList/Organization/Organization';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export default function DefaultPermissionsToolbar(
   props: DefaultPermissionsToolbarProps,
 ) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
+
   return (
     <>
       <Toolbar>
@@ -47,31 +50,35 @@ export default function DefaultPermissionsToolbar(
               />
             </FlexItem>
           </Flex>
-          <Button
-            onClick={() =>
-              props.setDrawerContent(
-                OrganizationDrawerContentType.CreatePermissionSpecificUser,
-              )
-            }
-            data-testid="create-default-permissions-btn"
-          >
-            Create default permission
-          </Button>
-          <Conditional if={props.selectedItems?.length !== 0}>
-            <ToolbarItem>
-              <Button
-                style={{paddingBottom: '0px'}}
-                icon={
-                  <Icon size="lg">
-                    <TrashIcon />
-                  </Icon>
-                }
-                variant="plain"
-                onClick={props.handleBulkDeleteModalToggle}
-                data-testid="default-perm-bulk-delete-icon"
-              />
-            </ToolbarItem>
-          </Conditional>
+          {!isReadOnlySuperUser && (
+            <Button
+              onClick={() =>
+                props.setDrawerContent(
+                  OrganizationDrawerContentType.CreatePermissionSpecificUser,
+                )
+              }
+              data-testid="create-default-permissions-btn"
+            >
+              Create default permission
+            </Button>
+          )}
+          {!isReadOnlySuperUser && (
+            <Conditional if={props.selectedItems?.length !== 0}>
+              <ToolbarItem>
+                <Button
+                  style={{paddingBottom: '0px'}}
+                  icon={
+                    <Icon size="lg">
+                      <TrashIcon />
+                    </Icon>
+                  }
+                  variant="plain"
+                  onClick={props.handleBulkDeleteModalToggle}
+                  data-testid="default-perm-bulk-delete-icon"
+                />
+              </ToolbarItem>
+            </Conditional>
+          )}
           <ToolbarPagination
             itemsList={props.allItems}
             perPage={props.perPage}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DeleteDefaultPermissionKebab.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DeleteDefaultPermissionKebab.test.tsx
@@ -1,0 +1,56 @@
+import {render, screen} from 'src/test-utils';
+import DeleteDefaultPermissionKebab from './DeleteDefaultPermissionKebab';
+import type {IDefaultPermission} from 'src/hooks/UseDefaultPermissions';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseDefaultPermissions', () => ({
+  useDeleteDefaultPermission: () => ({
+    removeDefaultPermission: vi.fn(),
+    errorDeleteDefaultPermission: false,
+    successDeleteDefaultPermission: false,
+  }),
+}));
+
+const defaultPermission = {
+  id: 1,
+  createdBy: 'testuser',
+  appliedTo: 'org+robot',
+  permission: 'read',
+} as unknown as IDefaultPermission;
+
+describe('DeleteDefaultPermissionKebab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('renders kebab for non-readonly user', () => {
+    render(
+      <DeleteDefaultPermissionKebab
+        orgName="myorg"
+        defaultPermission={defaultPermission}
+      />,
+    );
+    expect(
+      screen.getByTestId(`${defaultPermission.createdBy}-toggle-kebab`),
+    ).toBeInTheDocument();
+  });
+
+  it('returns null for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    const {container} = render(
+      <DeleteDefaultPermissionKebab
+        orgName="myorg"
+        defaultPermission={defaultPermission}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DeleteDefaultPermissionKebab.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/DefaultPermissions/DeleteDefaultPermissionKebab.tsx
@@ -12,10 +12,12 @@ import {
   IDefaultPermission,
   useDeleteDefaultPermission,
 } from 'src/hooks/UseDefaultPermissions';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export default function DeleteDefaultPermissionKebab(
   props: DefaultPermissionsDropdownProps,
 ) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [isOpen, setIsOpen] = useState(false);
   const {addAlert} = useUI();
 
@@ -42,6 +44,10 @@ export default function DeleteDefaultPermissionKebab(
       });
     }
   }, [success]);
+
+  if (isReadOnlySuperUser) {
+    return null;
+  }
 
   return (
     <Dropdown

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/OAuthInformationTab.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/OAuthInformationTab.test.tsx
@@ -1,0 +1,61 @@
+import {render, screen} from 'src/test-utils';
+import OAuthInformationTab from './OAuthInformationTab';
+import type {IOAuthApplication} from 'src/resources/OAuthApplicationTypes';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseOAuthApplications', () => ({
+  useResetOAuthApplicationClientSecret: () => ({
+    resetClientSecret: vi.fn(),
+    isResetting: false,
+    error: null,
+  }),
+}));
+
+const application = {
+  name: 'test-app',
+  client_id: 'client123',
+  client_secret: 'secret456',
+  redirect_uri: 'https://example.com/callback',
+  application_uri: 'https://example.com',
+  avatar_email: '',
+  description: 'Test',
+} as unknown as IOAuthApplication;
+
+describe('OAuthInformationTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('enables reset button for non-readonly user', () => {
+    render(
+      <OAuthInformationTab
+        application={application}
+        orgName="myorg"
+        onSuccess={vi.fn()}
+        updateSelectedApplication={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('reset-client-secret-button')).not.toBeDisabled();
+  });
+
+  it('disables reset button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(
+      <OAuthInformationTab
+        application={application}
+        orgName="myorg"
+        onSuccess={vi.fn()}
+        updateSelectedApplication={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('reset-client-secret-button')).toBeDisabled();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/OAuthInformationTab.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/OAuthInformationTab.tsx
@@ -15,6 +15,7 @@ import {useResetOAuthApplicationClientSecret} from 'src/hooks/UseOAuthApplicatio
 import type {IOAuthApplication} from 'src/resources/OAuthApplicationTypes';
 import {AlertVariant, useUI} from 'src/contexts/UIContext';
 import {ConfirmationModal} from 'src/components/modals/ConfirmationModal';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 interface OAuthInformationTabProps {
   application: IOAuthApplication | null;
@@ -26,6 +27,7 @@ interface OAuthInformationTabProps {
 const OAuthInformationTab: React.FC<OAuthInformationTabProps> = (
   props,
 ): React.ReactElement => {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [isResetModalOpen, setIsResetModalOpen] = useState(false);
   const {addAlert} = useUI();
 
@@ -99,6 +101,7 @@ const OAuthInformationTab: React.FC<OAuthInformationTabProps> = (
           <Button
             variant="primary"
             onClick={toggleResetModal}
+            isDisabled={isReadOnlySuperUser}
             data-testid="reset-client-secret-button"
           >
             Reset Client Secret

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/SettingsTab.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/SettingsTab.test.tsx
@@ -1,0 +1,59 @@
+import {render, screen} from 'src/test-utils';
+import SettingsTab from './SettingsTab';
+import type {IOAuthApplication} from 'src/resources/OAuthApplicationTypes';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseOAuthApplications', () => ({
+  useUpdateOAuthApplication: () => ({
+    updateOAuthApplication: vi.fn(),
+    isUpdating: false,
+    error: null,
+  }),
+}));
+
+const application = {
+  name: 'test-app',
+  client_id: 'client1',
+  client_secret: 'secret',
+  redirect_uri: 'https://example.com/callback',
+  application_uri: 'https://example.com',
+  avatar_email: '',
+  description: 'Test',
+} as unknown as IOAuthApplication;
+
+describe('SettingsTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('disables update button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(
+      <SettingsTab
+        application={application}
+        orgName="myorg"
+        onSuccess={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('update-application-button')).toBeDisabled();
+  });
+
+  it('renders update button for non-readonly user', () => {
+    render(
+      <SettingsTab
+        application={application}
+        orgName="myorg"
+        onSuccess={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('update-application-button')).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/SettingsTab.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/SettingsTab.tsx
@@ -6,6 +6,7 @@ import type {IOAuthApplication} from 'src/resources/OAuthApplicationTypes';
 import {AlertVariant, useUI} from 'src/contexts/UIContext';
 import {FormTextInput} from 'src/components/forms/FormTextInput';
 import {OAuthApplicationFormData} from '../types';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 interface SettingsTabProps {
   application: IOAuthApplication | null;
@@ -14,6 +15,7 @@ interface SettingsTabProps {
 }
 
 const SettingsTab: React.FC<SettingsTabProps> = (props): React.ReactElement => {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const {addAlert} = useUI();
 
   const {
@@ -140,7 +142,7 @@ const SettingsTab: React.FC<SettingsTabProps> = (props): React.ReactElement => {
           <Button
             variant="primary"
             onClick={handleSubmit(onSubmit)}
-            isDisabled={isSubmitting || !isDirty}
+            isDisabled={isSubmitting || !isDirty || isReadOnlySuperUser}
             isLoading={isSubmitting}
             data-testid="update-application-button"
           >

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationActionsKebab.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationActionsKebab.test.tsx
@@ -1,0 +1,83 @@
+import {render, screen} from 'src/test-utils';
+import OAuthApplicationActionsKebab from './OAuthApplicationActionsKebab';
+import type {IOAuthApplication} from 'src/resources/OAuthApplicationTypes';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseOAuthApplications', () => ({
+  useDeleteOAuthApplication: () => ({
+    removeOAuthApplication: vi.fn(),
+    errorDeleteOAuthApplication: null,
+    successDeleteOAuthApplication: false,
+  }),
+}));
+
+const application = {
+  name: 'test-app',
+  client_id: 'client1',
+  client_secret: 'secret',
+  redirect_uri: 'https://example.com/callback',
+  application_uri: 'https://example.com',
+  avatar_email: '',
+  description: 'Test app',
+};
+
+describe('OAuthApplicationActionsKebab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('shows delete option for non-readonly user', async () => {
+    render(
+      <OAuthApplicationActionsKebab
+        orgName="myorg"
+        oauthApplication={application as unknown as IOAuthApplication}
+        onEdit={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByTestId('oauth-application-actions');
+    await toggle.click();
+    expect(
+      screen.getByTestId(`${application.name}-del-option`),
+    ).toBeInTheDocument();
+  });
+
+  it('hides delete option for readonly superuser', async () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(
+      <OAuthApplicationActionsKebab
+        orgName="myorg"
+        oauthApplication={application as unknown as IOAuthApplication}
+        onEdit={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByTestId('oauth-application-actions');
+    await toggle.click();
+    expect(
+      screen.queryByTestId(`${application.name}-del-option`),
+    ).not.toBeInTheDocument();
+  });
+
+  it('always shows edit option regardless of readonly status', async () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(
+      <OAuthApplicationActionsKebab
+        orgName="myorg"
+        oauthApplication={application as unknown as IOAuthApplication}
+        onEdit={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByTestId('oauth-application-actions');
+    await toggle.click();
+    expect(
+      screen.getByTestId(`${application.name}-edit-option`),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationActionsKebab.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationActionsKebab.tsx
@@ -11,10 +11,12 @@ import {AlertVariant, useUI} from 'src/contexts/UIContext';
 import {useDeleteOAuthApplication} from 'src/hooks/UseOAuthApplications';
 import type {IOAuthApplication} from 'src/resources/OAuthApplicationTypes';
 import DeleteModalForRowTemplate from 'src/components/modals/DeleteModalForRowTemplate';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 const OAuthApplicationActionsKebab: React.FC<OAuthApplicationDropdownProps> = (
   props,
 ): React.ReactElement => {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [isOpen, setIsOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const {addAlert} = useUI();
@@ -85,12 +87,14 @@ const OAuthApplicationActionsKebab: React.FC<OAuthApplicationDropdownProps> = (
           >
             Edit
           </DropdownItem>
-          <DropdownItem
-            onClick={handleDeleteClick}
-            data-testid={`${props.oauthApplication.name}-del-option`}
-          >
-            Delete
-          </DropdownItem>
+          {!isReadOnlySuperUser && (
+            <DropdownItem
+              onClick={handleDeleteClick}
+              data-testid={`${props.oauthApplication.name}-del-option`}
+            >
+              Delete
+            </DropdownItem>
+          )}
         </DropdownList>
       </Dropdown>
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationsList.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationsList.test.tsx
@@ -1,0 +1,58 @@
+import {render, screen} from 'src/test-utils';
+import OAuthApplicationsList from './OAuthApplicationsList';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseOAuthApplications', () => ({
+  useFetchOAuthApplications: () => ({
+    oauthApplications: [],
+    loading: false,
+    error: null,
+  }),
+  useBulkDeleteOAuthApplications: () => ({
+    bulkDeleteOAuthApplications: vi.fn(),
+    errorBulkDeleteOAuthApplications: null,
+    successBulkDeleteOAuthApplications: false,
+  }),
+}));
+
+vi.mock('./CreateOAuthApplicationModal', () => ({
+  default: () => null,
+}));
+vi.mock('./OAuthApplicationActionsKebab', () => ({
+  default: () => null,
+}));
+vi.mock('./OAuthApplicationsToolbar', () => ({
+  default: ({children}: {children?: React.ReactNode}) => <div>{children}</div>,
+}));
+vi.mock('./ManageOAuthApplicationModal', () => ({
+  default: () => null,
+}));
+
+describe('OAuthApplicationsList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('shows create button in empty state for non-readonly user', () => {
+    render(<OAuthApplicationsList orgName="myorg" />);
+    expect(
+      screen.getByTestId('create-oauth-application-button'),
+    ).toBeInTheDocument();
+  });
+
+  it('hides create button in empty state for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<OAuthApplicationsList orgName="myorg" />);
+    expect(
+      screen.queryByTestId('create-oauth-application-button'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationsList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationsList.tsx
@@ -19,6 +19,7 @@ import Empty from 'src/components/empty/Empty';
 import {KeyIcon} from '@patternfly/react-icons';
 import {BulkDeleteModalTemplate} from 'src/components/modals/BulkDeleteModalTemplate';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export const oauthApplicationColumnName = {
   name: 'Application Name',
@@ -28,6 +29,7 @@ export const oauthApplicationColumnName = {
 const OAuthApplicationsList: React.FC<OAuthApplicationsListProps> = (
   props,
 ): React.ReactElement => {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [createModalIsOpen, setCreateModalIsOpen] = useState<boolean>(false);
   const [bulkDeleteModalIsOpen, setBulkDeleteModalIsOpen] =
     useState<boolean>(false);
@@ -185,12 +187,14 @@ const OAuthApplicationsList: React.FC<OAuthApplicationsListProps> = (
           icon={KeyIcon}
           body="The OAuth Applications panel allows organizations to define custom OAuth applications that can be used by internal or external customers to access Quay Container Registry data on behalf of the customers. More information about the Quay Container Registry API can be found by contacting support."
           button={
-            <Button
-              onClick={() => setCreateModalIsOpen(true)}
-              data-testid="create-oauth-application-button"
-            >
-              Create new application
-            </Button>
+            !isReadOnlySuperUser ? (
+              <Button
+                onClick={() => setCreateModalIsOpen(true)}
+                data-testid="create-oauth-application-button"
+              >
+                Create new application
+              </Button>
+            ) : undefined
           }
         />
       </>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationsToolbar.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationsToolbar.test.tsx
@@ -1,0 +1,62 @@
+import {render, screen} from 'src/test-utils';
+import OAuthApplicationsToolbar from './OAuthApplicationsToolbar';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+const defaultProps = {
+  selectedItems: [],
+  deSelectAll: vi.fn(),
+  allItems: [],
+  paginatedItems: [],
+  onItemSelect: vi.fn(),
+  page: 1,
+  setPage: vi.fn(),
+  perPage: 10,
+  setPerPage: vi.fn(),
+  searchOptions: ['Name'],
+  search: {field: 'Name', query: ''},
+  setSearch: vi.fn(),
+  handleCreateModalToggle: vi.fn(),
+  handleBulkDeleteModalToggle: vi.fn(),
+};
+
+describe('OAuthApplicationsToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('shows create button for non-readonly user', () => {
+    render(<OAuthApplicationsToolbar {...defaultProps} />);
+    expect(
+      screen.getByTestId('create-oauth-application-button'),
+    ).toBeInTheDocument();
+  });
+
+  it('hides create button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<OAuthApplicationsToolbar {...defaultProps} />);
+    expect(
+      screen.queryByTestId('create-oauth-application-button'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides bulk delete for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(
+      <OAuthApplicationsToolbar
+        {...defaultProps}
+        selectedItems={[{name: 'test'} as never]}
+      />,
+    );
+    expect(
+      screen.queryByTestId('default-perm-bulk-delete-icon'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationsToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/OAuthApplicationsToolbar.tsx
@@ -16,10 +16,12 @@ import {SearchState} from 'src/components/toolbar/SearchTypes';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import {TrashIcon} from '@patternfly/react-icons';
 import type {IOAuthApplication} from 'src/resources/OAuthApplicationTypes';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 const OAuthApplicationsToolbar: React.FC<OAuthApplicationsToolbarProps> = (
   props,
 ): React.ReactElement => {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   return (
     <Toolbar>
       <ToolbarContent>
@@ -45,27 +47,31 @@ const OAuthApplicationsToolbar: React.FC<OAuthApplicationsToolbarProps> = (
             />
           </FlexItem>
         </Flex>
-        <Button
-          onClick={props.handleCreateModalToggle}
-          data-testid="create-oauth-application-button"
-        >
-          Create OAuth Application
-        </Button>
-        <Conditional if={props.selectedItems?.length !== 0}>
-          <ToolbarItem>
-            <Button
-              style={{paddingBottom: '0px'}}
-              icon={
-                <Icon size="lg">
-                  <TrashIcon />
-                </Icon>
-              }
-              variant="plain"
-              onClick={props.handleBulkDeleteModalToggle}
-              data-testid="default-perm-bulk-delete-icon"
-            />
-          </ToolbarItem>
-        </Conditional>
+        {!isReadOnlySuperUser && (
+          <Button
+            onClick={props.handleCreateModalToggle}
+            data-testid="create-oauth-application-button"
+          >
+            Create OAuth Application
+          </Button>
+        )}
+        {!isReadOnlySuperUser && (
+          <Conditional if={props.selectedItems?.length !== 0}>
+            <ToolbarItem>
+              <Button
+                style={{paddingBottom: '0px'}}
+                icon={
+                  <Icon size="lg">
+                    <TrashIcon />
+                  </Icon>
+                }
+                variant="plain"
+                onClick={props.handleBulkDeleteModalToggle}
+                data-testid="default-perm-bulk-delete-icon"
+              />
+            </ToolbarItem>
+          </Conditional>
+        )}
         <ToolbarPagination
           itemsList={props.allItems}
           perPage={props.perPage}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.test.tsx
@@ -1,8 +1,21 @@
-import {render, screen} from 'src/test-utils';
+import {render, screen, userEvent} from 'src/test-utils';
 import {OrgMirroring} from './OrgMirroring';
 
 const mockUseSuperuserPermissions = vi.hoisted(() =>
   vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+const mockHandleSyncNow = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+);
+const mockHandleToggleEnabled = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+);
+const mockHandleCancelSync = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+);
+const mockHandleVerifyConnection = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({success: true, message: 'OK'}),
 );
 
 const mockConfig = vi.hoisted(() => ({
@@ -19,8 +32,12 @@ const mockConfig = vi.hoisted(() => ({
   repo_sync_status_counts: {SYNCING: 0, SYNC_NOW: 0, SUCCESS: 5},
 }));
 
-const mockUseOrgMirroringConfig = vi.hoisted(() =>
-  vi.fn(() => ({
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseOrgMirroringConfig', () => ({
+  useOrgMirroringConfig: () => ({
     config: mockConfig,
     isLoading: false,
     error: null,
@@ -29,17 +46,17 @@ const mockUseOrgMirroringConfig = vi.hoisted(() =>
     isOrgSyncing: false,
     isVerifying: false,
     submitConfig: vi.fn(),
-    handleSyncNow: vi.fn(),
-    handleToggleEnabled: vi.fn(),
-    handleCancelSync: vi.fn(),
-    handleVerifyConnection: vi.fn(),
+    handleSyncNow: mockHandleSyncNow,
+    handleToggleEnabled: mockHandleToggleEnabled,
+    handleCancelSync: mockHandleCancelSync,
+    handleVerifyConnection: mockHandleVerifyConnection,
     setConfig: vi.fn(),
     invalidateConfig: vi.fn(),
-  })),
-);
+  }),
+}));
 
-const mockUseOrgMirroringForm = vi.hoisted(() =>
-  vi.fn(() => ({
+vi.mock('src/hooks/UseOrgMirroringForm', () => ({
+  useOrgMirroringForm: () => ({
     control: {},
     errors: {},
     isEnabled: true,
@@ -53,19 +70,7 @@ const mockUseOrgMirroringForm = vi.hoisted(() =>
     handleRobotSelect: vi.fn(),
     isCreateRobotModalOpen: false,
     setIsCreateRobotModalOpen: vi.fn(),
-  })),
-);
-
-vi.mock('src/hooks/UseSuperuserPermissions', () => ({
-  useSuperuserPermissions: mockUseSuperuserPermissions,
-}));
-
-vi.mock('src/hooks/UseOrgMirroringConfig', () => ({
-  useOrgMirroringConfig: mockUseOrgMirroringConfig,
-}));
-
-vi.mock('src/hooks/UseOrgMirroringForm', () => ({
-  useOrgMirroringForm: mockUseOrgMirroringForm,
+  }),
   defaultFormValues: {},
 }));
 
@@ -81,23 +86,32 @@ vi.mock('src/resources/OrgMirrorResource', async () => {
   const actual = await vi.importActual<
     typeof import('src/resources/OrgMirrorResource')
   >('src/resources/OrgMirrorResource');
-  return {
-    ...actual,
-    deleteOrgMirrorConfig: vi.fn(),
-  };
+  return {...actual, deleteOrgMirrorConfig: vi.fn()};
 });
 
+// Stubs that capture and expose callback props via clickable buttons
 vi.mock('./OrgMirroringConfiguration', () => ({
   OrgMirroringConfiguration: (props: Record<string, unknown>) => (
     <div data-testid="org-mirror-config">
       <button
         data-testid="stub-sync-now"
         disabled={!props.onSyncNow}
-        onClick={props.onSyncNow as () => void}
+        onClick={() => (props.onSyncNow as () => Promise<void>)?.()}
       >
         Sync Now
       </button>
-      <button data-testid="stub-toggle" disabled={!props.onToggleEnabled}>
+      <button
+        data-testid="stub-toggle"
+        disabled={!props.onToggleEnabled}
+        onClick={() =>
+          (
+            props.onToggleEnabled as (
+              c: boolean,
+              o: (v: boolean) => void,
+            ) => Promise<void>
+          )?.(true, vi.fn())
+        }
+      >
         Toggle
       </button>
     </div>
@@ -107,11 +121,7 @@ vi.mock('./OrgMirroringConfiguration', () => ({
 vi.mock('./OrgMirroringCredentials', () => ({
   OrgMirroringCredentials: () => null,
 }));
-
-vi.mock('./OrgMirroringFilters', () => ({
-  OrgMirroringFilters: () => null,
-}));
-
+vi.mock('./OrgMirroringFilters', () => ({OrgMirroringFilters: () => null}));
 vi.mock('./OrgMirroringAdvancedSettings', () => ({
   OrgMirroringAdvancedSettings: () => null,
 }));
@@ -119,20 +129,25 @@ vi.mock('./OrgMirroringAdvancedSettings', () => ({
 vi.mock('./OrgMirroringStatus', () => ({
   OrgMirroringStatus: (props: Record<string, unknown>) => (
     <div data-testid="org-mirror-status">
-      <button data-testid="stub-cancel-sync" disabled={!props.onCancelSync}>
+      <button
+        data-testid="stub-cancel-sync"
+        disabled={!props.onCancelSync}
+        onClick={() => (props.onCancelSync as () => Promise<void>)?.()}
+      >
         Cancel
       </button>
-      <button data-testid="stub-verify" disabled={!props.onVerifyConnection}>
+      <button
+        data-testid="stub-verify"
+        disabled={!props.onVerifyConnection}
+        onClick={() => (props.onVerifyConnection as () => Promise<void>)?.()}
+      >
         Verify
       </button>
     </div>
   ),
 }));
 
-vi.mock('./OrgMirroringRepos', () => ({
-  OrgMirroringRepos: () => null,
-}));
-
+vi.mock('./OrgMirroringRepos', () => ({OrgMirroringRepos: () => null}));
 vi.mock('./CreateRobotModalWrapper', () => ({
   CreateRobotModalWrapper: () => null,
 }));
@@ -152,6 +167,13 @@ describe('OrgMirroring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+    mockHandleSyncNow.mockResolvedValue(undefined);
+    mockHandleToggleEnabled.mockResolvedValue(undefined);
+    mockHandleCancelSync.mockResolvedValue(undefined);
+    mockHandleVerifyConnection.mockResolvedValue({
+      success: true,
+      message: 'OK',
+    });
   });
 
   it('renders the form when config exists', () => {
@@ -176,20 +198,73 @@ describe('OrgMirroring', () => {
     expect(screen.getByTestId('stub-verify')).toBeDisabled();
   });
 
-  it('disables submit button for readonly superuser', () => {
+  it('disables submit and delete buttons for readonly superuser', () => {
     mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
     render(<OrgMirroring orgName="myorg" />);
     expect(screen.getByTestId('submit-button')).toBeDisabled();
-  });
-
-  it('disables delete button for readonly superuser', () => {
-    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
-    render(<OrgMirroring orgName="myorg" />);
     expect(screen.getByTestId('delete-mirror-button')).toBeDisabled();
   });
 
-  it('enables submit button for non-readonly superuser', () => {
+  it('invokes handleSyncNow callback on click', async () => {
+    const user = userEvent.setup();
     render(<OrgMirroring orgName="myorg" />);
-    expect(screen.getByTestId('submit-button')).toBeInTheDocument();
+    await user.click(screen.getByTestId('stub-sync-now'));
+    expect(mockHandleSyncNow).toHaveBeenCalled();
+  });
+
+  it('invokes handleToggleEnabled callback on click', async () => {
+    const user = userEvent.setup();
+    render(<OrgMirroring orgName="myorg" />);
+    await user.click(screen.getByTestId('stub-toggle'));
+    expect(mockHandleToggleEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('invokes handleCancelSync callback on click', async () => {
+    const user = userEvent.setup();
+    render(<OrgMirroring orgName="myorg" />);
+    await user.click(screen.getByTestId('stub-cancel-sync'));
+    expect(mockHandleCancelSync).toHaveBeenCalled();
+  });
+
+  it('invokes handleVerifyConnection callback on click', async () => {
+    const user = userEvent.setup();
+    render(<OrgMirroring orgName="myorg" />);
+    await user.click(screen.getByTestId('stub-verify'));
+    expect(mockHandleVerifyConnection).toHaveBeenCalled();
+  });
+
+  it('handles verify connection failure result', async () => {
+    mockHandleVerifyConnection.mockResolvedValue({
+      success: false,
+      message: 'Connection refused',
+    });
+    const user = userEvent.setup();
+    render(<OrgMirroring orgName="myorg" />);
+    await user.click(screen.getByTestId('stub-verify'));
+    expect(mockHandleVerifyConnection).toHaveBeenCalled();
+  });
+
+  it('handles sync now error', async () => {
+    mockHandleSyncNow.mockRejectedValue(new Error('sync failed'));
+    const user = userEvent.setup();
+    render(<OrgMirroring orgName="myorg" />);
+    await user.click(screen.getByTestId('stub-sync-now'));
+    expect(mockHandleSyncNow).toHaveBeenCalled();
+  });
+
+  it('handles cancel sync error', async () => {
+    mockHandleCancelSync.mockRejectedValue(new Error('cancel failed'));
+    const user = userEvent.setup();
+    render(<OrgMirroring orgName="myorg" />);
+    await user.click(screen.getByTestId('stub-cancel-sync'));
+    expect(mockHandleCancelSync).toHaveBeenCalled();
+  });
+
+  it('handles verify connection error', async () => {
+    mockHandleVerifyConnection.mockRejectedValue(new Error('verify failed'));
+    const user = userEvent.setup();
+    render(<OrgMirroring orgName="myorg" />);
+    await user.click(screen.getByTestId('stub-verify'));
+    expect(mockHandleVerifyConnection).toHaveBeenCalled();
   });
 });

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.test.tsx
@@ -1,0 +1,195 @@
+import {render, screen} from 'src/test-utils';
+import {OrgMirroring} from './OrgMirroring';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+const mockConfig = vi.hoisted(() => ({
+  id: 1,
+  is_enabled: true,
+  external_registry: 'quay.io',
+  external_namespace: 'test',
+  sync_interval: 3600,
+  sync_start_date: '2026-01-01T00:00:00Z',
+  sync_expiration_date: null,
+  robot_username: 'org+robot',
+  root_rule: {rule_kind: 'tag_glob_csv', rule_value: ['*']},
+  external_registry_config: {},
+  repo_sync_status_counts: {SYNCING: 0, SYNC_NOW: 0, SUCCESS: 5},
+}));
+
+const mockUseOrgMirroringConfig = vi.hoisted(() =>
+  vi.fn(() => ({
+    config: mockConfig,
+    isLoading: false,
+    error: null,
+    isSyncingNow: false,
+    isCancellingSync: false,
+    isOrgSyncing: false,
+    isVerifying: false,
+    submitConfig: vi.fn(),
+    handleSyncNow: vi.fn(),
+    handleToggleEnabled: vi.fn(),
+    handleCancelSync: vi.fn(),
+    handleVerifyConnection: vi.fn(),
+    setConfig: vi.fn(),
+    invalidateConfig: vi.fn(),
+  })),
+);
+
+const mockUseOrgMirroringForm = vi.hoisted(() =>
+  vi.fn(() => ({
+    control: {},
+    errors: {},
+    isEnabled: true,
+    isValid: true,
+    isDirty: false,
+    handleSubmit: vi.fn((fn) => fn),
+    reset: vi.fn(),
+    setValue: vi.fn(),
+    selectedRobot: null,
+    setSelectedRobot: vi.fn(),
+    handleRobotSelect: vi.fn(),
+    isCreateRobotModalOpen: false,
+    setIsCreateRobotModalOpen: vi.fn(),
+  })),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseOrgMirroringConfig', () => ({
+  useOrgMirroringConfig: mockUseOrgMirroringConfig,
+}));
+
+vi.mock('src/hooks/UseOrgMirroringForm', () => ({
+  useOrgMirroringForm: mockUseOrgMirroringForm,
+  defaultFormValues: {},
+}));
+
+vi.mock('src/hooks/useRobotAccounts', () => ({
+  useFetchRobotAccounts: () => ({robots: [], isLoadingRobots: false}),
+}));
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: () => ({config: {ROBOTS_DISALLOW: false}}),
+}));
+
+vi.mock('src/resources/OrgMirrorResource', async () => {
+  const actual = await vi.importActual<
+    typeof import('src/resources/OrgMirrorResource')
+  >('src/resources/OrgMirrorResource');
+  return {
+    ...actual,
+    deleteOrgMirrorConfig: vi.fn(),
+  };
+});
+
+vi.mock('./OrgMirroringConfiguration', () => ({
+  OrgMirroringConfiguration: (props: Record<string, unknown>) => (
+    <div data-testid="org-mirror-config">
+      <button
+        data-testid="stub-sync-now"
+        disabled={!props.onSyncNow}
+        onClick={props.onSyncNow as () => void}
+      >
+        Sync Now
+      </button>
+      <button data-testid="stub-toggle" disabled={!props.onToggleEnabled}>
+        Toggle
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./OrgMirroringCredentials', () => ({
+  OrgMirroringCredentials: () => null,
+}));
+
+vi.mock('./OrgMirroringFilters', () => ({
+  OrgMirroringFilters: () => null,
+}));
+
+vi.mock('./OrgMirroringAdvancedSettings', () => ({
+  OrgMirroringAdvancedSettings: () => null,
+}));
+
+vi.mock('./OrgMirroringStatus', () => ({
+  OrgMirroringStatus: (props: Record<string, unknown>) => (
+    <div data-testid="org-mirror-status">
+      <button data-testid="stub-cancel-sync" disabled={!props.onCancelSync}>
+        Cancel
+      </button>
+      <button data-testid="stub-verify" disabled={!props.onVerifyConnection}>
+        Verify
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./OrgMirroringRepos', () => ({
+  OrgMirroringRepos: () => null,
+}));
+
+vi.mock('./CreateRobotModalWrapper', () => ({
+  CreateRobotModalWrapper: () => null,
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+  return {
+    ...actual,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  };
+});
+
+describe('OrgMirroring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('renders the form when config exists', () => {
+    render(<OrgMirroring orgName="myorg" />);
+    expect(screen.getByTestId('org-mirror-form')).toBeInTheDocument();
+  });
+
+  it('passes callbacks when not readonly superuser', () => {
+    render(<OrgMirroring orgName="myorg" />);
+    expect(screen.getByTestId('stub-sync-now')).not.toBeDisabled();
+    expect(screen.getByTestId('stub-toggle')).not.toBeDisabled();
+    expect(screen.getByTestId('stub-cancel-sync')).not.toBeDisabled();
+    expect(screen.getByTestId('stub-verify')).not.toBeDisabled();
+  });
+
+  it('passes undefined callbacks when readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<OrgMirroring orgName="myorg" />);
+    expect(screen.getByTestId('stub-sync-now')).toBeDisabled();
+    expect(screen.getByTestId('stub-toggle')).toBeDisabled();
+    expect(screen.getByTestId('stub-cancel-sync')).toBeDisabled();
+    expect(screen.getByTestId('stub-verify')).toBeDisabled();
+  });
+
+  it('disables submit button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<OrgMirroring orgName="myorg" />);
+    expect(screen.getByTestId('submit-button')).toBeDisabled();
+  });
+
+  it('disables delete button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<OrgMirroring orgName="myorg" />);
+    expect(screen.getByTestId('delete-mirror-button')).toBeDisabled();
+  });
+
+  it('enables submit button for non-readonly superuser', () => {
+    render(<OrgMirroring orgName="myorg" />);
+    expect(screen.getByTestId('submit-button')).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.tsx
@@ -101,7 +101,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
   // Create dropdown options for robot selector
   const robotOptions = [
     <React.Fragment key="dropdown-options">
-      {!robotsDisallowed && (
+      {!robotsDisallowed && !isReadOnlySuperUser && (
         <>
           <SelectOption
             key="create-robot"
@@ -202,7 +202,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
           isSyncingNow={configHook.isSyncingNow}
           isCancellingSync={configHook.isCancellingSync}
           isOrgSyncing={configHook.isOrgSyncing}
-          onSyncNow={async () => {
+          onSyncNow={isReadOnlySuperUser ? undefined : async () => {
             try {
               await configHook.handleSyncNow();
               addAlert({
@@ -217,7 +217,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
               });
             }
           }}
-          onToggleEnabled={async (checked, onChange) => {
+          onToggleEnabled={isReadOnlySuperUser ? undefined : async (checked, onChange) => {
             try {
               await configHook.handleToggleEnabled(checked);
               onChange(checked);
@@ -255,7 +255,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
           config={configHook.config}
           isVerifying={configHook.isVerifying}
           isCancellingSync={configHook.isCancellingSync}
-          onCancelSync={async () => {
+          onCancelSync={isReadOnlySuperUser ? undefined : async () => {
             try {
               await configHook.handleCancelSync();
               addAlert({
@@ -270,7 +270,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
               });
             }
           }}
-          onVerifyConnection={async () => {
+          onVerifyConnection={isReadOnlySuperUser ? undefined : async () => {
             try {
               const result = await configHook.handleVerifyConnection();
               if (result.success) {

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.tsx
@@ -37,12 +37,14 @@ import {useQueryClient} from '@tanstack/react-query';
 import {deleteOrgMirrorConfig} from 'src/resources/OrgMirrorResource';
 import {CreateRobotModalWrapper} from './CreateRobotModalWrapper';
 import {useSearchParams} from 'react-router-dom';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 interface OrgMirroringProps {
   orgName: string;
 }
 
 export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const {addAlert} = useUI();
   const queryClient = useQueryClient();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
@@ -304,7 +306,9 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
             className="pf-v6-u-display-block pf-v6-u-mx-auto"
             type="submit"
             isDisabled={
-              !formHook.isValid || (configHook.config && !formHook.isDirty)
+              isReadOnlySuperUser ||
+              !formHook.isValid ||
+              (configHook.config && !formHook.isDirty)
             }
             data-testid="submit-button"
           >
@@ -318,6 +322,7 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
               type="button"
               onClick={() => setIsDeleteModalOpen(true)}
               data-testid="delete-mirror-button"
+              isDisabled={isReadOnlySuperUser}
             >
               Delete Mirror Configuration
             </Button>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroring.tsx
@@ -202,39 +202,47 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
           isSyncingNow={configHook.isSyncingNow}
           isCancellingSync={configHook.isCancellingSync}
           isOrgSyncing={configHook.isOrgSyncing}
-          onSyncNow={isReadOnlySuperUser ? undefined : async () => {
-            try {
-              await configHook.handleSyncNow();
-              addAlert({
-                variant: AlertVariant.Success,
-                title: 'Organization sync scheduled successfully',
-              });
-            } catch (err: unknown) {
-              addAlert({
-                variant: AlertVariant.Failure,
-                title: 'Error scheduling sync',
-                message: (err as Error).message,
-              });
-            }
-          }}
-          onToggleEnabled={isReadOnlySuperUser ? undefined : async (checked, onChange) => {
-            try {
-              await configHook.handleToggleEnabled(checked);
-              onChange(checked);
-              addAlert({
-                variant: AlertVariant.Success,
-                title: `Organization mirror ${
-                  checked ? 'enabled' : 'disabled'
-                } successfully`,
-              });
-            } catch (err: unknown) {
-              addAlert({
-                variant: AlertVariant.Failure,
-                title: 'Error toggling organization mirror',
-                message: (err as Error).message,
-              });
-            }
-          }}
+          onSyncNow={
+            isReadOnlySuperUser
+              ? undefined
+              : async () => {
+                  try {
+                    await configHook.handleSyncNow();
+                    addAlert({
+                      variant: AlertVariant.Success,
+                      title: 'Organization sync scheduled successfully',
+                    });
+                  } catch (err: unknown) {
+                    addAlert({
+                      variant: AlertVariant.Failure,
+                      title: 'Error scheduling sync',
+                      message: (err as Error).message,
+                    });
+                  }
+                }
+          }
+          onToggleEnabled={
+            isReadOnlySuperUser
+              ? undefined
+              : async (checked, onChange) => {
+                  try {
+                    await configHook.handleToggleEnabled(checked);
+                    onChange(checked);
+                    addAlert({
+                      variant: AlertVariant.Success,
+                      title: `Organization mirror ${
+                        checked ? 'enabled' : 'disabled'
+                      } successfully`,
+                    });
+                  } catch (err: unknown) {
+                    addAlert({
+                      variant: AlertVariant.Failure,
+                      title: 'Error toggling organization mirror',
+                      message: (err as Error).message,
+                    });
+                  }
+                }
+          }
           addAlert={addAlert}
         />
         <OrgMirroringFilters
@@ -255,45 +263,53 @@ export const OrgMirroring: React.FC<OrgMirroringProps> = ({orgName}) => {
           config={configHook.config}
           isVerifying={configHook.isVerifying}
           isCancellingSync={configHook.isCancellingSync}
-          onCancelSync={isReadOnlySuperUser ? undefined : async () => {
-            try {
-              await configHook.handleCancelSync();
-              addAlert({
-                variant: AlertVariant.Success,
-                title: 'Sync cancelled successfully',
-              });
-            } catch (err: unknown) {
-              addAlert({
-                variant: AlertVariant.Failure,
-                title: 'Error cancelling sync',
-                message: (err as Error).message,
-              });
-            }
-          }}
-          onVerifyConnection={isReadOnlySuperUser ? undefined : async () => {
-            try {
-              const result = await configHook.handleVerifyConnection();
-              if (result.success) {
-                addAlert({
-                  variant: AlertVariant.Success,
-                  title: 'Connection verified successfully',
-                  message: result.message,
-                });
-              } else {
-                addAlert({
-                  variant: AlertVariant.Failure,
-                  title: 'Connection verification failed',
-                  message: result.message,
-                });
-              }
-            } catch (err: unknown) {
-              addAlert({
-                variant: AlertVariant.Failure,
-                title: 'Error verifying connection',
-                message: (err as Error).message,
-              });
-            }
-          }}
+          onCancelSync={
+            isReadOnlySuperUser
+              ? undefined
+              : async () => {
+                  try {
+                    await configHook.handleCancelSync();
+                    addAlert({
+                      variant: AlertVariant.Success,
+                      title: 'Sync cancelled successfully',
+                    });
+                  } catch (err: unknown) {
+                    addAlert({
+                      variant: AlertVariant.Failure,
+                      title: 'Error cancelling sync',
+                      message: (err as Error).message,
+                    });
+                  }
+                }
+          }
+          onVerifyConnection={
+            isReadOnlySuperUser
+              ? undefined
+              : async () => {
+                  try {
+                    const result = await configHook.handleVerifyConnection();
+                    if (result.success) {
+                      addAlert({
+                        variant: AlertVariant.Success,
+                        title: 'Connection verified successfully',
+                        message: result.message,
+                      });
+                    } else {
+                      addAlert({
+                        variant: AlertVariant.Failure,
+                        title: 'Connection verification failed',
+                        message: result.message,
+                      });
+                    }
+                  } catch (err: unknown) {
+                    addAlert({
+                      variant: AlertVariant.Failure,
+                      title: 'Error verifying connection',
+                      message: (err as Error).message,
+                    });
+                  }
+                }
+          }
         />
         <OrgMirroringRepos
           config={configHook.config}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringConfiguration.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringConfiguration.tsx
@@ -22,8 +22,8 @@ interface OrgMirroringConfigurationProps {
   isSyncingNow: boolean;
   isCancellingSync: boolean;
   isOrgSyncing: boolean;
-  onSyncNow: () => Promise<void>;
-  onToggleEnabled: (
+  onSyncNow?: () => Promise<void>;
+  onToggleEnabled?: (
     checked: boolean,
     onChange: (value: boolean) => void,
   ) => Promise<void>;
@@ -70,9 +70,13 @@ export const OrgMirroringConfiguration: React.FC<
               : 'Scheduled organization mirroring disabled.'
           }
           data-testid="org-mirror-enabled-checkbox"
-          customOnChange={(checked, onChange) => {
-            void onToggleEnabled(checked, onChange);
-          }}
+          customOnChange={
+            onToggleEnabled
+              ? (checked, onChange) => {
+                  void onToggleEnabled(checked, onChange);
+                }
+              : undefined
+          }
         />
       )}
 

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.test.tsx
@@ -73,4 +73,47 @@ describe('OrgMirroringStatus', () => {
     );
     expect(container.firstChild).toBeNull();
   });
+
+  it('disables verify button when isVerifying is true', () => {
+    render(
+      <OrgMirroringStatus
+        config={baseConfig as unknown as OrgMirrorConfig}
+        isVerifying={true}
+        isCancellingSync={false}
+        onCancelSync={vi.fn()}
+        onVerifyConnection={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('verify-connection-button')).toBeDisabled();
+  });
+
+  it('disables cancel button when isCancellingSync is true', () => {
+    render(
+      <OrgMirroringStatus
+        config={baseConfig as unknown as OrgMirrorConfig}
+        isVerifying={false}
+        isCancellingSync={true}
+        onCancelSync={vi.fn()}
+        onVerifyConnection={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('cancel-sync-button')).toBeDisabled();
+  });
+
+  it('disables cancel button when no repos are syncing', () => {
+    const noSyncConfig = {
+      ...baseConfig,
+      repo_sync_status_counts: {SYNCING: 0, SYNC_NOW: 0, SUCCESS: 5},
+    };
+    render(
+      <OrgMirroringStatus
+        config={noSyncConfig as unknown as OrgMirrorConfig}
+        isVerifying={false}
+        isCancellingSync={false}
+        onCancelSync={vi.fn()}
+        onVerifyConnection={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('cancel-sync-button')).toBeDisabled();
+  });
 });

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.test.tsx
@@ -1,0 +1,76 @@
+import {render, screen} from 'src/test-utils';
+import {OrgMirroringStatus} from './OrgMirroringStatus';
+import {OrgMirrorConfig} from 'src/resources/OrgMirrorResource';
+
+describe('OrgMirroringStatus', () => {
+  const baseConfig = {
+    id: 1,
+    is_enabled: true,
+    external_registry: 'quay.io',
+    external_namespace: 'test',
+    sync_interval: 3600,
+    sync_start_date: '2026-01-01T00:00:00Z',
+    sync_expiration_date: null,
+    robot_username: 'org+robot',
+    root_rule: {rule_kind: 'tag_glob_csv', rule_value: ['*']},
+    external_registry_config: {},
+    repo_sync_status_counts: {SYNCING: 1, SYNC_NOW: 0, SUCCESS: 5},
+  };
+
+  it('disables cancel sync button when onCancelSync is undefined', () => {
+    render(
+      <OrgMirroringStatus
+        config={baseConfig as unknown as OrgMirrorConfig}
+        isVerifying={false}
+        isCancellingSync={false}
+        onCancelSync={undefined}
+        onVerifyConnection={vi.fn()}
+      />,
+    );
+    const cancelBtn = screen.getByTestId('cancel-sync-button');
+    expect(cancelBtn).toBeDisabled();
+  });
+
+  it('disables verify connection button when onVerifyConnection is undefined', () => {
+    render(
+      <OrgMirroringStatus
+        config={baseConfig as unknown as OrgMirrorConfig}
+        isVerifying={false}
+        isCancellingSync={false}
+        onCancelSync={vi.fn()}
+        onVerifyConnection={undefined}
+      />,
+    );
+    const verifyBtn = screen.getByTestId('verify-connection-button');
+    expect(verifyBtn).toBeDisabled();
+  });
+
+  it('enables buttons when callbacks are provided', () => {
+    render(
+      <OrgMirroringStatus
+        config={baseConfig as unknown as OrgMirrorConfig}
+        isVerifying={false}
+        isCancellingSync={false}
+        onCancelSync={vi.fn()}
+        onVerifyConnection={vi.fn()}
+      />,
+    );
+    const cancelBtn = screen.getByTestId('cancel-sync-button');
+    const verifyBtn = screen.getByTestId('verify-connection-button');
+    expect(cancelBtn).not.toBeDisabled();
+    expect(verifyBtn).not.toBeDisabled();
+  });
+
+  it('returns null when config is null', () => {
+    const {container} = render(
+      <OrgMirroringStatus
+        config={null}
+        isVerifying={false}
+        isCancellingSync={false}
+        onCancelSync={vi.fn()}
+        onVerifyConnection={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringStatus.tsx
@@ -22,8 +22,8 @@ interface OrgMirroringStatusProps {
   config: OrgMirrorConfig | null;
   isVerifying: boolean;
   isCancellingSync: boolean;
-  onCancelSync: () => Promise<void>;
-  onVerifyConnection: () => Promise<void>;
+  onCancelSync?: () => Promise<void>;
+  onVerifyConnection?: () => Promise<void>;
 }
 
 export const OrgMirroringStatus: React.FC<OrgMirroringStatusProps> = ({
@@ -57,7 +57,7 @@ export const OrgMirroringStatus: React.FC<OrgMirroringStatusProps> = ({
             variant="danger"
             onClick={async () => {
               setIsCancelModalOpen(false);
-              await onCancelSync();
+              await onCancelSync?.();
             }}
             data-testid="confirm-cancel-sync-button"
           >
@@ -104,6 +104,7 @@ export const OrgMirroringStatus: React.FC<OrgMirroringStatusProps> = ({
                 size="sm"
                 type="button"
                 isDisabled={
+                  !onCancelSync ||
                   isCancellingSync ||
                   !config.repo_sync_status_counts ||
                   ((config.repo_sync_status_counts['SYNCING'] ?? 0) === 0 &&
@@ -131,9 +132,9 @@ export const OrgMirroringStatus: React.FC<OrgMirroringStatusProps> = ({
                 size="sm"
                 type="button"
                 isLoading={isVerifying}
-                isDisabled={isVerifying}
+                isDisabled={!onVerifyConnection || isVerifying}
                 data-testid="verify-connection-button"
-                onClick={onVerifyConnection}
+                onClick={() => onVerifyConnection?.()}
               >
                 Verify Connection
               </Button>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringSyncSchedule.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OrgMirroring/OrgMirroringSyncSchedule.tsx
@@ -26,7 +26,7 @@ interface OrgMirroringSyncScheduleProps {
   isSyncingNow: boolean;
   isCancellingSync: boolean;
   isOrgSyncing: boolean;
-  onSyncNow: () => Promise<void>;
+  onSyncNow?: () => Promise<void>;
 }
 
 export const OrgMirroringSyncSchedule: React.FC<
@@ -85,7 +85,9 @@ export const OrgMirroringSyncSchedule: React.FC<
                 size="sm"
                 type="button"
                 isLoading={isSyncingNow || (isOrgSyncing && !isCancellingSync)}
-                isDisabled={isSyncingNow || isCancellingSync || isOrgSyncing}
+                isDisabled={
+                  !onSyncNow || isSyncingNow || isCancellingSync || isOrgSyncing
+                }
                 data-testid="sync-now-button"
                 onClick={onSyncNow}
               >

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/AutoPruning.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/AutoPruning.test.tsx
@@ -1,0 +1,119 @@
+import {render, screen} from 'src/test-utils';
+import AutoPruning from './AutoPruning';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+const mockUseNamespaceAutoPrunePolicies = vi.hoisted(() =>
+  vi.fn(() => ({
+    error: null,
+    isSuccess: true,
+    isLoading: false,
+    nsPolicies: [],
+    dataUpdatedAt: 0,
+  })),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseNamespaceAutoPrunePolicies', () => ({
+  useNamespaceAutoPrunePolicies: mockUseNamespaceAutoPrunePolicies,
+  useCreateNamespaceAutoPrunePolicy: () => ({
+    createPolicy: vi.fn(),
+    successCreatePolicy: false,
+    errorCreatePolicy: false,
+    errorCreatePolicyDetails: null,
+  }),
+  useUpdateNamespaceAutoPrunePolicy: () => ({
+    updatePolicy: vi.fn(),
+    successUpdatePolicy: false,
+    errorUpdatePolicy: false,
+    errorUpdatePolicyDetails: null,
+  }),
+  useDeleteNamespaceAutoPrunePolicy: () => ({
+    deletePolicy: vi.fn(),
+    successDeletePolicy: false,
+    errorDeletePolicy: false,
+    errorDeletePolicyDetails: null,
+  }),
+}));
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: () => ({config: {DEFAULT_NAMESPACE_AUTOPRUNE_POLICY: null}}),
+}));
+
+vi.mock('src/components/AutoPrunePolicyForm', () => ({
+  default: () => <div data-testid="autoprune-form-stub" />,
+}));
+
+vi.mock(
+  'src/routes/RepositoryDetails/Settings/RepositoryAutoPruningReadonlyPolicy',
+  () => ({
+    default: () => null,
+  }),
+);
+
+describe('AutoPruning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+    mockUseNamespaceAutoPrunePolicies.mockReturnValue({
+      error: null,
+      isSuccess: true,
+      isLoading: false,
+      nsPolicies: [],
+      dataUpdatedAt: 0,
+    });
+  });
+
+  it('shows add policy button for non-readonly user', () => {
+    mockUseNamespaceAutoPrunePolicies.mockReturnValue({
+      error: null,
+      isSuccess: true,
+      isLoading: false,
+      nsPolicies: [{method: 'number_of_tags', value: 10, uuid: '1'}],
+      dataUpdatedAt: 1,
+    });
+    render(<AutoPruning org="myorg" isUser={false} />);
+    expect(screen.getByText('Add Policy')).toBeInTheDocument();
+  });
+
+  it('hides add policy button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    mockUseNamespaceAutoPrunePolicies.mockReturnValue({
+      error: null,
+      isSuccess: true,
+      isLoading: false,
+      nsPolicies: [{method: 'number_of_tags', value: 10, uuid: '1'}],
+      dataUpdatedAt: 1,
+    });
+    render(<AutoPruning org="myorg" isUser={false} />);
+    expect(screen.queryByText('Add Policy')).not.toBeInTheDocument();
+  });
+
+  it('renders form for empty policies for non-readonly user', () => {
+    render(<AutoPruning org="myorg" isUser={false} />);
+    expect(screen.getByTestId('autoprune-form-stub')).toBeInTheDocument();
+  });
+
+  it('does not auto-open form for readonly superuser with empty policies', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<AutoPruning org="myorg" isUser={false} />);
+    expect(screen.queryByTestId('autoprune-form-stub')).not.toBeInTheDocument();
+  });
+
+  it('renders spinner while loading', () => {
+    mockUseNamespaceAutoPrunePolicies.mockReturnValue({
+      error: null,
+      isSuccess: false,
+      isLoading: true,
+      nsPolicies: [],
+      dataUpdatedAt: 0,
+    });
+    render(<AutoPruning org="myorg" isUser={false} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/AutoPruning.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/AutoPruning.tsx
@@ -62,7 +62,7 @@ export default function AutoPruning(props: AutoPruning) {
 
   useEffect(() => {
     if (successFetchingPolicies) {
-      if (nsPolicies.length == 0) {
+      if (nsPolicies.length == 0 && !isReadOnlySuperUser) {
         addNewPolicy(true);
         return;
       }
@@ -153,6 +153,7 @@ export default function AutoPruning(props: AutoPruning) {
   };
 
   const onSave = (method, value, uuid, tagPattern, tagPatternMatches) => {
+    if (isReadOnlySuperUser) return;
     if (method == AutoPruneMethod.NONE && !isNullOrUndefined(uuid)) {
       deletePolicy(uuid);
       return;

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/AutoPruning.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/AutoPruning.tsx
@@ -18,6 +18,7 @@ import {
 import ReadonlyAutoprunePolicy from 'src/routes/RepositoryDetails/Settings/RepositoryAutoPruningReadonlyPolicy';
 import AutoPrunePolicyForm from 'src/components/AutoPrunePolicyForm';
 import {getErrorMessageFromUnknown} from 'src/resources/ErrorHandling';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 // Must match convert_to_timedelta from backend
 export const shorthandTimeUnits = {
@@ -29,6 +30,7 @@ export const shorthandTimeUnits = {
 };
 
 export default function AutoPruning(props: AutoPruning) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [policies, setPolicies] = useState([]);
   const {addAlert} = useUI();
   const config = useQuayConfig();
@@ -213,9 +215,11 @@ export default function AutoPruning(props: AutoPruning) {
         />
       ))}
       <br />
-      <Button variant="primary" type="submit" onClick={() => addNewPolicy()}>
-        Add Policy
-      </Button>
+      {!isReadOnlySuperUser && (
+        <Button variant="primary" type="submit" onClick={() => addNewPolicy()}>
+          Add Policy
+        </Button>
+      )}
     </>
   );
 }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/AutoPruning.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/AutoPruning.tsx
@@ -68,7 +68,7 @@ export default function AutoPruning(props: AutoPruning) {
       }
       setPolicies(nsPolicies);
     }
-  }, [successFetchingPolicies, dataUpdatedAt]);
+  }, [successFetchingPolicies, dataUpdatedAt, isReadOnlySuperUser]);
 
   useEffect(() => {
     if (successCreatePolicy) {

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/GeneralSettings.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/GeneralSettings.tsx
@@ -41,6 +41,7 @@ import {getCookie, setPermanentCookie} from 'src/libs/cookieUtils';
 import {useDeleteAccount} from 'src/hooks/UseDeleteAccount';
 import {FormTextInput} from 'src/components/forms/FormTextInput';
 import {FormCheckbox} from 'src/components/forms/FormCheckbox';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 // Form data interface for react-hook-form
 interface GeneralSettingsFormData {
@@ -57,6 +58,7 @@ type GeneralSettingsProps = {
 };
 
 export const GeneralSettings = (props: GeneralSettingsProps) => {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const quayConfig = useQuayConfig();
   const [timeMachineOptions, setTimeMachineOptions] = useState<{
     [key: string]: string;
@@ -613,12 +615,12 @@ export const GeneralSettings = (props: GeneralSettingsProps) => {
           variant="primary"
           type="submit"
           onClick={handleSubmit(onSubmit)}
-          isDisabled={!isDirty || !isValid}
+          isDisabled={!isDirty || !isValid || isReadOnlySuperUser}
         >
           Save
         </Button>
 
-        {canShowDelete && (
+        {canShowDelete && !isReadOnlySuperUser && (
           <>
             {hasActiveBilling ? (
               <Flex alignItems={{default: 'alignItemsCenter'}}>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ImmutabilityPolicies.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ImmutabilityPolicies.test.tsx
@@ -1,0 +1,82 @@
+import {render, screen} from 'src/test-utils';
+import ImmutabilityPolicies from './ImmutabilityPolicies';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+const mockUseImmutabilityPolicies = vi.hoisted(() =>
+  vi.fn(() => ({
+    policies: [],
+    isLoading: false,
+    error: null,
+    createPolicy: vi.fn(),
+    updatePolicy: vi.fn(),
+    deletePolicy: vi.fn(),
+  })),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseNamespaceImmutabilityPolicies', () => ({
+  useNamespaceImmutabilityPolicies: mockUseImmutabilityPolicies,
+}));
+
+vi.mock('src/components/ImmutabilityPolicyForm', () => ({
+  default: () => <div data-testid="policy-form-stub" />,
+}));
+
+describe('ImmutabilityPolicies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+    mockUseImmutabilityPolicies.mockReturnValue({
+      policies: [],
+      isLoading: false,
+      error: null,
+      createPolicy: vi.fn(),
+      updatePolicy: vi.fn(),
+      deletePolicy: vi.fn(),
+    });
+  });
+
+  it('shows add policy button for non-readonly user in empty state', () => {
+    render(<ImmutabilityPolicies organizationName="myorg" />);
+    expect(screen.getByText('Add Policy')).toBeInTheDocument();
+  });
+
+  it('hides add policy button for readonly superuser in empty state', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<ImmutabilityPolicies organizationName="myorg" />);
+    expect(screen.queryByText('Add Policy')).not.toBeInTheDocument();
+  });
+
+  it('shows add policy button with existing policies', () => {
+    mockUseImmutabilityPolicies.mockReturnValue({
+      policies: [{id: '1', tag_pattern: 'latest', enabled: true}],
+      isLoading: false,
+      error: null,
+      createPolicy: vi.fn(),
+      updatePolicy: vi.fn(),
+      deletePolicy: vi.fn(),
+    });
+    render(<ImmutabilityPolicies organizationName="myorg" />);
+    expect(screen.getByText('Add Policy')).toBeInTheDocument();
+  });
+
+  it('hides add policy and action buttons for readonly superuser with policies', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    mockUseImmutabilityPolicies.mockReturnValue({
+      policies: [{id: '1', tag_pattern: 'latest', enabled: true}],
+      isLoading: false,
+      error: null,
+      createPolicy: vi.fn(),
+      updatePolicy: vi.fn(),
+      deletePolicy: vi.fn(),
+    });
+    render(<ImmutabilityPolicies organizationName="myorg" />);
+    expect(screen.queryByText('Add Policy')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ImmutabilityPolicies.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ImmutabilityPolicies.test.tsx
@@ -22,6 +22,21 @@ vi.mock('src/hooks/UseSuperuserPermissions', () => ({
 
 vi.mock('src/hooks/UseNamespaceImmutabilityPolicies', () => ({
   useNamespaceImmutabilityPolicies: mockUseImmutabilityPolicies,
+  useCreateNamespaceImmutabilityPolicy: () => ({createPolicy: vi.fn()}),
+  useUpdateNamespaceImmutabilityPolicy: () => ({updatePolicy: vi.fn()}),
+  useDeleteNamespaceImmutabilityPolicy: () => ({deletePolicy: vi.fn()}),
+}));
+
+vi.mock('src/hooks/UseOrgMirrorExists', () => ({
+  useOrgMirrorExists: () => ({exists: false, isLoading: false}),
+}));
+
+vi.mock('src/hooks/UseProxyCache', () => ({
+  useFetchProxyCacheConfig: () => ({
+    proxyCacheConfig: null,
+    isLoading: false,
+    isError: false,
+  }),
 }));
 
 vi.mock('src/components/ImmutabilityPolicyForm', () => ({
@@ -43,13 +58,13 @@ describe('ImmutabilityPolicies', () => {
   });
 
   it('shows add policy button for non-readonly user in empty state', () => {
-    render(<ImmutabilityPolicies organizationName="myorg" />);
+    render(<ImmutabilityPolicies org="myorg" />);
     expect(screen.getByText('Add Policy')).toBeInTheDocument();
   });
 
   it('hides add policy button for readonly superuser in empty state', () => {
     mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
-    render(<ImmutabilityPolicies organizationName="myorg" />);
+    render(<ImmutabilityPolicies org="myorg" />);
     expect(screen.queryByText('Add Policy')).not.toBeInTheDocument();
   });
 
@@ -62,7 +77,7 @@ describe('ImmutabilityPolicies', () => {
       updatePolicy: vi.fn(),
       deletePolicy: vi.fn(),
     });
-    render(<ImmutabilityPolicies organizationName="myorg" />);
+    render(<ImmutabilityPolicies org="myorg" />);
     expect(screen.getByText('Add Policy')).toBeInTheDocument();
   });
 
@@ -76,7 +91,7 @@ describe('ImmutabilityPolicies', () => {
       updatePolicy: vi.fn(),
       deletePolicy: vi.fn(),
     });
-    render(<ImmutabilityPolicies organizationName="myorg" />);
+    render(<ImmutabilityPolicies org="myorg" />);
     expect(screen.queryByText('Add Policy')).not.toBeInTheDocument();
   });
 });

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ImmutabilityPolicies.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ImmutabilityPolicies.tsx
@@ -25,16 +25,23 @@ import {isNullOrUndefined} from 'src/libs/utils';
 import {ImmutabilityPolicy} from 'src/resources/ImmutabilityPolicyResource';
 import ImmutabilityPolicyForm from 'src/components/ImmutabilityPolicyForm';
 import {getErrorMessageFromUnknown} from 'src/resources/ErrorHandling';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 function PolicyActionButtons({
   uuid,
   onEdit,
   onDelete,
+  isReadOnlySuperUser,
 }: {
   uuid: string;
   onEdit: (uuid: string) => void;
   onDelete: (uuid: string) => void;
+  isReadOnlySuperUser?: boolean;
 }) {
+  if (isReadOnlySuperUser) {
+    return null;
+  }
+
   return (
     <div className="pf-v6-u-display-flex pf-v6-u-flex-direction-row">
       <Button
@@ -56,6 +63,7 @@ function PolicyActionButtons({
 }
 
 export default function ImmutabilityPolicies(props: ImmutabilityPoliciesProps) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [policies, setPolicies] = useState<ImmutabilityPolicy[]>([]);
   const [editingPolicyUuid, setEditingPolicyUuid] = useState<string | null>(
     null,
@@ -178,7 +186,7 @@ export default function ImmutabilityPolicies(props: ImmutabilityPoliciesProps) {
     <>
       <div className="pf-v6-u-display-flex pf-v6-u-justify-content-space-between pf-v6-u-align-items-center pf-v6-u-pb-sm">
         <Title headingLevel="h2">Immutability Policies</Title>
-        {(hasPolicies || isAddingNew) && (
+        {(hasPolicies || isAddingNew) && !isReadOnlySuperUser && (
           <Button
             variant="primary"
             onClick={handleAddNew}
@@ -251,21 +259,23 @@ export default function ImmutabilityPolicies(props: ImmutabilityPoliciesProps) {
           </EmptyStateBody>
           <EmptyStateFooter>
             <EmptyStateActions>
-              <Button
-                variant="primary"
-                onClick={handleAddNew}
-                data-testid="add-immutability-policy-btn"
-                isDisabled={
-                  isOrgMirrorLoading ||
-                  isOrgMirrorError ||
-                  isOrgMirrored ||
-                  isProxyCacheLoading ||
-                  isProxyCacheError ||
-                  isProxyCacheConfigured
-                }
-              >
-                Add Policy
-              </Button>
+              {!isReadOnlySuperUser && (
+                <Button
+                  variant="primary"
+                  onClick={handleAddNew}
+                  data-testid="add-immutability-policy-btn"
+                  isDisabled={
+                    isOrgMirrorLoading ||
+                    isOrgMirrorError ||
+                    isOrgMirrored ||
+                    isProxyCacheLoading ||
+                    isProxyCacheError ||
+                    isProxyCacheConfigured
+                  }
+                >
+                  Add Policy
+                </Button>
+              )}
             </EmptyStateActions>
           </EmptyStateFooter>
         </EmptyState>
@@ -330,6 +340,7 @@ export default function ImmutabilityPolicies(props: ImmutabilityPoliciesProps) {
                         uuid={policy.uuid}
                         onEdit={setEditingPolicyUuid}
                         onDelete={onDelete}
+                        isReadOnlySuperUser={isReadOnlySuperUser}
                       />
                     )}
                   </Td>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/NamespaceNotifications.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/NamespaceNotifications.test.tsx
@@ -5,6 +5,14 @@ import {
   NamespaceNotificationMethodType,
 } from 'src/resources/NamespaceNotificationResource';
 
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
 const mockUseQuayConfig = vi.hoisted(() =>
   vi.fn(() => ({
     features: {QUOTA_NOTIFICATIONS: true},
@@ -54,6 +62,7 @@ vi.mock('./NamespaceNotificationsKebab', () => ({
 describe('NamespaceNotifications', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
     mockUseQuayConfig.mockReturnValue({
       features: {QUOTA_NOTIFICATIONS: true},
       config: {REGISTRY_TITLE_SHORT: 'Quay'},
@@ -212,6 +221,74 @@ describe('NamespaceNotifications', () => {
     expect(
       screen.getByText('Disabled (3 failed attempts)'),
     ).toBeInTheDocument();
+  });
+
+  it('hides create button for readonly superuser in empty state', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    mockUseNamespaceNotifications.mockReturnValue({
+      notifications: [],
+      loading: false,
+      error: false,
+      filter: {event: [], status: []},
+      setFilter: vi.fn(),
+      resetFilter: vi.fn(),
+    });
+    render(<NamespaceNotifications organizationName="myorg" />);
+    expect(
+      screen.queryByTestId('create-ns-notification-btn'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides create button for readonly superuser in table view', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    const notifications = [
+      {
+        uuid: 'n1',
+        title: 'test',
+        event: NamespaceNotificationEventType.quotaWarning,
+        method: NamespaceNotificationMethodType.email,
+        config: {},
+        event_config: {},
+        number_of_failures: 0,
+      },
+    ];
+    mockUseNamespaceNotifications.mockReturnValue({
+      notifications,
+      loading: false,
+      error: false,
+      filter: {event: [], status: []},
+      setFilter: vi.fn(),
+      resetFilter: vi.fn(),
+    });
+    render(<NamespaceNotifications organizationName="myorg" />);
+    expect(
+      screen.queryByTestId('create-ns-notification-btn'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides notification kebab for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    const notifications = [
+      {
+        uuid: 'n1',
+        title: 'test',
+        event: NamespaceNotificationEventType.quotaWarning,
+        method: NamespaceNotificationMethodType.email,
+        config: {},
+        event_config: {},
+        number_of_failures: 0,
+      },
+    ];
+    mockUseNamespaceNotifications.mockReturnValue({
+      notifications,
+      loading: false,
+      error: false,
+      filter: {event: [], status: []},
+      setFilter: vi.fn(),
+      resetFilter: vi.fn(),
+    });
+    render(<NamespaceNotifications organizationName="myorg" />);
+    expect(screen.queryByTestId('kebab-stub')).not.toBeInTheDocument();
   });
 
   it('renders create notification button in table view', () => {

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/NamespaceNotifications.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/NamespaceNotifications.tsx
@@ -276,11 +276,13 @@ export default function NamespaceNotifications({
                 )}
               </Td>
               <Td data-label="kebab">
-                <NamespaceNotificationsKebab
-                  orgname={organizationName}
-                  isUser={isUser}
-                  notification={notification}
-                />
+                {!isReadOnlySuperUser && (
+                  <NamespaceNotificationsKebab
+                    orgname={organizationName}
+                    isUser={isUser}
+                    notification={notification}
+                  />
+                )}
               </Td>
             </Tr>
             <Tr isExpanded={isExpanded(notification.uuid)}>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/NamespaceNotifications.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/NamespaceNotifications.tsx
@@ -35,6 +35,7 @@ import {
 } from 'src/resources/NamespaceNotificationResource';
 import NamespaceNotificationsCreateForm from './NamespaceNotificationsCreateForm';
 import NamespaceNotificationsKebab from './NamespaceNotificationsKebab';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 const EVENT_TITLES: Record<NamespaceNotificationEventType, string> = {
   [NamespaceNotificationEventType.quotaWarning]: 'Quota Warning',
@@ -125,6 +126,7 @@ export default function NamespaceNotifications({
   organizationName,
   isUser = false,
 }: NamespaceNotificationsProps) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const config = useQuayConfig();
   const registryTitle = config?.config?.REGISTRY_TITLE_SHORT || 'Quay';
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -173,12 +175,14 @@ export default function NamespaceNotifications({
           title="No notifications configured"
           body="Configure notifications to receive alerts when quota thresholds are crossed"
           button={
-            <Button
-              data-testid="create-ns-notification-btn"
-              onClick={() => setIsCreateOpen(true)}
-            >
-              Create notification
-            </Button>
+            !isReadOnlySuperUser ? (
+              <Button
+                data-testid="create-ns-notification-btn"
+                onClick={() => setIsCreateOpen(true)}
+              >
+                Create notification
+              </Button>
+            ) : null
           }
         />
         <NamespaceNotificationsCreateForm
@@ -195,14 +199,16 @@ export default function NamespaceNotifications({
     <>
       <Toolbar>
         <ToolbarContent>
-          <ToolbarItem>
-            <Button
-              data-testid="create-ns-notification-btn"
-              onClick={() => setIsCreateOpen(true)}
-            >
-              Create notification
-            </Button>
-          </ToolbarItem>
+          {!isReadOnlySuperUser && (
+            <ToolbarItem>
+              <Button
+                data-testid="create-ns-notification-btn"
+                onClick={() => setIsCreateOpen(true)}
+              >
+                Create notification
+              </Button>
+            </ToolbarItem>
+          )}
           <ToolbarPagination
             total={paginationProps.total}
             perPage={paginationProps.perPage}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/OrgMirroringState.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/OrgMirroringState.test.tsx
@@ -1,0 +1,58 @@
+import {render, screen} from 'src/test-utils';
+import {OrgMirroringState} from './OrgMirroringState';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseOrgMirrorExists', () => ({
+  useOrgMirrorExists: () => ({exists: false, isLoading: false}),
+}));
+
+vi.mock('src/hooks/UseProxyCache', () => ({
+  useFetchProxyCacheConfig: () => ({
+    proxyCacheConfig: null,
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+vi.mock('src/hooks/UseNamespaceImmutabilityPolicies', () => ({
+  useNamespaceImmutabilityPolicies: () => ({
+    policies: [],
+    isLoading: false,
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom',
+    );
+  return {
+    ...actual,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  };
+});
+
+describe('OrgMirroringState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('renders the submit button', () => {
+    render(<OrgMirroringState organizationName="myorg" />);
+    expect(screen.getByText('Submit')).toBeInTheDocument();
+  });
+
+  it('disables submit button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<OrgMirroringState organizationName="myorg" />);
+    expect(screen.getByText('Submit').closest('button')).toBeDisabled();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/OrgMirroringState.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/OrgMirroringState.tsx
@@ -11,6 +11,7 @@ import {useSearchParams} from 'react-router-dom';
 import {useOrgMirrorExists} from 'src/hooks/UseOrgMirrorExists';
 import {useFetchProxyCacheConfig} from 'src/hooks/UseProxyCache';
 import {useNamespaceImmutabilityPolicies} from 'src/hooks/UseNamespaceImmutabilityPolicies';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 interface OrgMirroringStateProps {
   organizationName: string;
@@ -19,6 +20,7 @@ interface OrgMirroringStateProps {
 export const OrgMirroringState = ({
   organizationName,
 }: OrgMirroringStateProps) => {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [selectedState, setSelectedState] = useState<'NORMAL' | 'MIRROR'>(
     'NORMAL',
   );
@@ -147,6 +149,7 @@ export const OrgMirroringState = ({
           variant="primary"
           size="sm"
           isDisabled={
+            isReadOnlySuperUser ||
             selectedState === 'NORMAL' ||
             isPoliciesLoading ||
             isProxyCacheLoading ||

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.test.tsx
@@ -1,0 +1,71 @@
+import {render, screen} from 'src/test-utils';
+import ProxyCacheConfig from './ProxyCacheConfig';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+const mockUseFetchProxyCacheConfig = vi.hoisted(() =>
+  vi.fn(() => ({
+    fetchedProxyCacheConfig: {
+      upstream_registry: 'docker.io',
+      expiration_s: 86400,
+    },
+    isLoading: false,
+    isError: false,
+  })),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+vi.mock('src/hooks/UseProxyCache', () => ({
+  useFetchProxyCacheConfig: mockUseFetchProxyCacheConfig,
+  useCreateProxyCacheConfig: () => ({
+    createProxyCacheConfig: vi.fn(),
+    isCreating: false,
+    errorCreating: null,
+    successCreating: false,
+  }),
+  useDeleteProxyCacheConfig: () => ({
+    deleteProxyCacheConfig: vi.fn(),
+    isDeleting: false,
+    errorDeleting: null,
+    successDeleting: false,
+  }),
+}));
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: () => ({
+    features: {PROXY_CACHE: true},
+    config: {},
+  }),
+}));
+
+describe('ProxyCacheConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('enables save button for non-readonly user', () => {
+    render(<ProxyCacheConfig organizationName="myorg" isUser={false} />);
+    const saveBtn = screen.getByText('Save');
+    expect(saveBtn.closest('button')).not.toBeDisabled();
+  });
+
+  it('disables save button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<ProxyCacheConfig organizationName="myorg" isUser={false} />);
+    const saveBtn = screen.getByText('Save');
+    expect(saveBtn.closest('button')).toBeDisabled();
+  });
+
+  it('disables delete button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<ProxyCacheConfig organizationName="myorg" isUser={false} />);
+    const deleteBtn = screen.getByText('Delete');
+    expect(deleteBtn.closest('button')).toBeDisabled();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.test.tsx
@@ -1,5 +1,5 @@
 import {render, screen} from 'src/test-utils';
-import ProxyCacheConfig from './ProxyCacheConfig';
+import {ProxyCacheConfig} from './ProxyCacheConfig';
 
 const mockUseSuperuserPermissions = vi.hoisted(() =>
   vi.fn(() => ({isReadOnlySuperUser: false})),
@@ -36,11 +36,30 @@ vi.mock('src/hooks/UseProxyCache', () => ({
   }),
 }));
 
+vi.mock('src/hooks/UseOrgMirrorExists', () => ({
+  useOrgMirrorExists: () => ({exists: false, isLoading: false}),
+}));
+
+vi.mock('src/hooks/UseNamespaceImmutabilityPolicies', () => ({
+  useNamespaceImmutabilityPolicies: () => ({
+    policies: [],
+    isLoading: false,
+  }),
+}));
+
 vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfigWithLoading: () => ({
+    config: {features: {PROXY_CACHE: true}, config: {}},
+    loading: false,
+  }),
   useQuayConfig: () => ({
     features: {PROXY_CACHE: true},
     config: {},
   }),
+}));
+
+vi.mock('src/routes/Alerts', () => ({
+  default: () => null,
 }));
 
 describe('ProxyCacheConfig', () => {

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
@@ -373,7 +373,9 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           </Button>
 
           <Button
-            isDisabled={isReadOnlySuperUser || !fetchedProxyCacheConfig?.upstream_registry}
+            isDisabled={
+              isReadOnlySuperUser || !fetchedProxyCacheConfig?.upstream_registry
+            }
             id="delete-proxy-cache"
             data-testid="delete-proxy-cache-btn"
             variant="danger"

--- a/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/Settings/ProxyCacheConfig.tsx
@@ -25,6 +25,7 @@ import {useOrgMirrorExists} from 'src/hooks/UseOrgMirrorExists';
 import {useNamespaceImmutabilityPolicies} from 'src/hooks/UseNamespaceImmutabilityPolicies';
 import {useQuayConfigWithLoading} from 'src/hooks/UseQuayConfig';
 import Alerts from 'src/routes/Alerts';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 type ProxyCacheConfigProps = {
   organizationName: string;
@@ -34,6 +35,7 @@ type ProxyCacheConfigProps = {
 const tagExpirationInSecsForProxyCache = 86400;
 
 export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const defaultProxyCacheConfig = {
     upstream_registry: '',
     expiration_s: tagExpirationInSecsForProxyCache,
@@ -355,6 +357,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
               proxyCacheConfigValidation();
             }}
             isDisabled={
+              isReadOnlySuperUser ||
               isQuayConfigLoading ||
               !proxyCacheConfig?.upstream_registry ||
               !!fetchedProxyCacheConfig?.upstream_registry ||
@@ -370,7 +373,7 @@ export const ProxyCacheConfig = (props: ProxyCacheConfigProps) => {
           </Button>
 
           <Button
-            isDisabled={!fetchedProxyCacheConfig?.upstream_registry}
+            isDisabled={isReadOnlySuperUser || !fetchedProxyCacheConfig?.upstream_registry}
             id="delete-proxy-cache"
             data-testid="delete-proxy-cache-btn"
             variant="danger"

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/CollaboratorsView/CollaboratorsViewList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/CollaboratorsView/CollaboratorsViewList.tsx
@@ -15,6 +15,7 @@ import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import CollaboratorsDeleteModal from './CollaboratorsDeleteModal';
 import Conditional from 'src/components/empty/Conditional';
 import {usePaginatedSortableTable} from '../../../../../../hooks/usePaginatedSortableTable';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export const collaboratorViewColumnNames = {
   username: 'User name',
@@ -24,6 +25,7 @@ export const collaboratorViewColumnNames = {
 export default function CollaboratorsViewList(
   props: CollaboratorsViewListProps,
 ) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const {collaborators, loading, error, search, setSearch} =
@@ -151,17 +153,19 @@ export default function CollaboratorsViewList(
                   Direct permissions on {collaborator.repositories?.length}{' '}
                   repositories under this organization
                 </Td>
-                <Td>
-                  <Button
-                    icon={<TrashIcon />}
-                    variant="plain"
-                    onClick={() => {
-                      setCollaboratorToBeDeleted(collaborator);
-                      setIsDeleteModalOpen(true);
-                    }}
-                    data-testid={`${collaborator.name}-del-icon`}
-                  />
-                </Td>
+                {!isReadOnlySuperUser && (
+                  <Td>
+                    <Button
+                      icon={<TrashIcon />}
+                      variant="plain"
+                      onClick={() => {
+                        setCollaboratorToBeDeleted(collaborator);
+                        setIsDeleteModalOpen(true);
+                      }}
+                      data-testid={`${collaborator.name}-del-icon`}
+                    />
+                  </Td>
+                )}
               </Tr>
             ))}
           </Tbody>

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/CollaboratorsView/CollaboratorsViewToolbar.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/CollaboratorsView/CollaboratorsViewToolbar.test.tsx
@@ -1,0 +1,46 @@
+import {render, screen} from 'src/test-utils';
+import CollaboratorsViewToolbar from './CollaboratorsViewToolbar';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+const defaultProps = {
+  selectedMembers: [],
+  deSelectAll: vi.fn(),
+  allItems: [],
+  paginatedItems: [],
+  onItemSelect: vi.fn(),
+  page: 1,
+  setPage: vi.fn(),
+  perPage: 10,
+  setPerPage: vi.fn(),
+  searchOptions: ['User name'],
+  search: {field: 'User name', query: ''},
+  setSearch: vi.fn(),
+  handleModalToggle: vi.fn(),
+};
+
+describe('CollaboratorsViewToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('shows create team button for non-readonly user', () => {
+    render(<CollaboratorsViewToolbar {...defaultProps} />);
+    expect(screen.getByTestId('create-new-team-button')).toBeInTheDocument();
+  });
+
+  it('hides create team button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<CollaboratorsViewToolbar {...defaultProps} />);
+    expect(
+      screen.queryByTestId('create-new-team-button'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/CollaboratorsView/CollaboratorsViewToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/CollaboratorsView/CollaboratorsViewToolbar.tsx
@@ -43,14 +43,14 @@ export default function CollaboratorsViewToolbar(
           </FlexItem>
         </Flex>
         {!isReadOnlySuperUser && (
-        <ToolbarItem>
-          <Button
-            onClick={() => props.handleModalToggle()}
-            data-testid="create-new-team-button"
-          >
-            Create new team
-          </Button>
-        </ToolbarItem>
+          <ToolbarItem>
+            <Button
+              onClick={() => props.handleModalToggle()}
+              data-testid="create-new-team-button"
+            >
+              Create new team
+            </Button>
+          </ToolbarItem>
         )}
         <ToolbarPagination
           itemsList={props.allItems}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/CollaboratorsView/CollaboratorsViewToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/CollaboratorsView/CollaboratorsViewToolbar.tsx
@@ -12,10 +12,12 @@ import {SearchInput} from 'src/components/toolbar/SearchInput';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import {IMembers} from 'src/resources/MembersResource';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export default function CollaboratorsViewToolbar(
   props: CollaboratorsViewToolbarProps,
 ) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   return (
     <Toolbar>
       <ToolbarContent>
@@ -40,6 +42,7 @@ export default function CollaboratorsViewToolbar(
             />
           </FlexItem>
         </Flex>
+        {!isReadOnlySuperUser && (
         <ToolbarItem>
           <Button
             onClick={() => props.handleModalToggle()}
@@ -48,6 +51,7 @@ export default function CollaboratorsViewToolbar(
             Create new team
           </Button>
         </ToolbarItem>
+        )}
         <ToolbarPagination
           itemsList={props.allItems}
           perPage={props.perPage}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/MembersView/MembersViewToolbar.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/MembersView/MembersViewToolbar.test.tsx
@@ -1,0 +1,46 @@
+import {render, screen} from 'src/test-utils';
+import MembersViewToolbar from './MembersViewToolbar';
+
+const mockUseSuperuserPermissions = vi.hoisted(() =>
+  vi.fn(() => ({isReadOnlySuperUser: false})),
+);
+
+vi.mock('src/hooks/UseSuperuserPermissions', () => ({
+  useSuperuserPermissions: mockUseSuperuserPermissions,
+}));
+
+const defaultProps = {
+  selectedMembers: [],
+  deSelectAll: vi.fn(),
+  allItems: [],
+  paginatedItems: [],
+  onItemSelect: vi.fn(),
+  page: 1,
+  setPage: vi.fn(),
+  perPage: 10,
+  setPerPage: vi.fn(),
+  searchOptions: ['User name'],
+  search: {field: 'User name', query: ''},
+  setSearch: vi.fn(),
+  handleModalToggle: vi.fn(),
+};
+
+describe('MembersViewToolbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: false});
+  });
+
+  it('shows create team button for non-readonly user', () => {
+    render(<MembersViewToolbar {...defaultProps} />);
+    expect(screen.getByTestId('create-new-team-button')).toBeInTheDocument();
+  });
+
+  it('hides create team button for readonly superuser', () => {
+    mockUseSuperuserPermissions.mockReturnValue({isReadOnlySuperUser: true});
+    render(<MembersViewToolbar {...defaultProps} />);
+    expect(
+      screen.queryByTestId('create-new-team-button'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/MembersView/MembersViewToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/MembersView/MembersViewToolbar.tsx
@@ -41,14 +41,14 @@ export default function MembersViewToolbar(props: MembersViewToolbarProps) {
           </FlexItem>
         </Flex>
         {!isReadOnlySuperUser && (
-        <ToolbarItem>
-          <Button
-            onClick={() => props.handleModalToggle()}
-            data-testid="create-new-team-button"
-          >
-            Create new team
-          </Button>
-        </ToolbarItem>
+          <ToolbarItem>
+            <Button
+              onClick={() => props.handleModalToggle()}
+              data-testid="create-new-team-button"
+            >
+              Create new team
+            </Button>
+          </ToolbarItem>
         )}
         <ToolbarPagination
           itemsList={props.allItems}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/MembersView/MembersViewToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/MembersView/MembersViewToolbar.tsx
@@ -12,8 +12,10 @@ import {SearchInput} from 'src/components/toolbar/SearchInput';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import {IMembers} from 'src/resources/MembersResource';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export default function MembersViewToolbar(props: MembersViewToolbarProps) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   return (
     <Toolbar>
       <ToolbarContent>
@@ -38,6 +40,7 @@ export default function MembersViewToolbar(props: MembersViewToolbarProps) {
             />
           </FlexItem>
         </Flex>
+        {!isReadOnlySuperUser && (
         <ToolbarItem>
           <Button
             onClick={() => props.handleModalToggle()}
@@ -46,6 +49,7 @@ export default function MembersViewToolbar(props: MembersViewToolbarProps) {
             Create new team
           </Button>
         </ToolbarItem>
+        )}
         <ToolbarPagination
           itemsList={props.allItems}
           perPage={props.perPage}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsAndMembershipList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsAndMembershipList.tsx
@@ -17,6 +17,7 @@ import {validateTeamName} from 'src/libs/utils';
 import Conditional from 'src/components/empty/Conditional';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {useOrganization} from 'src/hooks/UseOrganization';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export enum TableModeType {
   Teams = 'Teams',
@@ -33,6 +34,7 @@ export default function TeamsAndMembershipList() {
   const {organizationName} = useParams();
   const config = useQuayConfig();
   const {organization} = useOrganization(organizationName);
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
 
   const [tableMode, setTableMode] = useState<TableModeType>(
     TableModeType.Teams,
@@ -121,7 +123,7 @@ export default function TeamsAndMembershipList() {
           <TeamsViewList
             organizationName={organizationName}
             handleModalToggle={() => setIsTeamModalOpen(!isTeamModalOpen)}
-            isReadOnly={config?.registry_state === 'readonly'}
+            isReadOnly={config?.registry_state === 'readonly' || isReadOnlySuperUser}
             isAdmin={organization.is_admin}
           >
             {viewToggle}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsAndMembershipList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsAndMembershipList.tsx
@@ -123,7 +123,9 @@ export default function TeamsAndMembershipList() {
           <TeamsViewList
             organizationName={organizationName}
             handleModalToggle={() => setIsTeamModalOpen(!isTeamModalOpen)}
-            isReadOnly={config?.registry_state === 'readonly' || isReadOnlySuperUser}
+            isReadOnly={
+              config?.registry_state === 'readonly' || isReadOnlySuperUser
+            }
             isAdmin={organization.is_admin}
           >
             {viewToggle}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/AddNewTeamMemberDrawer.tsx
@@ -32,10 +32,12 @@ import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {Entity} from 'src/resources/UserResource';
 import {OrganizationDrawerContentType} from 'src/routes/OrganizationsList/Organization/Organization';
 import {RepoPermissionDropdownItems} from 'src/routes/RepositoriesList/RobotAccountsList';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export default function AddNewTeamMemberDrawer(
   props: AddNewTeamMemberDrawerProps,
 ) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const [selectedEntity, setSelectedEntity] = useState<Entity>(null);
   const [isCreateRobotModalOpen, setIsCreateRobotModalOpen] = useState(false);
   const [error, setError] = useState<string>('');
@@ -79,7 +81,7 @@ export default function AddNewTeamMemberDrawer(
           ))
         )}
       </SelectGroup>
-      {!robotsDisallowed && (
+      {!robotsDisallowed && !isReadOnlySuperUser && (
         <>
           <Divider component="li" key={7} />
           <SelectOption
@@ -215,6 +217,7 @@ export default function AddNewTeamMemberDrawer(
               <Button
                 data-testid="add-new-member-submit-btn"
                 isDisabled={
+                  isReadOnlySuperUser ||
                   selectedEntity === null ||
                   Object.keys(selectedEntity).length === 0
                 }

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersList.tsx
@@ -54,6 +54,7 @@ import Conditional from 'src/components/empty/Conditional';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {useOrganization} from 'src/hooks/UseOrganization';
 import {useTeamSync, useRemoveTeamSync} from 'src/hooks/UseTeamSync';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 import DirectoryTeamSyncModal from 'src/components/modals/DirectoryTeamSyncModal';
 import {ConfirmationModal} from 'src/components/modals/ConfirmationModal';
 import {usePaginatedSortableTable} from '../../../../../../../hooks/usePaginatedSortableTable';
@@ -100,6 +101,7 @@ interface IMemberInfo {
 }
 
 export default function ManageMembersList(props: ManageMembersListProps) {
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const {organizationName, teamName} = useParams();
   const config = useQuayConfig();
   const {organization} = useOrganization(organizationName);
@@ -398,7 +400,11 @@ export default function ManageMembersList(props: ManageMembersListProps) {
           </Title>
         </FlexItem>
         <Conditional
-          if={config?.registry_state !== 'readonly' && organization.is_admin}
+          if={
+            config?.registry_state !== 'readonly' &&
+            organization.is_admin &&
+            !isReadOnlySuperUser
+          }
         >
           <Tooltip content={<div>Edit team description</div>}>
             <Button
@@ -475,7 +481,7 @@ export default function ManageMembersList(props: ManageMembersListProps) {
 
   const fetchSyncBtn = () => {
     const result = [];
-    if (displaySyncDirectory) {
+    if (displaySyncDirectory && !isReadOnlySuperUser) {
       result.push(
         <Button
           variant="link"
@@ -488,7 +494,7 @@ export default function ManageMembersList(props: ManageMembersListProps) {
         </Button>,
       );
     }
-    if (pageInReadOnlyMode && teamCanSync) {
+    if (pageInReadOnlyMode && teamCanSync && !isReadOnlySuperUser) {
       result.push(
         <Button
           onClick={() => setRemoveTeamSyncModalOpen(!isRemoveTeamSyncModalOpen)}
@@ -612,6 +618,7 @@ export default function ManageMembersList(props: ManageMembersListProps) {
               if={
                 config?.registry_state !== 'readonly' &&
                 organization.is_admin &&
+                !isReadOnlySuperUser &&
                 !pageInReadOnlyMode
               }
             >
@@ -659,7 +666,9 @@ export default function ManageMembersList(props: ManageMembersListProps) {
           setSearch={setSearch}
           searchOptions={[manageMemberColumnNames.teamMember]}
           setDrawerContent={props.setDrawerContent}
-          isReadOnly={config?.registry_state === 'readonly'}
+          isReadOnly={
+            config?.registry_state === 'readonly' || isReadOnlySuperUser
+          }
           isAdmin={organization.is_admin}
           displaySyncDirectory={displaySyncDirectory}
           isDirectoryTeamSyncModalOpen={isDirectoryTeamSyncModalOpen}
@@ -723,6 +732,7 @@ export default function ManageMembersList(props: ManageMembersListProps) {
                     if={
                       config?.registry_state !== 'readonly' &&
                       organization.is_admin &&
+                      !isReadOnlySuperUser &&
                       displayDeleteIcon(getAccountTypeForMember(teamMember))
                     }
                   >

--- a/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersToolbar.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/TeamsAndMembership/TeamsView/ManageMembers/ManageMembersToolbar.tsx
@@ -59,6 +59,7 @@ export default function ManageMembersToolbar(props: ManageMembersToolbarProps) {
 
             <Conditional
               if={
+                !props.isReadOnly &&
                 props.displaySyncDirectory &&
                 ['ldap', 'keystone', 'oidc'].includes(
                   props.teamCanSync?.service || '',
@@ -73,7 +74,11 @@ export default function ManageMembersToolbar(props: ManageMembersToolbarProps) {
             </Conditional>
 
             <Conditional
-              if={props.pageInReadOnlyMode && props.teamCanSync !== null}
+              if={
+                !props.isReadOnly &&
+                props.pageInReadOnlyMode &&
+                props.teamCanSync !== null
+              }
             >
               <FlexItem>
                 <Button onClick={props.toggleRemoveTeamSyncModal}>

--- a/web/src/routes/RepositoriesList/RobotAccountsList.tsx
+++ b/web/src/routes/RepositoriesList/RobotAccountsList.tsx
@@ -700,18 +700,20 @@ export default function RobotAccountsList(props: RobotAccountsListProps) {
                     {formatDate(robotAccount.created)}
                   </Td>
                   <Td data-label="kebab">
-                    <RobotAccountKebab
-                      robotAccount={robotAccount}
-                      namespace={props.organizationName}
-                      setError={setErr}
-                      deleteModal={bulkDeleteRobotAccountModal}
-                      deleteKebabIsOpen={isDeleteModalOpen}
-                      setDeleteModalOpen={setDeleteModalOpen}
-                      setSelectedRobotAccount={setRobotForDeletion}
-                      onSetRepoPermsClick={fetchReposModal}
-                      robotAccountRepos={robotAccount.repositories}
-                      onSetRobotFederationClick={robotFederationModal}
-                    />
+                    {!isReadOnlySuperUser && (
+                      <RobotAccountKebab
+                        robotAccount={robotAccount}
+                        namespace={props.organizationName}
+                        setError={setErr}
+                        deleteModal={bulkDeleteRobotAccountModal}
+                        deleteKebabIsOpen={isDeleteModalOpen}
+                        setDeleteModalOpen={setDeleteModalOpen}
+                        setSelectedRobotAccount={setRobotForDeletion}
+                        onSetRepoPermsClick={fetchReposModal}
+                        robotAccountRepos={robotAccount.repositories}
+                        onSetRobotFederationClick={robotFederationModal}
+                      />
+                    )}
                   </Td>
                 </Tr>
                 {robotAccount.description ? (

--- a/web/src/routes/RepositoriesList/RobotAccountsList.tsx
+++ b/web/src/routes/RepositoriesList/RobotAccountsList.tsx
@@ -52,6 +52,7 @@ import {AlertVariant, useUI} from 'src/contexts/UIContext';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {RobotFederationModal} from 'src/components/modals/RobotFederationModal';
 import {usePaginatedSortableTable} from '../../hooks/usePaginatedSortableTable';
+import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
 
 export const RepoPermissionDropdownItems = [
   {
@@ -112,6 +113,7 @@ export default function RobotAccountsList(props: RobotAccountsListProps) {
     useState<boolean>(false);
 
   const {addAlert} = useUI();
+  const {isReadOnlySuperUser} = useSuperuserPermissions();
   const quayConfig = useQuayConfig();
   const robotsDisallowed = quayConfig?.config?.ROBOTS_DISALLOW === true;
 
@@ -495,7 +497,7 @@ export default function RobotAccountsList(props: RobotAccountsListProps) {
             : 'Either no robot accounts exist yet or you may not have permission to view any. If you have the permissions, you may create robot accounts in this repository.'
         }
         button={
-          !robotsDisallowed ? (
+          !robotsDisallowed && !isReadOnlySuperUser ? (
             <ToolbarButton
               id=""
               buttonValue="Create robot account"
@@ -545,10 +547,10 @@ export default function RobotAccountsList(props: RobotAccountsListProps) {
           pageModal={createRobotModal}
           isModalOpen={isCreateRobotModalOpen}
           setModalOpen={setCreateRobotModalOpen}
-          hideCreateButton={robotsDisallowed}
+          hideCreateButton={robotsDisallowed || isReadOnlySuperUser}
           isKebabOpen={isKebabOpen}
           setKebabOpen={setKebabOpen}
-          kebabItems={kebabItems}
+          kebabItems={isReadOnlySuperUser ? [] : kebabItems}
           deleteModal={bulkDeleteRobotAccountModal}
           deleteKebabIsOpen={isDeleteModalOpen}
           setDeleteModalOpen={setDeleteModalOpen}


### PR DESCRIPTION
## Summary
- Hide or disable all create, delete, update, and save buttons across organization tabs when the current user is a global readonly superuser
- Uses the existing `useSuperuserPermissions()` hook to check `isReadOnlySuperUser` and conditionally render write-action controls
- UI-only changes — no backend modifications

## Root Cause
The backend `org_view()` sets `is_admin = true` for global readonly superusers so they can view all admin tabs. But the UI trusted `is_admin` blindly and showed all write-action buttons. The backend correctly rejects write requests with 401/403, but the UI should not allow the actions in the first place.

## Changes (18 files)

| Tab | Files | Actions Guarded |
|-----|-------|-----------------|
| OAuth Applications | `OAuthApplicationsToolbar.tsx`, `OAuthApplicationsList.tsx`, `OAuthApplicationActionsKebab.tsx` | Create, bulk delete, per-row delete |
| OAuth Apps (Manage) | `SettingsTab.tsx`, `OAuthInformationTab.tsx` | Update Application, Reset Client Secret |
| Teams & Membership | `TeamsAndMembershipList.tsx`, `MembersViewToolbar.tsx`, `CollaboratorsViewToolbar.tsx` | Create team (all 3 views) |
| Default Permissions | `DefaultPermissionsToolbar.tsx`, `DeleteDefaultPermissionKebab.tsx` | Create, bulk delete, per-row delete |
| Robot Accounts | `RobotAccountsList.tsx` | Create robot, bulk delete |
| Settings (General) | `GeneralSettings.tsx` | Save, Delete org |
| Settings (AutoPrune) | `AutoPruning.tsx` | Add Policy |
| Settings (Immutability) | `ImmutabilityPolicies.tsx` | Add/Edit/Delete Policy |
| Settings (Proxy Cache) | `ProxyCacheConfig.tsx` | Save, Delete |
| Settings (Org State) | `OrgMirroringState.tsx` | Submit |
| Settings (Notifications) | `NamespaceNotifications.tsx` | Create notification |
| Mirroring | `OrgMirroring.tsx` | Update/Enable, Delete Mirror |

## Pattern Used
- **Hide** (remove from DOM) for create/delete action buttons
- **Disable** (`isDisabled={isReadOnlySuperUser}`) for save/submit/update buttons in forms
- Follows the existing correct patterns in `RepositoriesList.tsx` and `APIAccessTokensTab.tsx`

## Test plan
- [ ] Login as global readonly superuser, navigate to another user's org
- [ ] Verify OAuth Applications tab: no Create/Delete buttons visible, Update/Reset disabled
- [ ] Verify Teams tab: no Create new team button visible across all 3 views
- [ ] Verify Default Permissions tab: no Create/Delete buttons visible
- [ ] Verify Robot Accounts tab: no Create/Delete buttons visible
- [ ] Verify Settings tabs: Save/Submit disabled, Delete/Add Policy hidden
- [ ] Verify Mirroring tab: Update/Delete disabled
- [ ] Login as regular org admin — verify all buttons still work normally (no regression)
- [ ] Login as full-access superuser — verify all buttons still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)