### PR TITLE
NO-ISSUE: docs(agents): clarify bot contribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,19 +62,21 @@ make types-test                      # Type checking (mypy)
 
 ## Universal Conventions
 
-1. **Testing:** Every code change must include tests. For frontend: use **Playwright** for all E2E and full-flow testing (add to existing spec files in `web/playwright/e2e/`); use vitest only for pure unit logic with no UI interaction (utilities, data transformers). For backend: add pytest tests in the appropriate `test/` directory. Always run relevant tests before committing.
-2. **Formatting:** Rely on pre-commit hook to format code on commit
-3. **No secrets:** Never commit credentials, API keys, or sensitive config
-4. **Imports:** Follow existing import ordering patterns in each file
-5. **Error handling:** Use appropriate exception types from `endpoints/exception.py`
-6. **Alembic migrations:** Never write migration files from scratch or fabricate revision IDs. Always run `alembic revision -m "description"` to scaffold the file first, then edit the generated file to add `upgrade()` and `downgrade()` logic. Hand-crafted revision IDs cause conflicts when multiple contributors independently generate migrations.
+1. **Testing:** Every code change must include tests. For frontend: use **Playwright** for all E2E and full-flow testing (add to existing spec files in `web/playwright/e2e/`); use vitest only for pure unit logic with no UI interaction (utilities, data transformers). For backend: add pytest tests in the appropriate `test/` directory. A backend-only change does not require Playwright unless it changes a browser-visible workflow or the requirements explicitly call for E2E coverage. Always run relevant tests before committing.
+2. **Test reporting:** In PR descriptions, report each exact command and its outcome as passed, failed, not run, or infrastructure-blocked. Do not describe an attempted or planned command as having run successfully, and keep infrastructure failures distinct from test failures.
+3. **Formatting:** Rely on pre-commit hook to format code on commit
+4. **No secrets:** Never commit credentials, API keys, or sensitive config
+5. **Imports:** Follow existing import ordering patterns in each file
+6. **Error handling:** Use appropriate exception types from `endpoints/exception.py`
+7. **Alembic migrations:** Never write migration files from scratch or fabricate revision IDs. Always run `alembic revision -m "description"` to scaffold the file first, then edit the generated file to add `upgrade()` and `downgrade()` logic. Hand-crafted revision IDs cause conflicts when multiple contributors independently generate migrations.
+8. **Review scope:** Address blocking or explicitly requested review feedback. Non-blocking observations do not authorize unrelated changes. Check equivalent execution paths needed to preserve the fix's invariant, but report other similar occurrences instead of expanding scope without approval.
 
 ## Contributing
 
 ### PR & Commit Format
 
 - **PR title:** `PROJQUAY-XXXXX: type(scope): lowercase description`
-  - Use `NO-ISSUE:` when there is no associated Jira ticket
+  - Use a Jira key only when the exact key is explicitly associated with the work. A GitHub issue reference such as `#6530` is not `PROJQUAY-6530`; use `NO-ISSUE:` when no Jira key is provided.
   - Types: `fix`, `feat`, `test`, `refactor`, `docs`, `chore`
   - `PROJQUAY-10983: fix(mirroring): add isRequired to robot user field`
   - `NO-ISSUE: docs(agents): add contributing guide`


### PR DESCRIPTION
## Summary

Clarify stable contribution rules in `AGENTS.md` for both human and automated contributors:

- do not infer a Jira key from a GitHub issue number;
- use backend pytest coverage for backend-only changes unless browser-visible behavior or explicit requirements call for Playwright;
- report exact validation commands and distinguish passed, failed, not run, and infrastructure-blocked outcomes;
- limit review fixes to blocking or explicitly requested feedback while checking equivalent execution paths required by the invariant.

These rules address recurring ambiguity without adding incident-specific Fullsend behavior to the repository guidance.

## Local harness evaluation

I ran the parent and candidate `AGENTS.md` through the same five-case local A/B evaluation using [`opendatahub-io/agent-eval-harness`](https://github.com/opendatahub-io/agent-eval-harness) v1.14.0 at commit `6fbba9f65c27568433187d735c470fab5acef85a`.

- Agent runner: Claude Code 2.1.217
- Execution model: Sonnet
- Judge model: `claude-sonnet-4-6` through Vertex AI
- Cases: GitHub-versus-Jira metadata, backend-versus-Playwright coverage, infrastructure-blocked reporting, review scope, and equivalent execution paths
- Comparison: position-swapped pairwise judging

| Measure | Parent `AGENTS.md` | Candidate `AGENTS.md` |
|---|---:|---:|
| Response artifact completion | 100% | 100% |
| Absolute guidance-adherence mean | 5.0/5 | 4.8/5 |
| Pairwise wins | 0 | **3** |
| Pairwise losses | 0 | **0** |
| Pairwise ties | 2 | 2 |

Pairwise outcomes:

| Case | Result |
|---|---|
| GitHub issue versus Jira key | Tie |
| Backend pytest versus Playwright | **Candidate win** |
| Infrastructure-blocked test reporting | Tie |
| Review-fix scope | **Candidate win** |
| Equivalent execution paths | **Candidate win** |

The absolute judge saturated because each scenario contained enough context for the parent guidance to infer the expected answer. The candidate's 4.8 score came from one minor formatting omission: it said `infrastructure-blocked` but did not also provide the literal `not run` label or exact replacement footer text. The pairwise result is the more useful signal: **candidate 3, parent 0, ties 2**.

Caveats: this is a five-case, single-generation local Claude Code proxy. It does not exercise Fullsend's sandbox, host scripts, or PR post-processing, and it is directional evidence rather than a statistically robust benchmark.

<details>
<summary>Harness commands</summary>

The temporary suite was stored outside the repository at `/tmp/quay-agents-guidance-eval`.

```bash
cd /tmp/quay-agents-guidance-eval
PY=/Users/mkok/.claude/plugins/marketplaces/agent-eval-harness-dev/.eval-venv/bin/python3
ROOT=/Users/mkok/.claude/plugins/marketplaces/agent-eval-harness-dev
export PYTHONPATH="$ROOT"

# Parent execution
$PY "$ROOT/skills/eval-run/scripts/execute.py" \
  --config eval.yaml \
  --workspace /var/folders/7m/j34x0t3530x68y6550x_cls40000gn/T/agent-eval/baseline \
  --skill agents-guidance-eval \
  --model sonnet \
  --output eval/runs/agents-guidance-eval/baseline \
  --run-id baseline

# Candidate execution
$PY "$ROOT/skills/eval-run/scripts/execute.py" \
  --config eval.yaml \
  --workspace /var/folders/7m/j34x0t3530x68y6550x_cls40000gn/T/agent-eval/candidate \
  --skill agents-guidance-eval \
  --model sonnet \
  --output eval/runs/agents-guidance-eval/candidate \
  --run-id candidate

# Position-swapped comparison
$PY "$ROOT/skills/eval-run/scripts/score.py" pairwise \
  --run-id candidate \
  --baseline baseline \
  --judge pairwise \
  --config eval.yaml \
  --model claude-sonnet-4-6
```

Both executions completed all five cases. The first parent attempt needed one case rerun after correcting the temporary harness's `Write(output/**)` permission to `Write`; this was an evaluation configuration issue, not a project test failure.

</details>

## Validation

- `git diff --check` — **passed**
- `git commit -m "NO-ISSUE: docs(agents): clarify bot contribution guidance"` — **passed** all applicable commit hooks
- Project tests — **not run**; documentation-only change
