### PR TITLE
[redhat-3.15] PROJQUAY-9998: feat(secscan): add retry limiting via metadata_json for v1 and v2 scanners (#6577)

### DIFF
--- a/config.py
+++ b/config.py
@@ -521,6 +521,9 @@ class DefaultConfig(ImmutableConfig):
     # Minimum number of seconds before re-indexing a manifest with the security scanner.
     SECURITY_SCANNER_V4_REINDEX_THRESHOLD = 300
 
+    # Maximum number of scan retries per indexer hash before a manifest is skipped.
+    SECURITY_SCANNER_MAX_SCAN_RETRIES = 5
+
     # Maximum layer size allowed for indexing.
     SECURITY_SCANNER_V4_INDEX_MAX_LAYER_SIZE = None
 

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from datetime import datetime, timedelta
 from math import log10
 
-from peewee import JOIN, fn
+from peewee import JOIN, IntegrityError, OperationalError, fn
 
 import features
 from data.cache import cache_key
@@ -52,6 +52,7 @@ from util.secscan.v4.api import (
     ClairSecurityScannerAPI,
     InvalidContentSent,
     LayerTooLargeException,
+    Non200ResponseException,
 )
 from util.secscan.validator import V4SecurityConfigValidator
 
@@ -59,6 +60,8 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_SECURITY_SCANNER_V4_REINDEX_THRESHOLD = 86400  # 1 day
+DEFAULT_MAX_SCAN_RETRIES = 5
+STALE_IN_PROGRESS_HOURS = 6  # Hours before an IN_PROGRESS manifest is considered stale
 TAG_LIMIT = 100
 
 IndexReportState = namedtuple("IndexReportState", ["Index_Finished", "Index_Error"])(  # type: ignore[call-arg]
@@ -339,7 +342,7 @@ class V4SecurityScanner(SecurityScannerInterface):
             reindex_threshold=reindex_threshold,
         )
 
-        self._index(iterator, reindex_threshold)
+        self._index(iterator, reindex_threshold, indexer_state.get("state", ""))
 
     def perform_indexing(self, start_token=None, batch_size=None):
         try:
@@ -373,11 +376,15 @@ class V4SecurityScanner(SecurityScannerInterface):
             reindex_threshold=reindex_threshold,
         )
 
-        self._index(iterator, reindex_threshold)
+        self._index(iterator, reindex_threshold, indexer_state.get("state", ""))
 
         return ScanToken(max_id + 1)
 
-    def _index(self, iterator, reindex_threshold):
+    def _index(self, iterator, reindex_threshold, current_indexer_hash):
+        max_retries = self.app.config.get(
+            "SECURITY_SCANNER_MAX_SCAN_RETRIES", DEFAULT_MAX_SCAN_RETRIES
+        )
+
         def mark_manifest_unsupported(manifest):
             with db_transaction():
                 ManifestSecurityStatus.delete().where(
@@ -408,17 +415,96 @@ class V4SecurityScanner(SecurityScannerInterface):
                     metadata_json={},
                 )
 
-        def should_skip_indexing(manifest_candidate):
-            """Check whether this manifest was preempted by another worker.
-            That would be the case if the manifest references a manifestsecuritystatus,
-            or if the reindex threshold is no longer valid.
+        def batch_preemption_check(candidate_ids):
             """
-            if getattr(manifest_candidate, "manifestsecuritystatus", None):
-                return manifest_candidate.manifestsecuritystatus.last_indexed >= reindex_threshold
+            This replaces individual should_skip_indexing() calls with a single bulk query,
+            reducing database round-trips by 50-100x per batch.
+            """
+            if not candidate_ids:
+                return set()
 
-            return len(manifest_candidate.manifestsecuritystatus_set) > 0
+            stale_in_progress_threshold = datetime.utcnow() - timedelta(
+                hours=STALE_IN_PROGRESS_HOURS
+            )
 
-        for candidate, abt, num_remaining in iterator:
+            preempted_query = ManifestSecurityStatus.select(
+                ManifestSecurityStatus.manifest_id
+            ).where(
+                ManifestSecurityStatus.manifest_id.in_(candidate_ids),
+                (
+                    (ManifestSecurityStatus.index_status == IndexStatus.IN_PROGRESS)
+                    & (ManifestSecurityStatus.last_indexed >= stale_in_progress_threshold)
+                )
+                | (
+                    (ManifestSecurityStatus.index_status != IndexStatus.IN_PROGRESS)
+                    & (ManifestSecurityStatus.last_indexed >= reindex_threshold)
+                ),
+            )
+
+            preempted_ids = {row.manifest_id for row in preempted_query}
+
+            retry_exhausted_query = ManifestSecurityStatus.select(
+                ManifestSecurityStatus.manifest_id,
+                ManifestSecurityStatus.metadata_json,
+            ).where(
+                ManifestSecurityStatus.manifest_id.in_(candidate_ids),
+                ManifestSecurityStatus.index_status == IndexStatus.FAILED,
+            )
+            exhausted_manifest_ids = []
+            for row in retry_exhausted_query:
+                metadata = row.metadata_json or {}
+                retry_count = metadata.get("retry_count", 0)
+                if metadata.get("last_failed_hash") != current_indexer_hash:
+                    retry_count = 0
+                if retry_count >= max_retries:
+                    preempted_ids.add(row.manifest_id)
+                    exhausted_manifest_ids.append(row.manifest_id)
+
+            if exhausted_manifest_ids:
+                ManifestSecurityStatus.update(
+                    index_status=IndexStatus.SCAN_RETRIES_EXHAUSTED,
+                    last_indexed=datetime.utcnow(),
+                ).where(
+                    ManifestSecurityStatus.manifest_id.in_(exhausted_manifest_ids),
+                ).execute()
+
+            return preempted_ids
+
+        def batched_iterator_with_preemption_check(iterator, batch_size=20):
+            """
+            Wrapper that collects candidates into batches and performs bulk preemption checks.
+            Yields (candidate, abt, num_remaining, should_skip) tuples.
+            """
+            batch = []
+            for item in iterator:
+                batch.append(item)
+
+                if len(batch) >= batch_size:
+                    candidate_ids = [c.id for c, _, _ in batch]
+                    preempted_ids = batch_preemption_check(candidate_ids)
+
+                    for candidate, abt, num_remaining in batch:
+                        should_skip = candidate.id in preempted_ids
+                        yield candidate, abt, num_remaining, should_skip
+
+                    batch = []
+
+            if batch:
+                candidate_ids = [c.id for c, _, _ in batch]
+                preempted_ids = batch_preemption_check(candidate_ids)
+
+                for candidate, abt, num_remaining in batch:
+                    should_skip = candidate.id in preempted_ids
+                    yield candidate, abt, num_remaining, should_skip
+
+        for candidate, abt, num_remaining, should_skip in batched_iterator_with_preemption_check(
+            iterator
+        ):
+            if should_skip:
+                logger.debug("Manifest %d preempted by another worker (batch check)", candidate.id)
+                abt.set()
+                continue
+
             manifest = ManifestDataType.for_manifest(candidate, None)
             if manifest.is_manifest_list:
                 mark_manifest_unsupported(manifest)
@@ -438,8 +524,6 @@ class V4SecurityScanner(SecurityScannerInterface):
                 mark_manifest_unsupported(manifest)
                 continue
 
-            # We need to verify that the image layers are actual container images. Since Docker v2 schema 1 images
-            # cannot be anything other than container images, for them specifically we should skip the layer check.
             if manifest.media_type not in DOCKER_SCHEMA1_CONTENT_TYPES:
                 if not _has_container_layers(layers):
                     logger.info(
@@ -453,11 +537,6 @@ class V4SecurityScanner(SecurityScannerInterface):
                     mark_manifest_unsupported(manifest)
                     continue
 
-            if should_skip_indexing(candidate):
-                logger.debug("Another worker preempted this worker")
-                abt.set()
-                continue
-
             logger.debug(
                 "Indexing manifest [%d] %s/%s@%s"
                 % (
@@ -468,13 +547,87 @@ class V4SecurityScanner(SecurityScannerInterface):
                 )
             )
 
+            stale_in_progress_threshold = datetime.utcnow() - timedelta(
+                hours=STALE_IN_PROGRESS_HOURS
+            )
+            rows_updated = (
+                ManifestSecurityStatus.update(
+                    index_status=IndexStatus.IN_PROGRESS,
+                    indexer_hash="in_progress",
+                    last_indexed=datetime.utcnow(),
+                )
+                .where(
+                    ManifestSecurityStatus.manifest == candidate,
+                    (ManifestSecurityStatus.index_status != IndexStatus.IN_PROGRESS)
+                    | (ManifestSecurityStatus.last_indexed < stale_in_progress_threshold),
+                )
+                .execute()
+            )
+
+            if rows_updated == 0:
+                try:
+                    ManifestSecurityStatus.create(
+                        manifest=candidate,
+                        repository=candidate.repository,
+                        index_status=IndexStatus.IN_PROGRESS,
+                        indexer_hash="in_progress",
+                        indexer_version=IndexerVersion.V4,
+                        metadata_json={},
+                    )
+                except IntegrityError:
+                    logger.debug("Manifest %d already claimed by another worker", candidate.id)
+                    abt.set()
+                    continue
+                except OperationalError:
+                    logger.debug("Manifest %d skipped due to lock conflict", candidate.id)
+                    continue
+
             try:
                 (report, state) = self._secscan_api.index(manifest, layers)
             except InvalidContentSent as ex:
                 mark_manifest_unsupported(manifest)
                 logger.exception("Failed to perform indexing, invalid content sent")
                 continue
+            except Non200ResponseException as ex:
+                try:
+                    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
+                    metadata = mss.metadata_json or {}
+                    if metadata.get("last_failed_hash") != current_indexer_hash:
+                        metadata["retry_count"] = 1
+                    else:
+                        metadata["retry_count"] = metadata.get("retry_count", 0) + 1
+                except ManifestSecurityStatus.DoesNotExist:
+                    metadata = {"retry_count": 1}
+                metadata["last_failed_hash"] = current_indexer_hash
+
+                ManifestSecurityStatus.update(
+                    index_status=IndexStatus.FAILED,
+                    indexer_hash="server_error",
+                    error_json={
+                        "error": "non-200 response",
+                        "status_code": ex.response.status_code,
+                    },
+                    metadata_json=metadata,
+                    last_indexed=datetime.utcnow(),
+                ).where(
+                    ManifestSecurityStatus.manifest == candidate,
+                    ManifestSecurityStatus.index_status == IndexStatus.IN_PROGRESS,
+                ).execute()
+                logger.exception(
+                    "Failed to perform indexing, security scanner returned %s",
+                    ex.response.status_code,
+                )
+                continue
             except APIRequestFailure as ex:
+                ManifestSecurityStatus.update(
+                    index_status=IndexStatus.FAILED,
+                    indexer_hash="api_failure",
+                    error_json={"error": str(ex)},
+                    last_indexed=datetime.utcnow(),
+                ).where(
+                    ManifestSecurityStatus.manifest == candidate,
+                    ManifestSecurityStatus.index_status == IndexStatus.IN_PROGRESS,
+                ).execute()
                 logger.exception("Failed to perform indexing, security scanner API error")
                 continue
             except LayerTooLargeException as ex:
@@ -572,8 +725,46 @@ class V4SecurityScanner(SecurityScannerInterface):
             elif report["state"] == IndexReportState.Index_Error:
                 index_status = IndexStatus.FAILED
             else:
-                # Unknown state don't save anything
+                try:
+                    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
+                    metadata = mss.metadata_json or {}
+                    if metadata.get("last_failed_hash") != current_indexer_hash:
+                        metadata["retry_count"] = 1
+                    else:
+                        metadata["retry_count"] = metadata.get("retry_count", 0) + 1
+                except ManifestSecurityStatus.DoesNotExist:
+                    metadata = {"retry_count": 1}
+                metadata["last_failed_hash"] = current_indexer_hash
+
+                ManifestSecurityStatus.update(
+                    index_status=IndexStatus.FAILED,
+                    indexer_hash="unknown_state",
+                    error_json={"error": "unknown_state", "state": report.get("state")},
+                    metadata_json=metadata,
+                    last_indexed=datetime.utcnow(),
+                ).where(
+                    ManifestSecurityStatus.manifest == candidate,
+                    ManifestSecurityStatus.index_status == IndexStatus.IN_PROGRESS,
+                ).execute()
+                logger.warning(
+                    "Unknown index state '%s' for manifest %d, marked as FAILED",
+                    report.get("state"),
+                    candidate.id,
+                )
                 continue
+
+            metadata = {}
+            if index_status == IndexStatus.FAILED:
+                try:
+                    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == candidate)
+                    old_metadata = mss.metadata_json or {}
+                    if old_metadata.get("last_failed_hash") != current_indexer_hash:
+                        metadata["retry_count"] = 1
+                    else:
+                        metadata["retry_count"] = old_metadata.get("retry_count", 0) + 1
+                except ManifestSecurityStatus.DoesNotExist:
+                    metadata["retry_count"] = 1
+                metadata["last_failed_hash"] = current_indexer_hash
 
             with db_transaction():
                 ManifestSecurityStatus.delete().where(
@@ -586,7 +777,7 @@ class V4SecurityScanner(SecurityScannerInterface):
                     index_status=index_status,
                     indexer_hash=state,
                     indexer_version=IndexerVersion.V4,
-                    metadata_json={},
+                    metadata_json=metadata,
                 )
 
     def lookup_notification_page(self, notification_id, page_index=None):

--- a/data/secscan_model/test/test_secscan_v4_model.py
+++ b/data/secscan_model/test/test_secscan_v4_model.py
@@ -22,7 +22,8 @@ from data.database import (
     db_transaction,
 )
 from data.registry_model import registry_model
-from data.registry_model.datatypes import ManifestLayer
+from data.registry_model.datatypes import Manifest as ManifestDataType
+from data.registry_model.datatypes import ManifestLayer, RepositoryReference
 from data.secscan_model.datatypes import (
     NVD,
     CVSSv3,
@@ -50,7 +51,7 @@ from image.docker.schema2 import (
 )
 from image.oci import OCI_IMAGE_TAR_GZIP_LAYER_CONTENT_TYPE
 from test.fixtures import *
-from util.secscan.v4.api import APIRequestFailure
+from util.secscan.v4.api import APIRequestFailure, Non200ResponseException
 
 
 @pytest.fixture()
@@ -229,8 +230,10 @@ def test_perform_indexing_whitelist(initialized_db, set_secscan_config):
 
     assert next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
 
-    assert secscan._secscan_api.index.call_count == Manifest.select().count()
-    assert ManifestSecurityStatus.select().count() == Manifest.select().count()
+    manifest_count = Manifest.select().count()
+
+    assert secscan._secscan_api.index.call_count >= manifest_count
+    assert ManifestSecurityStatus.select().count() == manifest_count
     for mss in ManifestSecurityStatus.select():
         assert mss.index_status == IndexStatus.COMPLETED
 
@@ -519,7 +522,11 @@ def test_perform_indexing_api_request_non_finished_state(initialized_db, set_sec
     secscan.perform_indexing_recent_manifests()
     next_token = secscan.perform_indexing()
     assert next_token and next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
-    assert ManifestSecurityStatus.select().count() == 0
+
+    assert ManifestSecurityStatus.select().count() > 0
+    for status in ManifestSecurityStatus.select():
+        assert status.index_status == IndexStatus.FAILED
+        assert status.indexer_hash == "unknown_state"
 
 
 def test_perform_indexing_api_request_failure_index(initialized_db, set_secscan_config):
@@ -533,7 +540,11 @@ def test_perform_indexing_api_request_failure_index(initialized_db, set_secscan_
     next_token = secscan.perform_indexing()
 
     assert next_token and next_token.min_id == Manifest.select(fn.Max(Manifest.id)).scalar() + 1
-    assert ManifestSecurityStatus.select().count() == 0
+
+    assert ManifestSecurityStatus.select().count() > 0
+    for status in ManifestSecurityStatus.select():
+        assert status.index_status == IndexStatus.FAILED
+        assert status.indexer_hash == "api_failure"
 
     # Set security scanner to return good results and attempt indexing again
     secscan._secscan_api.index.side_effect = None
@@ -1048,3 +1059,582 @@ def test_perform_indexing_schema2_manifest(initialized_db, set_secscan_config):
     secscan.perform_indexing()
     mss = ManifestSecurityStatus.get(manifest=manifest._db_id)
     assert mss.index_status == IndexStatus.COMPLETED
+
+
+def test_batch_preemption_check(initialized_db, set_secscan_config):
+    """
+    Test that batch preemption checking correctly identifies manifests that have been
+    recently indexed and should be skipped by the worker.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    reindex_threshold = datetime.utcnow() - timedelta(
+        seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"]
+    )
+
+    # Get all manifests
+    manifests = list(Manifest.select())
+    assert len(manifests) > 0
+
+    # Create security status for some manifests with different timestamps
+    # Manifests 0-2: recently indexed (should be skipped)
+    for i in range(min(3, len(manifests))):
+        ManifestSecurityStatus.create(
+            manifest=manifests[i],
+            repository=manifests[i].repository,
+            error_json={},
+            index_status=IndexStatus.COMPLETED,
+            indexer_hash="abc",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=datetime.utcnow(),  # Recent
+            metadata_json={},
+        )
+
+    # Manifests 3-5: old indexing (should be reindexed)
+    if len(manifests) > 3:
+        for i in range(3, min(6, len(manifests))):
+            ManifestSecurityStatus.create(
+                manifest=manifests[i],
+                repository=manifests[i].repository,
+                error_json={},
+                index_status=IndexStatus.COMPLETED,
+                indexer_hash="abc",
+                indexer_version=IndexerVersion.V4,
+                last_indexed=reindex_threshold - timedelta(seconds=100),  # Old
+                metadata_json={},
+            )
+
+    # Manifests 6+: not indexed at all (should be indexed)
+
+    # Test batch preemption check
+    all_manifest_ids = [m.id for m in manifests]
+    recently_indexed_ids = [manifests[i].id for i in range(min(3, len(manifests)))]
+
+    # Call the internal batch_preemption_check through _index method
+    # We'll create a simple iterator and inspect results
+    from threading import Event
+
+    def simple_iterator():
+        for m in manifests:
+            yield m, Event(), 0
+
+    # Access the batch_preemption_check function by calling _index with a mock
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+
+    # Test that recently indexed manifests are skipped
+    indexed_count = 0
+
+    # Patch the index method to count calls instead of actually indexing
+    def count_index(*args, **kwargs):
+        nonlocal indexed_count
+        indexed_count += 1
+        return ({"err": None, "state": IndexReportState.Index_Finished}, "abc")
+
+    secscan._secscan_api.index = count_index
+
+    # Run indexing
+    secscan._index(simple_iterator(), reindex_threshold, "abc")
+
+    # Verify that recently indexed manifests were skipped
+    # We expect: 3 skipped (recently indexed), rest processed
+    # Note: Some manifests may be manifest lists or invalid, so actual count may be lower
+    # The key is that indexed_count should be less than total because some were skipped
+    assert indexed_count < len(
+        manifests
+    ), f"Expected some manifests to be skipped, but indexed {indexed_count} out of {len(manifests)}"
+
+
+def test_batched_iterator_with_preemption_check(initialized_db, set_secscan_config):
+    """
+    Test the batched_iterator_with_preemption_check wrapper function that processes
+    candidates in micro-batches to reduce database queries.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    reindex_threshold = datetime.utcnow() - timedelta(
+        seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"]
+    )
+
+    # Create test manifests with different statuses
+    manifests = list(Manifest.select().limit(25))  # Get 25 manifests for testing batching
+
+    if len(manifests) < 25:
+        # Need at least 25 for proper batch testing
+        pytest.skip("Not enough manifests for batch testing")
+
+    # Mark some as recently indexed
+    for i in range(10):
+        with db_transaction():
+            ManifestSecurityStatus.delete().where(
+                ManifestSecurityStatus.manifest == manifests[i]
+            ).execute()
+            ManifestSecurityStatus.create(
+                manifest=manifests[i],
+                repository=manifests[i].repository,
+                error_json={},
+                index_status=IndexStatus.COMPLETED,
+                indexer_hash="recent",
+                indexer_version=IndexerVersion.V4,
+                last_indexed=datetime.utcnow(),  # Recent - should skip
+                metadata_json={},
+            )
+
+    # Create iterator
+    from threading import Event
+
+    def test_iterator():
+        for m in manifests:
+            yield m, Event(), len(manifests)
+
+    # Alternative: Test by running _index and verifying behavior
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "test"}
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+    secscan._secscan_api.index.return_value = (
+        {"err": None, "state": IndexReportState.Index_Finished},
+        "test",
+    )
+
+    # Count how many manifests get indexed vs skipped
+    indexed_count = 0
+    original_index_method = secscan._secscan_api.index
+
+    def counting_index(*args, **kwargs):
+        nonlocal indexed_count
+        indexed_count += 1
+        return original_index_method(*args, **kwargs)
+
+    secscan._secscan_api.index = counting_index
+
+    # Run indexing
+    secscan._index(test_iterator(), reindex_threshold, "test")
+
+    # Verify that batching worked - some manifests were skipped
+    # We marked 10 as recently indexed, so they should be skipped
+    assert indexed_count < len(
+        manifests
+    ), f"Expected some skipped, but indexed {indexed_count}/{len(manifests)}"
+
+
+def test_batch_preemption_empty_and_edge_cases(initialized_db, set_secscan_config):
+    """
+    Test edge cases for batch preemption checking: empty batches, single items, etc.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    reindex_threshold = datetime.utcnow() - timedelta(
+        seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"]
+    )
+
+    from threading import Event
+
+    # Test 1: Empty iterator
+    def empty_iterator():
+        return
+        yield  # Make it a generator
+
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "test"}
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+
+    # Should not crash with empty iterator
+    secscan._index(empty_iterator(), reindex_threshold, "test")
+
+    # Test 2: Single manifest
+    manifests = list(Manifest.select().limit(1))
+    if manifests:
+
+        def single_iterator():
+            yield manifests[0], Event(), 1
+
+        secscan._secscan_api.index.return_value = (
+            {"err": None, "state": IndexReportState.Index_Finished},
+            "test",
+        )
+        secscan._index(single_iterator(), reindex_threshold, "test")
+
+        # Verify it was processed (may be marked as unsupported if it's a manifest list)
+        assert (
+            ManifestSecurityStatus.select()
+            .where(ManifestSecurityStatus.manifest == manifests[0])
+            .count()
+            > 0
+        )
+
+
+def test_deduplicate_recent_vs_full_catalog(initialized_db, set_secscan_config):
+    """
+    Test that the deduplication mechanism prevents overlap between
+    perform_indexing_recent_manifests() and perform_indexing() operations.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+    secscan._secscan_api.state.return_value = {"state": "test"}
+    secscan._secscan_api.index.return_value = (
+        {"err": None, "state": IndexReportState.Index_Finished},
+        "test",
+    )
+
+    # Get manifest range
+    manifest_count = Manifest.select().count()
+    if manifest_count < 10:
+        pytest.skip("Not enough manifests for deduplication testing")
+
+    # Track index calls
+    index_count_before = secscan._secscan_api.index.call_count
+
+    # First, run full catalog indexing (which should store its range)
+    secscan.perform_indexing()
+    index_count_after_full = secscan._secscan_api.index.call_count
+
+    # Then run recent manifests (which should detect overlap and skip if Redis available)
+    secscan.perform_indexing_recent_manifests()
+    index_count_after_recent = secscan._secscan_api.index.call_count
+
+    # The key insight: if deduplication works, recent manifest indexing should process
+    # fewer manifests (or none) because the full catalog just covered that range
+    # If Redis is not available, there will be overlap and more manifests indexed
+    manifests_by_full = index_count_after_full - index_count_before
+    manifests_by_recent = index_count_after_recent - index_count_after_full
+
+    # Verify deduplication: recent pass should not re-index manifests already covered by full pass.
+    # With working deduplication (Redis available), manifests_by_recent should be 0 or very small.
+    # Without Redis, we expect some overlap but still fewer than the full run.
+    assert (
+        manifests_by_recent <= manifests_by_full
+    ), f"Recent pass indexed {manifests_by_recent} manifests, but full pass only indexed {manifests_by_full}"
+
+    # Ideally with Redis, recent should index nothing
+    # This is a softer check - if Redis is available, we expect perfect dedup
+    if manifests_by_recent > 0:
+        logger.warning(
+            "Deduplication not perfect: recent pass indexed %d manifests after full pass indexed %d",
+            manifests_by_recent,
+            manifests_by_full,
+        )
+
+
+def test_retry_limit_skips_exhausted_manifests(initialized_db, set_secscan_config):
+    """
+    Test that manifests with retry_count >= max_retries are skipped during indexing.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    reindex_threshold = datetime.utcnow() - timedelta(
+        seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"]
+    )
+
+    manifests = list(Manifest.select().limit(6))
+    assert len(manifests) >= 6
+
+    for i in range(3):
+        ManifestSecurityStatus.create(
+            manifest=manifests[i],
+            repository=manifests[i].repository,
+            error_json={},
+            index_status=IndexStatus.FAILED,
+            indexer_hash="abc",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=reindex_threshold - timedelta(seconds=100),
+            metadata_json={"retry_count": 5, "last_failed_hash": "abc"},
+        )
+
+    for i in range(3, 6):
+        ManifestSecurityStatus.create(
+            manifest=manifests[i],
+            repository=manifests[i].repository,
+            error_json={},
+            index_status=IndexStatus.FAILED,
+            indexer_hash="abc",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=reindex_threshold - timedelta(seconds=100),
+            metadata_json={"retry_count": 1, "last_failed_hash": "abc"},
+        )
+
+    from threading import Event
+
+    def test_iterator():
+        for m in manifests:
+            yield m, Event(), len(manifests)
+
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+    secscan._secscan_api.index.return_value = (
+        {"err": None, "state": IndexReportState.Index_Finished},
+        "abc",
+    )
+    secscan._index(test_iterator(), reindex_threshold, "abc")
+
+    exhausted_ids = {manifests[i].id for i in range(3)}
+    for mss in ManifestSecurityStatus.select().where(
+        ManifestSecurityStatus.manifest_id.in_(list(exhausted_ids))
+    ):
+        assert mss.index_status == IndexStatus.SCAN_RETRIES_EXHAUSTED
+
+    under_limit_ids = {manifests[i].id for i in range(3, 6)}
+    for mss in ManifestSecurityStatus.select().where(
+        ManifestSecurityStatus.manifest_id.in_(list(under_limit_ids))
+    ):
+        assert mss.index_status == IndexStatus.COMPLETED
+
+
+def test_connection_failure_does_not_increment_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that APIRequestFailure (connection errors, timeouts) does not increment
+    retry_count. These are transient infrastructure errors, not a verdict on the
+    manifest itself.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.index.side_effect = APIRequestFailure("connection refused")
+
+    secscan.perform_indexing(batch_size=100)
+
+    for mss in ManifestSecurityStatus.select():
+        assert mss.index_status == IndexStatus.FAILED
+        assert mss.metadata_json.get("retry_count") is None
+
+
+def test_non200_response_increments_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that Non200ResponseException (e.g. Clair 500 for corrupt layers)
+    increments retry_count, since the server processed the request and rejected
+    it — retrying the same manifest will produce the same result.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    mock_response = mock.Mock()
+    mock_response.status_code = 500
+    secscan._secscan_api.index.side_effect = Non200ResponseException(mock_response)
+
+    secscan.perform_indexing(batch_size=100)
+
+    failed_count = 0
+    for mss in ManifestSecurityStatus.select():
+        if mss.index_status == IndexStatus.FAILED:
+            assert mss.metadata_json.get("retry_count") == 1
+            assert mss.metadata_json.get("last_failed_hash") == "abc"
+            failed_count += 1
+    assert failed_count > 0, "Expected at least one FAILED manifest"
+
+
+def test_index_error_increments_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that Index_Error response increments retry_count in metadata_json.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.index.return_value = (
+        {"err": "something went wrong", "state": IndexReportState.Index_Error},
+        "abc",
+    )
+
+    secscan.perform_indexing(batch_size=100)
+
+    failed_count = 0
+    for mss in ManifestSecurityStatus.select():
+        if mss.index_status == IndexStatus.FAILED:
+            assert mss.metadata_json.get("retry_count") == 1
+            failed_count += 1
+    assert failed_count > 0, "Expected at least one FAILED manifest"
+
+
+def test_successful_indexing_resets_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that successful indexing resets metadata_json (clears retry_count).
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+    secscan._secscan_api.index.return_value = (
+        {"err": None, "state": IndexReportState.Index_Finished},
+        "abc",
+    )
+
+    for manifest in Manifest.select():
+        ManifestSecurityStatus.create(
+            manifest=manifest,
+            repository=manifest.repository,
+            error_json={},
+            index_status=IndexStatus.FAILED,
+            indexer_hash="abc",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=datetime.utcnow()
+            - timedelta(seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"] + 60),
+            metadata_json={"retry_count": 2},
+        )
+
+    secscan.perform_indexing(batch_size=100)
+
+    completed_count = 0
+    for mss in ManifestSecurityStatus.select():
+        if mss.index_status == IndexStatus.COMPLETED:
+            assert mss.metadata_json == {}
+            completed_count += 1
+    assert completed_count > 0, "Expected at least one COMPLETED manifest"
+
+
+def test_batch_preemption_reduces_queries(initialized_db, set_secscan_config):
+    """
+    Integration test verifying that batch preemption checking actually reduces
+    the number of database queries compared to individual checks.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    reindex_threshold = datetime.utcnow() - timedelta(
+        seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"]
+    )
+
+    # Create 50 manifests for a realistic batch
+    manifests = list(Manifest.select().limit(50))
+
+    if len(manifests) < 50:
+        pytest.skip("Not enough manifests for query reduction testing")
+
+    # Mark half as recently indexed
+    for i in range(25):
+        with db_transaction():
+            ManifestSecurityStatus.delete().where(
+                ManifestSecurityStatus.manifest == manifests[i]
+            ).execute()
+            ManifestSecurityStatus.create(
+                manifest=manifests[i],
+                repository=manifests[i].repository,
+                error_json={},
+                index_status=IndexStatus.COMPLETED,
+                indexer_hash="test",
+                indexer_version=IndexerVersion.V4,
+                last_indexed=datetime.utcnow(),
+                metadata_json={},
+            )
+
+    from threading import Event
+
+    def test_iterator():
+        for m in manifests:
+            yield m, Event(), len(manifests)
+
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "test"}
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+    secscan._secscan_api.index.return_value = (
+        {"err": None, "state": IndexReportState.Index_Finished},
+        "test",
+    )
+
+    secscan._index(test_iterator(), reindex_threshold, "test")
+
+    # Verify that recently indexed manifests still have original hash
+    # (they were skipped, so hash wasn't updated)
+    still_test_hash = 0
+    for i in range(25):
+        try:
+            mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == manifests[i].id)
+            if mss.indexer_hash == "test":
+                still_test_hash += 1
+        except ManifestSecurityStatus.DoesNotExist:
+            pass
+
+    # Most of the 25 recently indexed should still have "test" hash (they were skipped)
+    assert still_test_hash >= 20, f"Expected at least 20 skipped manifests, got {still_test_hash}"
+
+
+def test_unknown_state_increments_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that an unknown report state increments retry_count in metadata_json.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.state.return_value = {"state": "abc"}
+    secscan._secscan_api.index.return_value = (
+        {"err": None, "state": "SomeUnknownState"},
+        "abc",
+    )
+
+    secscan.perform_indexing(batch_size=100)
+
+    failed_count = 0
+    for mss in ManifestSecurityStatus.select():
+        if mss.index_status == IndexStatus.FAILED:
+            assert mss.metadata_json.get("retry_count") == 1
+            assert mss.metadata_json.get("last_failed_hash") == "abc"
+            failed_count += 1
+    assert failed_count > 0, "Expected at least one FAILED manifest"
+
+
+def test_last_failed_hash_resets_retry_count(initialized_db, set_secscan_config):
+    """
+    Test that retry_count resets to 1 when the indexer hash changes, allowing
+    manifests to get a fresh set of retries after a Clair update.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+    secscan._secscan_api.vulnerability_report.return_value = {"vulnerabilities": {}}
+
+    manifest = Manifest.select().first()
+
+    # Mark all manifests as COMPLETED so only our target is picked up
+    for m in Manifest.select():
+        ManifestSecurityStatus.create(
+            manifest=m,
+            repository=m.repository,
+            error_json={},
+            index_status=IndexStatus.COMPLETED,
+            indexer_hash="old_hash",
+            indexer_version=IndexerVersion.V4,
+            last_indexed=datetime.utcnow(),
+            metadata_json={},
+        )
+
+    # Override the target: COMPLETED with stale hash so it only matches
+    # needs_reindexing_query (not index_error_query which also picks up FAILED)
+    ManifestSecurityStatus.delete().where(ManifestSecurityStatus.manifest == manifest).execute()
+    ManifestSecurityStatus.create(
+        manifest=manifest,
+        repository=manifest.repository,
+        error_json={},
+        index_status=IndexStatus.COMPLETED,
+        indexer_hash="old_hash",
+        indexer_version=IndexerVersion.V4,
+        last_indexed=datetime.utcnow()
+        - timedelta(seconds=application.config["SECURITY_SCANNER_V4_REINDEX_THRESHOLD"] + 60),
+        metadata_json={"retry_count": 4, "last_failed_hash": "old_hash"},
+    )
+
+    secscan._secscan_api.state.return_value = {"state": "new_hash"}
+    secscan._secscan_api.index.return_value = (
+        {"err": "still broken", "state": IndexReportState.Index_Error},
+        "new_hash",
+    )
+
+    secscan.perform_indexing(batch_size=100)
+
+    mss = ManifestSecurityStatus.get(ManifestSecurityStatus.manifest == manifest)
+    assert mss.metadata_json.get("retry_count") == 1
+    assert mss.metadata_json.get("last_failed_hash") == "new_hash"
+
+
+def test_load_security_information_scan_retries_exhausted(initialized_db, set_secscan_config):
+    """
+    Test that load_security_information returns FAILED_TO_INDEX for manifests
+    with SCAN_RETRIES_EXHAUSTED status.
+    """
+    secscan = V4SecurityScanner(application, instance_keys, storage)
+    secscan._secscan_api = mock.Mock()
+
+    manifest = ManifestDataType.for_manifest(Manifest.select().first(), None)
+    ManifestSecurityStatus.create(
+        manifest=manifest._db_id,
+        repository=manifest.repository._db_id,
+        error_json={},
+        index_status=IndexStatus.SCAN_RETRIES_EXHAUSTED,
+        indexer_hash="abc",
+        indexer_version=IndexerVersion.V4,
+        metadata_json={"retry_count": 5, "last_failed_hash": "abc"},
+    )
+
+    result = secscan.load_security_information(manifest)
+    assert result.status == ScanLookupStatus.FAILED_TO_INDEX

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -746,6 +746,12 @@ CONFIG_SCHEMA = {
             "description": "A base64 encoded string used to sign JWT(s) on Clair V4 requests. If 'None' jwt signing will not occur.",
             "x-example": "PSK",
         },
+        "SECURITY_SCANNER_MAX_SCAN_RETRIES": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "The maximum number of scan retries per indexer hash before a manifest is skipped. Defaults to 5.",
+            "x-example": 5,
+        },
         # Repository mirroring
         "REPO_MIRROR_INTERVAL": {
             "type": "number",

--- a/util/secscan/v4/api.py
+++ b/util/secscan/v4/api.py
@@ -257,7 +257,7 @@ class ClairSecurityScannerAPI(SecurityScannerAPIInterface):
             resp = self._perform(actions["Index"](body))
         except BadRequestResponseException as ex:
             raise InvalidContentSent(ex)
-        except (Non200ResponseException, IncompatibleAPIResponse) as ex:
+        except IncompatibleAPIResponse as ex:
             raise APIRequestFailure(ex)
 
         # Required clair indexer hash.


### PR DESCRIPTION
Cherry-pick of 8fcf0c0d7. V2 scanner files and Go schema test dropped (not present on redhat-3.15). OCI manifest test dropped (depends on helper not available on this branch).