### PR TITLE
PROJQUAY-12190: fix(mirroring): use separate authfiles for same-registry mirror

### DIFF
--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -94,6 +94,13 @@ def _authfile(entries: list) -> Iterator[str]:
         yield tmp.name
 
 
+@contextmanager
+def _src_dest_authfiles(src_entries: list, dest_entries: list) -> Iterator[tuple[str, str]]:
+    """Create separate source and destination authfiles, yielding both paths."""
+    with _authfile(src_entries) as src_path, _authfile(dest_entries) as dest_path:
+        yield src_path, dest_path
+
+
 class SkopeoMirror(object):
 
     # No DB calls here: This will be called from a separate worker that has no connection except
@@ -130,13 +137,11 @@ class SkopeoMirror(object):
         logger.debug(
             "Creating mirroring job: upstream image %s, local repository %s", src_image, dest_image
         )
-        with _authfile(
-            [
-                AuthContent(_registry_netloc(src_image), src_username, src_password),
-                AuthContent(_registry_netloc(dest_image), dest_username, dest_password),
-            ]
-        ) as authfile_path:
-            args.extend(["--authfile", authfile_path])
+        with _src_dest_authfiles(
+            [AuthContent(_registry_netloc(src_image), src_username, src_password)],
+            [AuthContent(_registry_netloc(dest_image), dest_username, dest_password)],
+        ) as (src_authfile_path, dest_authfile_path):
+            args.extend(["--src-authfile", src_authfile_path, "--dest-authfile", dest_authfile_path])
             args = args + [quote(src_image), quote(dest_image)]
             return self.run_skopeo(args, proxy, timeout)
 
@@ -250,21 +255,11 @@ class SkopeoMirror(object):
             "--src-tls-verify=%s" % src_tls_verify,
             "--dest-tls-verify=%s" % dest_tls_verify,
         ]
-        with _authfile(
-            [
-                AuthContent(
-                    _registry_netloc(src_image_with_digest),
-                    src_username,
-                    src_password,
-                ),
-                AuthContent(
-                    _registry_netloc(dest_image_with_digest),
-                    dest_username,
-                    dest_password,
-                ),
-            ]
-        ) as authfile_path:
-            args.extend(["--authfile", authfile_path])
+        with _src_dest_authfiles(
+            [AuthContent(_registry_netloc(src_image_with_digest), src_username, src_password)],
+            [AuthContent(_registry_netloc(dest_image_with_digest), dest_username, dest_password)],
+        ) as (src_authfile_path, dest_authfile_path):
+            args.extend(["--src-authfile", src_authfile_path, "--dest-authfile", dest_authfile_path])
             args = args + [quote(src_image_with_digest), quote(dest_image_with_digest)]
             return self.run_skopeo(args, proxy or {}, timeout)
 

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -141,7 +141,9 @@ class SkopeoMirror(object):
             [AuthContent(_registry_netloc(src_image), src_username, src_password)],
             [AuthContent(_registry_netloc(dest_image), dest_username, dest_password)],
         ) as (src_authfile_path, dest_authfile_path):
-            args.extend(["--src-authfile", src_authfile_path, "--dest-authfile", dest_authfile_path])
+            args.extend(
+                ["--src-authfile", src_authfile_path, "--dest-authfile", dest_authfile_path]
+            )
             args = args + [quote(src_image), quote(dest_image)]
             return self.run_skopeo(args, proxy, timeout)
 
@@ -259,7 +261,9 @@ class SkopeoMirror(object):
             [AuthContent(_registry_netloc(src_image_with_digest), src_username, src_password)],
             [AuthContent(_registry_netloc(dest_image_with_digest), dest_username, dest_password)],
         ) as (src_authfile_path, dest_authfile_path):
-            args.extend(["--src-authfile", src_authfile_path, "--dest-authfile", dest_authfile_path])
+            args.extend(
+                ["--src-authfile", src_authfile_path, "--dest-authfile", dest_authfile_path]
+            )
             args = args + [quote(src_image_with_digest), quote(dest_image_with_digest)]
             return self.run_skopeo(args, proxy or {}, timeout)
 

--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import os
 
 import pytest
@@ -8,6 +9,7 @@ from util.repomirror.skopeomirror import (
     AuthContent,
     SkopeoMirror,
     _registry_netloc,
+    _src_dest_authfiles,
     create_authfile_content,
 )
 
@@ -126,3 +128,46 @@ def test_skopeo_command_tags():
     assert result.success
     assert len(result.tags) > 0
     assert result.stderr == ""
+
+
+def test_src_dest_authfiles_yields_two_distinct_paths():
+    """_src_dest_authfiles creates two independent temp files."""
+    with _src_dest_authfiles(
+        [AuthContent("src.example.com", "src_user", "src_pass")],
+        [AuthContent("dest.example.com", "dest_user", "dest_pass")],
+    ) as (src_path, dest_path):
+        assert src_path != dest_path
+        assert os.path.exists(src_path)
+        assert os.path.exists(dest_path)
+
+        with open(src_path) as f:
+            src_content = json.loads(f.read())
+        with open(dest_path) as f:
+            dest_content = json.loads(f.read())
+
+        assert "src.example.com" in src_content["auths"]
+        assert "dest.example.com" not in src_content["auths"]
+        assert "dest.example.com" in dest_content["auths"]
+        assert "src.example.com" not in dest_content["auths"]
+
+
+def test_src_dest_authfiles_same_registry_preserves_both():
+    """When source and dest are on the same registry, each authfile has its own credentials."""
+    with _src_dest_authfiles(
+        [AuthContent("quay.example.com", "src_robot", "src_pass")],
+        [AuthContent("quay.example.com", "dest_robot", "dest_pass")],
+    ) as (src_path, dest_path):
+        with open(src_path) as f:
+            src_content = json.loads(f.read())
+        with open(dest_path) as f:
+            dest_content = json.loads(f.read())
+
+        src_auth = base64.b64decode(
+            src_content["auths"]["quay.example.com"]["auth"]
+        ).decode("utf8")
+        dest_auth = base64.b64decode(
+            dest_content["auths"]["quay.example.com"]["auth"]
+        ).decode("utf8")
+
+        assert src_auth == "src_robot:src_pass"
+        assert dest_auth == "dest_robot:dest_pass"

--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -50,6 +50,25 @@ def test_create_authfile_content_empty_when_no_credentials():
     assert content == {"auths": {}}
 
 
+def test_create_authfile_content_same_registry_overwrites():
+    """Reproduce PROJQUAY-12190: when source and dest are on the same registry,
+    the dict comprehension keeps only the last entry, losing source credentials."""
+    content = create_authfile_content(
+        [
+            AuthContent("quay.example.com", "src_robot", "src_pass"),
+            AuthContent("quay.example.com", "dest_robot", "dest_pass"),
+        ]
+    )
+    auths = content["auths"]
+    # With a single shared authfile keyed by hostname, only one entry survives.
+    # This test documents the bug: two different credentials for the same host
+    # collapse into one.
+    assert len(auths) == 1
+    assert auths["quay.example.com"]["auth"] == base64.b64encode(
+        "dest_robot:dest_pass".encode("utf8")
+    ).decode("utf8")
+
+
 def test_registry_netloc_docker_transport():
     assert _registry_netloc("docker://quay.io/repo:tag") == "quay.io"
     assert _registry_netloc("docker://registry.example.com/repo:tag") == "registry.example.com"

--- a/util/test/test_skopeomirror.py
+++ b/util/test/test_skopeomirror.py
@@ -162,12 +162,10 @@ def test_src_dest_authfiles_same_registry_preserves_both():
         with open(dest_path) as f:
             dest_content = json.loads(f.read())
 
-        src_auth = base64.b64decode(
-            src_content["auths"]["quay.example.com"]["auth"]
-        ).decode("utf8")
-        dest_auth = base64.b64decode(
-            dest_content["auths"]["quay.example.com"]["auth"]
-        ).decode("utf8")
+        src_auth = base64.b64decode(src_content["auths"]["quay.example.com"]["auth"]).decode("utf8")
+        dest_auth = base64.b64decode(dest_content["auths"]["quay.example.com"]["auth"]).decode(
+            "utf8"
+        )
 
         assert src_auth == "src_robot:src_pass"
         assert dest_auth == "dest_robot:dest_pass"

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -33,18 +33,27 @@ from workers.repomirrorworker.repomirrorworker import RepoMirrorWorker
 
 
 def _assert_skopeo_args(actual_args, expected_args):
-    """Assert skopeo args match, stripping transient --authfile and legacy inline --*-creds pairs."""
+    """Assert skopeo args match, stripping transient authfile and legacy inline --*-creds pairs."""
+    auth_flags = ("--authfile", "--src-authfile", "--dest-authfile", "--src-creds", "--dest-creds", "--creds")
 
     def strip_cred_flags(args):
         a = list(args)
-        for flag in ("--authfile", "--src-creds", "--dest-creds", "--creds"):
+        for flag in auth_flags:
             while flag in a:
                 i = a.index(flag)
                 del a[i : i + 2]
         return a
 
     assert strip_cred_flags(actual_args) == strip_cred_flags(expected_args)
-    assert "--authfile" in actual_args
+
+    is_copy = "copy" in actual_args
+    if is_copy:
+        assert "--src-authfile" in actual_args, "copy commands must use --src-authfile"
+        assert "--dest-authfile" in actual_args, "copy commands must use --dest-authfile"
+        assert "--authfile" not in actual_args, "copy commands must not use shared --authfile"
+    else:
+        assert "--authfile" in actual_args, "non-copy commands must use --authfile"
+
     for legacy in ("--src-creds", "--dest-creds", "--creds"):
         assert legacy not in actual_args
 

--- a/workers/repomirrorworker/test/test_repomirrorworker.py
+++ b/workers/repomirrorworker/test/test_repomirrorworker.py
@@ -34,7 +34,14 @@ from workers.repomirrorworker.repomirrorworker import RepoMirrorWorker
 
 def _assert_skopeo_args(actual_args, expected_args):
     """Assert skopeo args match, stripping transient authfile and legacy inline --*-creds pairs."""
-    auth_flags = ("--authfile", "--src-authfile", "--dest-authfile", "--src-creds", "--dest-creds", "--creds")
+    auth_flags = (
+        "--authfile",
+        "--src-authfile",
+        "--dest-authfile",
+        "--src-creds",
+        "--dest-creds",
+        "--creds",
+    )
 
     def strip_cred_flags(args):
         a = list(args)
@@ -455,11 +462,11 @@ def test_rollback(
             _assert_skopeo_args(args, skopeo_call["args"])
             assert proxy == {}
 
-            if args[1] == "copy" and args[8].endswith(":updated"):
+            if args[1] == "copy" and args[-2].endswith(":updated"):
                 _create_tag(repo, "updated")
-            elif args[1] == "copy" and args[8].endswith(":created"):
+            elif args[1] == "copy" and args[-2].endswith(":created"):
                 _create_tag(repo, "created")
-            elif args[1] == "copy" and args[8].endswith(":zzerror"):
+            elif args[1] == "copy" and args[-2].endswith(":zzerror"):
                 _create_tag(repo, "zzerror")
 
             return skopeo_call["results"]


### PR DESCRIPTION
## Summary

- Fix repository mirroring failure when source and destination are on the same Quay registry
- Replace single `--authfile` with `--src-authfile` and `--dest-authfile` skopeo flags in `copy()` and `copy_by_digest()`
- Add `_src_dest_authfiles()` context manager that creates independent temp files per credential set

## Root Cause

PR #5813 ([PROJQUAY-7340](https://redhat.atlassian.net/browse/PROJQUAY-7340)) replaced `--src-creds`/`--dest-creds` CLI flags with a single `--authfile` to prevent credentials from appearing in process listings. The authfile uses the registry hostname as the lookup key. When both source and destination share a hostname, `create_authfile_content()` produces a dict where the destination credentials overwrite the source credentials, causing `unauthorized` errors on the source repo.

## Fix

Skopeo supports `--src-authfile` and `--dest-authfile` flags (since v1.5.0, all Quay releases ship >= 1.22.2). Each side now gets its own temp file with exactly one credential entry, making key collisions structurally impossible. Single-credential methods (`tags`, `inspect`, `inspect_raw`) are unchanged.

## Test plan

- [x] Unit test documenting the bug (`test_create_authfile_content_same_registry_overwrites`)
- [x] Unit tests for `_src_dest_authfiles()` — distinct paths and same-registry credential isolation
- [x] Updated `_assert_skopeo_args()` to validate `--src-authfile`/`--dest-authfile` for copy commands and `--authfile` for non-copy commands
- [ ] CI unit tests
- [ ] CI worker integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)