### PR TITLE
PROJQUAY-12113: fix(ui): Quay UI does not display shield icon for images signed with cosign

### DIFF
--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -283,6 +283,11 @@ jobs:
       - name: Install regctl for CLI interop tests
         uses: regclient/actions/regctl-installer@1b705e32d40851370799ea5814e83d0a5f6a70dc # v0.1.0
 
+      - name: Install cosign for Cosign v3 referrer tests
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.2
+
       - name: Run Database auth tests (React + Legacy UI)
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-results/db

--- a/data/model/oci/manifest.py
+++ b/data/model/oci/manifest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import os
 from collections import namedtuple
@@ -64,6 +65,84 @@ def is_manifest_present(manifest) -> bool:
 
 
 CreatedManifest = namedtuple("CreatedManifest", ["manifest", "newly_created", "labels_to_apply"])
+
+# Cosign / Sigstore signature artifact types stored as OCI referrers (cosign v3+).
+COSIGN_SIGNATURE_ARTIFACT_TYPES = frozenset(
+    {
+        "application/vnd.dev.sigstore.bundle.v0.3+json",
+        "application/vnd.dev.sigstore.bundle.v0.2+json",
+        "application/vnd.dev.sigstore.bundle.v0.1+json",
+        "application/vnd.dev.sigstore.bundle+json",
+        "application/vnd.dev.cosign.simplesigning.v1+json",
+    }
+)
+COSIGN_SIMPLESIGNING_ARTIFACT_TYPE = "application/vnd.dev.cosign.simplesigning.v1+json"
+SIGSTORE_BUNDLE_PREDICATE_TYPE_ANNOTATION = "dev.sigstore.bundle.predicateType"
+SIGSTORE_BUNDLE_CONTENT_ANNOTATION = "dev.sigstore.bundle.content"
+SIGSTORE_BUNDLE_CONTENT_DSSE_ENVELOPE = "dsse-envelope"
+SIGSTORE_BUNDLE_CONTENT_MESSAGE_SIGNATURE = "message-signature"
+# Cosign v3.0.x ``cosign sign --new-bundle-format`` writes a DSSE-wrapped
+# in-toto statement with this predicate, not content=message-signature.
+COSIGN_SIGN_PREDICATE_TYPE = "https://sigstore.dev/cosign/sign/v1"
+
+CosignSignature = namedtuple(
+    "CosignSignature",
+    ["manifest_digest", "artifact_type", "tag_name"],
+)
+
+
+def _is_cosign_signature_artifact_type(artifact_type):
+    if not artifact_type:
+        return False
+    if artifact_type in COSIGN_SIGNATURE_ARTIFACT_TYPES:
+        return True
+    # Forward-compatible with newer sigstore bundle media types.
+    return artifact_type.startswith("application/vnd.dev.sigstore.bundle")
+
+
+def _manifest_annotations(manifest_bytes):
+    if not manifest_bytes:
+        return {}
+    try:
+        parsed = json.loads(manifest_bytes)
+    except (TypeError, ValueError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    annotations = parsed.get("annotations") or {}
+    if not isinstance(annotations, dict):
+        return {}
+    return annotations
+
+
+def _referrer_is_image_signature(artifact_type, manifest_bytes):
+    """
+    True when a Cosign/Sigstore referrer is an image signature, not an attestation.
+
+    Cosign v3 uses the same Sigstore bundle artifact type for ``cosign sign`` and
+    ``cosign attest``. Distinguish using bundle annotations:
+
+    - ``content=message-signature``: image signature (BUNDLE_SPEC)
+    - ``predicateType=https://sigstore.dev/cosign/sign/v1``: Cosign 3.0.x
+      ``cosign sign`` (DSSE-wrapped sign statement)
+    - other ``predicateType`` / ``content=dsse-envelope``: attestations
+    """
+    if artifact_type == COSIGN_SIMPLESIGNING_ARTIFACT_TYPE:
+        return True
+    if not _is_cosign_signature_artifact_type(artifact_type):
+        return False
+
+    annotations = _manifest_annotations(manifest_bytes)
+    predicate_type = annotations.get(SIGSTORE_BUNDLE_PREDICATE_TYPE_ANNOTATION)
+    content = annotations.get(SIGSTORE_BUNDLE_CONTENT_ANNOTATION)
+
+    if predicate_type == COSIGN_SIGN_PREDICATE_TYPE:
+        return True
+    if content == SIGSTORE_BUNDLE_CONTENT_MESSAGE_SIGNATURE:
+        return True
+    if predicate_type or content == SIGSTORE_BUNDLE_CONTENT_DSSE_ENVELOPE:
+        return False
+    return True
 
 
 class CreateManifestException(Exception):
@@ -172,6 +251,90 @@ def lookup_manifest_referrers(repository_id, manifest_digest, artifact_type=None
         query = query.where(Manifest.artifact_type == artifact_type)
 
     return query
+
+
+def lookup_cosign_signatures_for_digests(repository_id, digests):
+    """
+    Batch-lookup Cosign signatures for the given image manifest digests.
+
+    Returns a dict mapping each signed image digest to a CosignSignature.
+
+    Covers:
+      - Cosign v3+: OCI referrers where Manifest.subject matches the digest and
+        artifact_type is a known Sigstore/Cosign signature type (no visible .sig tag).
+      - Cosign v2 tag schema: alive tags named ``sha256-<hex>.sig``.
+
+    Digests with no matching signature are omitted from the result. When multiple
+    signature artifacts exist for one digest, the first found is returned (referrers
+    take precedence over classic .sig tags).
+    """
+    if not digests:
+        return {}
+
+    digests = list({digest for digest in digests if digest})
+    if not digests:
+        return {}
+
+    result = {}
+
+    # Cosign v3+ / OCI 1.1 referrers (subject-based, typically hidden $temp-* tags).
+    referrers = Manifest.select(
+        Manifest.digest,
+        Manifest.subject,
+        Manifest.artifact_type,
+        Manifest.manifest_bytes,
+    ).where(
+        Manifest.repository == repository_id,
+        Manifest.subject << digests,
+    )
+
+    for referrer in referrers:
+        if not _referrer_is_image_signature(referrer.artifact_type, referrer.manifest_bytes):
+            continue
+        if referrer.subject in result:
+            continue
+        result[referrer.subject] = CosignSignature(
+            manifest_digest=referrer.digest,
+            artifact_type=referrer.artifact_type,
+            tag_name=None,
+        )
+
+    # Cosign v2 classic tag schema: sha256-<hex>.sig
+    missing = [digest for digest in digests if digest not in result]
+    if not missing:
+        return result
+
+    sig_tag_name_to_digest = {}
+    for digest in missing:
+        if not digest.startswith("sha256:"):
+            continue
+        hex_digest = digest.split(":", 1)[1]
+        sig_tag_name_to_digest["sha256-%s.sig" % hex_digest] = digest
+
+    if not sig_tag_name_to_digest:
+        return result
+
+    query = (
+        Tag.select(Tag, Manifest)
+        .join(Manifest)
+        .where(
+            Tag.repository == repository_id,
+            Tag.name << list(sig_tag_name_to_digest.keys()),
+        )
+    )
+    query = filter_to_alive_tags(query)
+
+    for tag in query:
+        subject_digest = sig_tag_name_to_digest.get(tag.name)
+        if subject_digest is None or subject_digest in result:
+            continue
+        result[subject_digest] = CosignSignature(
+            manifest_digest=tag.manifest.digest,
+            artifact_type=tag.manifest.artifact_type,
+            tag_name=tag.name,
+        )
+
+    return result
 
 
 @overload

--- a/data/model/oci/test/test_oci_manifest.py
+++ b/data/model/oci/test/test_oci_manifest.py
@@ -24,11 +24,12 @@ from data.model.oci.manifest import (
     CreateManifestException,
     connect_manifests,
     get_or_create_manifest,
+    lookup_cosign_signatures_for_digests,
     lookup_manifest,
     lookup_manifest_referrers,
 )
 from data.model.oci.retriever import RepositoryContentRetriever
-from data.model.oci.tag import filter_to_alive_tags, get_tag
+from data.model.oci.tag import filter_to_alive_tags, get_tag, retarget_tag
 from data.model.repository import create_repository, get_repository
 from data.model.storage import get_layer_path
 from digest.digest_tools import sha256_digest
@@ -781,6 +782,299 @@ def test_get_or_create_manifest_with_subject(initialized_db):
 
     referrer = referrers[0]
     assert referrer.digest == oci_manifest2.digest
+
+
+def test_lookup_cosign_signatures_for_digests_referrer(initialized_db):
+    """Cosign v3-style signatures stored as OCI referrers with a subject field."""
+    from data.database import Manifest as ManifestTable
+    from data.model.oci.manifest import COSIGN_SIGNATURE_ARTIFACT_TYPES
+
+    def generate_random_data_for_layer():
+        charset = string.ascii_uppercase + string.ascii_lowercase + string.digits
+        return "".join(random.choice(charset) for _ in range(random.randrange(1, 20)))
+
+    # _populate_blob is hardcoded to devtable/newrepo
+    repository = create_repository("devtable", "newrepo", None)
+
+    config1 = {
+        "os": "linux",
+        "architecture": "amd64",
+        "rootfs": {"type": "layers", "diff_ids": []},
+        "history": [],
+    }
+    config1_json = json.dumps(config1)
+    _, config1_digest = _populate_blob(config1_json)
+    random_data1 = generate_random_data_for_layer()
+    _, random_digest1 = _populate_blob(random_data1)
+
+    image_builder = OCIManifestBuilder()
+    image_builder.set_config_digest(config1_digest, len(config1_json.encode("utf-8")))
+    image_builder.add_layer(random_digest1, len(random_data1.encode("utf-8")))
+    image_manifest = image_builder.build()
+    created_image = get_or_create_manifest(repository, image_manifest, storage)
+    assert created_image
+
+    config2 = {
+        "os": "linux",
+        "architecture": "amd64",
+        "rootfs": {"type": "layers", "diff_ids": []},
+        "history": [],
+    }
+    config2_json = json.dumps(config2)
+    _, config2_digest = _populate_blob(config2_json)
+    random_data2 = generate_random_data_for_layer()
+    _, random_digest2 = _populate_blob(random_data2)
+
+    sig_builder = OCIManifestBuilder()
+    sig_builder.set_config_digest(config2_digest, len(config2_json.encode("utf-8")))
+    sig_builder.add_layer(random_digest2, len(random_data2.encode("utf-8")))
+    sig_builder.set_subject(
+        image_manifest.digest,
+        len(image_manifest.bytes.as_encoded_str()),
+        image_manifest.media_type,
+    )
+    sig_manifest = sig_builder.build()
+    created_sig = get_or_create_manifest(repository, sig_manifest, storage)
+    assert created_sig
+
+    artifact_type = "application/vnd.dev.sigstore.bundle.v0.3+json"
+    assert artifact_type in COSIGN_SIGNATURE_ARTIFACT_TYPES
+    ManifestTable.update(artifact_type=artifact_type).where(
+        ManifestTable.id == created_sig.manifest.id
+    ).execute()
+
+    # Unrelated referrer (non-cosign artifact type) should be ignored
+    config3 = {
+        "os": "linux",
+        "architecture": "amd64",
+        "rootfs": {"type": "layers", "diff_ids": []},
+        "history": [],
+    }
+    config3_json = json.dumps(config3)
+    _, config3_digest = _populate_blob(config3_json)
+    random_data3 = generate_random_data_for_layer()
+    _, random_digest3 = _populate_blob(random_data3)
+    other_builder = OCIManifestBuilder()
+    other_builder.set_config_digest(config3_digest, len(config3_json.encode("utf-8")))
+    other_builder.add_layer(random_digest3, len(random_data3.encode("utf-8")))
+    other_builder.set_subject(
+        image_manifest.digest,
+        len(image_manifest.bytes.as_encoded_str()),
+        image_manifest.media_type,
+    )
+    other_manifest = other_builder.build()
+    created_other = get_or_create_manifest(repository, other_manifest, storage)
+    assert created_other
+    ManifestTable.update(artifact_type="application/vnd.example.sbom+json").where(
+        ManifestTable.id == created_other.manifest.id
+    ).execute()
+
+    assert lookup_cosign_signatures_for_digests(repository.id, []) == {}
+
+    unsigned = "sha256:" + ("a" * 64)
+    assert lookup_cosign_signatures_for_digests(repository.id, [unsigned]) == {}
+
+    found = lookup_cosign_signatures_for_digests(repository.id, [image_manifest.digest, unsigned])
+    assert image_manifest.digest in found
+    assert unsigned not in found
+    signature = found[image_manifest.digest]
+    assert signature.manifest_digest == created_sig.manifest.digest
+    assert signature.artifact_type == artifact_type
+    assert signature.tag_name is None
+
+
+def test_lookup_cosign_signatures_for_digests_sig_tag(initialized_db):
+    """Cosign v2-style signatures stored as sha256-<hex>.sig tags."""
+    repository = create_repository("devtable", "newrepo", None)
+    image_manifest, _ = create_manifest_for_testing(repository, differentiation_field="img")
+    sig_manifest, _ = create_manifest_for_testing(repository, differentiation_field="sig")
+
+    hex_digest = image_manifest.digest.split(":", 1)[1]
+    sig_tag_name = "sha256-%s.sig" % hex_digest
+    retarget_tag(sig_tag_name, sig_manifest.id, is_reversion=False)
+
+    found = lookup_cosign_signatures_for_digests(repository.id, [image_manifest.digest])
+    assert image_manifest.digest in found
+    signature = found[image_manifest.digest]
+    assert signature.manifest_digest == sig_manifest.digest
+    assert signature.tag_name == sig_tag_name
+
+
+def test_lookup_cosign_signatures_for_digests_referrer_precedes_sig_tag(initialized_db):
+    """When both a referrer and a classic .sig exist, the referrer wins."""
+    from data.database import Manifest as ManifestTable
+    from data.model.oci.manifest import COSIGN_SIGNATURE_ARTIFACT_TYPES
+
+    def generate_random_data_for_layer():
+        charset = string.ascii_uppercase + string.ascii_lowercase + string.digits
+        return "".join(random.choice(charset) for _ in range(random.randrange(1, 20)))
+
+    repository = create_repository("devtable", "newrepo", None)
+    image_manifest, image_interface = create_manifest_for_testing(
+        repository, differentiation_field="img"
+    )
+    classic_sig_manifest, _ = create_manifest_for_testing(repository, differentiation_field="sig")
+
+    hex_digest = image_manifest.digest.split(":", 1)[1]
+    sig_tag_name = "sha256-%s.sig" % hex_digest
+    retarget_tag(sig_tag_name, classic_sig_manifest.id, is_reversion=False)
+
+    config_json = json.dumps(
+        {
+            "os": "linux",
+            "architecture": "amd64",
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "history": [],
+        }
+    )
+    _, config_digest = _populate_blob(config_json)
+    random_data = generate_random_data_for_layer()
+    _, random_digest = _populate_blob(random_data)
+
+    referrer_builder = OCIManifestBuilder()
+    referrer_builder.set_config_digest(config_digest, len(config_json.encode("utf-8")))
+    referrer_builder.add_layer(random_digest, len(random_data.encode("utf-8")))
+    referrer_builder.set_subject(
+        image_interface.digest,
+        len(image_interface.bytes.as_encoded_str()),
+        image_interface.media_type,
+    )
+    referrer_manifest = referrer_builder.build()
+    created_referrer = get_or_create_manifest(repository, referrer_manifest, storage)
+    assert created_referrer
+
+    artifact_type = "application/vnd.dev.sigstore.bundle.v0.3+json"
+    assert artifact_type in COSIGN_SIGNATURE_ARTIFACT_TYPES
+    ManifestTable.update(artifact_type=artifact_type).where(
+        ManifestTable.id == created_referrer.manifest.id
+    ).execute()
+
+    found = lookup_cosign_signatures_for_digests(repository.id, [image_manifest.digest])
+    assert image_manifest.digest in found
+    signature = found[image_manifest.digest]
+    assert signature.manifest_digest == created_referrer.manifest.digest
+    assert signature.artifact_type == artifact_type
+    assert signature.tag_name is None
+
+
+def _create_oci_referrer(repository, subject_manifest, annotations=None):
+    def generate_random_data_for_layer():
+        charset = string.ascii_uppercase + string.ascii_lowercase + string.digits
+        return "".join(random.choice(charset) for _ in range(random.randrange(1, 20)))
+
+    config_json = json.dumps(
+        {
+            "os": "linux",
+            "architecture": "amd64",
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "history": [],
+        }
+    )
+    _, config_digest = _populate_blob(config_json)
+    random_data = generate_random_data_for_layer()
+    _, random_digest = _populate_blob(random_data)
+
+    builder = OCIManifestBuilder()
+    builder.set_config_digest(config_digest, len(config_json.encode("utf-8")))
+    builder.add_layer(random_digest, len(random_data.encode("utf-8")))
+    builder.set_subject(
+        subject_manifest.digest,
+        len(subject_manifest.bytes.as_encoded_str()),
+        subject_manifest.media_type,
+    )
+    for key, value in (annotations or {}).items():
+        builder.add_annotation(key, value)
+    created = get_or_create_manifest(repository, builder.build(), storage)
+    assert created
+    return created
+
+
+def test_lookup_cosign_signatures_ignores_attestation_referrer(initialized_db):
+    """Cosign v3 attestations share the Sigstore bundle artifact type but are not signatures."""
+    from data.database import Manifest as ManifestTable
+    from data.model.oci.manifest import COSIGN_SIGNATURE_ARTIFACT_TYPES
+
+    repository = create_repository("devtable", "newrepo", None)
+    image_manifest, image_interface = create_manifest_for_testing(
+        repository, differentiation_field="img"
+    )
+    created_att = _create_oci_referrer(
+        repository,
+        image_interface,
+        annotations={
+            "dev.sigstore.bundle.content": "dsse-envelope",
+            "dev.sigstore.bundle.predicateType": "https://slsa.dev/provenance/v1",
+        },
+    )
+
+    artifact_type = "application/vnd.dev.sigstore.bundle.v0.3+json"
+    assert artifact_type in COSIGN_SIGNATURE_ARTIFACT_TYPES
+    ManifestTable.update(artifact_type=artifact_type).where(
+        ManifestTable.id == created_att.manifest.id
+    ).execute()
+
+    found = lookup_cosign_signatures_for_digests(repository.id, [image_manifest.digest])
+    assert found == {}
+
+
+def test_lookup_cosign_signatures_accepts_message_signature_referrer(initialized_db):
+    """Cosign v3 sign referrers use message-signature content and no predicateType."""
+    from data.database import Manifest as ManifestTable
+    from data.model.oci.manifest import COSIGN_SIGNATURE_ARTIFACT_TYPES
+
+    repository = create_repository("devtable", "newrepo", None)
+    image_manifest, image_interface = create_manifest_for_testing(
+        repository, differentiation_field="img"
+    )
+    created_sig = _create_oci_referrer(
+        repository,
+        image_interface,
+        annotations={"dev.sigstore.bundle.content": "message-signature"},
+    )
+
+    artifact_type = "application/vnd.dev.sigstore.bundle.v0.3+json"
+    assert artifact_type in COSIGN_SIGNATURE_ARTIFACT_TYPES
+    ManifestTable.update(artifact_type=artifact_type).where(
+        ManifestTable.id == created_sig.manifest.id
+    ).execute()
+
+    found = lookup_cosign_signatures_for_digests(repository.id, [image_manifest.digest])
+    assert image_manifest.digest in found
+    signature = found[image_manifest.digest]
+    assert signature.manifest_digest == created_sig.manifest.digest
+    assert signature.artifact_type == artifact_type
+    assert signature.tag_name is None
+
+
+def test_lookup_cosign_signatures_accepts_cosign_sign_dsse_referrer(initialized_db):
+    """Cosign 3.0.x sign writes DSSE with predicateType https://sigstore.dev/cosign/sign/v1."""
+    from data.database import Manifest as ManifestTable
+    from data.model.oci.manifest import COSIGN_SIGNATURE_ARTIFACT_TYPES
+
+    repository = create_repository("devtable", "newrepo", None)
+    image_manifest, image_interface = create_manifest_for_testing(
+        repository, differentiation_field="img"
+    )
+    created_sig = _create_oci_referrer(
+        repository,
+        image_interface,
+        annotations={
+            "dev.sigstore.bundle.content": "dsse-envelope",
+            "dev.sigstore.bundle.predicateType": "https://sigstore.dev/cosign/sign/v1",
+        },
+    )
+
+    artifact_type = "application/vnd.dev.sigstore.bundle.v0.3+json"
+    assert artifact_type in COSIGN_SIGNATURE_ARTIFACT_TYPES
+    ManifestTable.update(artifact_type=artifact_type).where(
+        ManifestTable.id == created_sig.manifest.id
+    ).execute()
+
+    found = lookup_cosign_signatures_for_digests(repository.id, [image_manifest.digest])
+    assert image_manifest.digest in found
+    signature = found[image_manifest.digest]
+    assert signature.manifest_digest == created_sig.manifest.digest
+    assert signature.tag_name is None
 
 
 def test_is_manifest_present_with_content(initialized_db):

--- a/endpoints/api/tag.py
+++ b/endpoints/api/tag.py
@@ -13,14 +13,19 @@ from auth.auth_context import get_authenticated_user
 from auth.permissions import AdministerRepositoryPermission
 from data.database import Manifest as ManifestTable
 from data.model import ImmutableTagException
-from data.model.oci.manifest import is_manifest_present
+from data.model.oci.manifest import (
+    is_manifest_present,
+    lookup_cosign_signatures_for_digests,
+)
 from data.model.oci.tag import RetargetTagException
 from data.model.pull_statistics import (
     get_manifest_pull_statistics,
     get_tag_pull_statistics,
 )
 from data.registry_model import registry_model
-from endpoints.api import RepositoryParamResource
+from endpoints.api import (
+    RepositoryParamResource,
+)
 from endpoints.api import abort as custom_abort
 from endpoints.api import (
     disallow_for_non_normal_repositories,
@@ -194,8 +199,20 @@ class ListRepositoryTags(RepositoryParamResource):
             print("error", error)
             custom_abort(400, message=str(error))
 
+        tag_dicts = [_tag_dict(tag) for tag in history]
+        digests = [t["manifest_digest"] for t in tag_dicts if t.get("manifest_digest")]
+        if digests:
+            signatures = lookup_cosign_signatures_for_digests(repo_ref.id, digests)
+            for tag_dict in tag_dicts:
+                signature = signatures.get(tag_dict.get("manifest_digest"))
+                if signature is None:
+                    continue
+                tag_dict["cosign_signature_manifest_digest"] = signature.manifest_digest
+                if signature.tag_name:
+                    tag_dict["cosign_signature_tag"] = signature.tag_name
+
         return {
-            "tags": [_tag_dict(tag) for tag in history],
+            "tags": tag_dicts,
             "page": page,
             "has_additional": has_more,
         }

--- a/endpoints/api/test/test_tag.py
+++ b/endpoints/api/test/test_tag.py
@@ -94,12 +94,12 @@ def test_move_tag(manifest_exists, test_tag, expected_status, app):
 @pytest.mark.parametrize(
     "repo_namespace, repo_name, query_count",
     [
-        ("devtable", "simple", 5),  # +2 for converting object to and from json
-        ("devtable", "history", 5),  # +2 for converting object to and from json
-        ("devtable", "complex", 5),  # +2 for converting object to and from json
-        ("devtable", "gargantuan", 5),  # +2 for converting object to and from json
-        ("buynlarge", "orgrepo", 5),  # +2 for permissions checks (uses UNION).
-        ("buynlarge", "anotherorgrepo", 5),  # +2 for permissions checks (uses UNION).
+        ("devtable", "simple", 7),  # +2 cosign signature lookup; +2 json convert
+        ("devtable", "history", 7),
+        ("devtable", "complex", 7),
+        ("devtable", "gargantuan", 7),
+        ("buynlarge", "orgrepo", 7),  # +2 permissions (UNION); +2 cosign
+        ("buynlarge", "anotherorgrepo", 7),
     ],
 )
 def test_list_repo_tags(repo_namespace, repo_name, query_count, app):
@@ -119,7 +119,7 @@ def test_list_repo_tags(repo_namespace, repo_name, query_count, app):
 @pytest.mark.parametrize(
     "repo_namespace, repo_name, query_count",
     [
-        ("devtable", "gargantuan", 5),  # +2 for converting object to and from json
+        ("devtable", "gargantuan", 7),
     ],
 )
 def test_list_repo_tags_filter(repo_namespace, repo_name, query_count, app):
@@ -141,6 +141,166 @@ def test_list_repo_tags_filter(repo_namespace, repo_name, query_count, app):
     with client_with_identity("devtable", app) as cl:
         params["filter_tag_name"] = "random"
         resp = conduct_api_call(cl, ListRepositoryTags, "get", params, None, expected_code=400)
+
+
+def test_list_repo_tags_includes_cosign_signature_fields(app):
+    """List tags enriches responses with cosign v2 .sig signature metadata."""
+    import json
+
+    from app import storage
+    from data.database import ImageStorageLocation
+    from data.model.blob import store_blob_record_and_temp_link
+    from data.model.oci.manifest import get_or_create_manifest
+    from data.model.oci.tag import retarget_tag
+    from data.model.repository import create_repository
+    from data.model.storage import get_layer_path
+    from digest.digest_tools import sha256_digest
+    from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
+    from util.bytes import Bytes
+
+    def populate_blob(namespace, repo_name, content):
+        content = Bytes.for_string_or_unicode(content).as_encoded_str()
+        digest = str(sha256_digest(content))
+        location = ImageStorageLocation.get(name="local_us")
+        blob = store_blob_record_and_temp_link(
+            namespace, repo_name, digest, location, len(content), 120
+        )
+        storage.put_content(["local_us"], get_layer_path(blob), content)
+        return blob, digest
+
+    def create_schema2_manifest(repository, differentiation_field):
+        layer_json = json.dumps(
+            {
+                "config": {},
+                "rootfs": {"type": "layers", "diff_ids": []},
+                "history": [],
+            }
+        )
+        _, config_digest = populate_blob(
+            repository.namespace_user.username, repository.name, layer_json
+        )
+        remote_digest = sha256_digest(b"something" + differentiation_field.encode("utf-8"))
+        builder = DockerSchema2ManifestBuilder()
+        builder.set_config_digest(config_digest, len(layer_json.encode("utf-8")))
+        builder.add_layer(remote_digest, 1234, urls=["http://hello/world" + differentiation_field])
+        manifest = builder.build()
+        created = get_or_create_manifest(repository, manifest, storage, raise_on_error=True)
+        assert created
+        return created.manifest
+
+    repository = create_repository("devtable", "cosignapitags", None)
+    image_manifest = create_schema2_manifest(repository, "img")
+    sig_manifest = create_schema2_manifest(repository, "sig")
+
+    retarget_tag("latest", image_manifest.id, is_reversion=False)
+    hex_digest = image_manifest.digest.split(":", 1)[1]
+    sig_tag_name = "sha256-%s.sig" % hex_digest
+    created_sig_tag = retarget_tag(sig_tag_name, sig_manifest.id, is_reversion=False)
+    assert created_sig_tag is not None
+
+    params = {
+        "repository": "devtable/cosignapitags",
+        "onlyActiveTags": True,
+        "specificTag": "latest",
+    }
+    with client_with_identity("devtable", app) as cl:
+        tags = conduct_api_call(cl, ListRepositoryTags, "get", params).json["tags"]
+
+    assert len(tags) == 1
+    assert tags[0]["name"] == "latest"
+    assert tags[0]["cosign_signature_tag"] == sig_tag_name
+    assert tags[0]["cosign_signature_manifest_digest"] == sig_manifest.digest
+
+
+def test_list_repo_tags_includes_cosign_referrer_fields(app):
+    """List tags enriches Cosign v3 referrer signatures without cosign_signature_tag."""
+    import json
+    import random
+    import string
+
+    from app import storage
+    from data.database import ImageStorageLocation
+    from data.database import Manifest as ManifestTable
+    from data.model.blob import store_blob_record_and_temp_link
+    from data.model.oci.manifest import (
+        COSIGN_SIGNATURE_ARTIFACT_TYPES,
+        get_or_create_manifest,
+    )
+    from data.model.oci.tag import retarget_tag
+    from data.model.repository import create_repository
+    from data.model.storage import get_layer_path
+    from digest.digest_tools import sha256_digest
+    from image.oci.manifest import OCIManifestBuilder
+    from util.bytes import Bytes
+
+    def populate_blob(namespace, repo_name, content):
+        content = Bytes.for_string_or_unicode(content).as_encoded_str()
+        digest = str(sha256_digest(content))
+        location = ImageStorageLocation.get(name="local_us")
+        blob = store_blob_record_and_temp_link(
+            namespace, repo_name, digest, location, len(content), 120
+        )
+        storage.put_content(["local_us"], get_layer_path(blob), content)
+        return blob, digest
+
+    def generate_random_data_for_layer():
+        charset = string.ascii_uppercase + string.ascii_lowercase + string.digits
+        return "".join(random.choice(charset) for _ in range(random.randrange(1, 20)))
+
+    def create_oci_manifest(repository, differentiation_field, subject=None):
+        config_json = json.dumps(
+            {
+                "os": "linux",
+                "architecture": "amd64",
+                "rootfs": {"type": "layers", "diff_ids": []},
+                "history": [],
+            }
+        )
+        _, config_digest = populate_blob(
+            repository.namespace_user.username, repository.name, config_json
+        )
+        random_data = generate_random_data_for_layer() + differentiation_field
+        _, random_digest = populate_blob(
+            repository.namespace_user.username, repository.name, random_data
+        )
+        builder = OCIManifestBuilder()
+        builder.set_config_digest(config_digest, len(config_json.encode("utf-8")))
+        builder.add_layer(random_digest, len(random_data.encode("utf-8")))
+        if subject is not None:
+            builder.set_subject(
+                subject.digest,
+                len(subject.bytes.as_encoded_str()),
+                subject.media_type,
+            )
+        manifest = builder.build()
+        created = get_or_create_manifest(repository, manifest, storage, raise_on_error=True)
+        assert created
+        return created.manifest, manifest
+
+    repository = create_repository("devtable", "cosignapireferrer", None)
+    image_manifest, image_interface = create_oci_manifest(repository, "img")
+    referrer_db, _ = create_oci_manifest(repository, "sig", subject=image_interface)
+
+    artifact_type = "application/vnd.dev.sigstore.bundle.v0.3+json"
+    assert artifact_type in COSIGN_SIGNATURE_ARTIFACT_TYPES
+    ManifestTable.update(artifact_type=artifact_type).where(
+        ManifestTable.id == referrer_db.id
+    ).execute()
+
+    retarget_tag("referrer-latest", image_manifest.id, is_reversion=False)
+
+    params = {
+        "repository": "devtable/cosignapireferrer",
+        "onlyActiveTags": True,
+        "specificTag": "referrer-latest",
+    }
+    with client_with_identity("devtable", app) as cl:
+        tags = conduct_api_call(cl, ListRepositoryTags, "get", params).json["tags"]
+
+    assert len(tags) == 1
+    assert tags[0]["name"] == "referrer-latest"
+    assert tags[0]["cosign_signature_manifest_digest"] == referrer_db.digest
+    assert tags[0].get("cosign_signature_tag") is None
 
 
 # Tag Immutability Tests

--- a/web/playwright/e2e/tags/signatures.spec.ts
+++ b/web/playwright/e2e/tags/signatures.spec.ts
@@ -1,7 +1,11 @@
-import {test, expect} from '../../fixtures';
+import {test, expect, uniqueName} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
 import {ApiClient} from '../../utils/api';
-import {pushImage} from '../../utils/container';
+import {
+  pushImage,
+  isCosignAvailable,
+  cosignSignWithKey,
+} from '../../utils/container';
 
 test.describe(
   'Tags - Show/Hide Signatures',
@@ -148,6 +152,147 @@ test.describe(
       await settingsToggle.click();
       await expect(sigMenuItem.getByRole('checkbox')).not.toBeChecked();
       await settingsToggle.click();
+    });
+
+    test(
+      'shows cosign shield for classic .sig signature tag',
+      {tag: '@PROJQUAY-12113'},
+      async ({authenticatedPage}) => {
+        await authenticatedPage.goto(
+          `/repository/${testRepo.fullName}?tab=tags`,
+        );
+
+        await expect(
+          authenticatedPage.getByRole('link', {name: 'latest'}),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByLabel('Cosign signed'),
+        ).toBeVisible();
+      },
+    );
+  },
+);
+
+test.describe(
+  'Tags - Cosign referrer shield',
+  {tag: ['@tags', '@container', '@PROJQUAY-12113']},
+  () => {
+    let testRepo: {namespace: string; name: string; fullName: string};
+
+    test.beforeAll(async ({userContext, cachedContainerAvailable}) => {
+      if (!cachedContainerAvailable) return;
+
+      const cosignAvailable = await isCosignAvailable();
+      if (!cosignAvailable) return;
+
+      const api = new ApiClient(userContext.request);
+      const repoName = uniqueName('cosign-referrer');
+      await api.createRepository(TEST_USERS.user.username, repoName, 'private');
+
+      testRepo = {
+        namespace: TEST_USERS.user.username,
+        name: repoName,
+        fullName: `${TEST_USERS.user.username}/${repoName}`,
+      };
+
+      await pushImage(
+        testRepo.namespace,
+        testRepo.name,
+        'latest',
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+
+      let digest: string | undefined;
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const tags = await api.getTags(testRepo.namespace, testRepo.name, {
+          specificTag: 'latest',
+        });
+        if (tags.tags.length > 0) {
+          digest = tags.tags[0].manifest_digest;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+      if (!digest) {
+        throw new Error('Pushed tag was not indexed after 10 attempts');
+      }
+
+      // Cosign v3 referrer: sign busybox with a generated key pair (no .sig tag)
+      await cosignSignWithKey(
+        testRepo.namespace,
+        testRepo.name,
+        digest,
+        TEST_USERS.user.username,
+        TEST_USERS.user.password,
+      );
+
+      // Wait for tags API enrichment to surface the referrer signature
+      await expect
+        .poll(
+          async () => {
+            const tags = await api.getTags(testRepo.namespace, testRepo.name, {
+              specificTag: 'latest',
+            });
+            const latest = tags.tags[0] as {
+              cosign_signature_manifest_digest?: string;
+              cosign_signature_tag?: string;
+            };
+            if (
+              latest?.cosign_signature_manifest_digest &&
+              !latest.cosign_signature_tag
+            ) {
+              return latest.cosign_signature_manifest_digest;
+            }
+            return null;
+          },
+          {
+            message:
+              'Waiting for referrer-only cosign_signature_manifest_digest (no cosign_signature_tag)',
+            timeout: 15_000,
+            intervals: [500, 1_000, 2_000],
+          },
+        )
+        .not.toBeNull();
+    });
+
+    test.afterAll(async ({userContext}) => {
+      if (!testRepo) return;
+      const api = new ApiClient(userContext.request);
+      try {
+        await api.deleteRepository(testRepo.namespace, testRepo.name);
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    test('shows cosign shield for OCI referrer signature without .sig tag', async ({
+      authenticatedPage,
+    }) => {
+      const cosignAvailable = await isCosignAvailable();
+      test.skip(!cosignAvailable, 'cosign v3 CLI required for referrer tests');
+
+      await authenticatedPage.goto(`/repository/${testRepo.fullName}?tab=tags`);
+
+      await expect(
+        authenticatedPage.getByRole('link', {name: 'latest'}),
+      ).toBeVisible();
+
+      // Show Signatures so classic .sig tags would be visible if Cosign
+      // used tag-schema storage instead of an OCI referrer.
+      const settingsToggle = authenticatedPage.locator('#tags-settings-toggle');
+      await settingsToggle.click();
+      await authenticatedPage
+        .getByRole('menuitem', {name: /Show Signatures/})
+        .click();
+      await settingsToggle.click();
+
+      await expect(
+        authenticatedPage.getByRole('link', {name: /\.sig$/}),
+      ).not.toBeAttached();
+
+      await expect(authenticatedPage.getByLabel('Cosign signed')).toBeVisible();
     });
   },
 );

--- a/web/playwright/utils/container.ts
+++ b/web/playwright/utils/container.ts
@@ -3,8 +3,8 @@
  *
  * These helpers intentionally avoid podman/docker. OpenShift CI pods can
  * block user namespaces, which makes container runtimes fail even when the
- * binaries are installed. Skopeo, crane, oras, and regctl operate directly
- * against registries and work in restricted pods.
+ * binaries are installed. Skopeo, crane, oras, regctl, and cosign operate
+ * directly against registries and work in restricted pods.
  */
 
 import {execFile, execFileSync, spawn} from 'child_process';
@@ -27,6 +27,7 @@ type ToolAvailability = {
   crane: boolean;
   oras: boolean;
   regctl: boolean;
+  cosign: boolean;
 };
 
 let toolAvailabilityPromise: Promise<ToolAvailability> | null = null;
@@ -132,11 +133,13 @@ async function detectRegistryTools(): Promise<ToolAvailability> {
       commandAvailable('crane', ['version']),
       commandAvailable('oras', ['version']),
       commandAvailable('regctl', ['version']),
-    ]).then(([skopeo, crane, oras, regctl]) => ({
+      commandAvailable('cosign', ['version']),
+    ]).then(([skopeo, crane, oras, regctl, cosign]) => ({
       skopeo,
       crane,
       oras,
       regctl,
+      cosign,
     }));
   }
   return toolAvailabilityPromise;
@@ -472,11 +475,87 @@ export async function pushOCIImage(
 }
 
 /**
+ * Sign an image digest with Cosign v3 using an ephemeral self-managed key pair.
+ *
+ * Keys are created with `cosign generate-key-pair` (see
+ * https://docs.sigstore.dev/cosign/key_management/signing_with_self-managed_keys/).
+ * Uses Cosign's new-bundle format so the signature is stored as an
+ * OCI 1.1 referrer (no classic sha256-<hex>.sig tag). Signing is offline
+ * (--use-signing-config=false --tlog-upload=false) so Rekor/TUF are not required.
+ */
+export async function cosignSignWithKey(
+  namespace: string,
+  repo: string,
+  digest: string,
+  username: string,
+  password: string,
+): Promise<void> {
+  await requireTool('cosign');
+
+  const imageRef = `${REGISTRY_HOST}/${namespace}/${repo}@${digest}`;
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'quay-cosign-'));
+  const keyPrefix = path.join(tmpDir, 'cosign');
+  const keyPath = `${keyPrefix}.key`;
+  const dockerConfigDir = path.join(tmpDir, 'docker');
+
+  try {
+    await mkdir(dockerConfigDir);
+    await writeFile(
+      path.join(dockerConfigDir, 'config.json'),
+      registryAuthConfig(username, password),
+      {mode: 0o600},
+    );
+
+    const cosignEnv = {
+      ...process.env,
+      // Empty password keeps generate-key-pair non-interactive without a
+      // committed secret. These keys exist only for this test run.
+      COSIGN_PASSWORD: '',
+      DOCKER_CONFIG: dockerConfigDir,
+    };
+
+    await execFileAsync(
+      'cosign',
+      ['generate-key-pair', `--output-key-prefix=${keyPrefix}`],
+      {env: cosignEnv},
+    );
+
+    await retryOperation(() =>
+      execFileAsync(
+        'cosign',
+        [
+          'sign',
+          '--yes',
+          '--key',
+          keyPath,
+          '--new-bundle-format=true',
+          '--use-signing-config=false',
+          '--tlog-upload=false',
+          '--allow-insecure-registry',
+          imageRef,
+        ],
+        {env: cosignEnv},
+      ).then(() => undefined),
+    );
+  } finally {
+    await rm(tmpDir, {recursive: true, force: true});
+  }
+}
+
+/**
  * Check if oras CLI is available on the system.
  */
 export async function isOrasAvailable(): Promise<boolean> {
   const tools = await detectRegistryTools();
   return tools.oras;
+}
+
+/**
+ * Check if cosign CLI is available on the system.
+ */
+export async function isCosignAvailable(): Promise<boolean> {
+  const tools = await detectRegistryTools();
+  return tools.cosign;
 }
 
 /**

--- a/web/src/libs/cosign.test.ts
+++ b/web/src/libs/cosign.test.ts
@@ -1,5 +1,9 @@
 import {Tag} from 'src/resources/TagResource';
-import {isCosignSignatureTag, enrichTagsWithCosignData} from './cosign';
+import {
+  isCosignSignatureTag,
+  isCosignSigned,
+  enrichTagsWithCosignData,
+} from './cosign';
 
 const digest =
   'sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
@@ -59,6 +63,34 @@ describe('isCosignSignatureTag', () => {
   });
 });
 
+describe('isCosignSigned', () => {
+  it('is true when signature digest is set (cosign v3 referrer)', () => {
+    expect(
+      isCosignSigned(
+        makeTag({
+          cosign_signature_manifest_digest:
+            'sha256:9999991234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is true when signature tag is set (cosign v2)', () => {
+    expect(
+      isCosignSigned(
+        makeTag({
+          cosign_signature_tag:
+            'sha256-abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890.sig',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false when neither field is set', () => {
+    expect(isCosignSigned(makeTag({}))).toBe(false);
+  });
+});
+
 describe('enrichTagsWithCosignData', () => {
   const hexDigest =
     'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
@@ -82,6 +114,25 @@ describe('enrichTagsWithCosignData', () => {
     const enriched = result.find((t) => t.name === 'latest');
     expect(enriched?.cosign_signature_tag).toBe(sigTagName);
     expect(enriched?.cosign_signature_manifest_digest).toBe(sigManifestDigest);
+  });
+
+  it('does not overwrite API-provided cosign fields', () => {
+    const apiDigest =
+      'sha256:1111111234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+    const signedTag = makeTag({
+      name: 'latest',
+      manifest_digest: signedDigest,
+      cosign_signature_manifest_digest: apiDigest,
+    });
+    const sigTag = makeTag({
+      name: sigTagName,
+      manifest_digest: sigManifestDigest,
+    });
+
+    const result = enrichTagsWithCosignData([signedTag, sigTag]);
+    const enriched = result.find((t) => t.name === 'latest');
+    expect(enriched?.cosign_signature_manifest_digest).toBe(apiDigest);
+    expect(enriched?.cosign_signature_tag).toBeUndefined();
   });
 
   it('does not enrich tags without signatures', () => {

--- a/web/src/libs/cosign.ts
+++ b/web/src/libs/cosign.ts
@@ -60,13 +60,31 @@ export function isCosignSignatureTag(tagName: string): boolean {
 }
 
 /**
+ * True when the tag is signed via cosign (v2 .sig tag and/or v3 referrer).
+ * API enrichment may set only cosign_signature_manifest_digest for v3.
+ */
+export function isCosignSigned(tag: Tag): boolean {
+  return Boolean(
+    tag.cosign_signature_manifest_digest || tag.cosign_signature_tag,
+  );
+}
+
+/**
  * Enriches tags with Cosign signature information by adding
- * cosign_signature_tag and cosign_signature_manifest_digest fields
+ * cosign_signature_tag and cosign_signature_manifest_digest fields.
+ *
+ * Prefers fields already set by the tags API (v3 referrers / v2 server-side
+ * lookup). Falls back to client-side scanning for classic `.sig` sibling tags.
  */
 export function enrichTagsWithCosignData(tags: Tag[]): Tag[] {
   const cosignedManifests = getCosignSignatures(tags);
 
   return tags.map((tag) => {
+    // Preserve API-provided cosign fields (e.g. v3 referrers with no .sig tag).
+    if (isCosignSigned(tag)) {
+      return tag;
+    }
+
     if (cosignedManifests[tag.manifest_digest]) {
       return {
         ...tag,

--- a/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
+++ b/web/src/routes/RepositoryDetails/Tags/TagsTable.tsx
@@ -41,6 +41,7 @@ import {useTagPullStatistics} from 'src/hooks/UseTags';
 import TagExpiration from './TagsTableExpiration';
 import {useManifestTracks, TrackEntry} from './useManifestTracks';
 import ManifestTrackCell from './ManifestTrackCell';
+import {isCosignSigned} from 'src/libs/cosign';
 import './Tags.css';
 
 function SubRow(props: SubRowProps) {
@@ -242,7 +243,7 @@ function TagsTableRow(props: RowProps) {
           >
             {tag.name}
           </Link>
-          {tag.cosign_signature_tag && (
+          {isCosignSigned(tag) && (
             <Tooltip content="This tag has been signed via cosign.">
               <ShieldAltIcon
                 style={{marginLeft: '8px'}}
@@ -401,7 +402,7 @@ function TagsTableRow(props: RowProps) {
             ) : isErrorPullStats ? (
               '-'
             ) : (
-              pullStatistics?.tag_pull_count ?? 0
+              (pullStatistics?.tag_pull_count ?? 0)
             )}
           </Td>
         </Conditional>
@@ -496,7 +497,7 @@ function TagsTableRow(props: RowProps) {
                   setCache={props.setLabelCache}
                 />
               </div>
-              {tag.cosign_signature_tag && (
+              {isCosignSigned(tag) && (
                 <div className="expanded-row-section">
                   <Tooltip content="Cosign Signature">
                     <ShieldAltIcon style={{marginRight: '8px'}} />
@@ -504,17 +505,26 @@ function TagsTableRow(props: RowProps) {
                   <Tooltip content="The artifact containing the cosign signature for this tag">
                     <span className="manifest-link">
                       <span className="id-label">cosign</span>{' '}
-                      <Link
-                        to={getTagDetailPath(
-                          location.pathname,
-                          props.org,
-                          props.repo,
-                          tag.cosign_signature_tag,
-                          new Map([['tab', 'layers']]),
-                        )}
-                      >
-                        {tag.cosign_signature_tag}
-                      </Link>
+                      {tag.cosign_signature_tag ? (
+                        <Link
+                          to={getTagDetailPath(
+                            location.pathname,
+                            props.org,
+                            props.repo,
+                            tag.cosign_signature_tag,
+                            new Map([['tab', 'layers']]),
+                          )}
+                        >
+                          {tag.cosign_signature_tag}
+                        </Link>
+                      ) : (
+                        <span>
+                          {tag.cosign_signature_manifest_digest.substring(
+                            'sha256:'.length,
+                            'sha256:'.length + 12,
+                          )}
+                        </span>
+                      )}
                     </span>
                   </Tooltip>
                 </div>


### PR DESCRIPTION
## Summary

Fixes missing cosign shield icons in both the legacy Angular UI and the V2 React UI for images signed with Cosign v3+.

Cosign v3 stores signatures as OCI referrers (`Manifest.subject` + Sigstore artifact types) without visible `sha256-<digest>.sig` tags. Both UIs previously detected signatures only by scanning sibling `.sig` tags client-side, so signed images never showed the shield.

This change:
- Adds server-side batch lookup of Cosign signatures (OCI referrers and classic `.sig` tags) and enriches the tags list API with `cosign_signature_manifest_digest` / `cosign_signature_tag`
- Updates Angular and React UIs to treat either field as “signed” when rendering the shield
- Preserves API-provided cosign fields in the React enricher, with client-side `.sig` scanning as a fallback
- `data/model/oci/manifest.py` — `lookup_cosign_signatures_for_digests()` for referrers + classic `.sig` tags
- `endpoints/api/tag.py` — enrich `ListRepositoryTags` responses with cosign fields
- `static/.../repo-panel-tags.{js,html}` — show shield when digest and/or tag is present
- `web/src/libs/cosign.ts` + `TagsTable.tsx` — same for V2 UI; link to `.sig` tag when available, otherwise show signature manifest digest

## Test plan
1. Open Quay UI and navigate to a repository you can push to
2. Push an image to the repository (for example with `podman push` / `docker push`)
3. Sign the image with Cosign v3 (for example `cosign sign $IMAGE`)
4. Confirm the signature with `cosign verify` (using the appropriate identity / issuer flags)
5. Reload the repository tags page in the **legacy UI** and confirm the shield icon appears next to the signed tag
6. Open the same repository in the **V2 UI** and confirm the shield icon appears next to the signed tag
7. Expand the signed tag row and confirm cosign signature details are shown
8. Confirm an unsigned tag in the same repository does **not** show a shield icon
