### PR TITLE
NO-ISSUE: chore: Remove references to old config tool deployment form the startup scripts

### DIFF
--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -64,47 +64,6 @@ def registry_services():
     }
 
 
-def config_services():
-    return {
-        "blobuploadcleanupworker": {"autostart": "false"},
-        "buildlogsarchiver": {"autostart": "false"},
-        "builder": {"autostart": "false"},
-        "chunkcleanupworker": {"autostart": "false"},
-        "expiredappspecifictokenworker": {"autostart": "false"},
-        "exportactionlogsworker": {"autostart": "false"},
-        "gcworker": {"autostart": "false"},
-        "globalpromstats": {"autostart": "false"},
-        "logrotateworker": {"autostart": "false"},
-        "namespacegcworker": {"autostart": "false"},
-        "repositorygcworker": {"autostart": "false"},
-        "notificationworker": {"autostart": "false"},
-        "queuecleanupworker": {"autostart": "false"},
-        "repositoryactioncounter": {"autostart": "false"},
-        "reconciliationworker": {"autostart": "false"},
-        "securityworker": {"autostart": "false"},
-        "storagereplication": {"autostart": "false"},
-        "teamsyncworker": {"autostart": "false"},
-        "dnsmasq": {"autostart": "false"},
-        "gunicorn-registry": {"autostart": "false"},
-        "gunicorn-secscan": {"autostart": "false"},
-        "gunicorn-web": {"autostart": "false"},
-        "ip-resolver-update-worker": {"autostart": "false"},
-        "memcache": {"autostart": "false"},
-        "nginx": {"autostart": "false"},
-        "pushgateway": {"autostart": "false"},
-        "servicekey": {"autostart": "false"},
-        "repomirrorworker": {"autostart": "false"},
-        "manifestbackfillworker": {"autostart": "false"},
-        "manifestsubjectbackfillworker": {"autostart": "false"},
-        "securityscanningnotificationworker": {"autostart": "false"},
-        "quotatotalworker": {"autostart": "false"},
-        "quotaregistrysizeworker": {"autostart": "false"},
-        "autopruneworker": {"autostart": "false"},
-        "proxycacheblobworker": {"autostart": "false"},
-        "pullstatsredisflushworker": {"autostart": "false"},
-    }
-
-
 def generate_supervisord_config(filename, config, logdriver, hotreload):
     with open(filename + ".jnj") as f:
         template = jinja2.Template(f.read())
@@ -137,10 +96,7 @@ def override_services(config, override_services):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1 and sys.argv[1] == "config":
-        config = config_services()
-    else:
-        config = registry_services()
+    config = registry_services()
     limit_services(config, QUAY_SERVICES)
     override_services(config, QUAY_OVERRIDE_SERVICES)
 

--- a/quay-entrypoint.sh
+++ b/quay-entrypoint.sh
@@ -49,31 +49,6 @@ case "$QUAYENTRY" in
         echo "Entering shell mode"
         exec /bin/bash
         ;;
-    "config")
-        echo ""; echo "Startup timestamp: "; date; echo ""
-        if [ -z "${QUAY_SERVICES}" ]; then
-            echo "Running all default config services"
-        else
-            echo "Running services ${QUAY_SERVICES}"
-        fi
-        if [ $CONFIG_APP_PASSWORD = "\"\"" ]; then
-            CONFIG_APP_PASSWORD=$2
-        fi
-        : "${CONFIG_APP_PASSWORD:?Missing password argument for configuration tool}"
-        export CONFIG_APP_PASSWORD="${CONFIG_APP_PASSWORD}"
-
-        if [ $OPERATOR_ENDPOINT = "\"\"" ]; then
-            if [ -n "$3" ]; then
-                OPERATOR_ENDPOINT=$3
-            fi
-        fi
-        export OPERATOR_ENDPOINT="${OPERATOR_ENDPOINT}"
-
-        "${QUAYPATH}/conf/init/certs_install.sh" || exit
-        "${QUAYPATH}/conf/init/client_certs.sh" || exit
-        "${QUAYPATH}/conf/init/supervisord_conf_create.sh" config || exit
-        exec supervisord -c "${QUAYCONF}/supervisord.conf" 2>&1
-        ;;
     "migrate")
         echo ""; echo "Startup timestamp: "; date; echo ""
         : "${MIGRATION_VERSION:=$2}"


### PR DESCRIPTION
While code for the deprecated config tool was removed, the startup script still referenced it, meaning it was possible to start the container with `config secret` arguments. 

This PR removes the obsolete code from the startup script and config generation script.