### PR TITLE
PROJQUAY-11682: fix(autoprune): Autopruner matching on .sig tags instead of filtering them

### DIFF
--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import re
 import uuid
 from calendar import timegm
 
@@ -42,6 +43,51 @@ from util.timedeltastring import convert_to_timedelta
 logger = logging.getLogger(__name__)
 
 GC_CANDIDATE_COUNT = 500  # repositories
+
+COSIGN_TAG_SCHEMA_PATTERN = r"^sha256-[a-f0-9]{64}\.(sig|att|sbom)$"
+COSIGN_TAG_SCHEMA_RE = re.compile(COSIGN_TAG_SCHEMA_PATTERN)
+COSIGN_TAG_SCHEMA_PREFIX = "sha256-"
+COSIGN_TAG_SCHEMA_DIGEST_LEN = 64
+COSIGN_TAG_SCHEMA_SUFFIXES = ("sig", "att", "sbom")
+
+
+def is_cosign_tag_schema(tag_name):
+    return bool(COSIGN_TAG_SCHEMA_RE.fullmatch(tag_name))
+
+
+def _lowercase_hex_digest_clause(digest_expr):
+    """True when digest_expr is exactly lowercase hexadecimal (empty after stripping hex digits)."""
+    stripped = digest_expr
+    for ch in "0123456789abcdef":
+        stripped = fn.REPLACE(stripped, ch, "")
+    return stripped == ""
+
+
+def _not_cosign_tag_schema_clause(model=Tag):
+    """
+    SQL clause matching is_cosign_tag_schema without REGEXP (SQLite-safe).
+
+    Requires sha256- prefix, exactly 64 lowercase hex digest chars, and a supported suffix.
+    Uses SUBSTR equality so prefix/suffix checks are case-sensitive (unlike LIKE).
+    Accepts a Tag model or alias so the clause can be used in subqueries.
+    """
+    prefix = COSIGN_TAG_SCHEMA_PREFIX
+    digest_len = COSIGN_TAG_SCHEMA_DIGEST_LEN
+    digest_expr = fn.SUBSTR(model.name, len(prefix) + 1, digest_len)
+    hex_digest = _lowercase_hex_digest_clause(digest_expr)
+    prefix_match = fn.SUBSTR(model.name, 1, len(prefix)) == prefix
+    suffix_clauses = []
+    for suffix in COSIGN_TAG_SCHEMA_SUFFIXES:
+        expected_len = len(prefix) + digest_len + 1 + len(suffix)
+        suffix_start = len(prefix) + digest_len + 1
+        suffix_clauses.append(
+            (fn.LENGTH(model.name) == expected_len)
+            & (fn.SUBSTR(model.name, suffix_start, 1 + len(suffix)) == f".{suffix}")
+        )
+    suffix_match = suffix_clauses[0]
+    for clause in suffix_clauses[1:]:
+        suffix_match = suffix_match | clause
+    return ~(prefix_match & hex_digest & suffix_match)
 
 
 class RetargetTagException(Exception):
@@ -489,7 +535,24 @@ def retarget_tag(
                 return None
 
             delete_tag_notifications_for_tag(existing_tag)
+            displaced_manifest = existing_tag.manifest
             Tag.update(lifetime_end_ms=now_ms).where(Tag.id == existing_tag.id).execute()
+
+            # Cascade Cosign cleanup for the displaced subject digest. Autoprune
+            # excludes Cosign-schema names, so orphans left by retarget would
+            # otherwise persist forever.
+            if (
+                displaced_manifest is not None
+                and not is_cosign_tag_schema(existing_tag.name)
+                and displaced_manifest.id != manifest.id
+            ):
+                _expire_cosign_sibling_tags(
+                    existing_tag.repository,
+                    displaced_manifest.digest,
+                    now_ms,
+                    subject_manifest=displaced_manifest,
+                    exclude_tag_id=existing_tag.id,
+                )
 
         # Check if tag should be immutable based on manifest label or policies
         immutable = False
@@ -557,6 +620,49 @@ def retarget_tag(
     return created
 
 
+def _expire_cosign_sibling_tags(
+    repository_id, manifest_digest, now_ms, *, subject_manifest=None, exclude_tag_id=None
+):
+    """
+    Expire alive, mutable Cosign tag-schema siblings for the given subject digest.
+
+    When subject_manifest is provided, the UPDATE includes a NOT EXISTS guard so
+    Cosign siblings are only expired if no other visible, non-Cosign alive tag
+    still references that manifest (excluding exclude_tag_id when set).
+    Returns the number of Cosign tags expired.
+    """
+    cosign_tag_prefix = manifest_digest.replace(":", "-")
+    cosign_names = [f"{cosign_tag_prefix}.{suffix}" for suffix in COSIGN_TAG_SCHEMA_SUFFIXES]
+    conditions = [
+        Tag.repository == repository_id,
+        Tag.name.in_(cosign_names),
+        Tag.immutable == False,
+        (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
+    ]
+    if subject_manifest is not None:
+        OtherTag = Tag.alias()
+        other_alive = OtherTag.select(1).where(
+            OtherTag.repository == repository_id,
+            OtherTag.manifest == subject_manifest,
+            OtherTag.hidden == False,
+            _not_cosign_tag_schema_clause(OtherTag),
+            (OtherTag.lifetime_end_ms >> None) | (OtherTag.lifetime_end_ms > now_ms),
+        )
+        if exclude_tag_id is not None:
+            other_alive = other_alive.where(OtherTag.id != exclude_tag_id)
+        conditions.append(~fn.EXISTS(other_alive))
+
+    updated = Tag.update(lifetime_end_ms=now_ms).where(*conditions).execute()
+    if updated > 0:
+        logger.info(
+            "Expired %s Cosign sibling tag(s) for digest %s in repository %s",
+            updated,
+            manifest_digest,
+            repository_id,
+        )
+    return updated
+
+
 def delete_tag(repository_id, tag_name):
     """
     Deletes the alive tag with the given name in the specified repository and returns the deleted
@@ -574,10 +680,7 @@ def delete_tag(repository_id, tag_name):
     return _delete_tag(tag, get_epoch_timestamp_ms())
 
 
-def _delete_tag(tag, now_ms):
-    """
-    Deletes the given tag by marking it as expired.
-    """
+def _delete_tag(tag, now_ms, expire_cosign=True):
     with db_transaction():
         # Clear pull statistics so re-pushed tags start fresh
         if features.IMAGE_PULL_STATS:
@@ -597,6 +700,16 @@ def _delete_tag(tag, now_ms):
         if updated != 1:
             return None
 
+        # clean up cosign tags derived from the deleted image digest
+        if expire_cosign and not is_cosign_tag_schema(tag.name) and tag.manifest is not None:
+            _expire_cosign_sibling_tags(
+                tag.repository,
+                tag.manifest.digest,
+                now_ms,
+                subject_manifest=tag.manifest,
+                exclude_tag_id=tag.id,
+            )
+
         reset_child_manifest_expiration(tag.repository, tag.manifest)
         return tag
 
@@ -608,20 +721,41 @@ def delete_tags_for_manifest(manifest):
     Returns the list of tags deleted.
     Raises ImmutableTagException if any tag is immutable.
     """
-    query = Tag.select().where(Tag.manifest == manifest)
-    query = filter_to_alive_tags(query)
-
-    tags = list(query)
     now_ms = get_epoch_timestamp_ms()
 
-    if features.IMMUTABLE_TAGS:
-        for tag in tags:
-            if tag.immutable:
-                raise ImmutableTagException(tag.name, "delete", tag.repository_id)
-
     with db_transaction():
+        # Read alive tags inside the transaction so a tag retargeted/created onto
+        # this manifest between an earlier read and Cosign expiry cannot be missed.
+        query = filter_to_alive_tags(Tag.select().where(Tag.manifest == manifest))
+        tags = list(query)
+
+        if features.IMMUTABLE_TAGS:
+            for tag in tags:
+                if tag.immutable:
+                    raise ImmutableTagException(tag.name, "delete", tag.repository_id)
+
         for tag in tags:
-            _delete_tag(tag, now_ms)
+            _delete_tag(tag, now_ms, expire_cosign=False)
+
+        # Expire Cosign siblings once after all aliases on this subject are removed.
+        # `manifest` may be a Manifest row or a raw manifest id (registry_model passes _db_id).
+        # Pass subject_manifest so the NOT EXISTS guard applies if any alive
+        # non-Cosign alias remains (e.g. concurrent create visible mid-transaction).
+        subject_tag = next(
+            (
+                tag
+                for tag in tags
+                if not is_cosign_tag_schema(tag.name) and tag.manifest is not None
+            ),
+            None,
+        )
+        if subject_tag is not None:
+            _expire_cosign_sibling_tags(
+                subject_tag.repository,
+                subject_tag.manifest.digest,
+                now_ms,
+                subject_manifest=subject_tag.manifest,
+            )
 
     return tags
 
@@ -993,6 +1127,7 @@ def fetch_paginated_autoprune_repo_tags_by_number(
                 (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
                 Tag.hidden == False,
                 Tag.immutable == False,
+                _not_cosign_tag_schema_clause(),
             )
             # TODO: Ignoring type error for now, but it seems order_by doesn't
             # return anything to be modified by offset. Need to investigate
@@ -1000,7 +1135,7 @@ def fetch_paginated_autoprune_repo_tags_by_number(
         )
 
         if exclude_tags and len(exclude_tags) > 0:
-            query.where(Tag.name.not_in([tag.name for tag in exclude_tags]))
+            query = query.where(Tag.name.not_in([tag.name for tag in exclude_tags]))
 
         if tag_pattern is not None:
             query = db_regex_search(
@@ -1040,6 +1175,7 @@ def fetch_paginated_autoprune_repo_tags_older_than_ms(
             (now_ms - Tag.lifetime_start_ms) > tag_lifetime_ms,
             Tag.hidden == False,
             Tag.immutable == False,
+            _not_cosign_tag_schema_clause(),
         )
         if tag_pattern is not None:
             query = db_regex_search(

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 
 import pytest
 from mock import MagicMock, patch
+from peewee import fn
 from playhouse.test_utils import assert_query_count
 
 from app import storage
@@ -13,11 +14,17 @@ from data.model import ImmutableTagException
 from data.model.blob import store_blob_record_and_temp_link
 from data.model.oci.manifest import get_or_create_manifest
 from data.model.oci.tag import (
+    _delete_tag,
+    _expire_cosign_sibling_tags,
+    _lowercase_hex_digest_clause,
+    _not_cosign_tag_schema_clause,
     change_tag_expiration,
     create_temporary_tag_if_necessary,
     create_temporary_tag_outside_timemachine,
     delete_tag,
     delete_tags_for_manifest,
+    fetch_paginated_autoprune_repo_tags_by_number,
+    fetch_paginated_autoprune_repo_tags_older_than_ms,
     filter_to_alive_tags,
     filter_to_visible_tags,
     find_matching_tag,
@@ -29,6 +36,7 @@ from data.model.oci.tag import (
     get_most_recent_tag_lifetime_start,
     get_tag,
     get_tag_by_manifest_id,
+    is_cosign_tag_schema,
     is_tag_immutable,
     list_alive_tags,
     list_repository_tag_history,
@@ -373,7 +381,7 @@ def test_delete_tag(initialized_db):
             assert get_tag(repo, tag.name) == tag
             assert tag.lifetime_end_ms is None
 
-            with assert_query_count(5):
+            with assert_query_count(6):
                 assert delete_tag(repo, tag.name) == tag
 
             assert get_tag(repo, tag.name) is None
@@ -395,7 +403,7 @@ def test_delete_tag_manifest_list(initialized_db):
             assert child_tag.name.startswith("$temp-")
             assert child_tag.lifetime_end_ms > get_epoch_timestamp_ms()
 
-        with assert_query_count(10):
+        with assert_query_count(11):
             assert delete_tag(repository.id, tag.name) == tag
 
         # Assert temporary tags pointing to child manifest are now expired
@@ -413,7 +421,7 @@ def test_delete_tags_for_manifest(initialized_db):
             repo = tag.repository
             assert get_tag(repo, tag.name) == tag
 
-            with assert_query_count(7):
+            with assert_query_count(8):
                 assert delete_tags_for_manifest(tag.manifest) == [tag]
 
             assert get_tag(repo, tag.name) is None
@@ -1273,3 +1281,486 @@ class TestRetargetTagRaceCondition:
         with pytest.raises(RetargetTagException) as exc_info:
             retarget_tag("failingtag", manifest.id, raise_on_error=True)
         assert "Repository no longer exists" in str(exc_info.value)
+
+
+def test_delete_tag_cascades_cosign_sig(initialized_db):
+    """Deleting an image tag should also expire the associated cosign .sig tag."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img1")
+        tag = retarget_tag("v1.0", manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig1")
+        sig_tag = retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert sig_tag is not None
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        delete_tag(repo.id, "v1.0")
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_delete_tag_cascades_cosign_att_sbom(initialized_db):
+    """Deleting an image tag should also expire associated .att and .sbom tags."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img2")
+        tag = retarget_tag("v2.0", manifest.id)
+        assert tag is not None
+
+        digest_prefix = manifest.digest.replace(":", "-")
+        att_name = digest_prefix + ".att"
+        sbom_name = digest_prefix + ".sbom"
+        att_manifest, _ = create_manifest_for_testing(repo, "att1")
+        retarget_tag(att_name, att_manifest.id)
+        sbom_manifest, _ = create_manifest_for_testing(repo, "sbom1")
+        retarget_tag(sbom_name, sbom_manifest.id)
+        assert get_tag(repo.id, att_name) is not None
+        assert get_tag(repo.id, sbom_name) is not None
+
+        delete_tag(repo.id, "v2.0")
+        assert get_tag(repo.id, att_name) is None
+        assert get_tag(repo.id, sbom_name) is None
+
+
+def test_delete_cosign_tag_does_not_cascade_to_image(initialized_db):
+    """Deleting a .sig tag should NOT cascade back to the image tag."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img3")
+        tag = retarget_tag("v3.0", manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig3")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        delete_tag(repo.id, cosign_tag_name)
+        assert get_tag(repo.id, "v3.0") is not None
+
+
+def test_stale_tag_delete_does_not_expire_cosign_tags(initialized_db):
+    """A stale optimistic delete must not expire Cosign sibling tags."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-stale")
+        tag = retarget_tag("v-stale", manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-stale")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        # Make the in-memory tag stale: DB row already has a different lifetime_end_ms.
+        now_ms = get_epoch_timestamp_ms()
+        Tag.update(lifetime_end_ms=now_ms - 1).where(Tag.id == tag.id).execute()
+
+        assert _delete_tag(tag, now_ms) is None
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+
+def test_delete_tag_keeps_cosign_if_other_aliases_exist(initialized_db):
+    """Cosign siblings must remain while another alive alias still references the manifest."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-alias")
+        tag1 = retarget_tag("v1.0", manifest.id)
+        tag2 = retarget_tag("latest", manifest.id)
+        assert tag1 is not None
+        assert tag2 is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-alias")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        delete_tag(repo.id, "v1.0")
+        assert get_tag(repo.id, cosign_tag_name) is not None
+        assert get_tag(repo.id, "latest") is not None
+
+        delete_tag(repo.id, "latest")
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_delete_tag_skips_immutable_cosign_sibling(initialized_db):
+    """Immutable Cosign siblings must not be expired by cascade."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        with patch(
+            "data.model.oci.tag.features", MagicMock(IMMUTABLE_TAGS=True, IMAGE_PULL_STATS=False)
+        ):
+            repo = create_repository("devtable", "newrepo", None)
+            manifest, _ = create_manifest_for_testing(repo, "img-imm")
+            tag = retarget_tag("v-imm", manifest.id)
+            assert tag is not None
+
+            cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+            sig_manifest, _ = create_manifest_for_testing(repo, "sig-imm")
+            sig_tag = retarget_tag(cosign_tag_name, sig_manifest.id)
+            assert sig_tag is not None
+            Tag.update(immutable=True).where(Tag.id == sig_tag.id).execute()
+
+            delete_tag(repo.id, "v-imm")
+            assert get_tag(repo.id, cosign_tag_name) is not None
+
+
+def test_delete_tags_for_manifest_cascades_cosign_once(initialized_db):
+    """Deleting all aliases for a manifest expires Cosign siblings once."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-mtf")
+        tag1 = retarget_tag("v1.0", manifest.id)
+        tag2 = retarget_tag("latest", manifest.id)
+        assert tag1 is not None
+        assert tag2 is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-mtf")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        deleted = delete_tags_for_manifest(manifest)
+        assert {t.name for t in deleted} == {"v1.0", "latest"}
+        assert get_tag(repo.id, "v1.0") is None
+        assert get_tag(repo.id, "latest") is None
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_expire_cosign_sibling_tags_logs_when_rows_updated(initialized_db, caplog):
+    """Cascade logs when Cosign sibling tags are expired."""
+    import logging
+
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-log")
+        tag = retarget_tag("v-log", manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-log")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        with caplog.at_level(logging.INFO, logger="data.model.oci.tag"):
+            updated = _expire_cosign_sibling_tags(
+                repo.id, manifest.digest, get_epoch_timestamp_ms()
+            )
+
+        assert updated == 1
+        assert "Expired 1 Cosign sibling tag(s)" in caplog.text
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_expire_cosign_with_subject_manifest_without_exclude_id(initialized_db):
+    """NOT EXISTS guard works when subject_manifest is set without exclude_tag_id."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-noexcl")
+        retarget_tag("v-alive", manifest.id)
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-noexcl")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        now_ms = get_epoch_timestamp_ms()
+        # Alive alias still present: Cosign siblings must be kept.
+        assert (
+            _expire_cosign_sibling_tags(repo.id, manifest.digest, now_ms, subject_manifest=manifest)
+            == 0
+        )
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        # Soft-expire the only user-facing alias, then expire Cosign without exclude_tag_id.
+        Tag.update(lifetime_end_ms=now_ms).where(
+            Tag.repository == repo.id, Tag.name == "v-alive"
+        ).execute()
+        assert (
+            _expire_cosign_sibling_tags(repo.id, manifest.digest, now_ms, subject_manifest=manifest)
+            == 1
+        )
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_expire_cosign_ignores_hidden_aliases(initialized_db):
+    """Hidden $temp-* tags must not block Cosign sibling expiration."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-hidden")
+        image_tag = retarget_tag("v-hidden", manifest.id)
+        assert image_tag is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-hidden")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        now_ms = get_epoch_timestamp_ms()
+        Tag.create(
+            name="$temp-keep-manifest",
+            repository=repo.id,
+            lifetime_start_ms=now_ms,
+            lifetime_end_ms=None,
+            reversion=False,
+            hidden=True,
+            manifest=manifest,
+            tag_kind=Tag.tag_kind.get_id("tag"),
+        )
+
+        delete_tag(repo.id, "v-hidden")
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_delete_tags_for_manifest_skips_expire_when_only_cosign_tags(initialized_db):
+    """Cosign-only tags on a manifest should not trigger subject Cosign expire."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        image_manifest, _ = create_manifest_for_testing(repo, "img-only-cosign")
+        retarget_tag("v-image", image_manifest.id)
+
+        cosign_tag_name = image_manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-only-cosign")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        # Deleting tags on the signature manifest itself: only Cosign-named tags.
+        deleted = delete_tags_for_manifest(sig_manifest)
+        assert {t.name for t in deleted} == {cosign_tag_name}
+        assert get_tag(repo.id, cosign_tag_name) is None
+        # Image tag must remain; no subject-digest Cosign cascade ran against it.
+        assert get_tag(repo.id, "v-image") is not None
+
+
+def test_delete_tags_for_manifest_keeps_cosign_if_alias_not_expired(initialized_db):
+    """If an alive alias is missed/not expired, Cosign siblings must not expire."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        manifest, _ = create_manifest_for_testing(repo, "img-missed")
+        tag1 = retarget_tag("v1.0", manifest.id)
+        tag2 = retarget_tag("keep-alive", manifest.id)
+        assert tag1 is not None
+        assert tag2 is not None
+
+        cosign_tag_name = manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-missed")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        import data.model.oci.tag as tag_module
+
+        real_delete = tag_module._delete_tag
+
+        def selective_delete(tag, now_ms, expire_cosign=True):
+            if tag.name == "keep-alive":
+                # Simulate a missed alias that stays alive through the Cosign expire call.
+                return tag
+            return real_delete(tag, now_ms, expire_cosign=False)
+
+        with patch("data.model.oci.tag._delete_tag", side_effect=selective_delete):
+            delete_tags_for_manifest(manifest)
+
+        assert get_tag(repo.id, "keep-alive") is not None
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+
+def test_retarget_tag_cascades_cosign_when_last_alias(initialized_db):
+    """Retargeting the last alias away from a manifest expires Cosign siblings."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        old_manifest, _ = create_manifest_for_testing(repo, "img-retarget-old")
+        new_manifest, _ = create_manifest_for_testing(repo, "img-retarget-new")
+        tag = retarget_tag("v1.0", old_manifest.id)
+        assert tag is not None
+
+        cosign_tag_name = old_manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-retarget")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        retarget_tag("v1.0", new_manifest.id)
+        assert get_tag(repo.id, "v1.0").manifest == new_manifest
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_retarget_tag_keeps_cosign_if_other_aliases_exist(initialized_db):
+    """Retargeting one alias must keep Cosign siblings while another alias remains."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        old_manifest, _ = create_manifest_for_testing(repo, "img-retarget-alias")
+        new_manifest, _ = create_manifest_for_testing(repo, "img-retarget-alias-new")
+        tag1 = retarget_tag("v1.0", old_manifest.id)
+        tag2 = retarget_tag("latest", old_manifest.id)
+        assert tag1 is not None
+        assert tag2 is not None
+
+        cosign_tag_name = old_manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-retarget-alias")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+
+        retarget_tag("v1.0", new_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is not None
+        assert get_tag(repo.id, "latest") is not None
+
+        retarget_tag("latest", new_manifest.id)
+        assert get_tag(repo.id, cosign_tag_name) is None
+
+
+def test_retarget_cosign_tag_does_not_cascade_as_subject(initialized_db):
+    """Retargeting a .sig tag must not treat its signature manifest as a Cosign subject."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        image_manifest, _ = create_manifest_for_testing(repo, "img-retarget-sig")
+        retarget_tag("v-image", image_manifest.id)
+
+        cosign_tag_name = image_manifest.digest.replace(":", "-") + ".sig"
+        sig_manifest, _ = create_manifest_for_testing(repo, "sig-retarget-subject")
+        retarget_tag(cosign_tag_name, sig_manifest.id)
+
+        # Sibling named after the signature digest — would be wrongly expired if
+        # retarget treated the Cosign tag's manifest as a subject digest.
+        nested_cosign_name = sig_manifest.digest.replace(":", "-") + ".sig"
+        nested_sig_manifest, _ = create_manifest_for_testing(repo, "sig-nested")
+        retarget_tag(nested_cosign_name, nested_sig_manifest.id)
+        assert get_tag(repo.id, nested_cosign_name) is not None
+
+        new_sig_manifest, _ = create_manifest_for_testing(repo, "sig-retarget-new")
+        retarget_tag(cosign_tag_name, new_sig_manifest.id)
+
+        assert get_tag(repo.id, "v-image") is not None
+        assert get_tag(repo.id, nested_cosign_name) is not None
+        assert get_tag(repo.id, cosign_tag_name).manifest == new_sig_manifest
+
+
+def test_is_cosign_tag_schema():
+    valid = "sha256-" + ("a" * 64) + ".sig"
+    assert is_cosign_tag_schema(valid)
+    assert is_cosign_tag_schema("sha256-" + ("b" * 64) + ".att")
+    assert is_cosign_tag_schema("sha256-" + ("c" * 64) + ".sbom")
+    assert not is_cosign_tag_schema("sha256-not-a-digest.sig")
+    assert not is_cosign_tag_schema("sha256-" + ("Z" * 64) + ".sig")
+    assert not is_cosign_tag_schema("SHA256-" + ("a" * 64) + ".sig")
+    assert not is_cosign_tag_schema("sha256-" + ("a" * 64) + ".SIG")
+    assert not is_cosign_tag_schema("sha256-" + ("a" * 64) + ".sig\n")
+    assert not is_cosign_tag_schema("latest")
+
+
+def test_lowercase_hex_digest_clause_builds_expression():
+    clause = _lowercase_hex_digest_clause(fn.SUBSTR(Tag.name, 8, 64))
+    assert clause is not None
+
+
+def test_not_cosign_tag_schema_clause_builds_expression(initialized_db):
+    clause = _not_cosign_tag_schema_clause()
+    assert clause is not None
+    # Alias form is used by the Cosign expire NOT EXISTS subquery.
+    assert _not_cosign_tag_schema_clause(Tag.alias()) is not None
+
+
+def test_autoprune_excludes_valid_cosign_tags(initialized_db):
+    """Valid Cosign tag-schema names are excluded from both autoprune fetchers."""
+    repo = create_repository("devtable", "newrepo", None)
+    image_manifest, _ = create_manifest_for_testing(repo, "img-ap1")
+    retarget_tag("v1", image_manifest.id)
+
+    cosign_sig = "sha256-" + ("a" * 64) + ".sig"
+    cosign_att = "sha256-" + ("b" * 64) + ".att"
+    cosign_sbom = "sha256-" + ("c" * 64) + ".sbom"
+    lookalike_short = "sha256-not-a-digest.sig"
+    lookalike_non_hex = "sha256-" + ("Z" * 64) + ".sig"
+    lookalike_upper_prefix = "SHA256-" + ("d" * 64) + ".sig"
+    lookalike_upper_suffix = "sha256-" + ("e" * 64) + ".SIG"
+    for name, blob_id in (
+        (cosign_sig, "sig-ap1"),
+        (cosign_att, "att-ap1"),
+        (cosign_sbom, "sbom-ap1"),
+        (lookalike_short, "lookalike-ap1"),
+        (lookalike_non_hex, "lookalike-nonhex-ap1"),
+        (lookalike_upper_prefix, "lookalike-upper-prefix-ap1"),
+        (lookalike_upper_suffix, "lookalike-upper-suffix-ap1"),
+    ):
+        manifest, _ = create_manifest_for_testing(repo, blob_id)
+        retarget_tag(name, manifest.id)
+
+    excluded = {cosign_sig, cosign_att, cosign_sbom}
+    included = {
+        "v1",
+        lookalike_short,
+        lookalike_non_hex,
+        lookalike_upper_prefix,
+        lookalike_upper_suffix,
+    }
+
+    # Keep 0 tags so every eligible tag is returned by the number-based fetcher.
+    by_number_names = {
+        tag.name for tag in fetch_paginated_autoprune_repo_tags_by_number(repo.id, 0, 100, 1)
+    }
+    assert included.issubset(by_number_names)
+    assert by_number_names.isdisjoint(excluded)
+
+    # Age threshold of 0 ms makes every alive tag eligible by creation date.
+    by_date_names = {
+        tag.name for tag in fetch_paginated_autoprune_repo_tags_older_than_ms(repo.id, 0, 100, 1)
+    }
+    assert included.issubset(by_date_names)
+    assert by_date_names.isdisjoint(excluded)
+
+
+def test_autoprune_by_number_exclude_tags(initialized_db):
+    """exclude_tags removes already-selected tags from the number-based fetcher."""
+    repo = create_repository("devtable", "newrepo", None)
+    m1, _ = create_manifest_for_testing(repo, "img-ex1")
+    m2, _ = create_manifest_for_testing(repo, "img-ex2")
+    t1 = retarget_tag("keep-me", m1.id)
+    retarget_tag("prune-me", m2.id)
+
+    tags = fetch_paginated_autoprune_repo_tags_by_number(repo.id, 0, 100, 1, exclude_tags=[t1])
+    names = {tag.name for tag in tags}
+    assert "keep-me" not in names
+    assert "prune-me" in names
+
+
+def test_autoprune_excludes_cosign_tags_with_pattern(initialized_db):
+    """Cosign tags stay excluded even when a tag_pattern would otherwise match them."""
+    repo = create_repository("devtable", "newrepo", None)
+    image_manifest, _ = create_manifest_for_testing(repo, "img-pat")
+    retarget_tag("sha256-image", image_manifest.id)
+
+    cosign_sig = "sha256-" + ("a" * 64) + ".sig"
+    sig_manifest, _ = create_manifest_for_testing(repo, "sig-pat")
+    retarget_tag(cosign_sig, sig_manifest.id)
+
+    by_number_names = {
+        tag.name
+        for tag in fetch_paginated_autoprune_repo_tags_by_number(
+            repo.id, 0, 100, 1, tag_pattern="sha256-.*"
+        )
+    }
+    assert "sha256-image" in by_number_names
+    assert cosign_sig not in by_number_names
+
+    by_date_names = {
+        tag.name
+        for tag in fetch_paginated_autoprune_repo_tags_older_than_ms(
+            repo.id, 0, 100, 1, tag_pattern="sha256-.*"
+        )
+    }
+    assert "sha256-image" in by_date_names
+    assert cosign_sig not in by_date_names
+
+
+def test_delete_tag_skips_cosign_cleanup_when_manifest_null(initialized_db):
+    """Tags without a manifest still expire; Cosign cascade is skipped."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", "newrepo", None)
+        now_ms = get_epoch_timestamp_ms()
+        tag = Tag.create(
+            name="no-manifest",
+            repository=repo.id,
+            lifetime_start_ms=now_ms,
+            lifetime_end_ms=None,
+            reversion=False,
+            hidden=False,
+            manifest=None,
+            tag_kind=Tag.tag_kind.get_id("tag"),
+        )
+        deleted = _delete_tag(tag, now_ms)
+        assert deleted is not None
+        refreshed = Tag.get_by_id(tag.id)
+        assert refreshed.lifetime_end_ms == now_ms

--- a/web/playwright/e2e/repository/autopruning.spec.ts
+++ b/web/playwright/e2e/repository/autopruning.spec.ts
@@ -16,7 +16,32 @@
 
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
-import {pushImage, pushMultiArchImage} from '../../utils/container';
+import {ApiClient} from '../../utils/api';
+import {
+  pushImage,
+  pushMultiArchImage,
+  pushUniqueImage,
+} from '../../utils/container';
+
+/**
+ * Creates a Cosign tag-schema `.sig` tag for an image tag
+ * (`sha256-<hex>.sig` pointing at the image digest).
+ */
+async function createCosignSigTag(
+  api: ApiClient,
+  namespace: string,
+  repo: string,
+  imageTag: string,
+): Promise<string> {
+  const tags = await api.getTags(namespace, repo, {specificTag: imageTag});
+  if (tags.tags.length === 0) {
+    throw new Error(`Tag ${imageTag} not found in ${namespace}/${repo}`);
+  }
+  const digest = tags.tags[0].manifest_digest;
+  const sigName = `${digest.replace(':', '-')}.sig`;
+  await api.createTag(namespace, repo, sigName, digest);
+  return sigName;
+}
 
 test.describe(
   'Repository Auto-Prune Policies',
@@ -717,5 +742,113 @@ test.describe(
       expect(names).toContain('v3');
       expect(names).toContain('v4');
     });
+
+    test(
+      'tag-count pruning excludes cosign .sig tags and cascades on prune',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        test.slow();
+        const org = await api.organization('prunesigcnt');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        // Unique digests so each image tag gets a distinct Cosign .sig name
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v2',
+          user.username,
+          user.password,
+        );
+
+        const sigV1 = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+        const sigV2 = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v2',
+        );
+        expect(sigV1).not.toBe(sigV2);
+
+        const tagsBefore = await api.raw.getTags(org.name, repo.name);
+        expect(tagsBefore.tags).toHaveLength(4);
+
+        await api.repoAutoPrunePolicy(org.name, repo.name, {
+          method: 'number_of_tags',
+          value: 1,
+        });
+
+        // Keep-1 only counts image tags: prune v1 (and cascade its .sig), keep v2 + .sig
+        await expect(async () => {
+          const tags = await api.raw.getTags(org.name, repo.name);
+          const names = tags.tags.map((t) => t.name);
+          expect(names).toContain('v2');
+          expect(names).toContain(sigV2);
+          expect(names).not.toContain('v1');
+          expect(names).not.toContain(sigV1);
+          expect(tags.tags).toHaveLength(2);
+        }).toPass({timeout: 120_000, intervals: [5_000]});
+      },
+    );
+
+    test(
+      'creation-date pruning does not age-prune cosign .sig tags',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        test.slow();
+        const org = await api.organization('prunesigage');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        const v1Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v1',
+        });
+        const digest = v1Tags.tags[0].manifest_digest;
+
+        // Age both tags past the upcoming 60s policy threshold
+        await new Promise((r) => setTimeout(r, 70_000));
+
+        // Refresh only the image tag so it is young; .sig stays old
+        await api.raw.createTag(org.name, repo.name, 'v1', digest);
+
+        await api.repoAutoPrunePolicy(org.name, repo.name, {
+          method: 'creation_date',
+          value: '60s',
+        });
+
+        // One prune cycle: .sig (~115s) would age-prune without exclusion;
+        // refreshed v1 (~45s) stays under the 60s threshold
+        await new Promise((r) => setTimeout(r, 45_000));
+
+        const tags = await api.raw.getTags(org.name, repo.name);
+        const names = tags.tags.map((t) => t.name);
+        expect(names).toContain('v1');
+        expect(names).toContain(sigName);
+      },
+    );
   },
 );

--- a/web/playwright/e2e/repository/repository-delete.spec.ts
+++ b/web/playwright/e2e/repository/repository-delete.spec.ts
@@ -1,5 +1,28 @@
 import {test, expect} from '../../fixtures';
+import {TEST_USERS} from '../../global-setup';
+import {ApiClient} from '../../utils/api';
 import {API_URL} from '../../utils/config';
+import {pushImage, pushUniqueImage} from '../../utils/container';
+
+/**
+ * Creates a Cosign tag-schema `.sig` tag for an image tag
+ * (`sha256-<hex>.sig` pointing at the image digest).
+ */
+async function createCosignSigTag(
+  api: ApiClient,
+  namespace: string,
+  repo: string,
+  imageTag: string,
+): Promise<string> {
+  const tags = await api.getTags(namespace, repo, {specificTag: imageTag});
+  if (tags.tags.length === 0) {
+    throw new Error(`Tag ${imageTag} not found in ${namespace}/${repo}`);
+  }
+  const digest = tags.tags[0].manifest_digest;
+  const sigName = `${digest.replace(':', '-')}.sig`;
+  await api.createTag(namespace, repo, sigName, digest);
+  return sigName;
+}
 
 test.describe('Repository Delete', {tag: ['@repository']}, () => {
   test('deletes repository via settings page and verifies removal', async ({
@@ -160,3 +183,194 @@ test.describe('Repository Delete', {tag: ['@repository']}, () => {
     await expect(deleteButton).toBeEnabled();
   });
 });
+
+test.describe(
+  'Cosign tag cascade on delete and retarget',
+  {tag: ['@repository', '@container']},
+  () => {
+    const user = TEST_USERS.user;
+
+    test(
+      'deleting subject image tag cascades to cosign .sig tag',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        const org = await api.organization('prunesigdel');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        const tagsBefore = await api.raw.getTags(org.name, repo.name);
+        expect(tagsBefore.tags.map((t) => t.name)).toEqual(
+          expect.arrayContaining(['v1', sigName]),
+        );
+
+        await api.raw.deleteTag(org.name, repo.name, 'v1');
+
+        const tagsAfter = await api.raw.getTags(org.name, repo.name);
+        const names = tagsAfter.tags.map((t) => t.name);
+        expect(names).not.toContain('v1');
+        expect(names).not.toContain(sigName);
+      },
+    );
+
+    test(
+      'deleting one alias keeps cosign .sig while another alias remains',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        const org = await api.organization('prunesigalias');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const v1Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v1',
+        });
+        const digest = v1Tags.tags[0].manifest_digest;
+        await api.raw.createTag(org.name, repo.name, 'latest', digest);
+
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        await api.raw.deleteTag(org.name, repo.name, 'v1');
+
+        let tags = await api.raw.getTags(org.name, repo.name);
+        let names = tags.tags.map((t) => t.name);
+        expect(names).toContain('latest');
+        expect(names).toContain(sigName);
+        expect(names).not.toContain('v1');
+
+        await api.raw.deleteTag(org.name, repo.name, 'latest');
+
+        tags = await api.raw.getTags(org.name, repo.name);
+        names = tags.tags.map((t) => t.name);
+        expect(names).not.toContain('latest');
+        expect(names).not.toContain(sigName);
+      },
+    );
+
+    test(
+      'retargeting last alias cascades cosign .sig for displaced digest',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        const org = await api.organization('prunesigretarget');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v2',
+          user.username,
+          user.password,
+        );
+        const v2Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v2',
+        });
+        const newDigest = v2Tags.tags[0].manifest_digest;
+
+        // Retarget v1 onto v2's digest (displaces the old subject)
+        await api.raw.createTag(org.name, repo.name, 'v1', newDigest);
+
+        const tags = await api.raw.getTags(org.name, repo.name);
+        const names = tags.tags.map((t) => t.name);
+        expect(names).toContain('v1');
+        expect(names).toContain('v2');
+        expect(names).not.toContain(sigName);
+
+        const v1After = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v1',
+        });
+        expect(v1After.tags[0].manifest_digest).toBe(newDigest);
+      },
+    );
+
+    test(
+      'retargeting one alias keeps cosign .sig while another alias remains',
+      {tag: '@PROJQUAY-11682'},
+      async ({api}) => {
+        const org = await api.organization('prunesigretkeep');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+        const v1Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v1',
+        });
+        const oldDigest = v1Tags.tags[0].manifest_digest;
+        await api.raw.createTag(org.name, repo.name, 'latest', oldDigest);
+
+        const sigName = await createCosignSigTag(
+          api.raw,
+          org.name,
+          repo.name,
+          'v1',
+        );
+
+        await pushUniqueImage(
+          org.name,
+          repo.name,
+          'v2',
+          user.username,
+          user.password,
+        );
+        const v2Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v2',
+        });
+        const newDigest = v2Tags.tags[0].manifest_digest;
+
+        // Retarget only v1; latest still references oldDigest
+        await api.raw.createTag(org.name, repo.name, 'v1', newDigest);
+
+        const tags = await api.raw.getTags(org.name, repo.name);
+        const names = tags.tags.map((t) => t.name);
+        expect(names).toContain('v1');
+        expect(names).toContain('latest');
+        expect(names).toContain(sigName);
+
+        const latestTags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'latest',
+        });
+        expect(latestTags.tags[0].manifest_digest).toBe(oldDigest);
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Summary

Cosign tag-schema signatures (`.sig` ) are ordinary tags (`hidden=false`, no OCI `subject`), so the autopruner treated them like image tags. That meant they consumed `NUMBER_OF_TAGS` slots, aged out under `CREATION_DATE`, and could leave orphans when the parent image (or the signature) was pruned.

This change:
- Excludes Cosign tag-schema names (`sha256-<digest>.{sig}`) from both autopruner fetch paths so they are not matched or counted
- Cascades Cosign tag cleanup when a non-Cosign tag is deleted
- Fixes `exclude_tags` filtering in `fetch_paginated_autoprune_repo_tags_by_number` (the `where()` result was previously discarded)

## Test plan

- Push image tags plus Cosign `.sig` tags, set a keep-N policy, run autopruner, and confirm Cosign tags are not counted or pruned
- Create old Cosign tags past a creation-date policy threshold, run autopruner, and confirm they are not pruned by age
- Delete an image tag and confirm its matching Cosign `.sig` tags are also removed
- Confirm normal non-Cosign tags still prune correctly under both policy types