### PR TITLE
PROJQUAY-12123: chore(deps): override brace-expansion to address CVE-2026-13149

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1045,9 +1045,9 @@
       "integrity": "sha1-/3+Jj7h9RSflR/62QVj4hFDRoMk="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12680,9 +12680,9 @@
       "integrity": "sha1-/3+Jj7h9RSflR/62QVj4hFDRoMk="
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -17095,7 +17095,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^1.1.16"
       }
     },
     "minimist": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "overrides": {
     "cross-spawn": "^6.0.6",
     "qs": "^6.14.0",
-    "form-data": "^2.5.6"
+    "form-data": "^2.5.6",
+    "brace-expansion": "^1.1.16"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8053,9 +8053,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -11945,15 +11945,6 @@
         "minimatch": "^5.0.1"
       }
     },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/filelist/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -11964,6 +11955,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/filesize": {

--- a/web/package.json
+++ b/web/package.json
@@ -131,6 +131,7 @@
     },
     "immutable": "^5.1.5",
     "svgo": "4.0.1",
-    "fast-uri": "3.1.3"
+    "fast-uri": "3.1.3",
+    "brace-expansion": "^1.1.16"
   }
 }


### PR DESCRIPTION
Added Override for  brace-expansion to address CVE-2026-13149 

Affected Versions

  ┌────────────────┬───────────────┐
  │ Affected Range │ Fixed Version │
  ├────────────────┼───────────────┤
  │ <= 1.1.15      │ 1.1.16+       │
  ├────────────────┼───────────────┤
  │ 2.0.0 – 2.1.1  │ 2.1.2+        │
  ├────────────────┼───────────────┤
  │ 3.0.0 – 5.0.6  │ 5.0.7+        │
  └────────────────┴───────────────┘