### PR TITLE
PROJQUAY-12396: fix(autoprune): Cosign V3 signature temporary Tags are not getting Garbage Collected 

### DIFF
--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -714,7 +714,10 @@ def delete_tag(repository_id, tag_name):
     if features.IMMUTABLE_TAGS and tag.immutable:
         raise ImmutableTagException(tag_name, "delete", repository_id)
 
-    return _delete_tag(tag, get_epoch_timestamp_ms())
+    deleted = _delete_tag(tag, get_epoch_timestamp_ms())
+    if deleted is not None:
+        reset_referrer_manifest_expiration(deleted.repository, deleted.manifest)
+    return deleted
 
 
 def _delete_tag(tag, now_ms, expire_cosign=True):
@@ -793,6 +796,9 @@ def delete_tags_for_manifest(manifest):
                 now_ms,
                 subject_manifest=subject_tag.manifest,
             )
+
+    if tags:
+        reset_referrer_manifest_expiration(tags[0].repository, tags[0].manifest)
 
     return tags
 
@@ -1120,7 +1126,55 @@ def remove_tag_from_timemachine(
     if updated and include_submanifests:
         reset_child_manifest_expiration(repo_id, manifest_id, now_ms - time_machine_ms)
 
+    if updated:
+        reset_referrer_manifest_expiration(repo_id, manifest_id, now_ms - time_machine_ms)
+
     return updated
+
+
+def reset_referrer_manifest_expiration(repository_id, manifest, expiration=None):
+    """
+    Expires $temp-* hidden tags on referrer manifests whose subject
+    is the given manifest's digest, allowing GC to reclaim them.
+    Only acts when the subject manifest has no remaining live, visible tags.
+    """
+    now_ms = get_epoch_timestamp_ms()
+    expiry_ms = now_ms if expiration is None else expiration
+
+    try:
+        manifest_digest = manifest.digest
+    except AttributeError:
+        manifest_digest = Manifest.select(Manifest.digest).where(Manifest.id == manifest).scalar()
+        if manifest_digest is None:
+            return
+
+    # Materialize referrer IDs to avoid IN (SELECT...) in UPDATE,
+    # which triggers the transitive-modification guard in GC tests.
+    referrer_ids = [
+        row.id
+        for row in Manifest.select(Manifest.id).where(
+            Manifest.repository == repository_id,
+            Manifest.subject == manifest_digest,
+        )
+    ]
+    if not referrer_ids:
+        return
+
+    live_tags_subquery = Tag.select(Tag.id).where(
+        Tag.repository == repository_id,
+        Tag.manifest == manifest,
+        Tag.hidden == False,
+        (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
+    )
+
+    Tag.update(lifetime_end_ms=expiry_ms).where(
+        Tag.repository == repository_id,
+        Tag.manifest.in_(referrer_ids),
+        Tag.name.startswith("$temp-"),
+        Tag.hidden == True,
+        (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > expiry_ms),
+        ~fn.EXISTS(live_tags_subquery),
+    ).execute()
 
 
 def reset_child_manifest_expiration(repository_id, manifest, expiration=None):

--- a/data/model/oci/tag.py
+++ b/data/model/oci/tag.py
@@ -1137,9 +1137,15 @@ def reset_referrer_manifest_expiration(repository_id, manifest, expiration=None)
     Expires $temp-* hidden tags on referrer manifests whose subject
     is the given manifest's digest, allowing GC to reclaim them.
     Only acts when the subject manifest has no remaining live, visible tags.
+
+    Must use the same ("retarget_tag", repository_id) advisory lock as retarget_tag
+    so the NOT EXISTS check cannot race with a concurrent push that creates a new
+    alive alias on this manifest. Re-acquiring from a caller that already holds
+    the lock is safe (pg_advisory_xact_lock is re-entrant within a transaction).
     """
     now_ms = get_epoch_timestamp_ms()
     expiry_ms = now_ms if expiration is None else expiration
+    repo_id = getattr(repository_id, "id", repository_id)
 
     try:
         manifest_digest = manifest.digest
@@ -1148,33 +1154,38 @@ def reset_referrer_manifest_expiration(repository_id, manifest, expiration=None)
         if manifest_digest is None:
             return
 
-    # Materialize referrer IDs to avoid IN (SELECT...) in UPDATE,
-    # which triggers the transitive-modification guard in GC tests.
-    referrer_ids = [
-        row.id
-        for row in Manifest.select(Manifest.id).where(
-            Manifest.repository == repository_id,
-            Manifest.subject == manifest_digest,
+    with db_transaction():
+        # Serialize with retarget_tag: same namespace+key closes the check-then-act race.
+        lock_id = compute_advisory_lock_id("retarget_tag", repo_id)
+        db_advisory_xact_lock(lock_id)
+
+        # Materialize referrer IDs to avoid IN (SELECT...) in UPDATE,
+        # which triggers the transitive-modification guard in GC tests.
+        referrer_ids = [
+            row.id
+            for row in Manifest.select(Manifest.id).where(
+                Manifest.repository == repo_id,
+                Manifest.subject == manifest_digest,
+            )
+        ]
+        if not referrer_ids:
+            return
+
+        live_tags_subquery = Tag.select(Tag.id).where(
+            Tag.repository == repo_id,
+            Tag.manifest == manifest,
+            Tag.hidden == False,
+            (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
         )
-    ]
-    if not referrer_ids:
-        return
 
-    live_tags_subquery = Tag.select(Tag.id).where(
-        Tag.repository == repository_id,
-        Tag.manifest == manifest,
-        Tag.hidden == False,
-        (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > now_ms),
-    )
-
-    Tag.update(lifetime_end_ms=expiry_ms).where(
-        Tag.repository == repository_id,
-        Tag.manifest.in_(referrer_ids),
-        Tag.name.startswith("$temp-"),
-        Tag.hidden == True,
-        (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > expiry_ms),
-        ~fn.EXISTS(live_tags_subquery),
-    ).execute()
+        Tag.update(lifetime_end_ms=expiry_ms).where(
+            Tag.repository == repo_id,
+            Tag.manifest.in_(referrer_ids),
+            Tag.name.startswith("$temp-"),
+            Tag.hidden == True,
+            (Tag.lifetime_end_ms >> None) | (Tag.lifetime_end_ms > expiry_ms),
+            ~fn.EXISTS(live_tags_subquery),
+        ).execute()
 
 
 def reset_child_manifest_expiration(repository_id, manifest, expiration=None):

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -12,7 +12,15 @@ from playhouse.test_utils import assert_query_count
 
 from app import storage
 from data import model
-from data.database import ImageStorageLocation, ManifestChild, Repository, Tag, User, db
+from data.database import (
+    ImageStorageLocation,
+    Manifest,
+    ManifestChild,
+    Repository,
+    Tag,
+    User,
+    db,
+)
 from data.model import ImmutableTagException
 from data.model.blob import (
     store_blob_record_and_temp_link,
@@ -1953,3 +1961,117 @@ def test_cascade_serialized_with_concurrent_retarget(initialized_db):
             if repo_to_purge is not None:
                 model.gc.purge_repository(repo_to_purge, force=True)
             db.commit()
+
+
+def test_remove_tag_from_timemachine_expires_referrer_temp_tags(initialized_db):
+    """Permanently deleting the final visible subject tag via time-machine
+    removal should expire its referrer's $temp-* tag."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": True}):
+        repo = create_repository("devtable", "newrepo", None)
+        subject_manifest, _ = create_manifest_for_testing(repo, "tm_subject")
+        tag = retarget_tag("v1.0", subject_manifest.id)
+        assert tag is not None
+
+        referrer_manifest, _ = create_manifest_for_testing(repo, "tm_referrer")
+        Manifest.update(subject=subject_manifest.digest).where(
+            Manifest.id == referrer_manifest.id
+        ).execute()
+
+        temp_tag = create_temporary_tag_if_necessary(referrer_manifest, 300, skip_expiration=True)
+        assert temp_tag is not None
+        assert temp_tag.lifetime_end_ms is None
+
+        delete_tag(repo.id, "v1.0")
+        result = remove_tag_from_timemachine(
+            repo.id, "v1.0", subject_manifest.id, include_submanifests=False, is_alive=False
+        )
+        assert result is True
+
+        expiration_ms = get_user("devtable").removed_tag_expiration_s * 1000
+        refreshed = Tag.get_by_id(temp_tag.id)
+        assert refreshed.lifetime_end_ms is not None
+        assert refreshed.lifetime_end_ms <= get_epoch_timestamp_ms() - expiration_ms
+
+
+def test_delete_tag_expires_referrer_temp_tags(initialized_db):
+    """When the last tag on a subject manifest is deleted, $temp-* tags for
+    OCI 1.1 referrer manifests should be expired."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": True}):
+        repo = create_repository("devtable", "newrepo", None)
+        subject_manifest, _ = create_manifest_for_testing(repo, "subject1")
+        tag = retarget_tag("v1.0", subject_manifest.id)
+        assert tag is not None
+
+        referrer_manifest, _ = create_manifest_for_testing(repo, "referrer1")
+        Manifest.update(subject=subject_manifest.digest).where(
+            Manifest.id == referrer_manifest.id
+        ).execute()
+
+        temp_tag = create_temporary_tag_if_necessary(referrer_manifest, 300, skip_expiration=True)
+        assert temp_tag is not None
+        assert temp_tag.hidden is True
+        assert temp_tag.lifetime_end_ms is None
+
+        delete_tag(repo.id, "v1.0")
+
+        refreshed = Tag.get_by_id(temp_tag.id)
+        assert refreshed.lifetime_end_ms is not None
+        assert refreshed.lifetime_end_ms <= get_epoch_timestamp_ms()
+
+
+def test_delete_tag_keeps_referrer_if_other_tags_exist(initialized_db):
+    """$temp-* referrer tags should NOT be expired if the subject manifest
+    still has other live tags."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": True}):
+        repo = create_repository("devtable", "newrepo", None)
+        subject_manifest, _ = create_manifest_for_testing(repo, "subject2")
+        tag1 = retarget_tag("v1.0", subject_manifest.id)
+        tag2 = retarget_tag("latest", subject_manifest.id)
+        assert tag1 is not None
+        assert tag2 is not None
+
+        referrer_manifest, _ = create_manifest_for_testing(repo, "referrer2")
+        Manifest.update(subject=subject_manifest.digest).where(
+            Manifest.id == referrer_manifest.id
+        ).execute()
+
+        temp_tag = create_temporary_tag_if_necessary(referrer_manifest, 300, skip_expiration=True)
+        assert temp_tag is not None
+        assert temp_tag.lifetime_end_ms is None
+
+        delete_tag(repo.id, "v1.0")
+
+        refreshed = Tag.get_by_id(temp_tag.id)
+        assert refreshed.lifetime_end_ms is None
+
+        delete_tag(repo.id, "latest")
+
+        refreshed = Tag.get_by_id(temp_tag.id)
+        assert refreshed.lifetime_end_ms is not None
+        assert refreshed.lifetime_end_ms <= get_epoch_timestamp_ms()
+
+
+def test_delete_tags_for_manifest_expires_referrer_temp_tags(initialized_db):
+    """Deleting all tags on a subject manifest via delete_tags_for_manifest
+    should expire referrer $temp-* tags."""
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": True}):
+        repo = create_repository("devtable", "newrepo", None)
+        subject_manifest, _ = create_manifest_for_testing(repo, "dtfm_subject")
+        tag = retarget_tag("v1.0", subject_manifest.id)
+        assert tag is not None
+
+        referrer_manifest, _ = create_manifest_for_testing(repo, "dtfm_referrer")
+        Manifest.update(subject=subject_manifest.digest).where(
+            Manifest.id == referrer_manifest.id
+        ).execute()
+
+        temp_tag = create_temporary_tag_if_necessary(referrer_manifest, 300, skip_expiration=True)
+        assert temp_tag is not None
+        assert temp_tag.hidden is True
+        assert temp_tag.lifetime_end_ms is None
+
+        delete_tags_for_manifest(subject_manifest)
+
+        refreshed = Tag.get_by_id(temp_tag.id)
+        assert refreshed.lifetime_end_ms is not None
+        assert refreshed.lifetime_end_ms <= get_epoch_timestamp_ms()

--- a/data/model/oci/test/test_oci_tag.py
+++ b/data/model/oci/test/test_oci_tag.py
@@ -57,6 +57,7 @@ from data.model.oci.tag import (
     lookup_alive_tags_shallow,
     lookup_unrecoverable_tags,
     remove_tag_from_timemachine,
+    reset_referrer_manifest_expiration,
     retarget_tag,
     set_tag_expiration_for_manifest,
     set_tag_immutable,
@@ -72,7 +73,8 @@ from image.docker.schema2.manifest import DockerSchema2ManifestBuilder
 from test.fixtures import *
 from util.bytes import Bytes
 
-# Cosign cascade acquires pg_advisory_xact_lock on PostgreSQL (+1 SQL); SQLite lock is a no-op.
+# Cosign cascade and referrer expiry each acquire pg_advisory_xact_lock on
+# PostgreSQL (+1 SQL per acquire); SQLite lock is a no-op.
 _ADVISORY_LOCK_QUERY = 1 if os.environ.get("TEST_DATABASE_URI", "").startswith("postgresql") else 0
 
 
@@ -398,7 +400,7 @@ def test_delete_tag(initialized_db):
             assert get_tag(repo, tag.name) == tag
             assert tag.lifetime_end_ms is None
 
-            with assert_query_count(6 + _ADVISORY_LOCK_QUERY):
+            with assert_query_count(7 + 2 * _ADVISORY_LOCK_QUERY):
                 assert delete_tag(repo, tag.name) == tag
 
             assert get_tag(repo, tag.name) is None
@@ -420,7 +422,7 @@ def test_delete_tag_manifest_list(initialized_db):
             assert child_tag.name.startswith("$temp-")
             assert child_tag.lifetime_end_ms > get_epoch_timestamp_ms()
 
-        with assert_query_count(11 + _ADVISORY_LOCK_QUERY):
+        with assert_query_count(12 + 2 * _ADVISORY_LOCK_QUERY):
             assert delete_tag(repository.id, tag.name) == tag
 
         # Assert temporary tags pointing to child manifest are now expired
@@ -438,7 +440,7 @@ def test_delete_tags_for_manifest(initialized_db):
             repo = tag.repository
             assert get_tag(repo, tag.name) == tag
 
-            with assert_query_count(8 + _ADVISORY_LOCK_QUERY):
+            with assert_query_count(9 + 2 * _ADVISORY_LOCK_QUERY):
                 assert delete_tags_for_manifest(tag.manifest) == [tag]
 
             assert get_tag(repo, tag.name) is None
@@ -1954,6 +1956,103 @@ def test_cascade_serialized_with_concurrent_retarget(initialized_db):
         finally:
             # Same path as test_gc: purge tags/manifests/blobs (incl. ImageStorage) then
             # delete the repo. Commit so cleanup survives the fixture savepoint.
+            try:
+                repo_to_purge = Repository.get_by_id(repo_id)
+            except Repository.DoesNotExist:
+                repo_to_purge = None
+            if repo_to_purge is not None:
+                model.gc.purge_repository(repo_to_purge, force=True)
+            db.commit()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_DATABASE_URI", "").startswith("postgresql"),
+    reason="Advisory locks / multi-connection race coverage require PostgreSQL",
+)
+def test_referrer_expiry_serialized_with_concurrent_retarget(initialized_db):
+    """
+    Concurrent retarget that creates a new alive alias must prevent referrer
+    $temp-* expiry. The shared advisory lock serializes the paths.
+
+    Setup is committed so worker-thread connections can see the fixtures;
+    initialized_db's savepoint would otherwise hide them from other sessions.
+    Cleanup uses purge_repository (same as test_gc) so committed CAS rows do not
+    poison later assert_gc_integrity checks.
+    """
+    with patch("data.model.config.app_config", {"RESET_CHILD_MANIFEST_EXPIRATION": False}):
+        repo = create_repository("devtable", f"ref-race-{uuid.uuid4().hex[:12]}", None)
+        assert repo is not None
+        repo_id = repo.id
+        try:
+            subject_manifest, _ = _create_manifest_in_repo(repo, "img-ref-race")
+            assert retarget_tag("v1.0", subject_manifest.id) is not None
+            subject_manifest_id = subject_manifest.id
+
+            referrer_manifest, _ = _create_manifest_in_repo(repo, "ref-race")
+            Manifest.update(subject=subject_manifest.digest).where(
+                Manifest.id == referrer_manifest.id
+            ).execute()
+            temp_tag = create_temporary_tag_if_necessary(
+                referrer_manifest, 300, skip_expiration=True
+            )
+            assert temp_tag is not None
+            assert temp_tag.lifetime_end_ms is None
+            temp_tag_id = temp_tag.id
+
+            db.commit()
+
+            barrier = threading.Barrier(2, timeout=10)
+            retarget_done = threading.Event()
+            errors = []
+            results = {}
+            expire_tls = threading.local()
+            real_reset = reset_referrer_manifest_expiration
+
+            def reset_seam(*args, **kwargs):
+                if getattr(expire_tls, "wait_for_retarget", False):
+                    if not retarget_done.wait(timeout=10):
+                        raise TimeoutError("timed out waiting for concurrent retarget")
+                return real_reset(*args, **kwargs)
+
+            def thread_delete():
+                try:
+                    barrier.wait()
+                    expire_tls.wait_for_retarget = True
+                    with db.connection_context():
+                        results["deleted"] = delete_tag(repo_id, "v1.0")
+                except Exception as exc:  # pragma: no cover - surfaced via errors list
+                    errors.append(exc)
+
+            def thread_retarget():
+                try:
+                    barrier.wait()
+                    with db.connection_context():
+                        results["retarget"] = retarget_tag("v2.0", subject_manifest_id)
+                    retarget_done.set()
+                except Exception as exc:  # pragma: no cover - surfaced via errors list
+                    errors.append(exc)
+                    retarget_done.set()
+
+            with patch(
+                "data.model.oci.tag.reset_referrer_manifest_expiration",
+                side_effect=reset_seam,
+            ):
+                t_delete = threading.Thread(target=thread_delete)
+                t_retarget = threading.Thread(target=thread_retarget)
+                t_delete.start()
+                t_retarget.start()
+                t_delete.join(timeout=15)
+                t_retarget.join(timeout=15)
+                assert not t_delete.is_alive(), "delete worker did not finish within timeout"
+                assert not t_retarget.is_alive(), "retarget worker did not finish within timeout"
+
+            assert not errors, errors
+            assert results.get("deleted") is not None
+            assert results.get("retarget") is not None
+            assert get_tag(repo_id, "v2.0") is not None
+            refreshed = Tag.get_by_id(temp_tag_id)
+            assert refreshed.lifetime_end_ms is None
+        finally:
             try:
                 repo_to_purge = Repository.get_by_id(repo_id)
             except Repository.DoesNotExist:

--- a/web/playwright/e2e/repository/autopruning.spec.ts
+++ b/web/playwright/e2e/repository/autopruning.spec.ts
@@ -14,13 +14,19 @@
  * Migrated from: web/cypress/e2e/repository-autopruning.cy.ts (17 tests consolidated to 6)
  */
 
+import path from 'path';
+import {APIRequestContext} from '@playwright/test';
 import {test, expect} from '../../fixtures';
 import {TEST_USERS} from '../../global-setup';
 import {ApiClient} from '../../utils/api';
+import {getV2Token} from '../../utils/api/auth';
+import {API_URL} from '../../utils/config';
 import {
   pushImage,
   pushMultiArchImage,
   pushUniqueImage,
+  orasAttach,
+  isOrasAvailable,
 } from '../../utils/container';
 
 /**
@@ -41,6 +47,27 @@ async function createCosignSigTag(
   const sigName = `${digest.replace(':', '-')}.sig`;
   await api.createTag(namespace, repo, sigName, digest);
   return sigName;
+}
+
+async function countReferrers(
+  request: APIRequestContext,
+  token: string,
+  namespace: string,
+  repo: string,
+  digest: string,
+): Promise<number> {
+  const response = await request.get(
+    `${API_URL}/v2/${namespace}/${repo}/referrers/${digest}`,
+    {headers: {authorization: `Bearer ${token}`}},
+  );
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to list referrers for ${digest}: ${response.status()} - ${body}`,
+    );
+  }
+  const body = await response.json();
+  return body.manifests?.length ?? 0;
 }
 
 test.describe(
@@ -848,6 +875,100 @@ test.describe(
         const names = tags.tags.map((t) => t.name);
         expect(names).toContain('v1');
         expect(names).toContain(sigName);
+      },
+    );
+
+    test(
+      'autoprune of last subject tag allows Cosign V3 referrer GC',
+      {tag: ['@PROJQUAY-12396', '@container']},
+      async ({api, playwright}) => {
+        test.slow();
+        test.skip(
+          !(await isOrasAvailable()),
+          'oras CLI required for referrer attach',
+        );
+
+        const org = await api.organization('pruneref');
+        const repo = await api.repository(org.name, 'prunetest');
+
+        // Single subject tag so prune removes the last visible alias
+        await pushImage(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+        );
+
+        const v1Tags = await api.raw.getTags(org.name, repo.name, {
+          specificTag: 'v1',
+        });
+        expect(v1Tags.tags.length).toBeGreaterThan(0);
+        const digest = v1Tags.tags[0].manifest_digest;
+
+        const fixturesDir = path.resolve(__dirname, '../../fixtures/oras');
+        orasAttach(
+          org.name,
+          repo.name,
+          'v1',
+          user.username,
+          user.password,
+          'application/spdx+json',
+          'producer=syft 0.63.0',
+          path.join(fixturesDir, 'referrer.spdx.json'),
+        );
+
+        const request = await playwright.request.newContext({
+          ignoreHTTPSErrors: true,
+        });
+        try {
+          const scope = `repository:${org.name}/${repo.name}:pull,push`;
+          const v2Token = await getV2Token(
+            request,
+            API_URL,
+            user.username,
+            user.password,
+            scope,
+          );
+
+          await expect
+            .poll(
+              async () =>
+                countReferrers(request, v2Token, org.name, repo.name, digest),
+              {
+                message: 'Waiting for ORAS referrer to appear',
+                timeout: 30_000,
+                intervals: [500, 1_000, 2_000],
+              },
+            )
+            .toBe(1);
+
+          await api.repoAutoPrunePolicy(org.name, repo.name, {
+            method: 'creation_date',
+            value: '10s',
+          });
+
+          // Autoprune removes the last subject tag
+          await expect(async () => {
+            const tags = await api.raw.getTags(org.name, repo.name);
+            expect(tags.tags).toHaveLength(0);
+          }).toPass({timeout: 180_000, intervals: [10_000]});
+
+          // Temp-tag expiry unblocks GC of the referrer manifest
+          await expect
+            .poll(
+              async () =>
+                countReferrers(request, v2Token, org.name, repo.name, digest),
+              {
+                message: 'Waiting for referrer GC after subject autoprune',
+                timeout: 240_000,
+                intervals: [10_000],
+              },
+            )
+            .toBe(0);
+        } finally {
+          await request.dispose();
+        }
       },
     );
   },


### PR DESCRIPTION
## Summary
- Cosign V3 signs via the OCI 1.1 referrer API and leaves hidden `$temp-*` tags in the Tags table. Those tags keep an active relation to the signature/referrer manifest, so GC cannot reclaim it after the subject image is pruned.
- When the last visible tag on a subject manifest is deleted (including via autoprune), expire hidden `$temp-*` tags on referrer manifests whose `subject` matches that digest, so related manifests can be garbage-collected.
- Guarded so referrer temp tags are only expired when the subject has no remaining live (non-hidden) tags; wired from `_delete_tag`.

## Impact
When images are signed with Cosign V3, temporary tags are created in the Tags table. These tags are not cleaned up during garbage collection. This keeps an active relation to the image manifest, so the manifest is also not cleaned. This can prevent proper garbage collection.

## Expected behaviour
Temporary tags created by Cosign V3 signatures should be removed during garbage collection.
Related manifests should also be cleaned up when they are no longer needed.

## Actual behaviour
Cosign V3 uses the OCI 1.1 referrer API to push signatures, which creates temporary tags in the Tags table.
At the time of garbage collection, these temporary tags are not cleaned.
This leaves an active relation between the image manifest and the tags, so the manifest is also not cleaned.

## Test Plan
1. Sign an image with Cosign V3.
2. Configure an auto-prune policy.
3. Observe that the temporary tags in the Tags table are not removed.
4. Observe that the related manifest is also not cleaned.