### PR TITLE
QUAYIO-1708: fix(deploy): raise Envoy fd soft limit to hard limit

### DIFF
--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -77,8 +77,8 @@ objects:
         - name: envoy
           image: ${ENVOY_IMAGE}:${ENVOY_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
-          command: ["envoy"]
-          args: ["-c", "/etc/envoy/envoy.yaml", "--log-level", "${ENVOY_LOG_LEVEL}"]
+          command: ["/bin/sh", "-c"]
+          args: ["ulimit -n $(ulimit -Hn) && exec envoy -c /etc/envoy/envoy.yaml --log-level ${ENVOY_LOG_LEVEL}"]
           ports:
           - containerPort: 8443
             name: https


### PR DESCRIPTION
## Summary

- Raise the Envoy container's file descriptor soft limit to match the hard limit at startup
- Prevents segfault crashes caused by fd exhaustion under production traffic

## Problem

Envoy pods on production (quayp07ue1) were crashing with SIGSEGV (exit code 139) every ~50 minutes at just 1% traffic (~260 req/s). Root cause: the container's default fd soft limit is 1,024, but Envoy was consuming ~986 fds at 1% traffic. During connection bursts, it exceeded 1,024, causing `socket(2) failed: Too many open files` → assertion failure → segfault.

## Data

- **Measured at 1%:** 2,700 peak active connections (downstream + upstream + RLS), 986 fds
- **Extrapolated at 100%:** ~270,000 connections, ~270,000 fds needed
- **Container hard limit:** 524,288 (sufficient for 100% N-1)
- **Container soft limit (before fix):** 1,024 (far too low)

## Fix

Sets the soft limit to the hard limit dynamically at container startup:
```sh
ulimit -n $(ulimit -Hn) && exec envoy -c /etc/envoy/envoy.yaml ...
```

This is in line with recent Envoy upstream changes — newer versions raise the soft limit to the hard limit automatically at startup: https://github.com/envoyproxy/envoy/pull/39660

## Why setting the soft limit to the hard limit is safe

The fd limit is **per-process**, not a shared pool across the node. Setting Envoy's soft limit to 524,288 doesn't reserve those fds — it just means Envoy is *allowed* to open up to that many. Other containers on the same node have their own independent limits. The Envoy container only runs one process (`envoy`), so there is no resource contention within the container. The system-wide limit (`fs.file-max` on the node kernel) governs total fds across all processes on the node and is typically in the millions.

## Test plan

- [ ] Deploy to stage, verify fd soft limit is raised: `cat /proc/1/limits | grep "open files"`
- [ ] Confirm Envoy pods remain stable under traffic with no segfault crashes
- [ ] Re-deploy to production and re-route 1% traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)