### PR TITLE
PROJQUAY-12278: feat(config): add configurable gunicorn worker timeouts

### DIFF
--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -14,7 +14,7 @@ QUAYRUN_DIR = os.getenv("QUAYRUN", QUAYCONF_DIR)
 QUAY_LOGGING = os.getenv("QUAY_LOGGING", "stdout")  # or "syslog"
 QUAY_HOTRELOAD: bool = os.getenv("QUAY_HOTRELOAD", "false") == "true"
 
-MAX_GUNICORN_TIMEOUT = 1800
+MAX_GUNICORN_TIMEOUT = 300
 
 
 def _parse_csv_env(name):
@@ -121,9 +121,9 @@ if __name__ == "__main__":
         QUAY_LOGGING,
         QUAY_HOTRELOAD,
         gunicorn_registry_timeout=min(
-            app_config.get("GUNICORN_REGISTRY_TIMEOUT", 300), MAX_GUNICORN_TIMEOUT
+            app_config.get("GUNICORN_REGISTRY_TIMEOUT", 30), MAX_GUNICORN_TIMEOUT
         ),
         gunicorn_web_timeout=min(
-            app_config.get("GUNICORN_WEB_TIMEOUT", 60), MAX_GUNICORN_TIMEOUT
+            app_config.get("GUNICORN_WEB_TIMEOUT", 30), MAX_GUNICORN_TIMEOUT
         ),
     )

--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -4,6 +4,7 @@ import sys
 from typing import List
 
 import jinja2
+import yaml
 
 QUAYPATH = os.getenv("QUAYPATH", ".")
 QUAYDIR = os.getenv("QUAYDIR", "/")
@@ -64,10 +65,20 @@ def registry_services():
     }
 
 
-def generate_supervisord_config(filename, config, logdriver, hotreload):
+def load_app_config():
+    config_path = os.path.join(QUAYCONF_DIR, "stack/config.yaml")
+    if os.path.exists(config_path):
+        with open(config_path, "r") as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+
+def generate_supervisord_config(filename, config, logdriver, hotreload, **extra_vars):
     with open(filename + ".jnj") as f:
         template = jinja2.Template(f.read())
-    rendered = template.render(config=config, logdriver=logdriver, hotreload=hotreload)
+    rendered = template.render(
+        config=config, logdriver=logdriver, hotreload=hotreload, **extra_vars
+    )
 
     with open(filename, "w") as f:
         f.write(rendered)
@@ -100,9 +111,13 @@ if __name__ == "__main__":
     limit_services(config, QUAY_SERVICES)
     override_services(config, QUAY_OVERRIDE_SERVICES)
 
+    app_config = load_app_config()
+
     generate_supervisord_config(
         os.path.join(QUAYCONF_DIR, "supervisord.conf"),
         config,
         QUAY_LOGGING,
         QUAY_HOTRELOAD,
+        gunicorn_registry_timeout=app_config.get("GUNICORN_REGISTRY_TIMEOUT", 300),
+        gunicorn_web_timeout=app_config.get("GUNICORN_WEB_TIMEOUT", 60),
     )

--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -4,6 +4,7 @@ import sys
 from typing import List
 
 import jinja2
+import yaml
 
 QUAYPATH = os.getenv("QUAYPATH", ".")
 QUAYDIR = os.getenv("QUAYDIR", "/")
@@ -105,10 +106,20 @@ def config_services():
     }
 
 
-def generate_supervisord_config(filename, config, logdriver, hotreload):
+def load_app_config():
+    config_path = os.path.join(QUAYCONF_DIR, "stack/config.yaml")
+    if os.path.exists(config_path):
+        with open(config_path, "r") as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+
+def generate_supervisord_config(filename, config, logdriver, hotreload, **extra_vars):
     with open(filename + ".jnj") as f:
         template = jinja2.Template(f.read())
-    rendered = template.render(config=config, logdriver=logdriver, hotreload=hotreload)
+    rendered = template.render(
+        config=config, logdriver=logdriver, hotreload=hotreload, **extra_vars
+    )
 
     with open(filename, "w") as f:
         f.write(rendered)
@@ -144,9 +155,13 @@ if __name__ == "__main__":
     limit_services(config, QUAY_SERVICES)
     override_services(config, QUAY_OVERRIDE_SERVICES)
 
+    app_config = load_app_config()
+
     generate_supervisord_config(
         os.path.join(QUAYCONF_DIR, "supervisord.conf"),
         config,
         QUAY_LOGGING,
         QUAY_HOTRELOAD,
+        gunicorn_registry_timeout=app_config.get("GUNICORN_REGISTRY_TIMEOUT", 300),
+        gunicorn_web_timeout=app_config.get("GUNICORN_WEB_TIMEOUT", 60),
     )

--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -123,7 +123,5 @@ if __name__ == "__main__":
         gunicorn_registry_timeout=min(
             app_config.get("GUNICORN_REGISTRY_TIMEOUT", 30), MAX_GUNICORN_TIMEOUT
         ),
-        gunicorn_web_timeout=min(
-            app_config.get("GUNICORN_WEB_TIMEOUT", 30), MAX_GUNICORN_TIMEOUT
-        ),
+        gunicorn_web_timeout=min(app_config.get("GUNICORN_WEB_TIMEOUT", 30), MAX_GUNICORN_TIMEOUT),
     )

--- a/conf/init/supervisord_conf_create.py
+++ b/conf/init/supervisord_conf_create.py
@@ -14,6 +14,8 @@ QUAYRUN_DIR = os.getenv("QUAYRUN", QUAYCONF_DIR)
 QUAY_LOGGING = os.getenv("QUAY_LOGGING", "stdout")  # or "syslog"
 QUAY_HOTRELOAD: bool = os.getenv("QUAY_HOTRELOAD", "false") == "true"
 
+MAX_GUNICORN_TIMEOUT = 1800
+
 
 def _parse_csv_env(name):
     val = os.getenv(name, "")
@@ -118,6 +120,10 @@ if __name__ == "__main__":
         config,
         QUAY_LOGGING,
         QUAY_HOTRELOAD,
-        gunicorn_registry_timeout=app_config.get("GUNICORN_REGISTRY_TIMEOUT", 300),
-        gunicorn_web_timeout=app_config.get("GUNICORN_WEB_TIMEOUT", 60),
+        gunicorn_registry_timeout=min(
+            app_config.get("GUNICORN_REGISTRY_TIMEOUT", 300), MAX_GUNICORN_TIMEOUT
+        ),
+        gunicorn_web_timeout=min(
+            app_config.get("GUNICORN_WEB_TIMEOUT", 60), MAX_GUNICORN_TIMEOUT
+        ),
     )

--- a/conf/init/test/test_supervisord_conf_create.py
+++ b/conf/init/test/test_supervisord_conf_create.py
@@ -1,5 +1,8 @@
 import os
 import re
+import shutil
+import subprocess
+import sys
 import tempfile
 from contextlib import contextmanager
 
@@ -114,3 +117,44 @@ class TestGunicornTimeouts:
 
     def test_max_gunicorn_timeout_is_300(self):
         assert MAX_GUNICORN_TIMEOUT == 300
+
+    def test_config_yaml_reaches_gunicorn_commands(self, tmp_path):
+        """Exercise load_app_config() and the __main__ wiring end-to-end via a real config.yaml."""
+        quay_conf_dir = tmp_path / "conf"
+        (quay_conf_dir / "stack").mkdir(parents=True)
+        (quay_conf_dir / "stack" / "config.yaml").write_text(
+            "GUNICORN_REGISTRY_TIMEOUT: 111\nGUNICORN_WEB_TIMEOUT: 45\n"
+        )
+
+        repo_conf_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..")
+        shutil.copy(
+            os.path.join(repo_conf_dir, "supervisord.conf.jnj"),
+            quay_conf_dir / "supervisord.conf.jnj",
+        )
+
+        script_path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "../supervisord_conf_create.py"
+        )
+
+        env = os.environ.copy()
+        env.update(
+            QUAYDIR=str(tmp_path),
+            QUAYPATH=".",
+            QUAYCONF=str(quay_conf_dir),
+            QUAY_SERVICES="",
+            QUAY_OVERRIDE_SERVICES="",
+            QUAY_LOGGING="stdout",
+            QUAY_HOTRELOAD="false",
+        )
+
+        subprocess.run([sys.executable, script_path], env=env, check=True)
+
+        rendered = (quay_conf_dir / "supervisord.conf").read_text()
+
+        registry_match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_registry\.py", rendered)
+        assert registry_match is not None
+        assert registry_match.group(1) == "111"
+
+        web_match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_web\.py", rendered)
+        assert web_match is not None
+        assert web_match.group(1) == "45"

--- a/conf/init/test/test_supervisord_conf_create.py
+++ b/conf/init/test/test_supervisord_conf_create.py
@@ -64,21 +64,21 @@ class TestGunicornTimeouts:
         rendered = render_supervisord_conf(config)
         match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_registry\.py", rendered)
         assert match is not None, "gunicorn-registry should have --timeout flag"
-        assert match.group(1) == "300"
+        assert match.group(1) == "30"
 
     def test_registry_timeout_custom(self):
         config = registry_services()
-        rendered = render_supervisord_conf(config, gunicorn_registry_timeout=600)
+        rendered = render_supervisord_conf(config, gunicorn_registry_timeout=300)
         match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_registry\.py", rendered)
         assert match is not None
-        assert match.group(1) == "600"
+        assert match.group(1) == "300"
 
     def test_web_timeout_default(self):
         config = registry_services()
         rendered = render_supervisord_conf(config)
         match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_web\.py", rendered)
         assert match is not None, "gunicorn-web should have --timeout flag"
-        assert match.group(1) == "60"
+        assert match.group(1) == "30"
 
     def test_web_timeout_custom(self):
         config = registry_services()
@@ -112,5 +112,5 @@ class TestGunicornTimeouts:
         assert match is not None
         assert match.group(1) == str(MAX_GUNICORN_TIMEOUT)
 
-    def test_max_gunicorn_timeout_is_1800(self):
-        assert MAX_GUNICORN_TIMEOUT == 1800
+    def test_max_gunicorn_timeout_is_300(self):
+        assert MAX_GUNICORN_TIMEOUT == 300

--- a/conf/init/test/test_supervisord_conf_create.py
+++ b/conf/init/test/test_supervisord_conf_create.py
@@ -9,6 +9,7 @@ from six import iteritems
 from supervisor.options import ServerOptions
 
 from ..supervisord_conf_create import (
+    MAX_GUNICORN_TIMEOUT,
     QUAY_OVERRIDE_SERVICES,
     QUAY_SERVICES,
     limit_services,
@@ -92,3 +93,24 @@ class TestGunicornTimeouts:
         match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_web\.py", rendered)
         assert match is not None
         assert match.group(1) == "600", "hotreload mode should use 600s timeout regardless"
+
+    def test_registry_timeout_clamped_to_max(self):
+        config = registry_services()
+        rendered = render_supervisord_conf(
+            config, gunicorn_registry_timeout=min(7200, MAX_GUNICORN_TIMEOUT)
+        )
+        match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_registry\.py", rendered)
+        assert match is not None
+        assert match.group(1) == str(MAX_GUNICORN_TIMEOUT)
+
+    def test_web_timeout_clamped_to_max(self):
+        config = registry_services()
+        rendered = render_supervisord_conf(
+            config, gunicorn_web_timeout=min(7200, MAX_GUNICORN_TIMEOUT)
+        )
+        match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_web\.py", rendered)
+        assert match is not None
+        assert match.group(1) == str(MAX_GUNICORN_TIMEOUT)
+
+    def test_max_gunicorn_timeout_is_1800(self):
+        assert MAX_GUNICORN_TIMEOUT == 1800

--- a/conf/init/test/test_supervisord_conf_create.py
+++ b/conf/init/test/test_supervisord_conf_create.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 from contextlib import contextmanager
 
@@ -30,12 +31,12 @@ def environ(**kwargs):
                 os.environ[key] = value
 
 
-def render_supervisord_conf(config):
+def render_supervisord_conf(config, **extra_vars):
     with open(
         os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../supervisord.conf.jnj")
     ) as f:
         template = jinja2.Template(f.read())
-    return template.render(config=config)
+    return template.render(config=config, **extra_vars)
 
 
 def test_supervisord_conf_create_registry():
@@ -54,3 +55,40 @@ def test_supervisord_conf_create_registry():
 
             opts.searchpaths = [f.name]
             assert opts.default_configfile() == f.name
+
+
+class TestGunicornTimeouts:
+    def test_registry_timeout_default(self):
+        config = registry_services()
+        rendered = render_supervisord_conf(config)
+        match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_registry\.py", rendered)
+        assert match is not None, "gunicorn-registry should have --timeout flag"
+        assert match.group(1) == "300"
+
+    def test_registry_timeout_custom(self):
+        config = registry_services()
+        rendered = render_supervisord_conf(config, gunicorn_registry_timeout=600)
+        match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_registry\.py", rendered)
+        assert match is not None
+        assert match.group(1) == "600"
+
+    def test_web_timeout_default(self):
+        config = registry_services()
+        rendered = render_supervisord_conf(config)
+        match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_web\.py", rendered)
+        assert match is not None, "gunicorn-web should have --timeout flag"
+        assert match.group(1) == "60"
+
+    def test_web_timeout_custom(self):
+        config = registry_services()
+        rendered = render_supervisord_conf(config, gunicorn_web_timeout=120)
+        match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_web\.py", rendered)
+        assert match is not None
+        assert match.group(1) == "120"
+
+    def test_web_timeout_hotreload_uses_600(self):
+        config = registry_services()
+        rendered = render_supervisord_conf(config, hotreload=True, gunicorn_web_timeout=120)
+        match = re.search(r"gunicorn --timeout=(\d+) -c .+gunicorn_web\.py", rendered)
+        assert match is not None
+        assert match.group(1) == "600", "hotreload mode should use 600s timeout regardless"

--- a/conf/supervisord.conf.jnj
+++ b/conf/supervisord.conf.jnj
@@ -249,7 +249,7 @@ stderr_events_enabled = true
 environment=
   PYTHONPATH=%(ENV_PYTHONPATH)s,
   DB_CONNECTION_POOLING=%(ENV_DB_CONNECTION_POOLING_REGISTRY)s
-command=nice -n 10 gunicorn -c %(ENV_QUAYCONF)s/gunicorn_registry.py registry:application
+command=nice -n 10 gunicorn --timeout={{ gunicorn_registry_timeout|default(300) }} -c %(ENV_QUAYCONF)s/gunicorn_registry.py registry:application
 autostart = {{ config['gunicorn-registry']['autostart'] }}
 stdout_events_enabled = true
 stderr_events_enabled = true
@@ -272,7 +272,7 @@ environment=
 command={% if hotreload -%}
   gunicorn --timeout=600 -c %(ENV_QUAYCONF)s/gunicorn_web.py web:application
 {% else -%}
-  gunicorn -c %(ENV_QUAYCONF)s/gunicorn_web.py web:application
+  gunicorn --timeout={{ gunicorn_web_timeout|default(60) }} -c %(ENV_QUAYCONF)s/gunicorn_web.py web:application
 {% endif -%}
 autostart = {{ config['gunicorn-web']['autostart'] }}
 stdout_events_enabled = true

--- a/conf/supervisord.conf.jnj
+++ b/conf/supervisord.conf.jnj
@@ -249,7 +249,7 @@ stderr_events_enabled = true
 environment=
   PYTHONPATH=%(ENV_PYTHONPATH)s,
   DB_CONNECTION_POOLING=%(ENV_DB_CONNECTION_POOLING_REGISTRY)s
-command=nice -n 10 gunicorn --timeout={{ gunicorn_registry_timeout|default(300) }} -c %(ENV_QUAYCONF)s/gunicorn_registry.py registry:application
+command=nice -n 10 gunicorn --timeout={{ gunicorn_registry_timeout|default(30) }} -c %(ENV_QUAYCONF)s/gunicorn_registry.py registry:application
 autostart = {{ config['gunicorn-registry']['autostart'] }}
 stdout_events_enabled = true
 stderr_events_enabled = true
@@ -272,7 +272,7 @@ environment=
 command={% if hotreload -%}
   gunicorn --timeout=600 -c %(ENV_QUAYCONF)s/gunicorn_web.py web:application
 {% else -%}
-  gunicorn --timeout={{ gunicorn_web_timeout|default(60) }} -c %(ENV_QUAYCONF)s/gunicorn_web.py web:application
+  gunicorn --timeout={{ gunicorn_web_timeout|default(30) }} -c %(ENV_QUAYCONF)s/gunicorn_web.py web:application
 {% endif -%}
 autostart = {{ config['gunicorn-web']['autostart'] }}
 stdout_events_enabled = true

--- a/config.py
+++ b/config.py
@@ -675,6 +675,10 @@ class DefaultConfig(ImmutableConfig):
     # Maximum size allowed for layers in the registry.
     MAXIMUM_LAYER_SIZE = "20G"
 
+    # Gunicorn worker timeouts (seconds). Workers killed after this duration.
+    GUNICORN_REGISTRY_TIMEOUT = 300
+    GUNICORN_WEB_TIMEOUT = 60
+
     # Feature Flag: Whether team syncing from the backing auth is enabled.
     FEATURE_TEAM_SYNCING = False
     TEAM_RESYNC_STALE_TIME = "30m"

--- a/config.py
+++ b/config.py
@@ -679,8 +679,8 @@ class DefaultConfig(ImmutableConfig):
     MAXIMUM_LAYER_SIZE = "20G"
 
     # Gunicorn worker timeouts (seconds). Workers killed after this duration.
-    GUNICORN_REGISTRY_TIMEOUT = 300
-    GUNICORN_WEB_TIMEOUT = 60
+    GUNICORN_REGISTRY_TIMEOUT = 30
+    GUNICORN_WEB_TIMEOUT = 30
 
     # Feature Flag: Whether team syncing from the backing auth is enabled.
     FEATURE_TEAM_SYNCING = False

--- a/config.py
+++ b/config.py
@@ -678,6 +678,10 @@ class DefaultConfig(ImmutableConfig):
     # Maximum size allowed for layers in the registry.
     MAXIMUM_LAYER_SIZE = "20G"
 
+    # Gunicorn worker timeouts (seconds). Workers killed after this duration.
+    GUNICORN_REGISTRY_TIMEOUT = 300
+    GUNICORN_WEB_TIMEOUT = 60
+
     # Feature Flag: Whether team syncing from the backing auth is enabled.
     FEATURE_TEAM_SYNCING = False
     TEAM_RESYNC_STALE_TIME = "30m"

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -337,6 +337,18 @@ CONFIG_SCHEMA = {
             "description": "Whether to enable a background worker to download placeholder blobs. Defaults to True",
             "x-example": True,
         },
+        "GUNICORN_REGISTRY_TIMEOUT": {
+            "type": "integer",
+            "minimum": 30,
+            "description": "Timeout in seconds for gunicorn-registry workers. Workers that do not respond within this window are killed and restarted. Defaults to 300",
+            "x-example": 300,
+        },
+        "GUNICORN_WEB_TIMEOUT": {
+            "type": "integer",
+            "minimum": 30,
+            "description": "Timeout in seconds for gunicorn-web workers. Workers that do not respond within this window are killed and restarted. Defaults to 60",
+            "x-example": 60,
+        },
         "MAXIMUM_LAYER_SIZE": {
             "type": "string",
             "description": "Maximum allowed size of an image layer. Defaults to 20G",

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -340,13 +340,15 @@ CONFIG_SCHEMA = {
         "GUNICORN_REGISTRY_TIMEOUT": {
             "type": "integer",
             "minimum": 30,
-            "description": "Timeout in seconds for gunicorn-registry workers. Workers that do not respond within this window are killed and restarted. Defaults to 300",
+            "maximum": 1800,
+            "description": "Timeout in seconds for gunicorn-registry workers. Workers that do not respond within this window are killed and restarted. Must be between 30 and 1800 (30 minutes). Defaults to 300",
             "x-example": 300,
         },
         "GUNICORN_WEB_TIMEOUT": {
             "type": "integer",
             "minimum": 30,
-            "description": "Timeout in seconds for gunicorn-web workers. Workers that do not respond within this window are killed and restarted. Defaults to 60",
+            "maximum": 1800,
+            "description": "Timeout in seconds for gunicorn-web workers. Workers that do not respond within this window are killed and restarted. Must be between 30 and 1800 (30 minutes). Defaults to 60",
             "x-example": 60,
         },
         "MAXIMUM_LAYER_SIZE": {

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -340,15 +340,15 @@ CONFIG_SCHEMA = {
         "GUNICORN_REGISTRY_TIMEOUT": {
             "type": "integer",
             "minimum": 30,
-            "maximum": 1800,
-            "description": "Timeout in seconds for gunicorn-registry workers. Workers that do not respond within this window are killed and restarted. Must be between 30 and 1800 (30 minutes). Defaults to 300",
+            "maximum": 300,
+            "description": "Timeout in seconds for gunicorn-registry workers. Workers that do not respond within this window are killed and restarted. Must be between 30 and 300 (5 minutes). Defaults to 30",
             "x-example": 300,
         },
         "GUNICORN_WEB_TIMEOUT": {
             "type": "integer",
             "minimum": 30,
-            "maximum": 1800,
-            "description": "Timeout in seconds for gunicorn-web workers. Workers that do not respond within this window are killed and restarted. Must be between 30 and 1800 (30 minutes). Defaults to 60",
+            "maximum": 300,
+            "description": "Timeout in seconds for gunicorn-web workers. Workers that do not respond within this window are killed and restarted. Must be between 30 and 300 (5 minutes). Defaults to 30",
             "x-example": 60,
         },
         "MAXIMUM_LAYER_SIZE": {

--- a/util/config/test/test_schema.py
+++ b/util/config/test/test_schema.py
@@ -193,3 +193,31 @@ def test_programmatic_token_k8s_namespace_rejects_invalid_dns_labels(value):
 
     with pytest.raises(ValidationError):
         validate(value, schema)
+
+
+class TestGunicornTimeoutSchema:
+    @pytest.mark.parametrize("field", ["GUNICORN_REGISTRY_TIMEOUT", "GUNICORN_WEB_TIMEOUT"])
+    def test_accepts_valid_timeout(self, field):
+        schema = CONFIG_SCHEMA["properties"][field]
+        for value in [30, 60, 300, 600, 3600]:
+            validate(value, schema)
+
+    @pytest.mark.parametrize("field", ["GUNICORN_REGISTRY_TIMEOUT", "GUNICORN_WEB_TIMEOUT"])
+    def test_rejects_timeout_below_minimum(self, field):
+        schema = CONFIG_SCHEMA["properties"][field]
+        for value in [0, 1, 29]:
+            with pytest.raises(ValidationError):
+                validate(value, schema)
+
+    @pytest.mark.parametrize("field", ["GUNICORN_REGISTRY_TIMEOUT", "GUNICORN_WEB_TIMEOUT"])
+    def test_rejects_non_integer_timeout(self, field):
+        schema = CONFIG_SCHEMA["properties"][field]
+        for value in ["300", 30.5]:
+            with pytest.raises(ValidationError):
+                validate(value, schema)
+
+    def test_default_registry_timeout(self):
+        assert DefaultConfig.GUNICORN_REGISTRY_TIMEOUT == 300
+
+    def test_default_web_timeout(self):
+        assert DefaultConfig.GUNICORN_WEB_TIMEOUT == 60

--- a/util/config/test/test_schema.py
+++ b/util/config/test/test_schema.py
@@ -199,7 +199,7 @@ class TestGunicornTimeoutSchema:
     @pytest.mark.parametrize("field", ["GUNICORN_REGISTRY_TIMEOUT", "GUNICORN_WEB_TIMEOUT"])
     def test_accepts_valid_timeout(self, field):
         schema = CONFIG_SCHEMA["properties"][field]
-        for value in [30, 60, 300, 600, 1800]:
+        for value in [30, 60, 300]:
             validate(value, schema)
 
     @pytest.mark.parametrize("field", ["GUNICORN_REGISTRY_TIMEOUT", "GUNICORN_WEB_TIMEOUT"])
@@ -212,7 +212,7 @@ class TestGunicornTimeoutSchema:
     @pytest.mark.parametrize("field", ["GUNICORN_REGISTRY_TIMEOUT", "GUNICORN_WEB_TIMEOUT"])
     def test_rejects_timeout_above_maximum(self, field):
         schema = CONFIG_SCHEMA["properties"][field]
-        for value in [1801, 3600, 7200]:
+        for value in [301, 600, 1800, 3600, 7200]:
             with pytest.raises(ValidationError):
                 validate(value, schema)
 
@@ -224,7 +224,7 @@ class TestGunicornTimeoutSchema:
                 validate(value, schema)
 
     def test_default_registry_timeout(self):
-        assert DefaultConfig.GUNICORN_REGISTRY_TIMEOUT == 300
+        assert DefaultConfig.GUNICORN_REGISTRY_TIMEOUT == 30
 
     def test_default_web_timeout(self):
-        assert DefaultConfig.GUNICORN_WEB_TIMEOUT == 60
+        assert DefaultConfig.GUNICORN_WEB_TIMEOUT == 30

--- a/util/config/test/test_schema.py
+++ b/util/config/test/test_schema.py
@@ -199,13 +199,20 @@ class TestGunicornTimeoutSchema:
     @pytest.mark.parametrize("field", ["GUNICORN_REGISTRY_TIMEOUT", "GUNICORN_WEB_TIMEOUT"])
     def test_accepts_valid_timeout(self, field):
         schema = CONFIG_SCHEMA["properties"][field]
-        for value in [30, 60, 300, 600, 3600]:
+        for value in [30, 60, 300, 600, 1800]:
             validate(value, schema)
 
     @pytest.mark.parametrize("field", ["GUNICORN_REGISTRY_TIMEOUT", "GUNICORN_WEB_TIMEOUT"])
     def test_rejects_timeout_below_minimum(self, field):
         schema = CONFIG_SCHEMA["properties"][field]
         for value in [0, 1, 29]:
+            with pytest.raises(ValidationError):
+                validate(value, schema)
+
+    @pytest.mark.parametrize("field", ["GUNICORN_REGISTRY_TIMEOUT", "GUNICORN_WEB_TIMEOUT"])
+    def test_rejects_timeout_above_maximum(self, field):
+        schema = CONFIG_SCHEMA["properties"][field]
+        for value in [1801, 3600, 7200]:
             with pytest.raises(ValidationError):
                 validate(value, schema)
 

--- a/web/playwright/e2e/api/api-v1-advanced-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-advanced-features.spec.ts
@@ -793,8 +793,8 @@ test.describe(
   {tag: ['@api', '@superuser', '@PROJQUAY-12278']},
   () => {
     const TIMEOUT_FIELDS = [
-      {key: 'GUNICORN_REGISTRY_TIMEOUT', defaultValue: 300},
-      {key: 'GUNICORN_WEB_TIMEOUT', defaultValue: 60},
+      {key: 'GUNICORN_REGISTRY_TIMEOUT', defaultValue: 30},
+      {key: 'GUNICORN_WEB_TIMEOUT', defaultValue: 30},
     ];
 
     test('config dump exposes timeout schema with min and max constraints', async ({
@@ -813,7 +813,7 @@ test.describe(
         expect(fieldSchema, `${key} should be in schema`).toBeDefined();
         expect(fieldSchema.type).toBe('integer');
         expect(fieldSchema.minimum).toBe(30);
-        expect(fieldSchema.maximum).toBe(1800);
+        expect(fieldSchema.maximum).toBe(300);
       }
     });
 
@@ -831,7 +831,7 @@ test.describe(
       for (const {key, defaultValue} of TIMEOUT_FIELDS) {
         const value = body.config?.[key] ?? defaultValue;
         expect(value, `${key} should be >= 30`).toBeGreaterThanOrEqual(30);
-        expect(value, `${key} should be <= 1800`).toBeLessThanOrEqual(1800);
+        expect(value, `${key} should be <= 300`).toBeLessThanOrEqual(300);
       }
     });
 

--- a/web/playwright/e2e/api/api-v1-advanced-features.spec.ts
+++ b/web/playwright/e2e/api/api-v1-advanced-features.spec.ts
@@ -786,6 +786,63 @@ test.describe('Config Dump', {tag: ['@api']}, () => {
 });
 
 // ---------------------------------------------------------------------------
+// Gunicorn Timeout Config Schema
+// ---------------------------------------------------------------------------
+test.describe(
+  'Gunicorn Timeout Config Schema',
+  {tag: ['@api', '@superuser', '@PROJQUAY-12278']},
+  () => {
+    const TIMEOUT_FIELDS = [
+      {key: 'GUNICORN_REGISTRY_TIMEOUT', defaultValue: 300},
+      {key: 'GUNICORN_WEB_TIMEOUT', defaultValue: 60},
+    ];
+
+    test('config dump exposes timeout schema with min and max constraints', async ({
+      adminClient,
+    }) => {
+      const resp = await adminClient.get('/api/v1/superuser/config');
+      if (resp.status() === 404 || resp.status() === 403) {
+        test.skip(true, 'FEATURE_SUPERUSER_CONFIGDUMP not enabled');
+        return;
+      }
+      expect(resp.status()).toBe(200);
+      const body = await resp.json();
+
+      for (const {key} of TIMEOUT_FIELDS) {
+        const fieldSchema = body.schema?.properties?.[key];
+        expect(fieldSchema, `${key} should be in schema`).toBeDefined();
+        expect(fieldSchema.type).toBe('integer');
+        expect(fieldSchema.minimum).toBe(30);
+        expect(fieldSchema.maximum).toBe(1800);
+      }
+    });
+
+    test('config dump returns timeout values within valid range', async ({
+      adminClient,
+    }) => {
+      const resp = await adminClient.get('/api/v1/superuser/config');
+      if (resp.status() === 404 || resp.status() === 403) {
+        test.skip(true, 'FEATURE_SUPERUSER_CONFIGDUMP not enabled');
+        return;
+      }
+      expect(resp.status()).toBe(200);
+      const body = await resp.json();
+
+      for (const {key, defaultValue} of TIMEOUT_FIELDS) {
+        const value = body.config?.[key] ?? defaultValue;
+        expect(value, `${key} should be >= 30`).toBeGreaterThanOrEqual(30);
+        expect(value, `${key} should be <= 1800`).toBeLessThanOrEqual(1800);
+      }
+    });
+
+    test('normal user cannot access config dump', async ({userClient}) => {
+      const resp = await userClient.get('/api/v1/superuser/config');
+      expect(resp.status()).toBe(403);
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
 // App Tokens Superuser
 // ---------------------------------------------------------------------------
 test.describe('App Tokens Superuser', {tag: ['@api']}, () => {


### PR DESCRIPTION
## Summary
- Add GUNICORN_REGISTRY_TIMEOUT (default: 300s) and GUNICORN_WEB_TIMEOUT (default: 60s) config.yaml parameters
- supervisord.conf.jnj now passes --timeout to gunicorn-registry and gunicorn-web using these values
- supervisord_conf_create.py reads config.yaml at container init to extract timeout values
- Config schema validates both params as integers with minimum 30

## Motivation
Gunicorn hardcoded 30-second default timeout causes SIGKILL on legitimate long-running operations: proxy cache blob downloads (>500 MB), large image pushes, and API queries on large orgs with quota enabled. This affects at least 9 open PROJQUAY bugs (PROJQUAY-9103, PROJQUAY-8837, PROJQUAY-6564, PROJQUAY-8775, PROJQUAY-8765, PROJQUAY-8218, PROJQUAY-7462, PROJQUAY-6886, [PROJQUAY-8300](https://redhat.atlassian.net/browse/PROJQUAY-8300)).

The new defaults (300s registry, 60s web) provide immediate relief while a proper async fix for proxy cache is developed separately ([PROJQUAY-12311](https://redhat.atlassian.net/browse/PROJQUAY-12311)).

## Test plan
- [x] Schema validation tests: accepts valid integers >= 30, rejects values below minimum, rejects non-integers
- [x] Config default tests: verify 300s registry and 60s web defaults
- [x] Template rendering tests: default values, custom values, hotreload mode preserves 600s override
- [x] All 63 tests pass (57 schema + 6 supervisord)