### PR TITLE
PROJQUAY-9692: fix(audit): log org_delete event when superuser deletes organization

### DIFF
--- a/endpoints/api/superuser.py
+++ b/endpoints/api/superuser.py
@@ -876,6 +876,11 @@ class SuperUserOrganizationManagement(ApiResource):
         Deletes the specified organization.
         """
         if SuperUserPermission().can():
+            try:
+                model.organization.get_organization(name)
+            except model.InvalidOrganizationException:
+                raise NotFound()
+
             log_action("org_delete", name, {"namespace": name})
             pre_oci_model.mark_organization_for_deletion(name)
             return "", 204

--- a/endpoints/api/superuser.py
+++ b/endpoints/api/superuser.py
@@ -876,6 +876,7 @@ class SuperUserOrganizationManagement(ApiResource):
         Deletes the specified organization.
         """
         if SuperUserPermission().can():
+            log_action("org_delete", name, {"namespace": name})
             pre_oci_model.mark_organization_for_deletion(name)
             return "", 204
 

--- a/endpoints/api/test/test_superuser.py
+++ b/endpoints/api/test/test_superuser.py
@@ -1,11 +1,14 @@
 import pytest
+from mock import patch
 
+from data import model
 from data.database import DeletedNamespace, User
 from endpoints.api.superuser import (
     SuperUserDumpConfig,
     SuperUserList,
     SuperUserManagement,
     SuperUserOrganizationList,
+    SuperUserOrganizationManagement,
 )
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
@@ -106,3 +109,28 @@ def test_get_superuserdumpconfig(app):
             result.get("schema", {})["description"]
             result.get("schema", {})["required"]
             raise AttributeError()
+
+
+def test_delete_organization_logs_audit_event(app):
+    admin_user = model.user.get_user("devtable")
+    org = model.organization.create_organization("delauditorg", "delaudit@test.com", admin_user)
+
+    with client_with_identity("devtable", app) as cl:
+        with patch("endpoints.api.superuser.log_action") as mock_log:
+            params = {"name": org.username}
+            conduct_api_call(cl, SuperUserOrganizationManagement, "DELETE", params, None, 204)
+
+            mock_log.assert_called_once()
+            call_args = mock_log.call_args
+            assert call_args[0][0] == "org_delete"
+            assert call_args[0][1] == org.username
+            assert call_args[0][2] == {"namespace": org.username}
+
+
+def test_delete_nonexistent_organization_returns_404(app):
+    with client_with_identity("devtable", app) as cl:
+        with patch("endpoints.api.superuser.log_action") as mock_log:
+            params = {"name": "nonexistent_org_xyz"}
+            conduct_api_call(cl, SuperUserOrganizationManagement, "DELETE", params, None, 404)
+
+            mock_log.assert_not_called()

--- a/endpoints/api/test/test_superuser.py
+++ b/endpoints/api/test/test_superuser.py
@@ -134,3 +134,21 @@ def test_delete_nonexistent_organization_returns_404(app):
             conduct_api_call(cl, SuperUserOrganizationManagement, "DELETE", params, None, 404)
 
             mock_log.assert_not_called()
+
+
+def test_delete_organization_succeeds(app):
+    admin_user = model.user.get_user("devtable")
+    org = model.organization.create_organization("delcovorg", "delcov@test.com", admin_user)
+
+    with client_with_identity("devtable", app) as cl:
+        params = {"name": org.username}
+        conduct_api_call(cl, SuperUserOrganizationManagement, "DELETE", params, None, 204)
+
+    with pytest.raises(model.InvalidOrganizationException):
+        model.organization.get_organization("delcovorg")
+
+
+def test_delete_nonexistent_organization_no_phantom_log(app):
+    with client_with_identity("devtable", app) as cl:
+        params = {"name": "nonexistent_org_xyz"}
+        conduct_api_call(cl, SuperUserOrganizationManagement, "DELETE", params, None, 404)

--- a/web/playwright/e2e/superuser/org-actions.spec.ts
+++ b/web/playwright/e2e/superuser/org-actions.spec.ts
@@ -134,7 +134,6 @@ test.describe(
       // Filter for the deleted org name to find the audit entry
       await expect(superuserPage.getByPlaceholder('Filter logs')).toBeVisible();
       await superuserPage.getByPlaceholder('Filter logs').fill(org.name);
-      await superuserPage.waitForTimeout(500);
 
       await expect(
         superuserPage

--- a/web/playwright/e2e/superuser/org-actions.spec.ts
+++ b/web/playwright/e2e/superuser/org-actions.spec.ts
@@ -98,6 +98,55 @@ test.describe(
       ).not.toBeVisible();
     });
 
+    test('superuser org deletion generates audit log entry', async ({
+      superuserPage,
+      superuserApi,
+    }) => {
+      const org = await superuserApi.organization('auditdel');
+
+      await superuserPage.goto('/organization');
+
+      // Delete the org via kebab menu
+      const optionsToggle = superuserPage.getByTestId(
+        `${org.name}-options-toggle`,
+      );
+      await expect(optionsToggle).toBeVisible({timeout: 15000});
+      await optionsToggle.click();
+
+      await superuserPage
+        .getByRole('menuitem', {name: 'Delete Organization'})
+        .click();
+
+      const dialog = superuserPage.getByRole('dialog');
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole('button', {name: 'OK'}).click();
+      await expect(dialog).not.toBeVisible();
+      await expect(
+        superuserPage.getByText(
+          `Successfully deleted organization ${org.name}`,
+        ),
+      ).toBeVisible();
+
+      // Navigate to superuser usage logs and verify org_delete entry
+      await superuserPage.goto('/usage-logs');
+      await expect(
+        superuserPage.getByTestId('usage-logs-table'),
+      ).toBeVisible();
+
+      // Filter for the deleted org name to find the audit entry
+      await expect(
+        superuserPage.getByPlaceholder('Filter logs'),
+      ).toBeVisible();
+      await superuserPage.getByPlaceholder('Filter logs').fill(org.name);
+      await superuserPage.waitForTimeout(500);
+
+      await expect(
+        superuserPage
+          .getByTestId('usage-logs-table')
+          .getByText(`Organization ${org.name} deleted`),
+      ).toBeVisible();
+    });
+
     test('superuser can take ownership of an organization', async ({
       superuserPage,
       api,

--- a/web/playwright/e2e/superuser/org-actions.spec.ts
+++ b/web/playwright/e2e/superuser/org-actions.spec.ts
@@ -129,14 +129,10 @@ test.describe(
 
       // Navigate to superuser usage logs and verify org_delete entry
       await superuserPage.goto('/usage-logs');
-      await expect(
-        superuserPage.getByTestId('usage-logs-table'),
-      ).toBeVisible();
+      await expect(superuserPage.getByTestId('usage-logs-table')).toBeVisible();
 
       // Filter for the deleted org name to find the audit entry
-      await expect(
-        superuserPage.getByPlaceholder('Filter logs'),
-      ).toBeVisible();
+      await expect(superuserPage.getByPlaceholder('Filter logs')).toBeVisible();
       await superuserPage.getByPlaceholder('Filter logs').fill(org.name);
       await superuserPage.waitForTimeout(500);
 


### PR DESCRIPTION
## Summary
- Adds missing `log_action("org_delete", ...)` call to the superuser organization delete endpoint (`SuperUserOrganizationManagement.delete` in `endpoints/api/superuser.py`)
- The normal org-delete path (`endpoints/api/organization.py`) already logs this event correctly; the superuser path was an oversight
- Follows the same pattern used by the superuser user-delete handler (`log_action("user_delete", ...)`) and org-rename handler (`log_action("org_change_name", ...)`) in the same file

## Test plan
- [ ] Delete an organization from the superuser admin panel and verify an `org_delete` audit log entry is created
- [ ] Delete an organization from the organization settings page and verify `org_delete` audit log still works as before
- [ ] Verify the audit log entry contains the correct `namespace` metadata field

🤖 Generated with [Claude Code](https://claude.com/claude-code)