### PR TITLE
NO-ISSUE: docs(agents): add schema consistency checks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -49,6 +49,18 @@ reviews:
         - UPDATE statements that touch all rows without batching
         - Missing or incomplete downgrade() implementation
         - Verify down_revision matches the current migration chain head
+        - Verify internal/dal/schema/sqlite/quay_schema.sql reflects the post-migration DDL
+        - Verify internal/dal/schema/sqlite/seed_data.sql stamps the latest migration revision
+
+    - path: "internal/dal/schema/sqlite/migrations/**/*.sql"
+      instructions: |
+        Review SQLite migrations for consistency with the generated schema.
+
+        Check that:
+        - internal/dal/schema/sqlite/quay_schema.sql reflects the post-migration DDL
+        - internal/dal/schema/sqlite/seed_data.sql stamps the latest migration revision
+        - A fresh database created from the generated schema matches one upgraded through
+          every migration; request regenerated files from make go-schema when they drift
 
     - path: "data/model/**/*.py"
       instructions: |

--- a/agent_docs/database.md
+++ b/agent_docs/database.md
@@ -63,6 +63,20 @@ alembic downgrade -1
 3. Test migrations in both directions
 4. Include data migrations if needed (not just schema)
 
+### Generated Schema Consistency
+
+When adding or modifying Alembic migrations in `data/migrations/versions/` or
+SQLite migrations in `internal/dal/schema/sqlite/migrations/`:
+
+1. Verify that `internal/dal/schema/sqlite/quay_schema.sql` reflects the
+   post-migration DDL. If a migration immediately changes DDL in the generated
+   schema, run `make go-schema` and commit the regenerated files.
+2. Verify that `internal/dal/schema/sqlite/seed_data.sql` stamps the latest
+   migration revision.
+3. Run `make go-schema-check` to confirm that initializing a database from the
+   generated schema produces the same structure as applying all migrations to
+   an empty database.
+
 ## Database Connection
 
 ```python


### PR DESCRIPTION
## Summary
- document how to keep generated SQLite schema and seed data aligned with migration changes
- add migration review reminders for generated DDL and revision consistency

Closes #6683

## Test plan
- [x] `git diff --check`
- [x] Parse `.coderabbit.yaml` with Ruby YAML
- [ ] `pre-commit run --files agent_docs/database.md .coderabbit.yaml` (not run: `pre-commit` is not installed locally)