### PR TITLE
PROJQUAY-12402: chore(deps): override brace-expansion to address CVE-2026-13149

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1162,9 +1162,9 @@
       "integrity": "sha1-/3+Jj7h9RSflR/62QVj4hFDRoMk="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12902,9 +12902,9 @@
       "integrity": "sha1-/3+Jj7h9RSflR/62QVj4hFDRoMk="
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -17316,7 +17316,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^1.1.16"
       }
     },
     "minimist": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "overrides": {
     "cross-spawn": "^6.0.6",
     "qs": "^6.14.0",
-    "form-data": "^2.5.6"
+    "form-data": "^2.5.6",
+    "brace-expansion": "^1.1.16"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5819,9 +5819,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -135,7 +135,8 @@
     "minimatch": "3.1.5",
     "svgo": "4.0.1",
     "immutable": "^5.1.5",
-    "fast-uri": "^3.1.3"
+    "fast-uri": "^3.1.3",
+    "brace-expansion": "^1.1.16"
   },
   "pnpm": {
     "overrides": {
@@ -152,7 +153,8 @@
       "minimatch": "3.1.5",
       "svgo": "4.0.1",
       "immutable": "^5.1.5",
-      "fast-uri": "^3.1.3"
+      "fast-uri": "^3.1.3",
+      "brace-expansion": "^1.1.16"
     }
   }
 }


### PR DESCRIPTION
## Summary
Added Override for brace-expansion to address CVE-2026-13149

## Affected Versions

| Affected Range | Fixed Version |
|----------------|---------------|
| <= 1.1.15      | 1.1.16+       |
| 2.0.0 – 2.1.1 | 2.1.2+        |
| 3.0.0 – 5.0.6 | 5.0.7+        |

🤖 Generated with [Claude Code](https://claude.com/claude-code)