### PR TITLE
PROJQUAY-11868: fix(dbcore): pin go-schema baseline and fix OpenSQLite DSN encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -462,6 +462,12 @@ GO_LDFLAGS = $(if $(GO_VERSION),-ldflags "-X github.com/quay/quay/internal/cmd.v
 SCHEMA_DIR := internal/dal/schema
 SCHEMA_TMP := /tmp/quay-schema-tmp
 
+# GO_SCHEMA_ALEMBIC_REVISION pins the Go binary's generated schema baseline.
+# The Go migration framework bridges OMR sources to this exact revision, so
+# generation must not silently follow a future Python Alembic head; advancing
+# it is a deliberate decision, not a side effect of an unrelated migration.
+GO_SCHEMA_ALEMBIC_REVISION := 9fa37f66a9b6
+
 .PHONY: go-schema go-schema-check
 
 go-schema:
@@ -469,7 +475,7 @@ go-schema:
 	@rm -rf $(SCHEMA_TMP)
 	@mkdir -p $(SCHEMA_TMP)/stack $(SCHEMA_DIR)/sqlite
 	@echo 'DB_URI: sqlite:///$(SCHEMA_TMP)/quay.db' > $(SCHEMA_TMP)/stack/config.yaml
-	QUAYCONF=$(SCHEMA_TMP)/ PYTHONPATH="." alembic upgrade head
+	QUAYCONF=$(SCHEMA_TMP)/ PYTHONPATH="." alembic upgrade $(GO_SCHEMA_ALEMBIC_REVISION)
 	@echo "=== Extracting schema DDL ==="
 	sqlite3 $(SCHEMA_TMP)/quay.db .schema > $(SCHEMA_DIR)/sqlite/quay_schema.sql
 	@sed 's/[[:space:]]*$$//' $(SCHEMA_DIR)/sqlite/quay_schema.sql > $(SCHEMA_DIR)/sqlite/quay_schema.sql.tmp && mv $(SCHEMA_DIR)/sqlite/quay_schema.sql.tmp $(SCHEMA_DIR)/sqlite/quay_schema.sql

--- a/internal/dal/dbcore/fixture_test.go
+++ b/internal/dal/dbcore/fixture_test.go
@@ -161,6 +161,17 @@ func TestRunBridge_RejectsStructurallyAlteredArtifactFixture(t *testing.T) {
 	if !strings.Contains(err.Error(), "no such table: tag") {
 		t.Errorf("RunBridge error = %v, want it to report the missing tag table", err)
 	}
+
+	// RunBridge disables foreign_keys before its transaction and re-enables
+	// them via a deferred call regardless of outcome; a failed bridge must
+	// not leave enforcement off.
+	var foreignKeysEnabled int
+	if err := db.QueryRowContext(t.Context(), "PRAGMA foreign_keys").Scan(&foreignKeysEnabled); err != nil {
+		t.Fatalf("query foreign_keys pragma: %v", err)
+	}
+	if foreignKeysEnabled != 1 {
+		t.Error("expected foreign_keys to be re-enabled after a failed RunBridge")
+	}
 }
 
 func tableCounts(t *testing.T, db *sql.DB, tables []string) map[string]int {

--- a/internal/dal/dbcore/migrate_test.go
+++ b/internal/dal/dbcore/migrate_test.go
@@ -183,6 +183,88 @@ func TestIntegrityCheck(t *testing.T) {
 	}
 }
 
+// TestApplyMigrationTx_RollsBackSchemaAndVersionTogether proves that a
+// failure partway through a migration rolls back both the schema/data change
+// and the alembic_version stamp together, atomically.
+func TestApplyMigrationTx_RollsBackSchemaAndVersionTogether(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	defer db.Close()
+
+	ctx := t.Context()
+	if err := InitDatabase(ctx, db, &bytes.Buffer{}); err != nil {
+		t.Fatalf("InitDatabase: %v", err)
+	}
+
+	before, err := SchemaVersion(ctx, db)
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+
+	failingSQL := `
+CREATE TABLE rollback_marker (id INTEGER);
+INSERT INTO does_not_exist_xyz (id) VALUES (1);
+`
+	if err := applyMigrationTx(ctx, db, failingSQL, "should-not-persist"); err == nil {
+		t.Fatal("expected applyMigrationTx to fail")
+	}
+
+	var tableCount int
+	if err := db.QueryRowContext(ctx,
+		"SELECT count(*) FROM sqlite_master WHERE type='table' AND name='rollback_marker'",
+	).Scan(&tableCount); err != nil {
+		t.Fatalf("check rollback_marker: %v", err)
+	}
+	if tableCount != 0 {
+		t.Error("expected rollback_marker table to be rolled back, but it exists")
+	}
+
+	after, err := SchemaVersion(ctx, db)
+	if err != nil {
+		t.Fatalf("SchemaVersion after failed migration: %v", err)
+	}
+	if after != before {
+		t.Errorf("alembic_version changed after a failed migration: before=%q after=%q", before, after)
+	}
+}
+
+// TestApplyMigrationTx_RetryAfterFailureSucceeds proves that after a failed
+// migration rolls back, the durable (unchanged) revision can be retried and
+// still reaches the intended target.
+func TestApplyMigrationTx_RetryAfterFailureSucceeds(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	defer db.Close()
+
+	ctx := t.Context()
+	if err := InitDatabase(ctx, db, &bytes.Buffer{}); err != nil {
+		t.Fatalf("InitDatabase: %v", err)
+	}
+
+	if err := applyMigrationTx(ctx, db, "INSERT INTO does_not_exist_xyz (id) VALUES (1);", "should-not-persist"); err == nil {
+		t.Fatal("expected first attempt to fail")
+	}
+
+	// Retry starts from the still-durable pre-failure revision and succeeds.
+	if err := applyMigrationTx(ctx, db, "CREATE TABLE retry_marker (id INTEGER);", "retried-revision"); err != nil {
+		t.Fatalf("retry after failure: %v", err)
+	}
+
+	ver, err := SchemaVersion(ctx, db)
+	if err != nil {
+		t.Fatalf("SchemaVersion: %v", err)
+	}
+	if ver != "retried-revision" {
+		t.Errorf("version = %q, want %q", ver, "retried-revision")
+	}
+}
+
 func TestBackupAndClean(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")

--- a/internal/dal/dbcore/sqlite.go
+++ b/internal/dal/dbcore/sqlite.go
@@ -8,14 +8,18 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "modernc.org/sqlite" // Pure-Go SQLite driver, registers as "sqlite".
 )
 
-// pragmas are applied to every new SQLite connection via a DSN hook.
+// sqliteURIScheme is the URI scheme used to build SQLite DSNs.
+const sqliteURIScheme = "file"
+
+// dsnParams are applied to every new SQLite connection via a DSN hook.
 // WAL mode allows concurrent readers while a single writer holds the lock.
 // busy_timeout avoids immediate SQLITE_BUSY errors under brief contention.
-var pragmas = []string{
+var dsnParams = []string{
 	"_pragma=foreign_keys(1)",
 	"_pragma=journal_mode(WAL)",
 	"_pragma=busy_timeout(10000)",
@@ -33,15 +37,11 @@ func OpenSQLite(dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("create database directory %s: %w", dir, err)
 	}
 
-	dsn := fmt.Sprintf("file:%s?", dbPath)
-	for i, p := range pragmas {
-		if i > 0 {
-			dsn += "&"
-		}
-		dsn += p
-	}
+	// Encode dbPath into the URI so paths containing characters such as
+	// '?', '#', or '&' aren't misparsed as the start of the query string.
+	uri := url.URL{Scheme: sqliteURIScheme, Path: dbPath, RawQuery: strings.Join(dsnParams, "&"), OmitHost: true}
 
-	db, err := sql.Open("sqlite", dsn)
+	db, err := sql.Open("sqlite", uri.String())
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", dbPath, err)
 	}
@@ -65,7 +65,7 @@ func OpenSQLiteReadOnly(dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("source database not found: %s: %w", dbPath, err)
 	}
 
-	uri := url.URL{Scheme: "file", Path: dbPath, RawQuery: "mode=ro", OmitHost: true}
+	uri := url.URL{Scheme: sqliteURIScheme, Path: dbPath, RawQuery: "mode=ro", OmitHost: true}
 	db, err := sql.Open("sqlite", uri.String())
 	if err != nil {
 		return nil, fmt.Errorf("open %s read-only: %w", dbPath, err)

--- a/internal/dal/dbcore/sqlite_test.go
+++ b/internal/dal/dbcore/sqlite_test.go
@@ -3,6 +3,7 @@ package dbcore
 import (
 	"bytes"
 	"database/sql"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -90,9 +91,28 @@ func TestOpenSQLiteReadOnly(t *testing.T) {
 	})
 }
 
+func TestOpenSQLite_PathsContainingURIDelimiters(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "omr?with#symbols&.db")
+
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLite: %v", err)
+	}
+	defer db.Close()
+
+	if err := InitDatabase(t.Context(), db, io.Discard); err != nil {
+		t.Fatalf("InitDatabase: %v", err)
+	}
+
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("expected database created at literal path %q: %v", dbPath, err)
+	}
+}
+
 func createMarkerDatabase(t *testing.T, path, marker string) {
 	t.Helper()
-	uri := url.URL{Scheme: "file", Path: path}
+	uri := url.URL{Scheme: sqliteURIScheme, Path: path}
 	db, err := sql.Open("sqlite", uri.String())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
Two independent, small hardening fixes for the Go OMR migration bridge's schema generation and database open path.

## Related Issue
[PROJQUAY-11868](https://redhat.atlassian.net/browse/PROJQUAY-11868)

## Changes
- Pin `make go-schema`'s Alembic target from `head` to `9fa37f66a9b6` (new `GO_SCHEMA_ALEMBIC_REVISION`). `go-schema-check` calls `go-schema` internally, so it inherits the pin without further changes. Without this, an unrelated future Python migration could silently move the Go schema baseline forward the next time schema generation runs.
- Switch `OpenSQLite`'s DSN construction to `url.URL` (matching `OpenSQLiteReadOnly`'s existing pattern) so a `dbPath` containing `?`, `#`, or `&` is encoded correctly instead of being misparsed as the start of the query string.
- Added test coverage proving `applyMigrationTx`/`RunBridge` already roll back schema and `alembic_version` together atomically, and that a retry after a failed migration starts from the still-durable pre-failure revision (no production logic change there; it already worked, just untested).

## Testing
- [x] `go test ./internal/dal/dbcore ./internal/migrate -count=1` passes
- [x] `go test -race ./internal/dal/dbcore -count=1` passes
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./internal/dal/dbcore/... ./internal/migrate/...` passes (0 issues)
- [x] `gofmt -l` clean
- [x] `git diff --check` clean
- [ ] Not run: `make go-schema-check` (real run) — `alembic`/`sqlite3` are not available in the sandbox this PR was prepared in. Verified via `make -n go-schema` that the Makefile substitutes the pinned revision correctly; CI's `ci-go.yaml` `go-schema-check` step exercises the real pinned regeneration on this PR.

## Notes
Follow-up in the same migration-framework line of work as #6681 and #6692 (no schema/behavior change to `RunBridge`/`ValidateSourceCompatibility` admission logic, no Goose, no tag behavior change).
