### PR TITLE
PROJQUAY-12447: feat: config-tool: Add DATA_MODEL_CACHE_CONFIG to the validator

### DIFF
--- a/config-tool/pkg/lib/config/config.go
+++ b/config-tool/pkg/lib/config/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/autoprune"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/bitbucketbuildtrigger"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/buildmanager"
+	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/cache"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/database"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/distributedstorage"
 	"github.com/quay/quay/config-tool/pkg/lib/fieldgroups/elasticsearch"
@@ -164,5 +165,12 @@ func NewConfig(fullConfig map[string]interface{}) (Config, error) {
 		return newConfig, err
 	}
 	newConfig["AutoPrune"] = newAutoPruneFieldGroup
+
+	newDataModelCacheConfigGroup, err := cache.NewCacheFieldGroup(fullConfig)
+	if err != nil {
+		return newConfig, err
+	}
+	newConfig["ModelCacheConfig"] = newDataModelCacheConfigGroup
+
 	return newConfig, nil
 }

--- a/config-tool/pkg/lib/fieldgroups/cache/cache.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache.go
@@ -27,6 +27,13 @@ func NewDataModelCacheStructGroup(fullConfig map[string]any) (*DataModelCacheStr
 		}
 	}
 
+	// if engine is memcached but we don't have an endpoint, exit
+	if cacheStruct.Engine == "memcached" {
+		if _, ok := fullConfig["endpoint"]; !ok {
+			return cacheStruct, errors.New("wrong configuration: caching engine is memcached, but endpoint is missing")
+		}
+	}
+
 	if value, ok := fullConfig["endpoint"]; ok {
 		if cacheStruct.Engine != "memcached" {
 			return cacheStruct, errors.New("wrong configuration: endpoint is only used for memcached model")

--- a/config-tool/pkg/lib/fieldgroups/cache/cache.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache.go
@@ -1,0 +1,197 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/creasty/defaults"
+)
+
+// NewDataModelCacheStructGroup creates and validates the new cache group and returns it to the caller.
+// Raises an error if validation fails.
+func NewDataModelCacheStructGroup(fullConfig map[string]any) (*DataModelCacheStruct, error) {
+	cacheStruct := &DataModelCacheStruct{}
+	defaults.Set(cacheStruct)
+
+	if value, ok := fullConfig["engine"]; ok {
+		cacheStruct.Engine, ok = value.(string)
+		if !ok {
+			return cacheStruct, errors.New("engine must be of type string")
+		}
+
+		// fail if the caching engine is unsupported
+		if !(cacheStruct.Engine == "memcached" || cacheStruct.Engine == "inmemory" || cacheStruct.Engine == "redis" ||
+			cacheStruct.Engine == "rediscluster") {
+			return cacheStruct, errors.New("unsupported caching model: must be inmemory, redis, memcached or rediscluster")
+		}
+	}
+
+	if value, ok := fullConfig["endpoint"]; ok {
+		if cacheStruct.Engine != "memcached" {
+			return cacheStruct, errors.New("wrong configuration: endpoint is only used for memcached model")
+		}
+
+		endpointSlice, isSlice := value.([]any)
+		if !isSlice {
+			return cacheStruct, errors.New("wrong configuration: endpoint must be an array/slice")
+		}
+
+		if len(endpointSlice) != 2 {
+			return cacheStruct, errors.New("wrong configuration: endpoint should only contain hostname and port")
+		}
+
+		// verify hostname
+		_, ok := endpointSlice[0].(string)
+		if !ok {
+			return cacheStruct, errors.New("wrong configuration: host (first element) must be a string")
+		}
+
+		// verify port number and also check the type of the variable so it can be properly stored
+		var port int
+		switch v := endpointSlice[1].(type) {
+		case int:
+			port = v
+		case float64:
+			port = int(v)
+		default:
+			return cacheStruct, errors.New("wrong configuration: port must be a number")
+		}
+
+		if port < 1 || port > 65535 {
+			return cacheStruct, errors.New("wrong configuration: port must be in the range 1-65535")
+		}
+
+		cacheStruct.Endpoint = []any{endpointSlice[0], port}
+	}
+
+	if value, ok := fullConfig["repository_blob_cache_ttl"]; ok {
+		cacheStruct.RepositoryBlobCacheTTL, ok = value.(string)
+		if !ok {
+			return cacheStruct,
+				errors.New("wrong configuration: repository_blob_cache_ttl must be a time string, for example '60s'")
+		}
+	}
+
+	if value, ok := fullConfig["active_repo_tags_cache_ttl"]; ok {
+		cacheStruct.ActiveRepoTagsCacheTTL, ok = value.(string)
+		if !ok {
+			return cacheStruct,
+				errors.New("wrong configuration: active_repo_tags_cache_ttl must be a time string, for example '60s'")
+		}
+	}
+
+	if value, ok := fullConfig["catalog_page_cache_ttl"]; ok {
+		cacheStruct.CatalogPageCacheTTL, ok = value.(string)
+		if !ok {
+			return cacheStruct,
+				errors.New("wrong configuration: catalog_page_cache_ttl must be a time string, for example '60s'")
+		}
+	}
+
+	if value, ok := fullConfig["value_size_limit"]; ok {
+		cacheStruct.ValueSizeLimit, ok = value.(string)
+		if !ok {
+			return cacheStruct,
+				errors.New("wrong configuration: value_size_limit must be a string, for instance '1MiB'")
+		}
+	}
+
+	// if the engine is redis or rediscluster, check that we have a redis_config in place
+	if cacheStruct.Engine == "redis" || cacheStruct.Engine == "rediscluster" {
+		if _, ok := fullConfig["redis_config"]; !ok {
+			return cacheStruct, errors.New("wrong configuration: Engine set to Redis but config is missing redis_config fields")
+		}
+	}
+
+	if value, ok := fullConfig["redis_config"]; ok {
+		if cacheStruct.Engine != "redis" && cacheStruct.Engine != "rediscluster" {
+			errString := fmt.Sprintf("wrong configuration: redis_config is present, but engine is %s", cacheStruct.Engine)
+			return cacheStruct, errors.New(errString)
+		}
+
+		// temporaily marshal the value into JSON so we can properly store it
+		jsonBytes, err := json.Marshal(value)
+		if err != nil {
+			return cacheStruct, errors.New("wrong configuration: invalid redis_config format")
+		}
+
+		var redisConfig RedisConfigGroup
+		if err := json.Unmarshal(jsonBytes, &redisConfig); err != nil {
+			return cacheStruct, errors.New("wrong configuration: cannot parse redis_config")
+		}
+
+		// set defaults for the redisConfig
+		defaults.Set(&redisConfig)
+
+		// if engine is redis then we need to check if we have a primary (and potentially a replica) key present
+		if cacheStruct.Engine == "redis" {
+			if redisConfig.Primary == nil {
+				return cacheStruct, errors.New("wrong configuration: primary redis caching instance undefined")
+			}
+
+			// check that primary key contains host and port and they are not empty
+			if redisConfig.Primary.Host == "" {
+				return cacheStruct, errors.New("wrong configuration: no host found for primary redis instance")
+			}
+
+			if redisConfig.Primary.Port < 1 || redisConfig.Primary.Port > 65535 {
+				return cacheStruct, errors.New("wrong configuration: port number for primary instance must be in range 1-65535")
+			}
+			// if replica is defined, check host and port numbers, if not defined, don't fail
+			if redisConfig.Replica != nil {
+				// check that primary key contains host and port and they are not empty
+				if redisConfig.Replica.Host == "" {
+					return cacheStruct, errors.New("wrong configuration: no host found for replica redis instance")
+				}
+
+				if redisConfig.Replica.Port < 1 || redisConfig.Replica.Port > 65535 {
+					return cacheStruct, errors.New("wrong configuration: port number for replica instance must be in range 1-65535")
+				}
+			}
+			cacheStruct.RedisConfig.Primary = redisConfig.Primary
+			cacheStruct.RedisConfig.Replica = redisConfig.Replica
+		}
+
+		// if engine is rediscluster
+		if cacheStruct.Engine == "rediscluster" {
+			if len(redisConfig.StartupNodes) == 0 {
+				return cacheStruct, errors.New("wrong configuration: rediscluster requires a list of startup nodes to be present")
+			}
+
+			// for each startup node check that host and port are properly defined
+			for _, node := range redisConfig.StartupNodes {
+				if node.Host == "" {
+					return cacheStruct, errors.New("wrong configuration: each startup_node entry must have a hostname")
+				}
+
+				if node.Port < 1 || node.Port > 65535 {
+					return cacheStruct, errors.New("wrong configuration: startup_node port must be in range 1-65535")
+				}
+			}
+			cacheStruct.RedisConfig = redisConfig
+		}
+	}
+
+	return cacheStruct, nil
+}
+
+// NewCacheFieldGroup creates a new cache field group.
+func NewCacheFieldGroup(fullConfig map[string]any) (*CacheFieldGroup, error) {
+	newCacheFieldGroup := &CacheFieldGroup{}
+	defaults.Set(newCacheFieldGroup)
+
+	if value, ok := fullConfig["DATA_MODEL_CACHE_CONFIG"]; ok {
+		var err error
+		configMap, isMap := value.(map[string]any)
+		if !isMap {
+			return newCacheFieldGroup, errors.New("DATA_MODEL_CACHE_CONFIG must be a configuration map/block")
+		}
+
+		newCacheFieldGroup.DataModelCache, err = NewDataModelCacheStructGroup(configMap)
+		if err != nil {
+			return newCacheFieldGroup, err
+		}
+	}
+	return newCacheFieldGroup, nil
+}

--- a/config-tool/pkg/lib/fieldgroups/cache/cache_fields.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_fields.go
@@ -1,0 +1,6 @@
+package cache
+
+// Fields returns a list of strings representing the fields in this field group
+func (fg *CacheFieldGroup) Fields() []string {
+	return []string{"DATA_MODEL_CACHE_CONFIG"}
+}

--- a/config-tool/pkg/lib/fieldgroups/cache/cache_structs.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_structs.go
@@ -1,0 +1,37 @@
+package cache
+
+// CacheFieldGroup represents the cache object Quay will use
+type CacheFieldGroup struct {
+	DataModelCache *DataModelCacheStruct `default:"" validate:"" json:"DATA_MODEL_CACHE_CONFIG,omitempty" yaml:"DATA_MODEL_CACHE_CONFIG,omitempty"`
+}
+
+// DataModelCacheStruct represents the caching settings that Quay will use. Quay supports in-memory cache,
+// memcached and Redis.
+type DataModelCacheStruct struct {
+	Engine                 string           `default:"inmemory" validate:"" json:"engine,omitempty" yaml:"engine,omitempty"`
+	Endpoint               []any            `default:"" validate:"" json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	RepositoryBlobCacheTTL string           `default:"60s" validate:"" json:"repository_blob_cache_ttl,omitempty" yaml:"repository_blob_cache_ttl,omitempty"`
+	CatalogPageCacheTTL    string           `default:"60s" validate:"" json:"catalog_page_cache_ttl,omitempty" yaml:"catalog_page_cache_ttl,omitempty"`
+	ActiveRepoTagsCacheTTL string           `default:"60s" validate:"" json:"active_repo_tags_cache_ttl,omitempty" yaml:"active_repo_tags_cache_ttl,omitempty"`
+	ValueSizeLimit         string           `default:"1MiB" validate:"" json:"value_size_limit,omitempty" yaml:"value_size_limit,omitempty"`
+	RedisConfig            RedisConfigGroup `default:"" validate:"" json:"redis_config,omitempty" yaml:"redis_config,omitempty"`
+}
+
+// RedisConfigGroup contains fields for both standard Redis and Redis Cluster
+type RedisConfigGroup struct {
+	// when engine == redis
+	Primary *RedisNodeConfig `default:"" validate:"" json:"primary,omitempty" yaml:"primary,omitempty"`
+	Replica *RedisNodeConfig `default:"" validate:"" json:"replica,omitempty" yaml:"replica,omitempty"`
+
+	// when engine == rediscluster
+	StartupNodes    []RedisNodeConfig `json:"startup_nodes,omitempty" yaml:"startup_nodes,omitempty"`
+	ReadFromReplica bool              `json:"read_from_replica,omitempty" yaml:"read_from_replica,omitempty"`
+}
+
+// RedisNodeConfig contains the redis nodes
+type RedisNodeConfig struct {
+	Host string `json:"host,omitempty" yaml:"host,omitempty"`
+	Port int    `default:"6379" json:"port,omitempty" yaml:"port,omitempty"`
+	Pass string `json:"pass,omitempty" yaml:"pass,omitempty"`
+	SSL  bool   `default:"false" json:"ssl,omitempty" yaml:"ssl,omitempty"`
+}

--- a/config-tool/pkg/lib/fieldgroups/cache/cache_structs.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_structs.go
@@ -24,8 +24,8 @@ type RedisConfigGroup struct {
 	Replica *RedisNodeConfig `default:"" validate:"" json:"replica,omitempty" yaml:"replica,omitempty"`
 
 	// when engine == rediscluster
-	StartupNodes    []RedisNodeConfig `json:"startup_nodes,omitempty" yaml:"startup_nodes,omitempty"`
-	ReadFromReplica bool              `json:"read_from_replica,omitempty" yaml:"read_from_replica,omitempty"`
+	StartupNodes     []RedisNodeConfig `json:"startup_nodes,omitempty" yaml:"startup_nodes,omitempty"`
+	ReadFromReplicas bool              `json:"read_from_replicas,omitempty" yaml:"read_from_replicas,omitempty"`
 }
 
 // RedisNodeConfig contains the redis nodes

--- a/config-tool/pkg/lib/fieldgroups/cache/cache_test.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_test.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/quay/quay/config-tool/pkg/lib/shared"
@@ -142,6 +141,56 @@ func TestValidateCache(t *testing.T) {
 			},
 			want: "typeError",
 		},
+		{
+			name: "Cache_Test_Missing_Endpoint_When_Engine_Memcached",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine":                    "memcached",
+					"repository_blob_cache_ttl": "60s",
+				},
+			},
+			want: "typeError",
+		},
+		{
+			name: "Cache_Test_Too_Large_Cache_Size",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine":           "inmemory",
+					"value_size_limit": "512MiB",
+				},
+			},
+			want: "invalid",
+		},
+		{
+			name: "Cache_Size_Malformed_Entry",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine":           "inmemory",
+					"value_size_limit": "wrongvalue",
+				},
+			},
+			want: "invalid",
+		},
+		{
+			name: "Cache_Size_Correct_Value",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine":           "inmemory",
+					"value_size_limit": "7MiB",
+				},
+			},
+			want: "valid",
+		},
+		{
+			name: "Cache_Size_Set_In_KiB",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine":           "inmemory",
+					"value_size_limit": "2048KiB",
+				},
+			},
+			want: "invalid",
+		},
 	}
 
 	for _, tt := range tests {
@@ -174,7 +223,9 @@ func TestValidateCache(t *testing.T) {
 
 			if tt.want != received {
 				t.Errorf("Expected %s, received %s", tt.want, received)
-				fmt.Println(validationErrors[0].Message)
+				for _, ve := range validationErrors {
+					t.Logf("validation error: %s", ve.Message)
+				}
 			}
 		})
 	}

--- a/config-tool/pkg/lib/fieldgroups/cache/cache_test.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_test.go
@@ -1,0 +1,181 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/quay/quay/config-tool/pkg/lib/shared"
+)
+
+// TestValidateCache checks that Validate returns proper values
+
+func TestValidateCache(t *testing.T) {
+	var tests = []struct {
+		name   string
+		config map[string]any
+		want   string
+	}{
+		{
+			name: "Cache_Test_Wrong_Engine_Type",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine":                    "unsupported",
+					"repository_blob_cache_ttl": "60s",
+				},
+			},
+			want: "typeError",
+		},
+		{
+			name: "Cache_Test_Correct_Engine_Type",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine": "inmemory",
+				},
+			},
+			want: "valid",
+		},
+		{
+			name: "Cache_Test_Too_Large_Cache_Size",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine":           "inmemory",
+					"value_size_limit": "123GiB",
+				},
+			},
+			want: "invalid",
+		},
+		{
+			name: "Cache_Test_Redis_Port_Out_Of_Bounds",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine": "redis",
+					"redis_config": map[string]any{
+						"primary": map[string]any{
+							"host": "localhost",
+							"port": 654321,
+							"ssl":  true,
+						},
+					},
+				},
+			},
+			want: "typeError",
+		},
+		{
+			name: "Cache_Test_Redis_Primary_Valid_Secondary_Invalid",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine": "redis",
+					"redis_config": map[string]any{
+						"primary": map[string]any{
+							"host": "localhost",
+							"port": 1234,
+						},
+						"replica": map[string]any{
+							"host": "someotherhost",
+							"port": 123456,
+						},
+					},
+				},
+			},
+			want: "typeError",
+		},
+		{
+			name: "Cache_Test_Memcached_Valid_Config",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine": "memcached",
+					"endpoint": []any{
+						"localhost",
+						12345,
+					},
+					"repository_blob_cache_ttl":  "60s",
+					"catalog_page_cache_ttl":     "60s",
+					"active_repo_tags_cache_ttl": "60s",
+					"value_size_limit":           "2MiB",
+				},
+			},
+			want: "valid",
+		},
+		{
+			name: "Cache_Test_Rediscluster_Multiple_Nodes",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine": "rediscluster",
+					"redis_config": map[string]any{
+						"startup_nodes": []map[string]any{
+							{
+								"host": "localhost",
+								"port": 1234,
+							},
+							{
+								"host": "someotherhost",
+								"port": 5432,
+							},
+						},
+						"read_from_replica": true,
+					},
+				},
+			},
+			want: "valid",
+		},
+		{
+			name: "Cache_Test_Invalid_TTL_Pattern",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine":                    "inmemory",
+					"repository_blob_cache_ttl": "someinvalidvalue123456",
+				},
+			},
+			want: "invalid",
+		},
+		{
+			name:   "Cache_Test_Absent_Model_Cache",
+			config: map[string]any{},
+			want:   "valid",
+		},
+		{
+			name: "Cache_Test_Missing_Redis_Config",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine": "redis",
+				},
+			},
+			want: "typeError",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fg, err := NewCacheFieldGroup(tt.config)
+			if err != nil {
+				if tt.want != "typeError" {
+					t.Errorf("Expected %s, received constructor error: %s", tt.want, err.Error())
+				}
+				return
+			}
+
+			if tt.want == "typeError" {
+				t.Errorf("Expected constructor error, but got none")
+				return
+			}
+
+			opts := shared.Options{
+				Mode: "testing",
+			}
+
+			validationErrors := fg.Validate(opts)
+
+			received := ""
+			if len(validationErrors) == 0 {
+				received = "valid"
+			} else {
+				received = "invalid"
+			}
+
+			if tt.want != received {
+				t.Errorf("Expected %s, received %s", tt.want, received)
+				fmt.Println(validationErrors[0].Message)
+			}
+		})
+	}
+}

--- a/config-tool/pkg/lib/fieldgroups/cache/cache_test.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_test.go
@@ -111,7 +111,7 @@ func TestValidateCache(t *testing.T) {
 								"port": 5432,
 							},
 						},
-						"read_from_replica": true,
+						"read_from_replicas": true,
 					},
 				},
 			},

--- a/config-tool/pkg/lib/fieldgroups/cache/cache_validator.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_validator.go
@@ -1,0 +1,140 @@
+package cache
+
+import (
+	"crypto/tls"
+	"net"
+	"strconv"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/quay/quay/config-tool/pkg/lib/shared"
+)
+
+// Validate checks the configuration settings for the cache field group.
+func (fg *CacheFieldGroup) Validate(opts shared.Options) []shared.ValidationError {
+	errors := []shared.ValidationError{}
+	const fgName = "Cache"
+
+	// cache configuration is optional, if it's missing just return
+	if fg.DataModelCache == nil {
+		return errors
+	}
+
+	// validate engines
+	validateEngines := []string{"inmemory", "memcached", "redis", "rediscluster"}
+	if ok, err := shared.ValidateIsOneOfString(fg.DataModelCache.Engine, validateEngines,
+		"DATA_MODEL_CACHE_CONFIG.engine", fgName); !ok {
+		errors = append(errors, err)
+		return errors
+	}
+
+	// validate TTL fields are set
+	if fg.DataModelCache.RepositoryBlobCacheTTL != "" {
+		if ok, err := shared.ValidateTimePattern(fg.DataModelCache.RepositoryBlobCacheTTL,
+			"DATA_MODEL_CACHE_CONFIG.repository_blob_cache_ttl", fgName); !ok {
+			errors = append(errors, err)
+		}
+	}
+
+	if fg.DataModelCache.ActiveRepoTagsCacheTTL != "" {
+		if ok, err := shared.ValidateTimePattern(fg.DataModelCache.ActiveRepoTagsCacheTTL,
+			"DATA_MODEL_CACHE_CONFIG.active_repo_tags_cache_ttl", fgName); !ok {
+			errors = append(errors, err)
+		}
+	}
+
+	if fg.DataModelCache.CatalogPageCacheTTL != "" {
+		if ok, err := shared.ValidateTimePattern(fg.DataModelCache.CatalogPageCacheTTL,
+			"DATA_MODEL_CACHE_CONFIG.catalog_page_cache_ttl", fgName); !ok {
+			errors = append(errors, err)
+		}
+	}
+
+	// validate that the cache size is properly set
+	if fg.DataModelCache.ValueSizeLimit != "" {
+		if ok, err := shared.ValidateCacheSizePattern(fg.DataModelCache.ValueSizeLimit,
+			"DATA_MODEL_CACHE_CONFIG.value_size_limit", fgName); !ok {
+			errors = append(errors, err)
+		}
+	}
+
+	// only run if we are not in "testing" mode because we cannot confirm that these instances will be available
+	if opts.Mode != "testing" {
+		switch fg.DataModelCache.Engine {
+		// validate that memcached instance is available if defined
+		case "memcached":
+			if ok, err := shared.ValidateMemcachedInstance(fg.DataModelCache.Endpoint[0].(string),
+				fg.DataModelCache.Endpoint[1].(int), "DATA_MODEL_CACHE_CONFIG.endpoint", fgName); !ok {
+				errors = append(errors, err)
+			}
+
+		// validate that redis primary instance is available
+		case "redis":
+			var tlsConfig *tls.Config = nil
+			if fg.DataModelCache.RedisConfig.Primary.SSL {
+				tlsConfig = &tls.Config{
+					InsecureSkipVerify: false,
+				}
+			}
+
+			options := &redis.Options{
+				Addr: net.JoinHostPort(fg.DataModelCache.RedisConfig.Primary.Host,
+					strconv.Itoa(fg.DataModelCache.RedisConfig.Primary.Port)),
+				Password:  fg.DataModelCache.RedisConfig.Primary.Pass,
+				DB:        0,
+				TLSConfig: tlsConfig,
+			}
+
+			if ok, err := shared.ValidateRedisConnection(options,
+				"DATA_MODEL_CACHE_CONFIG.redis_config.primary.host", fgName); !ok {
+				errors = append(errors, err)
+			}
+
+			// check if there is a secondary redis instance
+			if fg.DataModelCache.RedisConfig.Replica != nil {
+				var tlsConfig *tls.Config = nil
+				if fg.DataModelCache.RedisConfig.Replica.SSL {
+					tlsConfig = &tls.Config{
+						InsecureSkipVerify: false,
+					}
+				}
+
+				options := &redis.Options{
+					Addr: net.JoinHostPort(fg.DataModelCache.RedisConfig.Replica.Host,
+						strconv.Itoa(fg.DataModelCache.RedisConfig.Replica.Port)),
+					Password:  fg.DataModelCache.RedisConfig.Replica.Pass,
+					DB:        0,
+					TLSConfig: tlsConfig,
+				}
+
+				if ok, err := shared.ValidateRedisConnection(options,
+					"DATA_MODEL_CACHE_CONFIG.redis_config.replica.host", fgName); !ok {
+					errors = append(errors, err)
+				}
+			}
+
+		case "rediscluster":
+			// we need to verify that all defined startup nodes are available
+			for _, node := range fg.DataModelCache.RedisConfig.StartupNodes {
+				var tlsConfig *tls.Config = nil
+				if node.SSL {
+					tlsConfig = &tls.Config{
+						InsecureSkipVerify: false,
+					}
+				}
+
+				options := &redis.Options{
+					Addr:      net.JoinHostPort(node.Host, strconv.Itoa(node.Port)),
+					Password:  node.Pass,
+					DB:        0,
+					TLSConfig: tlsConfig,
+				}
+
+				if ok, err := shared.ValidateRedisConnection(options,
+					"DATA_MODEL_CACHE_CONFIG.redis_config.startup_nodes.host", fgName); !ok {
+					errors = append(errors, err)
+				}
+			}
+		}
+	}
+	return errors
+}

--- a/config-tool/pkg/lib/generate/generate.go
+++ b/config-tool/pkg/lib/generate/generate.go
@@ -21,7 +21,7 @@ type AioiInputOptions struct {
 // Database, Redis, and Server Hostname settings must be included
 func GenerateBaseConfig(options AioiInputOptions) (config.Config, error) {
 
-	// Check that all fields are correctly populated (this is a naive validtion)
+	// Check that all fields are correctly populated (this is a naive validation)
 	if options.DatabaseURI == "" {
 		return nil, errors.New("Database URI is required")
 	}

--- a/config-tool/pkg/lib/shared/validators.go
+++ b/config-tool/pkg/lib/shared/validators.go
@@ -1015,17 +1015,45 @@ func ValidateDefaultAutoPruneKey(input string, field string, fgName string) (boo
 	return true, ValidationError{}
 }
 
-// ValidateCacheSizePattern validates that the provided cache size is no larger than 3 MiB. Returns
+// ValidateCacheSizePattern validates that the provided cache size is no larger than 10 MiB. Returns
 // an error otherwise.
 func ValidateCacheSizePattern(input string, field string, fgName string) (bool, ValidationError) {
-	re := regexp.MustCompile(`^[1-3]MiB$`)
+	re := regexp.MustCompile(`^([0-9]+)(MiB)$`)
 
-	// If the pattern is not matched
-	if !re.MatchString(input) {
+	result := re.FindStringSubmatch(input)
+	if len(result) == 0 {
 		newError := ValidationError{
 			Tags:       []string{field},
 			FieldGroup: fgName,
-			Message:    field + " must be exactly '1MiB', '2MiB' or '3MiB'",
+			Message:    fmt.Sprintf("%s format invalid, value must conform to regular expression '([0-9]+)MiB'", field),
+		}
+		return false, newError
+	}
+
+	if result[2] != "MiB" {
+		newError := ValidationError{
+			Tags:       []string{field},
+			FieldGroup: fgName,
+			Message:    fmt.Sprintf("%s cache size must be in MiB", field),
+		}
+		return false, newError
+	}
+
+	numResult, err := strconv.Atoi(result[1])
+	if err != nil {
+		newError := ValidationError{
+			Tags:       []string{field},
+			FieldGroup: fgName,
+			Message:    fmt.Sprintf("%s format invalid, value must conform to regular expression '([0-9]+)MiB'", field),
+		}
+		return false, newError
+	}
+
+	if numResult > 10 {
+		newError := ValidationError{
+			Tags:       []string{field},
+			FieldGroup: fgName,
+			Message:    fmt.Sprintf("%s is invalid: cache size cannot be larger than 10 MiB", field),
 		}
 		return false, newError
 	}
@@ -1043,7 +1071,7 @@ func ValidateMemcachedInstance(hostname string, port int, field string, fgName s
 		newError := ValidationError{
 			Tags:       []string{field},
 			FieldGroup: fgName,
-			Message:    field + ": memcached instance cannot be reached",
+			Message:    field + ": memcached instance cannot be reached, error: " + err.Error(),
 		}
 		return false, newError
 	}

--- a/config-tool/pkg/lib/shared/validators.go
+++ b/config-tool/pkg/lib/shared/validators.go
@@ -1014,3 +1014,39 @@ func ValidateDefaultAutoPruneKey(input string, field string, fgName string) (boo
 
 	return true, ValidationError{}
 }
+
+// ValidateCacheSizePattern validates that the provided cache size is no larger than 3 MiB. Returns
+// an error otherwise.
+func ValidateCacheSizePattern(input string, field string, fgName string) (bool, ValidationError) {
+	re := regexp.MustCompile(`^[1-3]MiB$`)
+
+	// If the pattern is not matched
+	if !re.MatchString(input) {
+		newError := ValidationError{
+			Tags:       []string{field},
+			FieldGroup: fgName,
+			Message:    field + " must be exactly '1MiB', '2MiB' or '3MiB'",
+		}
+		return false, newError
+	}
+
+	return true, ValidationError{}
+}
+
+// ValidateMemcachedInstance validates that the provided settings for a memcached instance are correct and
+// that the connection can be established
+func ValidateMemcachedInstance(hostname string, port int, field string, fgName string) (bool, ValidationError) {
+	endpoint := net.JoinHostPort(hostname, strconv.Itoa(port))
+
+	conn, err := net.DialTimeout("tcp", endpoint, 3*time.Second)
+	if err != nil {
+		newError := ValidationError{
+			Tags:       []string{field},
+			FieldGroup: fgName,
+			Message:    field + ": memcached instance cannot be reached",
+		}
+		return false, newError
+	}
+	defer conn.Close()
+	return true, ValidationError{}
+}

--- a/config-tool/testdata/config-bundle/config.yaml
+++ b/config-tool/testdata/config-bundle/config.yaml
@@ -5,6 +5,21 @@ BUILDLOGS_REDIS:
   port: 6379
 SECRET_KEY: "40157269433064266822674401740626984898972632465622168464725100311621640999470"
 DATABASE_SECRET_KEY: "81541057085600720484162638317561463611194901378275494293746615390984668417511"
+DATA_MODEL_CACHE_CONFIG:
+  engine: redis
+  redis_config:
+    primary:
+      host: 192.168.250.159
+      port: 6379
+    replica:
+      host: 192.168.250.160
+      port: 6379
+      pass: "supersecretpassword"
+      ssl: true
+  repository_blob_cache_ttl: 120s
+  catalog_page_cache_ttl: 360s
+  active_repo_tags_cache_ttl: 480s
+  value_size_limit: 3MiB
 DB_URI: postgresql://user:pass@192.168.250.159/quay
 DEFAULT_TAG_EXPIRATION: 2w
 DISTRIBUTED_STORAGE_DEFAULT_LOCATIONS: []


### PR DESCRIPTION
Adds the `DATA_MODEL_CACHE_CONFIG` to the validator.