### PR TITLE
PROJQUAY-8202: fix: Don't raise a 500 when basic auth is provided on Oauth requests

### DIFF
--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -730,7 +730,10 @@ def request_authorization_code():
     assignment_uuid = request.args.get("assignment_uuid", None)
     format_requested = request.args.get("format", "html").lower()
 
-    if not get_authenticated_user():
+    # get authenticated user
+    user = get_authenticated_user()
+
+    if not user:
         abort(401)
         return
 
@@ -745,15 +748,15 @@ def request_authorization_code():
     if not oauth_app:
         abort(404)
 
-    # check if user is org admin, if not check for user_assignment_id, then check that user belongs that assignment, if none exit with 401
+    # check if user is org admin, if not check for user_assignment_id,
+    # then check that user belongs that assignment, if none exit with 401
     if (
-        not is_org_admin(current_user.db_user(), oauth_app.organization)
-        and get_token_assignment(assignment_uuid, current_user.db_user(), oauth_app.organization)
-        is None
+        not is_org_admin(user, oauth_app.organization)
+        and get_token_assignment(assignment_uuid, user, oauth_app.organization) is None
     ):
         abort(403)
 
-    if not provider.validate_has_scopes(client_id, current_user.db_user().username, scope):
+    if not provider.validate_has_scopes(client_id, user.username, scope):
         if not provider.validate_redirect_uri(client_id, redirect_uri):
             current_app = provider.get_application_for_client_id(client_id)
             if not current_app:

--- a/endpoints/web.py
+++ b/endpoints/web.py
@@ -749,7 +749,7 @@ def request_authorization_code():
         abort(404)
 
     # check if user is org admin, if not check for user_assignment_id,
-    # then check that user belongs that assignment, if none exit with 401
+    # then check that user belongs that assignment, if none exit with 403
     if (
         not is_org_admin(user, oauth_app.organization)
         and get_token_assignment(assignment_uuid, user, oauth_app.organization) is None

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -814,6 +814,65 @@ class OAuthTestCase(EndpointTestCase):
             if r.status_code == 429:
                 break
 
+    def test_request_authorization_code_basic_auth(self):
+        """
+        Verifies that request authorization code does not raise a 500 anymore when basic
+        auth is provided (PROJQUAY-8202).
+        """
+        org = model.organization.get_organization("buynlarge")
+        app = model.oauth.create_application(org, "test", "http://foo/bar", "http://foo/bar/bah")
+
+        auth_header = gen_basic_auth("devtable", "password")
+        rv = self.app.get(
+            url_for(
+                "web.request_authorization_code",
+                client_id=app.client_id,
+                redirect_uri=app.redirect_uri,
+                scope="repo:read",
+                response_type="token",
+            ),
+            headers={"Authorization": auth_header},
+        )
+
+        self.assertEqual(rv.status_code, 200)
+
+    def test_request_authorization_code_basic_auth_invalid_credentials(self):
+        """
+        Verifies that when we have improper credentials that a proper 401 is returned back instead of a 500.
+        """
+        org = model.organization.get_organization("buynlarge")
+        app = model.oauth.create_application(org, "test", "http://foo/bar", "http://foo/bar/bah")
+
+        auth_header = gen_basic_auth("randomuserwithoutaccess", "password")
+
+        rv = self.app.get(
+            url_for(
+                "web.request_authorization_code",
+                client_id=app.client_id,
+                redirect_uri=app.redirect_uri,
+                scope="repo:read",
+                response_type="token",
+            ),
+            headers={"Authorization": auth_header},
+        )
+
+        self.assertEqual(rv.status_code, 401)
+
+        auth_header = gen_basic_auth("devtable", "completelywrongpassword")
+
+        rv = self.app.get(
+            url_for(
+                "web.request_authorization_code",
+                client_id=app.client_id,
+                redirect_uri=app.redirect_uri,
+                scope="repo:read",
+                response_type="token",
+            ),
+            headers={"Authorization": auth_header},
+        )
+
+        self.assertEqual(rv.status_code, 401)
+
 
 class KeyServerTestCase(EndpointTestCase):
     def _get_test_jwt_payload(self):

--- a/test/test_endpoints.py
+++ b/test/test_endpoints.py
@@ -817,7 +817,7 @@ class OAuthTestCase(EndpointTestCase):
     def test_request_authorization_code_basic_auth(self):
         """
         Verifies that request authorization code does not raise a 500 anymore when basic
-        auth is provided (PROJQUAY-8202).
+        auth is provided.
         """
         org = model.organization.get_organization("buynlarge")
         app = model.oauth.create_application(org, "test", "http://foo/bar", "http://foo/bar/bah")


### PR DESCRIPTION
Previously, because of missing proper Flask context, we would raise a 500 if basic auth was sent to the Oauth endpoint. 

With this change, we make sure that a proper context is set so that `AnonymousUserMixin` exception is never raised. Additionally, we added two tests to verify that a proper 401 is raised if wrong credentials are provided during basic auth.