### PR TITLE
PROJQUAY-11868: fix(dal): stop duplicating hidden referrer protection tags

### DIFF
--- a/internal/dal/daldb/tag.sql.go
+++ b/internal/dal/daldb/tag.sql.go
@@ -105,6 +105,21 @@ func (q *Queries) GetTagsByRepository(ctx context.Context, arg GetTagsByReposito
 	return items, nil
 }
 
+const hasNonExpiringTagForManifest = `-- name: HasNonExpiringTagForManifest :one
+SELECT EXISTS(
+    SELECT 1 FROM tag WHERE manifest_id = ? AND lifetime_end_ms IS NULL
+) AS has_tag
+`
+
+// Returns true if the manifest already has at least one non-expiring tag
+// (lifetime_end_ms IS NULL). Used to skip creating duplicate protection tags.
+func (q *Queries) HasNonExpiringTagForManifest(ctx context.Context, manifestID sql.NullInt64) (int64, error) {
+	row := q.db.QueryRowContext(ctx, hasNonExpiringTagForManifest, manifestID)
+	var has_tag int64
+	err := row.Scan(&has_tag)
+	return has_tag, err
+}
+
 const insertHiddenTag = `-- name: InsertHiddenTag :one
 INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, tag_kind_id, hidden)
 VALUES (?, ?, ?, ?, ?, 1)

--- a/internal/dal/metastore/metastore_sqlite.go
+++ b/internal/dal/metastore/metastore_sqlite.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/quay/quay/internal/dal/daldb"
@@ -180,9 +181,17 @@ func (s *SQLiteStore) PutManifest(ctx context.Context, repoID int64, m oci.Manif
 }
 
 // setSubjectAndProtect sets the subject column on a manifest and creates a
-// hidden tag to protect the referrer from GC. Referrer manifests typically
-// have no user-visible tag, so without the hidden tag FindOrphanedManifests
-// would collect them.
+// hidden tag to protect the referrer from GC, unless the manifest already
+// has a non-expiring tag. Referrer manifests typically have no user-visible
+// tag, so without the hidden tag FindOrphanedManifests would collect them.
+//
+// This mirrors Python's create_temporary_tag_if_necessary(skip_expiration=True)
+// (data/model/oci/tag.py): check-before-create avoids duplicate protection
+// tags on repeat pushes, and a random name ("$temp-" + uuid) means nothing
+// relies on ON CONFLICT against the (repository_id, name, lifetime_end_ms)
+// unique index, which never fires when lifetime_end_ms IS NULL (NULL != NULL
+// in SQL) -- that mismatch was the root cause of the duplication bug this
+// replaces.
 func (s *SQLiteStore) setSubjectAndProtect(ctx context.Context, q *daldb.Queries, repoID, manifestID int64, m *oci.ManifestRecord) error {
 	if err := q.SetManifestSubject(ctx, daldb.SetManifestSubjectParams{
 		Subject: sql.NullString{String: m.Subject.String(), Valid: true},
@@ -190,14 +199,23 @@ func (s *SQLiteStore) setSubjectAndProtect(ctx context.Context, q *daldb.Queries
 	}); err != nil {
 		return fmt.Errorf("set manifest subject %s: %w", m.Subject, err)
 	}
+
+	hasTag, err := q.HasNonExpiringTagForManifest(ctx, sql.NullInt64{Int64: manifestID, Valid: true})
+	if err != nil {
+		return fmt.Errorf("check existing tag for manifest %d: %w", manifestID, err)
+	}
+	if hasTag != 0 {
+		return nil
+	}
+
 	if _, err := q.InsertHiddenTag(ctx, daldb.InsertHiddenTagParams{
-		Name:            "$referrer-" + m.Digest.Encoded()[:12],
+		Name:            "$temp-" + uuid.NewString(),
 		RepositoryID:    repoID,
 		ManifestID:      sql.NullInt64{Int64: manifestID, Valid: true},
 		LifetimeStartMs: time.Now().UnixMilli(),
 		TagKindID:       s.tagKindTag,
 	}); err != nil {
-		return fmt.Errorf("insert hidden referrer tag: %w", err)
+		return fmt.Errorf("insert hidden protection tag: %w", err)
 	}
 	return nil
 }

--- a/internal/dal/metastore/metastore_sqlite_test.go
+++ b/internal/dal/metastore/metastore_sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 
@@ -436,6 +437,110 @@ func TestListReferrers_WithSubject(t *testing.T) {
 	}
 }
 
+func TestPutManifest_RepeatSubjectPush_NoDuplicateProtectionTag(t *testing.T) {
+	// Regression test: repeat pushes of the same subject/referrer manifest
+	// (e.g. re-signing with cosign, CI re-running an attestation push) must
+	// not create a new hidden protection tag row each time.
+	store := setupStore(t)
+	ctx := t.Context()
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "library", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subjectDgst := digest.FromString("subject-manifest")
+	referrerDgst := digest.FromString("sbom-referrer")
+	referrer := oci.ManifestRecord{
+		Digest:       referrerDgst,
+		MediaType:    "application/vnd.oci.image.manifest.v1+json",
+		Content:      []byte(`{"schemaVersion":2,"subject":{"digest":"` + subjectDgst.String() + `"}}`),
+		Subject:      subjectDgst,
+		ArtifactType: "application/vnd.example.sbom.v1",
+	}
+
+	manifestID, err := store.PutManifest(ctx, repoID, referrer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertProtectionTagCount(t, store.(*metastore.SQLiteStore), manifestID)
+
+	// Repeat push of the identical referrer manifest (same digest, same subject).
+	manifestID2, err := store.PutManifest(ctx, repoID, referrer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifestID2 != manifestID {
+		t.Fatalf("expected repeat push to resolve to the same manifest ID, got %d want %d", manifestID2, manifestID)
+	}
+	assertProtectionTagCount(t, store.(*metastore.SQLiteStore), manifestID)
+
+	// And a third push, for good measure.
+	if _, err := store.PutManifest(ctx, repoID, referrer); err != nil {
+		t.Fatal(err)
+	}
+	assertProtectionTagCount(t, store.(*metastore.SQLiteStore), manifestID)
+}
+
+func TestPutManifest_SubjectPush_PreExistingLegacyProtectionTag_NoOp(t *testing.T) {
+	// Simulates an already-affected install: a manifest that already has a
+	// non-expiring tag from before this fix shipped (e.g. a duplicate
+	// "$referrer-<digest>" row from a prior buggy push). The fix must detect
+	// any existing non-expiring tag by manifest_id --- not by name --- and
+	// skip creating another one.
+	store := setupStore(t)
+	ctx := t.Context()
+	sqliteStore := store.(*metastore.SQLiteStore)
+
+	repoID, err := store.EnsureRepository(ctx, oci.RepositoryName{Namespace: "library", Name: "nginx"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the referrer manifest without a subject, so setSubjectAndProtect
+	// is not yet invoked.
+	referrerDgst := digest.FromString("sbom-referrer")
+	manifestID, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:    referrerDgst,
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Content:   []byte(`{"schemaVersion":2}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually insert a legacy-style duplicate hidden tag, as the pre-fix
+	// code would have left behind.
+	db := sqliteStore.DB()
+	var tagKindID int64
+	if err := db.QueryRowContext(ctx, `SELECT id FROM tagkind WHERE name = 'tag'`).Scan(&tagKindID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO tag (name, repository_id, manifest_id, lifetime_start_ms, tag_kind_id, hidden) VALUES (?, ?, ?, ?, ?, 1)`,
+		"$referrer-"+referrerDgst.Encoded()[:12], repoID, manifestID, time.Now().UnixMilli(), tagKindID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	assertProtectionTagCount(t, sqliteStore, manifestID)
+
+	// Now push again with the subject set, as a real referrer push would.
+	subjectDgst := digest.FromString("subject-manifest")
+	if _, err := store.PutManifest(ctx, repoID, oci.ManifestRecord{
+		Digest:       referrerDgst,
+		MediaType:    "application/vnd.oci.image.manifest.v1+json",
+		Content:      []byte(`{"schemaVersion":2,"subject":{"digest":"` + subjectDgst.String() + `"}}`),
+		Subject:      subjectDgst,
+		ArtifactType: "application/vnd.example.sbom.v1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The pre-existing legacy row already satisfies the protection
+	// invariant, so no new tag should have been created.
+	assertProtectionTagCount(t, sqliteStore, manifestID)
+}
+
 func TestListReferrers_FilterByArtifactType(t *testing.T) {
 	store := setupStore(t)
 	ctx := t.Context()
@@ -583,5 +688,24 @@ func assertActiveTagCount(t *testing.T, s *metastore.SQLiteStore, repoID int64, 
 	}
 	if count != want {
 		t.Errorf("active tags named %q: got %d, want %d", tag, count, want)
+	}
+}
+
+// assertProtectionTagCount asserts exactly one non-expiring
+// (lifetime_end_ms IS NULL) tag exists for a given manifest, regardless of
+// name. Hidden protection tags created by setSubjectAndProtect use randomly
+// generated names, so they can't be matched by name like assertActiveTagCount does.
+func assertProtectionTagCount(t *testing.T, s *metastore.SQLiteStore, manifestID int64) {
+	t.Helper()
+	db := s.DB()
+	var count int
+	err := db.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM tag WHERE manifest_id = ? AND lifetime_end_ms IS NULL`,
+		manifestID).Scan(&count)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("non-expiring tags for manifest %d: got %d, want 1", manifestID, count)
 	}
 }

--- a/internal/dal/queries/tag.sql
+++ b/internal/dal/queries/tag.sql
@@ -27,6 +27,13 @@ VALUES (?, ?, ?, ?, ?, 1)
 ON CONFLICT (repository_id, name, lifetime_end_ms) DO UPDATE SET manifest_id = excluded.manifest_id
 RETURNING id;
 
+-- name: HasNonExpiringTagForManifest :one
+-- Returns true if the manifest already has at least one non-expiring tag
+-- (lifetime_end_ms IS NULL). Used to skip creating duplicate protection tags.
+SELECT EXISTS(
+    SELECT 1 FROM tag WHERE manifest_id = ? AND lifetime_end_ms IS NULL
+) AS has_tag;
+
 -- name: GetActiveTagDigest :one
 SELECT m.digest
 FROM tag t


### PR DESCRIPTION
## Summary
`setSubjectAndProtect` created a hidden referrer-protection tag using a
deterministic name (`"$referrer-" + digest prefix`) and relied on
`InsertHiddenTag`'s `ON CONFLICT (repository_id, name, lifetime_end_ms) DO
UPDATE` to be idempotent on repeat pushes. That conflict target never
matches for active/hidden tags because `lifetime_end_ms` is `NULL`, and
`NULL != NULL` for conflict-target matching in SQL. Any repeat push of the
same subject/referrer manifest (re-signing with cosign, CI re-running an
attestation push, etc.) silently inserted a duplicate protection tag every
time.

This ports Python's `create_temporary_tag_if_necessary` pattern
(`data/model/oci/tag.py`): check whether the manifest already has a
non-expiring tag before creating one, and use a random `"$temp-" + uuid`
name instead of one derived from the manifest digest.

## Related Issue
NO-ISSUE — no existing Jira/GitHub issue tracks this; searched `quay/quay`
issues for related reports and found none.

## Changes
- Add `HasNonExpiringTagForManifest` sqlc query (`internal/dal/queries/tag.sql`)
  and regenerate `internal/dal/daldb` (`sqlc generate`).
- Rewrite `setSubjectAndProtect` in `internal/dal/metastore/metastore_sqlite.go`
  to check-before-create and use a random `$temp-<uuid>` tag name instead of
  the deterministic `$referrer-<digest>` name.
- Add regression tests: repeat pushes of the same referrer manifest no
  longer create duplicate protection tags, and the check also short-circuits
  correctly on an already-affected install with a pre-existing legacy
  `$referrer-*` duplicate row (matched by `manifest_id`, not by name).

No schema migration is needed. Nothing else depends on the `$referrer-`
naming format (referrer listing uses the `manifest.subject` column, not tag
name). `setSubjectAndProtect` runs inside `PutManifest`'s single transaction
and `OpenSQLite` sets `MaxOpenConns(1)`, so there's no check-then-insert
race.

## Testing
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (all packages)
- [x] `go test -race ./internal/dal/metastore/... -count=1` passes
- [x] `gofmt -l` on touched files: clean (repo has pre-existing unrelated
      `gofmt` findings in `config-tool/`, confirmed present on `origin/master`
      before this change and untouched here)
- [x] `golangci-lint run` scoped to `internal/dal/metastore/...`,
      `internal/dal/daldb/...`, `internal/dal/queries/...`: 0 issues
- [x] `git diff --check`: clean
- [x] Manually verified both new regression tests fail against the
      pre-fix code (reproducing the bug) and pass with the fix

## Notes
No Target Version / backport applicable (`NO-ISSUE`). No schema migration.
