### PR TITLE
PROJQUAY-12474: refactor(distribution): isolate middleware metrics

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	apiv1 "github.com/quay/quay/internal/api/v1"
@@ -112,6 +113,7 @@ func runServe(ctx context.Context, configPath, dataDir, hostname, addr string) i
 		SuperUsers:                         resolved.Config.SuperUsers,
 		SuperUsersFullAccess:               superUsersFullAccess,
 		JWTService:                         jwtService,
+		MetricsRegisterer:                  prometheus.DefaultRegisterer,
 	})
 	if err != nil {
 		slog.Error("registry setup error", "err", err)

--- a/internal/registry/distribution/app.go
+++ b/internal/registry/distribution/app.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/distribution/distribution/v3/configuration"
 	"github.com/distribution/distribution/v3/registry/handlers"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/quay/quay/internal/oci"
 	"github.com/quay/quay/internal/oci/storage/local"
@@ -35,6 +36,10 @@ type Config struct {
 	SuperUsers                         []string
 	SuperUsersFullAccess               bool
 	JWTService                         registryTokenService
+	// MetricsRegisterer is the Prometheus registerer for middleware metrics.
+	// When nil, no metrics are recorded. Callers that want per-instance
+	// metrics must provide an explicit registerer (e.g. prometheus.NewRegistry()).
+	MetricsRegisterer prometheus.Registerer
 }
 
 type registryTokenService interface {
@@ -91,6 +96,15 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 		return nil, fmt.Errorf("register middleware: %w", err)
 	}
 
+	var metricsOpts []registrymw.Option
+	if cfg.MetricsRegisterer != nil {
+		metrics, err := registrymw.NewMetrics(cfg.MetricsRegisterer)
+		if err != nil {
+			return nil, fmt.Errorf("create middleware metrics: %w", err)
+		}
+		metricsOpts = append(metricsOpts, registrymw.WithMetrics(metrics))
+	}
+
 	authOptions := configuration.Parameters{
 		authOptionRealm:        cfg.TokenRealm,
 		authOptionService:      cfg.Hostname,
@@ -137,7 +151,7 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 	distCfg.Middleware = map[string][]configuration.Middleware{
 		repositoryResourceType: {{
 			Name:    registrymw.Name(),
-			Options: registrymw.Parameters(cfg.Store, cfg.BlobLocker, libraryNamespace),
+			Options: registrymw.Parameters(cfg.Store, cfg.BlobLocker, libraryNamespace, metricsOpts...),
 		}},
 	}
 

--- a/internal/registry/distribution/app.go
+++ b/internal/registry/distribution/app.go
@@ -87,7 +87,7 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 
 	local.Register()
 
-	if err := registrymw.Register(cfg.Store, cfg.BlobLocker, libraryNamespace); err != nil {
+	if err := registrymw.Register(); err != nil {
 		return nil, fmt.Errorf("register middleware: %w", err)
 	}
 
@@ -135,7 +135,10 @@ func NewRegistry(ctx context.Context, cfg *Config) (*Registry, error) {
 		},
 	}
 	distCfg.Middleware = map[string][]configuration.Middleware{
-		repositoryResourceType: {{Name: registrymw.Name()}},
+		repositoryResourceType: {{
+			Name:    registrymw.Name(),
+			Options: registrymw.Parameters(cfg.Store, cfg.BlobLocker, libraryNamespace),
+		}},
 	}
 
 	distCfg.HTTP.Addr = cfg.ListenAddr

--- a/internal/registry/distribution/app_test.go
+++ b/internal/registry/distribution/app_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 
 	"github.com/distribution/distribution/v3/registry/handlers"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/quay/quay/internal/oci"
+	registrymw "github.com/quay/quay/internal/registry/distribution/middleware"
 )
 
 type metadataStoreStub struct {
@@ -35,13 +37,14 @@ func TestNewRegistryPassesStoreToDistributionDriver(t *testing.T) {
 	locker := oci.NewBlobLockSet()
 
 	registry, err := NewRegistry(t.Context(), &Config{
-		StoragePath: t.TempDir(),
-		Hostname:    "registry.example.com",
-		TokenRealm:  "https://registry.example.com/v2/auth",
-		DB:          db,
-		Store:       store,
-		BlobLocker:  locker,
-		JWTService:  &registryTokenServiceStub{},
+		StoragePath:       t.TempDir(),
+		Hostname:          "registry.example.com",
+		TokenRealm:        "https://registry.example.com/v2/auth",
+		DB:                db,
+		Store:             store,
+		BlobLocker:        locker,
+		JWTService:        &registryTokenServiceStub{},
+		MetricsRegisterer: prometheus.NewRegistry(),
 	})
 	require.NoError(t, err)
 
@@ -54,6 +57,41 @@ func TestNewRegistryPassesStoreToDistributionDriver(t *testing.T) {
 	require.Same(t, store, middleware[0].Options["metastore"])
 	require.Same(t, locker, middleware[0].Options["bloblocker"])
 	require.Equal(t, defaultLibraryNamespace, middleware[0].Options["librarynamespace"])
+	require.IsType(t, &registrymw.Metrics{}, middleware[0].Options["metrics"])
+}
+
+// TestNewRegistry_NilMetricsRegistererIsolation verifies that two NewRegistry
+// calls without MetricsRegisterer both succeed. Before this fix, the fallback
+// to prometheus.DefaultRegisterer caused the second call to fail with a
+// duplicate registration error.
+func TestNewRegistry_NilMetricsRegistererIsolation(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	jwt := &registryTokenServiceStub{}
+
+	_, err := NewRegistry(t.Context(), &Config{
+		StoragePath: t.TempDir(),
+		Hostname:    "registry-a.example.com",
+		TokenRealm:  "https://registry-a.example.com/v2/auth",
+		DB:          db,
+		Store:       &metadataStoreStub{},
+		BlobLocker:  oci.NewBlobLockSet(),
+		JWTService:  jwt,
+		// MetricsRegisterer intentionally nil.
+	})
+	require.NoError(t, err)
+
+	_, err = NewRegistry(t.Context(), &Config{
+		StoragePath: t.TempDir(),
+		Hostname:    "registry-b.example.com",
+		TokenRealm:  "https://registry-b.example.com/v2/auth",
+		DB:          db,
+		Store:       &metadataStoreStub{},
+		BlobLocker:  oci.NewBlobLockSet(),
+		JWTService:  jwt,
+		// MetricsRegisterer intentionally nil.
+	})
+	require.NoError(t, err, "second NewRegistry with nil MetricsRegisterer must not fail")
 }
 
 func TestNewRegistryKeepsMiddlewareOptionsPerInstance(t *testing.T) {
@@ -66,25 +104,27 @@ func TestNewRegistryKeepsMiddlewareOptionsPerInstance(t *testing.T) {
 	lockerB := oci.NewBlobLockSet()
 
 	registryA, err := NewRegistry(t.Context(), &Config{
-		StoragePath:      t.TempDir(),
-		Hostname:         "registry-a.example.com",
-		TokenRealm:       "https://registry-a.example.com/v2/auth",
-		DB:               db,
-		Store:            storeA,
-		BlobLocker:       lockerA,
-		LibraryNamespace: "library-a",
-		JWTService:       jwt,
+		StoragePath:       t.TempDir(),
+		Hostname:          "registry-a.example.com",
+		TokenRealm:        "https://registry-a.example.com/v2/auth",
+		DB:                db,
+		Store:             storeA,
+		BlobLocker:        lockerA,
+		LibraryNamespace:  "library-a",
+		JWTService:        jwt,
+		MetricsRegisterer: prometheus.NewRegistry(),
 	})
 	require.NoError(t, err)
 	registryB, err := NewRegistry(t.Context(), &Config{
-		StoragePath:      t.TempDir(),
-		Hostname:         "registry-b.example.com",
-		TokenRealm:       "https://registry-b.example.com/v2/auth",
-		DB:               db,
-		Store:            storeB,
-		BlobLocker:       lockerB,
-		LibraryNamespace: "library-b",
-		JWTService:       jwt,
+		StoragePath:       t.TempDir(),
+		Hostname:          "registry-b.example.com",
+		TokenRealm:        "https://registry-b.example.com/v2/auth",
+		DB:                db,
+		Store:             storeB,
+		BlobLocker:        lockerB,
+		LibraryNamespace:  "library-b",
+		JWTService:        jwt,
+		MetricsRegisterer: prometheus.NewRegistry(),
 	})
 	require.NoError(t, err)
 
@@ -100,4 +140,5 @@ func TestNewRegistryKeepsMiddlewareOptionsPerInstance(t *testing.T) {
 	require.Same(t, storeB, optionsB["metastore"])
 	require.Same(t, lockerB, optionsB["bloblocker"])
 	require.Equal(t, "library-b", optionsB["librarynamespace"])
+	require.NotSame(t, optionsA["metrics"], optionsB["metrics"], "each registry must have its own metrics instance")
 }

--- a/internal/registry/distribution/app_test.go
+++ b/internal/registry/distribution/app_test.go
@@ -32,6 +32,7 @@ func TestNewRegistryPassesStoreToDistributionDriver(t *testing.T) {
 	db := setupTestDB(t)
 	t.Cleanup(func() { _ = db.Close() })
 	store := &metadataStoreStub{}
+	locker := oci.NewBlobLockSet()
 
 	registry, err := NewRegistry(t.Context(), &Config{
 		StoragePath: t.TempDir(),
@@ -39,7 +40,7 @@ func TestNewRegistryPassesStoreToDistributionDriver(t *testing.T) {
 		TokenRealm:  "https://registry.example.com/v2/auth",
 		DB:          db,
 		Store:       store,
-		BlobLocker:  oci.NewBlobLockSet(),
+		BlobLocker:  locker,
 		JWTService:  &registryTokenServiceStub{},
 	})
 	require.NoError(t, err)
@@ -47,4 +48,56 @@ func TestNewRegistryPassesStoreToDistributionDriver(t *testing.T) {
 	app, ok := registry.Handler().(*handlers.App)
 	require.True(t, ok)
 	require.Same(t, store, app.Config.Storage.Parameters()["metastore"])
+
+	middleware := app.Config.Middleware[repositoryResourceType]
+	require.Len(t, middleware, 1)
+	require.Same(t, store, middleware[0].Options["metastore"])
+	require.Same(t, locker, middleware[0].Options["bloblocker"])
+	require.Equal(t, defaultLibraryNamespace, middleware[0].Options["librarynamespace"])
+}
+
+func TestNewRegistryKeepsMiddlewareOptionsPerInstance(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { _ = db.Close() })
+	jwt := &registryTokenServiceStub{}
+	storeA := &metadataStoreStub{}
+	storeB := &metadataStoreStub{}
+	lockerA := oci.NewBlobLockSet()
+	lockerB := oci.NewBlobLockSet()
+
+	registryA, err := NewRegistry(t.Context(), &Config{
+		StoragePath:      t.TempDir(),
+		Hostname:         "registry-a.example.com",
+		TokenRealm:       "https://registry-a.example.com/v2/auth",
+		DB:               db,
+		Store:            storeA,
+		BlobLocker:       lockerA,
+		LibraryNamespace: "library-a",
+		JWTService:       jwt,
+	})
+	require.NoError(t, err)
+	registryB, err := NewRegistry(t.Context(), &Config{
+		StoragePath:      t.TempDir(),
+		Hostname:         "registry-b.example.com",
+		TokenRealm:       "https://registry-b.example.com/v2/auth",
+		DB:               db,
+		Store:            storeB,
+		BlobLocker:       lockerB,
+		LibraryNamespace: "library-b",
+		JWTService:       jwt,
+	})
+	require.NoError(t, err)
+
+	appA, ok := registryA.Handler().(*handlers.App)
+	require.True(t, ok)
+	appB, ok := registryB.Handler().(*handlers.App)
+	require.True(t, ok)
+	optionsA := appA.Config.Middleware[repositoryResourceType][0].Options
+	optionsB := appB.Config.Middleware[repositoryResourceType][0].Options
+	require.Same(t, storeA, optionsA["metastore"])
+	require.Same(t, lockerA, optionsA["bloblocker"])
+	require.Equal(t, "library-a", optionsA["librarynamespace"])
+	require.Same(t, storeB, optionsB["metastore"])
+	require.Same(t, lockerB, optionsB["bloblocker"])
+	require.Equal(t, "library-b", optionsB["librarynamespace"])
 }

--- a/internal/registry/distribution/middleware/blob.go
+++ b/internal/registry/distribution/middleware/blob.go
@@ -23,7 +23,7 @@ type blobStore struct {
 }
 
 func (bs *blobStore) Put(ctx context.Context, mediaType string, p []byte) (_ v1.Descriptor, retErr error) {
-	defer recordOp("blob_put", time.Now(), &retErr)
+	defer bs.repo.metrics.recordOp("blob_put", time.Now(), &retErr)
 
 	expected := digest.FromBytes(p)
 	unlock, err := bs.repo.locker.Lock(ctx, expected)
@@ -47,7 +47,7 @@ func (bs *blobStore) Put(ctx context.Context, mediaType string, p []byte) (_ v1.
 }
 
 func (bs *blobStore) Create(ctx context.Context, options ...distribution.BlobCreateOption) (_ distribution.BlobWriter, retErr error) {
-	defer recordOp("blob_create", time.Now(), &retErr)
+	defer bs.repo.metrics.recordOp("blob_create", time.Now(), &retErr)
 
 	mountLock := &mountLockOption{ctx: ctx, locker: bs.repo.locker}
 	coordinatedOptions := append([]distribution.BlobCreateOption(nil), options...)
@@ -106,7 +106,7 @@ type blobWriter struct {
 }
 
 func (bw *blobWriter) Commit(ctx context.Context, provisional v1.Descriptor) (_ v1.Descriptor, retErr error) { //nolint:gocritic // interface compliance
-	defer recordOp("blob_commit", time.Now(), &retErr)
+	defer bw.bs.repo.metrics.recordOp("blob_commit", time.Now(), &retErr)
 
 	unlock, err := bw.bs.repo.locker.Lock(ctx, provisional.Digest)
 	if err != nil {

--- a/internal/registry/distribution/middleware/manifest.go
+++ b/internal/registry/distribution/middleware/manifest.go
@@ -21,7 +21,7 @@ type manifestService struct {
 }
 
 func (ms *manifestService) Put(ctx context.Context, manifest distribution.Manifest, options ...distribution.ManifestServiceOption) (_ digest.Digest, retErr error) {
-	defer recordOp("manifest_put", time.Now(), &retErr)
+	defer ms.repo.metrics.recordOp("manifest_put", time.Now(), &retErr)
 
 	dgst, err := ms.ManifestService.Put(ctx, manifest, options...)
 	if err != nil {
@@ -79,7 +79,7 @@ func (ms *manifestService) Put(ctx context.Context, manifest distribution.Manife
 }
 
 func (ms *manifestService) Delete(ctx context.Context, dgst digest.Digest) (retErr error) {
-	defer recordOp("manifest_delete", time.Now(), &retErr)
+	defer ms.repo.metrics.recordOp("manifest_delete", time.Now(), &retErr)
 
 	if err := ms.ManifestService.Delete(ctx, dgst); err != nil {
 		return err

--- a/internal/registry/distribution/middleware/metrics.go
+++ b/internal/registry/distribution/middleware/metrics.go
@@ -1,30 +1,63 @@
 package middleware
 
 import (
+	"errors"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var (
-	opDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "quay_middleware_operation_duration_seconds",
-		Help:    "Time spent in metastore operations.",
-		Buckets: prometheus.DefBuckets,
-	}, []string{"op"})
-
-	opTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "quay_middleware_operations_total",
-		Help: "Total metastore operations by outcome.",
-	}, []string{"op", "status"})
+// Prometheus label names used in middleware metric collectors.
+const (
+	labelOp     = "op"
+	labelStatus = "status"
 )
 
-func recordOp(op string, start time.Time, err *error) { //nolint:gocritic // ptr needed for defer
-	opDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
-	status := "success"
-	if *err != nil {
-		status = "error"
+// Metrics holds per-instance Prometheus collectors for metastore middleware
+// operations. Create one per registry instance via NewMetrics to keep metric
+// state isolated between instances.
+type Metrics struct {
+	opDuration *prometheus.HistogramVec
+	opTotal    *prometheus.CounterVec
+}
+
+// NewMetrics creates and registers middleware metrics with the given
+// prometheus.Registerer. Each registry instance should use its own Registerer
+// (e.g. prometheus.NewRegistry()) to keep metric state isolated between
+// instances. A nil registerer is rejected with an error.
+func NewMetrics(reg prometheus.Registerer) (*Metrics, error) {
+	if reg == nil {
+		return nil, errors.New("middleware: nil prometheus.Registerer")
 	}
-	opTotal.WithLabelValues(op, status).Inc()
+	m := &Metrics{
+		opDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "quay_middleware_operation_duration_seconds",
+			Help:    "Time spent in metastore operations.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{labelOp}),
+		opTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "quay_middleware_operations_total",
+			Help: "Total metastore operations by outcome.",
+		}, []string{labelOp, labelStatus}),
+	}
+	if err := reg.Register(m.opDuration); err != nil {
+		return nil, err
+	}
+	if err := reg.Register(m.opTotal); err != nil {
+		reg.Unregister(m.opDuration) // Clean up partial registration.
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m *Metrics) recordOp(op string, start time.Time, err *error) { //nolint:gocritic // ptr needed for defer
+	if m == nil {
+		return
+	}
+	m.opDuration.WithLabelValues(op).Observe(time.Since(start).Seconds())
+	outcome := "success"
+	if *err != nil {
+		outcome = "error"
+	}
+	m.opTotal.WithLabelValues(op, outcome).Inc()
 }

--- a/internal/registry/distribution/middleware/metrics_test.go
+++ b/internal/registry/distribution/middleware/metrics_test.go
@@ -1,0 +1,283 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/quay/quay/internal/oci"
+)
+
+// TestNewMetrics_NilRegisterer verifies that NewMetrics returns an error
+// instead of panicking when given a nil Registerer.
+func TestNewMetrics_NilRegisterer(t *testing.T) {
+	m, err := NewMetrics(nil)
+	require.Error(t, err)
+	require.Nil(t, m)
+	require.ErrorContains(t, err, "nil prometheus.Registerer")
+}
+
+// TestNewMetrics_DuplicateRegistration verifies that registering the same
+// metric names twice on the same registerer fails cleanly instead of panicking.
+func TestNewMetrics_DuplicateRegistration(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	_, err := NewMetrics(reg)
+	require.NoError(t, err)
+	_, err = NewMetrics(reg)
+	require.Error(t, err, "second NewMetrics on the same registerer must fail")
+}
+
+// TestNewMetrics_PartialRegistrationCleanup verifies that if the second
+// collector registration fails, the first is unregistered so no partially
+// registered state leaks.
+func TestNewMetrics_PartialRegistrationCleanup(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	// Pre-register a conflicting counter with the same name as opTotal.
+	conflicting := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "quay_middleware_operations_total",
+		Help: "conflicting collector",
+	}, []string{labelOp, labelStatus})
+	require.NoError(t, reg.Register(conflicting))
+
+	// NewMetrics should fail on the second registration (opTotal).
+	_, err := NewMetrics(reg)
+	require.Error(t, err)
+
+	// The first collector (opDuration) should have been cleaned up.
+	// Verify by successfully re-registering a histogram with the same
+	// descriptor (Prometheus keeps a dimHashesByName consistency map that
+	// survives Unregister, so name/help/labels must match exactly).
+	checkHist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "quay_middleware_operation_duration_seconds",
+		Help:    "Time spent in metastore operations.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"op"})
+	require.NoError(t, reg.Register(checkHist), "opDuration should have been unregistered during cleanup")
+}
+
+// TestMetrics_NilRecordOp verifies that nil metrics silently skip recording.
+func TestMetrics_NilRecordOp(t *testing.T) {
+	var m *Metrics
+	var retErr error
+	require.NotPanics(t, func() {
+		m.recordOp("anything", time.Now(), &retErr)
+	})
+}
+
+// TestMetrics_Isolation verifies that two registry instances with separate
+// Prometheus registries record metrics independently—operations on one
+// instance do not affect counters visible through the other's registry.
+func TestMetrics_Isolation(t *testing.T) {
+	regA := prometheus.NewRegistry()
+	regB := prometheus.NewRegistry()
+	metricsA, err := NewMetrics(regA)
+	require.NoError(t, err)
+	metricsB, err := NewMetrics(regB)
+	require.NoError(t, err)
+
+	storeA := &mockStore{ensureRepoID: 1, putManifestID: 10}
+	storeB := &mockStore{ensureRepoID: 2, putManifestID: 20}
+
+	repoA := newRepository(
+		&fakeDistRepo{name: namedRef(t), ms: &mockManifestService{putDigest: digest.FromString("a")}},
+		storeA, oci.NewBlobLockSet(), "library", metricsA,
+	)
+	repoB := newRepository(
+		&fakeDistRepo{name: namedRef(t), ms: &mockManifestService{putDigest: digest.FromString("b")}},
+		storeB, oci.NewBlobLockSet(), "library", metricsB,
+	)
+
+	manifest := &mockManifest{
+		mediaType: "application/vnd.oci.image.manifest.v1+json",
+		payload:   []byte(`{"schemaVersion":2}`),
+	}
+
+	// Put two manifests through instance A, one through B.
+	msA, err := repoA.Manifests(context.Background())
+	require.NoError(t, err)
+	for range 2 {
+		_, err = msA.Put(context.Background(), manifest)
+		require.NoError(t, err)
+	}
+	msB, err := repoB.Manifests(context.Background())
+	require.NoError(t, err)
+	_, err = msB.Put(context.Background(), manifest)
+	require.NoError(t, err)
+
+	// Verify A recorded 2 successes, B recorded 1.
+	countA := counterValue(t, regA, "quay_middleware_operations_total", "manifest_put", "success")
+	countB := counterValue(t, regB, "quay_middleware_operations_total", "manifest_put", "success")
+	require.Equal(t, 2.0, countA, "registry A should have 2 manifest_put successes")
+	require.Equal(t, 1.0, countB, "registry B should have 1 manifest_put success")
+
+	histA := histogramCount(t, regA, "quay_middleware_operation_duration_seconds", "manifest_put")
+	histB := histogramCount(t, regB, "quay_middleware_operation_duration_seconds", "manifest_put")
+	require.Equal(t, uint64(2), histA)
+	require.Equal(t, uint64(1), histB)
+}
+
+// TestMetrics_ErrorOutcome verifies that failed operations record the "error"
+// status label.
+func TestMetrics_ErrorOutcome(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	metrics, err := NewMetrics(reg)
+	require.NoError(t, err)
+
+	store := &mockStore{ensureRepoID: 1, putManifestErr: errors.New("db locked")}
+	repo := newRepository(
+		&fakeDistRepo{name: namedRef(t), ms: &mockManifestService{putDigest: digest.FromString("err")}},
+		store, oci.NewBlobLockSet(), "library", metrics,
+	)
+	ms, err := repo.Manifests(context.Background())
+	require.NoError(t, err)
+
+	_, err = ms.Put(context.Background(), &mockManifest{
+		mediaType: "application/vnd.oci.image.manifest.v1+json",
+		payload:   []byte(`{}`),
+	})
+	require.Error(t, err)
+
+	errCount := counterValue(t, reg, "quay_middleware_operations_total", "manifest_put", "error")
+	require.Equal(t, 1.0, errCount, "error status should be recorded")
+}
+
+// TestMetrics_AllOperations verifies that each middleware operation records
+// metrics using the per-instance collectors.
+func TestMetrics_AllOperations(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	metrics, err := NewMetrics(reg)
+	require.NoError(t, err)
+
+	blobDgst := digest.FromString("blob-content")
+	blobDesc := v1.Descriptor{Digest: blobDgst, Size: 42}
+	store := &mockStore{ensureRepoID: 1, putManifestID: 1, putBlobID: 1, putTagID: 1}
+	innerBW := &mockBlobWriter{commitDesc: blobDesc}
+
+	repo := newRepository(
+		&fakeDistRepo{
+			name: namedRef(t),
+			ms:   &mockManifestService{putDigest: digest.FromString("m")},
+			bs:   &mockBlobStore{putDesc: blobDesc, createWr: innerBW},
+			ts:   &mockTagService{},
+		},
+		store, oci.NewBlobLockSet(), "library", metrics,
+	)
+
+	ctx := context.Background()
+	ms, err := repo.Manifests(ctx)
+	require.NoError(t, err)
+	_, err = ms.Put(ctx, &mockManifest{
+		mediaType: "application/vnd.oci.image.manifest.v1+json",
+		payload:   []byte(`{"schemaVersion":2}`),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ms.Delete(ctx, digest.FromString("d")))
+
+	bs := repo.Blobs(ctx)
+	_, err = bs.Put(ctx, "application/octet-stream", []byte("blob-content"))
+	require.NoError(t, err)
+	wr, err := bs.Create(ctx)
+	require.NoError(t, err)
+	_, err = wr.Commit(ctx, blobDesc)
+	require.NoError(t, err)
+
+	ts := repo.Tags(ctx)
+	require.NoError(t, ts.Tag(ctx, "v1", v1.Descriptor{Digest: digest.FromString("t")}))
+	require.NoError(t, ts.Untag(ctx, "old"))
+
+	for _, op := range []string{"manifest_put", "manifest_delete", "blob_put", "blob_create", "blob_commit", "tag", "untag"} {
+		count := counterValue(t, reg, "quay_middleware_operations_total", op, "success")
+		require.Equal(t, 1.0, count, "expected 1 success for %s", op)
+	}
+}
+
+// TestMetrics_ConcurrentConstruction verifies that creating metrics on
+// separate registries concurrently is safe.
+func TestMetrics_ConcurrentConstruction(t *testing.T) {
+	const goroutines = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			reg := prometheus.NewRegistry()
+			_, err := NewMetrics(reg)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+// --- test helpers ---
+
+// counterValue gathers metrics from a registry and returns the counter value
+// for the metric with the given name and label values (op, status).
+func counterValue(t *testing.T, reg *prometheus.Registry, name, op, status string) float64 { //nolint:unparam // name kept generic for reuse
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			if matchLabels(m.GetLabel(), map[string]string{"op": op, "status": status}) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	t.Fatalf("metric %s{op=%q,status=%q} not found", name, op, status)
+	return 0
+}
+
+// histogramCount returns the sample count for a histogram metric.
+func histogramCount(t *testing.T, reg *prometheus.Registry, name, op string) uint64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			if matchLabels(m.GetLabel(), map[string]string{"op": op}) {
+				return m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	t.Fatalf("metric %s{op=%q} not found", name, op)
+	return 0
+}
+
+func matchLabels(pairs []*io_prometheus_client.LabelPair, want map[string]string) bool {
+	if len(pairs) < len(want) {
+		return false
+	}
+	for k, v := range want {
+		found := false
+		for _, p := range pairs {
+			if p.GetName() == k && p.GetValue() == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/registry/distribution/middleware/middleware.go
+++ b/internal/registry/distribution/middleware/middleware.go
@@ -27,6 +27,7 @@ const (
 	storeParameter            = "metastore"
 	blobLockerParameter       = "bloblocker"
 	libraryNamespaceParameter = "librarynamespace"
+	metricsParameter          = "metrics"
 )
 
 var registerOnce sync.Once
@@ -47,15 +48,35 @@ func Register() error {
 // configuration to avoid string duplication.
 func Name() string { return middlewareName }
 
+// Option configures optional middleware parameters.
+type Option func(configuration.Parameters)
+
+// WithMetrics attaches per-instance Prometheus metrics to the middleware
+// parameters. When m is nil the option is a no-op and metric recording is
+// disabled.
+func WithMetrics(m *Metrics) Option {
+	return func(p configuration.Parameters) {
+		if m != nil {
+			p[metricsParameter] = m
+		}
+	}
+}
+
 // Parameters builds distribution parameters for the metadata-recording
 // middleware. The values are kept in the per-registry configuration rather than
-// in the globally registered factory.
-func Parameters(store oci.MetadataStore, locker oci.BlobLocker, libraryNamespace string) configuration.Parameters {
-	return configuration.Parameters{
+// in the globally registered factory. Optional settings (e.g. metrics) are
+// provided via Option values; omitting them is safe and preserves backward
+// compatibility.
+func Parameters(store oci.MetadataStore, locker oci.BlobLocker, libraryNamespace string, opts ...Option) configuration.Parameters {
+	p := configuration.Parameters{
 		storeParameter:            store,
 		blobLockerParameter:       locker,
 		libraryNamespaceParameter: libraryNamespace,
 	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
 }
 
 func newRepositoryMiddleware(_ context.Context, repo distribution.Repository, options map[string]interface{}) (distribution.Repository, error) {
@@ -71,7 +92,9 @@ func newRepositoryMiddleware(_ context.Context, repo distribution.Repository, op
 	if !ok || libraryNamespace == "" {
 		return nil, fmt.Errorf("middleware: %s parameter must be a non-empty string", libraryNamespaceParameter)
 	}
-	return newRepository(repo, store, locker, libraryNamespace), nil
+	// Metrics are optional; nil disables metric recording.
+	metrics, _ := options[metricsParameter].(*Metrics)
+	return newRepository(repo, store, locker, libraryNamespace, metrics), nil
 }
 
 // repository wraps a distribution.Repository to intercept metadata-producing
@@ -83,14 +106,15 @@ type repository struct {
 	store            oci.MetadataStore
 	locker           oci.BlobLocker
 	libraryNamespace string
+	metrics          *Metrics
 
 	repoOnce sync.Once
 	repoID   int64
 	repoErr  error
 }
 
-func newRepository(inner distribution.Repository, store oci.MetadataStore, locker oci.BlobLocker, libraryNamespace string) *repository {
-	return &repository{Repository: inner, store: store, locker: locker, libraryNamespace: libraryNamespace}
+func newRepository(inner distribution.Repository, store oci.MetadataStore, locker oci.BlobLocker, libraryNamespace string, metrics *Metrics) *repository {
+	return &repository{Repository: inner, store: store, locker: locker, libraryNamespace: libraryNamespace, metrics: metrics}
 }
 
 func (r *repository) Named() reference.Named { return r.Repository.Named() }

--- a/internal/registry/distribution/middleware/middleware.go
+++ b/internal/registry/distribution/middleware/middleware.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/distribution/distribution/v3"
+	"github.com/distribution/distribution/v3/configuration"
 	"github.com/distribution/reference"
 
 	repositorymiddleware "github.com/distribution/distribution/v3/registry/middleware/repository"
@@ -21,29 +22,57 @@ import (
 	"github.com/quay/quay/internal/oci"
 )
 
-const middlewareName = "quaydb"
+const (
+	middlewareName            = "quaydb"
+	storeParameter            = "metastore"
+	blobLockerParameter       = "bloblocker"
+	libraryNamespaceParameter = "librarynamespace"
+)
 
-// Register registers the metadata-recording middleware with distribution's
-// repository middleware registry. It must be called before
-// handlers.NewApp so that the middleware config reference resolves.
-//
-// The store is captured by closure---no options map is needed at runtime.
-func Register(store oci.MetadataStore, locker oci.BlobLocker, libraryNamespace string) error {
-	if locker == nil {
-		return fmt.Errorf("nil blob locker")
-	}
-	return repositorymiddleware.Register(middlewareName, func(
-		ctx context.Context,
-		repo distribution.Repository,
-		_ map[string]interface{},
-	) (distribution.Repository, error) {
-		return newRepository(repo, store, locker, libraryNamespace), nil
+var registerOnce sync.Once
+var registerErr error
+
+// Register makes the stateless metadata-recording middleware factory available
+// to distribution. It must be called before handlers.NewApp so that the
+// middleware config reference resolves. It is safe to call multiple times and
+// concurrently.
+func Register() error {
+	registerOnce.Do(func() {
+		registerErr = repositorymiddleware.Register(middlewareName, newRepositoryMiddleware)
 	})
+	return registerErr
 }
 
 // Name returns the name used to register with distribution. Use this in
 // configuration to avoid string duplication.
 func Name() string { return middlewareName }
+
+// Parameters builds distribution parameters for the metadata-recording
+// middleware. The values are kept in the per-registry configuration rather than
+// in the globally registered factory.
+func Parameters(store oci.MetadataStore, locker oci.BlobLocker, libraryNamespace string) configuration.Parameters {
+	return configuration.Parameters{
+		storeParameter:            store,
+		blobLockerParameter:       locker,
+		libraryNamespaceParameter: libraryNamespace,
+	}
+}
+
+func newRepositoryMiddleware(_ context.Context, repo distribution.Repository, options map[string]interface{}) (distribution.Repository, error) {
+	store, ok := options[storeParameter].(oci.MetadataStore)
+	if !ok || store == nil {
+		return nil, fmt.Errorf("middleware: %s parameter must implement oci.MetadataStore", storeParameter)
+	}
+	locker, ok := options[blobLockerParameter].(oci.BlobLocker)
+	if !ok || locker == nil {
+		return nil, fmt.Errorf("middleware: %s parameter must implement oci.BlobLocker", blobLockerParameter)
+	}
+	libraryNamespace, ok := options[libraryNamespaceParameter].(string)
+	if !ok || libraryNamespace == "" {
+		return nil, fmt.Errorf("middleware: %s parameter must be a non-empty string", libraryNamespaceParameter)
+	}
+	return newRepository(repo, store, locker, libraryNamespace), nil
+}
 
 // repository wraps a distribution.Repository to intercept metadata-producing
 // operations. It resolves the repository ID lazily on the first write and

--- a/internal/registry/distribution/middleware/middleware.go
+++ b/internal/registry/distribution/middleware/middleware.go
@@ -30,7 +30,7 @@ const (
 )
 
 var registerOnce sync.Once
-var registerErr error
+var errRegister error
 
 // Register makes the stateless metadata-recording middleware factory available
 // to distribution. It must be called before handlers.NewApp so that the
@@ -38,9 +38,9 @@ var registerErr error
 // concurrently.
 func Register() error {
 	registerOnce.Do(func() {
-		registerErr = repositorymiddleware.Register(middlewareName, newRepositoryMiddleware)
+		errRegister = repositorymiddleware.Register(middlewareName, newRepositoryMiddleware)
 	})
-	return registerErr
+	return errRegister
 }
 
 // Name returns the name used to register with distribution. Use this in

--- a/internal/registry/distribution/middleware/middleware_test.go
+++ b/internal/registry/distribution/middleware/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/distribution/distribution/v3"
+	repositorymiddleware "github.com/distribution/distribution/v3/registry/middleware/repository"
 	diststorage "github.com/distribution/distribution/v3/registry/storage"
 	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
@@ -301,6 +302,83 @@ func newTestRepository(inner distribution.Repository, store oci.MetadataStore) *
 }
 
 // --- tests ---
+
+func TestRegister_IsSafeToCallConcurrently(t *testing.T) {
+	const callers = 20
+	errs := make(chan error, callers)
+	for range callers {
+		go func() {
+			errs <- Register()
+		}()
+	}
+	for range callers {
+		require.NoError(t, <-errs)
+	}
+}
+
+func TestFactory_UsesPerInstanceOptions(t *testing.T) {
+	require.NoError(t, Register())
+
+	storeA := &mockStore{ensureRepoID: 1, putManifestID: 10}
+	storeB := &mockStore{ensureRepoID: 2, putManifestID: 20}
+	lockerA := &trackingBlobLocker{}
+	lockerB := &trackingBlobLocker{}
+	innerA := &fakeDistRepo{
+		name: namedRef(t),
+		ms:   &mockManifestService{putDigest: digest.FromString("manifest-a")},
+	}
+	innerB := &fakeDistRepo{
+		name: namedRef(t),
+		ms:   &mockManifestService{putDigest: digest.FromString("manifest-b")},
+	}
+
+	repoA, err := repositorymiddleware.Get(t.Context(), Name(), Parameters(storeA, lockerA, "library-a"), innerA)
+	require.NoError(t, err)
+	repoB, err := repositorymiddleware.Get(t.Context(), Name(), Parameters(storeB, lockerB, "library-b"), innerB)
+	require.NoError(t, err)
+
+	wrappedA, ok := repoA.(*repository)
+	require.True(t, ok)
+	wrappedB, ok := repoB.(*repository)
+	require.True(t, ok)
+	require.Same(t, storeA, wrappedA.store)
+	require.Same(t, lockerA, wrappedA.locker)
+	require.Equal(t, "library-a", wrappedA.libraryNamespace)
+	require.Same(t, storeB, wrappedB.store)
+	require.Same(t, lockerB, wrappedB.locker)
+	require.Equal(t, "library-b", wrappedB.libraryNamespace)
+
+	manifest := &mockManifest{
+		mediaType: "application/vnd.oci.image.manifest.v1+json",
+		payload:   []byte(`{"schemaVersion":2}`),
+	}
+	serviceA, err := wrappedA.Manifests(t.Context())
+	require.NoError(t, err)
+	_, err = serviceA.Put(t.Context(), manifest)
+	require.NoError(t, err)
+	serviceB, err := wrappedB.Manifests(t.Context())
+	require.NoError(t, err)
+	_, err = serviceB.Put(t.Context(), manifest)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), storeA.lastRepoID)
+	require.Equal(t, int64(2), storeB.lastRepoID)
+	require.Equal(t, digest.FromString("manifest-a"), storeA.putManifestRec.Digest)
+	require.Equal(t, digest.FromString("manifest-b"), storeB.putManifestRec.Digest)
+}
+
+func TestFactory_RejectsMissingOptions(t *testing.T) {
+	require.NoError(t, Register())
+	inner := &fakeDistRepo{name: namedRef(t)}
+
+	_, err := repositorymiddleware.Get(t.Context(), Name(), nil, inner)
+	require.ErrorContains(t, err, "metastore parameter")
+
+	_, err = repositorymiddleware.Get(t.Context(), Name(), Parameters(&mockStore{}, nil, "library"), inner)
+	require.ErrorContains(t, err, "bloblocker parameter")
+
+	_, err = repositorymiddleware.Get(t.Context(), Name(), Parameters(&mockStore{}, &trackingBlobLocker{}, ""), inner)
+	require.ErrorContains(t, err, "librarynamespace parameter")
+}
 
 func TestManifestPut_RecordsMetadata(t *testing.T) {
 	store := &mockStore{ensureRepoID: 1, putManifestID: 10}

--- a/internal/registry/distribution/middleware/middleware_test.go
+++ b/internal/registry/distribution/middleware/middleware_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/quay/quay/internal/oci"
@@ -298,7 +299,15 @@ func (r *fakeDistRepo) Blobs(_ context.Context) distribution.BlobStore { return 
 func (r *fakeDistRepo) Tags(_ context.Context) distribution.TagService { return r.ts }
 
 func newTestRepository(inner distribution.Repository, store oci.MetadataStore) *repository {
-	return newRepository(inner, store, oci.NewBlobLockSet(), "library")
+	return newRepository(inner, store, oci.NewBlobLockSet(), "library", nil)
+}
+
+func newTestMetrics(t *testing.T) *Metrics {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	m, err := NewMetrics(reg)
+	require.NoError(t, err)
+	return m
 }
 
 // --- tests ---
@@ -332,9 +341,11 @@ func TestFactory_UsesPerInstanceOptions(t *testing.T) {
 		ms:   &mockManifestService{putDigest: digest.FromString("manifest-b")},
 	}
 
-	repoA, err := repositorymiddleware.Get(t.Context(), Name(), Parameters(storeA, lockerA, "library-a"), innerA)
+	metricsA := newTestMetrics(t)
+	metricsB := newTestMetrics(t)
+	repoA, err := repositorymiddleware.Get(t.Context(), Name(), Parameters(storeA, lockerA, "library-a", WithMetrics(metricsA)), innerA)
 	require.NoError(t, err)
-	repoB, err := repositorymiddleware.Get(t.Context(), Name(), Parameters(storeB, lockerB, "library-b"), innerB)
+	repoB, err := repositorymiddleware.Get(t.Context(), Name(), Parameters(storeB, lockerB, "library-b", WithMetrics(metricsB)), innerB)
 	require.NoError(t, err)
 
 	wrappedA, ok := repoA.(*repository)
@@ -347,6 +358,8 @@ func TestFactory_UsesPerInstanceOptions(t *testing.T) {
 	require.Same(t, storeB, wrappedB.store)
 	require.Same(t, lockerB, wrappedB.locker)
 	require.Equal(t, "library-b", wrappedB.libraryNamespace)
+	require.Same(t, metricsA, wrappedA.metrics)
+	require.Same(t, metricsB, wrappedB.metrics)
 
 	manifest := &mockManifest{
 		mediaType: "application/vnd.oci.image.manifest.v1+json",
@@ -364,6 +377,38 @@ func TestFactory_UsesPerInstanceOptions(t *testing.T) {
 	require.Equal(t, int64(2), storeB.lastRepoID)
 	require.Equal(t, digest.FromString("manifest-a"), storeA.putManifestRec.Digest)
 	require.Equal(t, digest.FromString("manifest-b"), storeB.putManifestRec.Digest)
+}
+
+// TestParameters_BackwardCompatThreeArgs verifies that the original
+// three-argument call to Parameters still compiles and produces valid
+// middleware options with nil metrics (recording disabled).
+func TestParameters_BackwardCompatThreeArgs(t *testing.T) {
+	require.NoError(t, Register())
+	store := &mockStore{ensureRepoID: 1, putManifestID: 10}
+	locker := &trackingBlobLocker{}
+	inner := &fakeDistRepo{
+		name: namedRef(t),
+		ms:   &mockManifestService{putDigest: digest.FromString("compat")},
+	}
+
+	// Three-argument form — no Option values.
+	repo, err := repositorymiddleware.Get(t.Context(), Name(), Parameters(store, locker, "library"), inner)
+	require.NoError(t, err)
+
+	wrapped, ok := repo.(*repository)
+	require.True(t, ok)
+	require.Same(t, store, wrapped.store)
+	require.Same(t, locker, wrapped.locker)
+	require.Nil(t, wrapped.metrics, "3-arg Parameters must yield nil metrics")
+
+	// Operations should succeed without panic despite nil metrics.
+	ms, err := wrapped.Manifests(t.Context())
+	require.NoError(t, err)
+	_, err = ms.Put(t.Context(), &mockManifest{
+		mediaType: "application/vnd.oci.image.manifest.v1+json",
+		payload:   []byte(`{"schemaVersion":2}`),
+	})
+	require.NoError(t, err)
 }
 
 func TestFactory_RejectsMissingOptions(t *testing.T) {
@@ -660,7 +705,7 @@ func TestBlobPut_LocksFinalizationThroughMetadata(t *testing.T) {
 		},
 	}
 
-	repo := newRepository(innerRepo, store, locker, "library")
+	repo := newRepository(innerRepo, store, locker, "library", nil)
 	_, err := repo.Blobs(t.Context()).Put(t.Context(), "application/octet-stream", content)
 	require.NoError(t, err)
 	require.False(t, locker.isHeld(dgst), "digest lock retained after put")
@@ -677,7 +722,7 @@ func TestBlobPut_RejectsDigestMismatch(t *testing.T) {
 			putDesc: v1.Descriptor{Digest: digest.FromString("wrong-put-digest"), Size: int64(len(content))},
 		},
 	}
-	repo := newRepository(innerRepo, store, locker, "library")
+	repo := newRepository(innerRepo, store, locker, "library", nil)
 
 	_, err := repo.Blobs(t.Context()).Put(t.Context(), "application/octet-stream", content)
 	require.ErrorContains(t, err, "blob put digest mismatch")
@@ -704,7 +749,7 @@ func TestBlobCommit_RejectsDigestMismatch(t *testing.T) {
 		name: namedRef(t),
 		bs:   &mockBlobStore{createWr: innerWriter},
 	}
-	repo := newRepository(innerRepo, store, locker, "library")
+	repo := newRepository(innerRepo, store, locker, "library", nil)
 	wr, err := repo.Blobs(t.Context()).Create(t.Context())
 	require.NoError(t, err)
 
@@ -735,7 +780,7 @@ func testBlobCommitLocking(t *testing.T, resume bool) {
 	}
 	innerBlobs := &mockBlobStore{createWr: innerWriter, resumeWr: innerWriter}
 	innerRepo := &fakeDistRepo{name: namedRef(t), bs: innerBlobs}
-	repo := newRepository(innerRepo, store, locker, "library")
+	repo := newRepository(innerRepo, store, locker, "library", nil)
 	bs := repo.Blobs(t.Context())
 
 	var (
@@ -780,7 +825,7 @@ func TestBlobCreate_MountLocksLinkThroughMetadata(t *testing.T) {
 		},
 	}
 	innerRepo := &fakeDistRepo{name: namedRef(t), bs: innerBlobs}
-	repo := newRepository(innerRepo, store, locker, "library")
+	repo := newRepository(innerRepo, store, locker, "library", nil)
 
 	_, err = repo.Blobs(t.Context()).Create(t.Context(), diststorage.WithMountFrom(fromRef))
 	var mounted distribution.ErrBlobMounted
@@ -808,7 +853,7 @@ func TestBlobCreate_MountFallbackReleasesLock(t *testing.T) {
 		},
 	}
 	innerRepo := &fakeDistRepo{name: namedRef(t), bs: innerBlobs}
-	repo := newRepository(innerRepo, &mockStore{}, locker, "library")
+	repo := newRepository(innerRepo, &mockStore{}, locker, "library", nil)
 
 	wr, err := repo.Blobs(t.Context()).Create(t.Context(), diststorage.WithMountFrom(fromRef))
 	require.NoError(t, err)
@@ -841,7 +886,7 @@ func TestBlobCreate_MountRejectsDigestMismatch(t *testing.T) {
 		},
 	}
 	innerRepo := &fakeDistRepo{name: namedRef(t), bs: innerBlobs}
-	repo := newRepository(innerRepo, store, locker, "library")
+	repo := newRepository(innerRepo, store, locker, "library", nil)
 
 	_, err = repo.Blobs(t.Context()).Create(t.Context(), diststorage.WithMountFrom(fromRef))
 	require.ErrorContains(t, err, "mounted blob digest mismatch")

--- a/internal/registry/distribution/middleware/tag.go
+++ b/internal/registry/distribution/middleware/tag.go
@@ -31,7 +31,7 @@ func (ts *tagService) Get(ctx context.Context, tag string) (v1.Descriptor, error
 }
 
 func (ts *tagService) Tag(ctx context.Context, tag string, desc v1.Descriptor) (retErr error) { //nolint:gocritic // interface compliance
-	defer recordOp("tag", time.Now(), &retErr)
+	defer ts.repo.metrics.recordOp("tag", time.Now(), &retErr)
 
 	if err := ts.TagService.Tag(ctx, tag, desc); err != nil {
 		return err
@@ -53,7 +53,7 @@ func (ts *tagService) Tag(ctx context.Context, tag string, desc v1.Descriptor) (
 }
 
 func (ts *tagService) Untag(ctx context.Context, tag string) (retErr error) {
-	defer recordOp("untag", time.Now(), &retErr)
+	defer ts.repo.metrics.recordOp("untag", time.Now(), &retErr)
 
 	if err := ts.TagService.Untag(ctx, tag); err != nil {
 		return err


### PR DESCRIPTION
## Summary
Make distribution middleware metrics state instance-local so multiple in-process registries can coexist without sharing or colliding on Prometheus collectors, while preserving the standalone server's existing `/metrics` behavior.

## Related Issue
[PROJQUAY-12474](https://issues.redhat.com/browse/PROJQUAY-12474)

## Changes
- Replace global `promauto` collectors with explicitly constructed per-instance middleware metrics.
- Thread registerer-backed metrics through each repository middleware instance.
- Preserve the exported three-argument `Parameters` API through optional middleware options.
- Handle nil registerers and partial collector registration safely.
- Wire the standalone server explicitly to `prometheus.DefaultRegisterer` at the composition boundary.
- Add isolation, compatibility, cleanup, concurrent-construction, and application wiring tests.

## Testing
- [x] `gofmt -l` on changed Go files
- [x] `git diff --check`
- [x] `TEST=true PYTHONPATH=. go test -race ./internal/registry/distribution ./internal/registry/distribution/middleware ./internal/oci/storage/local`
- [x] `TEST=true PYTHONPATH=. go test -race ./internal/cmd`
- [x] `golangci-lint run ./internal/registry/distribution/...`
- [x] `golangci-lint run ./internal/cmd/...`

## Notes
- No database schema, migration, frontend, or CI changes are included.
- The standalone server retains the existing default Prometheus endpoint behavior; callers constructing multiple registries can provide distinct registerers for isolation.
- No backport target has been requested.