### PR TITLE
PROJQUAY-10068: fix: Make sure we deduplicate child manifest entries when inserting them into the database

### DIFF
--- a/data/model/oci/manifest.py
+++ b/data/model/oci/manifest.py
@@ -235,10 +235,22 @@ def connect_manifests(manifests: list[Manifest], parent: Manifest, repository_id
     Connects manifests to a manifest list.
     Raises a _ManifestAlreadyExists if any of the manifest children already exist.
     """
-    children = [
-        dict(manifest=parent, child_manifest=manifest, repository=repository_id)
-        for manifest in manifests
-    ]
+
+    # proxy code will send us a raw list of children, if we have multiple identical entries in the list,
+    # the insert will fail with a unique constraint violation.
+    # we need to make sure that duplicates are removed from the list
+
+    children = []
+    deduped_list = set()
+    for manifest in manifests:
+        if manifest.id not in deduped_list:
+            deduped_list.add(manifest.id)
+            children.append(
+                dict(manifest=parent, child_manifest=manifest, repository=repository_id)
+            )
+    if not children:
+        return
+
     try:
         ManifestChild.insert_many(children).execute()
     except IntegrityError as e:

--- a/data/model/oci/test/test_oci_manifest.py
+++ b/data/model/oci/test/test_oci_manifest.py
@@ -424,27 +424,43 @@ def test_connect_manifests_properly_deduplicates_child_manifest_entries(initiali
     # add a config blob
     _, config_digest = _populate_blob(layer_json)
 
-    # add a blob of random data
-    random_data = "Lorem ipsum...."
-    _, random_digest = _populate_blob(random_data)
+    # add 1 blobs of random data
+    random_data1 = "Lorem ipsum...."
+    _, random_digest1 = _populate_blob(random_data1)
+
+    # create a secondary image that will also be part of the OCI index but
+    # with different layer and data
+    random_data2 = "Another lorem ipsum..."
+    _, random_digest2 = _populate_blob(random_data2)
 
     # build the manifest
-    oci_builder = OCIManifestBuilder()
-    oci_builder.set_config_digest(config_digest, len(layer_json.encode("utf-8")))
-    oci_builder.add_layer(random_digest, len(random_data.encode("utf-8")))
-    oci_manifest = oci_builder.build()
+    oci_builder1 = OCIManifestBuilder()
+    oci_builder1.set_config_digest(config_digest, len(layer_json.encode("utf-8")))
+    oci_builder1.add_layer(random_digest1, len(random_data1.encode("utf-8")))
+    oci_manifest1 = oci_builder1.build()
+
+    # build manifest 2
+    oci_builder2 = OCIManifestBuilder()
+    oci_builder2.set_config_digest(config_digest, len(layer_json.encode("utf-8")))
+    oci_builder2.add_layer(random_digest2, len(random_data2.encode("utf-8")))
+    oci_manifest2 = oci_builder2.build()
 
     # write the manifest
-    oci_created = get_or_create_manifest(repository, oci_manifest, storage)
-    assert oci_created
-    assert oci_created.manifest.digest == oci_manifest.digest
+    oci_created1 = get_or_create_manifest(repository, oci_manifest1, storage)
+    oci_created2 = get_or_create_manifest(repository, oci_manifest2, storage)
+
+    assert oci_created1
+    assert oci_created2
+    assert oci_created1.manifest.digest == oci_manifest1.digest
+    assert oci_created2.manifest.digest == oci_manifest2.digest
 
     # create the OCI manifest index
     index_builder = OCIIndexBuilder()
-    index_builder.add_manifest(oci_manifest, "amd64", "linux")
-    index_builder.add_manifest(oci_manifest, "amd64", "linux")
-    index_builder.add_manifest(oci_manifest, "amd64", "linux")
-    index_builder.add_manifest(oci_manifest, "amd64", "linux")
+    index_builder.add_manifest(oci_manifest1, "amd64", "linux")
+    index_builder.add_manifest(oci_manifest1, "amd64", "linux")
+    index_builder.add_manifest(oci_manifest1, "amd64", "linux")
+    index_builder.add_manifest(oci_manifest1, "amd64", "linux")
+    index_builder.add_manifest(oci_manifest2, "amd64", "linux")
     oci_index = index_builder.build()
 
     # insert manifest directly in the database
@@ -465,14 +481,20 @@ def test_connect_manifests_properly_deduplicates_child_manifest_entries(initiali
 
     # explicitly call connect on child manifests
     connect_manifests(
-        [oci_created.manifest, oci_created.manifest, oci_created.manifest, oci_created.manifest],
+        [
+            oci_created1.manifest,
+            oci_created1.manifest,
+            oci_created1.manifest,
+            oci_created1.manifest,
+            oci_created2.manifest,
+        ],
         created_index,
         repository.id,
     )
 
     # verify that only one child was created
     children = ManifestChild.select().where(ManifestChild.manifest == created_index)
-    assert children.count() == 1
+    assert children.count() == 2
 
 
 def test_get_or_create_manifest_with_remote_layers(initialized_db):

--- a/data/model/oci/test/test_oci_manifest.py
+++ b/data/model/oci/test/test_oci_manifest.py
@@ -11,6 +11,7 @@ from data.database import (
     ImageStorageLocation,
     IndexerVersion,
     IndexStatus,
+    Manifest,
     ManifestBlob,
     ManifestChild,
     ManifestSecurityStatus,
@@ -21,6 +22,7 @@ from data.model.blob import store_blob_record_and_temp_link
 from data.model.oci.label import list_manifest_labels
 from data.model.oci.manifest import (
     CreateManifestException,
+    connect_manifests,
     get_or_create_manifest,
     lookup_manifest,
     lookup_manifest_referrers,
@@ -37,6 +39,7 @@ from image.docker.schema2.manifest import (
     DockerSchema2ManifestBuilder,
 )
 from image.oci.config import OCIConfig
+from image.oci.index import OCIIndexBuilder
 from image.oci.manifest import OCIManifestBuilder
 from image.shared.interfaces import ContentRetriever
 from image.shared.schemas import parse_manifest_from_bytes
@@ -386,6 +389,90 @@ def test_get_or_create_manifest_list_duplicate_child_manifest(initialized_db):
     created2_tuple = get_or_create_manifest(repository, manifest_list, storage)
     assert created2_tuple is not None
     assert created2_tuple.manifest == created_list
+
+
+def test_connect_manifests_properly_deduplicates_child_manifest_entries(initialized_db):
+    """
+    Tests that the connect_manifest function properly deduplicates child manifest entries if list
+    with duplicates is passed to it.
+    """
+    repository = create_repository("devtable", "newrepo", None)
+
+    expected_labels = {
+        "Foo": "Bar",
+        "Baz": "Meh",
+    }
+
+    layer_json = json.dumps(
+        {
+            "id": "somelegacyid",
+            "architecture": "amd64",
+            "os": "linux",
+            "config": {
+                "Labels": expected_labels,
+            },
+            "rootfs": {"type": "layers", "diff_ids": []},
+            "history": [
+                {
+                    "created": "2018-04-03T18:37:09.284840891Z",
+                    "created_by": "do something",
+                },
+            ],
+        }
+    )
+
+    # add a config blob
+    _, config_digest = _populate_blob(layer_json)
+
+    # add a blob of random data
+    random_data = "Lorem ipsum...."
+    _, random_digest = _populate_blob(random_data)
+
+    # build the manifest
+    oci_builder = OCIManifestBuilder()
+    oci_builder.set_config_digest(config_digest, len(layer_json.encode("utf-8")))
+    oci_builder.add_layer(random_digest, len(random_data.encode("utf-8")))
+    oci_manifest = oci_builder.build()
+
+    # write the manifest
+    oci_created = get_or_create_manifest(repository, oci_manifest, storage)
+    assert oci_created
+    assert oci_created.manifest.digest == oci_manifest.digest
+
+    # create the OCI manifest index
+    index_builder = OCIIndexBuilder()
+    index_builder.add_manifest(oci_manifest, "amd64", "linux")
+    index_builder.add_manifest(oci_manifest, "amd64", "linux")
+    index_builder.add_manifest(oci_manifest, "amd64", "linux")
+    index_builder.add_manifest(oci_manifest, "amd64", "linux")
+    oci_index = index_builder.build()
+
+    # insert manifest directly in the database
+    created_index = Manifest.create(
+        repository=repository.id,
+        digest=oci_index.digest,
+        media_type=Manifest.media_type.get_id(oci_index.media_type),
+        manifest_bytes=oci_index.bytes.as_encoded_str(),
+        config_media_type=oci_index.config_media_type,
+        layers_compressed_size=0,
+        subject_backfilled=True,
+        subject=None,
+        artifact_type_backfilled=True,
+        artifact_type=None,
+    )
+
+    assert created_index
+
+    # explicitly call connect on child manifests
+    connect_manifests(
+        [oci_created.manifest, oci_created.manifest, oci_created.manifest, oci_created.manifest],
+        created_index,
+        repository.id,
+    )
+
+    # verify that only one child was created
+    children = ManifestChild.select().where(ManifestChild.manifest == created_index)
+    assert children.count() == 1
 
 
 def test_get_or_create_manifest_with_remote_layers(initialized_db):

--- a/data/model/oci/test/test_oci_manifest.py
+++ b/data/model/oci/test/test_oci_manifest.py
@@ -492,7 +492,7 @@ def test_connect_manifests_properly_deduplicates_child_manifest_entries(initiali
         repository.id,
     )
 
-    # verify that only one child was created
+    # verify that two child manifests were created
     children = ManifestChild.select().where(ManifestChild.manifest == created_index)
     assert children.count() == 2
 

--- a/data/registry_model/test/test_registry_proxy_model.py
+++ b/data/registry_model/test/test_registry_proxy_model.py
@@ -522,6 +522,78 @@ class TestRegistryProxyModelCreateManifestAndRetargetTag:
         assert expected_count == created_count
 
     @patch("data.registry_model.registry_proxy_model.Proxy", MagicMock())
+    def test_accept_proxying_of_manifests_which_contain_duplicate_identical_child_manifests(
+        self, create_repo
+    ):
+        """
+        Verifies that a manifest with multiple identical child manifests (allowed per OCI spec) are properly stored
+        in the database and no longer throw a unique constraint error.
+        """
+        repo_ref = create_repo(self.orgname, self.upstream_repository, self.user)
+
+        # create child manifest, we're using UBI manifest
+        ubi_image = parse_manifest_from_bytes(
+            Bytes.for_string_or_unicode(testdata.UBI8_LINUX_AMD64["manifest"]),
+            testdata.UBI8_LINUX_AMD64["content-type"],
+            sparse_manifest_support=True,
+        )
+
+        # create needed manifests
+        oci_manifest = {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "mediaType": testdata.UBI8_LINUX_AMD64["content-type"],
+                    "digest": ubi_image.digest,
+                    "size": len(testdata.UBI8_LINUX_AMD64["manifest"]),
+                    "platform": {
+                        "architecture": "amd64",
+                        "os": "linux",
+                    },
+                },
+                {
+                    "mediaType": testdata.UBI8_LINUX_AMD64["content-type"],
+                    "digest": ubi_image.digest,
+                    "size": len(testdata.UBI8_LINUX_AMD64["manifest"]),
+                    "platform": {
+                        "architecture": "amd64",
+                        "os": "linux",
+                    },
+                },
+            ],
+        }
+
+        oci_manifest_bytes = parse_manifest_from_bytes(
+            Bytes.for_string_or_unicode(json.dumps(oci_manifest)),
+            "application/vnd.oci.image.index.v1+json",
+            sparse_manifest_support=True,
+        )
+
+        proxy_model = ProxyModel(
+            self.orgname,
+            self.upstream_registry,
+            self.user,
+        )
+
+        child_manifest, _ = proxy_model._create_manifest_with_temp_tag(repo_ref, ubi_image)
+
+        assert child_manifest
+
+        # create the OCI image index
+        index, _ = proxy_model._create_manifest_and_retarget_tag(
+            repo_ref, oci_manifest_bytes, self.tag
+        )
+
+        assert index
+
+        manifest_children = ManifestChild.select(ManifestChild.child_manifest_id).where(
+            ManifestChild.manifest == index.id
+        )
+
+        assert manifest_children.count() == 1
+
+    @patch("data.registry_model.registry_proxy_model.Proxy", MagicMock())
     def test_create_temp_tags_for_newly_created_sub_manifests_on_manifest_list(self, create_repo):
         repo_ref = create_repo(self.orgname, self.upstream_repository, self.user)
         input_manifest = parse_manifest_from_bytes(


### PR DESCRIPTION
Previously, this deduplication only happened on normal Docker v2 push side, but not on proxy side. This caused proxying of OCI indexes containing multiple references to same child manifests in one index to fail during manifest insertion. 

With this change, the deduplication is explicitly done in the `connect_manifests` function and applies to all proxy calls.