### PR TITLE
PROJQUAY-12456: feat(ui): display nightly build info in help dropdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -218,6 +218,8 @@ COPY --from=build-quaydir /quaydir $QUAYDIR
 # inert at runtime; removing them reduces scanner noise and attack surface.
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
 
+RUN date -u +%Y%m%d > $QUAYDIR/BUILD_DATE
+
 EXPOSE 8080 8443 7443 9091 55443
 # Don't expose /var/log as a volume, because we just configured it
 # correctly above.

--- a/Dockerfile
+++ b/Dockerfile
@@ -219,7 +219,7 @@ COPY --from=build-quaydir /quaydir $QUAYDIR
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
 
 ARG BUILD_TIMESTAMP
-RUN date -u +%Y%m%d > $QUAYDIR/BUILD_DATE
+RUN date -u +%Y%m%d%H%M > $QUAYDIR/BUILD_DATE
 
 EXPOSE 8080 8443 7443 9091 55443
 # Don't expose /var/log as a volume, because we just configured it

--- a/Dockerfile
+++ b/Dockerfile
@@ -218,6 +218,7 @@ COPY --from=build-quaydir /quaydir $QUAYDIR
 # inert at runtime; removing them reduces scanner noise and attack surface.
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
 
+ARG BUILD_TIMESTAMP
 RUN date -u +%Y%m%d > $QUAYDIR/BUILD_DATE
 
 EXPOSE 8080 8443 7443 9091 55443

--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -233,6 +233,7 @@ RUN set -ex \
 # inert at runtime; removing them reduces scanner noise and attack surface.
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
 
+ARG BUILD_TIMESTAMP
 RUN date -u +%Y%m%d > $QUAYDIR/BUILD_DATE
 
 EXPOSE 8080 8443 7443 9091 55443

--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -234,7 +234,7 @@ RUN set -ex \
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
 
 ARG BUILD_TIMESTAMP
-RUN date -u +%Y%m%d > $QUAYDIR/BUILD_DATE
+RUN date -u +%Y%m%d%H%M > $QUAYDIR/BUILD_DATE
 
 EXPOSE 8080 8443 7443 9091 55443
 # Don't expose /var/log as a volume, because we just configured it

--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -233,6 +233,8 @@ RUN set -ex \
 # inert at runtime; removing them reduces scanner noise and attack surface.
 RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
 
+RUN date -u +%Y%m%d > $QUAYDIR/BUILD_DATE
+
 EXPOSE 8080 8443 7443 9091 55443
 # Don't expose /var/log as a volume, because we just configured it
 # correctly above.

--- a/_init.py
+++ b/_init.py
@@ -1,6 +1,4 @@
 import os
-import re
-import subprocess
 
 try:
     from util.config.provider import get_config_provider
@@ -37,14 +35,15 @@ config_provider = get_config_provider(
 
 
 def _get_version_number():
-    # Try to get version from environment
     version = os.getenv("QUAY_VERSION", "")
+    if version:
+        return version
 
-    if not version:
-        # Fallback to getting version from changelog for standalone
-        version = _get_version_number_changelog()
-
-    return version
+    base = _get_version_number_changelog()
+    build_date = _get_build_date()
+    if base and build_date:
+        return f"{base}-nightly-{build_date}"
+    return base
 
 
 def _get_version_number_changelog():
@@ -54,6 +53,15 @@ def _get_version_number_changelog():
                 if line[0:5] == "## [v":
                     return line.split("[")[1].split("]")[0]
     except IOError:
+        pass
+    return ""
+
+
+def _get_build_date():
+    try:
+        with open(os.path.join(ROOT_DIR, "BUILD_DATE")) as f:
+            return f.read().strip()
+    except (IOError, OSError):
         return ""
 
 

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -21,7 +21,7 @@ def quay_root(tmp_path):
 
 class TestGetVersionNumber:
     def test_explicit_env_takes_precedence(self, quay_root):
-        (quay_root / "BUILD_DATE").write_text("20260803\n")
+        (quay_root / "BUILD_DATE").write_text("202608031425\n")
         with (
             patch.object(_init, "ROOT_DIR", str(quay_root)),
             patch.dict(os.environ, {"QUAY_VERSION": "v3.18.0"}),
@@ -29,13 +29,13 @@ class TestGetVersionNumber:
             assert _init._get_version_number() == "v3.18.0"
 
     def test_nightly_format_when_build_date_exists(self, quay_root):
-        (quay_root / "BUILD_DATE").write_text("20260803\n")
+        (quay_root / "BUILD_DATE").write_text("202608031425\n")
         with (
             patch.object(_init, "ROOT_DIR", str(quay_root)),
             patch.dict(os.environ, {}, clear=False),
         ):
             os.environ.pop("QUAY_VERSION", None)
-            assert _init._get_version_number() == "v3.18.0-nightly-20260803"
+            assert _init._get_version_number() == "v3.18.0-nightly-202608031425"
 
     def test_changelog_fallback_when_no_build_date(self, quay_root):
         with (

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -22,43 +22,49 @@ def quay_root(tmp_path):
 class TestGetVersionNumber:
     def test_explicit_env_takes_precedence(self, quay_root):
         (quay_root / "BUILD_DATE").write_text("20260803\n")
-        with patch.object(_init, "ROOT_DIR", str(quay_root)), patch.dict(
-            os.environ, {"QUAY_VERSION": "v3.18.0"}
+        with (
+            patch.object(_init, "ROOT_DIR", str(quay_root)),
+            patch.dict(os.environ, {"QUAY_VERSION": "v3.18.0"}),
         ):
             assert _init._get_version_number() == "v3.18.0"
 
     def test_nightly_format_when_build_date_exists(self, quay_root):
         (quay_root / "BUILD_DATE").write_text("20260803\n")
-        with patch.object(_init, "ROOT_DIR", str(quay_root)), patch.dict(
-            os.environ, {}, clear=False
+        with (
+            patch.object(_init, "ROOT_DIR", str(quay_root)),
+            patch.dict(os.environ, {}, clear=False),
         ):
             os.environ.pop("QUAY_VERSION", None)
             assert _init._get_version_number() == "v3.18.0-nightly-20260803"
 
     def test_changelog_fallback_when_no_build_date(self, quay_root):
-        with patch.object(_init, "ROOT_DIR", str(quay_root)), patch.dict(
-            os.environ, {}, clear=False
+        with (
+            patch.object(_init, "ROOT_DIR", str(quay_root)),
+            patch.dict(os.environ, {}, clear=False),
         ):
             os.environ.pop("QUAY_VERSION", None)
             assert _init._get_version_number() == "v3.18.0"
 
     def test_empty_when_no_changelog_and_no_env(self, tmp_path):
-        with patch.object(_init, "ROOT_DIR", str(tmp_path)), patch.dict(
-            os.environ, {}, clear=False
+        with (
+            patch.object(_init, "ROOT_DIR", str(tmp_path)),
+            patch.dict(os.environ, {}, clear=False),
         ):
             os.environ.pop("QUAY_VERSION", None)
             assert _init._get_version_number() == ""
 
     def test_local_dev_env_passthrough(self, quay_root):
-        with patch.object(_init, "ROOT_DIR", str(quay_root)), patch.dict(
-            os.environ, {"QUAY_VERSION": "local-dev"}
+        with (
+            patch.object(_init, "ROOT_DIR", str(quay_root)),
+            patch.dict(os.environ, {"QUAY_VERSION": "local-dev"}),
         ):
             assert _init._get_version_number() == "local-dev"
 
     def test_changelog_without_version_entry_returns_empty(self, tmp_path):
         (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\nNo releases yet.\n")
-        with patch.object(_init, "ROOT_DIR", str(tmp_path)), patch.dict(
-            os.environ, {}, clear=False
+        with (
+            patch.object(_init, "ROOT_DIR", str(tmp_path)),
+            patch.dict(os.environ, {}, clear=False),
         ):
             os.environ.pop("QUAY_VERSION", None)
             assert _init._get_version_number() == ""

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,75 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+import _init
+
+
+@pytest.fixture()
+def quay_root(tmp_path):
+    """Create a temporary directory simulating the Quay root with a CHANGELOG.md."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "# Changelog\n\n"
+        "## [v3.18.0] - 2026-07-01\n\n"
+        "### Added\n- New features\n\n"
+        "## [v3.17.0] - 2026-01-01\n"
+    )
+    return tmp_path
+
+
+class TestGetVersionNumber:
+    def test_explicit_env_takes_precedence(self, quay_root):
+        (quay_root / "BUILD_DATE").write_text("20260803\n")
+        with patch.object(_init, "ROOT_DIR", str(quay_root)), patch.dict(
+            os.environ, {"QUAY_VERSION": "v3.18.0"}
+        ):
+            assert _init._get_version_number() == "v3.18.0"
+
+    def test_nightly_format_when_build_date_exists(self, quay_root):
+        (quay_root / "BUILD_DATE").write_text("20260803\n")
+        with patch.object(_init, "ROOT_DIR", str(quay_root)), patch.dict(
+            os.environ, {}, clear=False
+        ):
+            os.environ.pop("QUAY_VERSION", None)
+            assert _init._get_version_number() == "v3.18.0-nightly-20260803"
+
+    def test_changelog_fallback_when_no_build_date(self, quay_root):
+        with patch.object(_init, "ROOT_DIR", str(quay_root)), patch.dict(
+            os.environ, {}, clear=False
+        ):
+            os.environ.pop("QUAY_VERSION", None)
+            assert _init._get_version_number() == "v3.18.0"
+
+    def test_empty_when_no_changelog_and_no_env(self, tmp_path):
+        with patch.object(_init, "ROOT_DIR", str(tmp_path)), patch.dict(
+            os.environ, {}, clear=False
+        ):
+            os.environ.pop("QUAY_VERSION", None)
+            assert _init._get_version_number() == ""
+
+    def test_local_dev_env_passthrough(self, quay_root):
+        with patch.object(_init, "ROOT_DIR", str(quay_root)), patch.dict(
+            os.environ, {"QUAY_VERSION": "local-dev"}
+        ):
+            assert _init._get_version_number() == "local-dev"
+
+    def test_changelog_without_version_entry_returns_empty(self, tmp_path):
+        (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\nNo releases yet.\n")
+        with patch.object(_init, "ROOT_DIR", str(tmp_path)), patch.dict(
+            os.environ, {}, clear=False
+        ):
+            os.environ.pop("QUAY_VERSION", None)
+            assert _init._get_version_number() == ""
+
+
+class TestGetBuildDate:
+    def test_reads_build_date_file(self, tmp_path):
+        (tmp_path / "BUILD_DATE").write_text("20260804\n")
+        with patch.object(_init, "ROOT_DIR", str(tmp_path)):
+            assert _init._get_build_date() == "20260804"
+
+    def test_returns_empty_when_file_missing(self, tmp_path):
+        with patch.object(_init, "ROOT_DIR", str(tmp_path)):
+            assert _init._get_build_date() == ""

--- a/web/playwright/e2e/ui/footer.spec.ts
+++ b/web/playwright/e2e/ui/footer.spec.ts
@@ -1,9 +1,29 @@
 import {test, expect} from '../../fixtures';
 
 test.describe('Footer', {tag: ['@ui']}, () => {
-  test('renders footer structure', async ({authenticatedPage}) => {
-    await authenticatedPage.goto('/organization');
+  test('renders footer when footer items are configured', async ({
+    authenticatedPage,
+    quayConfig,
+  }) => {
+    const serverHostname = quayConfig?.config?.SERVER_HOSTNAME as
+      | string
+      | undefined;
+    const isQuayIO =
+      serverHostname === 'quay.io' || serverHostname === 'stage.quay.io';
+    const hasFooterLinks = !!(
+      quayConfig?.config?.FOOTER_LINKS?.TERMS_OF_SERVICE_URL ||
+      quayConfig?.config?.FOOTER_LINKS?.PRIVACY_POLICY_URL ||
+      quayConfig?.config?.FOOTER_LINKS?.SECURITY_URL ||
+      quayConfig?.config?.FOOTER_LINKS?.ABOUT_URL ||
+      quayConfig?.config?.BRANDING?.footer_img ||
+      quayConfig?.config?.CONTACT_INFO?.length
+    );
+    test.skip(
+      !isQuayIO && !hasFooterLinks,
+      'No footer items configured in this environment',
+    );
 
+    await authenticatedPage.goto('/organization');
     await expect(authenticatedPage.locator('#quay-footer')).toBeVisible();
     await expect(
       authenticatedPage.locator('.quay-footer-container'),
@@ -11,7 +31,25 @@ test.describe('Footer', {tag: ['@ui']}, () => {
     await expect(authenticatedPage.locator('.quay-footer-list')).toBeVisible();
   });
 
-  test('footer is visible on multiple pages', async ({authenticatedPage}) => {
+  test('footer is visible on multiple pages when configured', async ({
+    authenticatedPage,
+    quayConfig,
+  }) => {
+    const serverHostname = quayConfig?.config?.SERVER_HOSTNAME as
+      | string
+      | undefined;
+    const isQuayIO =
+      serverHostname === 'quay.io' || serverHostname === 'stage.quay.io';
+    const hasFooterLinks = !!(
+      quayConfig?.config?.FOOTER_LINKS?.TERMS_OF_SERVICE_URL ||
+      quayConfig?.config?.BRANDING?.footer_img ||
+      quayConfig?.config?.CONTACT_INFO?.length
+    );
+    test.skip(
+      !isQuayIO && !hasFooterLinks,
+      'No footer items configured in this environment',
+    );
+
     await authenticatedPage.goto('/organization');
     await expect(authenticatedPage.locator('#quay-footer')).toBeVisible();
 

--- a/web/playwright/e2e/ui/footer.spec.ts
+++ b/web/playwright/e2e/ui/footer.spec.ts
@@ -1,10 +1,7 @@
 import {test, expect} from '../../fixtures';
 
 test.describe('Footer', {tag: ['@ui']}, () => {
-  test('renders footer structure and documentation link', async ({
-    authenticatedPage,
-    quayConfig,
-  }) => {
+  test('renders footer structure', async ({authenticatedPage}) => {
     await authenticatedPage.goto('/organization');
 
     await expect(authenticatedPage.locator('#quay-footer')).toBeVisible();
@@ -12,25 +9,6 @@ test.describe('Footer', {tag: ['@ui']}, () => {
       authenticatedPage.locator('.quay-footer-container'),
     ).toBeVisible();
     await expect(authenticatedPage.locator('.quay-footer-list')).toBeVisible();
-
-    if (quayConfig?.config?.DOCUMENTATION_ROOT) {
-      const docLink = authenticatedPage
-        .locator('.quay-footer-list')
-        .getByRole('link', {name: 'Documentation'});
-      await expect(docLink).toBeVisible();
-      await expect(docLink).toHaveAttribute(
-        'href',
-        quayConfig.config.DOCUMENTATION_ROOT as string,
-      );
-      await expect(docLink).toHaveAttribute('target', '_blank');
-      await expect(docLink).toHaveAttribute('rel', 'noopener noreferrer');
-    }
-
-    if (quayConfig?.version_number) {
-      await expect(
-        authenticatedPage.locator('.quay-footer-version'),
-      ).toContainText('Quay');
-    }
   });
 
   test('footer is visible on multiple pages', async ({authenticatedPage}) => {

--- a/web/playwright/e2e/ui/help-menu.spec.ts
+++ b/web/playwright/e2e/ui/help-menu.spec.ts
@@ -9,16 +9,23 @@ test.describe('Help menu', {tag: ['@ui']}, () => {
     await expect(toggle).toBeVisible();
   });
 
-  test('opens dropdown and shows documentation links', async ({
+  test('opens dropdown and shows links', async ({
     authenticatedPage,
+    quayConfig,
   }) => {
     await authenticatedPage.goto('/organization');
     const toggle = authenticatedPage.getByTestId('help-menu-toggle');
     await toggle.click();
 
-    const docLink = authenticatedPage.getByTestId('help-documentation-link');
-    await expect(docLink).toBeVisible();
-    await expect(docLink).toContainText('Documentation');
+    if (quayConfig?.config?.DOCUMENTATION_ROOT) {
+      const docLink = authenticatedPage.getByTestId('help-documentation-link');
+      await expect(docLink).toBeVisible();
+      await expect(docLink).toContainText('Documentation');
+      await expect(docLink).toHaveAttribute(
+        'href',
+        quayConfig.config.DOCUMENTATION_ROOT as string,
+      );
+    }
 
     const apiLink = authenticatedPage.getByTestId('help-api-reference-link');
     await expect(apiLink).toBeVisible();
@@ -47,13 +54,10 @@ test.describe('Help menu', {tag: ['@ui']}, () => {
     const toggle = authenticatedPage.getByTestId('help-menu-toggle');
 
     await toggle.click();
-    await expect(
-      authenticatedPage.getByTestId('help-documentation-link'),
-    ).toBeVisible();
+    const apiLink = authenticatedPage.getByTestId('help-api-reference-link');
+    await expect(apiLink).toBeVisible();
 
     await toggle.click();
-    await expect(
-      authenticatedPage.getByTestId('help-documentation-link'),
-    ).not.toBeVisible();
+    await expect(apiLink).not.toBeVisible();
   });
 });

--- a/web/playwright/e2e/ui/help-menu.spec.ts
+++ b/web/playwright/e2e/ui/help-menu.spec.ts
@@ -18,10 +18,11 @@ test.describe('Help menu', {tag: ['@ui']}, () => {
     await toggle.click();
 
     if (quayConfig?.config?.DOCUMENTATION_ROOT) {
-      const docLink = authenticatedPage.getByTestId('help-documentation-link');
-      await expect(docLink).toBeVisible();
-      await expect(docLink).toContainText('Documentation');
-      await expect(docLink).toHaveAttribute(
+      const docItem = authenticatedPage.getByTestId('help-documentation-link');
+      await expect(docItem).toBeVisible();
+      await expect(docItem).toContainText('Documentation');
+      const docAnchor = docItem.locator('a');
+      await expect(docAnchor).toHaveAttribute(
         'href',
         quayConfig.config.DOCUMENTATION_ROOT as string,
       );

--- a/web/playwright/e2e/ui/help-menu.spec.ts
+++ b/web/playwright/e2e/ui/help-menu.spec.ts
@@ -1,0 +1,59 @@
+import {test, expect} from '../../fixtures';
+
+test.describe('Help menu', {tag: ['@ui']}, () => {
+  test('renders help menu toggle in the masthead', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/organization');
+    const toggle = authenticatedPage.getByTestId('help-menu-toggle');
+    await expect(toggle).toBeVisible();
+  });
+
+  test('opens dropdown and shows documentation links', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/organization');
+    const toggle = authenticatedPage.getByTestId('help-menu-toggle');
+    await toggle.click();
+
+    const docLink = authenticatedPage.getByTestId('help-documentation-link');
+    await expect(docLink).toBeVisible();
+    await expect(docLink).toContainText('Documentation');
+
+    const apiLink = authenticatedPage.getByTestId('help-api-reference-link');
+    await expect(apiLink).toBeVisible();
+    await expect(apiLink).toContainText('API Reference');
+  });
+
+  test('shows version info when available', async ({
+    authenticatedPage,
+    quayConfig,
+  }) => {
+    test.skip(!quayConfig?.version_number, 'No version_number in config');
+
+    await authenticatedPage.goto('/organization');
+    const toggle = authenticatedPage.getByTestId('help-menu-toggle');
+    await toggle.click();
+
+    const versionItem = authenticatedPage.getByTestId('help-version-info');
+    await expect(versionItem).toBeVisible();
+    await expect(versionItem).not.toHaveText('');
+  });
+
+  test('closes dropdown when clicking toggle again', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/organization');
+    const toggle = authenticatedPage.getByTestId('help-menu-toggle');
+
+    await toggle.click();
+    await expect(
+      authenticatedPage.getByTestId('help-documentation-link'),
+    ).toBeVisible();
+
+    await toggle.click();
+    await expect(
+      authenticatedPage.getByTestId('help-documentation-link'),
+    ).not.toBeVisible();
+  });
+});

--- a/web/src/components/LoginFooter.tsx
+++ b/web/src/components/LoginFooter.tsx
@@ -7,12 +7,6 @@ export function useLoginFooterItems() {
 
   const footerItems: React.ReactNode[] = [];
 
-  if (quayConfig?.version_number) {
-    footerItems.push(
-      <ListItem key="version">{quayConfig.version_number}</ListItem>,
-    );
-  }
-
   if (quayConfig?.config?.FOOTER_LINKS?.TERMS_OF_SERVICE_URL) {
     footerItems.push(
       <ListItem key="terms">
@@ -64,20 +58,6 @@ export function useLoginFooterItems() {
           rel="noopener noreferrer"
         >
           About
-        </a>
-      </ListItem>,
-    );
-  }
-
-  if (quayConfig?.config?.DOCUMENTATION_ROOT) {
-    footerItems.push(
-      <ListItem key="docs">
-        <a
-          href={quayConfig.config.DOCUMENTATION_ROOT}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Documentation
         </a>
       </ListItem>,
     );

--- a/web/src/components/footer/QuayFooter.tsx
+++ b/web/src/components/footer/QuayFooter.tsx
@@ -35,21 +35,6 @@ export function QuayFooter() {
     );
   }
 
-  // Add Documentation link
-  if (quayConfig?.config?.DOCUMENTATION_ROOT) {
-    footerItems.push(
-      <li key="docs">
-        <a
-          href={quayConfig.config.DOCUMENTATION_ROOT}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Documentation
-        </a>
-      </li>,
-    );
-  }
-
   // For quay.io and stage.quay.io with BILLING feature
   const isQuayIO =
     quayConfig?.config?.SERVER_HOSTNAME === 'quay.io' ||
@@ -183,8 +168,8 @@ export function QuayFooter() {
     );
   }
 
-  // Don't render footer if there are no items and no version
-  if (footerItems.length === 0 && !quayConfig?.version_number) {
+  // Don't render footer if there are no items
+  if (footerItems.length === 0) {
     return null;
   }
 
@@ -193,11 +178,6 @@ export function QuayFooter() {
       <nav id="quay-footer" className="quay-footer">
         <div className="quay-footer-container">
           <ul className="quay-footer-list">{footerItems}</ul>
-          {quayConfig?.version_number && (
-            <div className="quay-footer-version">
-              {quayConfig.version_number}
-            </div>
-          )}
         </div>
       </nav>
       {isQuayIO && (

--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -180,15 +180,17 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
       )}
     >
       <DropdownList>
-        <DropdownItem
-          key="documentation"
-          to="https://docs.redhat.com/en/documentation/red_hat_quay/"
-          target="_blank"
-          rel="noopener noreferrer"
-          data-testid="help-documentation-link"
-        >
-          Documentation
-        </DropdownItem>
+        {quayConfig?.config?.DOCUMENTATION_ROOT && (
+          <DropdownItem
+            key="documentation"
+            to={quayConfig.config.DOCUMENTATION_ROOT}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="help-documentation-link"
+          >
+            Documentation
+          </DropdownItem>
+        )}
         <DropdownItem
           key="api-reference"
           to="/api/v1/discovery"

--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -1,6 +1,9 @@
 import {
   Button,
   Divider,
+  Dropdown,
+  DropdownItem,
+  DropdownList,
   MenuGroup,
   MenuItem,
   MenuList,
@@ -24,6 +27,7 @@ import {
 } from '@patternfly/react-core';
 import {
   PowerOffIcon,
+  QuestionCircleIcon,
   UserIcon,
   UserCogIcon,
   WindowMaximizeIcon,
@@ -47,23 +51,23 @@ import {useNavigate} from 'react-router-dom';
 
 export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
   const menuRef = React.useRef<HTMLDivElement>(null);
   const toggleRef = React.useRef<HTMLButtonElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const {themePreference, setThemePreference} = useTheme();
-  const config = useQuayConfig();
+  const quayConfig = useQuayConfig();
   const navigate = useNavigate();
   const showUIToggle =
-    config?.features?.UI_V2 &&
+    quayConfig?.features?.UI_V2 &&
     !(
-      config?.config?.DISABLE_ANGULAR_UI &&
-      config?.config?.DEFAULT_UI === 'react'
+      quayConfig?.config?.DISABLE_ANGULAR_UI &&
+      quayConfig?.config?.DEFAULT_UI === 'react'
     );
 
   const queryClient = useQueryClient();
   const {user} = useCurrentUser();
   const [err, setErr] = useState<string>();
-  const quayConfig = useQuayConfig();
 
   const onDropdownToggle = () => {
     setIsDropdownOpen((prev) => !prev);
@@ -155,6 +159,61 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
     const randomArg = '?_=' + new Date().getTime();
     window.location.replace(`${protocol}//${host}/${path}/${randomArg}`);
   };
+
+  const helpDropdown = (
+    <Dropdown
+      isOpen={isHelpOpen}
+      onSelect={() => setIsHelpOpen(false)}
+      onOpenChange={setIsHelpOpen}
+      popperProps={{position: 'end'}}
+      toggle={(toggleRef) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => setIsHelpOpen((prev) => !prev)}
+          isExpanded={isHelpOpen}
+          variant="plain"
+          aria-label="Help menu"
+          data-testid="help-menu-toggle"
+        >
+          <QuestionCircleIcon />
+        </MenuToggle>
+      )}
+    >
+      <DropdownList>
+        <DropdownItem
+          key="documentation"
+          to="https://docs.redhat.com/en/documentation/red_hat_quay/"
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="help-documentation-link"
+        >
+          Documentation
+        </DropdownItem>
+        <DropdownItem
+          key="api-reference"
+          to="/api/v1/discovery"
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="help-api-reference-link"
+        >
+          API Reference
+        </DropdownItem>
+        {quayConfig?.version_number && (
+          <>
+            <Divider component="li" />
+            <DropdownItem
+              key="version"
+              isDisabled
+              isAriaDisabled
+              data-testid="help-version-info"
+            >
+              {quayConfig.version_number}
+            </DropdownItem>
+          </>
+        )}
+      </DropdownList>
+    </Dropdown>
+  );
 
   const userMenu = (
     <Menu ref={menuRef} onSelect={onMenuSelect}>
@@ -358,6 +417,7 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
                 data-testid="notification-bell"
               />
             </ToolbarItem>
+            <ToolbarItem>{helpDropdown}</ToolbarItem>
             <ToolbarItem>
               {user.username ? menuContainer : signInButton}
             </ToolbarItem>


### PR DESCRIPTION
## Summary

Add a PatternFly help (`?`) dropdown to the masthead toolbar and display the build version string (e.g., `Quay v3.18.0-nightly-202608041425`). For Konflux nightly builds, the version auto-constructs from CHANGELOG.md + a build timestamp generated during Docker image build. Documentation and version are moved from the footer to the help dropdown to avoid duplication.

### Changes

**Build metadata:**
- Generate `BUILD_DATE` file (per-minute UTC timestamp) during Docker image build in both `Dockerfile` and `Dockerfile.downstream`
- Add `ARG BUILD_TIMESTAMP` to bust Docker layer cache so each build gets a fresh date

**Backend version logic (`_init.py`):**
- When `QUAY_VERSION` env is set → use as-is (release builds, local-dev)
- When `QUAY_VERSION` is not set + `BUILD_DATE` exists → construct nightly format: `v3.18.0-nightly-202608041425`
- When neither exists → fallback to CHANGELOG.md version
- Fix pre-existing bug where `_get_version_number_changelog()` could return `None`
- Remove unused `re` and `subprocess` imports

**Frontend help dropdown (`HeaderToolbar.tsx`):**
- Add PatternFly `Dropdown` with `QuestionCircleIcon` toggle between notification bell and user menu
- Show Documentation link (from `DOCUMENTATION_ROOT` config), API Reference link, and version string
- Use PatternFly best practice: `Dropdown` + `DropdownList` + `DropdownItem` with `MenuToggle variant="plain"`
- Deduplicate `useQuayConfig()` call (was called twice)

**Footer cleanup:**
- Remove Documentation link and version from `QuayFooter.tsx` (now in help dropdown)
- Remove version and Documentation from `LoginFooter.tsx` (now in help dropdown)
- Footer retains: branding, legal links (Terms/Privacy/Security/About), Contact, quay.io consent/status widgets

### Version display by build type

| Build Type | Version Displayed |
|---|---|
| Konflux push (nightly) | `Quay v3.18.0-nightly-202608041425` |
| Release | `Quay v3.18.0` |
| Local dev | `Quay local-dev` |

### Files changed (9 files, +274 / -77)

| File | Change |
|------|--------|
| `Dockerfile` | Add `ARG BUILD_TIMESTAMP` + `RUN date -u +%Y%m%d%H%M > BUILD_DATE` |
| `Dockerfile.downstream` | Same as above |
| `_init.py` | Enhanced version logic + `_get_build_date()` + bug fix + cleanup |
| `web/src/components/header/HeaderToolbar.tsx` | Add help dropdown with `QuestionCircleIcon` |
| `web/src/components/footer/QuayFooter.tsx` | Remove Documentation link and version |
| `web/src/components/LoginFooter.tsx` | Remove version and Documentation |
| `test/test_version.py` | 8 pytest tests for version logic (new) |
| `web/playwright/e2e/ui/help-menu.spec.ts` | 4 E2E tests for help dropdown (new) |
| `web/playwright/e2e/ui/footer.spec.ts` | Update: skip when no footer items configured |

## Test plan

- [x] Backend: `TEST=true PYTHONPATH="." pytest test/test_version.py -v` — 8/8 passed
- [x] Frontend: `npx tsc --noEmit` — no new TypeScript errors
- [x] Lint: `pre-commit` black/isort/flake8/eslint — all passed
- [x] Local validation: verified help dropdown shows `Quay v3.11.0-nightly-202608040745` with `QUAY_VERSION` unset
- [x] Playwright E2E: `help-menu.spec.ts` — tests help dropdown visibility, links, version display, toggle behavior
- [x] Playwright E2E: `footer.spec.ts` — updated to skip when no footer items configured

## References

- Jira: https://redhat.atlassian.net/browse/PROJQUAY-12456
- ACS console help dropdown (reference implementation for version display)
- Konflux builds: `quay-eng-tenant/applications/quay-v3-18/components`

🤖 Generated with [Claude Code](https://claude.com/claude-code)