### PR TITLE
NO-ISSUE: fix(ci): restore Playwright report deploy after workflow consolidation

### DIFF
--- a/.github/workflows/playwright-report-deploy.yaml
+++ b/.github/workflows/playwright-report-deploy.yaml
@@ -1,7 +1,10 @@
 name: Playwright Report Deploy
 on:
   workflow_run:
-    workflows: ["Playwright E2E Tests"]
+    # "Playwright E2E Tests" now runs as a job inside the reusable ci-web.yaml
+    # workflow, called from the top-level "CI" workflow (sentinel.yaml). Only
+    # "CI" itself is a directly-triggered workflow that can be targeted here.
+    workflows: ["CI"]
     types:
       - completed
 
@@ -19,30 +22,39 @@ jobs:
       contents: read
 
     steps:
+    # The "CI" run may not have executed the Playwright job at all (e.g. a
+    # Go/Python-only PR never calls ci-web.yaml), so no artifacts will exist.
+    # Treat that as a normal skip rather than a failure.
     - name: Download Playwright report artifact
+      id: download-report
       uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8
       with:
         name: playwright-report
-        workflow: web-playwright-ci.yaml
+        workflow: ci-web.yaml
         run_id: ${{ github.event.workflow_run.id }}
         path: ./playwright-report
+        if_no_artifact_found: ignore
 
     - name: Download PR number
+      id: download-pr-info
       uses: dawidd6/action-download-artifact@20319c5641d495c8a52e688b7dc5fada6c3a9fbc # v8
       with:
         name: pr-info
-        workflow: web-playwright-ci.yaml
+        workflow: ci-web.yaml
         run_id: ${{ github.event.workflow_run.id }}
         path: ./pr-info
+        if_no_artifact_found: ignore
 
     - name: Read PR number
       id: pr
+      if: steps.download-pr-info.outputs.found_artifact == 'true'
       run: |
         PR_NUMBER=$(cat pr-info/pr_number.txt)
         echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
     - name: Deploy to Surge
       id: deploy
+      if: steps.download-report.outputs.found_artifact == 'true' && steps.download-pr-info.outputs.found_artifact == 'true'
       env:
         PR_NUMBER: ${{ steps.pr.outputs.number }}
         SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
@@ -53,6 +65,7 @@ jobs:
         echo "url=https://$DEPLOY_DOMAIN" >> $GITHUB_OUTPUT
 
     - name: Comment PR with report URL
+      if: steps.deploy.outcome == 'success'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         REPORT_URL: ${{ steps.deploy.outputs.url }}

--- a/scripts/playwright-debug.sh
+++ b/scripts/playwright-debug.sh
@@ -37,9 +37,13 @@ elif [[ "$INPUT" =~ ^[0-9]+$ ]]; then
     exit 1
   fi
 
+  # Playwright runs as a job inside the reusable ci-web.yaml workflow, which
+  # is called via workflow_call from the top-level "CI" workflow
+  # (sentinel.yaml). Reusable workflow_call-only files have no independent
+  # run history, so we must look up runs of the caller workflow instead.
   RUN_ID=$(gh run list \
     --repo "$DEFAULT_REPO" \
-    --workflow "web-playwright-ci.yaml" \
+    --workflow "sentinel.yaml" \
     --commit "$HEAD_SHA" \
     --json databaseId,conclusion \
     --jq '.[0].databaseId') || {


### PR DESCRIPTION
## Summary
`playwright-report-deploy.yaml` and `scripts/playwright-debug.sh` still targeted the pre-consolidation workflow identity (`web-playwright-ci.yaml` / top-level `"Playwright E2E Tests"`) after #6162 folded that workflow into the reusable `ci-web.yaml`, called via `workflow_call` from `sentinel.yaml` (name `CI`). Reusable `workflow_call`-only workflows never independently complete, so both consumers silently stopped working: the Surge report/PR-comment job never triggers, and the debug script can never resolve a PR to a run.

## Related Issue
NO-ISSUE — CI reliability fix, no tracked ticket.

## Changes
- `playwright-report-deploy.yaml`: retarget `workflow_run.workflows` at `"CI"` (sentinel.yaml), the only workflow in the chain that produces independent runs. Add `if_no_artifact_found: ignore` plus step guards so runs that never touched `web/` (and therefore never ran Playwright) skip cleanly instead of posting a broken comment. Update the inert `workflow:` artifact-lookup input from `web-playwright-ci.yaml` to `ci-web.yaml` for clarity (it has no effect on behavior since `run_id` is supplied directly).
- `scripts/playwright-debug.sh`: change `gh run list --workflow` target from `web-playwright-ci.yaml` (0 independent runs, verified via API) to `sentinel.yaml` (the actual run-producing workflow) so PR-number lookups resolve again.

## Testing
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/playwright-report-deploy.yaml'))"` — YAML parses
- [x] `bash -n scripts/playwright-debug.sh` — syntax OK
- [x] `shellcheck scripts/playwright-debug.sh` — clean
- [x] Verified via `gh api repos/quay/quay/actions/workflows/<id>/runs` that `ci-web.yaml`/`ci-python.yaml`/`ci-lint.yaml` (all `workflow_call`-only) have 0 total runs, while `sentinel.yaml` has 1700+ and is actively growing — confirms `workflows: ["CI"]` can only ever match `sentinel.yaml` going forward
- [ ] Not run: full end-to-end `workflow_run` firing on a live PR (requires this PR to merge to master; no local Actions emulator). Recommend a maintainer watches the next PR that touches `web/` after merge to confirm the Surge comment reappears.

## Notes
Root cause traced back to PR #6162 ("ci: consolidate workflows into sentinel gate"), which renamed/restructured `web-playwright-ci.yaml` without updating these two downstream consumers.
