### PR TITLE
PROJQUAY-12494: feat(api): allow attaching external group id on team create/update

### DIFF
--- a/endpoints/api/team.py
+++ b/endpoints/api/team.py
@@ -202,12 +202,13 @@ def _extract_team_sync_config(details):
     return present
 
 
-def _enable_team_sync(orgname, team, config):
+def _validate_team_sync_request(orgname, config, teamname=None):
     """
-    Enable directory sync for a team using the given config.
+    Validate that team sync can be enabled for the given org/config.
 
-    Raises Unauthorized if the caller cannot configure syncing, InvalidRequest if the
-    team is already synced or the group lookup fails.
+    Call this before any team create/update mutations so a failed group lookup does not
+    leave partial team changes persisted. When teamname is provided, also rejects if that
+    team is already synced.
     """
     if not features.TEAM_SYNCING or not authentication.federated_service:
         raise InvalidRequest("Team syncing is not supported on this registry")
@@ -215,7 +216,7 @@ def _enable_team_sync(orgname, team, config):
     if not _syncing_setup_allowed(orgname):
         raise Unauthorized()
 
-    if model.team.get_team_sync_information(orgname, team.name):
+    if teamname and model.team.get_team_sync_information(orgname, teamname):
         raise InvalidRequest(
             "Team is already synced; disable syncing before attaching a different group"
         )
@@ -223,6 +224,18 @@ def _enable_team_sync(orgname, team, config):
     status, err = authentication.check_group_lookup_args(config)
     if not status:
         raise InvalidRequest("Could not sync to group: %s" % err)
+
+
+def _enable_team_sync(orgname, team, config, already_validated=False):
+    """
+    Enable directory sync for a team using the given config.
+
+    Raises Unauthorized if the caller cannot configure syncing, InvalidRequest if the
+    team is already synced or the group lookup fails. When already_validated is True,
+    preflight checks are skipped (caller must have run _validate_team_sync_request).
+    """
+    if not already_validated:
+        _validate_team_sync_request(orgname, config, teamname=team.name)
 
     model.team.set_team_syncing(team, authentication.federated_service, config)
     log_action("enable_team_sync", orgname, {"team": team.name})
@@ -304,19 +317,21 @@ class OrganizationTeam(ApiResource):
             details = request.get_json()
             sync_config = _extract_team_sync_config(details)
 
-            # Validate sync permission before creating a team so we do not leave an
-            # unsynced team behind when the caller cannot enable syncing.
-            if sync_config is not None:
-                if not features.TEAM_SYNCING or not authentication.federated_service:
-                    raise InvalidRequest("Team syncing is not supported on this registry")
-                if not _syncing_setup_allowed(orgname):
-                    raise Unauthorized()
-
             is_existing = False
             try:
                 team = model.team.get_organization_team(orgname, teamname)
                 is_existing = True
             except model.InvalidTeamException:
+                team = None
+
+            # Validate sync config before any team write so a failed group lookup does
+            # not leave a newly created team or partial description/role updates behind.
+            if sync_config is not None:
+                _validate_team_sync_request(
+                    orgname, sync_config, teamname=teamname if is_existing else None
+                )
+
+            if not is_existing:
                 # Create the new team.
                 description = details["description"] if "description" in details else ""
                 role = details["role"] if "role" in details else "member"
@@ -324,8 +339,7 @@ class OrganizationTeam(ApiResource):
                 org = model.organization.get_organization(orgname)
                 team = model.team.create_team(teamname, org, role, description)
                 log_action("org_create_team", orgname, {"team": teamname})
-
-            if is_existing:
+            else:
                 if "description" in details and team.description != details["description"]:
                     team.description = details["description"]
                     team.save()
@@ -348,7 +362,7 @@ class OrganizationTeam(ApiResource):
                         )
 
             if sync_config is not None:
-                _enable_team_sync(orgname, team, sync_config)
+                _enable_team_sync(orgname, team, sync_config, already_validated=True)
 
             return team_view(orgname, team, is_new_team=not is_existing), 200
 

--- a/endpoints/api/team.py
+++ b/endpoints/api/team.py
@@ -171,6 +171,66 @@ def disallow_for_synced_team(except_robots=False):
 disallow_nonrobots_for_synced_team = disallow_for_synced_team(except_robots=True)
 disallow_all_for_synced_team = disallow_for_synced_team(except_robots=False)
 
+# Directory sync identifier fields accepted on team create/update and /syncing.
+_TEAM_SYNC_CONFIG_FIELDS = ("group_dn", "group_name", "group_id")
+
+
+def _syncing_setup_allowed(orgname):
+    """
+    Returns whether syncing setup is allowed for the current user over the matching org.
+    """
+    if not features.NONSUPERUSER_TEAM_SYNCING_SETUP and not SuperUserPermission().can():
+        return False
+
+    return AdministerOrganizationPermission(orgname).can()
+
+
+def _extract_team_sync_config(details):
+    """
+    Extract optional directory sync config from a team create/update request body.
+
+    Returns None when no sync fields are present. Raises InvalidRequest if more than one
+    sync identifier is provided.
+    """
+    present = {field: details[field] for field in _TEAM_SYNC_CONFIG_FIELDS if field in details}
+    if not present:
+        return None
+    if len(present) > 1:
+        raise InvalidRequest(
+            "Specify only one of group_dn, group_name, or group_id when enabling team sync"
+        )
+    return present
+
+
+def _enable_team_sync(orgname, team, config):
+    """
+    Enable directory sync for a team using the given config.
+
+    Raises Unauthorized if the caller cannot configure syncing, InvalidRequest if the
+    team is already synced or the group lookup fails.
+    """
+    if not features.TEAM_SYNCING or not authentication.federated_service:
+        raise InvalidRequest("Team syncing is not supported on this registry")
+
+    if not _syncing_setup_allowed(orgname):
+        raise Unauthorized()
+
+    if model.team.get_team_sync_information(orgname, team.name):
+        raise InvalidRequest(
+            "Team is already synced; disable syncing before attaching a different group"
+        )
+
+    status, err = authentication.check_group_lookup_args(config)
+    if not status:
+        raise InvalidRequest("Could not sync to group: %s" % err)
+
+    model.team.set_team_syncing(team, authentication.federated_service, config)
+    log_action("enable_team_sync", orgname, {"team": team.name})
+
+    if app.config["AUTHENTICATION_TYPE"] == "OIDC":
+        # delete existing team members, team membership will be synced with OIDC group
+        model.team.delete_all_team_members(team)
+
 
 @resource("/v1/organization/<orgname>/team/<teamname>")
 @path_param("orgname", "The name of the organization")
@@ -201,6 +261,27 @@ class OrganizationTeam(ApiResource):
                     "type": "string",
                     "description": "Markdown description for the team",
                 },
+                "group_dn": {
+                    "type": "string",
+                    "description": (
+                        "LDAP group DN (relative to the configured base DN) to sync this team with. "
+                        "Mutually exclusive with group_name and group_id."
+                    ),
+                },
+                "group_name": {
+                    "type": "string",
+                    "description": (
+                        "OIDC group name or external object ID to sync this team with. "
+                        "Mutually exclusive with group_dn and group_id."
+                    ),
+                },
+                "group_id": {
+                    "type": "string",
+                    "description": (
+                        "Keystone group ID to sync this team with. "
+                        "Mutually exclusive with group_dn and group_name."
+                    ),
+                },
             },
         },
     }
@@ -211,12 +292,26 @@ class OrganizationTeam(ApiResource):
     def put(self, orgname, teamname):
         """
         Update the org-wide permission for the specified team.
+
+        Optionally attach a directory sync identifier (group_dn, group_name, or group_id)
+        at create or update time so the team is linked to an external group without a
+        separate call to the team syncing endpoint.
         """
         edit_permission = AdministerOrganizationPermission(orgname)
         if edit_permission.can() or allow_if_superuser_with_full_access():
             team = None
 
             details = request.get_json()
+            sync_config = _extract_team_sync_config(details)
+
+            # Validate sync permission before creating a team so we do not leave an
+            # unsynced team behind when the caller cannot enable syncing.
+            if sync_config is not None:
+                if not features.TEAM_SYNCING or not authentication.federated_service:
+                    raise InvalidRequest("Team syncing is not supported on this registry")
+                if not _syncing_setup_allowed(orgname):
+                    raise Unauthorized()
+
             is_existing = False
             try:
                 team = model.team.get_organization_team(orgname, teamname)
@@ -252,6 +347,9 @@ class OrganizationTeam(ApiResource):
                             {"team": teamname, "role": details["role"]},
                         )
 
+            if sync_config is not None:
+                _enable_team_sync(orgname, team, sync_config)
+
             return team_view(orgname, team, is_new_team=not is_existing), 200
 
         raise Unauthorized()
@@ -269,16 +367,6 @@ class OrganizationTeam(ApiResource):
             return "", 204
 
         raise Unauthorized()
-
-
-def _syncing_setup_allowed(orgname):
-    """
-    Returns whether syncing setup is allowed for the current user over the matching org.
-    """
-    if not features.NONSUPERUSER_TEAM_SYNCING_SETUP and not SuperUserPermission().can():
-        return False
-
-    return AdministerOrganizationPermission(orgname).can()
 
 
 @resource("/v1/organization/<orgname>/team/<teamname>/syncing")
@@ -303,20 +391,7 @@ class OrganizationTeamSyncing(ApiResource):
                 raise NotFound()
 
             config = request.get_json()
-
-            # Ensure that the specified config points to a valid group.
-            status, err = authentication.check_group_lookup_args(config)
-            if not status:
-                raise InvalidRequest("Could not sync to group: %s" % err)
-
-            # Set the team's syncing config.
-            model.team.set_team_syncing(team, authentication.federated_service, config)
-            log_action("enable_team_sync", orgname, {"team": teamname})
-
-            if app.config["AUTHENTICATION_TYPE"] == "OIDC":
-                # delete existing team members, team membership will be synced with OIDC group
-                model.team.delete_all_team_members(team)
-
+            _enable_team_sync(orgname, team, config)
             return team_view(orgname, team)
 
         raise Unauthorized()

--- a/endpoints/api/test/test_team.py
+++ b/endpoints/api/test/test_team.py
@@ -17,6 +17,7 @@ UNSYNCED_TEAM_PARAMS = {"orgname": "sellnsmall", "teamname": "owners"}
 NEW_TEAM_PARAMS = {"orgname": "sellnsmall", "teamname": "apisyncteam"}
 NEW_TEAM_OIDC_PARAMS = {"orgname": "sellnsmall", "teamname": "oidcsyncteam"}
 NEW_TEAM_KEYSTONE_PARAMS = {"orgname": "sellnsmall", "teamname": "keystonesyncteam"}
+UPDATE_TEAM_PARAMS = {"orgname": "sellnsmall", "teamname": "updatesyncteam"}
 FAILED_LOOKUP_CREATE_PARAMS = {"orgname": "sellnsmall", "teamname": "failedsyncteam"}
 
 
@@ -77,14 +78,24 @@ def test_update_team_with_group_dn_enables_sync(app):
     with mock_ldap() as ldap:
         with patch("endpoints.api.team.authentication", ldap):
             with client_with_identity("devtable", app) as cl:
+                # Create a non-owners team first — updating "owners" to role=member
+                # is rejected because it would remove the caller's org admin.
+                conduct_api_call(
+                    cl,
+                    OrganizationTeam,
+                    "PUT",
+                    UPDATE_TEAM_PARAMS,
+                    {"role": "member", "description": "to be synced"},
+                )
+
                 body = {
                     "role": "member",
                     "group_dn": "cn=AwesomeFolk",
                 }
-                conduct_api_call(cl, OrganizationTeam, "PUT", UNSYNCED_TEAM_PARAMS, body)
+                conduct_api_call(cl, OrganizationTeam, "PUT", UPDATE_TEAM_PARAMS, body)
 
                 sync_info = model.team.get_team_sync_information(
-                    UNSYNCED_TEAM_PARAMS["orgname"], UNSYNCED_TEAM_PARAMS["teamname"]
+                    UPDATE_TEAM_PARAMS["orgname"], UPDATE_TEAM_PARAMS["teamname"]
                 )
                 assert sync_info is not None
                 assert json.loads(sync_info.config) == {"group_dn": "cn=AwesomeFolk"}
@@ -107,7 +118,9 @@ def test_create_team_with_group_name_enables_sync(app):
                 )
                 assert sync_info is not None
                 assert json.loads(sync_info.config) == {"group_name": "external-object-id"}
-                oidc_auth.check_group_lookup_args.assert_called()
+                oidc_auth.check_group_lookup_args.assert_called_once_with(
+                    {"group_name": "external-object-id"}
+                )
 
 
 def test_create_team_with_group_id_enables_sync(app):
@@ -126,7 +139,9 @@ def test_create_team_with_group_id_enables_sync(app):
             )
             assert sync_info is not None
             assert json.loads(sync_info.config) == {"group_id": "keystone-group-123"}
-            keystone_auth.check_group_lookup_args.assert_called()
+            keystone_auth.check_group_lookup_args.assert_called_once_with(
+                {"group_id": "keystone-group-123"}
+            )
 
 
 def test_oidc_sync_removes_existing_team_members(app):

--- a/endpoints/api/test/test_team.py
+++ b/endpoints/api/test/test_team.py
@@ -7,12 +7,13 @@ from mock import patch
 from data import model
 from endpoints.api import api
 from endpoints.api.organization import Organization
-from endpoints.api.team import OrganizationTeamSyncing, TeamMemberList
+from endpoints.api.team import OrganizationTeam, OrganizationTeamSyncing, TeamMemberList
 from endpoints.api.test.shared import conduct_api_call
 from endpoints.test.shared import client_with_identity
 
 SYNCED_TEAM_PARAMS = {"orgname": "sellnsmall", "teamname": "synced"}
 UNSYNCED_TEAM_PARAMS = {"orgname": "sellnsmall", "teamname": "owners"}
+NEW_TEAM_PARAMS = {"orgname": "sellnsmall", "teamname": "apisyncteam"}
 
 
 def test_team_syncing(app):
@@ -38,6 +39,84 @@ def test_team_syncing(app):
                 # Ensure the team is no longer synced.
                 sync_info = model.team.get_team_sync_information(
                     UNSYNCED_TEAM_PARAMS["orgname"], UNSYNCED_TEAM_PARAMS["teamname"]
+                )
+                assert sync_info is None
+
+
+def test_create_team_with_group_dn_enables_sync(app):
+    with mock_ldap() as ldap:
+        with patch("endpoints.api.team.authentication", ldap):
+            with client_with_identity("devtable", app) as cl:
+                body = {
+                    "role": "member",
+                    "description": "created with sync",
+                    "group_dn": "cn=AwesomeFolk",
+                }
+                conduct_api_call(cl, OrganizationTeam, "PUT", NEW_TEAM_PARAMS, body)
+
+                sync_info = model.team.get_team_sync_information(
+                    NEW_TEAM_PARAMS["orgname"], NEW_TEAM_PARAMS["teamname"]
+                )
+                assert sync_info is not None
+                assert json.loads(sync_info.config) == {"group_dn": "cn=AwesomeFolk"}
+
+
+def test_update_team_with_group_dn_enables_sync(app):
+    with mock_ldap() as ldap:
+        with patch("endpoints.api.team.authentication", ldap):
+            with client_with_identity("devtable", app) as cl:
+                body = {
+                    "role": "member",
+                    "group_dn": "cn=AwesomeFolk",
+                }
+                conduct_api_call(cl, OrganizationTeam, "PUT", UNSYNCED_TEAM_PARAMS, body)
+
+                sync_info = model.team.get_team_sync_information(
+                    UNSYNCED_TEAM_PARAMS["orgname"], UNSYNCED_TEAM_PARAMS["teamname"]
+                )
+                assert sync_info is not None
+                assert json.loads(sync_info.config) == {"group_dn": "cn=AwesomeFolk"}
+
+
+def test_create_team_rejects_multiple_sync_fields(app):
+    with mock_ldap() as ldap:
+        with patch("endpoints.api.team.authentication", ldap):
+            with client_with_identity("devtable", app) as cl:
+                body = {
+                    "role": "member",
+                    "group_dn": "cn=AwesomeFolk",
+                    "group_name": "some-oidc-group",
+                }
+                conduct_api_call(
+                    cl, OrganizationTeam, "PUT", NEW_TEAM_PARAMS, body, expected_code=400
+                )
+
+
+def test_update_already_synced_team_rejects_new_group(app):
+    with mock_ldap() as ldap:
+        with patch("endpoints.api.team.authentication", ldap):
+            with client_with_identity("devtable", app) as cl:
+                body = {
+                    "role": "member",
+                    "group_dn": "cn=AwesomeFolk",
+                }
+                conduct_api_call(
+                    cl, OrganizationTeam, "PUT", SYNCED_TEAM_PARAMS, body, expected_code=400
+                )
+
+
+def test_create_team_without_sync_fields_unchanged(app):
+    with mock_ldap() as ldap:
+        with patch("endpoints.api.team.authentication", ldap):
+            with client_with_identity("devtable", app) as cl:
+                body = {
+                    "role": "member",
+                    "description": "no sync",
+                }
+                conduct_api_call(cl, OrganizationTeam, "PUT", NEW_TEAM_PARAMS, body)
+
+                sync_info = model.team.get_team_sync_information(
+                    NEW_TEAM_PARAMS["orgname"], NEW_TEAM_PARAMS["teamname"]
                 )
                 assert sync_info is None
 

--- a/endpoints/api/test/test_team.py
+++ b/endpoints/api/test/test_team.py
@@ -2,8 +2,9 @@ import json
 from test.fixtures import *
 from test.test_ldap import mock_ldap
 
-from mock import patch
+from mock import Mock, patch
 
+from app import app as quay_app
 from data import model
 from endpoints.api import api
 from endpoints.api.organization import Organization
@@ -14,6 +15,17 @@ from endpoints.test.shared import client_with_identity
 SYNCED_TEAM_PARAMS = {"orgname": "sellnsmall", "teamname": "synced"}
 UNSYNCED_TEAM_PARAMS = {"orgname": "sellnsmall", "teamname": "owners"}
 NEW_TEAM_PARAMS = {"orgname": "sellnsmall", "teamname": "apisyncteam"}
+NEW_TEAM_OIDC_PARAMS = {"orgname": "sellnsmall", "teamname": "oidcsyncteam"}
+NEW_TEAM_KEYSTONE_PARAMS = {"orgname": "sellnsmall", "teamname": "keystonesyncteam"}
+FAILED_LOOKUP_CREATE_PARAMS = {"orgname": "sellnsmall", "teamname": "failedsyncteam"}
+
+
+def _fake_auth(service_name):
+    auth = Mock()
+    auth.federated_service = service_name
+    auth.check_group_lookup_args.return_value = (True, None)
+    auth.service_metadata.return_value = {}
+    return auth
 
 
 def test_team_syncing(app):
@@ -78,6 +90,74 @@ def test_update_team_with_group_dn_enables_sync(app):
                 assert json.loads(sync_info.config) == {"group_dn": "cn=AwesomeFolk"}
 
 
+def test_create_team_with_group_name_enables_sync(app):
+    oidc_auth = _fake_auth("oidc")
+    with patch("endpoints.api.team.authentication", oidc_auth):
+        with patch.dict(quay_app.config, {"AUTHENTICATION_TYPE": "OIDC"}):
+            with client_with_identity("devtable", app) as cl:
+                body = {
+                    "role": "member",
+                    "description": "oidc synced",
+                    "group_name": "external-object-id",
+                }
+                conduct_api_call(cl, OrganizationTeam, "PUT", NEW_TEAM_OIDC_PARAMS, body)
+
+                sync_info = model.team.get_team_sync_information(
+                    NEW_TEAM_OIDC_PARAMS["orgname"], NEW_TEAM_OIDC_PARAMS["teamname"]
+                )
+                assert sync_info is not None
+                assert json.loads(sync_info.config) == {"group_name": "external-object-id"}
+                oidc_auth.check_group_lookup_args.assert_called()
+
+
+def test_create_team_with_group_id_enables_sync(app):
+    keystone_auth = _fake_auth("keystone")
+    with patch("endpoints.api.team.authentication", keystone_auth):
+        with client_with_identity("devtable", app) as cl:
+            body = {
+                "role": "member",
+                "description": "keystone synced",
+                "group_id": "keystone-group-123",
+            }
+            conduct_api_call(cl, OrganizationTeam, "PUT", NEW_TEAM_KEYSTONE_PARAMS, body)
+
+            sync_info = model.team.get_team_sync_information(
+                NEW_TEAM_KEYSTONE_PARAMS["orgname"], NEW_TEAM_KEYSTONE_PARAMS["teamname"]
+            )
+            assert sync_info is not None
+            assert json.loads(sync_info.config) == {"group_id": "keystone-group-123"}
+            keystone_auth.check_group_lookup_args.assert_called()
+
+
+def test_oidc_sync_removes_existing_team_members(app):
+    oidc_auth = _fake_auth("oidc")
+    org = model.organization.get_organization("sellnsmall")
+    team = model.team.create_team("oidcmemberclear", org, "member", "has members")
+    member = model.user.get_user("freshuser")
+    model.team.add_user_to_team(member, team)
+    assert len(list(model.team.list_team_users(team))) == 1
+
+    with patch("endpoints.api.team.authentication", oidc_auth):
+        with patch.dict(quay_app.config, {"AUTHENTICATION_TYPE": "OIDC"}):
+            with client_with_identity("devtable", app) as cl:
+                body = {
+                    "role": "member",
+                    "group_name": "oidc-group",
+                }
+                conduct_api_call(
+                    cl,
+                    OrganizationTeam,
+                    "PUT",
+                    {"orgname": "sellnsmall", "teamname": "oidcmemberclear"},
+                    body,
+                )
+
+    assert len(list(model.team.list_team_users(team))) == 0
+    sync_info = model.team.get_team_sync_information("sellnsmall", "oidcmemberclear")
+    assert sync_info is not None
+    assert json.loads(sync_info.config) == {"group_name": "oidc-group"}
+
+
 def test_create_team_rejects_multiple_sync_fields(app):
     with mock_ldap() as ldap:
         with patch("endpoints.api.team.authentication", ldap):
@@ -119,6 +199,59 @@ def test_create_team_without_sync_fields_unchanged(app):
                     NEW_TEAM_PARAMS["orgname"], NEW_TEAM_PARAMS["teamname"]
                 )
                 assert sync_info is None
+
+
+def test_create_team_failed_group_lookup_does_not_create_team(app):
+    with mock_ldap() as ldap:
+        with patch("endpoints.api.team.authentication", ldap):
+            with client_with_identity("devtable", app) as cl:
+                body = {
+                    "role": "member",
+                    "description": "should not persist",
+                    "group_dn": "cn=invalid",
+                }
+                conduct_api_call(
+                    cl, OrganizationTeam, "PUT", FAILED_LOOKUP_CREATE_PARAMS, body, expected_code=400
+                )
+
+                try:
+                    model.team.get_organization_team(
+                        FAILED_LOOKUP_CREATE_PARAMS["orgname"],
+                        FAILED_LOOKUP_CREATE_PARAMS["teamname"],
+                    )
+                    assert False, "team should not have been created after failed group lookup"
+                except model.InvalidTeamException:
+                    pass
+
+
+def test_update_team_failed_group_lookup_does_not_change_team(app):
+    with mock_ldap() as ldap:
+        with patch("endpoints.api.team.authentication", ldap):
+            team = model.team.get_organization_team(
+                UNSYNCED_TEAM_PARAMS["orgname"], UNSYNCED_TEAM_PARAMS["teamname"]
+            )
+            original_description = team.description
+
+            with client_with_identity("devtable", app) as cl:
+                body = {
+                    "role": "member",
+                    "description": "should-not-be-saved",
+                    "group_dn": "cn=invalid",
+                }
+                conduct_api_call(
+                    cl, OrganizationTeam, "PUT", UNSYNCED_TEAM_PARAMS, body, expected_code=400
+                )
+
+            team = model.team.get_organization_team(
+                UNSYNCED_TEAM_PARAMS["orgname"], UNSYNCED_TEAM_PARAMS["teamname"]
+            )
+            assert team.description == original_description
+            assert (
+                model.team.get_team_sync_information(
+                    UNSYNCED_TEAM_PARAMS["orgname"], UNSYNCED_TEAM_PARAMS["teamname"]
+                )
+                is None
+            )
 
 
 def test_team_member_sync_info_unsynced_superuser(app):

--- a/web/playwright/e2e/organization/team-sync-ldap.spec.ts
+++ b/web/playwright/e2e/organization/team-sync-ldap.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect} from '../../fixtures';
+import {test, expect, uniqueName} from '../../fixtures';
 
 // Relative group DN (relative to the configured LDAP_BASE_DN dc=example,dc=org).
 // The UI shows the base DN and asks for the relative part only.
@@ -85,6 +85,33 @@ test.describe(
         await page.getByRole('button', {name: 'Confirm'}).click();
         await expect(
           page.getByText('Successfully removed team synchronization').first(),
+        ).toBeVisible();
+      },
+    );
+
+    test(
+      'API-created team sync shows group DN in UI',
+      {tag: ['@superuser', '@PROJQUAY-12494']},
+      async ({superuserPage: page, superuserApi: api}) => {
+        const org = await api.organization('ldapapiteamsync');
+        const teamName = uniqueName('ldapapisync');
+
+        // Create team with LDAP sync attached in a single PUT (RFE-8184)
+        await api.raw.createTeam(org.name, teamName, 'member', {
+          group_dn: LDAP_GROUP_RELATIVE_DN,
+        });
+
+        await page.goto(
+          `/organization/${org.name}/teams/${teamName}?tab=Teamsandmembership`,
+        );
+
+        await expect(
+          page.getByText('synchronized with a group in ldap'),
+        ).toBeVisible();
+        await expect(page.getByText('Bound to group')).toBeVisible();
+        await expect(page.getByText(LDAP_GROUP_RELATIVE_DN)).toBeVisible();
+        await expect(
+          page.getByRole('button', {name: 'Remove synchronization'}),
         ).toBeVisible();
       },
     );

--- a/web/playwright/e2e/organization/team-sync.spec.ts
+++ b/web/playwright/e2e/organization/team-sync.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect} from '../../fixtures';
+import {test, expect, uniqueName} from '../../fixtures';
 
 test.describe(
   'OIDC Team Sync',
@@ -67,6 +67,34 @@ test.describe(
         await page.getByRole('button', {name: 'Confirm'}).click();
         await expect(
           page.getByText('Successfully removed team synchronization').first(),
+        ).toBeVisible();
+      },
+    );
+
+    test(
+      'API-created team sync shows group name in UI',
+      {tag: ['@superuser', '@PROJQUAY-12494']},
+      async ({superuserPage: page, superuserApi: api}) => {
+        const groupName = 'test_oidc_group';
+        const org = await api.organization('apiteamsync');
+        const teamName = uniqueName('apisyncteam');
+
+        // Create team with directory sync attached in a single PUT (RFE-8184)
+        await api.raw.createTeam(org.name, teamName, 'member', {
+          group_name: groupName,
+        });
+
+        await page.goto(
+          `/organization/${org.name}/teams/${teamName}?tab=Teamsandmembership`,
+        );
+
+        await expect(
+          page.getByText('synchronized with a group in oidc'),
+        ).toBeVisible();
+        await expect(page.getByText('Bound to group')).toBeVisible();
+        await expect(page.getByText(groupName)).toBeVisible();
+        await expect(
+          page.getByRole('button', {name: 'Remove synchronization'}),
         ).toBeVisible();
       },
     );

--- a/web/playwright/utils/api/client.ts
+++ b/web/playwright/utils/api/client.ts
@@ -916,6 +916,11 @@ export class ApiClient {
     orgName: string,
     teamName: string,
     role: TeamRole = 'member',
+    syncConfig?: {
+      group_dn?: string;
+      group_name?: string;
+      group_id?: string;
+    },
   ): Promise<{name: string; role: string}> {
     const token = await this.fetchToken();
     const response = await this.request.put(
@@ -927,6 +932,7 @@ export class ApiClient {
         },
         data: {
           role,
+          ...syncConfig,
         },
       },
     );
@@ -2795,8 +2801,16 @@ export class ApiClient {
   async enableTeamSync(
     orgName: string,
     teamName: string,
-    groupName: string,
+    groupIdentifier: string,
+    service: 'ldap' | 'oidc' | 'keystone' = 'ldap',
   ): Promise<void> {
+    const data =
+      service === 'oidc'
+        ? {group_name: groupIdentifier}
+        : service === 'keystone'
+          ? {group_id: groupIdentifier}
+          : {group_dn: groupIdentifier};
+
     const response = await this.withFreshLoginRetry(async () => {
       const token = await this.fetchToken();
       return this.request.post(
@@ -2804,7 +2818,7 @@ export class ApiClient {
         {
           timeout: 5000,
           headers: {'X-CSRF-Token': token},
-          data: {group_dn: groupName},
+          data,
         },
       );
     });


### PR DESCRIPTION
## Summary
- Extends `PUT /api/v1/organization/{org}/team/{team}` to accept optional `group_dn`, `group_name`, or `group_id` so an external directory group can be attached at team create/update time ([RFE-8184](https://redhat.atlassian.net/browse/RFE-8184)).
- Extracts shared `_enable_team_sync` helper used by both team PUT and the existing `/syncing` endpoint.
- Rejects multiple sync fields and rejects attaching a group when the team is already synced.

## Test plan
- [ ] `TEST=true PYTHONPATH=. pytest endpoints/api/test/test_team.py -v`
- [ ] Create a team with `group_name` (OIDC) or `group_dn` (LDAP) in a single PUT
- [ ] Confirm already-synced team returns 400 when attaching another group
- [ ] Confirm existing `POST/DELETE .../team/{team}/syncing` still works


Made with [Cursor](https://cursor.com)