### PR TITLE
QUAYIO-1826: feat(gc): add configurable grace period for namespace deletion

### DIFF
--- a/config.py
+++ b/config.py
@@ -534,6 +534,16 @@ class DefaultConfig(ImmutableConfig):
     # How often the Garbage Collection worker runs.
     GARBAGE_COLLECTION_FREQUENCY = 30  # seconds
 
+    # Grace period (seconds) before deleted namespaces are permanently purged by GC.
+    # During this window the data remains in the database and can be recovered via
+    # direct DB operations. 0 means immediate purge (current behavior).
+    NAMESPACE_GC_GRACE_PERIOD_SECONDS = 0
+
+    # Allowlist of namespace names that receive the grace period. When non-empty,
+    # only namespaces in this list are protected. When empty, no grace period is
+    # applied (current behavior).
+    NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST: list[str] = []
+
     # How long notifications will try to send before timing out.
     NOTIFICATION_SEND_TIMEOUT = 10
 

--- a/data/model/test/test_user.py
+++ b/data/model/test/test_user.py
@@ -15,10 +15,12 @@ from data.database import (
     OrgMirrorConfig,
     OrgMirrorRepository,
     OrgMirrorStatus,
+    QueueItem,
     QuotaNotificationState,
     Repository,
     RepositoryState,
     SourceRegistryType,
+    Team,
     User,
     Visibility,
 )
@@ -30,6 +32,7 @@ from data.model.oauth import (
     get_token_assignment,
 )
 from data.model.organization import (
+    InvalidOrganizationException,
     create_organization,
     get_organization,
     get_organizations,
@@ -38,6 +41,7 @@ from data.model.repository import create_repository
 from data.model.team import add_user_to_team, create_team
 from data.model.user import (
     InvalidRobotException,
+    InvalidUsernameException,
     RobotAccountToken,
     attach_federated_login,
     create_robot,
@@ -413,6 +417,212 @@ def test_delete_namespace_with_mixed_repo_states(initialized_db):
 
     with pytest.raises(User.DoesNotExist):
         User.get(id=user.id)
+
+
+def test_mark_namespace_for_deletion_with_grace_period(initialized_db):
+    """When available_after > 0, linked data (robots, teams, federated logins) is preserved."""
+    user = get_user("devtable")
+    org = create_organization("graceorg", "grace@example.com", user)
+
+    robot, _ = create_robot("bot", org)
+    create_team("graceteam", org, "member")
+    attach_federated_login(org, "google", "grace_oidc")
+
+    assert User.select().where(User.id == robot.id).count() == 1
+    assert Team.select().where(Team.organization == org).count() >= 1
+    assert FederatedLogin.select().where(FederatedLogin.user == org).count() == 1
+
+    queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
+    marker_id = mark_namespace_for_deletion(org, [], queue, available_after=86400)
+
+    assert marker_id is not None
+
+    marker = DeletedNamespace.get(id=marker_id)
+    assert marker.original_username == "graceorg"
+
+    org_after = User.get(id=org.id)
+    assert not org_after.enabled
+    assert org_after.username != "graceorg"
+
+    # Linked data is still present (query by ID since username was renamed).
+    assert User.select().where(User.id == robot.id).count() == 1
+    assert Team.select().where(Team.organization == org_after).count() >= 1
+    assert FederatedLogin.select().where(FederatedLogin.user == org_after).count() == 1
+
+    # Queue item has the grace period delay.
+    qi = QueueItem.get(id=marker.queue_id)
+    assert qi.available_after > datetime.utcnow()
+
+
+def test_mark_namespace_grace_period_config_allowlist(initialized_db):
+    """Config-driven grace period only applies to namespaces in the allowlist."""
+    user = get_user("devtable")
+    org = create_organization("listed_org", "listed@example.com", user)
+    org2 = create_organization("unlisted_org", "unlisted@example.com", user)
+
+    robot_listed, _ = create_robot("bot", org)
+    robot_unlisted, _ = create_robot("bot", org2)
+
+    mock_config = {
+        "NAMESPACE_GC_GRACE_PERIOD_SECONDS": 86400,
+        "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST": ["listed_org"],
+    }
+    queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
+
+    # Listed namespace gets grace period — robot preserved.
+    with patch("data.model.config.app_config", mock_config):
+        mark_namespace_for_deletion(org, [], queue)
+
+    assert User.select().where(User.id == robot_listed.id).count() == 1
+
+    # Unlisted namespace does NOT get grace period — robot deleted.
+    with patch("data.model.config.app_config", mock_config):
+        mark_namespace_for_deletion(org2, [], queue)
+
+    assert User.select().where(User.id == robot_unlisted.id).count() == 0
+
+
+def test_mark_namespace_for_deletion_without_grace_period(initialized_db):
+    """Without a grace period, linked data is eagerly deleted (current behavior)."""
+    user = get_user("devtable")
+    org = create_organization("nograceorg", "nograce@example.com", user)
+
+    create_robot("bot", org)
+    attach_federated_login(org, "google", "nograce_oidc")
+
+    queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
+    marker_id = mark_namespace_for_deletion(org, [], queue, available_after=0)
+
+    assert marker_id is not None
+    org_after = User.get(id=org.id)
+
+    # Linked data is eagerly deleted.
+    assert len(list(list_namespace_robots(org_after.username))) == 0
+    assert FederatedLogin.select().where(FederatedLogin.user == org_after).count() == 0
+
+
+def test_mark_namespace_gc_worker_cleans_deferred_linked_data(initialized_db):
+    """GC worker cleans up linked data that was deferred during grace period marking."""
+    user = get_user("devtable")
+    org = create_organization("deferorg", "defer@example.com", user)
+
+    robot, _ = create_robot("bot", org)
+    create_team("deferteam", org, "member")
+    attach_federated_login(org, "google", "defer_oidc")
+
+    queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
+    marker_id = mark_namespace_for_deletion(org, [], queue, available_after=86400)
+
+    # Linked data preserved at mark time.
+    assert User.select().where(User.id == robot.id).count() == 1
+
+    # Simulate GC worker running after grace period.
+    with check_transitive_modifications():
+        delete_namespace_via_marker(marker_id, [])
+
+    # Everything is cleaned up.
+    with pytest.raises(User.DoesNotExist):
+        User.get(id=org.id)
+
+    assert User.select().where(User.id == robot.id).count() == 0
+
+
+def test_force_delete_bypasses_grace_period(initialized_db):
+    """force=True skips the grace period even for allowlisted namespaces."""
+    user = get_user("devtable")
+    org = create_organization("forceorg", "force@example.com", user)
+
+    robot, _ = create_robot("bot", org)
+
+    queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
+
+    with patch(
+        "data.model.config.app_config",
+        {
+            "NAMESPACE_GC_GRACE_PERIOD_SECONDS": 86400,
+            "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST": ["forceorg"],
+        },
+    ):
+        marker_id = mark_namespace_for_deletion(org, [], queue, force=True)
+
+    assert marker_id is not None
+
+    # Linked data is eagerly deleted (no grace period).
+    assert User.select().where(User.id == robot.id).count() == 0
+
+    # Queue item is immediately available.
+    marker = DeletedNamespace.get(id=marker_id)
+    qi = QueueItem.get(id=marker.queue_id)
+    assert qi.available_after <= datetime.utcnow()
+
+
+def test_grace_period_blocks_namespace_reregistration(initialized_db):
+    """Re-registering a namespace name is blocked while its grace period is active."""
+    user = get_user("devtable")
+    org = create_organization("protectedorg", "protected@example.com", user)
+
+    queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
+    mark_namespace_for_deletion(org, [], queue, available_after=86400)
+
+    with patch(
+        "data.model.config.app_config",
+        {
+            "DEFAULT_TAG_EXPIRATION": "2w",
+            "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST": ["protectedorg"],
+        },
+    ):
+        with pytest.raises(InvalidUsernameException, match="Username is not available"):
+            create_user_noverify("protectedorg", "new@example.com", email_required=False)
+
+        with pytest.raises(InvalidOrganizationException, match="Username is not available"):
+            create_organization("protectedorg", "new@example.com", user)
+
+
+def test_grace_period_allows_reregistration_after_deletion_completes(initialized_db):
+    """Once the GC worker fully purges the namespace, the name can be re-registered."""
+    user = get_user("devtable")
+    org = create_organization("expiredorg", "expired@example.com", user)
+
+    queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
+    marker_id = mark_namespace_for_deletion(org, [], queue, available_after=0)
+
+    mock_config = {
+        "DEFAULT_TAG_EXPIRATION": "2w",
+        "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST": ["expiredorg"],
+    }
+
+    # Still blocked before GC worker runs, even though grace period expired.
+    with patch("data.model.config.app_config", mock_config):
+        with pytest.raises(InvalidUsernameException, match="Username is not available"):
+            create_user_noverify("expiredorg", "new@example.com", email_required=False)
+
+    # GC worker purges the namespace (cascade-deletes the DeletedNamespace marker).
+    with check_transitive_modifications():
+        delete_namespace_via_marker(marker_id, [])
+
+    # Now the name is available.
+    with patch("data.model.config.app_config", mock_config):
+        new_user = create_user_noverify("expiredorg", "new@example.com", email_required=False)
+        assert new_user.username == "expiredorg"
+
+
+def test_grace_period_allows_reregistration_for_unlisted_namespace(initialized_db):
+    """Namespaces not in the allowlist can be re-registered even during grace period."""
+    user = get_user("devtable")
+    org = create_organization("unlistedorg", "unlisted@example.com", user)
+
+    queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
+    mark_namespace_for_deletion(org, [], queue, available_after=86400)
+
+    with patch(
+        "data.model.config.app_config",
+        {
+            "DEFAULT_TAG_EXPIRATION": "2w",
+            "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST": ["some_other_org"],
+        },
+    ):
+        new_user = create_user_noverify("unlistedorg", "new@example.com", email_required=False)
+        assert new_user.username == "unlistedorg"
 
 
 def test_delete_robot(initialized_db):

--- a/data/model/test/test_user.py
+++ b/data/model/test/test_user.py
@@ -164,7 +164,7 @@ def test_mark_user_for_deletion(initialized_db):
 
     # Mark the user for deletion.
     queue = WorkQueue("testgcnamespace", create_transaction)
-    mark_namespace_for_deletion(user, [], queue)
+    marker_id = mark_namespace_for_deletion(user, [], queue)
 
     # Ensure the older user is still in the DB.
     older_user = User.get(id=user.id)
@@ -188,12 +188,13 @@ def test_mark_user_for_deletion(initialized_db):
     # Ensure the oauth assigned token is gone
     assert get_token_assignment(assigned_token.uuid, user, org) is None
 
+    # Complete the GC cycle so the DeletedNamespace marker is removed.
+    with check_transitive_modifications():
+        delete_namespace_via_marker(marker_id, [])
+
     # Ensure we can create a user with the same namespace again.
     new_user = create_user_noverify("foobar", "foo@example.com", email_required=False)
-    assert new_user.id != user.id
-
-    # Ensure the older user is still in the DB.
-    assert User.get(id=user.id).username != "foobar"
+    assert new_user.username == "foobar"
 
 
 def test_mark_organization_for_deletion(initialized_db):
@@ -230,13 +231,13 @@ def test_mark_organization_for_deletion(initialized_db):
     )
     assert get_token_assignment(assigned_token.uuid, user, org) is not None
 
-    # Mark the user for deletion.
+    # Mark the org for deletion.
     queue = WorkQueue("testgcnamespace", create_transaction)
-    mark_namespace_for_deletion(org, [], queue)
+    marker_id = mark_namespace_for_deletion(org, [], queue)
 
-    # Ensure the older user is still in the DB.
-    older_user = User.get(id=org.id)
-    assert older_user.username != "foobar"
+    # Ensure the older org is still in the DB (renamed to UUID).
+    older_org = User.get(id=org.id)
+    assert older_org.username != "foobar"
 
     # Ensure the robots are deleted.
     with pytest.raises(InvalidRobotException):
@@ -245,7 +246,7 @@ def test_mark_organization_for_deletion(initialized_db):
     with pytest.raises(InvalidRobotException):
         assert lookup_robot("foobar+bar")
 
-    assert len(list(list_namespace_robots(older_user.username))) == 0
+    assert len(list(list_namespace_robots(older_org.username))) == 0
 
     # Ensure the federated logins are gone.
     assert FederatedLogin.select().where(FederatedLogin.user == org).count() == 0
@@ -258,12 +259,13 @@ def test_mark_organization_for_deletion(initialized_db):
     assert get_oauth_application_for_client_id(application.client_id) is None
     assert get_token_assignment(assigned_token.uuid, org, org) is None
 
-    # Ensure we can create a user with the same namespace again.
-    new_org = create_organization("foobar", "foobar@devtable.com", user)
-    assert new_org.id != org.id
+    # Complete the GC cycle so the DeletedNamespace marker is removed.
+    with check_transitive_modifications():
+        delete_namespace_via_marker(marker_id, [])
 
-    # Ensure the older org is still in the DB.
-    assert User.get(id=org.id).username != "foobar"
+    # Ensure we can create an org with the same namespace again.
+    new_org = create_organization("foobar", "foobar@devtable.com", user)
+    assert new_org.username == "foobar"
 
 
 def test_mark_organization_for_deletion_with_org_mirror(initialized_db):
@@ -557,7 +559,7 @@ def test_force_delete_bypasses_grace_period(initialized_db):
 
 
 def test_grace_period_blocks_namespace_reregistration(initialized_db):
-    """Re-registering a namespace name is blocked while its grace period is active."""
+    """Re-registering a namespace name is blocked while a DeletedNamespace marker exists."""
     user = get_user("devtable")
     org = create_organization("protectedorg", "protected@example.com", user)
 
@@ -566,10 +568,7 @@ def test_grace_period_blocks_namespace_reregistration(initialized_db):
 
     with patch(
         "data.model.config.app_config",
-        {
-            "DEFAULT_TAG_EXPIRATION": "2w",
-            "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST": ["protectedorg"],
-        },
+        {"DEFAULT_TAG_EXPIRATION": "2w"},
     ):
         with pytest.raises(InvalidUsernameException, match="Username is not available"):
             create_user_noverify("protectedorg", "new@example.com", email_required=False)
@@ -586,10 +585,7 @@ def test_grace_period_allows_reregistration_after_deletion_completes(initialized
     queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
     marker_id = mark_namespace_for_deletion(org, [], queue, available_after=0)
 
-    mock_config = {
-        "DEFAULT_TAG_EXPIRATION": "2w",
-        "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST": ["expiredorg"],
-    }
+    mock_config = {"DEFAULT_TAG_EXPIRATION": "2w"}
 
     # Still blocked before GC worker runs, even though grace period expired.
     with patch("data.model.config.app_config", mock_config):
@@ -606,13 +602,14 @@ def test_grace_period_allows_reregistration_after_deletion_completes(initialized
         assert new_user.username == "expiredorg"
 
 
-def test_grace_period_allows_reregistration_for_unlisted_namespace(initialized_db):
-    """Namespaces not in the allowlist can be re-registered even during grace period."""
+def test_reregistration_blocked_regardless_of_allowlist(initialized_db):
+    """Re-registering is blocked while a DeletedNamespace marker exists, even if the
+    namespace is not in the current allowlist."""
     user = get_user("devtable")
     org = create_organization("unlistedorg", "unlisted@example.com", user)
 
     queue = WorkQueue("testgcnamespace", lambda db: db.transaction())
-    mark_namespace_for_deletion(org, [], queue, available_after=86400)
+    marker_id = mark_namespace_for_deletion(org, [], queue, available_after=86400)
 
     with patch(
         "data.model.config.app_config",
@@ -620,6 +617,17 @@ def test_grace_period_allows_reregistration_for_unlisted_namespace(initialized_d
             "DEFAULT_TAG_EXPIRATION": "2w",
             "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST": ["some_other_org"],
         },
+    ):
+        with pytest.raises(InvalidUsernameException, match="Username is not available"):
+            create_user_noverify("unlistedorg", "new@example.com", email_required=False)
+
+    # After GC completes, the name becomes available again.
+    with check_transitive_modifications():
+        delete_namespace_via_marker(marker_id, [])
+
+    with patch(
+        "data.model.config.app_config",
+        {"DEFAULT_TAG_EXPIRATION": "2w"},
     ):
         new_user = create_user_noverify("unlistedorg", "new@example.com", email_required=False)
         assert new_user.username == "unlistedorg"

--- a/data/model/user.py
+++ b/data/model/user.py
@@ -157,13 +157,11 @@ def create_user_noverify(
     except User.DoesNotExist:
         pass
 
-    allowlist = config.app_config.get("NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST", [])
-    if allowlist and username in allowlist:
-        try:
-            DeletedNamespace.get(DeletedNamespace.original_username == username)
-            raise InvalidUsernameException("Username is not available")
-        except DeletedNamespace.DoesNotExist:
-            pass
+    try:
+        DeletedNamespace.get(DeletedNamespace.original_username == username)
+        raise InvalidUsernameException("Username is not available")
+    except DeletedNamespace.DoesNotExist:
+        pass
 
     # Check email uniqueness only among non-organization users. Organizations are allowed
     # to share emails (enforced by the partial unique index on User.email).
@@ -1379,6 +1377,11 @@ def mark_namespace_for_deletion(
             allowlist = config.app_config.get("NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST", [])
             if grace_period > 0 and allowlist and user.username in allowlist:
                 available_after = grace_period
+                logger.info(
+                    "Namespace %s marked for deletion with %ds grace period",
+                    user.username,
+                    grace_period,
+                )
             else:
                 available_after = 0
 

--- a/data/model/user.py
+++ b/data/model/user.py
@@ -157,6 +157,14 @@ def create_user_noverify(
     except User.DoesNotExist:
         pass
 
+    allowlist = config.app_config.get("NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST", [])
+    if allowlist and username in allowlist:
+        try:
+            DeletedNamespace.get(DeletedNamespace.original_username == username)
+            raise InvalidUsernameException("Username is not available")
+        except DeletedNamespace.DoesNotExist:
+            pass
+
     # Check email uniqueness only among non-organization users. Organizations are allowed
     # to share emails (enforced by the partial unique index on User.email).
     if email_required:
@@ -1351,13 +1359,29 @@ def get_solely_admined_organizations(user_obj):
     return solely_admined
 
 
-def mark_namespace_for_deletion(user, queues, namespace_gc_queue, force=False):
+def mark_namespace_for_deletion(
+    user, queues, namespace_gc_queue, force=False, available_after=None
+):
     """
     Marks a namespace (as referenced by the given user) for deletion.
 
     A queue item will be added to delete the namespace's repositories and storage, while the
     namespace itself will be renamed, disabled, and delinked from other tables.
+
+    When available_after > 0 (grace period), linked data (teams, OAuth apps, robots, etc.) is
+    preserved so the namespace can be recovered via direct DB operations during the grace window.
     """
+    if available_after is None:
+        if force:
+            available_after = 0
+        else:
+            grace_period = config.app_config.get("NAMESPACE_GC_GRACE_PERIOD_SECONDS", 0)
+            allowlist = config.app_config.get("NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST", [])
+            if grace_period > 0 and allowlist and user.username in allowlist:
+                available_after = grace_period
+            else:
+                available_after = 0
+
     if not user.enabled:
         return None
 
@@ -1381,8 +1405,10 @@ def mark_namespace_for_deletion(user, queues, namespace_gc_queue, force=False):
     for queue in queues:
         queue.delete_namespaced_items(user.username)
 
-    # Delete non-repository related items. This operation is very quick, so we can do so here.
-    _delete_user_linked_data(user)
+    # When a grace period is active, defer linked data deletion so the namespace can be
+    # recovered. The GC worker (delete_user) will clean up linked data at purge time.
+    if available_after <= 0:
+        _delete_user_linked_data(user)
 
     with db_transaction():
         original_username = user.username
@@ -1411,6 +1437,7 @@ def mark_namespace_for_deletion(user, queues, namespace_gc_queue, force=False):
                 "original_username": original_username,
             }
         ),
+        available_after=available_after,
     )
     marker.save()
     return marker.id
@@ -1485,7 +1512,17 @@ def delete_user(user, queues):
         return False
 
 
+def _resolve_namespace_name(user):
+    """Returns the original namespace name, consulting the DeletedNamespace marker if the
+    username was replaced with a UUID during soft-delete."""
+    try:
+        return DeletedNamespace.get(DeletedNamespace.namespace == user).original_username
+    except DeletedNamespace.DoesNotExist:
+        return user.username
+
+
 def _delete_user_linked_data(user):
+    namespace_name = _resolve_namespace_name(user)
     if user.organization:
         # Delete the organization's teams.
         with db_transaction():
@@ -1510,7 +1547,7 @@ def _delete_user_linked_data(user):
             trigger.delete_instance(recursive=True, delete_nullable=False)
 
     with db_transaction():
-        quotas = namespacequota.get_namespace_quota_list(user.username)
+        quotas = namespacequota.get_namespace_quota_list(namespace_name)
         for quota in quotas:
             namespacequota.delete_namespace_quota(quota)
 
@@ -1526,12 +1563,12 @@ def _delete_user_linked_data(user):
 
     # Delete any mirrors with robots owned by this user.
     with db_transaction():
-        robots = list(list_namespace_robots(user.username))
+        robots = list(list_namespace_robots(namespace_name))
         RepoMirrorConfig.delete().where(RepoMirrorConfig.internal_robot << robots).execute()
 
     # Delete any robots owned by this user.
     with db_transaction():
-        robots = list(list_namespace_robots(user.username))
+        robots = list(list_namespace_robots(namespace_name))
         for robot in robots:
             robot.delete_instance(recursive=True, delete_nullable=True)
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -238,6 +238,8 @@ var knownUnmapped = map[string]bool{
 	"DISABLE_PUSHES":                                 true,
 	"ENTERPRISE_LOGO_URL":                            true,
 	"EXPIRED_APP_SPECIFIC_TOKEN_GC":                  true,
+	"NAMESPACE_GC_GRACE_PERIOD_SECONDS":              true,
+	"NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST":            true,
 	"FRESH_LOGIN_TIMEOUT":                            true,
 	"GLOBAL_READONLY_SUPER_USERS":                    true,
 	"IGNORE_UNKNOWN_MEDIATYPES":                      true,

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -55,6 +55,8 @@ INTERNAL_ONLY_PROPERTIES = {
     "QUEUE_WORKER_METRICS_REFRESH_SECONDS",
     "PUSH_TEMP_TAG_EXPIRATION_SEC",
     "GARBAGE_COLLECTION_FREQUENCY",
+    "NAMESPACE_GC_GRACE_PERIOD_SECONDS",
+    "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST",
     "PAGE_TOKEN_KEY",
     "BUILD_MANAGER",
     "SECURITY_SCANNER_V4_REINDEX_THRESHOLD",
@@ -2374,6 +2376,22 @@ CONFIG_SCHEMA = {
         "description": "[QUAY.IO] GARBAGE_COLLECTION_FREQUENCY. Defaults to 30",
         "x-example": 30,
         "x-reference": None,
+    },
+    "NAMESPACE_GC_GRACE_PERIOD_SECONDS": {
+        "type": "number",
+        "description": "Grace period in seconds before deleted namespaces (orgs/users) are permanently purged by GC. Only applies to namespaces listed in NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST. Defaults to 0 (immediate).",
+        "x-example": 1209600,
+        "x-reference": None,
+        "minimum": 0,
+    },
+    "NAMESPACE_GC_GRACE_PERIOD_ALLOWLIST": {
+        "type": "array",
+        "description": "Allowlist of namespace names that receive the GC grace period. When empty, no namespaces are protected.",
+        "x-example": ["important-org"],
+        "x-reference": None,
+        "items": {
+            "type": "string",
+        },
     },
     "GREENLET_TRACING": {
         "type": "boolean",


### PR DESCRIPTION
Introduce NAMESPACE_GC_GRACE_PERIOD_S and NAMESPACE_GC_GRACE_PERIOD_NAMESPACES config options so that namespaces in the allowlist receive a queue-level delay before the GC worker permanently purges them. During the grace window, linked data (teams, robots, OAuth apps, federated logins) is preserved in the database so SREs can recover the namespace via direct DB operations.

Also fixes _delete_user_linked_data to resolve the original namespace name from the DeletedNamespace marker, so robot and quota lookups succeed even after the username has been replaced with a UUID during soft-delete.