### PR TITLE
NO-ISSUE: fix(build): drop pyroscope-io for s390x community builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ RUN set -ex\
 WORKDIR /build
 RUN python3 -m ensurepip --upgrade
 COPY requirements.txt .
+# pyroscope-io depends on py-spy which has no s390x support
+RUN sed -i '/^pyroscope-io/d' requirements.txt
 # Note that it installs into PYTHONUSERBASE because of the '--user'
 # flag.
 


### PR DESCRIPTION
## Summary
- Strip pyroscope-io from requirements.txt before pip install in the community Dockerfile
- py-spy (a pyroscope-io dependency) has no s390x support
- The downstream Konflux Containerfile already does this (quay/quay-konflux-components@7f10406)
- This was previously masked by the runc /sys/firmware masking bug on s390x (fixed in #6703)

## Test plan
- [ ] Verify s390x multi-arch community build succeeds via build-and-publish.yaml