### PR TITLE
QUAYIO-1935: chore(deps): bump soupsieve to address CVE-2026-49477

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -116,7 +116,7 @@ rsa==4.9.1
 s3transfer==0.10.4
 semantic-version==2.10.0
 six==1.17.0
-soupsieve==2.8
+soupsieve==2.8.4
 splunk-sdk==2.1.0
 SQLAlchemy==1.4.49
 stevedore==5.1.0


### PR DESCRIPTION
## CVE Details
- **CVE ID**: CVE-2026-49477
- **Package**: soupsieve
- **Affected versions**: < 2.8.4
- **Fixed version**: 2.8.4
- **Impact**: Denial of Service via crafted CSS selector strings

## Summary
Bumped soupsieve from 2.8 to 2.8.4 in `requirements.txt` to address CVE-2026-49477.

## Affected Versions

| Affected Range | Fixed Version |
|----------------|---------------|
| < 2.8.4        | 2.8.4         |

## Jira References
- Resolves: [QUAYIO-1935](https://redhat.atlassian.net/browse/QUAYIO-1935)

🤖 Generated with [Claude Code](https://claude.com/claude-code)