### PR TITLE
PROJQUAY-7117: fix(ui): allow superuser to select any namespace when creating repo

### DIFF
--- a/web/src/components/modals/CreateRepoModalTemplate.tsx
+++ b/web/src/components/modals/CreateRepoModalTemplate.tsx
@@ -1,9 +1,12 @@
-import {useRef, useState} from 'react';
+import React, {useRef, useState} from 'react';
 import {
   Button,
   Form,
   FormGroup,
   TextInput,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
   Radio,
   Flex,
   FlexItem,
@@ -21,6 +24,7 @@ import {
   ModalBody,
   ModalFooter,
 } from '@patternfly/react-core';
+import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import {IRepository} from 'src/resources/RepositoryResource';
 import FormError from 'src/components/errors/FormError';
 import {ExclamationCircleIcon} from '@patternfly/react-icons';
@@ -140,6 +144,29 @@ export default function CreateRepositoryModalTemplate(
     }));
   };
 
+  const [namespaceFilter, setNamespaceFilter] = useState('');
+  const namespaceInputRef = useRef<HTMLInputElement>();
+
+  const filteredNamespaceOptions = () => {
+    const allNames = [
+      props.username,
+      ...props.organizations.map((o) => o.name),
+    ];
+    const unique = allNames.filter(
+      (name, idx) => allNames.indexOf(name) === idx,
+    );
+    const filtered = namespaceFilter
+      ? unique.filter((n) =>
+          n.toLowerCase().includes(namespaceFilter.toLowerCase()),
+        )
+      : unique;
+    return filtered.slice(0, 50).map((name) => (
+      <SelectOption key={name} value={name} data-testid={`ns-${name}`}>
+        {name}
+      </SelectOption>
+    ));
+  };
+
   // namespace list includes both the orgs list and the user namespace
   const namespaceSelectionList = () => {
     const userSelection = (
@@ -191,31 +218,118 @@ export default function CreateRepositoryModalTemplate(
                   spaceItems={{default: 'spaceItemsMd'}}
                 >
                   <FlexItem>
-                    <Select
-                      aria-label="Namespace select"
-                      isOpen={currentOrganization.isDropdownOpen}
-                      selected={currentOrganization.name || 'Select namespace'}
-                      onSelect={handleNamespaceSelection}
-                      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                        <MenuToggle
-                          ref={toggleRef}
-                          onClick={() =>
-                            setCurrentOrganization((prevState) => ({
-                              ...prevState,
-                              isDropdownOpen: !prevState.isDropdownOpen,
-                            }))
-                          }
-                          isExpanded={currentOrganization.isDropdownOpen}
-                          isDisabled={props.orgName !== null}
-                          data-testid="selected-namespace-dropdown"
-                        >
-                          {currentOrganization.name}
-                        </MenuToggle>
-                      )}
-                      shouldFocusToggleOnSelect
-                    >
-                      <SelectList>{namespaceSelectionList()}</SelectList>
-                    </Select>
+                    {props.enableNamespaceSearch && props.orgName === null ? (
+                      <Select
+                        aria-label="Namespace select"
+                        isOpen={currentOrganization.isDropdownOpen}
+                        selected={
+                          currentOrganization.name || 'Select namespace'
+                        }
+                        onSelect={(e, value) => {
+                          setCurrentOrganization({
+                            name: value as string,
+                            isDropdownOpen: false,
+                          });
+                          setNamespaceFilter(value as string);
+                        }}
+                        onOpenChange={(open) => {
+                          setCurrentOrganization((prev) => ({
+                            ...prev,
+                            isDropdownOpen: open,
+                          }));
+                        }}
+                        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                          <MenuToggle
+                            ref={toggleRef}
+                            variant="typeahead"
+                            onClick={() =>
+                              setCurrentOrganization((prev) => ({
+                                ...prev,
+                                isDropdownOpen: !prev.isDropdownOpen,
+                              }))
+                            }
+                            isExpanded={currentOrganization.isDropdownOpen}
+                            data-testid="selected-namespace-dropdown"
+                          >
+                            <TextInputGroup isPlain>
+                              <TextInputGroupMain
+                                value={namespaceFilter}
+                                onClick={() =>
+                                  setCurrentOrganization((prev) => ({
+                                    ...prev,
+                                    isDropdownOpen: true,
+                                  }))
+                                }
+                                onChange={(_e, value) => {
+                                  setNamespaceFilter(value);
+                                  if (!currentOrganization.isDropdownOpen) {
+                                    setCurrentOrganization((prev) => ({
+                                      ...prev,
+                                      isDropdownOpen: true,
+                                    }));
+                                  }
+                                }}
+                                autoComplete="off"
+                                innerRef={namespaceInputRef}
+                                placeholder="Type to search namespaces..."
+                                role="combobox"
+                                isExpanded={currentOrganization.isDropdownOpen}
+                                aria-controls="namespace-search-listbox"
+                              />
+                              <TextInputGroupUtilities>
+                                {namespaceFilter && (
+                                  <Button
+                                    icon={<TimesIcon aria-hidden />}
+                                    variant="plain"
+                                    onClick={() => {
+                                      setNamespaceFilter('');
+                                      setCurrentOrganization({
+                                        name: props.username,
+                                        isDropdownOpen: false,
+                                      });
+                                      namespaceInputRef.current?.focus();
+                                    }}
+                                    aria-label="Clear namespace search"
+                                  />
+                                )}
+                              </TextInputGroupUtilities>
+                            </TextInputGroup>
+                          </MenuToggle>
+                        )}
+                      >
+                        <SelectList id="namespace-search-listbox">
+                          {filteredNamespaceOptions()}
+                        </SelectList>
+                      </Select>
+                    ) : (
+                      <Select
+                        aria-label="Namespace select"
+                        isOpen={currentOrganization.isDropdownOpen}
+                        selected={
+                          currentOrganization.name || 'Select namespace'
+                        }
+                        onSelect={handleNamespaceSelection}
+                        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                          <MenuToggle
+                            ref={toggleRef}
+                            onClick={() =>
+                              setCurrentOrganization((prevState) => ({
+                                ...prevState,
+                                isDropdownOpen: !prevState.isDropdownOpen,
+                              }))
+                            }
+                            isExpanded={currentOrganization.isDropdownOpen}
+                            isDisabled={props.orgName !== null}
+                            data-testid="selected-namespace-dropdown"
+                          >
+                            {currentOrganization.name}
+                          </MenuToggle>
+                        )}
+                        shouldFocusToggleOnSelect
+                      >
+                        <SelectList>{namespaceSelectionList()}</SelectList>
+                      </Select>
+                    )}
                   </FlexItem>
                   <FlexItem>/</FlexItem>
                 </Flex>
@@ -348,4 +462,5 @@ interface CreateRepositoryModalTemplateProps {
   updateListHandler: (value: IRepository) => void;
   username: string;
   organizations: IOrganization[];
+  enableNamespaceSearch?: boolean;
 }

--- a/web/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/web/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -1,4 +1,4 @@
-import {ReactElement, useEffect, useState} from 'react';
+import {ReactElement, useEffect, useMemo, useState} from 'react';
 import {
   Alert,
   PageSection,
@@ -31,6 +31,8 @@ import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
 import {RepositoryListColumnNames} from './ColumnNames';
 import {useCurrentUser} from 'src/hooks/UseCurrentUser';
 import {useSuperuserPermissions} from 'src/hooks/UseSuperuserPermissions';
+import {useOrganizations} from 'src/hooks/UseOrganizations';
+import {IOrganization} from 'src/resources/OrganizationResource';
 import {useRepositories} from 'src/hooks/UseRepositories';
 import {useDeleteRepositories} from 'src/hooks/UseDeleteRepositories';
 import {usePaginatedSortableTable} from '../../hooks/usePaginatedSortableTable';
@@ -68,8 +70,33 @@ export default function RepositoriesList(props: RepositoriesListProps) {
   const location = useLocation();
 
   const quayConfig = useQuayConfig();
-  const {user} = useCurrentUser();
+  const {user, isSuperUser} = useCurrentUser();
   const {isReadOnlySuperUser} = useSuperuserPermissions();
+  const isSuperUserFullAccess =
+    isSuperUser && quayConfig?.features?.SUPERUSERS_FULL_ACCESS;
+  const {superUserOrganizations, superUserUsers} = useOrganizations();
+
+  const allNamespaces = useMemo(() => {
+    if (!isSuperUserFullAccess) {
+      return user.organizations;
+    }
+    const merged = [...(user.organizations || [])];
+    const seen = new Set(merged.map((o) => o.name));
+    for (const org of superUserOrganizations || []) {
+      if (!seen.has(org.name)) {
+        merged.push({name: org.name} as IOrganization);
+        seen.add(org.name);
+      }
+    }
+    for (const u of superUserUsers || []) {
+      if (u.username !== user.username && !seen.has(u.username)) {
+        merged.push({name: u.username} as IOrganization);
+        seen.add(u.username);
+      }
+    }
+    return merged.sort((a, b) => a.name.localeCompare(b.name));
+  }, [user, isSuperUserFullAccess, superUserOrganizations, superUserUsers]);
+
   const isQuotaManagementEnabled =
     quayConfig?.features?.QUOTA_MANAGEMENT === true &&
     quayConfig?.features?.EDIT_QUOTA === true;
@@ -272,7 +299,8 @@ export default function RepositoriesList(props: RepositoriesListProps) {
       orgName={currentOrg}
       updateListHandler={() => null}
       username={user.username}
-      organizations={user.organizations}
+      organizations={allNamespaces}
+      enableNamespaceSearch={isSuperUserFullAccess}
     />
   );
 


### PR DESCRIPTION
## Summary

- Use existing superuser APIs (`/api/v1/superuser/organizations` and `/api/v1/superuser/users`) via the `useOrganizations()` hook to populate all namespaces for superusers with `FEATURE_SUPERUSERS_FULL_ACCESS`
- Add a client-side typeahead filter to the namespace dropdown (same pattern as robot accounts search)
- Normal users see no change — the existing plain dropdown is preserved
- Zero backend changes

### Problem

When `FEATURE_SUPERUSERS_FULL_ACCESS` is enabled, the backend allows superusers to create repos in ANY namespace. However, the Create Repository modal's namespace dropdown only shows the user's own orgs, preventing superusers from selecting other namespaces in the UI.

### Solution (per reviewer feedback)

Instead of a new backend endpoint, reuse the existing superuser APIs that the Organizations page already calls:
- `RepositoriesList.tsx` detects `isSuperUserFullAccess`, calls `useOrganizations()` to get all orgs + users, passes the merged list to the modal
- `CreateRepoModalTemplate.tsx` renders a typeahead Select with client-side filtering when `enableNamespaceSearch` is true (capped at 50 displayed results for DOM performance)

### Files changed (2 files, +172 / -29)

| File | Change |
|------|--------|
| `web/src/routes/RepositoriesList/RepositoriesList.tsx` | Detect superuser, merge all namespaces via `useOrganizations()`, pass to modal |
| `web/src/components/modals/CreateRepoModalTemplate.tsx` | Add typeahead namespace selector with client-side filtering for superusers |

## Test plan

- [x] Frontend: `npx tsc --noEmit` — no new TypeScript errors
- [ ] Playwright E2E: existing `repositories-list.spec.ts` tests must pass (non-superuser path unchanged, `data-testid` preserved)
- [ ] Visual: enable `FEATURE_SUPERUSERS_FULL_ACCESS: true`, log in as superuser, open Create Repository, verify typeahead shows all namespaces

## References

- Jira: https://redhat.atlassian.net/browse/PROJQUAY-7117
- Reviewer feedback: use existing APIs with client-side filtering (like robot accounts pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)