### PR TITLE
PROJQUAY-12511: feat(tls): add SSL_PROTOCOLS config support

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"time"
 )
 
@@ -79,11 +80,11 @@ func GenerateSelfSigned(hostname, certPath, keyPath string) error {
 // TLS 1.3; otherwise MinVersion defaults to TLS 1.2.
 func SecureTLSConfig(protocols []string) *tls.Config {
 	minVersion := uint16(tls.VersionTLS12)
-	if len(protocols) > 0 && !slicesContains(protocols, "TLSv1.2") {
+	if len(protocols) > 0 && !slices.Contains(protocols, "TLSv1.2") {
 		minVersion = tls.VersionTLS13
 	}
 
-	return &tls.Config{
+	return &tls.Config{ //nolint:gosec // minVersion is always TLS 1.2 or 1.3
 		MinVersion: minVersion,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -98,15 +99,6 @@ func SecureTLSConfig(protocols []string) *tls.Config {
 			tls.CurveP256,
 		},
 	}
-}
-
-func slicesContains(ss []string, target string) bool {
-	for _, s := range ss {
-		if s == target {
-			return true
-		}
-	}
-	return false
 }
 
 // FilesExist returns true if both cert and key files exist.

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -74,10 +74,17 @@ func GenerateSelfSigned(hostname, certPath, keyPath string) error {
 }
 
 // SecureTLSConfig returns a hardened TLS configuration with ECDHE-only cipher
-// suites and modern curve preferences.
-func SecureTLSConfig() *tls.Config {
+// suites and modern curve preferences. The protocols parameter controls the
+// minimum TLS version: if it contains only "TLSv1.3", MinVersion is set to
+// TLS 1.3; otherwise MinVersion defaults to TLS 1.2.
+func SecureTLSConfig(protocols []string) *tls.Config {
+	minVersion := uint16(tls.VersionTLS12)
+	if len(protocols) > 0 && !slicesContains(protocols, "TLSv1.2") {
+		minVersion = tls.VersionTLS13
+	}
+
 	return &tls.Config{
-		MinVersion: tls.VersionTLS12,
+		MinVersion: minVersion,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
@@ -91,6 +98,15 @@ func SecureTLSConfig() *tls.Config {
 			tls.CurveP256,
 		},
 	}
+}
+
+func slicesContains(ss []string, target string) bool {
+	for _, s := range ss {
+		if s == target {
+			return true
+		}
+	}
+	return false
 }
 
 // FilesExist returns true if both cert and key files exist.

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -99,6 +99,41 @@ func TestFilesExist(t *testing.T) {
 	}
 }
 
+func TestSecureTLSConfig_NilProtocols(t *testing.T) {
+	cfg := SecureTLSConfig(nil)
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want TLS 1.2 (%d)", cfg.MinVersion, tls.VersionTLS12)
+	}
+}
+
+func TestSecureTLSConfig_EmptyProtocols(t *testing.T) {
+	cfg := SecureTLSConfig([]string{})
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want TLS 1.2 (%d)", cfg.MinVersion, tls.VersionTLS12)
+	}
+}
+
+func TestSecureTLSConfig_TLS12And13(t *testing.T) {
+	cfg := SecureTLSConfig([]string{"TLSv1.2", "TLSv1.3"})
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want TLS 1.2 (%d)", cfg.MinVersion, tls.VersionTLS12)
+	}
+}
+
+func TestSecureTLSConfig_TLS13Only(t *testing.T) {
+	cfg := SecureTLSConfig([]string{"TLSv1.3"})
+	if cfg.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("MinVersion = %d, want TLS 1.3 (%d)", cfg.MinVersion, tls.VersionTLS13)
+	}
+}
+
+func TestSecureTLSConfig_TLS12Only(t *testing.T) {
+	cfg := SecureTLSConfig([]string{"TLSv1.2"})
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want TLS 1.2 (%d)", cfg.MinVersion, tls.VersionTLS12)
+	}
+}
+
 func loadCert(t *testing.T, certPath, keyPath string) tls.Certificate {
 	t.Helper()
 	certPEM, err := os.ReadFile(certPath)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -208,6 +208,7 @@ func newRegistryServer(ctx context.Context, handler http.Handler, resolved *conf
 		Hostname:        tlsHostname,
 		PreferredScheme: resolved.Config.PreferredURLScheme,
 		CertDir:         resolved.DataDir,
+		SSLProtocols:    resolved.Config.SSLProtocols,
 	})
 }
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -16,8 +16,7 @@ import (
 // Go struct fields. This list should shrink over time as coverage increases.
 var knownUnmapped = map[string]bool{
 	// SSL/TLS
-	"SSL_CIPHERS":   true,
-	"SSL_PROTOCOLS": true,
+	"SSL_CIPHERS": true,
 
 	// User-visible
 	"CONTACT_INFO":                 true,

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -1,14 +1,17 @@
 package config
 
+import "fmt"
+
 // Server holds hosting and presentation settings.
 type Server struct {
-	ServerHostname         string `yaml:"SERVER_HOSTNAME"`
-	PreferredURLScheme     string `yaml:"PREFERRED_URL_SCHEME"`
-	ExternalTLSTermination *bool  `yaml:"EXTERNAL_TLS_TERMINATION"`
-	RegistryTitle          string `yaml:"REGISTRY_TITLE"`
-	RegistryTitleShort     string `yaml:"REGISTRY_TITLE_SHORT"`
-	RegistryState          string `yaml:"REGISTRY_STATE"`
-	LibraryNamespace       string `yaml:"LIBRARY_NAMESPACE"`
+	ServerHostname         string   `yaml:"SERVER_HOSTNAME"`
+	PreferredURLScheme     string   `yaml:"PREFERRED_URL_SCHEME"`
+	ExternalTLSTermination *bool    `yaml:"EXTERNAL_TLS_TERMINATION"`
+	SSLProtocols           []string `yaml:"SSL_PROTOCOLS"`
+	RegistryTitle          string   `yaml:"REGISTRY_TITLE"`
+	RegistryTitleShort     string   `yaml:"REGISTRY_TITLE_SHORT"`
+	RegistryState          string   `yaml:"REGISTRY_STATE"`
+	LibraryNamespace       string   `yaml:"LIBRARY_NAMESPACE"`
 }
 
 // validateServer checks server-related enum values and TLS consistency.
@@ -45,5 +48,25 @@ func validateServer(cfg *Config, _ ValidateOptions) []ValidationError {
 		})
 	}
 
+	errs = append(errs, validateSSLProtocols(cfg.SSLProtocols)...)
+
+	return errs
+}
+
+var validSSLProtocols = map[string]bool{
+	"TLSv1.2": true,
+	"TLSv1.3": true,
+}
+
+func validateSSLProtocols(protocols []string) []ValidationError {
+	var errs []ValidationError
+	for _, p := range protocols {
+		if !validSSLProtocols[p] {
+			errs = append(errs, ValidationError{
+				Field: "SSL_PROTOCOLS", Severity: SeverityError,
+				Message: fmt.Sprintf("unsupported protocol %q; valid values are TLSv1.2, TLSv1.3", p),
+			})
+		}
+	}
 	return errs
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -204,6 +204,77 @@ TAG_EXPIRATION_OPTIONS:
 	}
 }
 
+func TestValidateSSLProtocolsTLS13Only(t *testing.T) {
+	yaml := minimalValidYAML + `
+SSL_PROTOCOLS:
+  - TLSv1.3
+`
+	cfg, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+
+	errs := Validate(t.Context(), cfg, ValidateOptions{Mode: "offline"})
+	assert.False(t, hasFieldError(errs, "SSL_PROTOCOLS"), "TLSv1.3 should be valid")
+}
+
+func TestValidateSSLProtocolsBothVersions(t *testing.T) {
+	yaml := minimalValidYAML + `
+SSL_PROTOCOLS:
+  - TLSv1.2
+  - TLSv1.3
+`
+	cfg, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+
+	errs := Validate(t.Context(), cfg, ValidateOptions{Mode: "offline"})
+	assert.False(t, hasFieldError(errs, "SSL_PROTOCOLS"), "TLSv1.2 + TLSv1.3 should be valid")
+}
+
+func TestValidateSSLProtocolsInvalid(t *testing.T) {
+	yaml := minimalValidYAML + `
+SSL_PROTOCOLS:
+  - TLSv1.1
+`
+	cfg, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+
+	errs := Validate(t.Context(), cfg, ValidateOptions{Mode: "offline"})
+	assert.True(t, hasFieldError(errs, "SSL_PROTOCOLS"), "TLSv1.1 should be rejected")
+}
+
+func TestValidateSSLProtocolsInvalidMixed(t *testing.T) {
+	yaml := minimalValidYAML + `
+SSL_PROTOCOLS:
+  - TLSv1.3
+  - SSLv3
+`
+	cfg, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+
+	errs := Validate(t.Context(), cfg, ValidateOptions{Mode: "offline"})
+	assert.True(t, hasFieldError(errs, "SSL_PROTOCOLS"), "SSLv3 should be rejected even with valid TLSv1.3")
+}
+
+func TestValidateSSLProtocolsEmpty(t *testing.T) {
+	cfg, err := Parse([]byte(minimalValidYAML))
+	require.NoError(t, err)
+
+	errs := Validate(t.Context(), cfg, ValidateOptions{Mode: "offline"})
+	assert.False(t, hasFieldError(errs, "SSL_PROTOCOLS"), "missing SSL_PROTOCOLS should be valid")
+}
+
+func TestSSLProtocolsParsedIntoConfig(t *testing.T) {
+	yaml := minimalValidYAML + `
+SSL_PROTOCOLS:
+  - TLSv1.3
+`
+	cfg, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"TLSv1.3"}, cfg.SSLProtocols)
+	_, hasExtra := cfg.Extra["SSL_PROTOCOLS"]
+	assert.False(t, hasExtra, "SSL_PROTOCOLS should not appear in Extra")
+}
+
 // hasFieldError checks if any validation error has the given field and error severity.
 func hasFieldError(errs []ValidationError, field string) bool {
 	for _, e := range errs {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -392,7 +392,7 @@ func healthTLSConfig(caCert []byte, skipHostname bool) (*tls.Config, error) {
 		return nil, fmt.Errorf("no certificates found")
 	}
 
-	tlsCfg := certs.SecureTLSConfig()
+	tlsCfg := certs.SecureTLSConfig(nil)
 	tlsCfg.RootCAs = pool
 	if skipHostname {
 		cert, err := parseCertPEM(caCert)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,6 +25,7 @@ type Config struct {
 	Hostname        string
 	PreferredScheme string
 	CertDir         string
+	SSLProtocols    []string
 }
 
 // Server wraps an *http.Server with registry-specific lifecycle.
@@ -64,7 +65,7 @@ func New(ctx context.Context, handler http.Handler, cfg *Config, opts ...Option)
 	s := &Server{srv: srv}
 
 	if cfg.PreferredScheme == schemeHTTPS {
-		certPath, keyPath, err := ensureTLS(cfg.Hostname, cfg.CertDir, srv)
+		certPath, keyPath, err := ensureTLS(cfg.Hostname, cfg.CertDir, cfg.SSLProtocols, srv)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/tls.go
+++ b/internal/server/tls.go
@@ -11,7 +11,7 @@ import (
 
 const defaultHostname = "localhost"
 
-func ensureTLS(hostname, certDir string, srv *http.Server) (certPath, keyPath string, err error) {
+func ensureTLS(hostname, certDir string, protocols []string, srv *http.Server) (certPath, keyPath string, err error) {
 	certPath = filepath.Join(certDir, "ssl.cert")
 	keyPath = filepath.Join(certDir, "ssl.key")
 
@@ -25,6 +25,6 @@ func ensureTLS(hostname, certDir string, srv *http.Server) (certPath, keyPath st
 		}
 	}
 
-	srv.TLSConfig = certs.SecureTLSConfig()
+	srv.TLSConfig = certs.SecureTLSConfig(protocols)
 	return certPath, keyPath, nil
 }


### PR DESCRIPTION
## Summary

- Wire `SSL_PROTOCOLS` config key to Go's `crypto/tls` `MinVersion`, enabling TLS 1.3-only mode via `SSL_PROTOCOLS: ['TLSv1.3']` in config.yaml
- Validate each protocol element — only `TLSv1.2` and `TLSv1.3` are accepted; older protocols (TLSv1.1, SSLv3, etc.) produce a validation error
- Thread protocols through the full call chain: `config.Server` → `server.Config` → `ensureTLS()` → `SecureTLSConfig(protocols)`
- Remove `SSL_PROTOCOLS` from `knownUnmapped` in schema_test.go (it's now a mapped struct field)
- Default behavior unchanged: when `SSL_PROTOCOLS` is unset, TLS 1.2 remains the minimum version

### Files changed (9)

| File | Change |
|------|--------|
| `internal/config/server.go` | Add `SSLProtocols` field + `validateSSLProtocols()` |
| `internal/certs/certs.go` | `SecureTLSConfig(protocols []string)` — set `MinVersion` based on protocols |
| `internal/server/server.go` | Add `SSLProtocols` to `server.Config` |
| `internal/server/tls.go` | Pass protocols through `ensureTLS()` |
| `internal/cmd/serve.go` | Wire `resolved.Config.SSLProtocols` into server config |
| `internal/installer/installer.go` | Pass `nil` to `SecureTLSConfig` in health check client |
| `internal/config/schema_test.go` | Remove `SSL_PROTOCOLS` from `knownUnmapped` |
| `internal/certs/certs_test.go` | 5 tests for `SecureTLSConfig` protocol handling |
| `internal/config/validate_test.go` | 6 tests for validation (valid, invalid, mixed, empty, parse) |

## Test plan

- [x] `go build ./internal/...` — passes
- [x] `go test ./internal/certs/ -run TestSecureTLSConfig` — 5/5 pass
- [x] `go test ./internal/config/ -run "TestValidateSSL|TestSSLProtocols"` — 6/6 pass
- [x] `go test ./internal/...` — all 26 packages pass
- [x] Pre-commit hooks pass

## JIRA

[PROJQUAY-12511](https://redhat.atlassian.net/browse/PROJQUAY-12511)

🤖 Generated with [Claude Code](https://claude.com/claude-code)