### PR TITLE
PROJQUAY-12365: fix(api): hide robot account tokens from global readonly superusers

### DIFF
--- a/endpoints/api/robot.py
+++ b/endpoints/api/robot.py
@@ -230,20 +230,21 @@ class OrgRobotList(ApiResource):
             or allow_if_global_readonly_superuser()
             or (features.SUPERUSERS_FULL_ACCESS and allow_if_superuser())
         ):
-            include_token = (
-                AdministerOrganizationPermission(orgname).can()
-                or allow_if_global_readonly_superuser()
-            ) and parsed_args.get("token", True)
+            is_org_admin = AdministerOrganizationPermission(orgname).can()
+            is_full_access_superuser = features.SUPERUSERS_FULL_ACCESS and allow_if_superuser()
+            include_token = (is_org_admin or is_full_access_superuser) and parsed_args.get(
+                "token", True
+            )
             include_permissions = (
-                AdministerOrganizationPermission(orgname).can()
-                or allow_if_global_readonly_superuser()
+                is_org_admin or is_full_access_superuser or allow_if_global_readonly_superuser()
             ) and parsed_args.get("permissions", False)
-            return robots_list(
+            result = robots_list(
                 orgname,
                 include_permissions=include_permissions,
                 include_token=include_token,
                 limit=parsed_args.get("limit"),
             )
+            return result
 
         raise Unauthorized()
 
@@ -270,14 +271,18 @@ class OrgRobot(ApiResource):
         Returns the organization's robot with the specified name.
         """
         permission = AdministerOrganizationPermission(orgname)
-        # Global readonly superusers can always view, regular superusers need FULL_ACCESS
+        is_org_admin = permission.can()
         if (
-            permission.can()
+            is_org_admin
             or allow_if_global_readonly_superuser()
             or (features.SUPERUSERS_FULL_ACCESS and allow_if_superuser())
         ):
             robot = model.get_org_robot(robot_shortname, orgname)
-            return robot.to_dict(include_metadata=True, include_token=True)
+            include_token = is_org_admin or (
+                features.SUPERUSERS_FULL_ACCESS and allow_if_superuser()
+            )
+            result = robot.to_dict(include_metadata=True, include_token=include_token)
+            return result
 
         raise Unauthorized()
 

--- a/endpoints/api/test/test_robot.py
+++ b/endpoints/api/test/test_robot.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import requests
@@ -169,6 +169,86 @@ def test_duplicate_robot_creation(app):
             expected_code=400,
         )
         assert resp.json["error_message"] == "Existing robot with name: buynlarge+coolrobot"
+
+
+def test_globalreadonlysuperuser_org_robot_list_hides_token(app):
+    with client_with_identity("globalreadonlysuperuser", app) as cl:
+        result = conduct_api_call(
+            cl, OrgRobotList, "GET", {"orgname": "buynlarge", "token": "true"}, None
+        )
+        assert result.json["robots"]
+        for robot in result.json["robots"]:
+            assert robot.get("token") is None
+
+
+def test_globalreadonlysuperuser_org_robot_list_permissions(app):
+    with client_with_identity("globalreadonlysuperuser", app) as cl:
+        result = conduct_api_call(
+            cl,
+            OrgRobotList,
+            "GET",
+            {"orgname": "buynlarge", "token": "true", "permissions": "true"},
+            None,
+        )
+        assert result.json["robots"]
+        for robot in result.json["robots"]:
+            assert robot.get("token") is None
+            assert "teams" in robot
+            assert "repositories" in robot
+
+
+def test_globalreadonlysuperuser_org_robot_get_hides_token(app):
+    with client_with_identity("globalreadonlysuperuser", app) as cl:
+        result = conduct_api_call(
+            cl,
+            OrgRobot,
+            "GET",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            None,
+        )
+        assert result.json["name"] == "buynlarge+coolrobot"
+        assert result.json.get("token") is None
+
+
+def test_org_admin_still_sees_robot_token(app):
+    with client_with_identity("devtable", app) as cl:
+        result = conduct_api_call(
+            cl, OrgRobotList, "GET", {"orgname": "buynlarge", "token": "true"}, None
+        )
+        assert result.json["robots"]
+        for robot in result.json["robots"]:
+            assert robot.get("token") is not None
+
+        result = conduct_api_call(
+            cl,
+            OrgRobot,
+            "GET",
+            {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+            None,
+        )
+        assert result.json["token"] is not None
+
+
+def test_full_access_superuser_sees_robot_token(app):
+    with patch(
+        "auth.permissions.usermanager.is_superuser", lambda username: username == "freshuser"
+    ):
+        with client_with_identity("freshuser", app) as cl:
+            result = conduct_api_call(
+                cl, OrgRobotList, "GET", {"orgname": "buynlarge", "token": "true"}, None
+            )
+            assert result.json["robots"]
+            for robot in result.json["robots"]:
+                assert robot.get("token") is not None
+
+            result = conduct_api_call(
+                cl,
+                OrgRobot,
+                "GET",
+                {"orgname": "buynlarge", "robot_shortname": "coolrobot"},
+                None,
+            )
+            assert result.json["token"] is not None
 
 
 def test_robot_federation_create(app):

--- a/test/test_api_usage.py
+++ b/test/test_api_usage.py
@@ -4015,7 +4015,7 @@ class TestOrgRobots(ApiTestCase):
         self.login("globalreadonlysuperuser")
         params = dict(orgname=ORGANIZATION)
         for r in self.getJsonResponse(OrgRobotList, params=params)["robots"]:
-            assert "token" in r
+            assert r.get("token") is None
 
 
 class TestLogs(ApiTestCase):

--- a/web/playwright/e2e/api/api-v1-readonly-superuser.spec.ts
+++ b/web/playwright/e2e/api/api-v1-readonly-superuser.spec.ts
@@ -550,20 +550,49 @@ test.describe(
         await adminClient.delete(`/api/v1/organization/${orgName}`);
       });
 
-      test('can GET robot account', async () => {
+      test('can GET robot account but token is hidden', async () => {
         const r = await readonlyClient.get(
           `/api/v1/organization/${orgName}/robots/${robotShortname}`,
         );
         expect(r.status()).toBe(200);
+        const body = await r.json();
+        expect(body.name).toContain(robotShortname);
+        expect(body.token).toBeFalsy();
       });
 
-      test('can list all robot accounts', async () => {
+      test('can list all robot accounts but tokens are hidden', async () => {
         const r = await readonlyClient.get(
-          `/api/v1/organization/${orgName}/robots`,
+          `/api/v1/organization/${orgName}/robots?token=true`,
         );
         expect(r.status()).toBe(200);
         const body = await r.json();
         expect(body.robots.length).toBeGreaterThanOrEqual(1);
+        for (const robot of body.robots) {
+          expect(robot.token).toBeFalsy();
+        }
+      });
+
+      test('can list robot accounts with permissions but tokens are hidden', async () => {
+        const r = await readonlyClient.get(
+          `/api/v1/organization/${orgName}/robots?token=true&permissions=true`,
+        );
+        expect(r.status()).toBe(200);
+        const body = await r.json();
+        expect(body.robots.length).toBeGreaterThanOrEqual(1);
+        for (const robot of body.robots) {
+          expect(robot.token).toBeFalsy();
+          expect(robot.teams).toBeDefined();
+          expect(robot.repositories).toBeDefined();
+        }
+      });
+
+      test('admin can see robot token', async ({adminClient}) => {
+        const r = await adminClient.get(
+          `/api/v1/organization/${orgName}/robots/${robotShortname}`,
+        );
+        expect(r.status()).toBe(200);
+        const body = await r.json();
+        expect(body.token).toBeTruthy();
       });
 
       test('cannot PUT (create) robot account', async () => {


### PR DESCRIPTION
## Summary
- Global readonly superusers could view robot account tokens via the `OrgRobotList` and `OrgRobot` GET endpoints. Robot tokens are credentials that enable authentication as the robot, breaking the read-only privilege boundary.
- Removed `allow_if_global_readonly_superuser()` from the `include_token` gate in `OrgRobotList.get` and conditionally set `include_token=False` in `OrgRobot.get` when the caller is only a global readonly superuser (not an org admin or full-access superuser).
- Global readonly superusers retain access to robot metadata (name, description, creation date) for auditing purposes.

## Test plan
- [x] Reproduced bug: global readonly superuser sees robot token via UI and API
- [x] Verified fix: global readonly superuser sees robot metadata but no token
- [x] Verified regression: org admin still sees robot tokens as before
- [x] Added unit tests for global readonly superuser token hiding (`test_robot.py`)
- [x] Updated existing test assertion in `test_api_usage.py`
- [ ] CI unit tests pass