### PR TITLE
QUAYIO-2071: feat(deploy): add Dynatrace log injection support for Envoy and RLS

### DIFF
--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -57,6 +57,8 @@ objects:
       metadata:
         labels:
           app: quay-envoy
+        annotations:
+          oneagent.dynatrace.com/inject: "${DYNATRACE_MONITORING}"
       spec:
         nodeSelector:
           workload: envoy
@@ -176,6 +178,8 @@ objects:
       metadata:
         labels:
           app: quay-rls
+        annotations:
+          oneagent.dynatrace.com/inject: "${DYNATRACE_MONITORING}"
       spec:
         nodeSelector:
           workload: envoy
@@ -315,3 +319,6 @@ parameters:
 - name: RLS_LOG_LEVEL
   value: "info"
   displayName: RLS log level
+- name: DYNATRACE_MONITORING
+  value: "false"
+  displayName: Enable Dynatrace OneAgent injection


### PR DESCRIPTION
## Summary

Add Dynatrace OneAgent injection support to Envoy and RLS deployments, following the same pattern as the Quay app deployment.

## Changes

- Add `oneagent.dynatrace.com/inject` annotation to both Envoy and RLS pod templates
- Add `DYNATRACE_MONITORING` parameter (default: `false`)

## How it works

The Dynatrace Operator (already running on Quay clusters) automatically injects the OneAgent sidecar into any pod with the `oneagent.dynatrace.com/inject: "true"` annotation. No namespace or operator changes needed.

Enabled per-environment via the SaaS file by setting `DYNATRACE_MONITORING: "true"` on the target parameters.

## Test plan

- [ ] Deploy to stage with `DYNATRACE_MONITORING: "true"`
- [ ] Verify OneAgent sidecar is injected into Envoy and RLS pods
- [ ] Verify logs and metrics appear in Dynatrace

🤖 Generated with [Claude Code](https://claude.com/claude-code)