### PR TITLE
QUAYIO-2072: feat(secscan): add SECURITY_SCANNER_V4_INDEXING config to disable legacy indexer

### DIFF
--- a/config.py
+++ b/config.py
@@ -556,6 +556,9 @@ class DefaultConfig(ImmutableConfig):
     # Maximum number of scan retries per indexer hash before a manifest is skipped.
     SECURITY_SCANNER_MAX_SCAN_RETRIES = 5
 
+    # Whether to enable the legacy V4 security scanner indexing operations.
+    SECURITY_SCANNER_V4_INDEXING = True
+
     # Security scanner V2 worker (lock-free, uses FOR UPDATE SKIP LOCKED)
     FEATURE_SECURITY_SCANNER_V2 = False
     SECURITY_SCANNER_V2_INDEXING_INTERVAL = 30

--- a/data/secscan_model/secscan_v4_model.py
+++ b/data/secscan_model/secscan_v4_model.py
@@ -657,7 +657,7 @@ class V4SecurityScanner(SecurityScannerInterface):
                 (report, state) = self._secscan_api.index(manifest, layers)
             except InvalidContentSent as ex:
                 mark_manifest_unsupported(manifest)
-                logger.exception("Failed to perform indexing, invalid content sent")
+                logger.warning("Failed to perform indexing, invalid content sent")
                 continue
             except Non200ResponseException as ex:
                 try:

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -247,7 +247,7 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
         except InvalidContentSent:
             self._mark_unsupported(manifest)
             secscan_v2_scan_result.labels(result="unsupported").inc()
-            logger.exception("Failed to index: invalid content sent")
+            logger.warning("Failed to index: invalid content sent")
             return
         except Non200ResponseException as ex:
             self._mark_failed(

--- a/data/secscan_model/test/test_secscan_interface.py
+++ b/data/secscan_model/test/test_secscan_interface.py
@@ -74,3 +74,21 @@ def test_perform_indexing(next_token, expected_next_token, expected_error, initi
                 secscan_model.perform_indexing(next_token)
         else:
             assert secscan_model.perform_indexing(next_token) == expected_next_token
+
+
+def test_load_security_information_with_v4_indexing_disabled(initialized_db):
+    """Query path remains functional even when v4 indexing is disabled."""
+    flask_app.config["SECURITY_SCANNER_V4_INDEXING"] = False
+
+    secscan_model.configure(flask_app, instance_keys, storage)
+
+    repository_ref = registry_model.lookup_repository("devtable", "simple")
+    tag = registry_model.find_matching_tag(repository_ref, ["latest"])
+    manifest = registry_model.get_manifest_for_tag(tag)
+    assert manifest
+
+    result = secscan_model.load_security_information(manifest, True)
+    assert isinstance(result, SecurityInformationLookupResult)
+    assert result.status == ScanLookupStatus.NOT_YET_INDEXED
+
+    flask_app.config["SECURITY_SCANNER_V4_INDEXING"] = True

--- a/util/config/configutil.py
+++ b/util/config/configutil.py
@@ -53,6 +53,9 @@ def add_enterprise_config_defaults(config_obj, current_secret_key):
     )
 
     config_obj["FEATURE_SECURITY_SCANNER"] = config_obj.get("FEATURE_SECURITY_SCANNER", False)
+    config_obj["SECURITY_SCANNER_V4_INDEXING"] = config_obj.get(
+        "SECURITY_SCANNER_V4_INDEXING", True
+    )
 
     # Default time machine config.
     config_obj["TAG_EXPIRATION_OPTIONS"] = config_obj.get(

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -850,6 +850,11 @@ CONFIG_SCHEMA = {
             "description": "A base64 encoded string used to sign JWT(s) on Clair V4 requests. If 'None' jwt signing will not occur.",
             "x-example": "PSK",
         },
+        "SECURITY_SCANNER_V4_INDEXING": {
+            "type": "boolean",
+            "description": "Whether to enable the legacy V4 security scanner indexing operations. When set to False, the old indexing paths are disabled while the V2 indexer and security scan query APIs remain functional. Defaults to True",
+            "x-example": True,
+        },
         "FEATURE_SECURITY_SCANNER_V2": {
             "type": "boolean",
             "description": "Whether to enable the V2 lock-free security scanner indexer using PostgreSQL FOR UPDATE SKIP LOCKED for work distribution. Defaults to False",

--- a/workers/securityworker/securityworker.py
+++ b/workers/securityworker/securityworker.py
@@ -24,8 +24,12 @@ class SecurityWorker(Worker):
         self._model = secscan_model
 
         interval = app.config.get("SECURITY_SCANNER_INDEXING_INTERVAL", DEFAULT_INDEXING_INTERVAL)
-        self.add_operation(self._index_in_scanner, interval)
-        self.add_operation(self._index_recent_manifests_in_scanner, interval)
+
+        if app.config.get("SECURITY_SCANNER_V4_INDEXING", True):
+            self.add_operation(self._index_in_scanner, interval)
+            self.add_operation(self._index_recent_manifests_in_scanner, interval)
+        else:
+            logger.info("V4 indexing disabled via SECURITY_SCANNER_V4_INDEXING")
 
         if self._model.v2_enabled:
             v2_interval = app.config.get(


### PR DESCRIPTION
Allow disabling the old V4 security scanner indexing operations while
keeping the V2 indexer and security scan query APIs functional.