### PR TITLE
PROJQUAY-12421: fix(mirroring): prevent SSRF through mirror proxies

### DIFF
--- a/config.py
+++ b/config.py
@@ -574,9 +574,10 @@ class DefaultConfig(ImmutableConfig):
     # Organization-level repository mirror
     FEATURE_ORG_MIRROR = False
 
-    # Hostnames or CIDR ranges allowed to bypass SSRF blocklist for repository mirrors,
-    # organization mirrors, proxy cache registries, and export log callbacks. Use for
-    # enterprise deployments where endpoints run on private networks.
+    # Hostnames or CIDR ranges allowed to bypass SSRF blocklist for repository and
+    # organization mirror source registries and proxy endpoints, proxy cache registries,
+    # and export log callbacks. Scheme-less mirror proxy values remain supported and are
+    # interpreted as HTTP only while validating their destination.
     SSRF_ALLOWED_HOSTS: List[str] = []
 
     # The number of seconds between organization mirror worker iterations

--- a/data/model/org_mirror.py
+++ b/data/model/org_mirror.py
@@ -29,7 +29,10 @@ from data.fields import DecryptedValue
 from data.model import DataModelException
 from data.model.immutability import namespace_has_immutability_policies
 from util.names import parse_robot_username
-from util.security.ssrf import validate_external_registry_url
+from util.security.ssrf import (
+    validate_external_registry_url,
+    validate_mirror_proxy_config,
+)
 
 # Sentinel value to distinguish "not provided" from "explicitly set to None"
 _UNSET = object()
@@ -139,6 +142,15 @@ def create_org_mirror_config(
             external_registry_url, resolve_dns=False, allowed_hosts=allowed_hosts
         )
     except ValueError as e:
+        raise DataModelException(str(e))
+
+    try:
+        validate_mirror_proxy_config(
+            (external_registry_config or {}).get("proxy", {}),
+            resolve_dns=False,
+            allowed_hosts=allowed_hosts,
+        )
+    except (AttributeError, ValueError) as e:
         raise DataModelException(str(e))
 
     if not internal_robot.robot:
@@ -279,6 +291,16 @@ def update_org_mirror_config(
                 external_registry_url, resolve_dns=False, allowed_hosts=allowed_hosts
             )
         except ValueError as e:
+            raise DataModelException(str(e))
+
+    if external_registry_config is not None:
+        try:
+            validate_mirror_proxy_config(
+                external_registry_config.get("proxy", {}),
+                resolve_dns=False,
+                allowed_hosts=allowed_hosts,
+            )
+        except (AttributeError, ValueError) as e:
             raise DataModelException(str(e))
 
     # Validate robot belongs to organization if provided

--- a/data/model/repo_mirror.py
+++ b/data/model/repo_mirror.py
@@ -1,4 +1,5 @@
 import re
+from copy import deepcopy
 from datetime import datetime, timedelta
 
 from jsonschema import ValidationError
@@ -18,7 +19,10 @@ from data.database import (
 from data.fields import DecryptedValue
 from data.model import DataModelException
 from util.names import parse_robot_username
-from util.security.ssrf import validate_external_registry_reference
+from util.security.ssrf import (
+    validate_external_registry_reference,
+    validate_mirror_proxy_config,
+)
 
 # TODO: Move these to the configuration
 MAX_SYNC_RETRIES = 3
@@ -241,6 +245,15 @@ def enable_mirroring_for_repository(
             allowed_hosts=allowed_hosts,
         )
     except ValueError as e:
+        raise DataModelException(str(e))
+
+    try:
+        validate_mirror_proxy_config(
+            (external_registry_config or {}).get("proxy", {}),
+            resolve_dns=False,
+            allowed_hosts=allowed_hosts,
+        )
+    except (AttributeError, ValueError) as e:
         raise DataModelException(str(e))
 
     assert internal_robot.robot
@@ -547,32 +560,61 @@ def change_retries_remaining(repository, retries_remaining):
     return update_with_transaction(mirror, sync_retries_remaining=retries_remaining)
 
 
-def change_external_registry_config(repository, config_updates):
+def merge_external_registry_config(current_config, config_updates):
+    """Return a merged mirror config without changing either input mapping."""
+    if not isinstance(config_updates, dict):
+        raise ValueError("External registry configuration must be an object")
+
+    merged = deepcopy(current_config or {})
+    for key in ("verify_tls", "unsigned_images"):
+        if key in config_updates:
+            merged[key] = config_updates[key]
+
+    if "proxy" in config_updates:
+        proxy_updates = config_updates["proxy"]
+        if not isinstance(proxy_updates, dict):
+            raise ValueError("Mirror proxy configuration must be an object")
+        existing_proxy = merged.get("proxy")
+        if existing_proxy is None:
+            proxy_config = {}
+            merged["proxy"] = proxy_config
+        elif isinstance(existing_proxy, dict):
+            proxy_config = existing_proxy
+        else:
+            # Preserve malformed persisted data so validation reports a controlled error.
+            return merged
+        for key in ("http_proxy", "https_proxy", "no_proxy"):
+            if key in proxy_updates:
+                proxy_config[key] = proxy_updates[key]
+
+    return merged
+
+
+def change_external_registry_config(repository, config_updates, allowed_hosts=None):
     """
     Update the 'external_registry_config' with the passed in fields.
 
     Config has:
     verify_tls: True|False
     unsigned_images: True|False
-    proxy: JSON fields 'http_proxy', 'https_proxy', andn 'no_proxy'
+    proxy: JSON fields 'http_proxy', 'https_proxy', and 'no_proxy'
     """
     mirror = get_mirror(repository)
-    external_registry_config = mirror.external_registry_config
+    try:
+        external_registry_config = merge_external_registry_config(
+            mirror.external_registry_config,
+            config_updates,
+        )
+        validate_mirror_proxy_config(
+            external_registry_config.get("proxy", {}),
+            resolve_dns=False,
+            allowed_hosts=allowed_hosts,
+        )
+    except (AttributeError, ValueError) as e:
+        raise DataModelException(str(e))
 
-    if "verify_tls" in config_updates:
-        external_registry_config["verify_tls"] = config_updates["verify_tls"]
-
-    if "unsigned_images" in config_updates:
-        external_registry_config["unsigned_images"] = config_updates["unsigned_images"]
-
-    if "proxy" in config_updates:
-        proxy_updates = config_updates["proxy"]
-        for key in ("http_proxy", "https_proxy", "no_proxy"):
-            if key in config_updates["proxy"]:
-                if "proxy" not in external_registry_config:
-                    external_registry_config["proxy"] = {}
-                else:
-                    external_registry_config["proxy"][key] = proxy_updates[key]
+    if external_registry_config == (mirror.external_registry_config or {}):
+        return None
 
     return update_with_transaction(mirror, external_registry_config=external_registry_config)
 

--- a/data/model/test/test_org_mirror.py
+++ b/data/model/test/test_org_mirror.py
@@ -466,6 +466,42 @@ class TestCreateOrgMirrorConfig:
 
         assert "already contains repositories" in str(excinfo.value)
 
+    def test_create_org_mirror_config_rejects_private_proxy(self, initialized_db):
+        org, robot = _create_org_and_robot("create_private_proxy")
+
+        with pytest.raises(DataModelException, match="private or reserved"):
+            create_org_mirror_config(
+                organization=org,
+                internal_robot=robot,
+                external_registry_type=SourceRegistryType.HARBOR,
+                external_registry_url="https://harbor.example.com",
+                external_namespace="my-project",
+                visibility=Visibility.get(name="private"),
+                sync_interval=3600,
+                sync_start_date=datetime.utcnow(),
+                external_registry_config={"proxy": {"http_proxy": "http://169.254.169.254:8080"}},
+            )
+
+        assert get_org_mirror_config(org) is None
+
+    def test_create_org_mirror_config_allows_allowlisted_proxy(self, initialized_db):
+        org, robot = _create_org_and_robot("create_allowlisted_proxy")
+
+        config = create_org_mirror_config(
+            organization=org,
+            internal_robot=robot,
+            external_registry_type=SourceRegistryType.HARBOR,
+            external_registry_url="https://harbor.example.com",
+            external_namespace="my-project",
+            visibility=Visibility.get(name="private"),
+            sync_interval=3600,
+            sync_start_date=datetime.utcnow(),
+            external_registry_config={"proxy": {"https_proxy": "10.0.0.1:8443"}},
+            allowed_hosts=["10.0.0.0/8"],
+        )
+
+        assert config.external_registry_config["proxy"]["https_proxy"] == "10.0.0.1:8443"
+
 
 class TestDeleteOrgMirrorConfig:
     """Tests for delete_org_mirror_config function."""
@@ -795,6 +831,41 @@ class TestUpdateOrgMirrorConfig:
         updated = update_org_mirror_config(org, external_registry_config=new_config)
 
         assert updated is not None
+        assert updated.external_registry_config == new_config
+
+    def test_update_org_mirror_config_rejects_private_proxy_without_mutation(self, initialized_db):
+        org, robot = _create_org_and_robot("update_private_proxy")
+        config = _create_org_mirror_config(
+            org,
+            robot,
+            external_registry_config={"proxy": {"http_proxy": "http://proxy.example.com:8080"}},
+        )
+        original_config = config.external_registry_config
+
+        with pytest.raises(DataModelException, match="private or reserved"):
+            update_org_mirror_config(
+                org,
+                external_registry_config={"proxy": {"https_proxy": "https://127.0.0.1:8443"}},
+                sync_interval=7200,
+            )
+
+        unchanged = get_org_mirror_config(org)
+        assert unchanged.external_registry_config == original_config
+        assert unchanged.sync_interval == 3600
+
+    def test_update_org_mirror_config_preserves_no_proxy_and_nullable_values(self, initialized_db):
+        org, robot = _create_org_and_robot("update_nullable_proxy")
+        _create_org_mirror_config(org, robot)
+        new_config = {
+            "proxy": {
+                "http_proxy": None,
+                "https_proxy": "proxy.example.com:8443",
+                "no_proxy": "localhost,10.0.0.0/8",
+            }
+        }
+
+        updated = update_org_mirror_config(org, external_registry_config=new_config)
+
         assert updated.external_registry_config == new_config
 
     def test_update_org_mirror_config_multiple_fields(self, initialized_db):

--- a/data/model/test/test_repo_mirroring.py
+++ b/data/model/test/test_repo_mirroring.py
@@ -322,6 +322,56 @@ class TestRepoMirrorSSRFProtection:
         )
         assert model.repo_mirror.get_mirror(repo).external_reference == ("10.0.0.1/team/repository")
 
+    def test_create_rejects_private_proxy(self, initialized_db):
+        args = self._create_args()
+        args["external_registry_config"] = {
+            "proxy": {"https_proxy": "https://169.254.169.254:8443"}
+        }
+
+        with pytest.raises(model.DataModelException, match="private or reserved"):
+            model.repo_mirror.enable_mirroring_for_repository(**args)
+
+        assert model.repo_mirror.get_mirror(args["repository"]) is None
+
+    def test_change_proxy_rejects_private_destination_without_mutation(self, initialized_db):
+        mirror, repo = create_mirror_repo_robot(
+            ["latest"],
+            repo_name="ssrf_proxy_update",
+            external_registry_config={
+                "proxy": {"http_proxy": "proxy.example.com:8080", "no_proxy": "quay.io"}
+            },
+        )
+        original_config = mirror.external_registry_config
+
+        with pytest.raises(model.DataModelException, match="private or reserved"):
+            model.repo_mirror.change_external_registry_config(
+                repo,
+                {"proxy": {"https_proxy": "https://127.0.0.1:8443"}},
+            )
+
+        assert model.repo_mirror.get_mirror(repo).external_registry_config == original_config
+
+    def test_change_proxy_allows_allowlisted_destination_and_nullable_cleanup(self, initialized_db):
+        _, repo = create_mirror_repo_robot(["latest"], repo_name="ssrf_proxy_allowed")
+
+        assert model.repo_mirror.change_external_registry_config(
+            repo,
+            {
+                "proxy": {
+                    "http_proxy": "10.0.0.1:8080",
+                    "https_proxy": None,
+                    "no_proxy": "localhost,10.0.0.0/8",
+                }
+            },
+            allowed_hosts=["10.0.0.0/8"],
+        )
+        proxy = model.repo_mirror.get_mirror(repo).external_registry_config["proxy"]
+        assert proxy == {
+            "http_proxy": "10.0.0.1:8080",
+            "https_proxy": None,
+            "no_proxy": "localhost,10.0.0.0/8",
+        }
+
 
 class TestArchitectureFilter:
     """Tests for architecture_filter functionality."""

--- a/endpoints/api/mirror.py
+++ b/endpoints/api/mirror.py
@@ -25,9 +25,14 @@ from endpoints.api import (
 from endpoints.exception import InvalidRequest, NotFound
 from util.audit import track_and_log, wrap_repository
 from util.names import parse_robot_username
-from util.security.ssrf import SSRFBlockedError, validate_external_registry_reference
+from util.security.ssrf import (
+    SSRFBlockedError,
+    validate_external_registry_reference,
+    validate_mirror_proxy_config,
+)
 
 SSRF_GENERIC_ERROR = "The provided registry location is not allowed"
+PROXY_SSRF_GENERIC_ERROR = "The provided mirror proxy location is not allowed"
 
 
 def _get_ssrf_allowed_hosts():
@@ -44,6 +49,19 @@ def _validate_external_reference(reference):
     except SSRFBlockedError:
         raise InvalidRequest(SSRF_GENERIC_ERROR)
     except ValueError as e:
+        raise InvalidRequest(str(e))
+
+
+def _validate_proxy_config(external_registry_config):
+    """Validate mirror proxy destinations before any configuration mutation."""
+    try:
+        validate_mirror_proxy_config(
+            (external_registry_config or {}).get("proxy", {}),
+            allowed_hosts=_get_ssrf_allowed_hosts(),
+        )
+    except SSRFBlockedError:
+        raise InvalidRequest(PROXY_SSRF_GENERIC_ERROR)
+    except (AttributeError, ValueError) as e:
         raise InvalidRequest(str(e))
 
 
@@ -342,6 +360,7 @@ class RepoMirrorResource(RepositoryParamResource):
 
         # Validate the complete request before creating rules or changing permissions.
         _validate_external_reference(data["external_reference"])
+        _validate_proxy_config(data.get("external_registry_config", {}))
 
         arch_filter = data.get("architecture_filter")
         if arch_filter and not app.config.get("FEATURE_SPARSE_INDEX", False):
@@ -420,6 +439,12 @@ class RepoMirrorResource(RepositoryParamResource):
         # Validate and normalize every requested change before applying any update.
         if "external_reference" in values:
             _validate_external_reference(values["external_reference"])
+        if "external_registry_config" in values:
+            effective_config = model.repo_mirror.merge_external_registry_config(
+                mirror.external_registry_config,
+                values["external_registry_config"],
+            )
+            _validate_proxy_config(effective_config)
 
         if "sync_start_date" in values:
             try:
@@ -588,59 +613,29 @@ class RepoMirrorResource(RepositoryParamResource):
                 )
 
         if "external_registry_config" in values:
-            external_registry_config = values.get("external_registry_config", {})
+            external_registry_config = values["external_registry_config"]
+            if model.repo_mirror.change_external_registry_config(
+                repo,
+                external_registry_config,
+                allowed_hosts=_get_ssrf_allowed_hosts(),
+            ):
+                for field in ("verify_tls", "unsigned_images"):
+                    if field in external_registry_config:
+                        track_and_log(
+                            "repo_mirror_config_changed",
+                            wrap_repository(repo),
+                            changed=field,
+                            to=external_registry_config[field],
+                        )
 
-            if "verify_tls" in external_registry_config:
-                updates = {"verify_tls": external_registry_config["verify_tls"]}
-                if model.repo_mirror.change_external_registry_config(repo, updates):
-                    track_and_log(
-                        "repo_mirror_config_changed",
-                        wrap_repository(repo),
-                        changed="verify_tls",
-                        to=external_registry_config["verify_tls"],
-                    )
-
-            if "unsigned_images" in external_registry_config:
-                updates = {"unsigned_images": external_registry_config["unsigned_images"]}
-                if model.repo_mirror.change_external_registry_config(repo, updates):
-                    track_and_log(
-                        "repo_mirror_config_changed",
-                        wrap_repository(repo),
-                        changed="unsigned_images",
-                        to=external_registry_config["unsigned_images"],
-                    )
-
-            if "proxy" in external_registry_config:
                 proxy_values = external_registry_config.get("proxy", {})
-
-                if "http_proxy" in proxy_values:
-                    updates = {"proxy": {"http_proxy": proxy_values["http_proxy"]}}
-                    if model.repo_mirror.change_external_registry_config(repo, updates):
+                for field in ("http_proxy", "https_proxy", "no_proxy"):
+                    if field in proxy_values:
                         track_and_log(
                             "repo_mirror_config_changed",
                             wrap_repository(repo),
-                            changed="http_proxy",
-                            to=proxy_values["http_proxy"],
-                        )
-
-                if "https_proxy" in proxy_values:
-                    updates = {"proxy": {"https_proxy": proxy_values["https_proxy"]}}
-                    if model.repo_mirror.change_external_registry_config(repo, updates):
-                        track_and_log(
-                            "repo_mirror_config_changed",
-                            wrap_repository(repo),
-                            changed="https_proxy",
-                            to=proxy_values["https_proxy"],
-                        )
-
-                if "no_proxy" in proxy_values:
-                    updates = {"proxy": {"no_proxy": proxy_values["no_proxy"]}}
-                    if model.repo_mirror.change_external_registry_config(repo, updates):
-                        track_and_log(
-                            "repo_mirror_config_changed",
-                            wrap_repository(repo),
-                            changed="no_proxy",
-                            to=proxy_values["no_proxy"],
+                            changed=field,
+                            to=proxy_values[field],
                         )
 
         if "root_rule" in values:

--- a/endpoints/api/org_mirror.py
+++ b/endpoints/api/org_mirror.py
@@ -36,11 +36,16 @@ from endpoints.api import (
 from endpoints.exception import InvalidRequest, NotFound, Unauthorized
 from util.names import parse_robot_username
 from util.orgmirror import get_registry_adapter
-from util.security.ssrf import SSRFBlockedError, validate_external_registry_url
+from util.security.ssrf import (
+    SSRFBlockedError,
+    validate_external_registry_url,
+    validate_mirror_proxy_config,
+)
 
 # Generic error message for SSRF rejections. Avoids leaking internal network topology
 # by not distinguishing between blocked hostnames, private IPs, and DNS results.
 SSRF_GENERIC_ERROR = "The provided registry URL is not allowed"
+PROXY_SSRF_GENERIC_ERROR = "The provided mirror proxy location is not allowed"
 
 
 def _get_ssrf_allowed_hosts():
@@ -60,6 +65,19 @@ def _validate_registry_url(url):
     except SSRFBlockedError:
         raise InvalidRequest(SSRF_GENERIC_ERROR)
     except ValueError as e:
+        raise InvalidRequest(str(e))
+
+
+def _validate_proxy_config(external_registry_config):
+    """Validate organization mirror proxy destinations before any state change."""
+    try:
+        validate_mirror_proxy_config(
+            (external_registry_config or {}).get("proxy", {}),
+            allowed_hosts=_get_ssrf_allowed_hosts(),
+        )
+    except SSRFBlockedError:
+        raise InvalidRequest(PROXY_SSRF_GENERIC_ERROR)
+    except (AttributeError, ValueError) as e:
         raise InvalidRequest(str(e))
 
 
@@ -288,6 +306,10 @@ class OrgMirrorConfig(ApiResource):
 
         data = request.get_json()
 
+        # Validate all outbound destinations before any database mutation.
+        _validate_registry_url(data.get("external_registry_url"))
+        _validate_proxy_config(data.get("external_registry_config", {}))
+
         # Validate and look up robot account
         robot_username = data.get("robot_username")
         try:
@@ -333,9 +355,6 @@ class OrgMirrorConfig(ApiResource):
         skopeo_timeout = data.get("skopeo_timeout", 300)
         if skopeo_timeout < 30 or skopeo_timeout > 3600:
             raise InvalidRequest("skopeo_timeout must be between 30 and 3600 seconds")
-
-        # Validate external_registry_url to prevent SSRF (CWE-918)
-        _validate_registry_url(data.get("external_registry_url"))
 
         # Create the mirror config
         try:
@@ -395,6 +414,12 @@ class OrgMirrorConfig(ApiResource):
 
         data = request.get_json()
 
+        # Validate all outbound destinations before building or applying updates.
+        if "external_registry_url" in data:
+            _validate_registry_url(data["external_registry_url"])
+        if "external_registry_config" in data:
+            _validate_proxy_config(data["external_registry_config"])
+
         # Build update kwargs with validated values
         update_kwargs = {}
 
@@ -404,8 +429,6 @@ class OrgMirrorConfig(ApiResource):
 
         # Handle external_registry_url
         if "external_registry_url" in data:
-            # Validate URL to prevent SSRF (CWE-918)
-            _validate_registry_url(data["external_registry_url"])
             update_kwargs["external_registry_url"] = data["external_registry_url"]
 
         # Handle external_namespace

--- a/endpoints/api/test/test_mirror.py
+++ b/endpoints/api/test/test_mirror.py
@@ -190,15 +190,15 @@ def test_get_mirror(app):
         (
             "https_proxy",
             "proxy.example.com; rm -rf /",
-            201,
-        ),  # Safe; values only set in env, not eval'ed
+            400,
+        ),
         ("http_proxy", "http://proxy.corp.example.com", 201),
         ("http_proxy", None, 201),
         (
             "http_proxy",
             "proxy.example.com; rm -rf /",
-            201,
-        ),  # Safe; values only set in env, not eval'ed
+            400,
+        ),
         ("no_proxy", "quay.io", 201),
         ("no_proxy", None, 201),
         ("no_proxy", "quay.io; rm -rf /", 201),  # Safe because proxy values are not eval'ed
@@ -392,6 +392,38 @@ class TestRepoMirrorSSRFProtection:
         permissions = model.permission.get_user_repository_permissions(robot, "devtable", "simple")
         assert next(iter(permissions), None) is None
 
+    def test_create_with_unsafe_proxy_rejected_before_mutation(self, app):
+        robot, _ = model.user.create_robot(
+            "ssrfproxybot", model.user.get_namespace_user("devtable")
+        )
+        body = self._create_body("quay.io/team/repo", robot.username)
+        body["external_registry_config"] = {"proxy": {"http_proxy": "http://169.254.169.254:8080"}}
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"repository": "devtable/simple"}
+            resp = conduct_api_call(cl, RepoMirrorResource, "POST", params, body, 400)
+
+        assert resp.json["error_message"] == "The provided mirror proxy location is not allowed"
+        repo = model.repository.get_repository("devtable", "simple")
+        assert model.repo_mirror.get_mirror(repo) is None
+        assert list(RepoMirrorRule.select().where(RepoMirrorRule.repository == repo)) == []
+        permissions = model.permission.get_user_repository_permissions(robot, "devtable", "simple")
+        assert next(iter(permissions), None) is None
+
+    def test_create_with_scheme_less_proxy_succeeds(self, app):
+        robot, _ = model.user.create_robot(
+            "schemelessproxybot", model.user.get_namespace_user("devtable")
+        )
+        body = self._create_body("quay.io/team/repo", robot.username)
+        body["external_registry_config"] = {"proxy": {"https_proxy": "proxy.example.com:8443"}}
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"repository": "devtable/simple"}
+            conduct_api_call(cl, RepoMirrorResource, "POST", params, body, 201)
+
+        mirror = model.repo_mirror.get_mirror(model.repository.get_repository("devtable", "simple"))
+        assert mirror.external_registry_config["proxy"]["https_proxy"] == ("proxy.example.com:8443")
+
     def test_create_with_hostname_resolving_private_rejected(self, app):
         robot, _ = model.user.create_robot("ssrfdnsbot", model.user.get_namespace_user("devtable"))
 
@@ -510,6 +542,68 @@ class TestRepoMirrorSSRFProtection:
         updated = model.repo_mirror.get_mirror(mirror.repository)
         assert updated.external_reference == "quay.io/redhat/quay"
         assert updated.sync_start_date == mirror.sync_start_date
+
+    def test_update_with_unsafe_proxy_rejected_without_partial_updates(self, app):
+        mirror = _setup_mirror()
+        original_config = mirror.external_registry_config
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"repository": "devtable/simple"}
+            body = {
+                "sync_interval": mirror.sync_interval + 100,
+                "external_registry_config": {"proxy": {"https_proxy": "https://127.0.0.1:8443"}},
+            }
+            resp = conduct_api_call(cl, RepoMirrorResource, "PUT", params, body, 400)
+
+        assert resp.json["error_message"] == "The provided mirror proxy location is not allowed"
+        updated = model.repo_mirror.get_mirror(mirror.repository)
+        assert updated.sync_interval == mirror.sync_interval
+        assert updated.external_registry_config == original_config
+
+    def test_update_with_allowlisted_private_proxy_succeeds(self, app):
+        mirror = _setup_mirror()
+
+        with patch.dict(quay_app.config, {"SSRF_ALLOWED_HOSTS": ["10.0.0.0/8"]}):
+            with client_with_identity("devtable", app) as cl:
+                params = {"repository": "devtable/simple"}
+                body = {
+                    "external_registry_config": {"proxy": {"http_proxy": "http://10.0.0.1:8080"}}
+                }
+                conduct_api_call(cl, RepoMirrorResource, "PUT", params, body, 201)
+
+        updated = model.repo_mirror.get_mirror(mirror.repository)
+        assert updated.external_registry_config["proxy"]["http_proxy"] == ("http://10.0.0.1:8080")
+
+    def test_update_clears_multiple_legacy_unsafe_proxies_atomically(self, app):
+        mirror = _setup_mirror()
+        mirror.external_registry_config = {
+            "verify_tls": True,
+            "proxy": {
+                "http_proxy": "http://127.0.0.1:8080",
+                "https_proxy": "https://169.254.169.254:8443",
+                "no_proxy": "quay.io",
+            },
+        }
+        mirror.save()
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"repository": "devtable/simple"}
+            body = {
+                "sync_interval": mirror.sync_interval + 100,
+                "external_registry_config": {"proxy": {"http_proxy": None, "https_proxy": None}},
+            }
+            conduct_api_call(cl, RepoMirrorResource, "PUT", params, body, 201)
+
+        updated = model.repo_mirror.get_mirror(mirror.repository)
+        assert updated.sync_interval == mirror.sync_interval + 100
+        assert updated.external_registry_config == {
+            "verify_tls": True,
+            "proxy": {
+                "http_proxy": None,
+                "https_proxy": None,
+                "no_proxy": "quay.io",
+            },
+        }
 
     def test_update_with_allowlisted_private_registry_succeeds(self, app):
         mirror = _setup_mirror()

--- a/endpoints/api/test/test_org_mirror.py
+++ b/endpoints/api/test/test_org_mirror.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
+from app import app as quay_app
 from data import model
 from data.database import (
     OrgMirrorConfig,
@@ -1624,6 +1625,37 @@ class TestOrgMirrorSSRFProtection:
             resp = conduct_api_call(cl, org_mirror.OrgMirrorConfig, "POST", params, body, 400)
             assert "not allowed" in resp.json.get("error_message", "")
 
+    def test_create_with_private_proxy_rejected_before_persistence(self, app):
+        _cleanup_org_mirror_config(_EMPTY_ORG)
+        body = self._base_create_body("https://harbor.example.com")
+        body["external_registry_config"] = {
+            "proxy": {"https_proxy": "https://169.254.169.254:8443"}
+        }
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"orgname": _EMPTY_ORG}
+            resp = conduct_api_call(cl, org_mirror.OrgMirrorConfig, "POST", params, body, 400)
+
+        assert resp.json["error_message"] == "The provided mirror proxy location is not allowed"
+        org = model.organization.get_organization(_EMPTY_ORG)
+        assert model.org_mirror.get_org_mirror_config(org) is None
+
+    def test_create_with_scheme_less_proxy_succeeds(self, app):
+        _cleanup_org_mirror_config(_EMPTY_ORG)
+        body = self._base_create_body("https://harbor.example.com")
+        body["external_registry_config"] = {
+            "proxy": {"http_proxy": "proxy.example.com:8080", "no_proxy": "localhost"}
+        }
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"orgname": _EMPTY_ORG}
+            conduct_api_call(cl, org_mirror.OrgMirrorConfig, "POST", params, body, 201)
+
+        org = model.organization.get_organization(_EMPTY_ORG)
+        config = model.org_mirror.get_org_mirror_config(org)
+        assert config.external_registry_config["proxy"]["http_proxy"] == ("proxy.example.com:8080")
+        _cleanup_org_mirror_config(_EMPTY_ORG)
+
     def test_create_with_kubernetes_hostname_rejected(self, app):
         """POST with Kubernetes internal hostname returns 400 with generic error."""
         _cleanup_org_mirror_config(_EMPTY_ORG)
@@ -1677,6 +1709,53 @@ class TestOrgMirrorSSRFProtection:
             resp = conduct_api_call(cl, org_mirror.OrgMirrorConfig, "PUT", params, update_body, 400)
             assert "not allowed" in resp.json.get("error_message", "")
 
+        _cleanup_org_mirror_config("buynlarge")
+
+    def test_update_with_private_proxy_rejected_and_prior_config_preserved(self, app):
+        _cleanup_org_mirror_config("buynlarge")
+        config = _create_config_directly()
+        config.external_registry_config = {"proxy": {"http_proxy": "http://proxy.example.com:8080"}}
+        config.save()
+
+        with client_with_identity("devtable", app) as cl:
+            params = {"orgname": "buynlarge"}
+            update_body = {
+                "external_registry_config": {"proxy": {"http_proxy": "http://127.0.0.1:8080"}},
+                "sync_interval": config.sync_interval + 60,
+            }
+            resp = conduct_api_call(cl, org_mirror.OrgMirrorConfig, "PUT", params, update_body, 400)
+
+        assert resp.json["error_message"] == "The provided mirror proxy location is not allowed"
+        updated = model.org_mirror.get_org_mirror_config(config.organization)
+        assert updated.external_registry_config == {
+            "proxy": {"http_proxy": "http://proxy.example.com:8080"}
+        }
+        assert updated.sync_interval == config.sync_interval
+        _cleanup_org_mirror_config("buynlarge")
+
+    def test_update_with_allowlisted_private_proxy_succeeds(self, app):
+        _cleanup_org_mirror_config("buynlarge")
+        config = _create_config_directly()
+
+        with patch.dict(quay_app.config, {"SSRF_ALLOWED_HOSTS": ["10.0.0.0/8"]}):
+            with client_with_identity("devtable", app) as cl:
+                params = {"orgname": "buynlarge"}
+                update_body = {
+                    "external_registry_config": {
+                        "proxy": {
+                            "https_proxy": "10.0.0.1:8443",
+                            "http_proxy": None,
+                            "no_proxy": "localhost",
+                        }
+                    }
+                }
+                conduct_api_call(cl, org_mirror.OrgMirrorConfig, "PUT", params, update_body, 200)
+
+        updated = model.org_mirror.get_org_mirror_config(config.organization)
+        assert (
+            updated.external_registry_config["proxy"]
+            == update_body["external_registry_config"]["proxy"]
+        )
         _cleanup_org_mirror_config("buynlarge")
 
     def test_update_with_aws_metadata_rejected(self, app):

--- a/util/config/schema.py
+++ b/util/config/schema.py
@@ -1142,7 +1142,7 @@ CONFIG_SCHEMA = {
         },
         "SSRF_ALLOWED_HOSTS": {
             "type": "array",
-            "description": "List of hostnames or CIDR ranges allowed to bypass SSRF protection for repository and organization mirror source registries, proxy cache registries, and export log callback URLs. Use for enterprise deployments where endpoints are on private networks.",
+            "description": "List of hostnames or CIDR ranges allowed to bypass SSRF protection for repository and organization mirror source registries and proxy endpoints, proxy cache registries, and export log callback URLs. Use for enterprise deployments where endpoints are on private networks. Scheme-less mirror proxy values remain supported for backward compatibility and are interpreted as HTTP only during destination validation.",
             "uniqueItems": True,
             "items": {"type": "string"},
             "x-example": ["internal-harbor.corp.example.com", "10.0.0.0/8"],

--- a/util/orgmirror/harbor_adapter.py
+++ b/util/orgmirror/harbor_adapter.py
@@ -71,11 +71,10 @@ class HarborAdapter(RegistryAdapter):
 
                 logger.debug("Fetching repositories from %s with params %s", url, params)
 
-                response = self.session.get(
+                response = self._get(
                     url,
                     params=params,
                     verify=self.verify_tls,
-                    proxies=self._build_proxies(url),
                     timeout=self.timeout,
                     allow_redirects=False,
                 )
@@ -171,10 +170,9 @@ class HarborAdapter(RegistryAdapter):
         try:
             # Try to fetch project info
             url = f"{self.base_url}/api/v2.0/projects/{self.namespace}"
-            response = self.session.get(
+            response = self._get(
                 url,
                 verify=self.verify_tls,
-                proxies=self._build_proxies(url),
                 timeout=10,
                 allow_redirects=False,
             )

--- a/util/orgmirror/quay_adapter.py
+++ b/util/orgmirror/quay_adapter.py
@@ -98,10 +98,9 @@ class QuayAdapter(RegistryAdapter):
             QuayDiscoveryException: On 401, 403, or redirect responses.
         """
         url = f"{self.base_url}/api/v1/user/"
-        response = self.session.get(
+        response = self._get(
             url,
             verify=self.verify_tls,
-            proxies=self._build_proxies(url),
             timeout=self.timeout,
             allow_redirects=False,
         )
@@ -147,11 +146,10 @@ class QuayAdapter(RegistryAdapter):
 
                 logger.debug("Fetching repositories from %s with params %s", url, params)
 
-                response = self.session.get(
+                response = self._get(
                     url,
                     params=params,
                     verify=self.verify_tls,
-                    proxies=self._build_proxies(url),
                     timeout=self.timeout,
                     allow_redirects=False,
                 )
@@ -236,10 +234,9 @@ class QuayAdapter(RegistryAdapter):
 
             # Verify namespace exists
             url = f"{self.base_url}/api/v1/organization/{self.namespace}"
-            response = self.session.get(
+            response = self._get(
                 url,
                 verify=self.verify_tls,
-                proxies=self._build_proxies(url),
                 timeout=10,
                 allow_redirects=False,
             )
@@ -252,10 +249,9 @@ class QuayAdapter(RegistryAdapter):
                 # Namespace may be a user namespace rather than an organization.
                 # Fall back to the user endpoint before reporting not found.
                 ns_url = f"{self.base_url}/api/v1/users/{self.namespace}"
-                ns_response = self.session.get(
+                ns_response = self._get(
                     ns_url,
                     verify=self.verify_tls,
-                    proxies=self._build_proxies(ns_url),
                     timeout=10,
                     allow_redirects=False,
                 )

--- a/util/orgmirror/registry_adapter.py
+++ b/util/orgmirror/registry_adapter.py
@@ -4,13 +4,19 @@ Abstract base class for source registry adapters used in organization mirroring.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple
 
 import requests
 from requests.adapters import HTTPAdapter
+from requests.exceptions import ProxyError
 from requests.packages.urllib3.util.retry import Retry
 from requests.utils import should_bypass_proxies
 
+from util.security.proxy import (
+    MIRROR_PROXY_VALIDATION_ERROR,
+    MirrorProxyValidationError,
+    pinned_mirror_proxy_config,
+)
 from util.security.ssrf import validate_external_registry_url
 
 DEFAULT_TIMEOUT = 30
@@ -52,27 +58,43 @@ class RegistryAdapter(ABC):
         # DNS record changes between config creation (API layer) and actual HTTP use.
         validate_external_registry_url(url, resolve_dns=True, allowed_hosts=allowed_hosts)
 
+        self._config = config or {}
+        if not isinstance(self._config, dict):
+            raise ValueError("External registry configuration must be an object")
+        self._allowed_hosts = list(allowed_hosts or [])
+
         self.base_url = url.rstrip("/")
         self.namespace = namespace
         self.auth = (username, password) if username and password else None
-        self._config = config or {}
         self.verify_tls = self._config.get("verify_tls", True)
-        self.proxy = self._config.get("proxy", {})
+        configured_proxy = self._config.get("proxy")
+        self.proxy = configured_proxy if configured_proxy is not None else {}
         self.timeout = self._config.get("timeout", DEFAULT_TIMEOUT)
         self.max_retries = max_retries
         self.session = self._create_session()
 
-    def _build_proxies(self, url: str) -> Dict:
-        """Build proxies dict for requests, respecting no_proxy."""
+    def _get(self, url: str, **kwargs):
+        """Issue a GET through proxy addresses pinned during this request."""
+        if not isinstance(self.proxy, Mapping):
+            raise ProxyError(MIRROR_PROXY_VALIDATION_ERROR)
+
         no_proxy = self.proxy.get("no_proxy", "")
         if no_proxy and should_bypass_proxies(url, no_proxy=no_proxy):
-            return {}
-        proxies = {}
-        if self.proxy.get("http_proxy"):
-            proxies["http"] = self.proxy["http_proxy"]
-        if self.proxy.get("https_proxy"):
-            proxies["https"] = self.proxy["https_proxy"]
-        return proxies
+            return self.session.get(url, proxies={}, **kwargs)
+
+        try:
+            with pinned_mirror_proxy_config(
+                self.proxy,
+                allowed_hosts=self._allowed_hosts,
+            ) as effective_proxy:
+                proxies = {}
+                if effective_proxy.get("http_proxy"):
+                    proxies["http"] = effective_proxy["http_proxy"]
+                if effective_proxy.get("https_proxy"):
+                    proxies["https"] = effective_proxy["https_proxy"]
+                return self.session.get(url, proxies=proxies, **kwargs)
+        except MirrorProxyValidationError as e:
+            raise ProxyError(str(e)) from None
 
     def _create_session(self) -> requests.Session:
         """

--- a/util/orgmirror/test/test_adapters.py
+++ b/util/orgmirror/test/test_adapters.py
@@ -3,7 +3,7 @@
 Unit tests for organization mirroring registry adapters.
 """
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 import responses
@@ -22,14 +22,22 @@ from util.orgmirror.quay_adapter import QuayAdapter
 
 @pytest.fixture(autouse=True)
 def _mock_ssrf_validation():
-    """Mock SSRF validation to avoid DNS resolution in unit tests.
+    """Keep adapter tests independent of external DNS.
 
-    SSRF validation calls socket.getaddrinfo() which fails in CI for fake
-    hostnames like harbor.example.com. SSRF validation is tested separately
-    in util/security/test/test_ssrf.py.
+    Source URL validation is covered separately. Proxy validation remains active
+    with deterministic public DNS answers so every request boundary is exercised.
     """
     with patch("util.orgmirror.registry_adapter.validate_external_registry_url"):
-        yield
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+            yield
+
+
+def _request_proxies(adapter, url):
+    response = Mock(status_code=200)
+    with patch.object(adapter.session, "get", return_value=response) as request:
+        adapter._get(url)
+    return request.call_args.kwargs["proxies"]
 
 
 @pytest.fixture()
@@ -299,8 +307,56 @@ class TestQuayAdapter:
         assert success is False
         assert "500" in message
 
+    def test_proxy_is_revalidated_before_every_request(self):
+        config = {"proxy": {"https_proxy": "https://proxy.example.com:8443"}}
+
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.side_effect = [
+                [(2, 1, 6, "", ("93.184.216.34", 0))],
+                [(2, 1, 6, "", ("10.0.0.1", 0))],
+            ]
+            adapter = QuayAdapter(
+                url="https://quay.io",
+                namespace="testorg",
+                config=config,
+            )
+            response = Mock(status_code=200)
+
+            with patch.object(adapter.session, "get", return_value=response) as request:
+                assert adapter.test_connection() == (True, "Connection successful")
+                assert adapter.test_connection() == (
+                    False,
+                    "Connection error: Mirror proxy location is not allowed",
+                )
+
+        request.assert_called_once()
+        assert mock_dns.call_count == 2
+
+    def test_request_proxy_revalidation_honors_allowed_hosts(self):
+        adapter = QuayAdapter(
+            url="https://quay.io",
+            namespace="testorg",
+            config={"proxy": {"http_proxy": "http://10.0.0.1:8080"}},
+            allowed_hosts=["10.0.0.0/8"],
+        )
+
+        proxies = _request_proxies(adapter, "https://quay.io/api/v1/repository")
+
+        assert proxies["http"].startswith("http://127.0.0.1:")
+
+    def test_request_value_error_is_not_reported_as_proxy_validation(self):
+        adapter = QuayAdapter(
+            url="https://quay.io",
+            namespace="testorg",
+            config={"proxy": {"http_proxy": "http://proxy.example.com:8080"}},
+        )
+
+        with patch.object(adapter.session, "get", side_effect=ValueError("request failure")):
+            with pytest.raises(ValueError, match="request failure"):
+                adapter._get("https://quay.io/api/v1/repository")
+
     def test_proxy_configuration(self):
-        """Test that proxy settings are passed to requests."""
+        """Test that proxy settings are passed to requests through pinned relays."""
         adapter = QuayAdapter(
             url="https://quay.io",
             namespace="testorg",
@@ -312,9 +368,29 @@ class TestQuayAdapter:
             },
         )
 
-        proxies = adapter._build_proxies("https://quay.io/api/v1/repository")
-        assert proxies["http"] == "http://proxy:8080"
-        assert proxies["https"] == "https://proxy:8443"
+        proxies = _request_proxies(adapter, "https://quay.io/api/v1/repository")
+        assert proxies["http"].startswith("http://127.0.0.1:")
+        assert proxies["https"].startswith("http://127.0.0.1:")
+
+    def test_scheme_less_proxies_are_copied_and_normalized_for_requests(self):
+        proxy_config = {
+            "http_proxy": "proxy.example.com:8080",
+            "https_proxy": "alice:secret@secure-proxy.example.com:8443",
+        }
+        adapter = QuayAdapter(
+            url="https://quay.io",
+            namespace="testorg",
+            config={"proxy": proxy_config},
+        )
+
+        proxies = _request_proxies(adapter, "https://quay.io/api/v1/repository")
+
+        assert proxies["http"].startswith("http://127.0.0.1:")
+        assert proxies["https"].startswith("http://alice:secret@127.0.0.1:")
+        assert proxy_config == {
+            "http_proxy": "proxy.example.com:8080",
+            "https_proxy": "alice:secret@secure-proxy.example.com:8443",
+        }
 
     def test_no_proxy_bypasses_proxy(self):
         """Test that no_proxy returns empty proxies for matching hosts."""
@@ -331,17 +407,15 @@ class TestQuayAdapter:
         )
 
         # Host in no_proxy list -> empty proxies (direct connection)
-        proxies = adapter._build_proxies("https://quay.io/api/v1/repository")
-        assert proxies == {}
+        assert _request_proxies(adapter, "https://quay.io/api/v1/repository") == {}
 
         # Suffix match
-        proxies = adapter._build_proxies("https://registry.internal/v2")
-        assert proxies == {}
+        assert _request_proxies(adapter, "https://registry.internal/v2") == {}
 
-        # Host NOT in no_proxy list -> proxies returned
-        proxies = adapter._build_proxies("https://other-registry.com/v2")
-        assert proxies["http"] == "http://proxy:8080"
-        assert proxies["https"] == "https://proxy:8443"
+        # Host NOT in no_proxy list -> pinned proxies returned
+        proxies = _request_proxies(adapter, "https://other-registry.com/v2")
+        assert proxies["http"].startswith("http://127.0.0.1:")
+        assert proxies["https"].startswith("http://127.0.0.1:")
 
     def test_no_proxy_not_configured(self):
         """Test that without no_proxy, all hosts use the proxy."""
@@ -355,8 +429,8 @@ class TestQuayAdapter:
             },
         )
 
-        proxies = adapter._build_proxies("https://quay.io/api/v1/repository")
-        assert proxies["http"] == "http://proxy:8080"
+        proxies = _request_proxies(adapter, "https://quay.io/api/v1/repository")
+        assert proxies["http"].startswith("http://127.0.0.1:")
 
     def test_tls_verification_disabled(self):
         """Test that TLS verification can be disabled."""

--- a/util/repomirror/skopeomirror.py
+++ b/util/repomirror/skopeomirror.py
@@ -9,7 +9,13 @@ from collections import namedtuple
 from contextlib import contextmanager
 from shlex import quote
 from tempfile import NamedTemporaryFile, SpooledTemporaryFile
-from typing import Iterator, Optional
+from typing import Iterator, List, Optional
+
+from util.security.proxy import (
+    MIRROR_PROXY_VALIDATION_ERROR,
+    MirrorProxyValidationError,
+    pinned_mirror_proxy_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +108,8 @@ def _src_dest_authfiles(src_entries: list, dest_entries: list) -> Iterator[tuple
 
 
 class SkopeoMirror(object):
+    def __init__(self, allowed_hosts: Optional[List[str]] = None):
+        self._allowed_hosts = list(allowed_hosts or [])
 
     # No DB calls here: This will be called from a separate worker that has no connection except
     # to/from the mirror worker
@@ -269,6 +277,7 @@ class SkopeoMirror(object):
 
     def setup_env(self, proxy):
         env = os.environ.copy()
+        proxy = proxy or {}
 
         if proxy.get("http_proxy"):
             env["HTTP_PROXY"] = proxy.get("http_proxy")
@@ -283,31 +292,38 @@ class SkopeoMirror(object):
         # Using a tempfile makes sure that if --debug is set, the stdout and stderr output
         # doesn't get truncated by the system's pipe limit.
 
-        with SpooledTemporaryFile() as stdoutpipe, SpooledTemporaryFile() as stderrpipe:
-            logger.debug("Setting job timeout: %s s", timeout)
-            job = subprocess.Popen(
-                args,
-                shell=False,
-                stdout=stdoutpipe,
-                stderr=stderrpipe,
-                env=self.setup_env(proxy),
-            )
-
-            try:
-                job.wait(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                job.kill()
-            finally:
-                stdoutpipe.seek(0)
-                stderrpipe.seek(0)
-                stdout = sanitize_skopeo_output(stdoutpipe.read().decode("utf-8"))
-                stderr = sanitize_skopeo_output(stderrpipe.read().decode("utf-8"))
-
-                if job.returncode != 0:
-                    logger.debug(
-                        "Skopeo command failed (exit code %s): %s",
-                        job.returncode,
-                        stderr.strip(),
+        try:
+            with SpooledTemporaryFile() as stdoutpipe, SpooledTemporaryFile() as stderrpipe:
+                logger.debug("Setting job timeout: %s s", timeout)
+                with pinned_mirror_proxy_config(
+                    proxy,
+                    allowed_hosts=self._allowed_hosts,
+                ) as effective_proxy:
+                    job = subprocess.Popen(
+                        args,
+                        shell=False,
+                        stdout=stdoutpipe,
+                        stderr=stderrpipe,
+                        env=self.setup_env(effective_proxy),
                     )
 
-                return SkopeoResults(job.returncode == 0, [], stdout, stderr)
+                    try:
+                        job.wait(timeout=timeout)
+                    except subprocess.TimeoutExpired:
+                        job.kill()
+                    finally:
+                        stdoutpipe.seek(0)
+                        stderrpipe.seek(0)
+                        stdout = sanitize_skopeo_output(stdoutpipe.read().decode("utf-8"))
+                        stderr = sanitize_skopeo_output(stderrpipe.read().decode("utf-8"))
+
+                        if job.returncode != 0:
+                            logger.debug(
+                                "Skopeo command failed (exit code %s): %s",
+                                job.returncode,
+                                stderr.strip(),
+                            )
+
+                        return SkopeoResults(job.returncode == 0, [], stdout, stderr)
+        except MirrorProxyValidationError:
+            return SkopeoResults(False, [], "", MIRROR_PROXY_VALIDATION_ERROR)

--- a/util/repomirror/test/test_skopeomirror.py
+++ b/util/repomirror/test/test_skopeomirror.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock, patch
+
+from util.repomirror.skopeomirror import SkopeoMirror
+
+
+def _address(ip):
+    return [(2, 1, 6, "", (ip, 0))]
+
+
+def test_proxy_is_revalidated_before_every_skopeo_process():
+    skopeo = SkopeoMirror()
+    process = Mock(returncode=0)
+    proxy = {"https_proxy": "https://proxy.example.com:8443"}
+
+    with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+        mock_dns.side_effect = [_address("93.184.216.34"), _address("10.0.0.1")]
+        with patch("util.repomirror.skopeomirror.subprocess.Popen", return_value=process) as popen:
+            result = skopeo.run_skopeo(["/usr/bin/skopeo", "list-tags"], proxy, 300)
+            blocked = skopeo.run_skopeo(["/usr/bin/skopeo", "copy"], proxy, 300)
+
+    assert result.success is True
+    assert blocked.success is False
+    assert blocked.stderr == "Mirror proxy location is not allowed"
+    popen.assert_called_once()
+    assert popen.call_args.kwargs["env"]["HTTPS_PROXY"].startswith("http://127.0.0.1:")
+    assert proxy == {"https_proxy": "https://proxy.example.com:8443"}
+    assert mock_dns.call_count == 2
+
+
+def test_allowlisted_proxy_is_revalidated_before_skopeo_process():
+    skopeo = SkopeoMirror(allowed_hosts=["10.0.0.0/8"])
+    process = Mock(returncode=0)
+    proxy = {"http_proxy": "http://10.0.0.1:8080"}
+
+    with patch("util.repomirror.skopeomirror.subprocess.Popen", return_value=process) as popen:
+        result = skopeo.run_skopeo(["/usr/bin/skopeo", "list-tags"], proxy, 300)
+
+    assert result.success is True
+    popen.assert_called_once()
+    assert popen.call_args.kwargs["env"]["HTTP_PROXY"].startswith("http://127.0.0.1:")

--- a/util/security/proxy.py
+++ b/util/security/proxy.py
@@ -1,0 +1,184 @@
+"""Connection-time pinning for validated mirror proxy destinations."""
+
+import logging
+import socket
+import socketserver
+import ssl
+import threading
+from contextlib import ExitStack, contextmanager
+from typing import Dict, Iterator, List, Mapping, Optional, Set
+
+from util.security.ssrf import ValidatedMirrorProxy, validate_mirror_proxy_config
+
+logger = logging.getLogger(__name__)
+
+MIRROR_PROXY_VALIDATION_ERROR = "Mirror proxy location is not allowed"
+
+
+class MirrorProxyValidationError(ValueError):
+    """Raised when mirror proxy validation fails at a connection boundary."""
+
+    def __init__(self):
+        super().__init__(MIRROR_PROXY_VALIDATION_ERROR)
+
+
+_CONNECT_TIMEOUT = 30
+
+
+class _PinnedProxyServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def __init__(self, proxy: ValidatedMirrorProxy):
+        self.proxy = proxy
+        self._connections: Set[socket.socket] = set()
+        self._connections_lock = threading.Lock()
+        self._closing = False
+        super().__init__(("127.0.0.1", 0), _PinnedProxyHandler)
+
+    def track_connections(self, *connections) -> bool:
+        with self._connections_lock:
+            if self._closing:
+                for connection in connections:
+                    connection.close()
+                return False
+            self._connections.update(connections)
+            return True
+
+    def untrack_connections(self, *connections):
+        with self._connections_lock:
+            self._connections.difference_update(connections)
+
+    def close_connections(self):
+        with self._connections_lock:
+            self._closing = True
+            connections = list(self._connections)
+            self._connections.clear()
+
+        for connection in connections:
+            try:
+                connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            connection.close()
+
+    def open_remote(self):
+        last_error = None
+        for ip in self.proxy.resolved_ips:
+            try:
+                remote = socket.create_connection(
+                    (ip, self.proxy.port),
+                    timeout=_CONNECT_TIMEOUT,
+                )
+                if self.proxy.scheme == "https":
+                    context = ssl.create_default_context()
+                    remote = context.wrap_socket(remote, server_hostname=self.proxy.hostname)
+                remote.settimeout(None)
+                return remote
+            except OSError as e:
+                last_error = e
+
+        if last_error is not None:
+            raise last_error
+        raise OSError("Proxy destination has no validated addresses")
+
+
+class _PinnedProxyHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        try:
+            remote = self.server.open_remote()
+        except OSError:
+            logger.warning("Unable to connect to a validated mirror proxy destination")
+            return
+
+        if not self.server.track_connections(self.request, remote):
+            return
+
+        try:
+            forward = threading.Thread(
+                target=self._copy,
+                args=(self.request, remote),
+                daemon=True,
+            )
+            forward.start()
+            self._copy(remote, self.request)
+            forward.join(timeout=1)
+        finally:
+            self.server.untrack_connections(self.request, remote)
+            remote.close()
+
+    @staticmethod
+    def _copy(source, destination):
+        try:
+            while True:
+                data = source.recv(64 * 1024)
+                if not data:
+                    break
+                destination.sendall(data)
+        except OSError:
+            pass
+        finally:
+            try:
+                destination.shutdown(socket.SHUT_WR)
+            except OSError:
+                pass
+
+
+class _PinnedProxyRelay:
+    def __init__(self, proxy: ValidatedMirrorProxy):
+        self._proxy = proxy
+        self._server = _PinnedProxyServer(proxy)
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            kwargs={"poll_interval": 0.05},
+            daemon=True,
+        )
+
+    @property
+    def url(self) -> str:
+        userinfo = f"{self._proxy.userinfo}@" if self._proxy.userinfo else ""
+        port = self._server.server_address[1]
+        return f"http://{userinfo}127.0.0.1:{port}"
+
+    def start(self):
+        self._thread.start()
+
+    def close(self):
+        self._server.shutdown()
+        self._server.close_connections()
+        self._server.server_close()
+        self._thread.join(timeout=1)
+
+
+@contextmanager
+def pinned_mirror_proxy_config(
+    proxy_config: Optional[Mapping[str, object]],
+    allowed_hosts: Optional[List[str]] = None,
+) -> Iterator[Dict[str, object]]:
+    """Yield proxy settings routed through the exact addresses validated here.
+
+    A short-lived loopback relay prevents Requests or Skopeo from resolving the
+    user-controlled proxy hostname a second time. For HTTPS proxies, the relay
+    establishes TLS using the original hostname for certificate verification.
+    """
+    try:
+        validated = validate_mirror_proxy_config(
+            proxy_config,
+            resolve_dns=True,
+            allowed_hosts=allowed_hosts,
+        )
+    except ValueError:
+        raise MirrorProxyValidationError() from None
+    pinned: Dict[str, object] = {}
+    if proxy_config:
+        no_proxy = proxy_config.get("no_proxy")
+        if no_proxy is not None:
+            pinned["no_proxy"] = no_proxy
+
+    with ExitStack() as stack:
+        for key, proxy in validated.items():
+            relay = _PinnedProxyRelay(proxy)
+            relay.start()
+            stack.callback(relay.close)
+            pinned[key] = relay.url
+        yield pinned

--- a/util/security/ssrf.py
+++ b/util/security/ssrf.py
@@ -6,10 +6,11 @@ SSRF prevention utilities for validating user-supplied URLs.
 import ipaddress
 import logging
 import re
+from dataclasses import dataclass
 from socket import AF_UNSPEC, SOCK_STREAM
 from socket import gaierror as _gaierror
 from socket import getaddrinfo as _getaddrinfo
-from typing import List, Optional
+from typing import Dict, List, Mapping, Optional, Tuple
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,17 @@ class SSRFBlockedError(ValueError):
     modification.  The API layer catches this type explicitly to return a
     generic error message instead of leaking internal network topology.
     """
+
+
+@dataclass(frozen=True)
+class ValidatedMirrorProxy:
+    """Canonical proxy destination and the addresses approved for connection."""
+
+    scheme: str
+    hostname: str
+    port: int
+    userinfo: Optional[str]
+    resolved_ips: Tuple[str, ...]
 
 
 # Private and reserved IP networks that must never be accessed by user-controlled URLs.
@@ -70,6 +82,10 @@ _REGISTRY_HOSTNAME_RE = re.compile(
     r"^(?=.{1,253}$)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
     r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$"
 )
+_EXPLICIT_URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
+_VALID_PERCENT_ESCAPE_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_ASCII_DECIMAL_RE = re.compile(r"^[0-9]+$")
+_PROXY_KEYS = ("http_proxy", "https_proxy")
 
 
 def _is_ip_blocked(ip_str: str) -> bool:
@@ -135,6 +151,118 @@ def _is_allowed(hostname: str, ip_str: Optional[str], allowed_hosts: List[str]) 
             return True
 
     return False
+
+
+def validate_mirror_proxy_config(
+    proxy_config: Optional[Mapping[str, object]],
+    resolve_dns: bool = True,
+    allowed_hosts: Optional[List[str]] = None,
+) -> Dict[str, ValidatedMirrorProxy]:
+    """Validate outbound destinations in a repository or organization mirror proxy mapping.
+
+    Explicit HTTP and HTTPS URLs and legacy scheme-less authorities are accepted. Scheme-less
+    values are prefixed with ``http://`` only for parsing and validation; the caller's mapping and
+    values are never changed. ``no_proxy`` is routing policy and is intentionally ignored.
+
+    Args:
+        proxy_config: Mapping containing optional ``http_proxy`` and ``https_proxy`` values
+        resolve_dns: Whether to resolve and inspect every address for proxy hostnames
+        allowed_hosts: Optional hostnames/CIDRs that bypass the SSRF blocklist
+
+    Raises:
+        SSRFBlockedError: If a proxy destination is blocked by SSRF protection
+        ValueError: If the proxy mapping or a configured destination is malformed
+    """
+    if proxy_config is None:
+        return {}
+    if not isinstance(proxy_config, Mapping):
+        raise ValueError("Mirror proxy configuration must be an object")
+
+    validated = {}
+    for proxy_key in _PROXY_KEYS:
+        proxy_value = proxy_config.get(proxy_key)
+        if proxy_value is None or proxy_value == "":
+            continue
+        if not isinstance(proxy_value, str):
+            raise ValueError(f"{proxy_key} must be a string or null")
+        if proxy_value != proxy_value.strip() or any(char.isspace() for char in proxy_value):
+            raise ValueError(f"{proxy_key} must not include whitespace")
+        if "\\" in proxy_value:
+            raise ValueError(f"{proxy_key} contains an invalid character")
+
+        explicit_scheme = _EXPLICIT_URL_SCHEME_RE.match(proxy_value)
+        if "://" in proxy_value and not explicit_scheme:
+            raise ValueError(f"{proxy_key} has an invalid URL scheme")
+        validation_url = proxy_value if explicit_scheme else f"http://{proxy_value}"
+
+        try:
+            parsed = urlparse(validation_url)
+            scheme = parsed.scheme.lower()
+            hostname = parsed.hostname
+            port = parsed.port
+            username = parsed.username
+            password = parsed.password
+        except (TypeError, ValueError):
+            raise ValueError(f"{proxy_key} contains an invalid proxy authority")
+
+        if scheme not in ALLOWED_SCHEMES:
+            raise ValueError(f"{proxy_key} must use an HTTP or HTTPS proxy")
+        if not parsed.netloc or not hostname:
+            raise ValueError(f"{proxy_key} must include a valid proxy hostname")
+        if parsed.params or parsed.query or parsed.fragment or parsed.path not in ("", "/"):
+            raise ValueError(f"{proxy_key} must contain only a proxy authority")
+        if parsed.netloc.count("@") > 1:
+            raise ValueError(f"{proxy_key} contains an ambiguous proxy authority")
+
+        authority = parsed.netloc.rsplit("@", 1)[-1]
+        if "@" in parsed.netloc:
+            userinfo = parsed.netloc.rsplit("@", 1)[0]
+            if not userinfo or (username is None and password is None):
+                raise ValueError(f"{proxy_key} contains invalid proxy credentials")
+            if _VALID_PERCENT_ESCAPE_RE.search(userinfo):
+                raise ValueError(f"{proxy_key} contains invalid proxy credentials")
+
+        if authority.startswith("["):
+            bracket_end = authority.find("]")
+            if bracket_end < 0:
+                raise ValueError(f"{proxy_key} contains an invalid proxy authority")
+            suffix = authority[bracket_end + 1 :]
+            if suffix and not suffix.startswith(":"):
+                raise ValueError(f"{proxy_key} contains an invalid proxy authority")
+            if suffix == ":" or (
+                suffix.startswith(":") and not _ASCII_DECIMAL_RE.fullmatch(suffix[1:])
+            ):
+                raise ValueError(f"{proxy_key} contains an invalid proxy port")
+        else:
+            if authority.count(":") > 1:
+                raise ValueError(f"{proxy_key} contains an invalid proxy authority")
+            if ":" in authority:
+                _, raw_port = authority.rsplit(":", 1)
+                if not _ASCII_DECIMAL_RE.fullmatch(raw_port):
+                    raise ValueError(f"{proxy_key} contains an invalid proxy port")
+
+        if port == 0:
+            raise ValueError(f"{proxy_key} contains an invalid proxy port")
+
+        try:
+            ipaddress.ip_address(hostname)
+        except ValueError:
+            if hostname.endswith(".") or not _REGISTRY_HOSTNAME_RE.fullmatch(hostname):
+                raise ValueError(f"{proxy_key} must include a valid proxy hostname")
+
+        resolved_ips = _validate_host_destination(hostname, resolve_dns, allowed_hosts)
+        proxy_userinfo: Optional[str] = (
+            parsed.netloc.rsplit("@", 1)[0] if "@" in parsed.netloc else None
+        )
+        validated[proxy_key] = ValidatedMirrorProxy(
+            scheme=scheme,
+            hostname=hostname,
+            port=port or (443 if scheme == "https" else 80),
+            userinfo=proxy_userinfo,
+            resolved_ips=tuple(resolved_ips),
+        )
+
+    return validated
 
 
 def validate_external_registry_reference(
@@ -221,7 +349,7 @@ def validate_external_registry_url(
     url: str,
     resolve_dns: bool = True,
     allowed_hosts: Optional[List[str]] = None,
-) -> None:
+) -> List[str]:
     """
     Validate an external registry URL to prevent Server-Side Request Forgery (SSRF).
 
@@ -277,6 +405,15 @@ def validate_external_registry_url(
     if not hostname:
         raise ValueError("URL must include a hostname")
 
+    return _validate_host_destination(hostname, resolve_dns, allowed_hosts)
+
+
+def _validate_host_destination(
+    hostname: str,
+    resolve_dns: bool,
+    allowed_hosts: Optional[List[str]],
+) -> List[str]:
+    """Validate a hostname or IP against the shared SSRF policy and return approved IPs."""
     _allowed_hosts = allowed_hosts or []
 
     # Check blocked hostnames (case-insensitive)
@@ -299,7 +436,7 @@ def validate_external_registry_url(
                 logger.warning("SSRF blocked: IP literal '%s' is in a blocked network", hostname)
                 raise SSRFBlockedError("URL points to a private or reserved IP address")
         # IP literal is allowed (public or allowlisted), no DNS resolution needed
-        return
+        return [str(ip)]
     except SSRFBlockedError:
         raise
     except ValueError:
@@ -307,7 +444,7 @@ def validate_external_registry_url(
         pass
 
     if not resolve_dns:
-        return
+        return []
 
     # Resolve hostname and check all resulting IPs
     try:
@@ -337,3 +474,5 @@ def validate_external_registry_url(
                     ip_str,
                 )
                 raise SSRFBlockedError("URL resolves to a private or reserved IP address")
+
+    return list(dict.fromkeys(resolved_ips))

--- a/util/security/test/test_proxy.py
+++ b/util/security/test/test_proxy.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock, patch
+
+from util.security.proxy import _PinnedProxyServer
+from util.security.ssrf import ValidatedMirrorProxy
+
+
+def _proxy(scheme="http"):
+    return ValidatedMirrorProxy(
+        scheme=scheme,
+        hostname="proxy.example.com",
+        port=8443,
+        userinfo=None,
+        resolved_ips=("93.184.216.34", "93.184.216.35"),
+    )
+
+
+def test_relay_connects_to_validated_ip_instead_of_resolving_hostname():
+    remote = Mock()
+    server = _PinnedProxyServer(_proxy())
+    try:
+        with patch("util.security.proxy.socket.create_connection", return_value=remote) as connect:
+            assert server.open_remote() is remote
+    finally:
+        server.server_close()
+
+    connect.assert_called_once_with(("93.184.216.34", 8443), timeout=30)
+
+
+def test_https_relay_preserves_original_hostname_for_tls_verification():
+    remote = Mock()
+    wrapped = Mock()
+    context = Mock()
+    context.wrap_socket.return_value = wrapped
+    server = _PinnedProxyServer(_proxy("https"))
+    try:
+        with patch("util.security.proxy.socket.create_connection", return_value=remote):
+            with patch("util.security.proxy.ssl.create_default_context", return_value=context):
+                assert server.open_remote() is wrapped
+    finally:
+        server.server_close()
+
+    context.wrap_socket.assert_called_once_with(remote, server_hostname="proxy.example.com")
+
+
+def test_relay_shutdown_closes_active_tunnels_and_rejects_new_ones():
+    client = Mock()
+    remote = Mock()
+    late_connection = Mock()
+    server = _PinnedProxyServer(_proxy())
+    try:
+        assert server.track_connections(client, remote)
+
+        server.close_connections()
+
+        assert not server.track_connections(late_connection)
+    finally:
+        server.server_close()
+
+    client.shutdown.assert_called_once()
+    client.close.assert_called_once()
+    remote.shutdown.assert_called_once()
+    remote.close.assert_called_once()
+    late_connection.close.assert_called_once()

--- a/util/security/test/test_ssrf.py
+++ b/util/security/test/test_ssrf.py
@@ -11,6 +11,7 @@ from util.security.ssrf import (
     SSRFBlockedError,
     validate_external_registry_reference,
     validate_external_registry_url,
+    validate_mirror_proxy_config,
 )
 
 
@@ -282,6 +283,112 @@ class TestValidateExternalRegistryUrl:
             mock_dns.return_value = [(10, 1, 6, "", ("::", 0, 0, 0))]
             with pytest.raises(SSRFBlockedError, match="private or reserved"):
                 validate_external_registry_url("https://registry.example.com")
+
+
+class TestValidateMirrorProxyConfig:
+    """Tests for repository and organization mirror proxy destination validation."""
+
+    @pytest.mark.parametrize(
+        "proxy_value",
+        [
+            "http://proxy.example.com:8080",
+            "https://proxy.example.com:8443",
+            "proxy.example.com:8080",
+            "http://user:password@proxy.example.com:8080",
+            "http://user%40example.com:p%2Fass@proxy.example.com:8080",
+            "http://93.184.216.34:8080",
+            "http://[2606:2800:220:1:248:1893:25c8:1946]:8080",
+        ],
+    )
+    def test_supported_proxy_values_pass(self, proxy_value):
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(2, 1, 6, "", ("93.184.216.34", 0))]
+            validate_mirror_proxy_config({"https_proxy": proxy_value})
+
+    def test_scheme_less_proxy_is_not_added_to_caller_config(self):
+        proxy = {
+            "http_proxy": "proxy.example.com:8080",
+            "https_proxy": None,
+            "no_proxy": "localhost,10.0.0.0/8",
+        }
+        original = proxy.copy()
+
+        validate_mirror_proxy_config(proxy, resolve_dns=False)
+
+        assert proxy == original
+
+    @pytest.mark.parametrize(
+        "proxy",
+        [
+            None,
+            {},
+            {"http_proxy": None, "https_proxy": ""},
+            {"no_proxy": "localhost; rm -rf /"},
+        ],
+    )
+    def test_unset_values_and_no_proxy_are_unchanged(self, proxy):
+        original = proxy.copy() if proxy is not None else None
+        validate_mirror_proxy_config(proxy, resolve_dns=False)
+        assert proxy == original
+
+    @pytest.mark.parametrize(
+        "proxy_value",
+        [
+            "ftp://proxy.example.com:21",
+            "socks5://proxy.example.com:1080",
+            "http://proxy.example.com:bad",
+            "http://proxy.example.com:１２３",
+            "http://[2606:4700:4700::1111]:１２３",
+            "http://proxy.example.com:0",
+            "http://proxy.example.com:70000",
+            "http://proxy.example.com/path",
+            "http://proxy.example.com?target=127.0.0.1",
+            "http://proxy.example.com#@127.0.0.1",
+            "http://first.example@second.example@proxy.example.com",
+            "http://127.0.0.1%40proxy.example.com",
+            "http://proxy.example.com%2F@127.0.0.1",
+            "proxy.example.com; rm -rf /",
+            " proxy.example.com:8080",
+            "2001:4860:4860::8888",
+            "http://[2606:4700:4700::1111]suffix:8080",
+        ],
+    )
+    def test_malformed_or_ambiguous_proxy_rejected(self, proxy_value):
+        with pytest.raises(ValueError):
+            validate_mirror_proxy_config({"http_proxy": proxy_value}, resolve_dns=False)
+
+    @pytest.mark.parametrize(
+        "proxy_value",
+        [
+            "http://127.0.0.1:8080",
+            "169.254.169.254:8080",
+            "http://[::1]:8080",
+            "http://[fc00::1]:8080",
+            "http://user:password@10.0.0.1:8080",
+        ],
+    )
+    def test_blocked_ip_literals_rejected(self, proxy_value):
+        with pytest.raises(SSRFBlockedError):
+            validate_mirror_proxy_config({"http_proxy": proxy_value}, resolve_dns=False)
+
+    def test_mixed_public_and_private_dns_answers_rejected(self):
+        with patch("util.security.ssrf._getaddrinfo") as mock_dns:
+            mock_dns.return_value = [
+                (2, 1, 6, "", ("93.184.216.34", 0)),
+                (2, 1, 6, "", ("10.0.0.1", 0)),
+            ]
+            with pytest.raises(SSRFBlockedError):
+                validate_mirror_proxy_config({"https_proxy": "proxy.example.com:8443"})
+
+    def test_allowlisted_private_proxy_passes(self):
+        validate_mirror_proxy_config(
+            {"http_proxy": "http://10.0.0.1:8080"},
+            allowed_hosts=["10.0.0.0/8"],
+        )
+
+    def test_non_string_proxy_rejected(self):
+        with pytest.raises(ValueError, match="string or null"):
+            validate_mirror_proxy_config({"http_proxy": 8080}, resolve_dns=False)
 
 
 class TestValidateExternalRegistryReference:

--- a/workers/repomirrorworker/repomirrorworker.py
+++ b/workers/repomirrorworker/repomirrorworker.py
@@ -27,7 +27,9 @@ class RepoMirrorWorker(Worker):
         super(RepoMirrorWorker, self).__init__()
         RepoMirrorConfigValidator(features.REPO_MIRROR).valid()
 
-        self._mirrorer = SkopeoMirror()
+        self._mirrorer = SkopeoMirror(
+            allowed_hosts=app.config.get("SSRF_ALLOWED_HOSTS", []),
+        )
         self._next_token = None
         self._org_discovery_token = None
         self._org_next_token = None


### PR DESCRIPTION
Validate repository and organization mirror proxy destinations before configuration mutation. Parse proxy settings consistently and route Requests and Skopeo through short-lived relays pinned to validated IPs to prevent DNS rebinding. Group proxy updates so unsafe legacy values can be cleared atomically.