### PR TITLE
NO-ISSUE: fix(ci): restore Python OCI Start Quay after memcached validation

### DIFF
--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -251,6 +251,7 @@ jobs:
     - name: Start Quay
       run: |
         IP=$(ip addr show dev eth0 | sed -n 's: *inet \([0-9.]*\)/.*:\1:p')
+        echo "Resolved host IP for DB/Redis: ${IP:-<empty>}"
 
         mkdir -p /tmp/config
         cat >/tmp/config/config.yaml <<EOF
@@ -264,14 +265,15 @@ jobs:
         USER_EVENTS_REDIS: {"host": "$IP", "port": 6379}
         PULL_METRICS_REDIS: {"host": "$IP", "port": 6379}
 
-
+        # Use inmemory (config-tool-valid; no external dial). Do NOT use redis
+        # with active_repo_tags_cache_ttl: 0s — RedisDataModelCache treats
+        # timedelta(0) as falsy, so SET gets ex=None + nx=True and the first
+        # tags/list page is cached forever (breaks OCI discovery pagination).
+        # Matches test/testconfig.py: inmemory + 0s expires immediately.
         DATA_MODEL_CACHE_CONFIG:
-          engine: memcached
-          endpoint: [127.0.0.1, 18080]
+          engine: inmemory
           repository_blob_cache_ttl: 60s
           catalog_page_cache_ttl: 60s
-          # OCI Conformance tests don't expect tags to be cached.
-          # If we implement cache invalidation, we can enable it back.
           active_repo_tags_cache_ttl: 0s
         EOF
 
@@ -289,14 +291,33 @@ jobs:
           --volume=/tmp/config:/conf/stack:Z \
           localhost/quay
 
+        status="starting"
         for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-          status=$(docker inspect -f '{{.State.Health.Status}}' quay)
+          status=$(docker inspect -f '{{.State.Health.Status}}' quay 2>/dev/null || echo "not-running")
           printf "[%s] status: %s\n" "$(date -u +'%F %T')" "$status"
-          if [ "$status" == "healthy" ]; then
+          if [ "$status" == "healthy" ] || [ "$status" == "not-running" ]; then
             break
           fi
           sleep 10
         done
+
+        if [ "$status" != "healthy" ]; then
+          echo "::error::Quay container failed to become healthy (status=$status)"
+          echo "=== Resolved IP ==="
+          echo "${IP:-<empty>}"
+          echo "=== docker inspect quay ==="
+          inspect_stop=$(uuidgen)
+          echo "::stop-commands::$inspect_stop"
+          docker inspect quay || true
+          echo "::$inspect_stop::"
+          echo "=== docker logs quay ==="
+          logs_stop=$(uuidgen)
+          echo "::stop-commands::$logs_stop"
+          docker logs quay || true
+          echo "::$logs_stop::"
+          exit 1
+        fi
+
         docker inspect --format='{{json .State.Health}}' quay
 
         docker exec -i quay python <<EOF


### PR DESCRIPTION
Python / OCI Distribution Spec has been failing across unrelated PRs since ~2026-08-05. Failures progressed in two stages: Quay never became healthy, then (after pointing model cache at Redis) conformance panicked on tag discovery.

### Root cause 1 — boot failure (memcached validation)

[#6699](https://github.com/quay/quay/pull/6699) ([PROJQUAY-12447](https://redhat.atlassian.net/browse/PROJQUAY-12447)) taught **config-tool** to validate `DATA_MODEL_CACHE_CONFIG`. For `engine: memcached`, boot runs:

```bash
config-tool validate -c $QUAYCONF/stack/ --mode online
```

via [`conf/init/d_validate_config_bundle.sh`](conf/init/d_validate_config_bundle.sh), and **TCP-dials** the configured endpoint.

OCI CI still used the historical default:

```yaml
DATA_MODEL_CACHE_CONFIG:
  engine: memcached
  endpoint: [127.0.0.1, 18080]
```

No memcached service is started in that job (only Postgres + Redis). Validation failed with:

```text
ModelCacheConfig | DATA_MODEL_CACHE_CONFIG.endpoint: memcached instance cannot be reached,
error: dial tcp 127.0.0.1:18080: connection refused
```

Entrypoint exits before supervisord/Python starts, so `/health/instance` never succeeds.

Memcached is **not** required for Quay; it is one optional model-cache engine. Config-tool accepts `inmemory` / `memcached` / `redis` / `rediscluster` (not `noop`). OCI CI only “needed” memcached because the workflow copied that default.

Unreachable memcached previously made tag-list caching a de facto no-op (get/set failed open), which hid a second bug.

### Root cause 2 — stale tag list after Redis model cache

Switching OCI to `engine: redis` + `active_repo_tags_cache_ttl: 0s` fixed boot but broke Content Discovery:

- Tag list is served via `lookup_cached_active_repository_tags` → `model_cache.retrieve` (**cache first**, then DB).
- There is **no** invalidation of `repo_active_tags__…` on tag push (unlike referrers cache; no open PR for tag-list invalidation).
- `active_repo_tags_cache_ttl: 0s` does **not** disable Redis caching. In `RedisDataModelCache`:

  ```python
  ex=int(expires.total_seconds()) if expires else None
  ```

  `timedelta(0)` is falsy, so Redis `SET` gets `ex=None` (no expiry) with `nx=True` → the first `tags/list` page is cached forever.

Conformance then panics on `GET start of tag is set by last query parameter` (`index out of range [-1]`) because pagination sees a stale/empty tag list after pushing `test0`–`test3`.

Omitting `DATA_MODEL_CACHE_CONFIG` is also wrong: Python falls back to `config.py` defaults (`engine: memcached` @ `127.0.0.1:18080`), which re-triggers root cause 1 if present in the validated bundle path, or otherwise is still the wrong default for this job.

## Changes

In [`.github/workflows/ci-python.yaml`](.github/workflows/ci-python.yaml) **Start Quay**:

1. **Fix boot + tag list:** use in-process model cache (config-tool-valid, no external dial), matching [`test/testconfig.py`](test/testconfig.py). With inmemory, `0s` expires immediately (`ExpiresDict`), so OCI sees fresh tags:

   ```yaml
   DATA_MODEL_CACHE_CONFIG:
     engine: inmemory
     repository_blob_cache_ttl: 60s
     catalog_page_cache_ttl: 60s
     active_repo_tags_cache_ttl: 0s
   ```

2. **Diagnostics:** on non-healthy / exited container, print resolved `$IP`, full `docker inspect quay`, and `docker logs quay`, then `exit 1`. Health poll treats inspect failure as `not-running` and stops waiting early.

3. **Log safety:** wrap `docker inspect` / `docker logs` dumps with unique `::stop-commands::` / resume tokens so untrusted container output cannot inject Actions workflow commands.

## Test plan

- [ ] Python / OCI Distribution Spec becomes healthy and conformance passes (including Content Discovery / `last` pagination)
- [ ] On a forced Start Quay failure, job log shows IP + inspect + logs (with stop-commands wrappers)
- [ ] Confirm config-tool no longer reports memcached `127.0.0.1:18080` connection refused
- [ ] Confirm tag list is not stuck on the first cached page after multiple tag pushes