### PR TITLE
PROJQUAY-12443: fix(api): redirect bootstrap renewal trailing slash

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -143,6 +143,10 @@ location ~ ^/v2/(.+)/_trust/tuf/(.*)$ {
 }
 {% endif %}
 
+location = /api/v1/bootstrap/renew/ {
+    return 307 /api/v1/bootstrap/renew;
+}
+
 location = /api/v1/bootstrap/renew {
     proxy_pass   http://web_app_server;
 

--- a/test/test_nginx_bootstrap.py
+++ b/test/test_nginx_bootstrap.py
@@ -35,7 +35,7 @@ def test_nginx_passes_bootstrap_renewal_location_only_to_renew_endpoint():
 
 def test_nginx_renew_location_repeats_common_proxy_headers():
     server_base = (ROOT / "conf/nginx/server-base.conf.jnj").read_text()
-    renew_block = server_base.split("location = /api/v1/bootstrap/renew", 1)[1].split(
+    renew_block = server_base.split("location = /api/v1/bootstrap/renew {", 1)[1].split(
         "location /api/", 1
     )[0]
 

--- a/test/test_nginx_bootstrap.py
+++ b/test/test_nginx_bootstrap.py
@@ -19,8 +19,9 @@ def test_nginx_maps_bootstrap_renewal_location_from_original_remote_addr():
 def test_nginx_passes_bootstrap_renewal_location_only_to_renew_endpoint():
     server_base = (ROOT / "conf/nginx/server-base.conf.jnj").read_text()
 
-    assert "location = /api/v1/bootstrap/renew" in server_base
-    assert server_base.index("location = /api/v1/bootstrap/renew") < server_base.index(
+    assert "location = /api/v1/bootstrap/renew/" in server_base
+    assert "return 307 /api/v1/bootstrap/renew;" in server_base
+    assert server_base.index("location = /api/v1/bootstrap/renew/") < server_base.index(
         "location /api/"
     )
     assert server_base.count("proxy_set_header X-Quay-Bootstrap-Renewal-Location") == 1

--- a/web/playwright/e2e/api/bootstrap-renew.spec.ts
+++ b/web/playwright/e2e/api/bootstrap-renew.spec.ts
@@ -18,8 +18,38 @@ function isProgrammaticBootstrapEnabled(features: unknown): boolean {
 
 test.describe(
   'Bootstrap token renewal API',
-  {tag: ['@api', '@auth:Database', '@PROJQUAY-12148']},
+  {
+    tag: [
+      '@api',
+      '@auth:Database',
+      '@feature:PROGRAMMATIC_BOOTSTRAP',
+      '@PROJQUAY-12443',
+    ],
+  },
   () => {
+    test('redirects trailing slash to canonical renewal endpoint', async ({
+      playwright,
+    }) => {
+      const request = await playwright.request.newContext({
+        ignoreHTTPSErrors: true,
+      });
+
+      try {
+        const response = await request.post(
+          `${API_URL}${BOOTSTRAP_RENEW_PATH}/`,
+          {
+            maxRedirects: 0,
+            timeout: 10_000,
+          },
+        );
+
+        expect(response.status()).toBe(307);
+        expect(response.headers().location).toBe(BOOTSTRAP_RENEW_PATH);
+      } finally {
+        await request.dispose();
+      }
+    });
+
     test('rejects invalid bearer token without accepting CSRF fallback', async ({
       playwright,
       quayConfig,


### PR DESCRIPTION
## What does this PR do?
Adds an nginx exact-location redirect for the trailing-slash bootstrap token renewal endpoint.

`POST /api/v1/bootstrap/renew/` now returns `307 Temporary Redirect` to `/api/v1/bootstrap/renew`, preserving POST semantics.

## Why?
The trailing-slash request previously bypassed the API resource and returned `405 Method Not Allowed`; the canonical unslashed endpoint reached the expected Flask handler.

## Tests
- `TEST=true PYTHONPATH=. uv run pytest test/test_nginx_bootstrap.py -q` — passed (3 tests)
- Playwright E2E coverage added to `web/playwright/e2e/api/bootstrap-renew.spec.ts`, tagged `@feature:PROGRAMMATIC_BOOTSTRAP` and `@[PROJQUAY-12443](https://redhat.atlassian.net/browse/PROJQUAY-12443)`
- Pre-commit hooks — passed, including ESLint and Playwright required-tag validation
- Broader bootstrap pytest suite executed via `uv run` but currently has unrelated test-environment failures returning 405 for the canonical route; details documented in the handoff.