### PR TITLE
PROJQUAY-12442: fix(config): reject bootstrap scope lists

### DIFF
--- a/util/config/provider/baseprovider.py
+++ b/util/config/provider/baseprovider.py
@@ -42,13 +42,12 @@ def import_yaml(config_obj, config_file):
         if isinstance(c, str):
             raise Exception("Invalid YAML config file: " + str(c))
 
-        for key in c.keys():
-            if key.isupper():
-                config_obj[key] = c[key]
-
-        bootstrap_scope = config_obj.get("BOOTSTRAP_TOKEN_SCOPE")
-        if not isinstance(bootstrap_scope, str):
+        config_updates = {key: value for key, value in c.items() if key.isupper()}
+        bootstrap_scope = config_updates.get("BOOTSTRAP_TOKEN_SCOPE")
+        if "BOOTSTRAP_TOKEN_SCOPE" in config_updates and not isinstance(bootstrap_scope, str):
             raise InvalidConfigException("BOOTSTRAP_TOKEN_SCOPE must be a space-separated string")
+
+        config_obj.update(config_updates)
 
     # if config_obj.get("SETUP_COMPLETE", True):
     #     try:

--- a/util/config/provider/baseprovider.py
+++ b/util/config/provider/baseprovider.py
@@ -47,10 +47,8 @@ def import_yaml(config_obj, config_file):
                 config_obj[key] = c[key]
 
         bootstrap_scope = config_obj.get("BOOTSTRAP_TOKEN_SCOPE")
-        if isinstance(bootstrap_scope, list):
-            raise InvalidConfigException(
-                "BOOTSTRAP_TOKEN_SCOPE must be a space-separated string, " "not a YAML list"
-            )
+        if not isinstance(bootstrap_scope, str):
+            raise InvalidConfigException("BOOTSTRAP_TOKEN_SCOPE must be a space-separated string")
 
     # if config_obj.get("SETUP_COMPLETE", True):
     #     try:

--- a/util/config/provider/baseprovider.py
+++ b/util/config/provider/baseprovider.py
@@ -10,6 +10,12 @@ from util.config.schema import CONFIG_SCHEMA
 logger = logging.getLogger(__name__)
 
 
+class InvalidConfigException(Exception):
+    """Exception raised when an override configuration has an invalid value."""
+
+    pass
+
+
 class CannotWriteConfigException(Exception):
     """
     Exception raised when the config cannot be written.
@@ -39,6 +45,12 @@ def import_yaml(config_obj, config_file):
         for key in c.keys():
             if key.isupper():
                 config_obj[key] = c[key]
+
+        bootstrap_scope = config_obj.get("BOOTSTRAP_TOKEN_SCOPE")
+        if isinstance(bootstrap_scope, list):
+            raise InvalidConfigException(
+                "BOOTSTRAP_TOKEN_SCOPE must be a space-separated string, " "not a YAML list"
+            )
 
     # if config_obj.get("SETUP_COMPLETE", True):
     #     try:

--- a/util/config/test/test_provider.py
+++ b/util/config/test/test_provider.py
@@ -14,11 +14,15 @@ def test_import_yaml_rejects_non_string_bootstrap_token_scope(tmp_path, value):
     else:
         config_file.write_text(f"BOOTSTRAP_TOKEN_SCOPE: {value}\n")
 
+    config = {"EXISTING_CONFIG": "preserved"}
+
     with pytest.raises(
         InvalidConfigException,
         match="BOOTSTRAP_TOKEN_SCOPE must be a space-separated string",
     ):
-        import_yaml({}, str(config_file))
+        import_yaml(config, str(config_file))
+
+    assert config == {"EXISTING_CONFIG": "preserved"}
 
 
 def test_import_yaml_accepts_bootstrap_token_scope_string(tmp_path):

--- a/util/config/test/test_provider.py
+++ b/util/config/test/test_provider.py
@@ -1,0 +1,23 @@
+import pytest
+
+from util.config.provider.baseprovider import InvalidConfigException, import_yaml
+
+
+def test_import_yaml_rejects_bootstrap_token_scope_list(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("BOOTSTRAP_TOKEN_SCOPE:\n" "  - repo:read\n" "  - repo:write\n")
+
+    with pytest.raises(
+        InvalidConfigException,
+        match="BOOTSTRAP_TOKEN_SCOPE must be a space-separated string, not a YAML list",
+    ):
+        import_yaml({}, str(config_file))
+
+
+def test_import_yaml_accepts_bootstrap_token_scope_string(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text('BOOTSTRAP_TOKEN_SCOPE: "repo:read repo:write"\n')
+
+    config = import_yaml({}, str(config_file))
+
+    assert config["BOOTSTRAP_TOKEN_SCOPE"] == "repo:read repo:write"

--- a/util/config/test/test_provider.py
+++ b/util/config/test/test_provider.py
@@ -3,13 +3,20 @@ import pytest
 from util.config.provider.baseprovider import InvalidConfigException, import_yaml
 
 
-def test_import_yaml_rejects_bootstrap_token_scope_list(tmp_path):
+@pytest.mark.parametrize(
+    "value",
+    ["- repo:read\n  - repo:write", "42", "true", "null"],
+)
+def test_import_yaml_rejects_non_string_bootstrap_token_scope(tmp_path, value):
     config_file = tmp_path / "config.yaml"
-    config_file.write_text("BOOTSTRAP_TOKEN_SCOPE:\n" "  - repo:read\n" "  - repo:write\n")
+    if value.startswith("-"):
+        config_file.write_text(f"BOOTSTRAP_TOKEN_SCOPE:\n  {value}\n")
+    else:
+        config_file.write_text(f"BOOTSTRAP_TOKEN_SCOPE: {value}\n")
 
     with pytest.raises(
         InvalidConfigException,
-        match="BOOTSTRAP_TOKEN_SCOPE must be a space-separated string, not a YAML list",
+        match="BOOTSTRAP_TOKEN_SCOPE must be a space-separated string",
     ):
         import_yaml({}, str(config_file))
 


### PR DESCRIPTION
## What does this PR do?

Rejects YAML list values for `BOOTSTRAP_TOKEN_SCOPE` during configuration loading while preserving the existing space-separated string format. This prevents invalid values from reaching OAuth bootstrap token provisioning and failing later with an unclear HTTP 500.

## Testing

- `TEST=true PYTHONPATH=. pytest util/config/test/test_provider.py util/config/test/test_schema.py -q --tb=short` — passed (51 tests)
- Pre-commit hooks — passed

## Jira

[PROJQUAY-12442](https://redhat.atlassian.net/browse/PROJQUAY-12442)