### PR TITLE
QUAYIO-2081: feat(deploy): add graceful shutdown and component-level logging for Envoy

### DIFF
--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -95,7 +95,7 @@ objects:
                 command:
                 - "/bin/sh"
                 - "-c"
-                - "curl -s -X POST http://localhost:9901/drain_listeners?graceful && sleep 30"
+                - "curl -sf --max-time 10 -X POST http://localhost:9901/drain_listeners?graceful ; sleep 30"
           env:
           - name: ENVOY_LOG_LEVEL
             value: "${ENVOY_LOG_LEVEL}"

--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -75,12 +75,25 @@ objects:
                   matchLabels:
                     app: quay-envoy
                 topologyKey: topology.kubernetes.io/zone
+        terminationGracePeriodSeconds: 45
         containers:
         - name: envoy
           image: ${ENVOY_IMAGE}:${ENVOY_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
-          args: ["ulimit -n $(ulimit -Hn) && exec envoy -c /etc/envoy/envoy.yaml --log-level ${ENVOY_LOG_LEVEL}"]
+          args:
+          - |
+            ulimit -n $(ulimit -Hn)
+            ARGS="-c /etc/envoy/envoy.yaml --log-level $ENVOY_LOG_LEVEL --drain-time-s 30"
+            if [ -n "$ENVOY_COMPONENT_LOG_LEVEL" ]; then
+              ARGS="$ARGS --component-log-level $ENVOY_COMPONENT_LOG_LEVEL"
+            fi
+            exec envoy $ARGS
+          env:
+          - name: ENVOY_LOG_LEVEL
+            value: "${ENVOY_LOG_LEVEL}"
+          - name: ENVOY_COMPONENT_LOG_LEVEL
+            value: "${ENVOY_COMPONENT_LOG_LEVEL}"
           ports:
           - containerPort: 8443
             name: https
@@ -181,6 +194,7 @@ objects:
         annotations:
           oneagent.dynatrace.com/inject: "${DYNATRACE_MONITORING}"
       spec:
+        terminationGracePeriodSeconds: 45
         nodeSelector:
           workload: envoy
         tolerations:
@@ -292,6 +306,9 @@ parameters:
 - name: ENVOY_LOG_LEVEL
   value: "info"
   displayName: Envoy log level
+- name: ENVOY_COMPONENT_LOG_LEVEL
+  value: ""
+  displayName: Per-component log levels (e.g. upstream:debug,connection:debug)
 - name: RLS_IMAGE
   value: "docker.io/envoyproxy/ratelimit"
   displayName: Rate limit service container image

--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -75,7 +75,7 @@ objects:
                   matchLabels:
                     app: quay-envoy
                 topologyKey: topology.kubernetes.io/zone
-        terminationGracePeriodSeconds: 45
+        terminationGracePeriodSeconds: 60
         containers:
         - name: envoy
           image: ${ENVOY_IMAGE}:${ENVOY_IMAGE_TAG}
@@ -201,7 +201,7 @@ objects:
         annotations:
           oneagent.dynatrace.com/inject: "${DYNATRACE_MONITORING}"
       spec:
-        terminationGracePeriodSeconds: 45
+        terminationGracePeriodSeconds: 60
         nodeSelector:
           workload: envoy
         tolerations:

--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -89,6 +89,13 @@ objects:
               ARGS="$ARGS --component-log-level $ENVOY_COMPONENT_LOG_LEVEL"
             fi
             exec envoy $ARGS
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - "/bin/sh"
+                - "-c"
+                - "curl -s -X POST http://localhost:9901/drain_listeners?graceful && sleep 30"
           env:
           - name: ENVOY_LOG_LEVEL
             value: "${ENVOY_LOG_LEVEL}"


### PR DESCRIPTION
## Summary

- Add graceful connection draining for Envoy and RLS pods during rollouts
- Add configurable per-component debug logging for Envoy

## Problem

During pod rollouts, Envoy shuts down immediately on SIGTERM, dropping active connections. At 5% traffic (~1,410 req/s), we observed a 13% dip in request rate during rollouts as clients lost their connections and had to reconnect.

## Changes

### Graceful shutdown
- `terminationGracePeriodSeconds: 45` on both Envoy and RLS pods
- `--drain-time-s 30` on the Envoy process
- `preStop` hook that calls `POST /drain_listeners?graceful` to explicitly trigger draining before SIGTERM

On pod termination, the sequence is:
1. Kubernetes triggers `preStop` hook
2. `POST /drain_listeners?graceful` → Envoy stops accepting new connections
3. `/ready` returns 503 → ALB detects unhealthy target, stops routing new traffic
4. Envoy sends `Connection: close` on idle keep-alive connections
5. In-flight requests complete normally
6. `sleep 30` → wait for drain period
7. SIGTERM sent → Envoy shuts down
8. 45s hard deadline → Kubernetes force-kills if needed (safety net)

Without the `preStop` hook, `--drain-time-s` only sets the drain duration but does not trigger draining on SIGTERM — Envoy closes listeners immediately.

### Component-level logging
- New `ENVOY_COMPONENT_LOG_LEVEL` parameter (default: empty)
- When set, enables debug logging for specific Envoy components without flooding all logs
- Example: `upstream:debug,connection:debug,pool:debug`
- Controlled via SaaS file parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)