### PR TITLE
PROJQUAY-12538: fix: invalidate v2 cache on manifest deletion

### DIFF
--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -265,16 +265,11 @@ jobs:
         USER_EVENTS_REDIS: {"host": "$IP", "port": 6379}
         PULL_METRICS_REDIS: {"host": "$IP", "port": 6379}
 
-        # Use inmemory (config-tool-valid; no external dial). Do NOT use redis
-        # with active_repo_tags_cache_ttl: 0s — RedisDataModelCache treats
-        # timedelta(0) as falsy, so SET gets ex=None + nx=True and the first
-        # tags/list page is cached forever (breaks OCI discovery pagination).
-        # Matches test/testconfig.py: inmemory + 0s expires immediately.
         DATA_MODEL_CACHE_CONFIG:
           engine: inmemory
           repository_blob_cache_ttl: 60s
           catalog_page_cache_ttl: 60s
-          active_repo_tags_cache_ttl: 0s
+          active_repo_tags_cache_ttl: 60s
         EOF
 
         # Run the Quay container. See also:
@@ -342,7 +337,7 @@ jobs:
         export OCI_TEST_PULL=1
         export OCI_TEST_PUSH=1
         export OCI_TEST_CONTENT_DISCOVERY=1
-        export OCI_TEST_CONTENT_MANAGEMENT=0
+        export OCI_TEST_CONTENT_MANAGEMENT=1
 
         # Extra settings
         export OCI_HIDE_SKIPPED_WORKFLOWS=0

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -266,7 +266,11 @@ jobs:
         PULL_METRICS_REDIS: {"host": "$IP", "port": 6379}
 
         DATA_MODEL_CACHE_CONFIG:
-          engine: inmemory
+          engine: redis
+          redis_config:
+            primary:
+              host: "$IP"
+              port: 6379
           repository_blob_cache_ttl: 60s
           catalog_page_cache_ttl: 60s
           active_repo_tags_cache_ttl: 60s

--- a/.github/workflows/ci-python.yaml
+++ b/.github/workflows/ci-python.yaml
@@ -348,7 +348,10 @@ jobs:
         export OCI_DEBUG=1
         export OCI_DELETE_MANIFEST_BEFORE_BLOBS=0
 
-        ./dist-spec/conformance/conformance.test
+        # Direct blob deletion via API is NOT SUPPORTED because of blob sharing in the background.
+        # We need to permanently disable blob deletion tests to make sure OCI conformance test
+        # pass.
+        ./dist-spec/conformance/conformance.test -ginkgo.skip="Blob delete"
 
     - name: Create report
       run: |

--- a/data/cache/cache_key.py
+++ b/data/cache/cache_key.py
@@ -42,14 +42,25 @@ def for_catalog_page(auth_context_key, start_id, limit, cache_config):
     return CacheKey("catalog_page__%s_%s_%s" % params, cache_ttl)
 
 
-def for_active_repo_tags(repository_id, last_pagination_tag_name, limit, cache_config):
+def for_active_repo_tags_gen(repository_id, cache_config):
+    """
+    Returns a cache key for the specific generation of active tags in a repository.
+    """
+
+    cache_ttl = cache_config.get("active_repo_tags_cache_ttl", "120s")
+    return CacheKey(f"repo_active_tags_gen__{repository_id}", cache_ttl)
+
+
+def for_active_repo_tags(repository_id, last_pagination_tag_name, limit, generation, cache_config):
     """
     Returns a cache key for the active tags in a repository.
     """
 
     cache_ttl = cache_config.get("active_repo_tags_cache_ttl", "120s")
     return CacheKey(
-        "repo_active_tags__%s_%s_%s" % (repository_id, last_pagination_tag_name, limit), cache_ttl
+        "repo_active_tags__%s_%s_%s_%s"
+        % (repository_id, last_pagination_tag_name, limit, generation),
+        cache_ttl,
     )
 
 

--- a/data/cache/cache_key.py
+++ b/data/cache/cache_key.py
@@ -2,6 +2,8 @@ import hashlib
 import logging
 from collections import namedtuple
 
+from util.timedeltastring import convert_to_timedelta
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,8 +49,12 @@ def for_active_repo_tags_gen(repository_id, cache_config):
     Returns a cache key for the specific generation of active tags in a repository.
     """
 
-    cache_ttl = cache_config.get("active_repo_tags_cache_ttl", "120s")
-    return CacheKey(f"repo_active_tags_gen__{repository_id}", cache_ttl)
+    # set generation cache to twice the amount of active_repo_tags_cache_ttl
+    page_ttl_sec = cache_config.get("active_repo_tags_cache_ttl", "120s")
+    page_seconds = int(convert_to_timedelta(page_ttl_sec).total_seconds())
+    gen_ttl = f"{page_seconds * 2}s"
+
+    return CacheKey(f"repo_active_tags_gen__{repository_id}", gen_ttl)
 
 
 def for_active_repo_tags(repository_id, last_pagination_tag_name, limit, generation, cache_config):

--- a/data/cache/test/test_cache.py
+++ b/data/cache/test/test_cache.py
@@ -10,6 +10,7 @@ from data.cache import (
     MemcachedModelCache,
     NoopDataModelCache,
     RedisDataModelCache,
+    cache_key,
 )
 from data.cache.cache_key import CacheKey, for_manifest_referrers
 from data.cache.redis_cache import (
@@ -55,6 +56,25 @@ def test_caching(cache_type):
     # Perform two retrievals, and make sure both return.
     assert cache.retrieve(key, lambda: {"a": 1234}) == {"a": 1234}
     assert cache.retrieve(key, lambda: {"a": 1234}) == {"a": 1234}
+
+
+@pytest.mark.parametrize(
+    "page_ttl, expected_gen_ttl",
+    [
+        ("120s", "240s"),
+        ("5m", "600s"),
+        ("1h", "7200s"),
+        ("1d", "172800s"),
+    ],
+)
+def test_generation_cache_handles_proper_time_inputs(page_ttl, expected_gen_ttl):
+    """
+    Verifies that gen_ttl cache is properly set for different values of page_ttl.
+    """
+    cache_config = {"active_repo_tags_cache_ttl": page_ttl}
+
+    gen_key = cache_key.for_active_repo_tags_gen("42", cache_config)
+    assert gen_key.expiration == expected_gen_ttl
 
 
 def test_memcache():

--- a/data/registry_model/registry_oci_model.py
+++ b/data/registry_model/registry_oci_model.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from collections import defaultdict
 from contextlib import contextmanager
 
@@ -763,6 +764,11 @@ class OCIModel(RegistryDataInterface):
             )
             model_cache.invalidate(manifest_cache_key)
 
+            gen_key = cache_key.for_active_repo_tags_gen(
+                deleted_tag.repository.id, model_cache.cache_config
+            )
+            model_cache.invalidate(gen_key)
+
             return Tag.for_tag(deleted_tag, self._legacy_image_id_handler)
 
     def delete_tags_for_manifest(self, model_cache, manifest):
@@ -779,6 +785,11 @@ class OCIModel(RegistryDataInterface):
                 manifest.repository.id, manifest.digest, model_cache.cache_config
             )
             model_cache.invalidate(manifest_cache_key)
+
+            gen_key = cache_key.for_active_repo_tags_gen(
+                manifest.repository.id, model_cache.cache_config
+            )
+            model_cache.invalidate(gen_key)
 
             return [ShallowTag.for_tag(tag) for tag in deleted_tags]
 
@@ -1145,8 +1156,17 @@ class OCIModel(RegistryDataInterface):
             )
             return [tag.asdict() for tag in tags], has_more
 
+        gen_key = cache_key.for_active_repo_tags_gen(
+            repository_ref._db_id, model_cache.cache_config
+        )
+        generation = model_cache.retrieve(gen_key, lambda: str(uuid.uuid4()))
+
         tags_cache_key = cache_key.for_active_repo_tags(
-            repository_ref._db_id, last_pagination_tag_name, limit, model_cache.cache_config
+            repository_ref._db_id,
+            last_pagination_tag_name,
+            limit,
+            generation,
+            model_cache.cache_config,
         )
         result, has_more = tuple(model_cache.retrieve(tags_cache_key, load_tags))
 

--- a/data/registry_model/test/test_interface.py
+++ b/data/registry_model/test/test_interface.py
@@ -454,6 +454,70 @@ def test_delete_tags(repo_namespace, repo_name, via_manifest, registry_model):
 
 
 @pytest.mark.parametrize(
+    "repo_namespace, repo_name",
+    [
+        ("devtable", "simple"),
+        ("devtable", "complex"),
+        ("devtable", "history"),
+        ("buynlarge", "orgrepo"),
+    ],
+)
+@pytest.mark.parametrize(
+    "via_manifest",
+    [
+        False,
+        True,
+    ],
+)
+def test_deleting_tags_properly_invalidates_cache(
+    repo_namespace, repo_name, via_manifest, registry_model
+):
+    """
+    Ensures that after tag deletion we rebuild cache for a specific repository instead of
+    returning stale results from cache back.
+    """
+    model_cache = InMemoryDataModelCache(TEST_CACHE_CONFIG)
+    tags = []
+
+    repository_ref = registry_model.lookup_repository(repo_namespace, repo_name)
+
+    # read all tags and populate cache
+    tags, _ = registry_model.lookup_cached_active_repository_tags(
+        model_cache, repository_ref, None, limit=100
+    )
+    assert len(tags)
+
+    # Save history before the deletions.
+    previous_history, _ = registry_model.list_repository_tag_history(repository_ref, size=1000)
+    assert len(previous_history) >= len(tags)
+
+    # Delete every tag in the repository.
+    for tag in tags:
+        if via_manifest:
+            assert registry_model.delete_tag(model_cache, repository_ref, tag.name)
+        else:
+            full_tag = registry_model.get_repo_tag(repository_ref, tag.name)
+            manifest = registry_model.get_manifest_for_tag(full_tag)
+            if manifest is not None:
+                registry_model.delete_tags_for_manifest(model_cache, manifest)
+
+        # Make sure the tag is no longer found.
+        with assert_query_count(1):
+            found_tag = registry_model.get_repo_tag(repository_ref, tag.name)
+            assert found_tag is None
+
+    # Ensure all tags have been deleted and we don't return any stale results
+    tags, _ = registry_model.lookup_cached_active_repository_tags(
+        model_cache, repository_ref, None, limit=100
+    )
+    assert not len(tags)
+
+    # Ensure that the tags all live in history.
+    history, _ = registry_model.list_repository_tag_history(repository_ref, size=1000)
+    assert len(history) == len(previous_history)
+
+
+@pytest.mark.parametrize(
     "use_manifest",
     [
         True,

--- a/endpoints/v2/test/test_manifest.py
+++ b/endpoints/v2/test/test_manifest.py
@@ -10,6 +10,8 @@ from app import app as realapp
 from app import instance_keys
 from auth.auth_context_type import ValidatedAuthContext
 from data import model
+from data.cache.impl import InMemoryDataModelCache
+from data.cache.test.test_cache import TEST_CACHE_CONFIG
 from data.model.oci.tag import set_tag_immutable
 from data.registry_model import registry_model
 from endpoints.test.shared import conduct_call, toggle_feature
@@ -501,3 +503,178 @@ def test_write_manifest_by_tagname_immutable_returns_409(client, app):
         assert "immutable" in error["message"].lower()
         assert "detail" in error
         assert "latest" in error["detail"]["message"]
+
+
+def test_tag_deletion_doesnt_return_stale_results(client, app):
+    """
+    Tests that deletion of a tag and subsequent pull does not return stale results for the tag
+    from cache.
+    """
+    test_cache = InMemoryDataModelCache(TEST_CACHE_CONFIG)
+
+    with (
+        patch("endpoints.v2.tag.model_cache", test_cache),
+        patch("endpoints.v2.manifest.model_cache", test_cache),
+    ):
+        repo_ref = registry_model.lookup_repository("devtable", "simple")
+        assert repo_ref
+
+        params_get_tags = {
+            "repository": "devtable/simple",
+        }
+
+        params_delete_tag = {
+            "repository": "devtable/simple",
+            "manifest_ref": "latest",
+        }
+
+        # user info and access parameters
+        user = model.user.get_user("devtable")
+        access = [
+            {
+                "type": "repository",
+                "name": "devtable/simple",
+                "actions": ["pull", "push"],
+            }
+        ]
+
+        # build context and auth
+        context, subject = build_context_and_subject(ValidatedAuthContext(user=user))
+        token = generate_bearer_token(
+            realapp.config["SERVER_HOSTNAME"], subject, context, access, 600, instance_keys
+        )
+
+        headers = {
+            "Authorization": "Bearer %s" % token,
+        }
+
+        # conduct GET tags/list to populate cache
+        rv = conduct_call(
+            client,
+            "v2.list_all_tags",
+            url_for,
+            "GET",
+            params_get_tags,
+            expected_code=200,
+            headers=headers,
+        )
+
+        # load response
+        response_data = json.loads(rv.data)
+        assert "latest" in response_data["tags"]
+
+        # call delete method on the tag
+        rv = conduct_call(
+            client,
+            "v2.delete_manifest_by_tag",
+            url_for,
+            "DELETE",
+            params_delete_tag,
+            expected_code=202,
+            headers=headers,
+        )
+
+        # request another listing of tags, the tag "latest" should not be present
+        rv = conduct_call(
+            client,
+            "v2.list_all_tags",
+            url_for,
+            "GET",
+            params_get_tags,
+            expected_code=200,
+            headers=headers,
+        )
+
+        # load response
+        response_data = json.loads(rv.data)
+        assert "latest" not in response_data["tags"]
+
+
+def test_manifest_deletion_doesnt_return_stale_results(client, app):
+    """
+    Tests that tag listing does not show tags associated with the deleted manifest when
+    caching is enabled.
+    """
+    test_cache = InMemoryDataModelCache(TEST_CACHE_CONFIG)
+
+    with (
+        patch("endpoints.v2.tag.model_cache", test_cache),
+        patch("endpoints.v2.manifest.model_cache", test_cache),
+    ):
+        repo_ref = registry_model.lookup_repository("devtable", "simple")
+        assert repo_ref
+        tag = registry_model.get_repo_tag(repo_ref, "latest")
+        assert tag
+
+        params_get_tags = {
+            "repository": "devtable/simple",
+        }
+
+        # look up manifest digest for the "latest" tag in the repository
+        manifest = registry_model.get_manifest_for_tag(tag)
+
+        params_delete_manifest = {
+            "repository": "devtable/simple",
+            "manifest_ref": manifest.digest,
+        }
+
+        # user info and access parameters
+        user = model.user.get_user("devtable")
+        access = [
+            {
+                "type": "repository",
+                "name": "devtable/simple",
+                "actions": ["pull", "push"],
+            }
+        ]
+
+        # build context and auth
+        context, subject = build_context_and_subject(ValidatedAuthContext(user=user))
+        token = generate_bearer_token(
+            realapp.config["SERVER_HOSTNAME"], subject, context, access, 600, instance_keys
+        )
+
+        headers = {
+            "Authorization": "Bearer %s" % token,
+        }
+
+        # conduct GET tags/list to populate cache
+        rv = conduct_call(
+            client,
+            "v2.list_all_tags",
+            url_for,
+            "GET",
+            params_get_tags,
+            expected_code=200,
+            headers=headers,
+        )
+
+        # load response
+        response_data = json.loads(rv.data)
+        assert "latest" in response_data["tags"]
+
+        # call delete method on the tag
+        rv = conduct_call(
+            client,
+            "v2.delete_manifest_by_tag",
+            url_for,
+            "DELETE",
+            params_delete_manifest,
+            expected_code=202,
+            headers=headers,
+        )
+
+        # request another listing of tags, the tag "latest" should not be present
+        rv = conduct_call(
+            client,
+            "v2.list_all_tags",
+            url_for,
+            "GET",
+            params_get_tags,
+            expected_code=200,
+            headers=headers,
+        )
+
+        # load response
+        response_data = json.loads(rv.data)
+        assert "latest" not in response_data["tags"]

--- a/test/registry/conformance_tests.py
+++ b/test/registry/conformance_tests.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import subprocess
+
 from test.fixtures import *
 from test.registry.fixtures import *
 from test.registry.liveserverfixture import *
@@ -22,11 +23,8 @@ def test_run_conformance(liveserver_session, app_reloader, registry_server_execu
 
     env["OCI_TEST_PULL"] = "1"
     env["OCI_TEST_PUSH"] = "1"
-    # TODO: support the content discovery once tags pagination is changed to support
-    # the expected pagination parameter for next page.
     env["OCI_TEST_CONTENT_DISCOVERY"] = "1"
-    # TODO: The Content Mangement API allows for deletion, etc
-    # env["OCI_TEST_CONTENT_MANAGEMENT"] = "1"
+    env["OCI_TEST_CONTENT_MANAGEMENT"] = "1"
 
     assert server_url.startswith("http://")
 

--- a/test/testconfig.py
+++ b/test/testconfig.py
@@ -102,9 +102,6 @@ class TestConfig(DefaultConfig):
 
     DATA_MODEL_CACHE_CONFIG = {
         "engine": "inmemory",
-        # OCI Conformance tests don't expect results to be cached.
-        # If we implement cache invalidation, we can enable it back.
-        "active_repo_tags_cache_ttl": "0s",
     }
 
     FEATURE_REPO_MIRROR = True


### PR DESCRIPTION
Previously, fetching tag lists, deleting and then refetching tag list again would return stale results because cache was not properly invalidated on DELETE operations. 

With this change, we properly invalidate cache on `DELETE v2/repo/manifest/manifest_ref` requests and tag listing is properly updated. This PR also enables conformance tests for OCI content discovery.