### PR TITLE
NO-ISSUE: fix: platform KeyError in _get_legacy_manifest

### DIFF
--- a/image/oci/index.py
+++ b/image/oci/index.py
@@ -346,7 +346,9 @@ class OCIIndex(ManifestListInterface):
         if none.
         """
         for manifest_ref in self._parsed[INDEX_MANIFESTS_KEY]:
-            platform = manifest_ref[INDEX_PLATFORM_KEY]
+            platform = manifest_ref.get(INDEX_PLATFORM_KEY)
+            if platform is None:
+                continue
             architecture = platform.get(INDEX_ARCHITECTURE_KEY, None)
             os = platform.get(INDEX_OS_KEY, None)
             if architecture == "amd64" and os == "linux":

--- a/image/oci/index.py
+++ b/image/oci/index.py
@@ -391,9 +391,11 @@ class OCIIndex(ManifestListInterface):
         if none or error.
         """
         for manifest_ref in self.manifests(content_retriever):
-            platform = manifest_ref._manifest_data[INDEX_PLATFORM_KEY]
-            architecture = platform[INDEX_ARCHITECTURE_KEY]
-            os = platform[INDEX_OS_KEY]
+            platform = manifest_ref._manifest_data.get(INDEX_PLATFORM_KEY)
+            if platform is None:
+                continue
+            architecture = platform.get(INDEX_ARCHITECTURE_KEY)
+            os = platform.get(INDEX_OS_KEY)
             if architecture != "amd64" or os != "linux":
                 continue
 

--- a/image/oci/test/test_oci_index.py
+++ b/image/oci/test/test_oci_index.py
@@ -9,6 +9,8 @@ from image.oci.index import MalformedIndex, OCIIndex, OCIIndexBuilder
 from image.oci.manifest import OCIManifest
 from image.oci.test.testdata import (
     OCI_IMAGE_INDEX_MANIFEST,
+    OCI_IMAGE_INDEX_MANIFEST_ALL_MISSING_PLATFORM,
+    OCI_IMAGE_INDEX_MANIFEST_MISSING_PLATFORM,
     OCI_IMAGE_INDEX_MANIFEST_WITH_ARTIFACT_TYPE_AND_SUBJECT,
     OCI_IMAGE_INDEX_MANIFEST_WITHOUT_AMD,
     OCI_IMAGE_WITH_ARTIFACT_TYPES_AND_ANNOTATIONS,
@@ -229,3 +231,22 @@ def test_oci_index_with_mixed_docker_and_oci_children():
     assert isinstance(manifests[3].manifest_obj, DockerSchema2ManifestList)
 
     assert index.amd64_linux_manifest_digest == "sha256:aaa111"
+
+
+def test_index_missing_platform_skips_to_valid():
+    index = OCIIndex(Bytes.for_string_or_unicode(OCI_IMAGE_INDEX_MANIFEST_MISSING_PLATFORM))
+    assert index.is_manifest_list
+    assert index.child_manifest_digests() == [
+        "sha256:aaaa111111111111111111111111111111111111111111111111111111111111",
+        "sha256:bbbb222222222222222222222222222222222222222222222222222222222222",
+    ]
+    assert (
+        index.amd64_linux_manifest_digest
+        == "sha256:bbbb222222222222222222222222222222222222222222222222222222222222"
+    )
+
+
+def test_index_all_missing_platform_returns_none():
+    index = OCIIndex(Bytes.for_string_or_unicode(OCI_IMAGE_INDEX_MANIFEST_ALL_MISSING_PLATFORM))
+    assert index.is_manifest_list
+    assert index.amd64_linux_manifest_digest is None

--- a/image/oci/test/testdata/__init__.py
+++ b/image/oci/test/testdata/__init__.py
@@ -33,3 +33,39 @@ OCI_IMAGE_INDEX_MANIFEST_WITH_ARTIFACT_TYPE_AND_SUBJECT = '{"schemaVersion":2,"a
 
 
 OCI_IMAGE_WITH_ARTIFACT_TYPES_AND_ANNOTATIONS = '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/vnd.cyclonedx+json","config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2,"data":"e30="},"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar","digest":"sha256:f9d5ec3c9dd70ddccedc62cda9e91302635f217b44ebdeef6a67baff8fc73549","size":14,"annotations":{"org.opencontainers.image.title":"hi.txt"}}],"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:506db421764d1fb236de66d61fe81ccb92af2ab9b89f6ef7afbfeebd220b883f","size":521},"annotations":{"key1":"val1","org.opencontainers.image.created":"2024-07-18T14:43:47Z"}}'
+
+OCI_IMAGE_INDEX_MANIFEST_MISSING_PLATFORM = """{
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 1334,
+      "digest": "sha256:aaaa111111111111111111111111111111111111111111111111111111111111"
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 1334,
+      "digest": "sha256:bbbb222222222222222222222222222222222222222222222222222222222222",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ]
+}"""
+
+OCI_IMAGE_INDEX_MANIFEST_ALL_MISSING_PLATFORM = """{
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 1334,
+      "digest": "sha256:aaaa111111111111111111111111111111111111111111111111111111111111"
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 1334,
+      "digest": "sha256:cccc333333333333333333333333333333333333333333333333333333333333"
+    }
+  ]
+}"""


### PR DESCRIPTION
Fixes a `KeyError`, https://coreos.sentry.io/issues/6885209238/?end=2026-08-07T20%3A30%3A00&project=52148&query=is%3Aunresolved&referrer=issue-stream&start=2026-08-07T17%3A54%3A00

We are seeing this pop-up on Quay.io.