### PR TITLE
QUAYIO-1828: feat(build): enable ECR backup for quayio-frontend Konflux builds

### DIFF
--- a/.tekton/quayio-frontend-pull-request.yaml
+++ b/.tekton/quayio-frontend-pull-request.yaml
@@ -25,8 +25,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: use-ecr
+    value: "true"
   - name: output-image
-    value: quay.io/redhat-user-workloads/quayio-tenant/quayio-frontend/quayio-frontend:on-pr-{{revision}}
+    value: 'quayio-frontend-backup-staging:on-pr-{{revision}}'
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/quayio-frontend-push.yaml
+++ b/.tekton/quayio-frontend-push.yaml
@@ -24,8 +24,10 @@ spec:
     value: '{{source_url}}'
   - name: revision
     value: '{{revision}}'
+  - name: use-ecr
+    value: 'true'
   - name: output-image
-    value: quay.io/redhat-user-workloads/quayio-tenant/quayio-frontend/quayio-frontend:{{revision}}
+    value: 'quayio-frontend-backup-staging:{{revision}}'
   - name: dockerfile
     value: build-tools/Dockerfile
   - name: path-context


### PR DESCRIPTION
## Summary
- Enable ECR backup push for the quayio-frontend Konflux pipelines (both push and PR), matching the existing quay-py3 pattern
- Adds `use-ecr: true` param and sets `output-image` to `quayio-frontend-backup-staging`

In Konflux I had to run `oc secrets link build-pipeline-quayio-frontend ecr-token-quayio-prod -n quayio-tenant --for=pull,mount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)