### PR TITLE
PROJQUAY-12447: fix: Fix password parameter typo

### DIFF
--- a/config-tool/pkg/lib/fieldgroups/cache/cache_structs.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_structs.go
@@ -30,8 +30,8 @@ type RedisConfigGroup struct {
 
 // RedisNodeConfig contains the redis nodes
 type RedisNodeConfig struct {
-	Host string `json:"host,omitempty" yaml:"host,omitempty"`
-	Port int    `default:"6379" json:"port,omitempty" yaml:"port,omitempty"`
-	Pass string `json:"pass,omitempty" yaml:"pass,omitempty"`
-	SSL  bool   `default:"false" json:"ssl,omitempty" yaml:"ssl,omitempty"`
+	Host     string `json:"host,omitempty" yaml:"host,omitempty"`
+	Port     int    `default:"6379" json:"port,omitempty" yaml:"port,omitempty"`
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	SSL      bool   `default:"false" json:"ssl,omitempty" yaml:"ssl,omitempty"`
 }

--- a/config-tool/pkg/lib/fieldgroups/cache/cache_test.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_test.go
@@ -79,6 +79,22 @@ func TestValidateCache(t *testing.T) {
 			want: "typeError",
 		},
 		{
+			name: "Cache_Tst_Redis_Primary_With_Password",
+			config: map[string]any{
+				"DATA_MODEL_CACHE_CONFIG": map[string]any{
+					"engine": "redis",
+					"redis_config": map[string]any{
+						"primary": map[string]any{
+							"host":     "localhost",
+							"port":     1234,
+							"password": "somesupersecrettoken",
+						},
+					},
+				},
+			},
+			want: "valid",
+		},
+		{
 			name: "Cache_Test_Memcached_Valid_Config",
 			config: map[string]any{
 				"DATA_MODEL_CACHE_CONFIG": map[string]any{

--- a/config-tool/pkg/lib/fieldgroups/cache/cache_validator.go
+++ b/config-tool/pkg/lib/fieldgroups/cache/cache_validator.go
@@ -79,7 +79,7 @@ func (fg *CacheFieldGroup) Validate(opts shared.Options) []shared.ValidationErro
 			options := &redis.Options{
 				Addr: net.JoinHostPort(fg.DataModelCache.RedisConfig.Primary.Host,
 					strconv.Itoa(fg.DataModelCache.RedisConfig.Primary.Port)),
-				Password:  fg.DataModelCache.RedisConfig.Primary.Pass,
+				Password:  fg.DataModelCache.RedisConfig.Primary.Password,
 				DB:        0,
 				TLSConfig: tlsConfig,
 			}
@@ -101,7 +101,7 @@ func (fg *CacheFieldGroup) Validate(opts shared.Options) []shared.ValidationErro
 				options := &redis.Options{
 					Addr: net.JoinHostPort(fg.DataModelCache.RedisConfig.Replica.Host,
 						strconv.Itoa(fg.DataModelCache.RedisConfig.Replica.Port)),
-					Password:  fg.DataModelCache.RedisConfig.Replica.Pass,
+					Password:  fg.DataModelCache.RedisConfig.Replica.Password,
 					DB:        0,
 					TLSConfig: tlsConfig,
 				}
@@ -124,7 +124,7 @@ func (fg *CacheFieldGroup) Validate(opts shared.Options) []shared.ValidationErro
 
 				options := &redis.Options{
 					Addr:      net.JoinHostPort(node.Host, strconv.Itoa(node.Port)),
-					Password:  node.Pass,
+					Password:  node.Password,
 					DB:        0,
 					TLSConfig: tlsConfig,
 				}

--- a/config-tool/testdata/config-bundle/config.yaml
+++ b/config-tool/testdata/config-bundle/config.yaml
@@ -14,7 +14,7 @@ DATA_MODEL_CACHE_CONFIG:
     replica:
       host: 192.168.250.160
       port: 6379
-      pass: "supersecretpassword"
+      password: "supersecretpassword"
       ssl: true
   repository_blob_cache_ttl: 120s
   catalog_page_cache_ttl: 360s

--- a/data/cache/redis_cache.py
+++ b/data/cache/redis_cache.py
@@ -55,10 +55,10 @@ def redis_cache_from_config(cache_config):
         redis_config:
           primary:
             host: localhost
-            pass: password
+            password: password
           replica:
             host: localhost
-            pass: password
+            password: password
 
     rediscluster:
 


### PR DESCRIPTION
The original PR had an error where the password field in Redis configuration was incorrectly marked as `pass` instead of `password`. This was caused by a faulty docs string in the Redis module. This PR fixes both the validator and the docs string.

Addresses #6742 .