### PR TITLE
NO-ISSUE: fix(ci): match nested test/ dirs in e2e coverage check

### DIFF
--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -143,7 +143,7 @@ jobs:
 
           # Subtract files that are themselves tests within source directories
           TEST_FILES_IN_SOURCE=$(echo "$CHANGED_FILES" | grep -cE \
-            '^(auth|buildman|buildstatus|buildtrigger|data|digest|endpoints|events|features|health|image|notifications|oauth|plans|proxy|storage|util|workers)/(.*/)?test/' \
+            '^(auth|buildman|buildstatus|buildtrigger|data|digest|endpoints|events|features|health|image|notifications|oauth|plans|proxy|storage|util|workers)/(.*/)?test/|^web/src/(.*/)?[^/]+\.test\.[^/]+$' \
             || true)
 
           SOURCE_CHANGES=$((SOURCE_CHANGES - TEST_FILES_IN_SOURCE))

--- a/.github/workflows/ci-web.yaml
+++ b/.github/workflows/ci-web.yaml
@@ -143,7 +143,7 @@ jobs:
 
           # Subtract files that are themselves tests within source directories
           TEST_FILES_IN_SOURCE=$(echo "$CHANGED_FILES" | grep -cE \
-            '^(auth|buildman|buildstatus|buildtrigger|data|digest|endpoints|events|features|health|image|notifications|oauth|plans|proxy|storage|util|workers)/test/' \
+            '^(auth|buildman|buildstatus|buildtrigger|data|digest|endpoints|events|features|health|image|notifications|oauth|plans|proxy|storage|util|workers)/(.*/)?test/' \
             || true)
 
           SOURCE_CHANGES=$((SOURCE_CHANGES - TEST_FILES_IN_SOURCE))


### PR DESCRIPTION
The e2e-test-check job's TEST_FILES_IN_SOURCE regex only excluded files directly under <dir>/test/, so files under nested test dirs like image/shared/test/ were still counted as source changes, triggering a false-positive e2e coverage failure.