### PR TITLE
QUAYIO-2044: feat(gc): add audit logging for blob deletion with S3 delete marker

### DIFF
--- a/data/model/gc.py
+++ b/data/model/gc.py
@@ -342,7 +342,13 @@ def _run_garbage_collection(context):
 
         # GC any blobs encountered.
         if context.blob_ids:
-            storage_ids_removed = set(storage.garbage_collect_storage(context.blob_ids))
+            storage_ids_removed = set(
+                storage.garbage_collect_storage(
+                    context.blob_ids,
+                    namespace=context.repository.namespace_user.username,
+                    repo_name=context.repository.name,
+                )
+            )
             for blob_removed_id in storage_ids_removed:
                 context.mark_blob_id_removed(blob_removed_id)
                 has_changes = True

--- a/data/model/storage.py
+++ b/data/model/storage.py
@@ -101,7 +101,7 @@ def _is_storage_orphaned(candidate_id):
     return True
 
 
-def garbage_collect_storage(storage_id_whitelist):
+def garbage_collect_storage(storage_id_whitelist, namespace=None, repo_name=None):
     """
     Performs GC on a possible subset of the storage's with the IDs found in the whitelist.
 
@@ -239,8 +239,14 @@ def garbage_collect_storage(storage_id_whitelist):
                     ):
                         continue
 
-                    logger.debug("Removing %s from %s", image_path, location_name)
-                    config.store.remove({location_name}, image_path)
+                    version_id = config.store.remove({location_name}, image_path)
+                    if namespace:
+                        msg = "Removed blob %s from %s (path: %s) " "under namespace %s (repo: %s)"
+                        args = [storage_checksum, location_name, image_path, namespace, repo_name]
+                        if version_id:
+                            msg += " (delete_marker: %s)"
+                            args.append(version_id)
+                        logger.info(msg, *args)
                     gc_storage_blobs_deleted.inc()
             # If a lock cannot be acquired, skip deletion of the blob from storage backend (safe option)
             except LockNotAcquiredException:

--- a/data/model/test/test_gc.py
+++ b/data/model/test/test_gc.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import logging
 import random
 import string
 from contextlib import contextmanager
@@ -1304,6 +1305,140 @@ def test_gc_collects_orphaned_blobs_with_placement(default_tag_policy, initializ
     assert normal_blob.id in orphaned_ids
 
     assert not ImageStorage.select().where(ImageStorage.id == normal_blob.id).exists()
+
+
+def test_gc_storage_logs_namespace_and_repo(default_tag_policy, initialized_db):
+    """
+    When namespace and repo_name are provided, garbage_collect_storage emits an
+    info-level log line containing both values for each removed blob.
+    """
+    location = ImageStorageLocation.get(name="local_us")
+
+    blob_content = random.randbytes(1024)
+    blob_digest = _get_digest(blob_content)
+
+    orphan = ImageStorage.create(
+        content_checksum=blob_digest,
+        image_size=len(blob_content),
+        uncompressed_size=len(blob_content),
+    )
+    ImageStoragePlacement.create(storage=orphan, location=location)
+    storage.put_content(["local_us"], storage.blob_path(blob_digest), blob_content)
+
+    with mock_patch("data.model.storage.logger") as mock_logger:
+        mock_logger.debug = logging.getLogger().debug
+        mock_logger.warning = logging.getLogger().warning
+
+        orphaned_ids = storage_model.garbage_collect_storage(
+            [orphan.id], namespace="testns", repo_name="testrepo"
+        )
+
+    assert orphan.id in orphaned_ids
+    mock_logger.info.assert_called()
+    log_msg = mock_logger.info.call_args[0][0] % tuple(mock_logger.info.call_args[0][1:])
+    assert "testns" in log_msg
+    assert "testrepo" in log_msg
+    assert blob_digest in log_msg
+
+
+def test_gc_storage_no_log_without_namespace(default_tag_policy, initialized_db):
+    """
+    When namespace is not provided, garbage_collect_storage does not emit
+    the audit log line.
+    """
+    location = ImageStorageLocation.get(name="local_us")
+
+    blob_content = random.randbytes(1024)
+    blob_digest = _get_digest(blob_content)
+
+    orphan = ImageStorage.create(
+        content_checksum=blob_digest,
+        image_size=len(blob_content),
+        uncompressed_size=len(blob_content),
+    )
+    ImageStoragePlacement.create(storage=orphan, location=location)
+    storage.put_content(["local_us"], storage.blob_path(blob_digest), blob_content)
+
+    with mock_patch("data.model.storage.logger") as mock_logger:
+        mock_logger.debug = logging.getLogger().debug
+        mock_logger.warning = logging.getLogger().warning
+
+        orphaned_ids = storage_model.garbage_collect_storage([orphan.id])
+
+    assert orphan.id in orphaned_ids
+    mock_logger.info.assert_not_called()
+
+
+def test_gc_storage_returns_version_id_from_store(default_tag_policy, initialized_db):
+    """
+    garbage_collect_storage captures the return value of config.store.remove
+    and includes a delete_marker in the log when the storage backend returns
+    a version id.
+    """
+    location = ImageStorageLocation.get(name="local_us")
+
+    blob_content = random.randbytes(1024)
+    blob_digest = _get_digest(blob_content)
+
+    orphan = ImageStorage.create(
+        content_checksum=blob_digest,
+        image_size=len(blob_content),
+        uncompressed_size=len(blob_content),
+    )
+    ImageStoragePlacement.create(storage=orphan, location=location)
+    storage.put_content(["local_us"], storage.blob_path(blob_digest), blob_content)
+
+    fake_version_id = "v-abc123"
+    original_remove = storage.remove
+
+    def patched_remove(locations, path):
+        original_remove(locations, path)
+        return fake_version_id
+
+    import logging
+
+    with mock_patch.object(storage, "remove", side_effect=patched_remove):
+        with mock_patch("data.model.storage.logger") as mock_logger:
+            mock_logger.debug = logging.getLogger().debug
+            mock_logger.warning = logging.getLogger().warning
+
+            storage_model.garbage_collect_storage(
+                [orphan.id], namespace="testns", repo_name="testrepo"
+            )
+
+    mock_logger.info.assert_called()
+    log_msg = mock_logger.info.call_args[0][0] % tuple(mock_logger.info.call_args[0][1:])
+    assert fake_version_id in log_msg
+    assert "delete_marker" in log_msg
+
+
+def test_gc_storage_omits_delete_marker_when_none(default_tag_policy, initialized_db):
+    """
+    When the storage backend returns None (non-versioned bucket), the log
+    line should not include a delete_marker fragment.
+    """
+    location = ImageStorageLocation.get(name="local_us")
+
+    blob_content = random.randbytes(1024)
+    blob_digest = _get_digest(blob_content)
+
+    orphan = ImageStorage.create(
+        content_checksum=blob_digest,
+        image_size=len(blob_content),
+        uncompressed_size=len(blob_content),
+    )
+    ImageStoragePlacement.create(storage=orphan, location=location)
+    storage.put_content(["local_us"], storage.blob_path(blob_digest), blob_content)
+
+    with mock_patch("data.model.storage.logger") as mock_logger:
+        mock_logger.debug = logging.getLogger().debug
+        mock_logger.warning = logging.getLogger().warning
+
+        storage_model.garbage_collect_storage([orphan.id], namespace="testns", repo_name="testrepo")
+
+    mock_logger.info.assert_called()
+    log_msg = mock_logger.info.call_args[0][0] % tuple(mock_logger.info.call_args[0][1:])
+    assert "delete_marker" not in log_msg
 
 
 def test_gc_proxy_cache_expired_temp_tag(default_tag_policy, initialized_db):

--- a/storage/cloud.py
+++ b/storage/cloud.py
@@ -440,8 +440,8 @@ class _CloudStorage(BaseStorageV2):
         obj = self.get_cloud_bucket().Object(path)
         try:
             obj.load()
-            obj.delete()
-            return
+            resp = obj.delete()
+            return resp.get("VersionId")
         except botocore.exceptions.ClientError as s3r:
             if not s3r.response["Error"]["Code"] in _MISSING_KEY_ERROR_CODES:
                 raise

--- a/storage/test/test_cloud_storage.py
+++ b/storage/test/test_cloud_storage.py
@@ -68,7 +68,8 @@ def test_basicop(storage_engine):
     storage_engine.get_checksum(_TEST_PATH)
 
     # Remove the file.
-    storage_engine.remove(_TEST_PATH)
+    result = storage_engine.remove(_TEST_PATH)
+    assert result is None
 
     # Ensure it no longer exists.
     with pytest.raises(IOError):
@@ -78,6 +79,32 @@ def test_basicop(storage_engine):
         storage_engine.get_checksum(_TEST_PATH)
 
     assert not storage_engine.exists(_TEST_PATH)
+
+
+def test_remove_returns_version_id_on_versioned_bucket():
+    with mock_s3():
+        client = boto3.client("s3", region_name=_TEST_REGION)
+        client.create_bucket(
+            Bucket=_TEST_BUCKET,
+            CreateBucketConfiguration={"LocationConstraint": _TEST_REGION},
+        )
+        client.put_bucket_versioning(
+            Bucket=_TEST_BUCKET,
+            VersioningConfiguration={"Status": "Enabled"},
+        )
+
+        engine = S3Storage(
+            _TEST_CONTEXT, "some/path", _TEST_BUCKET, _TEST_USER, _TEST_PASSWORD, _TEST_REGION
+        )
+        engine.put_content(_TEST_PATH, _TEST_CONTENT)
+
+        version_id = engine.remove(_TEST_PATH)
+        assert version_id is not None
+
+
+def test_remove_nonexistent_returns_none(storage_engine):
+    result = storage_engine.remove("does/not/exist")
+    assert result is None
 
 
 def test_storage_setup(storage_engine):


### PR DESCRIPTION
Pass namespace and repo name into garbage_collect_storage so each blob removal is logged with its checksum, location, path, and owning repo. Return the S3 VersionId (delete marker) from cloud storage remove and include it in the log when present.