### PR TITLE
QUAYIO-1708: feat(nginx): enable stub_status for connection monitoring

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -374,6 +374,13 @@ location /static/ {
     error_page 404 /404;
 }
 
+location /nginx_status {
+    stub_status on;
+    allow 127.0.0.1;
+    allow ::1;
+    deny all;
+}
+
 error_page 502 =502 /502.html;
 
 location = /502.html {


### PR DESCRIPTION
## Summary

Enable nginx `stub_status` module on a localhost-only endpoint (`/nginx_status`) for monitoring active connections.

## Why

As we ramp production traffic through Envoy we need visibility into nginx's connection capacity. 

Currently nginx has `worker_connections: 10,240` per worker, but we have no visibility into how many are in use. If `accepts > handled` in the stub_status output, nginx is dropping connections.

## What it exposes

`GET /nginx_status` (localhost only) returns:

```
Active connections: 291
server accepts handled requests
 16630948 16630948 31070465
Reading: 6 Writing: 179 Waiting: 106
```

- **Active connections** — total open connections
- **accepts vs handled** — if handled < accepts, nginx is dropping connections
- **Reading/Writing/Waiting** — connection state breakdown

## Security

Access restricted to localhost only (`allow 127.0.0.1; allow ::1; deny all;`). Not accessible from outside the pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)