### PR TITLE
NO-ISSUE: feat(mirror-registry): log initialization steps for quay init

### DIFF
--- a/internal/dal/dbcore/bootstrap.go
+++ b/internal/dal/dbcore/bootstrap.go
@@ -34,7 +34,7 @@ func ensureSchema(ctx context.Context, db *sql.DB, dbPath string) error {
 	}
 
 	if tableCount == 0 {
-		slog.Info("initializing database")
+		slog.Info("initializing database", "path", dbPath)
 		if err := InitDatabase(ctx, db, io.Discard); err != nil {
 			return fmt.Errorf("init database: %w", err)
 		}

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -443,16 +443,23 @@ func validateInitConfig(cfg *Config) error {
 }
 
 func (inst *Installer) initialize(ctx context.Context, cfg *Config) error {
-	for _, dir := range []string{cfg.DataDir, filepath.Join(cfg.DataDir, "storage")} {
+	slog.Info("initializing registry", "data-dir", cfg.DataDir)
+
+	storageDir := filepath.Join(cfg.DataDir, "storage")
+	for _, dir := range []string{cfg.DataDir, storageDir} {
 		if err := inst.fs.MkdirAll(dir, 0o750); err != nil {
 			return fmt.Errorf("create directory %s: %w", dir, err)
 		}
 	}
 
+	if cfg.ConfigPath != "" {
+		slog.Debug("resolving database from configuration file", "config", cfg.ConfigPath)
+	}
 	dbPath, runtimeCfg, err := resolveInitDatabase(cfg)
 	if err != nil {
 		return err
 	}
+	slog.Debug("database path resolved", "path", dbPath)
 
 	db, err := dbcore.Setup(ctx, dbPath)
 	if err != nil {
@@ -469,6 +476,7 @@ func (inst *Installer) initialize(ctx context.Context, cfg *Config) error {
 			return fmt.Errorf("registry is already initialized; supplied password was not applied and existing credentials are unchanged")
 		}
 		slog.Info("initial administrator already provisioned")
+		slog.Info("registry initialization complete", "data-dir", cfg.DataDir, "database", dbPath)
 		return nil
 	}
 
@@ -480,6 +488,8 @@ func (inst *Installer) initialize(ctx context.Context, cfg *Config) error {
 	if err != nil {
 		return err
 	}
+	credentialPath := filepath.Join(cfg.DataDir, "auth", "admin-password")
+
 	created, err := bootstrap.AdminUser(ctx, db, cfg.InitUser, password)
 	if err != nil {
 		return fmt.Errorf("create initial administrator: %w", err)
@@ -487,6 +497,13 @@ func (inst *Installer) initialize(ctx context.Context, cfg *Config) error {
 	if !created {
 		return fmt.Errorf("initial administrator was created concurrently; credentials were not changed")
 	}
+
+	slog.Info("registry initialization complete",
+		"data-dir", cfg.DataDir,
+		"database", dbPath,
+		"admin-user", cfg.InitUser,
+		"credential", credentialPath,
+	)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
Adds `slog` logging throughout `installer.initialize()` (shared by `quay init` and `quay install`) so runs report what is actually being set up: data/storage directory creation, database resolution (debug level), database initialization, whether an existing admin was found vs newly provisioned, the admin credential file location, and a final "registry initialization complete" summary. Also includes the resolved database path on the existing dbcore `initializing database` log line. Log-only change; no behavior change.

## Related Issue
NO-ISSUE: logging usability improvement, no tracked ticket.

## Changes
- `internal/installer/installer.go`: add `slog.Info`/`slog.Debug` calls around directory creation, database resolution, admin provisioning, and a completion summary in `initialize()`.
- `internal/dal/dbcore/bootstrap.go`: include the database path on the `initializing database` log line.

## Testing
- [x] `go build ./...` passes
- [x] `go vet ./internal/installer/... ./internal/dal/dbcore/... ./internal/mirrorregistry/...` passes
- [x] `gofmt -l` on changed files — no output (clean)
- [x] `go test ./internal/installer/... ./internal/dal/dbcore/... ./internal/mirrorregistry/...` — all packages pass
- [x] Manual: `go run ./cmd/quay init -data-dir <dir> -hostname registry.example.com -log-format text` — verified new log lines on both a fresh initialization and a re-run against an already-initialized data dir, and again with `-log-level debug` to confirm the debug-level database resolution line.

## Notes
Pure logging addition with no functional/behavioral change, so no new tests were added beyond the existing installer test suite (which already covers `initialize()` behavior).
