### PR TITLE
QUAYIO-2118: fix(ui): hide super:user scope when FEATURE_SUPER_USERS is disabled

### DIFF
--- a/web/playwright/e2e/organization/oauth-applications.spec.ts
+++ b/web/playwright/e2e/organization/oauth-applications.spec.ts
@@ -244,9 +244,7 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
       await page.getByRole('tab', {name: 'API Access Tokens'}).click();
       await page.getByTestId('generate-new-api-token-button').click();
 
-      await expect(
-        page.getByTestId('api-token-scope-repo:read'),
-      ).toBeVisible();
+      await expect(page.getByTestId('api-token-scope-repo:read')).toBeVisible();
       await expect(
         page.getByTestId('api-token-scope-super:user'),
       ).not.toBeVisible();

--- a/web/playwright/e2e/organization/oauth-applications.spec.ts
+++ b/web/playwright/e2e/organization/oauth-applications.spec.ts
@@ -1,4 +1,4 @@
-import {test, expect} from '../../fixtures';
+import {test, expect, skipUnlessFeature} from '../../fixtures';
 
 test.describe('OAuth Applications', {tag: ['@organization']}, () => {
   test('OAuth app lifecycle: create, view, update, delete', async ({
@@ -223,6 +223,58 @@ test.describe('OAuth Applications', {tag: ['@organization']}, () => {
     const remaining = await api.raw.getOAuthApplications(org.name);
     expect(remaining).toHaveLength(0);
   });
+
+  test(
+    'hides super:user scope when FEATURE_SUPER_USERS is disabled',
+    {tag: '@QUAYIO-2118'},
+    async ({authenticatedPage: page, api, quayConfig}) => {
+      test.skip(
+        quayConfig?.features?.SUPER_USERS === true,
+        'SUPER_USERS is enabled on this instance',
+      );
+
+      const org = await api.organization('oauth-scope');
+      const app = await api.oauthApplication(org.name, 'scope-test-app');
+
+      await page.goto(`/organization/${org.name}?tab=OAuthApplications`);
+      await page
+        .getByTestId('oauth-applications-table')
+        .getByRole('button', {name: app.name, exact: true})
+        .click();
+      await page.getByRole('tab', {name: 'API Access Tokens'}).click();
+      await page.getByTestId('generate-new-api-token-button').click();
+
+      await expect(
+        page.getByTestId('api-token-scope-repo:read'),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId('api-token-scope-super:user'),
+      ).not.toBeVisible();
+    },
+  );
+
+  test(
+    'shows super:user scope when FEATURE_SUPER_USERS is enabled',
+    {tag: '@QUAYIO-2118'},
+    async ({authenticatedPage: page, api, quayConfig}) => {
+      test.skip(...skipUnlessFeature(quayConfig, 'SUPER_USERS'));
+
+      const org = await api.organization('oauth-scope-su');
+      const app = await api.oauthApplication(org.name, 'scope-su-app');
+
+      await page.goto(`/organization/${org.name}?tab=OAuthApplications`);
+      await page
+        .getByTestId('oauth-applications-table')
+        .getByRole('button', {name: app.name, exact: true})
+        .click();
+      await page.getByRole('tab', {name: 'API Access Tokens'}).click();
+      await page.getByTestId('generate-new-api-token-button').click();
+
+      await expect(
+        page.getByTestId('api-token-scope-super:user'),
+      ).toBeVisible();
+    },
+  );
 
   test('reset client secret with confirmation', async ({
     authenticatedPage: page,

--- a/web/playwright/fixtures.ts
+++ b/web/playwright/fixtures.ts
@@ -931,7 +931,8 @@ export type QuayFeature =
   | 'NONSUPERUSER_TEAM_SYNCING_SETUP'
   | 'BUILD_SUPPORT'
   | 'STORAGE_REPLICATION'
-  | 'SPAM_DETECTION';
+  | 'SPAM_DETECTION'
+  | 'SUPER_USERS';
 
 /**
  * Quay configuration from /config endpoint

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/APIAccessTokensTab.test.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/APIAccessTokensTab.test.tsx
@@ -422,6 +422,51 @@ describe('APIAccessTokensTab', () => {
     expect(screen.getByTestId('api-token-scope-repo:read')).not.toBeChecked();
   });
 
+  it('hides super:user scope when FEATURE_SUPER_USERS is disabled', async () => {
+    const user = userEvent.setup();
+    mockDefaultHooks();
+    vi.mocked(useQuayConfig).mockReturnValue({
+      features: {ASSIGN_OAUTH_TOKEN: true, SUPER_USERS: false},
+      config: {LOCAL_OAUTH_HANDLER: '/oauth/localapp'},
+    });
+    render(<APIAccessTokensTab application={application} orgName="myorg" />);
+
+    await user.click(screen.getByTestId('generate-new-api-token-button'));
+
+    expect(
+      screen.queryByTestId('api-token-scope-super:user'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Super User Access')).not.toBeInTheDocument();
+    expect(screen.getByTestId('api-token-scope-org:admin')).toBeVisible();
+  });
+
+  it('hides super:user scope when FEATURE_SUPER_USERS is undefined', async () => {
+    const user = userEvent.setup();
+    mockDefaultHooks();
+    render(<APIAccessTokensTab application={application} orgName="myorg" />);
+
+    await user.click(screen.getByTestId('generate-new-api-token-button'));
+
+    expect(
+      screen.queryByTestId('api-token-scope-super:user'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows super:user scope when FEATURE_SUPER_USERS is enabled', async () => {
+    const user = userEvent.setup();
+    mockDefaultHooks();
+    vi.mocked(useQuayConfig).mockReturnValue({
+      features: {ASSIGN_OAUTH_TOKEN: true, SUPER_USERS: true},
+      config: {LOCAL_OAUTH_HANDLER: '/oauth/localapp'},
+    });
+    render(<APIAccessTokensTab application={application} orgName="myorg" />);
+
+    await user.click(screen.getByTestId('generate-new-api-token-button'));
+
+    expect(screen.getByTestId('api-token-scope-super:user')).toBeVisible();
+    expect(screen.getByText('Super User Access')).toBeVisible();
+  });
+
   it('hides user assignment when the feature is disabled', async () => {
     const user = userEvent.setup();
     mockDefaultHooks();

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/APIAccessTokensTab.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/APIAccessTokensTab.tsx
@@ -643,8 +643,13 @@ const APIAccessTokensTab: React.FC<APIAccessTokensTabProps> = (
           </FormGroup>
           <FormGroup label="Scopes" fieldId="api-token-scopes" isRequired>
             <Stack hasGutter>
-              {Object.entries(OAUTH_SCOPES).map(
-                ([scopeName, scopeInfo]: [string, OAuthScope]) => (
+              {Object.entries(OAUTH_SCOPES)
+                .filter(
+                  ([scopeName]) =>
+                    scopeName !== 'super:user' ||
+                    quayConfig?.features?.SUPER_USERS === true,
+                )
+                .map(([scopeName, scopeInfo]: [string, OAuthScope]) => (
                   <StackItem key={scopeName}>
                     <Checkbox
                       id={`api-token-scope-${scopeName}`}

--- a/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/APIAccessTokensTab.tsx
+++ b/web/src/routes/OrganizationsList/Organization/Tabs/OAuthApplications/ManageOAuthApplicationTabs/APIAccessTokensTab.tsx
@@ -662,8 +662,7 @@ const APIAccessTokensTab: React.FC<APIAccessTokensTabProps> = (
                       data-testid={`api-token-scope-${scopeName}`}
                     />
                   </StackItem>
-                ),
-              )}
+                ))}
             </Stack>
           </FormGroup>
         </Form>


### PR DESCRIPTION
## Summary
- Hide the "Super User Access" (`super:user`) scope checkbox in the OAuth API token generation modal when `FEATURE_SUPER_USERS` is not enabled
- On quay.io (where `FEATURE_SUPER_USERS` is `false`), selecting this scope caused a 403 `insufficient_scope` error because `_can_mint_scope` calls `SuperUserPermission().can()` which always fails on non-superuser deployments
- Add vitest coverage for the three states: feature disabled, undefined, and enabled


🤖 Generated with [Claude Code](https://claude.com/claude-code)