### PR TITLE
PROJQUAY-12593: fix(migrate): handle rootless podman UID namespace in SQLite access

### DIFF
--- a/internal/dal/dbcore/sqlite.go
+++ b/internal/dal/dbcore/sqlite.go
@@ -65,7 +65,7 @@ func OpenSQLiteReadOnly(dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("source database not found: %s: %w", dbPath, err)
 	}
 
-	uri := url.URL{Scheme: sqliteURIScheme, Path: dbPath, RawQuery: "mode=ro", OmitHost: true}
+	uri := url.URL{Scheme: sqliteURIScheme, Path: dbPath, RawQuery: "mode=ro&immutable=1", OmitHost: true}
 	db, err := sql.Open("sqlite", uri.String())
 	if err != nil {
 		return nil, fmt.Errorf("open %s read-only: %w", dbPath, err)

--- a/internal/dal/dbcore/sqlite.go
+++ b/internal/dal/dbcore/sqlite.go
@@ -59,7 +59,11 @@ func OpenSQLite(dbPath string) (*sql.DB, error) {
 }
 
 // OpenSQLiteReadOnly opens an existing SQLite database for source preflight.
-// mode=ro prevents schema or data changes and never creates a missing source.
+// mode=ro&immutable=1 prevents schema or data changes, never creates a missing
+// source, and avoids creating WAL/SHM lock files. immutable=1 is required for
+// rootless podman volumes where the directory is owned by the container's
+// user-namespace-mapped UID. WAL-resident data will not be visible; callers
+// that need uncheckpointed WAL data must copy the DB first.
 func OpenSQLiteReadOnly(dbPath string) (*sql.DB, error) {
 	if _, err := os.Stat(dbPath); err != nil {
 		return nil, fmt.Errorf("source database not found: %s: %w", dbPath, err)

--- a/internal/dal/dbcore/sqlite_test.go
+++ b/internal/dal/dbcore/sqlite_test.go
@@ -91,6 +91,53 @@ func TestOpenSQLiteReadOnly(t *testing.T) {
 	})
 }
 
+func TestOpenSQLiteReadOnly_SucceedsWithReadOnlyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "source.db")
+
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(t.Context(), "CREATE TABLE ro_test (v TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(t.Context(), "INSERT INTO ro_test (v) VALUES ('hello')"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+
+	readOnly, err := OpenSQLiteReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLiteReadOnly should succeed on read-only directory: %v", err)
+	}
+	defer readOnly.Close()
+
+	var v string
+	if err := readOnly.QueryRowContext(t.Context(), "SELECT v FROM ro_test").Scan(&v); err != nil {
+		t.Fatalf("SELECT failed: %v", err)
+	}
+	if v != "hello" {
+		t.Fatalf("got %q, want hello", v)
+	}
+
+	walPath := dbPath + "-wal"
+	shmPath := dbPath + "-shm"
+	if _, err := os.Stat(walPath); err == nil {
+		t.Fatalf("WAL file should not be created in read-only directory: %s", walPath)
+	}
+	if _, err := os.Stat(shmPath); err == nil {
+		t.Fatalf("SHM file should not be created in read-only directory: %s", shmPath)
+	}
+}
+
 func TestOpenSQLite_PathsContainingURIDelimiters(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "omr?with#symbols&.db")

--- a/internal/dal/dbcore/sqlite_test.go
+++ b/internal/dal/dbcore/sqlite_test.go
@@ -138,6 +138,38 @@ func TestOpenSQLiteReadOnly_SucceedsWithReadOnlyDirectory(t *testing.T) {
 	}
 }
 
+func TestOpenSQLiteReadOnly_ModeRoAloneFailsOnReadOnlyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "source.db")
+
+	db, err := OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(t.Context(), "CREATE TABLE ro_test (v TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+
+	uri := url.URL{Scheme: sqliteURIScheme, Path: dbPath, RawQuery: "mode=ro", OmitHost: true}
+	roOnly, err := sql.Open("sqlite", uri.String())
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer roOnly.Close()
+
+	if err := roOnly.PingContext(t.Context()); err == nil {
+		t.Fatal("mode=ro without immutable=1 should fail on a read-only directory, but Ping succeeded")
+	}
+}
+
 func TestOpenSQLite_PathsContainingURIDelimiters(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "omr?with#symbols&.db")

--- a/internal/dal/dbcore/sqlite_test.go
+++ b/internal/dal/dbcore/sqlite_test.go
@@ -112,6 +112,13 @@ func TestOpenSQLiteReadOnly_SucceedsWithReadOnlyDirectory(t *testing.T) {
 	if err := os.Chmod(dir, 0o555); err != nil {
 		t.Fatal(err)
 	}
+	probe := filepath.Join(dir, ".probe")
+	if f, err := os.Create(probe); err == nil {
+		f.Close()
+		os.Remove(probe)
+		os.Chmod(dir, 0o755)
+		t.Skip("test identity can write to 0555 directory (CAP_DAC_OVERRIDE); skipping")
+	}
 	t.Cleanup(func() { os.Chmod(dir, 0o755) })
 
 	readOnly, err := OpenSQLiteReadOnly(dbPath)
@@ -140,8 +147,20 @@ func TestOpenSQLiteReadOnly_SucceedsWithReadOnlyDirectory(t *testing.T) {
 
 func TestOpenSQLiteReadOnly_ModeRoAloneFailsOnReadOnlyDirectory(t *testing.T) {
 	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "source.db")
 
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	probe := filepath.Join(dir, ".probe")
+	if f, err := os.Create(probe); err == nil {
+		f.Close()
+		os.Remove(probe)
+		os.Chmod(dir, 0o755)
+		t.Skip("test identity can write to 0555 directory (CAP_DAC_OVERRIDE); skipping")
+	}
+	os.Chmod(dir, 0o755)
+
+	dbPath := filepath.Join(dir, "source.db")
 	db, err := OpenSQLite(dbPath)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/migrate/copy.go
+++ b/internal/migrate/copy.go
@@ -37,43 +37,10 @@ func (m *Migrator) copyData(ctx context.Context) error {
 	// source modes is enough. If the image moves to a non-root USER, add an
 	// ownership or ACL normalization step for the target data directory here.
 
-	// Copy database (rename quay_sqlite.db → quay.db).
 	targetDB := filepath.Join(m.DataDir, "quay.db")
-	if resuming {
-		slog.Info("migration marker already existed, recopying database", "dst", targetDB)
+	if err := m.copyDatabase(ctx, targetDB, resuming); err != nil {
+		return err
 	}
-
-	if err := checkpointSQLite(ctx, m.Source.DBPath); err != nil {
-		// Rootless podman volumes are owned by the container's mapped UID.
-		// Checkpoint requires write access to the source, which the host
-		// user lacks. Fall back to copying the DB plus any WAL/SHM files,
-		// then checkpoint the target copy that we own.
-		slog.Warn("cannot checkpoint source database in place, copying with WAL", "err", err)
-		if err := copyFileIdempotent(ctx, m.Source.DBPath, targetDB, resuming); err != nil {
-			return fmt.Errorf("copy database: %w", err)
-		}
-		for _, suffix := range []string{"-wal", "-shm"} {
-			src := m.Source.DBPath + suffix
-			if _, serr := os.Stat(src); serr == nil {
-				dst := targetDB + suffix
-				if err := copyFileIdempotent(ctx, src, dst, resuming); err != nil {
-					return fmt.Errorf("copy database %s: %w", suffix, err)
-				}
-				slog.Info("copied database sidecar", "file", suffix)
-			}
-		}
-		if err := checkpointSQLite(ctx, targetDB); err != nil {
-			return fmt.Errorf("checkpoint target database: %w", err)
-		}
-		for _, suffix := range []string{"-wal", "-shm"} {
-			_ = os.Remove(targetDB + suffix)
-		}
-	} else {
-		if err := copyFileIdempotent(ctx, m.Source.DBPath, targetDB, resuming); err != nil {
-			return fmt.Errorf("copy database: %w", err)
-		}
-	}
-	slog.Info("copied database", "src", m.Source.DBPath, "dst", targetDB)
 
 	sourceConfig, err := m.loadSourceConfigAndImportRegistryKey(ctx, targetDB, resuming)
 	if err != nil {
@@ -217,6 +184,64 @@ func (m *Migrator) writeRuntimeConfig(sourceCfg *config.Config) error {
 		return fmt.Errorf("write runtime config: %w", err)
 	}
 	slog.Info("wrote runtime config", "src", sourcePath, "dst", targetPath)
+	return nil
+}
+
+func (m *Migrator) checkpoint(ctx context.Context, dbPath string) error {
+	if m.Checkpoint != nil {
+		return m.Checkpoint(ctx, dbPath)
+	}
+	return checkpointSQLite(ctx, dbPath)
+}
+
+// copyDatabase copies the source SQLite DB to targetDB. It attempts to
+// checkpoint the source WAL first. On rootless podman volumes (where the
+// source is owned by the container's mapped UID), the checkpoint fails
+// because the host user lacks write access. In that case we fall back to
+// copying the DB plus any WAL/SHM sidecar files, then checkpoint the
+// target copy that we own.
+func (m *Migrator) copyDatabase(ctx context.Context, targetDB string, resuming bool) error {
+	if resuming {
+		slog.Info("migration marker already existed, recopying database", "dst", targetDB)
+	}
+
+	if err := m.checkpoint(ctx, m.Source.DBPath); err != nil {
+		slog.Warn("cannot checkpoint source database in place, copying with WAL", "err", err)
+		if err := copyFileIdempotent(ctx, m.Source.DBPath, targetDB, resuming); err != nil {
+			return fmt.Errorf("copy database: %w", err)
+		}
+		if err := copySidecars(ctx, m.Source.DBPath, targetDB, resuming); err != nil {
+			return err
+		}
+		if err := m.checkpoint(ctx, targetDB); err != nil {
+			return fmt.Errorf("checkpoint target database: %w", err)
+		}
+		for _, suffix := range []string{"-wal", "-shm"} {
+			_ = os.Remove(targetDB + suffix)
+		}
+	} else {
+		if err := copyFileIdempotent(ctx, m.Source.DBPath, targetDB, resuming); err != nil {
+			return fmt.Errorf("copy database: %w", err)
+		}
+	}
+	slog.Info("copied database", "src", m.Source.DBPath, "dst", targetDB)
+	return nil
+}
+
+func copySidecars(ctx context.Context, srcDB, dstDB string, force bool) error {
+	for _, suffix := range []string{"-wal", "-shm"} {
+		src := srcDB + suffix
+		if _, err := os.Stat(src); os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("stat database %s: %w", suffix, err)
+		}
+		dst := dstDB + suffix
+		if err := copyFileIdempotent(ctx, src, dst, force); err != nil {
+			return fmt.Errorf("copy database %s: %w", suffix, err)
+		}
+		slog.Info("copied database sidecar", "file", suffix)
+	}
 	return nil
 }
 

--- a/internal/migrate/copy.go
+++ b/internal/migrate/copy.go
@@ -38,15 +38,40 @@ func (m *Migrator) copyData(ctx context.Context) error {
 	// ownership or ACL normalization step for the target data directory here.
 
 	// Copy database (rename quay_sqlite.db → quay.db).
-	if err := checkpointSQLite(ctx, m.Source.DBPath); err != nil {
-		return fmt.Errorf("checkpoint source database: %w", err)
-	}
 	targetDB := filepath.Join(m.DataDir, "quay.db")
 	if resuming {
 		slog.Info("migration marker already existed, recopying database", "dst", targetDB)
 	}
-	if err := copyFileIdempotent(ctx, m.Source.DBPath, targetDB, resuming); err != nil {
-		return fmt.Errorf("copy database: %w", err)
+
+	if err := checkpointSQLite(ctx, m.Source.DBPath); err != nil {
+		// Rootless podman volumes are owned by the container's mapped UID.
+		// Checkpoint requires write access to the source, which the host
+		// user lacks. Fall back to copying the DB plus any WAL/SHM files,
+		// then checkpoint the target copy that we own.
+		slog.Warn("cannot checkpoint source database in place, copying with WAL", "err", err)
+		if err := copyFileIdempotent(ctx, m.Source.DBPath, targetDB, resuming); err != nil {
+			return fmt.Errorf("copy database: %w", err)
+		}
+		for _, suffix := range []string{"-wal", "-shm"} {
+			src := m.Source.DBPath + suffix
+			if _, serr := os.Stat(src); serr == nil {
+				dst := targetDB + suffix
+				if err := copyFileIdempotent(ctx, src, dst, resuming); err != nil {
+					return fmt.Errorf("copy database %s: %w", suffix, err)
+				}
+				slog.Info("copied database sidecar", "file", suffix)
+			}
+		}
+		if err := checkpointSQLite(ctx, targetDB); err != nil {
+			return fmt.Errorf("checkpoint target database: %w", err)
+		}
+		for _, suffix := range []string{"-wal", "-shm"} {
+			_ = os.Remove(targetDB + suffix)
+		}
+	} else {
+		if err := copyFileIdempotent(ctx, m.Source.DBPath, targetDB, resuming); err != nil {
+			return fmt.Errorf("copy database: %w", err)
+		}
 	}
 	slog.Info("copied database", "src", m.Source.DBPath, "dst", targetDB)
 

--- a/internal/migrate/copy_test.go
+++ b/internal/migrate/copy_test.go
@@ -2,9 +2,11 @@ package migrate
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -478,21 +480,31 @@ func TestCopyData_SkipsRootCAWhenNotDetected(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
-func TestCopyData_FallsBackWhenCheckpointFails(t *testing.T) {
-	dbDir := t.TempDir()
-	dbPath := filepath.Join(dbDir, "quay_sqlite.db")
-	createCopyTestDB(t, dbPath)
+var errSimulatedPermission = fmt.Errorf("simulated: permission denied")
 
-	// Make source directory read-only to simulate rootless UID mismatch.
-	if err := os.Chmod(dbDir, 0o555); err != nil {
-		t.Fatal(err)
+// failFirstCheckpoint returns a checkpoint function that fails the first call
+// (simulating rootless source access) and delegates subsequent calls (target
+// checkpoint) to the real implementation.
+func failFirstCheckpoint() checkpointFunc {
+	called := false
+	return func(ctx context.Context, dbPath string) error {
+		if !called {
+			called = true
+			return errSimulatedPermission
+		}
+		return checkpointSQLite(ctx, dbPath)
 	}
-	t.Cleanup(func() { os.Chmod(dbDir, 0o755) })
+}
+
+func TestCopyData_FallsBackWhenCheckpointFails(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "quay_sqlite.db")
+	createCopyTestDB(t, dbPath)
 
 	targetDir := filepath.Join(t.TempDir(), "target")
 	m := &Migrator{
-		DataDir: targetDir,
-		Out:     &bytes.Buffer{},
+		DataDir:    targetDir,
+		Out:        &bytes.Buffer{},
+		Checkpoint: failFirstCheckpoint(),
 		Source: OMRSource{
 			DBPath: dbPath,
 		},
@@ -521,33 +533,35 @@ func TestCopyData_FallbackPreservesWALData(t *testing.T) {
 	dbDir := t.TempDir()
 	dbPath := filepath.Join(dbDir, "quay_sqlite.db")
 
-	srcDB, err := dbcore.OpenSQLite(dbPath)
+	// Open two connections: the first keeps the WAL alive (SQLite only
+	// auto-checkpoints when the LAST connection closes), and the second
+	// writes the test data.
+	keepAlive, err := dbcore.OpenSQLite(dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := srcDB.ExecContext(t.Context(), "PRAGMA journal_mode=WAL"); err != nil {
+	defer func() { _ = keepAlive.Close() }()
+
+	if _, err := keepAlive.ExecContext(t.Context(), "PRAGMA journal_mode=WAL"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := srcDB.ExecContext(t.Context(), "CREATE TABLE wal_test (value TEXT)"); err != nil {
+	if _, err := keepAlive.ExecContext(t.Context(), "CREATE TABLE wal_test (value TEXT)"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := srcDB.ExecContext(t.Context(), "INSERT INTO wal_test (value) VALUES ('committed-in-wal')"); err != nil {
-		t.Fatal(err)
-	}
-	if err := srcDB.Close(); err != nil {
+	if _, err := keepAlive.ExecContext(t.Context(), "INSERT INTO wal_test (value) VALUES ('committed-in-wal')"); err != nil {
 		t.Fatal(err)
 	}
 
-	// Make source directory read-only to simulate rootless UID mismatch.
-	if err := os.Chmod(dbDir, 0o555); err != nil {
-		t.Fatal(err)
+	walPath := dbPath + "-wal"
+	if _, err := os.Stat(walPath); os.IsNotExist(err) {
+		t.Fatal("WAL file should exist before fallback copy")
 	}
-	t.Cleanup(func() { os.Chmod(dbDir, 0o755) })
 
 	targetDir := filepath.Join(t.TempDir(), "target")
 	m := &Migrator{
-		DataDir: targetDir,
-		Out:     &bytes.Buffer{},
+		DataDir:    targetDir,
+		Out:        &bytes.Buffer{},
+		Checkpoint: failFirstCheckpoint(),
 		Source: OMRSource{
 			DBPath: dbPath,
 		},

--- a/internal/migrate/copy_test.go
+++ b/internal/migrate/copy_test.go
@@ -478,6 +478,100 @@ func TestCopyData_SkipsRootCAWhenNotDetected(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
+func TestCopyData_FallsBackWhenCheckpointFails(t *testing.T) {
+	dbDir := t.TempDir()
+	dbPath := filepath.Join(dbDir, "quay_sqlite.db")
+	createCopyTestDB(t, dbPath)
+
+	// Make source directory read-only to simulate rootless UID mismatch.
+	if err := os.Chmod(dbDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dbDir, 0o755) })
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+	m := &Migrator{
+		DataDir: targetDir,
+		Out:     &bytes.Buffer{},
+		Source: OMRSource{
+			DBPath: dbPath,
+		},
+	}
+
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("copyData should succeed via fallback: %v", err)
+	}
+
+	targetDB, err := dbcore.OpenSQLite(filepath.Join(targetDir, "quay.db"))
+	if err != nil {
+		t.Fatalf("open target: %v", err)
+	}
+	defer func() { _ = targetDB.Close() }()
+
+	var value string
+	if err := targetDB.QueryRowContext(t.Context(), "SELECT value FROM copy_test").Scan(&value); err != nil {
+		t.Fatalf("query copied row: %v", err)
+	}
+	if value != "ok" {
+		t.Errorf("copied value = %q, want ok", value)
+	}
+}
+
+func TestCopyData_FallbackPreservesWALData(t *testing.T) {
+	dbDir := t.TempDir()
+	dbPath := filepath.Join(dbDir, "quay_sqlite.db")
+
+	srcDB, err := dbcore.OpenSQLite(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := srcDB.ExecContext(t.Context(), "PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := srcDB.ExecContext(t.Context(), "CREATE TABLE wal_test (value TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := srcDB.ExecContext(t.Context(), "INSERT INTO wal_test (value) VALUES ('committed-in-wal')"); err != nil {
+		t.Fatal(err)
+	}
+	if err := srcDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make source directory read-only to simulate rootless UID mismatch.
+	if err := os.Chmod(dbDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dbDir, 0o755) })
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+	m := &Migrator{
+		DataDir: targetDir,
+		Out:     &bytes.Buffer{},
+		Source: OMRSource{
+			DBPath: dbPath,
+		},
+	}
+
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("copyData should succeed via fallback: %v", err)
+	}
+
+	targetDB, err := dbcore.OpenSQLite(filepath.Join(targetDir, "quay.db"))
+	if err != nil {
+		t.Fatalf("open target: %v", err)
+	}
+	defer func() { _ = targetDB.Close() }()
+
+	var value string
+	if err := targetDB.QueryRowContext(t.Context(), "SELECT value FROM wal_test").Scan(&value); err != nil {
+		t.Fatalf("query WAL row from fallback copy: %v", err)
+	}
+	if value != "committed-in-wal" {
+		t.Errorf("copied value = %q, want committed-in-wal", value)
+	}
+}
+
 func mkdirCopyTestDir(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(path, 0o750); err != nil {

--- a/internal/migrate/copy_test.go
+++ b/internal/migrate/copy_test.go
@@ -314,6 +314,48 @@ func TestCopyData_RecopiesDatabaseWhenMarkerExists(t *testing.T) {
 	}
 }
 
+func TestCopyData_RecopiesDatabaseWhenMarkerExistsAndCheckpointFails(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "quay_sqlite.db")
+	createCopyTestDB(t, dbPath)
+
+	targetDir := filepath.Join(t.TempDir(), "target")
+	mkdirCopyTestDir(t, targetDir)
+	writeCopyTestFile(t, filepath.Join(targetDir, markerFile), []byte("migration in progress\n"), 0o600)
+
+	sourceBytes, err := os.ReadFile(dbPath) //nolint:gosec // test fixture path is under t.TempDir.
+	if err != nil {
+		t.Fatalf("read source db: %v", err)
+	}
+	writeCopyTestFile(t, filepath.Join(targetDir, "quay.db"), bytes.Repeat([]byte("x"), len(sourceBytes)), 0o600)
+
+	m := &Migrator{
+		DataDir:    targetDir,
+		Out:        &bytes.Buffer{},
+		Checkpoint: failFirstCheckpoint(),
+		Source: OMRSource{
+			DBPath: dbPath,
+		},
+	}
+
+	if err := m.copyData(t.Context()); err != nil {
+		t.Fatalf("copyData: %v", err)
+	}
+
+	targetDB, err := dbcore.OpenSQLite(filepath.Join(targetDir, "quay.db"))
+	if err != nil {
+		t.Fatalf("open target: %v", err)
+	}
+	defer func() { _ = targetDB.Close() }()
+
+	var value string
+	if err := targetDB.QueryRowContext(t.Context(), "SELECT value FROM copy_test").Scan(&value); err != nil {
+		t.Fatalf("query copied row: %v", err)
+	}
+	if value != "ok" {
+		t.Errorf("copied value = %q, want ok", value)
+	}
+}
+
 func TestCopyData_CheckpointsSourceWAL(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "quay_sqlite.db")
 	srcDB, err := dbcore.OpenSQLite(dbPath)

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -36,6 +36,9 @@ type OMRSource struct {
 	Method       string   // "systemd", "podman-volume", or "defaults"
 }
 
+// checkpointFunc is the signature for the WAL checkpoint operation.
+type checkpointFunc func(ctx context.Context, dbPath string) error
+
 // Migrator orchestrates the OMR-to-Go-binary migration phases.
 type Migrator struct {
 	Source OMRSource
@@ -54,8 +57,9 @@ type Migrator struct {
 	Cleanup     bool
 	SkipInstall bool
 
-	Out    io.Writer
-	Runner system.CommandRunner
+	Out        io.Writer
+	Runner     system.CommandRunner
+	Checkpoint checkpointFunc
 
 	sourceRegistryJWTKey *rsa.PrivateKey
 }


### PR DESCRIPTION
## Summary

Rootless `quay migrate` fails at the validate step because SQLite creates WAL/SHM
lock files even in `mode=ro`, and the source database directory is owned by
podman's user-namespace-mapped UID (from `/etc/subuid`), not the host user.

- **Fix 1** (`sqlite.go`): Add `immutable=1` to `OpenSQLiteReadOnly` URI, preventing
  all filesystem writes during validation. Safe because we only run SELECT queries.
- **Fix 2** (`copy.go`): When `checkpointSQLite` fails on the source (can't write),
  fall back to copying the DB plus any WAL/SHM sidecar files, then checkpoint the
  target copy which we own. The rootful path is unchanged.

Both fixes work for any subuid mapping — they avoid writing to the source entirely
rather than checking or entering the user namespace.

## Root Cause

OMR 2.0 rootless containers run under podman's user namespace. Container UID 0 is
mapped to a subordinate host UID (e.g. 100000+), so the SQLite database file on the
host volume is owned by a UID the host user cannot write to. The `quay migrate`
binary runs on the host and hits three failure points:

| Location | Call | Why it fails |
|----------|------|-------------|
| `validate.go:21` | `OpenSQLiteReadOnly()` | `mode=ro` still creates WAL/SHM lock files |
| `jwt_key.go:91` | `OpenSQLiteReadOnly()` | Same — called during JWT key validation |
| `copy.go:41` | `checkpointSQLite()` | Opens source DB read-write to flush WAL |

The failure occurs before `stopSourceServices`, so OMR 2.0 is never modified — no
data loss or corruption on failure.

## Test Plan

- [x] `go test ./internal/dal/dbcore/...` — passed (including new `TestOpenSQLiteReadOnly_SucceedsWithReadOnlyDirectory`)
- [x] `go test ./internal/migrate/...` — passed (including new `TestCopyData_FallsBackWhenCheckpointFails` and `TestCopyData_FallbackPreservesWALData`)
- [x] Manual: rootless dry-run migration on RHEL 8.10 / podman 4.9.4 / cgroups v1 — passed
- [x] Manual: rootless full migration (validate → stop → copy → schema upgrade → install) — passed
- [x] Manual: rootful dry-run regression test — passed (no behavior change)
