### PR TITLE
PROJQUAY-4775: fix: Set secscan endpoint to explicitly communicate via HTTP/1.1

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -16,7 +16,10 @@ proxy_set_header X-Forwarded-For $proper_forwarded_for;
 proxy_set_header X-Forwarded-Proto $final_proto;
 
 proxy_redirect off;
-proxy_set_header Transfer-Encoding $http_transfer_encoding;
+
+# temporarily removing to debug clair notifications
+# proxy_set_header Transfer-Encoding $http_transfer_encoding;
+
 absolute_redirect off;
 
 # Pass safe host for non standard external ports
@@ -133,6 +136,7 @@ location ~ ^/v2/_catalog(.*)$ {
 
 location /secscan/ {
     proxy_pass http://secscan_app_server;
+    proxy_http_version 1.1;
 }
 
 {% if signing_enabled %}

--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -17,9 +17,6 @@ proxy_set_header X-Forwarded-Proto $final_proto;
 
 proxy_redirect off;
 
-# temporarily removing to debug clair notifications
-# proxy_set_header Transfer-Encoding $http_transfer_encoding;
-
 absolute_redirect off;
 
 # Pass safe host for non standard external ports

--- a/endpoints/secscan.py
+++ b/endpoints/secscan.py
@@ -4,7 +4,6 @@ import logging
 
 import jwt
 from flask import Blueprint, abort, jsonify, make_response, request
-from werkzeug.exceptions import BadRequest
 
 import features
 from app import app, secscan_notification_queue
@@ -48,10 +47,15 @@ def secscan_notification():
             abort(401)
         logger.debug("Successfully verified jwt")
 
-    data = request.get_json(silent=True)
-    if data is None:
-        raw_body = request.get_data(as_text=True)
-        logger.error(f">>> JSON PARSE FAILED. Raw Body: '{raw_body}'")
+    try:
+        data = request.get_json(force=True, silent=False)
+    except Exception as e:
+        logger.error(
+            "Parsing of notification body failed: %s, content-type=%s, content-length=%s",
+            e,
+            request.content_type,
+            request.content_length,
+        )
         abort(400)
 
     logger.debug("Got notification from V4 Security Scanner: %s", data)

--- a/endpoints/secscan.py
+++ b/endpoints/secscan.py
@@ -58,6 +58,10 @@ def secscan_notification():
         )
         abort(400)
 
+    if not isinstance(data, dict):
+        logger.error("Expected JSON object, got %s", type(data).__name__)
+        abort(400)
+
     logger.debug("Got notification from V4 Security Scanner: %s", data)
     if "notification_id" not in data or "callback" not in data:
         abort(400)

--- a/endpoints/secscan.py
+++ b/endpoints/secscan.py
@@ -4,6 +4,7 @@ import logging
 
 import jwt
 from flask import Blueprint, abort, jsonify, make_response, request
+from werkzeug.exceptions import BadRequest
 
 import features
 from app import app, secscan_notification_queue
@@ -47,9 +48,10 @@ def secscan_notification():
             abort(401)
         logger.debug("Successfully verified jwt")
 
-    data = request.get_json()
+    data = request.get_json(silent=True)
     if data is None:
-        logger.error("expected json request")
+        raw_body = request.get_data(as_text=True)
+        logger.error(f">>> JSON PARSE FAILED. Raw Body: '{raw_body}'")
         abort(400)
 
     logger.debug("Got notification from V4 Security Scanner: %s", data)

--- a/endpoints/test/test_secscan.py
+++ b/endpoints/test/test_secscan.py
@@ -118,6 +118,16 @@ class TestSecscanNotificationQueue:
 
         assert resp.status_code == 400
 
+    def test_non_object_json_returns_400(self, secscan_client):
+        resp = secscan_client.post(
+            "/secscan/notification",
+            data="[1, 2, 3]",
+            content_type="text/plain",
+            headers=_return_access_headers(),
+        )
+
+        assert resp.status_code == 400
+
 
 class TestSecscanJWTAuthentication:
     def test_valid_jwt_accepted(self, secscan_client):

--- a/endpoints/test/test_secscan.py
+++ b/endpoints/test/test_secscan.py
@@ -1,0 +1,166 @@
+import base64
+import json
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from flask import url_for
+from freezegun import freeze_time
+
+from app import app as realapp
+from endpoints.secscan import secscan
+from test.fixtures import *
+
+FAKE_V4_PSK = base64.b64encode(b"faketoken").decode()
+
+VALID_PAYLOAD = {
+    "notification_id": "someuuid",
+    "callback": "http://clair/notifier/api/v1/notification/someuuid",
+}
+
+
+@pytest.fixture()
+def secscan_client(app):
+    app.register_blueprint(secscan, url_prefix="/secscan")
+    with app.test_client() as c:
+        yield c
+
+
+def _create_access_token_parameters():
+    now = datetime.now(timezone.utc)
+
+    with freeze_time(now):
+        TOKEN_PARAMS = {
+            "iss": "clair-notifier",
+            "exp": int(now.timestamp()) + 300,
+            "nbf": int(now.timestamp()),
+            "iat": int(now.timestamp()),
+        }
+
+    return TOKEN_PARAMS
+
+
+def _return_access_headers():
+    token = jwt.encode(
+        _create_access_token_parameters(), base64.b64decode(FAKE_V4_PSK), algorithm="HS256"
+    )
+    assert token
+
+    headers = {
+        "Authorization": "Bearer " + token,
+    }
+
+    return headers
+
+
+def _post_notification(client, payload, headers=None):
+    return client.post(
+        "/secscan/notification",
+        data=json.dumps(payload),
+        content_type="application/json",
+        headers=headers or {},
+    )
+
+
+class TestSecscanNotificationQueue:
+    def test_has_valid_notification_enqueued(self, secscan_client):
+        with patch("endpoints.secscan.secscan_notification_queue") as mock_queue:
+            mock_queue.alive.return_value = False
+            resp = _post_notification(
+                secscan_client, VALID_PAYLOAD, headers=_return_access_headers()
+            )
+
+        assert resp.status_code == 200
+        mock_queue.put.assert_called_once()
+
+    def test_valid_notification_already_in_queue(self, secscan_client):
+        with patch("endpoints.secscan.secscan_notification_queue") as mock_queue:
+            mock_queue.alive.return_value = True
+            resp = _post_notification(
+                secscan_client, VALID_PAYLOAD, headers=_return_access_headers()
+            )
+
+        assert resp.status_code == 200
+        mock_queue.put.assert_not_called()
+
+    def test_missing_notification_id_returns_400(self, secscan_client):
+        INVALID_PAYLOAD = {
+            "callback": "http://clair/notifier/api/v1/notification/someuuid",
+        }
+        with patch("endpoints.secscan.secscan_notification_queue"):
+            resp = _post_notification(
+                secscan_client, INVALID_PAYLOAD, headers=_return_access_headers()
+            )
+
+        assert resp.status_code == 400
+
+    def test_missing_callback_address_returns_400(self, secscan_client):
+        INVALID_PAYLOAD = {
+            "notification_id": str(uuid.uuid4()),
+        }
+        with patch("endpoints.secscan.secscan_notification_queue"):
+            resp = _post_notification(
+                secscan_client, INVALID_PAYLOAD, headers=_return_access_headers()
+            )
+
+        assert resp.status_code == 400
+
+    def test_invalid_json_returns_400(self, secscan_client):
+        INVALID_PAYLOAD = "Lorem ipsum...."
+        resp = secscan_client.post(
+            "/secscan/notification",
+            data=INVALID_PAYLOAD,
+            content_type="application/json",
+            headers=_return_access_headers(),
+        )
+
+        assert resp.status_code == 400
+
+
+class TestSecscanJWTAuthentication:
+    def test_valid_jwt_accepted(self, secscan_client):
+        with patch.dict(realapp.config, {"SECURITY_SCANNER_V4_PSK": FAKE_V4_PSK}):
+            with patch("endpoints.secscan.secscan_notification_queue") as mock_queue:
+                mock_queue.alive.return_value = False
+                resp = _post_notification(
+                    secscan_client,
+                    VALID_PAYLOAD,
+                    headers=_return_access_headers(),
+                )
+
+            assert resp.status_code == 200
+
+    def test_invalid_jwt_returns_401(self, secscan_client):
+        WRONG_PSK = base64.b64encode(b"wrong key").decode()
+
+        token = jwt.encode(
+            _create_access_token_parameters(),
+            WRONG_PSK,
+            algorithm="HS256",
+        )
+        assert token
+
+        headers = {
+            "Authorization": "Bearer " + token,
+        }
+
+        with patch.dict(realapp.config, {"SECURITY_SCANNER_V4_PSK": FAKE_V4_PSK}):
+            resp = _post_notification(
+                secscan_client,
+                VALID_PAYLOAD,
+                headers=headers,
+            )
+
+        assert resp.status_code == 401
+
+    def test_no_jwt_sent_to_secscan_returns_401(self, secscan_client):
+        with patch.dict(realapp.config, {"SECURITY_SCANNER_V4_PSK": FAKE_V4_PSK}):
+            resp = _post_notification(
+                secscan_client,
+                VALID_PAYLOAD,
+                headers={},
+            )
+
+        assert resp.status_code == 401


### PR DESCRIPTION
Previously, communication between nginx and `gunicorn-secscan` worker was exclusively done over `HTTP/1.0`. In addition, the transfer encoding was blindly passed directly to the worker via the global

~~~
proxy_set_header Transfer-Encoding $http_transfer_encoding; 
~~~

set in `server-base.conf.jnj`. Gunicorn rejected these requests due to improper headers: `Transfer-Encoding` header is strictly a `HTTP/1.1` request header and doesn't work over `HTTP/1.0`. However, setting just the proxy to `HTTP/1.1` doesn't resolve the problem fully, as gunicorn does not allow having both `Content-Length` (appended by nginx) and `Transfer-Encoding` (proxied from the client) in the same request.

This PR removes the global `Transfer-Encoding` header from the list of headers and explicitly enables `HTTP/1.1` on the `/secscan` endpoint, allowing nginx to correctly do header translation and allowing `gunicorn-secscan` to properly process security notifications.