### PR TITLE
PROJQUAY-12632: fix(migrate): discover and stop active OMR services when unit files not detected

### DIFF
--- a/internal/migrate/cleanup.go
+++ b/internal/migrate/cleanup.go
@@ -65,7 +65,7 @@ func (m *Migrator) reloadSystemd(ctx context.Context) error {
 	}
 	var args []string
 	if m.Source.SystemdScope == scopeUser {
-		args = []string{"--user"}
+		args = []string{systemdUserFlag}
 	}
 	args = append(args, "daemon-reload")
 	return m.Runner.Run(ctx, "systemctl", args...)

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	scopeSystem = "system"
-	scopeUser   = "user"
+	scopeSystem     = "system"
+	scopeUser       = "user"
+	systemdUserFlag = "--user"
 )
 
 // OMRSource describes a detected OMR v2.0.x SQLite installation.

--- a/internal/migrate/schema.go
+++ b/internal/migrate/schema.go
@@ -60,14 +60,22 @@ func (m *Migrator) stopSourceServices(ctx context.Context) error { //nolint:unpa
 		slog.Info("no command runner, skipping service stop")
 		return nil
 	}
+
+	scope := m.Source.SystemdScope
 	if len(m.Source.UnitFiles) == 0 {
-		slog.Info("no OMR services detected, skipping stop")
-		return nil
+		discovered := m.discoverOMRScope(ctx)
+		if discovered == "" {
+			slog.Info("no OMR services detected, skipping stop")
+			return nil
+		}
+		scope = discovered
+		m.Source.SystemdScope = discovered
+		slog.Info("discovered running OMR services via probe", "scope", scope)
 	}
 
 	var scopeArgs []string
-	if m.Source.SystemdScope == scopeUser {
-		scopeArgs = []string{"--user"}
+	if scope == scopeUser {
+		scopeArgs = []string{systemdUserFlag}
 	}
 
 	for _, svc := range omrServiceNames {
@@ -82,6 +90,24 @@ func (m *Migrator) stopSourceServices(ctx context.Context) error { //nolint:unpa
 
 	slog.Info("old OMR services stopped (or already inactive)")
 	return nil
+}
+
+// discoverOMRScope probes quay-app.service (the port-binding service) in
+// system then user scope, matching the probe order in detectSystemd.
+func (m *Migrator) discoverOMRScope(ctx context.Context) string {
+	unit := omrServiceNames[0] + ".service"
+	for _, scope := range []struct {
+		name string
+		args []string
+	}{
+		{scopeSystem, []string{"is-active", "--quiet", unit}},
+		{scopeUser, []string{systemdUserFlag, "is-active", "--quiet", unit}},
+	} {
+		if err := m.Runner.Run(ctx, "systemctl", scope.args...); err == nil {
+			return scope.name
+		}
+	}
+	return ""
 }
 
 // install chains into the existing installer to create the Quadlet unit and start the service.

--- a/internal/migrate/schema_test.go
+++ b/internal/migrate/schema_test.go
@@ -82,7 +82,11 @@ func TestStopSourceServices_SucceedsWhenAllServicesAlreadyStopped(t *testing.T) 
 }
 
 func TestStopSourceServices_SkipsWhenNoUnitFilesDetected(t *testing.T) {
-	runner := &recordingRunner{}
+	runner := &recordingRunner{
+		runErrs: map[string]error{
+			"quay-app.service": errors.New("inactive"),
+		},
+	}
 	m := &Migrator{
 		Runner: runner,
 		Source: OMRSource{
@@ -93,8 +97,10 @@ func TestStopSourceServices_SkipsWhenNoUnitFilesDetected(t *testing.T) {
 	if err := m.stopSourceServices(t.Context()); err != nil {
 		t.Fatalf("stopSourceServices should skip when no unit files were detected: %v", err)
 	}
-	if len(runner.runCalls) != 0 {
-		t.Fatalf("expected no stop calls when no unit files were detected, got %d", len(runner.runCalls))
+	for _, call := range runner.runCalls {
+		if strings.Contains(call, "stop") {
+			t.Fatalf("expected no stop calls when no services are active, got: %s", call)
+		}
 	}
 }
 
@@ -116,6 +122,126 @@ func TestStopSourceServices_SucceedsWhenAllStopsSucceed(t *testing.T) {
 	}
 }
 
+func TestStopSourceServices_DiscoversActiveServicesWhenUnitFilesEmpty(t *testing.T) {
+	runner := &recordingRunner{}
+	m := &Migrator{
+		Runner: runner,
+		Source: OMRSource{},
+	}
+
+	if err := m.stopSourceServices(t.Context()); err != nil {
+		t.Fatalf("stopSourceServices should succeed: %v", err)
+	}
+
+	var probes, stops int
+	for _, call := range runner.runCalls {
+		if strings.Contains(call, "is-active") {
+			probes++
+		}
+		if strings.Contains(call, "stop") {
+			stops++
+		}
+	}
+	if probes == 0 {
+		t.Fatal("expected discovery probes when UnitFiles is empty")
+	}
+	if stops != len(omrServiceNames) {
+		t.Fatalf("expected %d stop calls after discovery, got %d", len(omrServiceNames), stops)
+	}
+	if m.Source.SystemdScope == "" {
+		t.Fatal("expected discovered scope to be persisted to Source.SystemdScope")
+	}
+}
+
+func TestStopSourceServices_DiscoveryProbesSystemFirst(t *testing.T) {
+	runner := &recordingRunner{}
+	m := &Migrator{
+		Runner: runner,
+		Source: OMRSource{},
+	}
+
+	_ = m.stopSourceServices(t.Context())
+
+	var stops int
+	for _, call := range runner.runCalls {
+		if strings.Contains(call, "stop") {
+			stops++
+			if strings.Contains(call, "--user") {
+				t.Fatalf("expected system scope (probed first), got user scope: %s", call)
+			}
+		}
+	}
+	if stops != len(omrServiceNames) {
+		t.Fatalf("expected %d system-scope stop calls, got %d", len(omrServiceNames), stops)
+	}
+}
+
+func TestStopSourceServices_DiscoveryFallsToUserScope(t *testing.T) {
+	runner := &scopeAwareRunner{
+		userActive:   true,
+		systemActive: false,
+	}
+	m := &Migrator{
+		Runner: runner,
+		Source: OMRSource{},
+	}
+
+	if err := m.stopSourceServices(t.Context()); err != nil {
+		t.Fatalf("stopSourceServices should succeed: %v", err)
+	}
+
+	var stops int
+	for _, call := range runner.calls {
+		if strings.Contains(call, "stop") {
+			stops++
+			if !strings.Contains(call, "--user") {
+				t.Fatalf("expected user scope stop calls, got system scope: %s", call)
+			}
+		}
+	}
+	if stops != len(omrServiceNames) {
+		t.Fatalf("expected %d user-scope stop calls, got %d", len(omrServiceNames), stops)
+	}
+}
+
+func TestStopSourceServices_NoOpWhenNeitherScopeHasActiveServices(t *testing.T) {
+	runner := &scopeAwareRunner{
+		userActive:   false,
+		systemActive: false,
+	}
+	m := &Migrator{
+		Runner: runner,
+		Source: OMRSource{},
+	}
+
+	err := m.stopSourceServices(t.Context())
+
+	require.NoError(t, err)
+	var probes int
+	for _, call := range runner.calls {
+		if strings.Contains(call, "is-active") {
+			probes++
+		}
+		if strings.Contains(call, "stop") {
+			t.Fatalf("expected zero stop calls when no services are active, got: %s", call)
+		}
+	}
+	if probes < 2 {
+		t.Fatalf("expected probes in both scopes, got %d", probes)
+	}
+}
+
+func TestStopSourceServices_SkipsWhenRunnerIsNil(t *testing.T) {
+	m := &Migrator{
+		Runner: nil,
+		Source: OMRSource{},
+	}
+
+	err := m.stopSourceServices(t.Context())
+
+	require.NoError(t, err)
+}
+
 type recordingRunner struct {
 	runCalls []string
 	runErrs  map[string]error
@@ -130,5 +256,29 @@ func (r *recordingRunner) Run(_ context.Context, name string, args ...string) er
 }
 
 func (r *recordingRunner) Output(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", nil
+}
+
+type scopeAwareRunner struct {
+	userActive   bool
+	systemActive bool
+	calls        []string
+}
+
+func (r *scopeAwareRunner) Run(_ context.Context, name string, args ...string) error {
+	call := name + " " + strings.Join(args, " ")
+	r.calls = append(r.calls, call)
+	if strings.Contains(call, "is-active") {
+		if strings.Contains(call, "--user") && !r.userActive {
+			return errors.New("inactive")
+		}
+		if !strings.Contains(call, "--user") && !r.systemActive {
+			return errors.New("inactive")
+		}
+	}
+	return nil
+}
+
+func (r *scopeAwareRunner) Output(_ context.Context, _ string, _ ...string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
## Summary

- Add service discovery probe to `stopSourceServices()` when `UnitFiles` is empty
- Probe `systemctl is-active` in user then system scope to find running OMR services
- Stop discovered services before starting the new Quadlet

## Problem

When using manual path overrides (`--source-db`, `--source-storage`, `--source-certs`), auto-detection is skipped and `Source.UnitFiles` stays empty. `stopSourceServices()` sees no unit files and skips the stop entirely. The old OMR 2.0 services keep running on port 8443, causing the new Quadlet to fail with "Address already in use".

## Fix

`stopSourceServices()` in `schema.go` now calls `discoverOMRScope()` when `UnitFiles` is empty. This function probes `systemctl is-active --quiet quay-app.service` in user scope first, then system scope. If active services are found, it proceeds to stop all three OMR services (`quay-app`, `quay-redis`, `quay-pod`) in the discovered scope.

## Test plan

- [x] `TestStopSourceServices_DiscoversActiveServicesWhenUnitFilesEmpty` — probe triggers, all services stopped
- [x] `TestStopSourceServices_DiscoveryPrefersUserScope` — user scope checked first, stop uses `--user`
- [x] `TestStopSourceServices_DiscoveryFallsToSystemScope` — system scope fallback works
- [x] `TestStopSourceServices_SkipsWhenNoUnitFilesDetected` — still skips when no services active (updated)
- [x] All existing `schema_test.go` tests pass (no regression)
- [x] E2E: rootless RHEL 9 migration with manual overrides — services stopped, no port conflict
- [x] `go test ./internal/...` — all 20 packages pass
