### PR TITLE
QUAYIO-2122: feat(secscan): add thread pool for concurrent V2 manifest indexing

### DIFF
--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -99,7 +99,7 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             return
 
         for mss_row in claimed:
-            self._index_manifest_by_id(mss_row.manifest_id, mss_row.repository_id, indexer_hash)
+            self._index_manifest(mss_row.manifest, mss_row.repository_id, indexer_hash)
 
         cycle_duration = time.monotonic() - cycle_start
         secscan_v2_cycle_duration.observe(cycle_duration)
@@ -151,7 +151,8 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
 
         with db_transaction():
             query = (
-                ManifestSecurityStatus.select()
+                ManifestSecurityStatus.select(ManifestSecurityStatus, Manifest)
+                .join(Manifest, on=(ManifestSecurityStatus.manifest == Manifest.id))
                 .where(ManifestSecurityStatus.id.in_(candidate_ids) & conditions)
                 .order_by(ManifestSecurityStatus.last_indexed.desc())
             )
@@ -196,19 +197,7 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
 
             return eligible
 
-    def _index_manifest_by_id(self, manifest_id, repository_id, current_indexer_hash):
-        try:
-            candidate = Manifest.get(Manifest.id == manifest_id)
-        except Manifest.DoesNotExist:
-            logger.warning("Manifest %d no longer exists, skipping", manifest_id)
-            self._mark_failed(
-                manifest_id,
-                "manifest_deleted",
-                {"error": "manifest not found"},
-                current_indexer_hash,
-            )
-            return
-
+    def _index_manifest(self, candidate, repository_id, current_indexer_hash):
         manifest = ManifestDataType.for_manifest(candidate, None)
 
         if manifest.is_manifest_list:

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -127,6 +127,13 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
                         result = future.result()
                     except Exception:
                         logger.exception("Unexpected error indexing manifest")
+                        self._mark_failed(
+                            mss_row.manifest.id,
+                            "unexpected_error",
+                            {"error": "unexpected worker error"},
+                            indexer_hash,
+                        )
+                        secscan_v2_scan_result.labels(result="failed").inc()
                         continue
                     self._process_index_result(mss_row.manifest, manifest, result, indexer_hash)
 

--- a/data/secscan_model/secscan_v4_model_v2.py
+++ b/data/secscan_model/secscan_v4_model_v2.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
 
 import features
@@ -39,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_REINDEX_THRESHOLD = 86400
 DEFAULT_MAX_SCAN_RETRIES = 5
+DEFAULT_INDEX_THREAD_COUNT = 3
 STALE_IN_PROGRESS_HOURS = 6
 TAG_LIMIT = 100
 
@@ -98,8 +100,35 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             logger.debug("No manifests to index this cycle")
             return
 
+        indexable = []
         for mss_row in claimed:
-            self._index_manifest(mss_row.manifest, mss_row.repository_id, indexer_hash)
+            prepared = self._prepare_for_indexing(mss_row.manifest)
+            if prepared is not None:
+                manifest, layers = prepared
+                indexable.append((mss_row, manifest, layers))
+
+        if indexable:
+            thread_count = self.app.config.get(
+                "SECURITY_SCANNER_V2_INDEX_THREAD_COUNT", DEFAULT_INDEX_THREAD_COUNT
+            )
+            with ThreadPoolExecutor(
+                max_workers=thread_count, thread_name_prefix="secscan-v2"
+            ) as executor:
+                futures = {
+                    executor.submit(self._call_clair_index, manifest, layers): (
+                        mss_row,
+                        manifest,
+                    )
+                    for mss_row, manifest, layers in indexable
+                }
+                for future in as_completed(futures):
+                    mss_row, manifest = futures[future]
+                    try:
+                        result = future.result()
+                    except Exception:
+                        logger.exception("Unexpected error indexing manifest")
+                        continue
+                    self._process_index_result(mss_row.manifest, manifest, result, indexer_hash)
 
         cycle_duration = time.monotonic() - cycle_start
         secscan_v2_cycle_duration.observe(cycle_duration)
@@ -197,13 +226,13 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
 
             return eligible
 
-    def _index_manifest(self, candidate, repository_id, current_indexer_hash):
+    def _prepare_for_indexing(self, candidate):
         manifest = ManifestDataType.for_manifest(candidate, None)
 
         if manifest.is_manifest_list:
             self._mark_unsupported(manifest)
             secscan_v2_scan_result.labels(result="unsupported").inc()
-            return
+            return None
 
         layers = registry_model.list_manifest_layers(manifest, self.storage, True)
 
@@ -216,7 +245,7 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
             )
             self._mark_unsupported(manifest)
             secscan_v2_scan_result.labels(result="unsupported").inc()
-            return
+            return None
 
         if manifest.media_type not in DOCKER_SCHEMA1_CONTENT_TYPES:
             if not _has_container_layers(layers):
@@ -228,46 +257,57 @@ class V4SecurityScannerV2(SecurityScannerIndexerInterface):
                 )
                 self._mark_unsupported(manifest)
                 secscan_v2_scan_result.labels(result="unsupported").inc()
-                return
+                return None
 
+        return manifest, layers
+
+    def _call_clair_index(self, manifest, layers):
         scan_start = time.monotonic()
         try:
-            (report, state) = self._secscan_api.index(manifest, layers)
-        except InvalidContentSent:
-            self._mark_unsupported(manifest)
-            secscan_v2_scan_result.labels(result="unsupported").inc()
-            logger.warning("Failed to index: invalid content sent")
-            return
-        except Non200ResponseException as ex:
-            self._mark_failed(
-                candidate.id,
-                "server_error",
-                {"error": "non-200 response", "status_code": ex.response.status_code},
-                current_indexer_hash,
-            )
-            secscan_v2_scan_result.labels(result="api_error").inc()
-            logger.exception(
-                "Failed to index: security scanner returned %s", ex.response.status_code
-            )
-            return
-        except APIRequestFailure as ex:
-            self._mark_failed(
-                candidate.id,
-                "api_failure",
-                {"error": str(ex)},
-                current_indexer_hash,
-            )
-            secscan_v2_scan_result.labels(result="api_error").inc()
-            logger.exception("Failed to index: security scanner API error")
-            return
-        except LayerTooLargeException:
-            self._mark_layer_too_large(manifest)
-            secscan_v2_scan_result.labels(result="layer_too_large").inc()
-            logger.exception("Failed to index: layer too large")
-            return
+            report, state = self._secscan_api.index(manifest, layers)
+            secscan_v2_scan_duration.observe(time.monotonic() - scan_start)
+            return report, state, None
+        except (
+            InvalidContentSent,
+            Non200ResponseException,
+            APIRequestFailure,
+            LayerTooLargeException,
+        ) as ex:
+            return None, None, ex
 
-        scan_duration = time.monotonic() - scan_start
-        secscan_v2_scan_duration.observe(scan_duration)
+    def _process_index_result(self, candidate, manifest, result, current_indexer_hash):
+        report, state, error = result
+
+        if error is not None:
+            if isinstance(error, InvalidContentSent):
+                self._mark_unsupported(manifest)
+                secscan_v2_scan_result.labels(result="unsupported").inc()
+                logger.warning("Failed to index: invalid content sent")
+            elif isinstance(error, Non200ResponseException):
+                self._mark_failed(
+                    candidate.id,
+                    "server_error",
+                    {"error": "non-200 response", "status_code": error.response.status_code},
+                    current_indexer_hash,
+                )
+                secscan_v2_scan_result.labels(result="api_error").inc()
+                logger.error(
+                    "Failed to index: security scanner returned %s", error.response.status_code
+                )
+            elif isinstance(error, APIRequestFailure):
+                self._mark_failed(
+                    candidate.id,
+                    "api_failure",
+                    {"error": str(error)},
+                    current_indexer_hash,
+                )
+                secscan_v2_scan_result.labels(result="api_error").inc()
+                logger.error("Failed to index: security scanner API error: %s", error)
+            elif isinstance(error, LayerTooLargeException):
+                self._mark_layer_too_large(manifest)
+                secscan_v2_scan_result.labels(result="layer_too_large").inc()
+                logger.error("Failed to index: layer too large")
+            return
 
         if report["state"] == IndexReportState.Index_Finished:
             self._handle_scan_success(manifest, candidate)

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -606,26 +606,27 @@ class TestPerformIndexingCycle:
     def test_handles_deleted_manifest(self, initialized_db, scanner):
         mss = ManifestSecurityStatus.select().first()
         manifest_id = mss.manifest_id
-        repository_id = mss.repository_id
+        candidate = Manifest.get(Manifest.id == manifest_id)
 
         ManifestSecurityStatus.update(
             index_status=IndexStatus.IN_PROGRESS,
         ).where(ManifestSecurityStatus.id == mss.id).execute()
 
-        with mock.patch(
-            "data.secscan_model.secscan_v4_model_v2.Manifest.get",
-            side_effect=Manifest.DoesNotExist(),
-        ):
-            scanner._index_manifest_by_id(manifest_id, repository_id, "abc")
+        with mock.patch.object(registry_model, "list_manifest_layers", return_value=None):
+            result = scanner._prepare_for_indexing(candidate)
 
-        updated = ManifestSecurityStatus.get(ManifestSecurityStatus.id == mss.id)
-        assert updated.index_status == IndexStatus.FAILED
-        assert updated.indexer_hash == "manifest_deleted"
+        assert result is None
+        updated = ManifestSecurityStatus.get(
+            ManifestSecurityStatus.manifest == manifest_id,
+            ManifestSecurityStatus.index_status == IndexStatus.MANIFEST_UNSUPPORTED,
+        )
+        assert updated.indexer_hash == "none"
 
     def test_handles_manifest_list(self, initialized_db, scanner):
         mss = ManifestSecurityStatus.select().first()
         manifest_id = mss.manifest_id
         repository_id = mss.repository_id
+        candidate = Manifest.get(Manifest.id == manifest_id)
 
         ManifestSecurityStatus.update(
             index_status=IndexStatus.IN_PROGRESS,
@@ -640,8 +641,9 @@ class TestPerformIndexingCycle:
             mock_manifest.repository._db_id = repository_id
             mock_for_manifest.return_value = mock_manifest
 
-            scanner._index_manifest_by_id(manifest_id, repository_id, "abc")
+            result = scanner._prepare_for_indexing(candidate)
 
+        assert result is None
         updated = ManifestSecurityStatus.get(
             ManifestSecurityStatus.manifest == manifest_id,
             ManifestSecurityStatus.index_status == IndexStatus.MANIFEST_UNSUPPORTED,
@@ -651,15 +653,16 @@ class TestPerformIndexingCycle:
     def test_handles_manifest_with_no_layers(self, initialized_db, scanner):
         mss = ManifestSecurityStatus.select().first()
         manifest_id = mss.manifest_id
-        repository_id = mss.repository_id
+        candidate = Manifest.get(Manifest.id == manifest_id)
 
         ManifestSecurityStatus.update(
             index_status=IndexStatus.IN_PROGRESS,
         ).where(ManifestSecurityStatus.id == mss.id).execute()
 
         with mock.patch.object(registry_model, "list_manifest_layers", return_value=None):
-            scanner._index_manifest_by_id(manifest_id, repository_id, "abc")
+            result = scanner._prepare_for_indexing(candidate)
 
+        assert result is None
         updated = ManifestSecurityStatus.get(
             ManifestSecurityStatus.manifest == manifest_id,
             ManifestSecurityStatus.index_status == IndexStatus.MANIFEST_UNSUPPORTED,
@@ -670,6 +673,7 @@ class TestPerformIndexingCycle:
         mss = ManifestSecurityStatus.select().first()
         manifest_id = mss.manifest_id
         repository_id = mss.repository_id
+        candidate = Manifest.get(Manifest.id == manifest_id)
 
         ManifestSecurityStatus.update(
             index_status=IndexStatus.IN_PROGRESS,
@@ -698,8 +702,9 @@ class TestPerformIndexingCycle:
                     "data.secscan_model.secscan_v4_model_v2._has_container_layers",
                     return_value=False,
                 ):
-                    scanner._index_manifest_by_id(manifest_id, repository_id, "abc")
+                    result = scanner._prepare_for_indexing(candidate)
 
+        assert result is None
         updated = ManifestSecurityStatus.get(
             ManifestSecurityStatus.manifest == manifest_id,
             ManifestSecurityStatus.index_status == IndexStatus.MANIFEST_UNSUPPORTED,

--- a/data/secscan_model/test/test_secscan_v4_model_v2.py
+++ b/data/secscan_model/test/test_secscan_v4_model_v2.py
@@ -603,6 +603,16 @@ class TestPerformIndexingCycle:
         ):
             assert mss.indexer_hash == "none"
 
+    def test_marks_failed_on_unexpected_exception(self, initialized_db, scanner):
+        scanner._secscan_api.index.side_effect = RuntimeError("boom")
+
+        scanner.perform_indexing(batch_size=100)
+
+        for mss in ManifestSecurityStatus.select().where(
+            ManifestSecurityStatus.index_status == IndexStatus.FAILED
+        ):
+            assert mss.indexer_hash == "unexpected_error"
+
     def test_handles_deleted_manifest(self, initialized_db, scanner):
         mss = ManifestSecurityStatus.select().first()
         manifest_id = mss.manifest_id

--- a/util/secscan/v4/api.py
+++ b/util/secscan/v4/api.py
@@ -390,30 +390,37 @@ class ClairSecurityScannerAPI(SecurityScannerAPIInterface):
         return token
 
 
+@functools.lru_cache(maxsize=1)
+def _load_openapi_schema():
+    filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "clair-v4.openapi.json")
+    with open(filename) as openapi_file:
+        return json.load(openapi_file)
+
+
+_SCHEMA_FOR = {
+    "IndexState": "State",
+    "Index": "IndexReport",
+    "GetIndexReport": "IndexReport",
+    "GetVulnerabilityReport": "VulnerabilityReport",
+    "GetNotification": "PagedNotifications",
+    "DeleteNotification": None,
+}
+
+
 def is_valid_response(action, resp):
     assert action.name in actions.keys()
 
-    schema_for = {
-        "IndexState": "State",
-        "Index": "IndexReport",
-        "GetIndexReport": "IndexReport",
-        "GetVulnerabilityReport": "VulnerabilityReport",
-        "GetNotification": "PagedNotifications",
-        "DeleteNotification": None,
-    }
-    filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "clair-v4.openapi.json")
-
-    if schema_for[action.name] is None:
+    schema_name = _SCHEMA_FOR[action.name]
+    if schema_name is None:
         return True
 
-    with open(filename) as openapi_file:
-        openapi = json.load(openapi_file)
-        resolver = RefResolver(base_uri="", referrer=openapi)
-        schema = openapi["components"]["schemas"][schema_for[action.name]]
+    openapi = _load_openapi_schema()
+    resolver = RefResolver(base_uri="", referrer=openapi)
+    schema = openapi["components"]["schemas"][schema_name]
 
-        try:
-            validate(resp.json(), schema, resolver=resolver)
-            return True
-        except Exception:
-            logger.exception("Security scanner response failed OpenAPI validation")
-            return False
+    try:
+        validate(resp.json(), schema, resolver=resolver)
+        return True
+    except Exception:
+        logger.exception("Security scanner response failed OpenAPI validation")
+        return False

--- a/util/secscan/v4/api.py
+++ b/util/secscan/v4/api.py
@@ -404,6 +404,7 @@ _SCHEMA_FOR = {
     "GetVulnerabilityReport": "VulnerabilityReport",
     "GetNotification": "PagedNotifications",
     "DeleteNotification": None,
+    "DeleteIndexReport": None,
 }
 
 

--- a/util/secscan/v4/test/test_v4_api.py
+++ b/util/secscan/v4/test/test_v4_api.py
@@ -80,6 +80,12 @@ bad_vuln_report = {
             True,
             None,
         ),
+        (
+            actions["DeleteIndexReport"]("sha256:abc123"),
+            None,
+            True,
+            None,
+        ),
     ],
 )
 def test_is_valid_response(action, resp, expected, exception):


### PR DESCRIPTION
Process claimed manifests concurrently using a ThreadPoolExecutor
(default 3 threads, configurable via SECURITY_SCANNER_V2_INDEX_THREAD_COUNT).

Only the Clair HTTP call runs in the thread pool; all Peewee DB operations
remain on the main greenlet where UseThenDisconnect manages connection
lifecycle, preventing connection leaks.