### PR TITLE
PROJQUAY-12522: feat(install): add cgroups v2 preflight check

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -119,6 +119,10 @@ func (inst *Installer) Run(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("initial administrator: %w", err)
 	}
 
+	if err := system.ValidateCgroupsForQuadlet(ctx, inst.runner); err != nil {
+		return fmt.Errorf("system compatibility: %w", err)
+	}
+
 	upgrading := inst.quadlet.Exists(quadletServiceName)
 	hostname, err := inst.resolveHostname(ctx, cfg.Hostname, upgrading)
 	if err != nil {

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -575,7 +575,7 @@ func TestRunRejectsCgroupV1Rootless(t *testing.T) {
 	err := inst.Run(t.Context(), &Config{DataDir: dataDir})
 
 	require.ErrorContains(t, err, "cgroups v1")
-	require.ErrorContains(t, err, "OMR 3.0 requires cgroups v2")
+	require.ErrorContains(t, err, "OMR 3.0 requires cgroups v2 for rootless installs")
 	_, statErr := os.Stat(dataDir)
 	assert.ErrorIs(t, statErr, os.ErrNotExist, "data directory should not be created on cgroup failure")
 }

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -545,6 +545,46 @@ func (r *recordingServiceManager) DisableLinger(context.Context) error {
 
 var _ system.ServiceManager = (*recordingServiceManager)(nil)
 
+type cgroupFakeRunner struct {
+	version string
+}
+
+func (r *cgroupFakeRunner) Run(context.Context, string, ...string) error { return nil }
+func (r *cgroupFakeRunner) Output(_ context.Context, name string, args ...string) (string, error) {
+	if name == "podman" && len(args) > 0 && args[0] == "info" {
+		return r.version, nil
+	}
+	return "", nil
+}
+
+func TestRunRejectsCgroupV1Rootless(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root to exercise rootless cgroup check")
+	}
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "registry-data")
+	env := &system.Env{Mode: system.UserMode, HomeDir: filepath.Join(root, "home")}
+	inst := &Installer{
+		runner:  &cgroupFakeRunner{version: "v1"},
+		quadlet: system.NewQuadletManager(system.OSFS{}, env),
+		hostname: func(context.Context) (string, error) {
+			return "registry.example.com", nil
+		},
+	}
+
+	err := inst.Run(t.Context(), &Config{DataDir: dataDir})
+
+	require.ErrorContains(t, err, "cgroups v1")
+	require.ErrorContains(t, err, "OMR 3.0 requires cgroups v2")
+	_, statErr := os.Stat(dataDir)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "data directory should not be created on cgroup failure")
+}
+
+func TestCgroupV2PassesCheck(t *testing.T) {
+	err := system.ValidateCgroupsForQuadlet(t.Context(), &cgroupFakeRunner{version: "v2"})
+	require.NoError(t, err)
+}
+
 func TestValidateSSLFlags(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/migrate/schema_test.go
+++ b/internal/migrate/schema_test.go
@@ -129,6 +129,9 @@ func (r *recordingRunner) Run(_ context.Context, name string, args ...string) er
 	return r.runErrs[args[len(args)-1]]
 }
 
-func (r *recordingRunner) Output(_ context.Context, _ string, _ ...string) (string, error) {
+func (r *recordingRunner) Output(_ context.Context, name string, args ...string) (string, error) {
+	if name == "podman" && len(args) > 0 && args[0] == "info" {
+		return "v2", nil
+	}
 	return "", nil
 }

--- a/internal/migrate/validate.go
+++ b/internal/migrate/validate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/quay/quay/internal/config"
 	"github.com/quay/quay/internal/dal/dbcore"
 	"github.com/quay/quay/internal/installer"
+	"github.com/quay/quay/internal/system"
 )
 
 const markerFile = ".migration-in-progress"
@@ -18,6 +19,12 @@ const markerFile = ".migration-in-progress"
 // validate checks source compatibility, authentication policy, and target readiness.
 // All source database checks are read-only and finish before source shutdown.
 func (m *Migrator) validate(ctx context.Context) error {
+	if !m.SkipInstall {
+		if err := system.ValidateCgroupsForQuadlet(ctx, m.Runner); err != nil {
+			return fmt.Errorf("system compatibility: %w", err)
+		}
+	}
+
 	db, err := dbcore.OpenSQLiteReadOnly(m.Source.DBPath)
 	if err != nil {
 		return fmt.Errorf("open source database: %w", err)

--- a/internal/system/cgroup.go
+++ b/internal/system/cgroup.go
@@ -25,7 +25,7 @@ func CheckCgroupVersion(ctx context.Context, runner CommandRunner) (string, erro
 func ValidateCgroupsForQuadlet(ctx context.Context, runner CommandRunner) error {
 	version, err := CheckCgroupVersion(ctx, runner)
 	if err != nil {
-		return nil
+		return nil //nolint:nilerr // podman may not be installed yet; don't block
 	}
 	if version == "v2" {
 		return nil
@@ -38,7 +38,7 @@ func ValidateCgroupsForQuadlet(ctx context.Context, runner CommandRunner) error 
 				"  sudo reboot\n\n"+
 				"After reboot, verify with:\n\n"+
 				"  podman info --format '{{.Host.CgroupsVersion}}'\n\n"+
-				"Then re-run this command. Your existing installation has not been modified.", version)
+				"then re-run this command; your existing installation has not been modified", version)
 	}
 	return nil
 }

--- a/internal/system/cgroup.go
+++ b/internal/system/cgroup.go
@@ -1,0 +1,44 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// CheckCgroupVersion returns the cgroups version reported by podman (e.g., "v1" or "v2").
+func CheckCgroupVersion(ctx context.Context, runner CommandRunner) (string, error) {
+	if runner == nil {
+		return "", fmt.Errorf("no command runner available")
+	}
+	output, err := runner.Output(ctx, "podman", "info", "--format", "{{.Host.CgroupsVersion}}")
+	if err != nil {
+		return "", fmt.Errorf("check cgroups version: %w", err)
+	}
+	return strings.TrimSpace(output), nil
+}
+
+// ValidateCgroupsForQuadlet checks that the host meets the cgroups requirements
+// for OMR 3.0. Rootless installs require cgroups v2; rootful installs work on
+// both v1 and v2.
+func ValidateCgroupsForQuadlet(ctx context.Context, runner CommandRunner) error {
+	version, err := CheckCgroupVersion(ctx, runner)
+	if err != nil {
+		return nil
+	}
+	if version == "v2" {
+		return nil
+	}
+	if os.Getuid() != 0 {
+		return fmt.Errorf(
+			"this host uses cgroups %s but OMR 3.0 requires cgroups v2 for rootless installs\n\n"+
+				"To fix this, enable cgroups v2 and reboot:\n\n"+
+				"  sudo grubby --update-kernel=ALL --args=\"systemd.unified_cgroup_hierarchy=1\"\n"+
+				"  sudo reboot\n\n"+
+				"After reboot, verify with:\n\n"+
+				"  podman info --format '{{.Host.CgroupsVersion}}'\n\n"+
+				"Then re-run this command. Your existing installation has not been modified.", version)
+	}
+	return nil
+}

--- a/internal/system/cgroup_test.go
+++ b/internal/system/cgroup_test.go
@@ -1,0 +1,71 @@
+package system
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+type fakeCgroupRunner struct {
+	output string
+	err    error
+}
+
+func (f *fakeCgroupRunner) Run(_ context.Context, _ string, _ ...string) error {
+	return f.err
+}
+
+func (f *fakeCgroupRunner) Output(_ context.Context, _ string, _ ...string) (string, error) {
+	return f.output, f.err
+}
+
+func TestCheckCgroupVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		err     error
+		want    string
+		wantErr bool
+	}{
+		{name: "v2", output: "v2\n", want: "v2"},
+		{name: "v1", output: "v1\n", want: "v1"},
+		{name: "v2 no newline", output: "v2", want: "v2"},
+		{name: "podman not found", err: fmt.Errorf("exec: podman: not found"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CheckCgroupVersion(context.Background(), &fakeCgroupRunner{output: tt.output, err: tt.err})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CheckCgroupVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("CheckCgroupVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCgroupsForQuadlet(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		err     error
+		wantErr bool
+	}{
+		{name: "v2 passes", output: "v2", wantErr: false},
+		{name: "podman unavailable passes", err: fmt.Errorf("not found"), wantErr: false},
+		// v1 rootful/rootless behavior depends on os.Getuid() which we
+		// cannot fake in unit tests without build tags. The rootless v1
+		// path is covered by integration tests (PROJQUAY-12523 test 2).
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCgroupsForQuadlet(context.Background(), &fakeCgroupRunner{output: tt.output, err: tt.err})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCgroupsForQuadlet() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add a preflight check that detects cgroups v1 before any destructive operations in both `quay install` and `quay migrate`.

**Why**: OMR 3.0 uses Podman Quadlets for service management. Rootless Quadlets require cgroups v2 (RHEL 8 defaults to v1). Without this check, a rootless migration on cgroups v1 stops OMR 2.0, upgrades the database, then fails to start the Quadlet — leaving the registry down with no rollback.

**Tested scenarios** ([PROJQUAY-12523](https://redhat.atlassian.net/browse/PROJQUAY-12523)):

| Scenario | Quadlet works? | Preflight behavior |
|---|---|---|
| Rootful + cgroups v1 | Yes | Passes silently |
| Rootful + cgroups v2 | Yes | Passes silently |
| Rootless + cgroups v1 | No | Hard error with fix instructions |
| Rootless + cgroups v2 | Yes | Passes silently |

**What changed**:

- `internal/system/cgroup.go`: New — `CheckCgroupVersion()` runs `podman info`, `ValidateCgroupsForQuadlet()` validates and returns actionable error for rootless + v1
- `internal/installer/installer.go`: Added check in `Run()` before hostname resolution
- `internal/migrate/validate.go`: Added check in `validate()` before any database operations (skipped when `--skip-install`)
- `internal/migrate/schema_test.go`: Updated `recordingRunner.Output()` to return "v2" for `podman info` calls

**Error message on rootless + cgroups v1**:
```
error: system compatibility: this host uses cgroups v1 but OMR 3.0
requires cgroups v2 for rootless installs

To fix this, enable cgroups v2 and reboot:

  sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=1"
  sudo reboot

After reboot, verify with:

  podman info --format '{{.Host.CgroupsVersion}}'

Then re-run this command. Your existing installation has not been modified.
```

## Test plan

- [x] `go test ./internal/system/ ./internal/installer/ ./internal/migrate/` — all pass
- [x] `go build ./cmd/quay/` — compiles
- [x] `TestRunRejectsCgroupV1Rootless` — verifies Run() fails early, no files created
- [x] `TestCgroupV2PassesCheck` — verifies v2 passes
- [x] `TestCheckCgroupVersion` — verifies detection logic
- [ ] E2E: `e2e-mirror` CI job runs `quay install` on Ubuntu (cgroups v2) — check passes silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)