### PR TITLE
QUAYIO-1928: feat(deploy): add pod anti-affinity for Envoy and RLS deployments

### DIFF
--- a/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
+++ b/deploy/openshift/rosa/quay-envoy-deploy-template.yaml
@@ -74,6 +74,12 @@ objects:
                 labelSelector:
                   matchLabels:
                     app: quay-envoy
+                topologyKey: kubernetes.io/hostname
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: quay-envoy
                 topologyKey: topology.kubernetes.io/zone
         terminationGracePeriodSeconds: 60
         containers:
@@ -208,6 +214,21 @@ objects:
         - key: workload
           value: envoy
           effect: NoSchedule
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: quay-rls
+                topologyKey: kubernetes.io/hostname
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: quay-rls
+                topologyKey: topology.kubernetes.io/zone
         containers:
         - name: quay-rls
           image: ${RLS_IMAGE}:${RLS_IMAGE_TAG}


### PR DESCRIPTION
## Summary
- Adds `podAntiAffinity` to the RLS deployment to spread pods across different nodes (weight 100) and zones (weight 50)
- Adds hostname-level anti-affinity to the Envoy deployment (previously only had zone-level)
- Fixes `deployment_validation_operator_no_anti_affinity` alert firing on quayp08ue2 for both `quay-envoy` and `quay-rls`

## Test plan
- [ ] Verify RLS pods are scheduled on different nodes after deployment
- [ ] Verify Envoy pods remain on different nodes
- [ ] Confirm `deployment_validation_operator_no_anti_affinity` alert resolves

JIRA: https://redhat.atlassian.net/browse/QUAYIO-1928

🤖 Generated with [Claude Code](https://claude.com/claude-code)