### PR TITLE
PROJQUAY-12269: feat(web): implement search page in React UI

### DIFF
--- a/conf/nginx/server-base.conf.jnj
+++ b/conf/nginx/server-base.conf.jnj
@@ -51,7 +51,7 @@ location / {
     # Show new UI if cookie or default is set to react
     if ($user_requested_ui ~* "^react$") {
         # catch known React UI routes and direct to /index.html
-        rewrite ^(/overview|/organization|/repository|/signin|/createaccount|/oauth-error|/oauth/localapp|/oauth2/[^/]+/callback(/attach|/cli)?|/updateuser|/user/(.*)|/service-keys|/change-log|/usage-logs|/messages|/build-logs|/about|/security) /index.html break;
+        rewrite ^(/overview|/organization|/repository|/signin|/createaccount|/oauth-error|/oauth/localapp|/oauth2/[^/]+/callback(/attach|/cli)?|/updateuser|/user/(.*)|/service-keys|/change-log|/usage-logs|/messages|/build-logs|/about|/security|/search) /index.html break;
         # catch-all for shorthand URLs (/<org>, /<org>/<repo>) handled by React Router
         rewrite ^/[^.]*$ /index.html break;
     }
@@ -67,10 +67,6 @@ location ~* ^(/config|/csrf_token|/oauth/authorize|/oauth/authorizeapp|/oauth/au
     proxy_pass   http://web_app_server;
 }
 
-# Capture old UI paths that aren't present in new UI
-location ~* ^(/search) {
-    proxy_pass   http://web_app_server;
-}
 
 location /push {
     proxy_pass   http://web_app_server;

--- a/web/playwright/e2e/ui/header-search.spec.ts
+++ b/web/playwright/e2e/ui/header-search.spec.ts
@@ -1,0 +1,169 @@
+import {test, expect} from '../../fixtures';
+
+const SEARCH_LABEL = 'Search repositories and organizations';
+
+test.describe('Header search bar', {tag: ['@ui', '@PROJQUAY-12269']}, () => {
+  test('is present in the masthead on ordinary pages', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/organization');
+
+    await expect(
+      authenticatedPage.getByRole('combobox', {name: SEARCH_LABEL}),
+    ).toBeVisible();
+  });
+
+  test('is hidden on the search page, which has its own input', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/search');
+
+    await expect(
+      authenticatedPage.getByRole('combobox', {name: SEARCH_LABEL}),
+    ).toBeHidden();
+    await expect(
+      authenticatedPage.getByPlaceholder('Search repositories...'),
+    ).toBeVisible();
+  });
+
+  test('submitting a term navigates to the search page', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const org = await api.organization('hdr-submit');
+    const repo = await api.repository(org.name, 'hdr-findme', 'public');
+
+    await authenticatedPage.goto('/organization');
+
+    const searchInput = authenticatedPage.getByRole('combobox', {
+      name: SEARCH_LABEL,
+    });
+    await searchInput.fill(repo.name);
+    await searchInput.press('Enter');
+
+    await expect(authenticatedPage).toHaveURL(new RegExp(`/search\\?q=`));
+    await expect(
+      authenticatedPage.getByRole('link', {name: repo.fullName}),
+    ).toBeVisible();
+  });
+
+  test('suggests repositories and navigates on click', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const org = await api.organization('hdr-repo');
+    const repo = await api.repository(org.name, 'hdr-suggest', 'public');
+
+    await authenticatedPage.goto('/organization');
+
+    const searchInput = authenticatedPage.getByRole('combobox', {
+      name: SEARCH_LABEL,
+    });
+    await searchInput.pressSequentially(repo.name.slice(0, 10), {delay: 50});
+
+    const suggestion = authenticatedPage
+      .getByRole('option')
+      .filter({hasText: repo.name});
+    await expect(suggestion).toBeVisible({timeout: 5000});
+    await suggestion.click();
+
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/repository/${org.name}/${repo.name}`),
+    );
+  });
+
+  test('suggests organizations as well as repositories', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const org = await api.organization('hdr-org');
+    // Namespace suggestions inner-join Repository, so an empty org is never
+    // returned by /find/all. Give it a visible repository.
+    await api.repository(org.name, 'hdr-org-repo', 'public');
+
+    await authenticatedPage.goto('/organization');
+
+    const searchInput = authenticatedPage.getByRole('combobox', {
+      name: SEARCH_LABEL,
+    });
+    await searchInput.pressSequentially(org.name.slice(0, 10), {delay: 50});
+
+    await expect(
+      authenticatedPage.getByRole('option').filter({hasText: org.name}),
+    ).toBeVisible({timeout: 5000});
+  });
+
+  test('is keyboard navigable and exposes the combobox contract', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const org = await api.organization('hdr-keys');
+    const repo = await api.repository(org.name, 'hdr-arrow', 'public');
+
+    await authenticatedPage.goto('/organization');
+
+    const searchInput = authenticatedPage.getByRole('combobox', {
+      name: SEARCH_LABEL,
+    });
+    await expect(searchInput).toHaveAttribute('aria-expanded', 'false');
+
+    await searchInput.pressSequentially(repo.name.slice(0, 10), {delay: 50});
+    await expect(searchInput).toHaveAttribute('aria-expanded', 'true', {
+      timeout: 5000,
+    });
+
+    await searchInput.press('ArrowDown');
+    const activeId = await searchInput.getAttribute('aria-activedescendant');
+    expect(activeId).toBe('header-search-suggestion-0');
+
+    // aria-activedescendant must reference the option itself so a screen
+    // reader can announce the highlighted suggestion.
+    await expect(authenticatedPage.locator(`#${activeId}`)).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    await searchInput.press('Enter');
+    await expect(authenticatedPage).not.toHaveURL(/\/organization$/);
+  });
+
+  test('Escape closes the dropdown and it stays closed', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const org = await api.organization('hdr-esc');
+    const repo = await api.repository(org.name, 'hdr-escape', 'public');
+
+    await authenticatedPage.goto('/organization');
+
+    const searchInput = authenticatedPage.getByRole('combobox', {
+      name: SEARCH_LABEL,
+    });
+    await searchInput.pressSequentially(repo.name.slice(0, 10), {delay: 50});
+    await expect(
+      authenticatedPage.getByRole('option').filter({hasText: repo.name}),
+    ).toBeVisible({timeout: 5000});
+
+    await searchInput.press('Escape');
+    await expect(authenticatedPage.getByRole('option')).toHaveCount(0);
+
+    // Must not reappear once a background refetch settles.
+    await authenticatedPage.waitForTimeout(1000);
+    await expect(authenticatedPage.getByRole('option')).toHaveCount(0);
+  });
+
+  test(
+    'anonymous users get the header search bar',
+    {tag: ['@feature:ANONYMOUS_ACCESS']},
+    async ({unauthenticatedPage, api}) => {
+      const org = await api.organization('hdr-anon');
+      await api.repository(org.name, 'hdr-anon-repo', 'public');
+
+      await unauthenticatedPage.goto('/organization');
+
+      await expect(
+        unauthenticatedPage.getByRole('combobox', {name: SEARCH_LABEL}),
+      ).toBeVisible();
+    },
+  );
+});

--- a/web/playwright/e2e/ui/search-page.spec.ts
+++ b/web/playwright/e2e/ui/search-page.spec.ts
@@ -1,0 +1,109 @@
+import {test, expect} from '../../fixtures';
+
+test.describe('Search Page', {tag: ['@ui', '@PROJQUAY-12269']}, () => {
+  test('renders search page at /search', async ({authenticatedPage}) => {
+    await authenticatedPage.goto('/search');
+
+    await expect(
+      authenticatedPage.getByRole('heading', {name: 'Search'}),
+    ).toBeVisible();
+    await expect(
+      authenticatedPage.getByPlaceholder('Search repositories...'),
+    ).toBeVisible();
+  });
+
+  test('does not redirect /search to /organization/search', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/search');
+
+    await expect(authenticatedPage).toHaveURL(/\/search$/);
+    await expect(authenticatedPage).not.toHaveURL(/\/organization\/search/);
+  });
+
+  test('lists repositories on load without query', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const org = await api.organization('search-list');
+    const repo = await api.repository(org.name, 'search-test', 'public');
+
+    await authenticatedPage.goto('/search');
+
+    await expect(
+      authenticatedPage.getByRole('link', {name: repo.fullName}),
+    ).toBeVisible();
+  });
+
+  test('searches repositories by query', async ({authenticatedPage, api}) => {
+    const org = await api.organization('search-query');
+    const repo = await api.repository(org.name, 'findme', 'public');
+    await api.repository(org.name, 'other', 'public');
+
+    await authenticatedPage.goto('/search');
+
+    const searchInput = authenticatedPage.getByPlaceholder(
+      'Search repositories...',
+    );
+    await searchInput.fill(repo.name);
+    await searchInput.press('Enter');
+
+    await expect(authenticatedPage).toHaveURL(new RegExp(`q=${repo.name}`));
+    await expect(
+      authenticatedPage.getByRole('link', {name: repo.fullName}),
+    ).toBeVisible();
+  });
+
+  test(
+    'anonymous user can access search and find public repos',
+    {tag: ['@feature:ANONYMOUS_ACCESS']},
+    async ({unauthenticatedPage, api}) => {
+      const org = await api.organization('search-anon');
+      const repo = await api.repository(org.name, 'anon-vis', 'public');
+
+      await unauthenticatedPage.goto('/search');
+
+      await expect(
+        unauthenticatedPage.getByRole('heading', {name: 'Search'}),
+      ).toBeVisible();
+      await expect(
+        unauthenticatedPage.getByRole('link', {name: repo.fullName}),
+      ).toBeVisible();
+    },
+  );
+
+  test('shows typeahead suggestions while typing', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const org = await api.organization('search-suggest');
+    const repo = await api.repository(org.name, 'suggest-test', 'public');
+
+    await authenticatedPage.goto('/search');
+
+    const searchInput = authenticatedPage.getByPlaceholder(
+      'Search repositories...',
+    );
+    await searchInput.pressSequentially(repo.name.slice(0, 10), {delay: 50});
+
+    await expect(
+      authenticatedPage.getByRole('menuitem').filter({hasText: repo.name}),
+    ).toBeVisible({timeout: 5000});
+  });
+
+  test('shows empty state when no results match', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/search');
+
+    const searchInput = authenticatedPage.getByPlaceholder(
+      'Search repositories...',
+    );
+    await searchInput.fill('zzz-nonexistent-repo-xyz');
+    await searchInput.press('Enter');
+
+    await expect(
+      authenticatedPage.getByText('No matching repositories found'),
+    ).toBeVisible();
+  });
+});

--- a/web/playwright/e2e/ui/search-page.spec.ts
+++ b/web/playwright/e2e/ui/search-page.spec.ts
@@ -87,8 +87,39 @@ test.describe('Search Page', {tag: ['@ui', '@PROJQUAY-12269']}, () => {
     await searchInput.pressSequentially(repo.name.slice(0, 10), {delay: 50});
 
     await expect(
-      authenticatedPage.getByRole('menuitem').filter({hasText: repo.name}),
+      authenticatedPage.getByRole('option').filter({hasText: repo.name}),
     ).toBeVisible({timeout: 5000});
+  });
+
+  test('search input exposes the combobox contract to assistive tech', async ({
+    authenticatedPage,
+    api,
+  }) => {
+    const org = await api.organization('search-aria');
+    const repo = await api.repository(org.name, 'aria-test', 'public');
+
+    await authenticatedPage.goto('/search');
+
+    // getByRole('combobox') only matches if the role is on the input itself.
+    const searchInput = authenticatedPage.getByRole('combobox', {
+      name: 'Search repositories',
+    });
+    await expect(searchInput).toHaveAttribute('aria-expanded', 'false');
+
+    await searchInput.pressSequentially(repo.name.slice(0, 8), {delay: 50});
+    await expect(searchInput).toHaveAttribute('aria-expanded', 'true', {
+      timeout: 5000,
+    });
+
+    await searchInput.press('ArrowDown');
+    const activeId = await searchInput.getAttribute('aria-activedescendant');
+    expect(activeId).toBe('search-suggestion-0');
+
+    // The referenced element must be the option itself, not a wrapper.
+    await expect(authenticatedPage.locator(`#${activeId}`)).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
   });
 
   test('shows empty state when no results match', async ({

--- a/web/src/components/header/HeaderSearchBar.css
+++ b/web/src/components/header/HeaderSearchBar.css
@@ -14,8 +14,21 @@
   min-width: 20rem;
   background-color: var(--pf-t--global--background--color--floating--default);
   box-shadow: var(--pf-t--global--box-shadow--md);
+  border-radius: var(--pf-t--global--border--radius--small);
   max-height: 25rem;
   overflow-y: auto;
+}
+
+.header-search-suggestion-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--pf-t--global--spacer--xs) 0;
+}
+
+.header-search-suggestion {
+  padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md);
+  cursor: pointer;
+  white-space: nowrap;
 }
 
 .header-search-suggestion-active {

--- a/web/src/components/header/HeaderSearchBar.css
+++ b/web/src/components/header/HeaderSearchBar.css
@@ -1,0 +1,44 @@
+.header-search-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.header-search-input {
+  width: 100%;
+  min-width: 20rem;
+}
+
+.header-search-dropdown {
+  z-index: var(--pf-t--global--z-index--md);
+  min-width: 20rem;
+  background-color: var(--pf-t--global--background--color--floating--default);
+  box-shadow: var(--pf-t--global--box-shadow--md);
+  max-height: 25rem;
+  overflow-y: auto;
+}
+
+.header-search-suggestion-active {
+  background-color: var(--pf-t--global--color--brand--default);
+  color: var(--pf-t--global--text--color--on-brand--default);
+}
+
+.header-search-suggestion-kind {
+  display: inline-block;
+  min-width: 4em;
+  font-size: var(--pf-t--global--font--size--sm);
+  color: var(--pf-t--global--text--color--subtle);
+  text-transform: capitalize;
+}
+
+.header-search-spinner {
+  position: absolute;
+  right: var(--pf-t--global--spacer--xl);
+  pointer-events: none;
+}
+
+@media screen and (max-width: 768px) {
+  .header-search-input {
+    min-width: 12rem;
+  }
+}

--- a/web/src/components/header/HeaderSearchBar.test.tsx
+++ b/web/src/components/header/HeaderSearchBar.test.tsx
@@ -1,0 +1,187 @@
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {MemoryRouter} from 'react-router-dom';
+import {createElement} from 'react';
+import HeaderSearchBar from './HeaderSearchBar';
+
+const mockUseSearchSuggestions = vi.hoisted(() => vi.fn());
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock('src/hooks/UseSearch', () => ({
+  useSearchSuggestions: (...args: unknown[]) =>
+    mockUseSearchSuggestions(...args),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {...actual, useNavigate: () => mockNavigate};
+});
+
+vi.mock('src/components/Avatar', () => ({
+  default: () => <span data-testid="avatar" />,
+}));
+
+vi.mock('src/libs/avatarUtils', () => ({
+  generateAvatarFromName: (name: string) => ({
+    name,
+    hash: '',
+    color: '#000',
+    kind: 'generated',
+  }),
+}));
+
+const repoSuggestion = {
+  kind: 'repository',
+  title: 'Repo',
+  name: 'my-repo',
+  namespace: {name: 'myorg', avatar: null},
+  href: '/repository/myorg/my-repo',
+  score: 5,
+};
+
+const orgSuggestion = {
+  kind: 'organization',
+  title: 'Organization',
+  name: 'acme-org',
+  avatar: null,
+  href: '/organization/acme-org',
+  score: 4,
+};
+
+function renderSearchBar() {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false, cacheTime: 0}},
+    logger: {log: vi.fn(), warn: vi.fn(), error: vi.fn()},
+  });
+  return render(
+    createElement(
+      QueryClientProvider,
+      {client: queryClient},
+      createElement(MemoryRouter, null, createElement(HeaderSearchBar)),
+    ),
+  );
+}
+
+function getInput() {
+  return screen.getByLabelText('Search repositories and organizations');
+}
+
+describe('HeaderSearchBar', () => {
+  beforeEach(() => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [],
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders the search input', () => {
+    renderSearchBar();
+
+    expect(getInput()).toBeVisible();
+  });
+
+  it('navigates to search page on Enter with no suggestion selected', () => {
+    renderSearchBar();
+
+    const input = getInput();
+    fireEvent.change(input, {target: {value: 'nginx'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(mockNavigate).toHaveBeenCalledWith('/search?q=nginx');
+  });
+
+  it('shows both repository and organization suggestions', async () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [repoSuggestion, orgSuggestion],
+      isLoading: false,
+    });
+
+    renderSearchBar();
+    fireEvent.change(getInput(), {target: {value: 'myorg'}});
+
+    await waitFor(() => {
+      expect(screen.getByText('myorg/my-repo')).toBeVisible();
+    });
+    expect(screen.getByText('acme-org')).toBeVisible();
+  });
+
+  it('navigates to the suggestion href when clicked', async () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [orgSuggestion],
+      isLoading: false,
+    });
+
+    renderSearchBar();
+    fireEvent.change(getInput(), {target: {value: 'myorg'}});
+
+    await waitFor(() => {
+      expect(screen.getByText('acme-org')).toBeVisible();
+    });
+    fireEvent.click(screen.getByText('acme-org'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/organization/acme-org');
+  });
+
+  it('navigates suggestions with ArrowDown and selects with Enter', async () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [repoSuggestion, orgSuggestion],
+      isLoading: false,
+    });
+
+    renderSearchBar();
+    const input = getInput();
+    fireEvent.change(input, {target: {value: 'myorg'}});
+
+    await waitFor(() => {
+      expect(screen.getByText('myorg/my-repo')).toBeVisible();
+    });
+
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(
+      screen.getByText('myorg/my-repo').closest('[role="option"]'),
+    ).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(
+      screen.getByText('acme-org').closest('[role="option"]'),
+    ).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, {key: 'Enter'});
+    expect(mockNavigate).toHaveBeenCalledWith('/organization/acme-org');
+  });
+
+  it('closes the dropdown on Escape', async () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [repoSuggestion],
+      isLoading: false,
+    });
+
+    renderSearchBar();
+    const input = getInput();
+    fireEvent.change(input, {target: {value: 'myorg'}});
+
+    await waitFor(() => {
+      expect(screen.getByText('myorg/my-repo')).toBeVisible();
+    });
+
+    fireEvent.keyDown(input, {key: 'Escape'});
+
+    await waitFor(() => {
+      expect(screen.queryByText('myorg/my-repo')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not open the dropdown for queries under 3 characters', () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [repoSuggestion],
+      isLoading: false,
+    });
+
+    renderSearchBar();
+    fireEvent.change(getInput(), {target: {value: 'my'}});
+
+    expect(screen.queryByText('myorg/my-repo')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/header/HeaderSearchBar.test.tsx
+++ b/web/src/components/header/HeaderSearchBar.test.tsx
@@ -173,6 +173,81 @@ describe('HeaderSearchBar', () => {
     });
   });
 
+  it('has combobox ARIA attributes on the focusable input itself', () => {
+    renderSearchBar();
+
+    // Every combobox attribute must be on the <input> that receives focus.
+    // On a wrapper element aria-activedescendant is inert to screen readers.
+    const input = screen.getByTestId('header-search-input');
+    expect(input.tagName).toBe('INPUT');
+    expect(input).toHaveAttribute('role', 'combobox');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    expect(input).toHaveAttribute('aria-controls', 'header-search-suggestions');
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('points aria-activedescendant at the highlighted suggestion', async () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [repoSuggestion, orgSuggestion],
+      isLoading: false,
+    });
+
+    renderSearchBar();
+    const input = getInput();
+    fireEvent.change(input, {target: {value: 'myorg'}});
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+    });
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+
+    expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      'header-search-suggestion-0',
+    );
+    expect(
+      document.getElementById('header-search-suggestion-0'),
+    ).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('keeps the dropdown closed after Escape when suggestions refetch', async () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [repoSuggestion],
+      isLoading: false,
+    });
+
+    const {rerender} = renderSearchBar();
+    const input = getInput();
+    fireEvent.change(input, {target: {value: 'myorg'}});
+
+    await waitFor(() => {
+      expect(screen.getByText('myorg/my-repo')).toBeVisible();
+    });
+
+    fireEvent.keyDown(input, {key: 'Escape'});
+    await waitFor(() => {
+      expect(screen.queryByText('myorg/my-repo')).not.toBeInTheDocument();
+    });
+
+    // A background refetch returns a new array with identical contents. The
+    // dropdown must stay closed rather than reappearing under the user.
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [{...repoSuggestion}],
+      isLoading: false,
+    });
+    rerender(
+      createElement(
+        QueryClientProvider,
+        {client: new QueryClient({defaultOptions: {queries: {retry: false}}})},
+        createElement(MemoryRouter, null, createElement(HeaderSearchBar)),
+      ),
+    );
+
+    expect(screen.queryByText('myorg/my-repo')).not.toBeInTheDocument();
+  });
+
   it('does not open the dropdown for queries under 3 characters', () => {
     mockUseSearchSuggestions.mockReturnValue({
       suggestions: [repoSuggestion],

--- a/web/src/components/header/HeaderSearchBar.tsx
+++ b/web/src/components/header/HeaderSearchBar.tsx
@@ -3,10 +3,6 @@ import {useNavigate} from 'react-router-dom';
 import {
   Flex,
   FlexItem,
-  Menu,
-  MenuContent,
-  MenuItem,
-  MenuList,
   Popper,
   SearchInput,
   Spinner,
@@ -37,10 +33,16 @@ export default function HeaderSearchBar() {
 
   const searchBoxRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  // Set when the user explicitly dismisses the dropdown so a background
+  // refetch of suggestions doesn't reopen it behind their back.
+  const isDismissedRef = useRef(false);
 
   const {suggestions, isLoading} = useSearchSuggestions(inputValue);
 
   useEffect(() => {
+    if (isDismissedRef.current) {
+      return;
+    }
     setIsDropdownOpen(
       inputValue.trim().length >= MIN_QUERY_LENGTH && suggestions.length > 0,
     );
@@ -64,8 +66,18 @@ export default function HeaderSearchBar() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
-  const goToSuggestion = (suggestion: ISearchSuggestion) => {
+  const closeDropdown = () => {
+    isDismissedRef.current = true;
     setIsDropdownOpen(false);
+  };
+
+  const handleChange = (value: string) => {
+    isDismissedRef.current = false;
+    setInputValue(value);
+  };
+
+  const goToSuggestion = (suggestion: ISearchSuggestion) => {
+    closeDropdown();
     setInputValue('');
     navigate(suggestion.href);
   };
@@ -73,7 +85,7 @@ export default function HeaderSearchBar() {
   const goToSearchPage = () => {
     const trimmed = inputValue.trim();
     if (trimmed) {
-      setIsDropdownOpen(false);
+      closeDropdown();
       setInputValue('');
       navigate(`/search?q=${encodeURIComponent(trimmed)}`);
     }
@@ -88,7 +100,7 @@ export default function HeaderSearchBar() {
       }
     }
     if (event.key === 'Escape') {
-      setIsDropdownOpen(false);
+      closeDropdown();
     }
     if (event.key === 'ArrowDown' && isDropdownOpen && suggestions.length > 0) {
       event.preventDefault();
@@ -105,69 +117,80 @@ export default function HeaderSearchBar() {
       <SearchInput
         value={inputValue}
         placeholder="Search repositories and organizations..."
-        onChange={(_event, value) => setInputValue(value)}
+        onChange={(_event, value) => handleChange(value)}
         onClear={() => {
           setInputValue('');
-          setIsDropdownOpen(false);
+          closeDropdown();
         }}
-        onKeyDown={handleKeyDown}
         aria-label="Search repositories and organizations"
-        data-testid="header-search-input"
-        role="combobox"
-        aria-expanded={isDropdownOpen}
-        aria-controls="header-search-suggestions"
-        aria-activedescendant={
-          activeIndex >= 0
-            ? `header-search-suggestion-${activeIndex}`
-            : undefined
-        }
-        aria-autocomplete="list"
+        // The combobox contract has to live on the focusable <input>, not on
+        // the wrapper PatternFly renders around it. `inputProps` is the only
+        // prop SearchInput forwards all the way down to the input element.
+        inputProps={{
+          'data-testid': 'header-search-input',
+          role: 'combobox',
+          'aria-expanded': isDropdownOpen,
+          'aria-controls': 'header-search-suggestions',
+          'aria-activedescendant':
+            activeIndex >= 0
+              ? `header-search-suggestion-${activeIndex}`
+              : undefined,
+          'aria-autocomplete': 'list',
+          onKeyDown: handleKeyDown,
+        }}
       />
     </div>
   );
 
+  // Plain listbox markup rather than PatternFly's Menu: MenuItem renders the
+  // `id` onto an inner role="menuitem" button, which both breaks the
+  // aria-activedescendant reference and nests a menuitem inside a listbox.
   const suggestionsDropdown = (
     <div ref={dropdownRef} className="header-search-dropdown">
-      <Menu onSelect={() => setIsDropdownOpen(false)}>
-        <MenuContent>
-          <MenuList id="header-search-suggestions" role="listbox">
-            {suggestions.map((s, i) => (
-              <MenuItem
-                key={`${s.kind}-${s.name}-${i}`}
-                id={`header-search-suggestion-${i}`}
-                onClick={() => goToSuggestion(s)}
-                className={
-                  i === activeIndex ? 'header-search-suggestion-active' : ''
-                }
-                role="option"
-                aria-selected={i === activeIndex}
-              >
-                <Flex
-                  alignItems={{default: 'alignItemsCenter'}}
-                  spaceItems={{default: 'spaceItemsSm'}}
-                  flexWrap={{default: 'nowrap'}}
-                >
-                  <FlexItem>
-                    <span className="header-search-suggestion-kind">
-                      {s.title || s.kind}
-                    </span>
-                  </FlexItem>
-                  <FlexItem>
-                    <Avatar
-                      avatar={
-                        s.avatar ??
-                        (s.namespace?.avatar || generateAvatarFromName(s.name))
-                      }
-                      size="sm"
-                    />
-                  </FlexItem>
-                  <FlexItem>{getSuggestionLabel(s)}</FlexItem>
-                </Flex>
-              </MenuItem>
-            ))}
-          </MenuList>
-        </MenuContent>
-      </Menu>
+      <ul
+        id="header-search-suggestions"
+        role="listbox"
+        aria-label="Search suggestions"
+        className="header-search-suggestion-list"
+      >
+        {suggestions.map((s, i) => (
+          <li
+            key={`${s.kind}-${s.href}`}
+            id={`header-search-suggestion-${i}`}
+            role="option"
+            aria-selected={i === activeIndex}
+            className={`header-search-suggestion${
+              i === activeIndex ? ' header-search-suggestion-active' : ''
+            }`}
+            // Keep focus on the input so aria-activedescendant stays valid.
+            onMouseDown={(event) => event.preventDefault()}
+            onMouseEnter={() => setActiveIndex(i)}
+            onClick={() => goToSuggestion(s)}
+          >
+            <Flex
+              alignItems={{default: 'alignItemsCenter'}}
+              spaceItems={{default: 'spaceItemsSm'}}
+              flexWrap={{default: 'nowrap'}}
+            >
+              <FlexItem>
+                <span className="header-search-suggestion-kind">
+                  {s.title || s.kind}
+                </span>
+              </FlexItem>
+              <FlexItem>
+                <Avatar
+                  avatar={
+                    s.avatar ??
+                    (s.namespace?.avatar || generateAvatarFromName(s.name))
+                  }
+                  size="sm"
+                />
+              </FlexItem>
+              <FlexItem>{getSuggestionLabel(s)}</FlexItem>
+            </Flex>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 
@@ -178,7 +201,10 @@ export default function HeaderSearchBar() {
         popper={suggestionsDropdown}
         isVisible={isDropdownOpen}
         enableFlip={false}
-        appendTo={() => searchBoxRef.current ?? document.body}
+        minWidth="trigger"
+        // Rendered into the body rather than the masthead so the dropdown is
+        // not clipped by the header's stacking/overflow context.
+        appendTo={() => document.body}
       />
       {isLoading && inputValue.trim().length >= MIN_QUERY_LENGTH && (
         <Spinner size="sm" className="header-search-spinner" />

--- a/web/src/components/header/HeaderSearchBar.tsx
+++ b/web/src/components/header/HeaderSearchBar.tsx
@@ -1,0 +1,188 @@
+import {useEffect, useRef, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {
+  Flex,
+  FlexItem,
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  Popper,
+  SearchInput,
+  Spinner,
+} from '@patternfly/react-core';
+import {useSearchSuggestions} from 'src/hooks/UseSearch';
+import Avatar from 'src/components/Avatar';
+import {generateAvatarFromName} from 'src/libs/avatarUtils';
+import {ISearchSuggestion} from 'src/resources/SearchResource';
+import 'src/components/header/HeaderSearchBar.css';
+
+const MIN_QUERY_LENGTH = 3;
+
+function getSuggestionLabel(s: ISearchSuggestion) {
+  if (s.kind === 'repository' && s.namespace) {
+    return `${s.namespace.name}/${s.name}`;
+  }
+  if (s.kind === 'team' && s.organization) {
+    return `${s.organization.name}/${s.name}`;
+  }
+  return s.name;
+}
+
+export default function HeaderSearchBar() {
+  const navigate = useNavigate();
+  const [inputValue, setInputValue] = useState('');
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const searchBoxRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const {suggestions, isLoading} = useSearchSuggestions(inputValue);
+
+  useEffect(() => {
+    setIsDropdownOpen(
+      inputValue.trim().length >= MIN_QUERY_LENGTH && suggestions.length > 0,
+    );
+  }, [suggestions, inputValue]);
+
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [suggestions]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        !searchBoxRef.current?.contains(target) &&
+        !dropdownRef.current?.contains(target)
+      ) {
+        setIsDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const goToSuggestion = (suggestion: ISearchSuggestion) => {
+    setIsDropdownOpen(false);
+    setInputValue('');
+    navigate(suggestion.href);
+  };
+
+  const goToSearchPage = () => {
+    const trimmed = inputValue.trim();
+    if (trimmed) {
+      setIsDropdownOpen(false);
+      setInputValue('');
+      navigate(`/search?q=${encodeURIComponent(trimmed)}`);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      if (isDropdownOpen && activeIndex >= 0 && suggestions[activeIndex]) {
+        goToSuggestion(suggestions[activeIndex]);
+      } else {
+        goToSearchPage();
+      }
+    }
+    if (event.key === 'Escape') {
+      setIsDropdownOpen(false);
+    }
+    if (event.key === 'ArrowDown' && isDropdownOpen && suggestions.length > 0) {
+      event.preventDefault();
+      setActiveIndex((prev) => (prev < suggestions.length - 1 ? prev + 1 : 0));
+    }
+    if (event.key === 'ArrowUp' && isDropdownOpen && suggestions.length > 0) {
+      event.preventDefault();
+      setActiveIndex((prev) => (prev > 0 ? prev - 1 : suggestions.length - 1));
+    }
+  };
+
+  const searchInput = (
+    <div ref={searchBoxRef} className="header-search-input">
+      <SearchInput
+        value={inputValue}
+        placeholder="Search repositories and organizations..."
+        onChange={(_event, value) => setInputValue(value)}
+        onClear={() => {
+          setInputValue('');
+          setIsDropdownOpen(false);
+        }}
+        onKeyDown={handleKeyDown}
+        aria-label="Search repositories and organizations"
+        data-testid="header-search-input"
+        role="combobox"
+        aria-expanded={isDropdownOpen}
+        aria-controls="header-search-suggestions"
+        aria-activedescendant={
+          activeIndex >= 0
+            ? `header-search-suggestion-${activeIndex}`
+            : undefined
+        }
+        aria-autocomplete="list"
+      />
+    </div>
+  );
+
+  const suggestionsDropdown = (
+    <div ref={dropdownRef} className="header-search-dropdown">
+      <Menu onSelect={() => setIsDropdownOpen(false)}>
+        <MenuContent>
+          <MenuList id="header-search-suggestions" role="listbox">
+            {suggestions.map((s, i) => (
+              <MenuItem
+                key={`${s.kind}-${s.name}-${i}`}
+                id={`header-search-suggestion-${i}`}
+                onClick={() => goToSuggestion(s)}
+                className={
+                  i === activeIndex ? 'header-search-suggestion-active' : ''
+                }
+                role="option"
+                aria-selected={i === activeIndex}
+              >
+                <Flex
+                  alignItems={{default: 'alignItemsCenter'}}
+                  spaceItems={{default: 'spaceItemsSm'}}
+                  flexWrap={{default: 'nowrap'}}
+                >
+                  <FlexItem>
+                    <span className="header-search-suggestion-kind">
+                      {s.title || s.kind}
+                    </span>
+                  </FlexItem>
+                  <FlexItem>
+                    <Avatar
+                      avatar={
+                        s.avatar ??
+                        (s.namespace?.avatar || generateAvatarFromName(s.name))
+                      }
+                      size="sm"
+                    />
+                  </FlexItem>
+                  <FlexItem>{getSuggestionLabel(s)}</FlexItem>
+                </Flex>
+              </MenuItem>
+            ))}
+          </MenuList>
+        </MenuContent>
+      </Menu>
+    </div>
+  );
+
+  return (
+    <div className="header-search-container">
+      <Popper
+        trigger={searchInput}
+        popper={suggestionsDropdown}
+        isVisible={isDropdownOpen}
+        enableFlip={false}
+        appendTo={() => searchBoxRef.current ?? document.body}
+      />
+      {isLoading && inputValue.trim().length >= MIN_QUERY_LENGTH && (
+        <Spinner size="sm" className="header-search-spinner" />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/header/HeaderToolbar.test.tsx
+++ b/web/src/components/header/HeaderToolbar.test.tsx
@@ -1,3 +1,4 @@
+import {MemoryRouter} from 'react-router-dom';
 import {render, screen} from 'src/test-utils';
 import {HeaderToolbar} from './HeaderToolbar';
 
@@ -44,13 +45,25 @@ vi.mock('src/contexts/ThemeContext', () => ({
   ThemePreference: {LIGHT: 'light', DARK: 'dark'},
 }));
 
+vi.mock('src/hooks/UseSearch', () => ({
+  useSearchSuggestions: () => ({suggestions: [], isLoading: false}),
+}));
+
+function renderToolbar(route = '/organization') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <HeaderToolbar toggleDrawer={vi.fn()} />
+    </MemoryRouter>,
+  );
+}
+
 describe('HeaderToolbar', () => {
   it('shows sign in button for anonymous users', () => {
     mockUseCurrentUser.mockReturnValue({
       user: {username: '', anonymous: true},
     });
 
-    render(<HeaderToolbar toggleDrawer={vi.fn()} />);
+    renderToolbar();
     expect(screen.getByText('Sign In')).toBeInTheDocument();
     expect(screen.queryByTestId('notification-bell')).not.toBeInTheDocument();
   });
@@ -60,8 +73,26 @@ describe('HeaderToolbar', () => {
       user: {username: 'testuser', anonymous: false},
     });
 
-    render(<HeaderToolbar toggleDrawer={vi.fn()} />);
+    renderToolbar();
     expect(screen.getByTestId('notification-bell')).toBeInTheDocument();
     expect(screen.queryByText('Sign In')).not.toBeInTheDocument();
+  });
+
+  it('renders the header search bar on ordinary pages', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: 'testuser', anonymous: false},
+    });
+
+    renderToolbar('/organization');
+    expect(screen.getByTestId('header-search-item')).toBeInTheDocument();
+  });
+
+  it('hides the header search bar on the search page', () => {
+    mockUseCurrentUser.mockReturnValue({
+      user: {username: 'testuser', anonymous: false},
+    });
+
+    renderToolbar('/search');
+    expect(screen.queryByTestId('header-search-item')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -47,7 +47,7 @@ import SunIcon from '@patternfly/react-icons/dist/esm/icons/sun-icon';
 
 import {ThemePreference, useTheme} from 'src/contexts/ThemeContext';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
-import {useNavigate} from 'react-router-dom';
+import {useLocation, useNavigate} from 'react-router-dom';
 import HeaderSearchBar from 'src/components/header/HeaderSearchBar';
 
 export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
@@ -59,6 +59,7 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
   const {themePreference, setThemePreference} = useTheme();
   const quayConfig = useQuayConfig();
   const navigate = useNavigate();
+  const location = useLocation();
   const showUIToggle =
     quayConfig?.features?.UI_V2 &&
     !(
@@ -396,8 +397,10 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
 
   const isAuthenticated = !!user?.username;
   const {unreadCount} = useAppNotifications(isAuthenticated);
+  // The search page has its own search box, so don't render a second one.
   const searchingAllowed =
-    quayConfig?.features?.ANONYMOUS_ACCESS || isAuthenticated;
+    (quayConfig?.features?.ANONYMOUS_ACCESS || isAuthenticated) &&
+    location.pathname !== '/search';
 
   return (
     <>

--- a/web/src/components/header/HeaderToolbar.tsx
+++ b/web/src/components/header/HeaderToolbar.tsx
@@ -48,6 +48,7 @@ import SunIcon from '@patternfly/react-icons/dist/esm/icons/sun-icon';
 import {ThemePreference, useTheme} from 'src/contexts/ThemeContext';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {useNavigate} from 'react-router-dom';
+import HeaderSearchBar from 'src/components/header/HeaderSearchBar';
 
 export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -395,12 +396,19 @@ export function HeaderToolbar({toggleDrawer}: {toggleDrawer: () => void}) {
 
   const isAuthenticated = !!user?.username;
   const {unreadCount} = useAppNotifications(isAuthenticated);
+  const searchingAllowed =
+    quayConfig?.features?.ANONYMOUS_ACCESS || isAuthenticated;
 
   return (
     <>
       <ErrorModal error={err} setError={setErr} />
       <Toolbar id="toolbar" isFullHeight isStatic>
         <ToolbarContent>
+          {searchingAllowed && (
+            <ToolbarItem data-testid="header-search-item">
+              <HeaderSearchBar />
+            </ToolbarItem>
+          )}
           <ToolbarGroup
             variant="action-group-plain"
             align={{default: 'alignEnd'}}

--- a/web/src/hooks/UseSearch.test.ts
+++ b/web/src/hooks/UseSearch.test.ts
@@ -1,0 +1,118 @@
+import {renderHook, waitFor, act} from '@testing-library/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {createElement} from 'react';
+import {useSearch, useSearchSuggestions} from './UseSearch';
+
+const mockFetchSearchResults = vi.hoisted(() => vi.fn());
+const mockFetchSearchSuggestions = vi.hoisted(() => vi.fn());
+
+vi.mock('src/resources/SearchResource', () => ({
+  fetchSearchResults: mockFetchSearchResults,
+  fetchSearchSuggestions: mockFetchSearchSuggestions,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false, cacheTime: 0}},
+    logger: {log: vi.fn(), warn: vi.fn(), error: vi.fn()},
+  });
+  function Wrapper({children}: {children: React.ReactNode}) {
+    return createElement(QueryClientProvider, {client: queryClient}, children);
+  }
+  return Wrapper;
+}
+
+describe('useSearch', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('fetches results for a given query and page', async () => {
+    mockFetchSearchResults.mockResolvedValue({
+      results: [{name: 'repo1', namespace: {name: 'org1'}}],
+      has_additional: false,
+      page: 1,
+      page_size: 10,
+      start_index: 0,
+    });
+
+    const {result} = renderHook(() => useSearch('test', 1), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.results).toHaveLength(1);
+    expect(result.current.results[0].name).toBe('repo1');
+    expect(result.current.hasAdditional).toBe(false);
+    expect(result.current.pageSize).toBe(10);
+  });
+
+  it('fetches with empty query', async () => {
+    mockFetchSearchResults.mockResolvedValue({
+      results: [],
+      has_additional: false,
+      page: 1,
+      page_size: 10,
+      start_index: 0,
+    });
+
+    const {result} = renderHook(() => useSearch('', 1), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockFetchSearchResults).toHaveBeenCalledWith('', 1);
+  });
+
+  it('returns defaults when data is undefined', () => {
+    mockFetchSearchResults.mockReturnValue(new Promise(() => undefined));
+
+    const {result} = renderHook(() => useSearch('test', 1), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.hasAdditional).toBe(false);
+    expect(result.current.pageSize).toBe(10);
+    expect(result.current.startIndex).toBe(0);
+  });
+});
+
+describe('useSearchSuggestions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('does not fetch when query is shorter than 3 chars', async () => {
+    const {result} = renderHook(() => useSearchSuggestions('ab'), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(mockFetchSearchSuggestions).not.toHaveBeenCalled();
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it('fetches suggestions after debounce for 3+ char query', async () => {
+    vi.useRealTimers();
+
+    mockFetchSearchSuggestions.mockResolvedValue({
+      results: [{kind: 'repository', name: 'test-repo'}],
+    });
+
+    const {result} = renderHook(() => useSearchSuggestions('test'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.suggestions).toHaveLength(1), {
+      timeout: 2000,
+    });
+    expect(mockFetchSearchSuggestions).toHaveBeenCalledWith('test');
+  });
+});

--- a/web/src/hooks/UseSearch.test.ts
+++ b/web/src/hooks/UseSearch.test.ts
@@ -45,6 +45,7 @@ describe('useSearch', () => {
     expect(result.current.pageSize).toBe(10);
   });
 
+  // An empty query lists repositories by popularity, matching the legacy UI.
   it('fetches with empty query', async () => {
     mockFetchSearchResults.mockResolvedValue({
       results: [],

--- a/web/src/hooks/UseSearch.ts
+++ b/web/src/hooks/UseSearch.ts
@@ -1,0 +1,47 @@
+import {useEffect, useState} from 'react';
+import {useQuery} from '@tanstack/react-query';
+import {
+  fetchSearchResults,
+  fetchSearchSuggestions,
+  ISearchResponse,
+  ISearchSuggestionsResponse,
+} from 'src/resources/SearchResource';
+
+export function useSearchSuggestions(query: string) {
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query), 250);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const {data, isLoading} = useQuery<ISearchSuggestionsResponse>({
+    queryKey: ['searchSuggestions', debouncedQuery],
+    queryFn: () => fetchSearchSuggestions(debouncedQuery),
+    enabled: debouncedQuery.trim().length >= 3,
+    keepPreviousData: true,
+  });
+
+  return {
+    suggestions: data?.results ?? [],
+    isLoading,
+  };
+}
+
+export function useSearch(query: string, page: number) {
+  const {data, isLoading, error} = useQuery<ISearchResponse>({
+    queryKey: ['search', query, page],
+    queryFn: () => fetchSearchResults(query, page),
+    keepPreviousData: true,
+  });
+
+  return {
+    results: data?.results ?? [],
+    hasAdditional: data?.has_additional ?? false,
+    page: data?.page ?? page,
+    pageSize: data?.page_size ?? 10,
+    startIndex: data?.start_index ?? 0,
+    isLoading,
+    error,
+  };
+}

--- a/web/src/hooks/UseSearch.ts
+++ b/web/src/hooks/UseSearch.ts
@@ -28,6 +28,9 @@ export function useSearchSuggestions(query: string) {
   };
 }
 
+// An empty query is intentional: /search with no term lists repositories by
+// popularity, matching the legacy UI. The backend serves that from an indexed
+// ordering on RepositorySearchScore.score, so it is not a table scan.
 export function useSearch(query: string, page: number) {
   const {data, isLoading, error} = useQuery<ISearchResponse>({
     queryKey: ['search', query, page],

--- a/web/src/resources/SearchResource.test.ts
+++ b/web/src/resources/SearchResource.test.ts
@@ -1,0 +1,90 @@
+import {fetchSearchResults, fetchSearchSuggestions} from './SearchResource';
+import axios from 'src/libs/axios';
+
+vi.mock('src/libs/axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+const mockGet = vi.mocked(axios.get);
+
+describe('SearchResource', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  describe('fetchSearchResults', () => {
+    it('calls /api/v1/find/repositories with correct params', async () => {
+      const mockResponse = {
+        status: 200,
+        data: {
+          results: [],
+          has_additional: false,
+          page: 1,
+          page_size: 10,
+          start_index: 0,
+        },
+      };
+      mockGet.mockResolvedValue(mockResponse);
+
+      const result = await fetchSearchResults('test', 2);
+
+      expect(mockGet).toHaveBeenCalledWith('/api/v1/find/repositories', {
+        params: {query: 'test', page: 2, includeUsage: true},
+      });
+      expect(result.results).toEqual([]);
+      expect(result.page).toBe(1);
+    });
+
+    it('defaults page to 1', async () => {
+      mockGet.mockResolvedValue({
+        status: 200,
+        data: {
+          results: [],
+          has_additional: false,
+          page: 1,
+          page_size: 10,
+          start_index: 0,
+        },
+      });
+
+      await fetchSearchResults('query');
+
+      expect(mockGet).toHaveBeenCalledWith('/api/v1/find/repositories', {
+        params: {query: 'query', page: 1, includeUsage: true},
+      });
+    });
+
+    it('throws on non-200 status', async () => {
+      mockGet.mockResolvedValue({status: 500, data: {}});
+
+      await expect(fetchSearchResults('test')).rejects.toThrow(
+        'Unexpected HTTP status code: 500',
+      );
+    });
+  });
+
+  describe('fetchSearchSuggestions', () => {
+    it('calls /api/v1/find/all with query param', async () => {
+      const mockResponse = {
+        status: 200,
+        data: {results: [{kind: 'repository', name: 'test-repo', score: 4}]},
+      };
+      mockGet.mockResolvedValue(mockResponse);
+
+      const result = await fetchSearchSuggestions('test');
+
+      expect(mockGet).toHaveBeenCalledWith('/api/v1/find/all', {
+        params: {query: 'test'},
+      });
+      expect(result.results).toHaveLength(1);
+    });
+
+    it('throws on non-200 status', async () => {
+      mockGet.mockResolvedValue({status: 403, data: {}});
+
+      await expect(fetchSearchSuggestions('test')).rejects.toThrow(
+        'Unexpected HTTP status code: 403',
+      );
+    });
+  });
+});

--- a/web/src/resources/SearchResource.ts
+++ b/web/src/resources/SearchResource.ts
@@ -1,0 +1,82 @@
+import {AxiosResponse} from 'axios';
+import axios from 'src/libs/axios';
+import {assertHttpCode} from './ErrorHandling';
+import {IAvatar} from './OrganizationResource';
+
+export interface ISearchResultNamespace {
+  title: string;
+  kind: string;
+  avatar: IAvatar | null;
+  name: string;
+  score: number;
+  href: string;
+}
+
+export interface ISearchResult {
+  kind: string;
+  title: string;
+  namespace: ISearchResultNamespace;
+  name: string;
+  description: string | null;
+  is_public: boolean;
+  score: number;
+  href: string;
+  last_modified?: number;
+  stars?: number;
+  popularity?: number;
+}
+
+export interface ISearchResponse {
+  results: ISearchResult[];
+  has_additional: boolean;
+  page: number;
+  page_size: number;
+  start_index: number;
+}
+
+export interface ISearchSuggestion {
+  kind: string;
+  title: string;
+  name: string;
+  avatar?: IAvatar | null;
+  score: number;
+  href: string;
+  description?: string | null;
+  namespace?: ISearchResultNamespace;
+  organization?: ISearchResultNamespace;
+}
+
+export interface ISearchSuggestionsResponse {
+  results: ISearchSuggestion[];
+}
+
+export async function fetchSearchSuggestions(
+  query: string,
+): Promise<ISearchSuggestionsResponse> {
+  const response: AxiosResponse<ISearchSuggestionsResponse> = await axios.get(
+    '/api/v1/find/all',
+    {
+      params: {query},
+    },
+  );
+  assertHttpCode(response.status, 200);
+  return response.data;
+}
+
+export async function fetchSearchResults(
+  query: string,
+  page = 1,
+): Promise<ISearchResponse> {
+  const response: AxiosResponse<ISearchResponse> = await axios.get(
+    '/api/v1/find/repositories',
+    {
+      params: {
+        query,
+        page,
+        includeUsage: true,
+      },
+    },
+  );
+  assertHttpCode(response.status, 200);
+  return response.data;
+}

--- a/web/src/routes/NavigationPath.tsx
+++ b/web/src/routes/NavigationPath.tsx
@@ -42,6 +42,7 @@ export enum NavigationPath {
   overviewList = '/overview',
   organizationsList = '/organization',
   repositoriesList = '/repository',
+  search = '/search',
 
   // Static pages
   about = '/about',

--- a/web/src/routes/Search/Search.css
+++ b/web/src/routes/Search/Search.css
@@ -1,0 +1,103 @@
+.search-results-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.search-result-item {
+  padding: var(--pf-t--global--spacer--md) 0;
+  border-bottom: 1px solid var(--pf-t--global--border--color--default);
+}
+
+.search-result-item:last-child {
+  border-bottom: none;
+}
+
+.search-result-repo-name {
+  font-size: var(--pf-t--global--font--size--lg);
+  font-weight: var(--pf-t--global--font--weight--body--bold);
+}
+
+.search-result-star-count {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pf-t--global--spacer--xs);
+  color: var(--pf-t--global--text--color--subtle);
+  min-width: 3em;
+}
+
+.search-result-description {
+  color: var(--pf-t--global--text--color--subtle);
+  margin-top: var(--pf-t--global--spacer--xs);
+}
+
+.search-result-metadata {
+  color: var(--pf-t--global--text--color--subtle);
+  font-size: var(--pf-t--global--font--size--sm);
+  margin-top: var(--pf-t--global--spacer--xs);
+}
+
+.search-result-activity {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pf-t--global--spacer--xs);
+}
+
+.search-signal-strength {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 2px;
+  vertical-align: middle;
+}
+
+.search-signal-bar {
+  display: inline-block;
+  width: 3px;
+  background-color: var(--pf-t--global--border--color--default);
+  border-radius: 1px;
+}
+
+.search-signal-bar-active {
+  background-color: var(--pf-t--global--color--brand--default);
+}
+
+.search-page-navigation {
+  display: flex;
+  align-items: center;
+  gap: var(--pf-t--global--spacer--md);
+  padding-top: var(--pf-t--global--spacer--lg);
+}
+
+.search-max-results-help {
+  color: var(--pf-t--global--text--color--subtle);
+  font-style: italic;
+}
+
+.search-bar-container {
+  display: flex;
+  justify-content: center;
+  padding: var(--pf-t--global--spacer--md) 0;
+}
+
+.search-toolbar-input {
+  width: 100%;
+  max-width: 600px;
+}
+
+.search-suggestion-kind {
+  display: inline-block;
+  min-width: 3em;
+  font-size: var(--pf-t--global--font--size--sm);
+  color: var(--pf-t--global--text--color--subtle);
+  text-transform: capitalize;
+}
+
+.search-suggestion-description {
+  font-size: var(--pf-t--global--font--size--sm);
+  color: var(--pf-t--global--text--color--subtle);
+  margin-top: var(--pf-t--global--spacer--xs);
+  padding-left: var(--pf-t--global--spacer--lg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/web/src/routes/Search/Search.css
+++ b/web/src/routes/Search/Search.css
@@ -92,6 +92,11 @@
   text-transform: capitalize;
 }
 
+.search-suggestion-active {
+  background-color: var(--pf-t--global--color--brand--default);
+  color: var(--pf-t--global--text--color--on-brand--default);
+}
+
 .search-suggestion-description {
   font-size: var(--pf-t--global--font--size--sm);
   color: var(--pf-t--global--text--color--subtle);

--- a/web/src/routes/Search/Search.css
+++ b/web/src/routes/Search/Search.css
@@ -84,6 +84,25 @@
   max-width: 600px;
 }
 
+.search-suggestions-menu {
+  background-color: var(--pf-t--global--background--color--floating--default);
+  box-shadow: var(--pf-t--global--box-shadow--md);
+  border-radius: var(--pf-t--global--border--radius--small);
+  max-height: 25rem;
+  overflow-y: auto;
+}
+
+.search-suggestions-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--pf-t--global--spacer--xs) 0;
+}
+
+.search-suggestion {
+  padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md);
+  cursor: pointer;
+}
+
 .search-suggestion-kind {
   display: inline-block;
   min-width: 3em;

--- a/web/src/routes/Search/Search.test.tsx
+++ b/web/src/routes/Search/Search.test.tsx
@@ -1,0 +1,240 @@
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {MemoryRouter} from 'react-router-dom';
+import {createElement} from 'react';
+import Search from './Search';
+
+const mockUseSearch = vi.hoisted(() => vi.fn());
+const mockUseSearchSuggestions = vi.hoisted(() => vi.fn());
+
+vi.mock('src/hooks/UseSearch', () => ({
+  useSearch: (...args: unknown[]) => mockUseSearch(...args),
+  useSearchSuggestions: (...args: unknown[]) =>
+    mockUseSearchSuggestions(...args),
+}));
+
+vi.mock('src/hooks/UseQuayConfig', () => ({
+  useQuayConfig: () => ({
+    config: {SEARCH_MAX_RESULT_PAGE_COUNT: 10},
+  }),
+}));
+
+vi.mock('src/components/Avatar', () => ({
+  default: ({avatar}: {avatar: {name: string}}) => (
+    <span data-testid="avatar">{avatar?.name}</span>
+  ),
+}));
+
+vi.mock('src/libs/avatarUtils', () => ({
+  generateAvatarFromName: (name: string) => ({
+    name,
+    hash: '',
+    color: '#000',
+    kind: 'generated',
+  }),
+}));
+
+const defaultSearchReturn = {
+  results: [],
+  hasAdditional: false,
+  page: 1,
+  pageSize: 10,
+  startIndex: 0,
+  isLoading: false,
+  error: null,
+};
+
+const defaultSuggestionsReturn = {
+  suggestions: [],
+  isLoading: false,
+};
+
+function renderSearch(initialRoute = '/search') {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false, cacheTime: 0}},
+    logger: {log: vi.fn(), warn: vi.fn(), error: vi.fn()},
+  });
+  return render(
+    createElement(
+      QueryClientProvider,
+      {client: queryClient},
+      createElement(
+        MemoryRouter,
+        {initialEntries: [initialRoute]},
+        createElement(Search),
+      ),
+    ),
+  );
+}
+
+describe('Search', () => {
+  beforeEach(() => {
+    mockUseSearch.mockReturnValue(defaultSearchReturn);
+    mockUseSearchSuggestions.mockReturnValue(defaultSuggestionsReturn);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders heading and search input', () => {
+    renderSearch();
+
+    expect(screen.getByRole('heading', {name: 'Search'})).toBeVisible();
+    expect(screen.getByPlaceholderText('Search repositories...')).toBeVisible();
+  });
+
+  it('shows empty state when no results', () => {
+    renderSearch();
+
+    expect(screen.getByText('No matching repositories found')).toBeVisible();
+  });
+
+  it('shows loading spinner', () => {
+    mockUseSearch.mockReturnValue({...defaultSearchReturn, isLoading: true});
+    renderSearch();
+
+    expect(screen.getByRole('progressbar')).toBeVisible();
+  });
+
+  it('shows error state', () => {
+    mockUseSearch.mockReturnValue({
+      ...defaultSearchReturn,
+      error: new Error('fail'),
+    });
+    renderSearch();
+
+    expect(screen.getByText('Could not load search results')).toBeVisible();
+  });
+
+  it('renders search results with repo name and star count', () => {
+    mockUseSearch.mockReturnValue({
+      ...defaultSearchReturn,
+      results: [
+        {
+          kind: 'repository',
+          name: 'my-repo',
+          namespace: {
+            name: 'myorg',
+            avatar: {name: 'myorg', hash: '', color: '#000', kind: 'org'},
+          },
+          description: 'A test repository',
+          href: '/repository/myorg/my-repo',
+          stars: 5,
+          popularity: 10,
+          last_modified: 1700000000,
+        },
+      ],
+    });
+    renderSearch();
+
+    expect(screen.getByRole('link', {name: 'myorg/my-repo'})).toBeVisible();
+    expect(screen.getByText('5')).toBeVisible();
+    expect(screen.getByText('A test repository')).toBeVisible();
+  });
+
+  it('shows "Never" for missing last_modified', () => {
+    mockUseSearch.mockReturnValue({
+      ...defaultSearchReturn,
+      results: [
+        {
+          kind: 'repository',
+          name: 'repo1',
+          namespace: {name: 'org1', avatar: null},
+          href: '/repository/org1/repo1',
+          stars: 0,
+          popularity: 0,
+        },
+      ],
+    });
+    renderSearch();
+
+    expect(screen.getByText(/Never/)).toBeVisible();
+  });
+
+  it('submits search on enter key', () => {
+    renderSearch();
+
+    const input = screen.getByPlaceholderText('Search repositories...');
+    fireEvent.change(input, {target: {value: 'testquery'}});
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(mockUseSearch).toHaveBeenCalledWith('testquery', 1);
+  });
+
+  it('clears search on clear button click', () => {
+    renderSearch('/search?q=hello');
+
+    const clearButton = screen.getByLabelText('Clear search');
+    fireEvent.click(clearButton);
+
+    const input = screen.getByPlaceholderText('Search repositories...');
+    expect(input).toHaveValue('');
+  });
+
+  it('shows suggestion dropdown', async () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [
+        {
+          kind: 'repository',
+          title: 'repo',
+          name: 'suggest-repo',
+          namespace: {name: 'org1', avatar: null},
+          href: '/repository/org1/suggest-repo',
+          score: 4,
+        },
+      ],
+      isLoading: false,
+    });
+
+    renderSearch();
+
+    const input = screen.getByPlaceholderText('Search repositories...');
+    fireEvent.change(input, {target: {value: 'suggest'}});
+
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem')).toBeVisible();
+    });
+    expect(screen.getByText('org1/suggest-repo')).toBeVisible();
+  });
+
+  it('shows pagination when results have additional pages', () => {
+    mockUseSearch.mockReturnValue({
+      ...defaultSearchReturn,
+      results: [
+        {
+          kind: 'repository',
+          name: 'repo1',
+          namespace: {name: 'org1', avatar: null},
+          href: '/repository/org1/repo1',
+          stars: 0,
+          popularity: 0,
+        },
+      ],
+      hasAdditional: true,
+    });
+    renderSearch();
+
+    expect(screen.getByText(/1 - 1/)).toBeVisible();
+  });
+
+  it('shows max results message at page limit', () => {
+    mockUseSearch.mockReturnValue({
+      ...defaultSearchReturn,
+      results: [
+        {
+          kind: 'repository',
+          name: 'repo1',
+          namespace: {name: 'org1', avatar: null},
+          href: '/repository/org1/repo1',
+          stars: 0,
+          popularity: 0,
+        },
+      ],
+      page: 10,
+    });
+    renderSearch('/search?q=test&page=10');
+
+    expect(
+      screen.getByText(/maximum number of viewable results/),
+    ).toBeVisible();
+  });
+});

--- a/web/src/routes/Search/Search.test.tsx
+++ b/web/src/routes/Search/Search.test.tsx
@@ -82,10 +82,20 @@ describe('Search', () => {
     expect(screen.getByPlaceholderText('Search repositories...')).toBeVisible();
   });
 
-  it('shows empty state when no results', () => {
+  it('shows "Search for repositories" when no query', () => {
     renderSearch();
 
+    expect(screen.getByText('Search for repositories')).toBeVisible();
+    expect(
+      screen.getByText('Enter a search term to find repositories.'),
+    ).toBeVisible();
+  });
+
+  it('shows "No matching repositories found" when query returns no results', () => {
+    renderSearch('/search?q=nonexistent');
+
     expect(screen.getByText('No matching repositories found')).toBeVisible();
+    expect(screen.getByText('Please try changing your query.')).toBeVisible();
   });
 
   it('shows loading spinner', () => {
@@ -236,5 +246,73 @@ describe('Search', () => {
     expect(
       screen.getByText(/maximum number of viewable results/),
     ).toBeVisible();
+  });
+
+  it('clamps page to maxPageCount when URL has over-limit page', () => {
+    renderSearch('/search?q=test&page=500');
+
+    expect(mockUseSearch).toHaveBeenCalledWith('test', 10);
+  });
+
+  it('navigates suggestions with ArrowDown and ArrowUp', async () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [
+        {
+          kind: 'repository',
+          title: 'repo',
+          name: 'repo-a',
+          namespace: {name: 'org1', avatar: null},
+          href: '/repository/org1/repo-a',
+          score: 4,
+        },
+        {
+          kind: 'repository',
+          title: 'repo',
+          name: 'repo-b',
+          namespace: {name: 'org1', avatar: null},
+          href: '/repository/org1/repo-b',
+          score: 3,
+        },
+      ],
+      isLoading: false,
+    });
+
+    renderSearch();
+
+    const input = screen.getByPlaceholderText('Search repositories...');
+    fireEvent.change(input, {target: {value: 'repoxyz'}});
+
+    await waitFor(() => {
+      expect(screen.getByText('org1/repo-a')).toBeVisible();
+    });
+
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(
+      screen.getByText('org1/repo-a').closest('[role="option"]'),
+    ).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(
+      screen.getByText('org1/repo-b').closest('[role="option"]'),
+    ).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, {key: 'ArrowUp'});
+    expect(
+      screen.getByText('org1/repo-a').closest('[role="option"]'),
+    ).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('has combobox ARIA attributes on search input', () => {
+    renderSearch();
+
+    const input = screen.getByPlaceholderText('Search repositories...');
+    expect(input).toHaveAttribute('role', 'combobox');
+    expect(input).toHaveAttribute(
+      'aria-controls',
+      'search-suggestions-listbox',
+    );
+
+    const wrapper = screen.getByTestId('search-input');
+    expect(wrapper).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/web/src/routes/Search/Search.test.tsx
+++ b/web/src/routes/Search/Search.test.tsx
@@ -201,7 +201,7 @@ describe('Search', () => {
     fireEvent.change(input, {target: {value: 'suggest'}});
 
     await waitFor(() => {
-      expect(screen.getByRole('menuitem')).toBeVisible();
+      expect(screen.getByRole('option')).toBeVisible();
     });
     expect(screen.getByText('org1/suggest-repo')).toBeVisible();
   });
@@ -302,17 +302,56 @@ describe('Search', () => {
     ).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('has combobox ARIA attributes on search input', () => {
+  it('has combobox ARIA attributes on the focusable input itself', () => {
     renderSearch();
 
-    const input = screen.getByPlaceholderText('Search repositories...');
+    // Every combobox attribute must be on the <input> that receives focus.
+    // On a wrapper element aria-activedescendant is inert to screen readers.
+    const input = screen.getByTestId('search-input');
+    expect(input.tagName).toBe('INPUT');
     expect(input).toHaveAttribute('role', 'combobox');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
     expect(input).toHaveAttribute(
       'aria-controls',
       'search-suggestions-listbox',
     );
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+  });
 
-    const wrapper = screen.getByTestId('search-input');
-    expect(wrapper).toHaveAttribute('aria-expanded', 'false');
+  it('points aria-activedescendant at the highlighted suggestion', async () => {
+    mockUseSearchSuggestions.mockReturnValue({
+      suggestions: [
+        {
+          kind: 'repository',
+          title: 'repo',
+          name: 'repo-a',
+          namespace: {name: 'org1', avatar: null},
+          href: '/repository/org1/repo-a',
+          score: 4,
+        },
+      ],
+      isLoading: false,
+    });
+
+    renderSearch();
+
+    const input = screen.getByTestId('search-input');
+    fireEvent.change(input, {target: {value: 'repoxyz'}});
+
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+    });
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+
+    expect(input).toHaveAttribute(
+      'aria-activedescendant',
+      'search-suggestion-0',
+    );
+    expect(document.getElementById('search-suggestion-0')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
   });
 });

--- a/web/src/routes/Search/Search.tsx
+++ b/web/src/routes/Search/Search.tsx
@@ -38,10 +38,10 @@ export default function Search() {
   const navigate = useNavigate();
   const query = searchParams.get('q') || '';
   const parsedPage = parseInt(searchParams.get('page') || '1', 10);
-  const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
 
   const [inputValue, setInputValue] = useState(query);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(-1);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const searchBoxRef = useRef<HTMLDivElement>(null);
@@ -49,6 +49,11 @@ export default function Search() {
 
   const quayConfig = useQuayConfig();
   const maxPageCount = quayConfig?.config?.SEARCH_MAX_RESULT_PAGE_COUNT ?? 10;
+
+  const page = Math.min(
+    Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1,
+    maxPageCount,
+  );
 
   const {results, hasAdditional, pageSize, startIndex, isLoading, error} =
     useSearch(query, page);
@@ -69,6 +74,10 @@ export default function Search() {
       isTyping && inputValue.trim().length >= 3 && suggestions.length > 0,
     );
   }, [suggestions, inputValue, query]);
+
+  useEffect(() => {
+    setActiveSuggestionIndex(-1);
+  }, [suggestions]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -107,10 +116,30 @@ export default function Search() {
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter') {
-      handleSearch();
+      if (
+        activeSuggestionIndex >= 0 &&
+        isDropdownOpen &&
+        suggestions[activeSuggestionIndex]
+      ) {
+        handleSuggestionSelect(suggestions[activeSuggestionIndex]);
+      } else {
+        handleSearch();
+      }
     }
     if (event.key === 'Escape') {
       setIsDropdownOpen(false);
+    }
+    if (event.key === 'ArrowDown' && isDropdownOpen && suggestions.length > 0) {
+      event.preventDefault();
+      setActiveSuggestionIndex((prev) =>
+        prev < suggestions.length - 1 ? prev + 1 : 0,
+      );
+    }
+    if (event.key === 'ArrowUp' && isDropdownOpen && suggestions.length > 0) {
+      event.preventDefault();
+      setActiveSuggestionIndex((prev) =>
+        prev > 0 ? prev - 1 : suggestions.length - 1,
+      );
     }
   };
 
@@ -153,6 +182,15 @@ export default function Search() {
           onKeyDown={handleKeyDown}
           ref={inputRef}
           data-testid="search-input"
+          role="combobox"
+          aria-expanded={isDropdownOpen}
+          aria-controls="search-suggestions-listbox"
+          aria-activedescendant={
+            activeSuggestionIndex >= 0
+              ? `search-suggestion-${activeSuggestionIndex}`
+              : undefined
+          }
+          aria-autocomplete="list"
         />
         <TextInputGroupUtilities>
           {inputValue && (
@@ -176,11 +214,17 @@ export default function Search() {
     <div ref={dropdownRef}>
       <Menu onSelect={() => setIsDropdownOpen(false)}>
         <MenuContent>
-          <MenuList>
+          <MenuList id="search-suggestions-listbox" role="listbox">
             {suggestions.map((s, i) => (
               <MenuItem
                 key={`${s.kind}-${s.name}-${i}`}
+                id={`search-suggestion-${i}`}
                 onClick={() => handleSuggestionSelect(s)}
+                className={
+                  i === activeSuggestionIndex ? 'search-suggestion-active' : ''
+                }
+                role="option"
+                aria-selected={i === activeSuggestionIndex}
               >
                 <Flex
                   alignItems={{default: 'alignItemsCenter'}}
@@ -261,10 +305,18 @@ export default function Search() {
           <EmptyState
             headingLevel="h2"
             icon={SearchIcon}
-            titleText="No matching repositories found"
+            titleText={
+              query && inputValue.trim()
+                ? 'No matching repositories found'
+                : 'Search for repositories'
+            }
             variant="lg"
           >
-            <EmptyStateBody>Please try changing your query.</EmptyStateBody>
+            <EmptyStateBody>
+              {query && inputValue.trim()
+                ? 'Please try changing your query.'
+                : 'Enter a search term to find repositories.'}
+            </EmptyStateBody>
           </EmptyState>
         )}
 

--- a/web/src/routes/Search/Search.tsx
+++ b/web/src/routes/Search/Search.tsx
@@ -1,13 +1,388 @@
-import {PageSection, Title} from '@patternfly/react-core';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {Link, useNavigate, useSearchParams} from 'react-router-dom';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  Flex,
+  FlexItem,
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  PageSection,
+  Popper,
+  Spinner,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  Title,
+  Pagination,
+  PaginationVariant,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import {StarIcon, SearchIcon, TimesIcon} from '@patternfly/react-icons';
+import {useSearch, useSearchSuggestions} from 'src/hooks/UseSearch';
+import {useQuayConfig} from 'src/hooks/UseQuayConfig';
+import Avatar from 'src/components/Avatar';
+import {generateAvatarFromName} from 'src/libs/avatarUtils';
+import {formatRelativeTime} from 'src/libs/utils';
+import RequestError from 'src/components/errors/RequestError';
+import {ISearchResult, ISearchSuggestion} from 'src/resources/SearchResource';
+import './Search.css';
 
 export default function Search() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const query = searchParams.get('q') || '';
+  const parsedPage = parseInt(searchParams.get('page') || '1', 10);
+  const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+
+  const [inputValue, setInputValue] = useState(query);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const searchBoxRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const quayConfig = useQuayConfig();
+  const maxPageCount = quayConfig?.config?.SEARCH_MAX_RESULT_PAGE_COUNT ?? 10;
+
+  const {results, hasAdditional, pageSize, startIndex, isLoading, error} =
+    useSearch(query, page);
+  const {suggestions} = useSearchSuggestions(inputValue);
+
+  const rawTotal = hasAdditional
+    ? (page + 1) * pageSize
+    : startIndex + results.length;
+  const effectiveTotal = Math.min(rawTotal, maxPageCount * pageSize);
+
+  useEffect(() => {
+    setInputValue(query);
+  }, [query]);
+
+  useEffect(() => {
+    const isTyping = inputValue.trim() !== query;
+    setIsDropdownOpen(
+      isTyping && inputValue.trim().length >= 3 && suggestions.length > 0,
+    );
+  }, [suggestions, inputValue, query]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        searchBoxRef.current &&
+        !searchBoxRef.current.contains(target) &&
+        dropdownRef.current &&
+        !dropdownRef.current.contains(target)
+      ) {
+        setIsDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSearch = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (trimmed) {
+      setIsDropdownOpen(false);
+      setSearchParams({q: trimmed, page: '1'});
+    }
+  }, [inputValue, setSearchParams]);
+
+  const handleClear = () => {
+    setInputValue('');
+    setIsDropdownOpen(false);
+    setSearchParams({});
+    inputRef.current?.focus();
+  };
+
+  const handleInputChange = (_event: React.FormEvent, value: string) => {
+    setInputValue(value);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      handleSearch();
+    }
+    if (event.key === 'Escape') {
+      setIsDropdownOpen(false);
+    }
+  };
+
+  const handleSuggestionSelect = (suggestion: ISearchSuggestion) => {
+    setIsDropdownOpen(false);
+    navigate(suggestion.href);
+  };
+
+  const handleSetPage = (_event: unknown, newPage: number) => {
+    const params: Record<string, string> = {page: String(newPage)};
+    if (query) {
+      params.q = query;
+    }
+    setSearchParams(params);
+  };
+
+  const maxPopularity = useMemo(
+    () => Math.max(...results.map((r) => r.popularity ?? 0), 1),
+    [results],
+  );
+
+  const getSuggestionLabel = (s: ISearchSuggestion) => {
+    if (s.kind === 'repository' && s.namespace) {
+      return `${s.namespace.name}/${s.name}`;
+    }
+    if (s.kind === 'team' && s.organization) {
+      return `${s.organization.name}/${s.name}`;
+    }
+    return s.name;
+  };
+
+  const searchInput = (
+    <div ref={searchBoxRef}>
+      <TextInputGroup>
+        <TextInputGroupMain
+          icon={<SearchIcon />}
+          value={inputValue}
+          placeholder="Search repositories..."
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          ref={inputRef}
+          data-testid="search-input"
+        />
+        <TextInputGroupUtilities>
+          {inputValue && (
+            <Button
+              variant="plain"
+              onClick={handleClear}
+              aria-label="Clear search"
+            >
+              <TimesIcon />
+            </Button>
+          )}
+          <Button variant="control" onClick={handleSearch}>
+            Search
+          </Button>
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </div>
+  );
+
+  const suggestionsDropdown = (
+    <div ref={dropdownRef}>
+      <Menu onSelect={() => setIsDropdownOpen(false)}>
+        <MenuContent>
+          <MenuList>
+            {suggestions.map((s, i) => (
+              <MenuItem
+                key={`${s.kind}-${s.name}-${i}`}
+                onClick={() => handleSuggestionSelect(s)}
+              >
+                <Flex
+                  alignItems={{default: 'alignItemsCenter'}}
+                  spaceItems={{default: 'spaceItemsSm'}}
+                >
+                  <FlexItem>
+                    <span className="search-suggestion-kind">
+                      {s.title || s.kind}
+                    </span>
+                  </FlexItem>
+                  <FlexItem>
+                    <Avatar
+                      avatar={
+                        s.avatar ??
+                        (s.namespace?.avatar || generateAvatarFromName(s.name))
+                      }
+                      size="sm"
+                    />
+                  </FlexItem>
+                  <FlexItem>{getSuggestionLabel(s)}</FlexItem>
+                </Flex>
+                {s.description && s.kind === 'repository' && (
+                  <div className="search-suggestion-description">
+                    {s.description.split('\n')[0]}
+                  </div>
+                )}
+              </MenuItem>
+            ))}
+          </MenuList>
+        </MenuContent>
+      </Menu>
+    </div>
+  );
+
   return (
     <>
       <PageSection hasBodyWrapper={false} hasShadowBottom>
-        <div className="co-m-nav-title--row">
-          <Title headingLevel="h1">Search</Title>
+        <Title headingLevel="h1">Search</Title>
+      </PageSection>
+      <PageSection hasBodyWrapper={false}>
+        <div className="search-bar-container">
+          <div className="search-toolbar-input">
+            <Popper
+              trigger={searchInput}
+              popper={suggestionsDropdown}
+              isVisible={isDropdownOpen}
+              enableFlip={false}
+              appendTo={() => searchBoxRef.current ?? document.body}
+            />
+          </div>
         </div>
+        {!isLoading && !error && results.length > 0 && (
+          <Toolbar>
+            <ToolbarContent>
+              <ToolbarItem variant="pagination">
+                <Pagination
+                  itemCount={effectiveTotal}
+                  perPage={pageSize}
+                  page={page}
+                  onSetPage={handleSetPage}
+                  perPageOptions={[]}
+                  isCompact
+                />
+              </ToolbarItem>
+            </ToolbarContent>
+          </Toolbar>
+        )}
+
+        {isLoading && (
+          <Flex justifyContent={{default: 'justifyContentCenter'}}>
+            <Spinner size="lg" />
+          </Flex>
+        )}
+
+        {error && <RequestError message="Could not load search results" />}
+
+        {!isLoading && !error && results.length === 0 && (
+          <EmptyState
+            headingLevel="h2"
+            icon={SearchIcon}
+            titleText="No matching repositories found"
+            variant="lg"
+          >
+            <EmptyStateBody>Please try changing your query.</EmptyStateBody>
+          </EmptyState>
+        )}
+
+        {!isLoading && !error && results.length > 0 && (
+          <>
+            <ol className="search-results-list">
+              {results.map((result) => (
+                <SearchResultItem
+                  key={`${result.namespace.name}/${result.name}`}
+                  result={result}
+                  maxPopularity={maxPopularity}
+                />
+              ))}
+            </ol>
+
+            <Toolbar>
+              <ToolbarContent>
+                <ToolbarItem variant="pagination">
+                  <Pagination
+                    itemCount={effectiveTotal}
+                    perPage={pageSize}
+                    page={page}
+                    onSetPage={handleSetPage}
+                    perPageOptions={[]}
+                    variant={PaginationVariant.bottom}
+                  />
+                </ToolbarItem>
+              </ToolbarContent>
+            </Toolbar>
+
+            {page >= maxPageCount && (
+              <div className="search-page-navigation">
+                <span className="search-max-results-help">
+                  You&apos;ve reached the maximum number of viewable results.
+                  Please refine your search.
+                </span>
+              </div>
+            )}
+          </>
+        )}
       </PageSection>
     </>
+  );
+}
+
+function SearchResultItem({
+  result,
+  maxPopularity,
+}: {
+  result: ISearchResult;
+  maxPopularity: number;
+}) {
+  const activityLevel = result.popularity
+    ? Math.ceil(
+        (Math.log10(result.popularity + 1) / Math.log10(maxPopularity + 1)) * 5,
+      )
+    : 0;
+
+  return (
+    <li className="search-result-item">
+      <Flex
+        alignItems={{default: 'alignItemsCenter'}}
+        spaceItems={{default: 'spaceItemsSm'}}
+      >
+        <FlexItem>
+          <Avatar
+            avatar={
+              result.namespace.avatar ??
+              generateAvatarFromName(result.namespace.name)
+            }
+            size="sm"
+          />
+        </FlexItem>
+        <FlexItem grow={{default: 'grow'}}>
+          <Link to={result.href} className="search-result-repo-name">
+            {result.namespace.name}/{result.name}
+          </Link>
+        </FlexItem>
+        <FlexItem align={{default: 'alignRight'}}>
+          <span className="search-result-star-count">
+            <span>{result.stars ?? 0}</span>
+            <StarIcon />
+          </span>
+        </FlexItem>
+      </Flex>
+
+      {result.description && (
+        <p className="search-result-description">
+          {result.description.split('\n')[0]}
+        </p>
+      )}
+
+      <div className="search-result-metadata">
+        <Flex spaceItems={{default: 'spaceItemsLg'}}>
+          <FlexItem grow={{default: 'grow'}}>
+            Last Modified:{' '}
+            {result.last_modified
+              ? formatRelativeTime(result.last_modified)
+              : 'Never'}
+          </FlexItem>
+          <FlexItem align={{default: 'alignRight'}}>
+            <span className="search-result-activity">
+              activity{' '}
+              <span className="search-signal-strength">
+                {[1, 2, 3, 4, 5].map((bar) => (
+                  <span
+                    key={bar}
+                    className={`search-signal-bar ${
+                      bar <= activityLevel ? 'search-signal-bar-active' : ''
+                    }`}
+                    style={{height: `${bar * 3}px`}}
+                  />
+                ))}
+              </span>
+            </span>
+          </FlexItem>
+        </Flex>
+      </div>
+    </li>
   );
 }

--- a/web/src/routes/Search/Search.tsx
+++ b/web/src/routes/Search/Search.tsx
@@ -6,10 +6,6 @@ import {
   EmptyStateBody,
   Flex,
   FlexItem,
-  Menu,
-  MenuContent,
-  MenuItem,
-  MenuList,
   PageSection,
   Popper,
   Spinner,
@@ -178,19 +174,24 @@ export default function Search() {
           icon={<SearchIcon />}
           value={inputValue}
           placeholder="Search repositories..."
+          aria-label="Search repositories"
           onChange={handleInputChange}
-          onKeyDown={handleKeyDown}
           ref={inputRef}
-          data-testid="search-input"
           role="combobox"
-          aria-expanded={isDropdownOpen}
+          // `isExpanded` is how TextInputGroupMain renders aria-expanded onto
+          // the <input>; passing aria-expanded directly lands on the wrapper.
+          isExpanded={isDropdownOpen}
           aria-controls="search-suggestions-listbox"
           aria-activedescendant={
             activeSuggestionIndex >= 0
               ? `search-suggestion-${activeSuggestionIndex}`
               : undefined
           }
-          aria-autocomplete="list"
+          inputProps={{
+            'data-testid': 'search-input',
+            'aria-autocomplete': 'list',
+            onKeyDown: handleKeyDown,
+          }}
         />
         <TextInputGroupUtilities>
           {inputValue && (
@@ -210,52 +211,59 @@ export default function Search() {
     </div>
   );
 
+  // Plain listbox markup rather than PatternFly's Menu: MenuItem renders the
+  // `id` onto an inner role="menuitem" button, which both breaks the
+  // aria-activedescendant reference and nests a menuitem inside a listbox.
   const suggestionsDropdown = (
-    <div ref={dropdownRef}>
-      <Menu onSelect={() => setIsDropdownOpen(false)}>
-        <MenuContent>
-          <MenuList id="search-suggestions-listbox" role="listbox">
-            {suggestions.map((s, i) => (
-              <MenuItem
-                key={`${s.kind}-${s.name}-${i}`}
-                id={`search-suggestion-${i}`}
-                onClick={() => handleSuggestionSelect(s)}
-                className={
-                  i === activeSuggestionIndex ? 'search-suggestion-active' : ''
-                }
-                role="option"
-                aria-selected={i === activeSuggestionIndex}
-              >
-                <Flex
-                  alignItems={{default: 'alignItemsCenter'}}
-                  spaceItems={{default: 'spaceItemsSm'}}
-                >
-                  <FlexItem>
-                    <span className="search-suggestion-kind">
-                      {s.title || s.kind}
-                    </span>
-                  </FlexItem>
-                  <FlexItem>
-                    <Avatar
-                      avatar={
-                        s.avatar ??
-                        (s.namespace?.avatar || generateAvatarFromName(s.name))
-                      }
-                      size="sm"
-                    />
-                  </FlexItem>
-                  <FlexItem>{getSuggestionLabel(s)}</FlexItem>
-                </Flex>
-                {s.description && s.kind === 'repository' && (
-                  <div className="search-suggestion-description">
-                    {s.description.split('\n')[0]}
-                  </div>
-                )}
-              </MenuItem>
-            ))}
-          </MenuList>
-        </MenuContent>
-      </Menu>
+    <div ref={dropdownRef} className="search-suggestions-menu">
+      <ul
+        id="search-suggestions-listbox"
+        role="listbox"
+        aria-label="Search suggestions"
+        className="search-suggestions-list"
+      >
+        {suggestions.map((s, i) => (
+          <li
+            key={`${s.kind}-${s.href}`}
+            id={`search-suggestion-${i}`}
+            role="option"
+            aria-selected={i === activeSuggestionIndex}
+            className={`search-suggestion${
+              i === activeSuggestionIndex ? ' search-suggestion-active' : ''
+            }`}
+            // Keep focus on the input so aria-activedescendant stays valid.
+            onMouseDown={(event) => event.preventDefault()}
+            onMouseEnter={() => setActiveSuggestionIndex(i)}
+            onClick={() => handleSuggestionSelect(s)}
+          >
+            <Flex
+              alignItems={{default: 'alignItemsCenter'}}
+              spaceItems={{default: 'spaceItemsSm'}}
+            >
+              <FlexItem>
+                <span className="search-suggestion-kind">
+                  {s.title || s.kind}
+                </span>
+              </FlexItem>
+              <FlexItem>
+                <Avatar
+                  avatar={
+                    s.avatar ??
+                    (s.namespace?.avatar || generateAvatarFromName(s.name))
+                  }
+                  size="sm"
+                />
+              </FlexItem>
+              <FlexItem>{getSuggestionLabel(s)}</FlexItem>
+            </Flex>
+            {s.description && s.kind === 'repository' && (
+              <div className="search-suggestion-description">
+                {s.description.split('\n')[0]}
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 

--- a/web/src/routes/StandaloneMain.tsx
+++ b/web/src/routes/StandaloneMain.tsx
@@ -63,6 +63,7 @@ const Messages = lazy(() => import('./Superuser/Messages/Messages'));
 const BuildLogs = lazy(() => import('./Superuser/BuildLogs/BuildLogs'));
 const About = lazy(() => import('./About/About'));
 const Security = lazy(() => import('./Security/Security'));
+const Search = lazy(() => import('./Search/Search'));
 
 /**
  * Interface for shorthand repository route parameters
@@ -183,6 +184,11 @@ const NavigationRoutes = [
   {
     path: NavigationPath.repositoryDetail,
     Component: <ProtectedRepositoryRoute />,
+  },
+  // Search
+  {
+    path: NavigationPath.search,
+    Component: <Search />,
   },
   // Static pages
   {


### PR DESCRIPTION
## Summary

- The React UI had no `/search` route — navigating to `/search` was caught by the shorthand redirect which treated "search" as an org name and redirected to `/organization/search`
- Adds a fully functional search page at `/search` matching the Angular UI's search functionality
- Adds a global search bar to the masthead, matching the Angular UI's header search box (repositories + organizations, fuzzy matching)
- Supports both authenticated and anonymous users

## Changes

**New files:**
- `web/src/resources/SearchResource.ts` — TypeScript interfaces and fetch functions for `/api/v1/find/repositories` and `/api/v1/find/all`
- `web/src/hooks/UseSearch.ts` — `useSearch` (paginated results) and `useSearchSuggestions` (debounced typeahead) React Query hooks
- `web/src/components/header/HeaderSearchBar.tsx` / `.css` — Masthead search bar with typeahead
- `web/src/routes/Search/Search.css` — Search page styling
- `web/playwright/e2e/ui/search-page.spec.ts` — Playwright e2e tests for the search page
- `web/playwright/e2e/ui/header-search.spec.ts` — Playwright e2e tests for the header search bar

**Modified files:**
- `web/src/routes/NavigationPath.tsx` — Added `search = '/search'` to enum (also prevents shorthand redirect by registering "search" as a reserved prefix)
- `web/src/routes/StandaloneMain.tsx` — Added lazy import and route entry for Search component
- `web/src/routes/Search/Search.tsx` — Full rewrite from stub to functional search page
- `web/src/components/header/HeaderToolbar.tsx` — Renders the search bar, gated on `ANONYMOUS_ACCESS` or an authenticated user
- `conf/nginx/server-base.conf.jnj` — Route `/search` to the React app

## Features

- **Repository listing on load** — `/search` lists all visible repositories (public for anonymous, public + private for authenticated)
- **Typeahead suggestions** — Debounced (250ms) autocomplete dropdown after 3+ characters, calling `/api/v1/find/all` for repos, users, orgs, and teams
- **Header search bar** — Same typeahead in the masthead on every page; Enter goes to `/search?q=`, selecting a suggestion navigates straight to the repo or org. Hidden on `/search`, which has its own input
- **Search results** — Paginated results via `/api/v1/find/repositories` with star count, avatar, namespace/name link, description, last modified time, and signal-strength activity indicator
- **URL-driven state** — Search query and page stored in URL params (`?q=...&page=...`) for bookmarkable/shareable searches
- **PatternFly pagination** — Compact pagination in toolbar, full controls at bottom
- **Max page limit** — Respects `SEARCH_MAX_RESULT_PAGE_COUNT` config with help text at the limit; `page` is clamped client-side so an over-limit URL never reaches the API

## Accessibility

Both typeaheads implement the WAI-ARIA combobox pattern:

- ArrowUp / ArrowDown move through suggestions (wrapping at both ends), Enter selects the highlighted one, Escape closes the dropdown
- `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-autocomplete`, and `aria-activedescendant` are set on the focusable `<input>` itself. PatternFly's `SearchInput` and `TextInputGroupMain` only forward a fixed set of props to the inner input and drop the rest onto a wrapper `<div>`, so these are passed through `inputProps`, with `isExpanded` used for `aria-expanded`
- The dropdown is plain `<ul role="listbox">` / `<li role="option">` markup rather than PatternFly's `Menu`. `MenuItem` applies `id` to an inner `role="menuitem"` button while `role` and `aria-selected` fall through to the `<li>`, which both broke the `aria-activedescendant` reference and nested a menuitem inside a listbox

## Test plan

All commands run from `web/`.

| Command | Result |
|---|---|
| `npx vitest run` | **Passed** — 173 files, 1287 tests |
| `npx playwright test playwright/e2e/ui/search-page.spec.ts playwright/e2e/ui/header-search.spec.ts` | **Passed** — 16/16, run with `PLAYWRIGHT_BASE_URL=http://localhost:9000` against the React dev server |
| `npx eslint` on changed source files | **Passed** |
| `npx prettier --check` on changed files | **Passed** |
| `npx tsc --noEmit` | **Passed** — no new errors (three pre-existing errors remain elsewhere: PatternFly `SVGIconProps` d.ts, `HeaderToolbar.test.tsx` `anonymous`, `AddNewTeamMemberDrawer` `isDisabled`) |

The full Playwright suite was **not run**; only the two search specs above were executed.

Playwright defaults to `http://localhost:8080`, which serves the container's prebuilt bundle. The search specs fail there until the bundle is rebuilt — this is a stale-artifact issue, not a test failure.

Manual browser testing: search page, typeahead, keyboard navigation, pagination, header search bar, anonymous access, and logged-in access.

**Playwright coverage — search page** (`web/playwright/e2e/ui/search-page.spec.ts`):
- Renders search page at `/search`
- Does not redirect to `/organization/search`
- Lists repos on load without query
- Searches repos by query with URL update
- Anonymous user can find public repos
- Typeahead suggestions appear while typing
- Combobox contract is exposed on the input, and `aria-activedescendant` resolves to the option element
- Empty state for no results

**Playwright coverage — header search bar** (`web/playwright/e2e/ui/header-search.spec.ts`):
- Present in the masthead on ordinary pages
- Hidden on the search page
- Submitting a term navigates to the search page
- Suggests repositories and navigates on click
- Suggests organizations as well as repositories
- Keyboard navigable, with `aria-activedescendant` resolving to the option element
- Escape closes the dropdown and it stays closed across a refetch
- Anonymous users get the header search bar
