### PR TITLE
PROJQUAY-12710: ci(go): add FIPS build and test verification

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -29,6 +29,28 @@ jobs:
           path: bin/quay
           retention-days: 1
 
+  build-fips:
+    name: Build (FIPS)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build with FIPS tags
+        run: >
+          GOEXPERIMENT=strictfipsruntime go build
+          -tags='strictfipsruntime,noresumabledigest'
+          -ldflags="-s -w" -trimpath
+          -o bin/quay-fips ./cmd/quay
+
   lint:
     name: Lint
     needs: [build]
@@ -69,6 +91,25 @@ jobs:
 
       - name: Run tests
         run: make go-test
+
+  test-fips:
+    name: Test (FIPS tags)
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests with FIPS tags
+        run: go test -cover -tags='strictfipsruntime,noresumabledigest' ./...
 
   schema-sync:
     name: Schema Drift Check


### PR DESCRIPTION
## Summary

- Add `Build (FIPS)` CI job that compiles with `GOEXPERIMENT=strictfipsruntime` and `-tags='strictfipsruntime,noresumabledigest'`
- Add `Test (FIPS tags)` CI job that runs the Go test suite with the FIPS build tags

## Problem

The Go CI pipeline only builds and tests the standard (non-FIPS) binary. Regressions to FIPS compatibility — such as a dependency importing a package incompatible with `strictfipsruntime`, or a change that breaks the `noresumabledigest` code path — go undetected until manual testing on a FIPS-enabled host.

## What this adds

| Job | What it does | Catches |
|-----|-------------|---------|
| **Build (FIPS)** | `GOEXPERIMENT=strictfipsruntime go build -tags='strictfipsruntime,noresumabledigest'` | Compile-time breakage from dependencies or code incompatible with FIPS build tags |
| **Test (FIPS tags)** | `go test -cover -tags='strictfipsruntime,noresumabledigest' ./...` | Logic regressions in the `noresumabledigest` code path (e.g. the chunked upload flow) |

Both jobs run on standard (non-FIPS) CI runners. They cannot reproduce the runtime FIPS failure (which requires an OpenSSL-backed FIPS host). Full runtime FIPS validation is covered by manual testing on RHEL 8/9 FIPS hosts (see [PROJQUAY-11857](https://redhat.atlassian.net/browse/PROJQUAY-11857)).

## Related

- quay/quay#6315 — FIPS blob upload fix (`noresumabledigest` tag + Makefile target)
- quay/quay-konflux-components#2829 — Adds `noresumabledigest` to shipped Containerfile

## Test plan

- [x] `Build (FIPS)` job compiles successfully
- [x] `Test (FIPS tags)` job passes all tests
- [ ] Both jobs appear in the PR checks dashboard

Made with [Cursor](https://cursor.com)