### PR TITLE
[redhat-3.16] PROJQUAY-12473: fix(cve): CVE-2026-69152 - brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,9 +1153,9 @@
       "integrity": "sha1-/3+Jj7h9RSflR/62QVj4hFDRoMk="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12922,9 +12922,9 @@
       "integrity": "sha1-/3+Jj7h9RSflR/62QVj4hFDRoMk="
     },
     "brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -17367,7 +17367,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.16"
+        "brace-expansion": "^1.1.18"
       }
     },
     "minimist": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "cross-spawn": "^6.0.6",
     "qs": "^6.14.0",
     "form-data": "^2.5.6",
-    "brace-expansion": "^1.1.16",
+    "brace-expansion": "^1.1.18",
     "js-yaml": "3.15.0"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5616,9 +5616,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -141,7 +141,7 @@
     "svgo": "4.0.1",
     "fast-uri": "3.1.3",
     "decode-uri-component": "^0.5.0",
-    "brace-expansion": "^1.1.16",
+    "brace-expansion": "^1.1.18",
     "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
Summary

`
Security fix for # CVE-2026-69152 affecting brace-expansion
`

Details

```
CVE: # CVE-2026-69152
Severity: Important (CVSSv3: 7.5)
Impact: # Denial of Service via unbounded intermediate arrays
Component: brace-expansion
Old Version: 1.1.16
New Version: 1.1.18
```

Changes

```
Updated brace-expansion from 1.1.16 to 1.1.18 in web/package.json
Updated brace-expansion from 1.1.16 to 1.1.18 in web/package-lock.json
Updated brace-expansion from 1.1.16 to 1.1.18 in package.json
Updated brace-expansion from 1.1.16 to 1.1.18 in package-lock.json
```

References

```
https://www.cve.org/CVERecord?id=CVE-2026-69152
https://www.npmjs.com/package/brace-expansion
```

Resolves: [PROJQUAY-12473](https://redhat.atlassian.net/browse/PROJQUAY-12473)