### PR TITLE
NO-ISSUE: chore(playwright): add CodeRabbit review guidance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -86,6 +86,18 @@ reviews:
         - Large blob operations that buffer into memory instead of streaming
         - Missing connection pooling or timeout configuration
 
+    - path: "web/playwright/**"
+      instructions: |
+        Apply Project Quay's Playwright E2E test conventions.
+
+        Check for:
+        - TestApi fixture methods (organization(), repository(), team(), robot(),
+          user(), oauthApplication()) already call uniqueName() internally; do not
+          suggest wrapping their arguments in uniqueName()
+        - Tests include Playwright tags appropriate for their suite and CI filtering
+        - Locators prefer getByRole(), getByText(), or getByTestId() over CSS selectors
+        - Changes follow the full conventions in web/playwright/AGENTS.md
+
   pre_merge_checks:
     title:
       mode: "warning"


### PR DESCRIPTION
## Summary

- add CodeRabbit path instructions for `web/playwright/**`
- document the `TestApi` helpers that already apply `uniqueName()` internally
- direct reviews toward the repository's tag and locator conventions

This gives CodeRabbit the same Playwright-specific context documented in
`web/playwright/AGENTS.md` and avoids false-positive review suggestions.

Closes #6826.

## Validation

- `python -c "... yaml.safe_load(...) ..."` - passed; the new path instruction was parsed and asserted
- `git diff --check` - passed
- relevant repository shell checks - passed when run directly with Git Bash
- `pre-commit run --files .coderabbit.yaml` - portable hooks passed; three script wrappers were infrastructure-blocked because `/bin/bash` is unavailable to pre-commit in this Windows environment
