### PR TITLE
[redhat-3.18] PROJQUAY-12480: fix(cve): CVE-2026-44705 - tmp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4138,17 +4138,6 @@
         "tmp": "0.0.28"
       }
     },
-    "node_modules/git-package-json/node_modules/tmp": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/git-source": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/git-source/-/git-source-1.1.10.tgz",
@@ -7352,14 +7341,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz",
@@ -8958,18 +8939,6 @@
         "node": ">= 6.9.0"
       }
     },
-    "node_modules/selenium-webdriver/node_modules/tmp": {
-      "version": "0.0.30",
-      "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-      "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/semver": {
       "version": "5.3.0",
       "resolved": "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz",
@@ -10067,10 +10036,10 @@
       "integrity": "sha1-bchFBSywjr78GHRyO1jySmSMO28="
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true,
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
@@ -11094,15 +11063,6 @@
       },
       "engines": {
         "node": ">= 4.2.x"
-      }
-    },
-    "node_modules/webdriver-js-extender/node_modules/tmp": {
-      "version": "0.0.24",
-      "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.24.tgz",
-      "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/webdriver-js-extender/node_modules/xml2js": {
@@ -15279,17 +15239,7 @@
         "one-by-one": "^3.1.0",
         "r-json": "^1.2.1",
         "r-package-json": "^1.0.0",
-        "tmp": "0.0.28"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.28",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
+        "tmp": "^0.2.6"
       }
     },
     "git-source": {
@@ -16539,7 +16489,7 @@
         "rimraf": "^3.0.2",
         "socket.io": "^4.7.2",
         "source-map": "^0.6.1",
-        "tmp": "^0.2.1",
+        "tmp": "^0.2.6",
         "ua-parser-js": "^0.7.30",
         "yargs": "^16.1.1"
       },
@@ -17856,11 +17806,6 @@
       "requires": {
         "lcid": "^1.0.0"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
       "version": "1.0.0",
@@ -19212,19 +19157,8 @@
       "requires": {
         "adm-zip": "^0.4.7",
         "rimraf": "^2.5.4",
-        "tmp": "0.0.30",
+        "tmp": "^0.2.6",
         "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.30",
-          "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-          "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
       }
     },
     "semver": {
@@ -20088,10 +20022,9 @@
       "integrity": "sha1-bchFBSywjr78GHRyO1jySmSMO28="
     },
     "tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -20903,16 +20836,10 @@
           "requires": {
             "adm-zip": "0.4.4",
             "rimraf": "^2.2.8",
-            "tmp": "0.0.24",
+            "tmp": "^0.2.6",
             "ws": "^1.0.1",
             "xml2js": "0.4.4"
           }
-        },
-        "tmp": {
-          "version": "0.0.24",
-          "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.24.tgz",
-          "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
-          "dev": true
         },
         "xml2js": {
           "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "overrides": {
     "cross-spawn": "^6.0.6",
     "qs": "^6.14.0",
+    "tmp": "^0.2.6",
     "form-data": "^2.5.6"
   }
 }


### PR DESCRIPTION
Summary

```
Security fix for #CVE-2026-44705 affecting tmp
```

Details

```
CVE: #CVE-2026-44705
Severity: Important (CVSSv3: 7.7)
Impact: # path Traversal via unsanitized prefix/postfix enables directory escape
Component: tmp
Old Version: 0.0.24, 0.0.28, 0.0.30, 0.2.3
New Version: 0.2.6
```

Changes

```
Fixed tmp to 0.2.6 package.json
Updated tmp from 0.0.24, 0.0.28, 0.0.30, 0.2.3 to 0.2.6 package-lock.json
```

References

```
https://www.cve.org/CVERecord?id=CVE-2026-44705
https://www.npmjs.com/package/tmp
```

Resolves: [PROJQUAY-12480](https://redhat.atlassian.net/browse/PROJQUAY-12480)