### PR TITLE
NO-ISSUE: chore(ci): pin migrate runner version

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -526,7 +526,7 @@ jobs:
 
   e2e-migrate:
     name: E2E Mirror Migrate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [test, schema-sync]
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -556,13 +556,18 @@ jobs:
 
       - name: Download and install old OMR
         run: |
+          set -xo pipefail
+
           curl -fsSL -o /tmp/mirror-registry.tar.gz \
             https://github.com/quay/mirror-registry/releases/download/v2.0.11/mirror-registry-offline.tar.gz
           mkdir -p /tmp/omr && tar xzf /tmp/mirror-registry.tar.gz -C /tmp/omr
           cd /tmp/omr
+          mkdir -p /tmp/e2e-migrate-diagnostics
+
           sudo ./mirror-registry install \
+            --verbose \
             --initPassword testpassword123 \
-            --quayHostname localhost
+            --quayHostname localhost 2>&1 | tee /tmp/e2e-migrate-diagnostics/omr-install.log
 
       - name: Wait for old OMR
         run: |

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -554,6 +554,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo sqlite3
 
+      - name: Ensure podman is available for OMR
+        run: |
+          # OMR v2.0.x hard-codes /usr/bin/podman in its image-import
+          # commands. Ensure the binary exists at that path so the
+          # offline installer does not fail with "exit status 127".
+          if command -v podman >/dev/null 2>&1; then
+            echo "podman $(podman --version) found at $(command -v podman)"
+            if [ ! -x /usr/bin/podman ]; then
+              echo "Creating symlink /usr/bin/podman -> $(command -v podman)"
+              sudo ln -s "$(command -v podman)" /usr/bin/podman
+            fi
+          else
+            echo "podman not found — installing"
+            sudo apt-get update
+            sudo apt-get install -y podman
+          fi
+          /usr/bin/podman --version
+
       - name: Download and install old OMR
         run: |
           set -xo pipefail

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -582,6 +582,13 @@ jobs:
           cd /tmp/omr
           mkdir -p /tmp/e2e-migrate-diagnostics
 
+          # GHA ubuntu-22.04 runner image 20260810+ ships conmon without
+          # journald support.  The old OMR's Ansible template hard-codes
+          # --log-driver=journald, which makes conmon exit 1 immediately.
+          # Swap to passthrough so the container can start.
+          find /tmp/omr -name 'quay.service.j2' \
+            -exec sed -i 's/--log-driver=journald/--log-driver=passthrough/g' {} +
+
           sudo ./mirror-registry install \
             --verbose \
             --initPassword testpassword123 \

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -583,11 +583,25 @@ jobs:
           mkdir -p /tmp/e2e-migrate-diagnostics
 
           # GHA ubuntu-22.04 runner image 20260810+ ships conmon without
-          # journald support.  The old OMR's Ansible template hard-codes
-          # --log-driver=journald, which makes conmon exit 1 immediately.
-          # Swap to passthrough so the container can start.
-          find /tmp/omr -name 'quay.service.j2' \
-            -exec sed -i 's/--log-driver=journald/--log-driver=passthrough/g' {} +
+          # journald support.  OMR v2.0.11 packages its Ansible templates
+          # inside execution-environment.tar, so patch the archive before
+          # the installer imports it and starts the target services.
+          ee_template=./runner/project/roles/mirror_appliance/templates/quay.service.j2
+          if ! tar -tf execution-environment.tar | grep -Fxq "$ee_template"; then
+            echo "::error::OMR execution environment is missing $ee_template"
+            exit 1
+          fi
+          mkdir -p /tmp/omr-ee
+          tar -xf execution-environment.tar -C /tmp/omr-ee "$ee_template"
+          sed -i 's/--log-driver=journald/--log-driver=passthrough/g' \
+            "/tmp/omr-ee/$ee_template"
+          tar --delete -f execution-environment.tar "$ee_template"
+          tar --append -f execution-environment.tar -C /tmp/omr-ee "$ee_template"
+          if tar xOf execution-environment.tar "$ee_template" | \
+              grep -Fq -- '--log-driver=journald'; then
+            echo "::error::journald log driver remains in patched OMR template"
+            exit 1
+          fi
 
           sudo ./mirror-registry install \
             --verbose \

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -554,22 +554,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo sqlite3
 
-      - name: Ensure podman is available for OMR
+      - name: Verify podman is available for OMR
         run: |
+          set -euo pipefail
           # OMR v2.0.x hard-codes /usr/bin/podman in its image-import
-          # commands. Ensure the binary exists at that path so the
-          # offline installer does not fail with "exit status 127".
-          if command -v podman >/dev/null 2>&1; then
-            echo "podman $(podman --version) found at $(command -v podman)"
-            if [ ! -x /usr/bin/podman ]; then
-              echo "Creating symlink /usr/bin/podman -> $(command -v podman)"
-              sudo ln -s "$(command -v podman)" /usr/bin/podman
-            fi
-          else
-            echo "podman not found — installing"
-            sudo apt-get update
-            sudo apt-get install -y podman
-          fi
+          # commands, so fail clearly if the expected runner binary is absent.
+          test -x /usr/bin/podman
           /usr/bin/podman --version
 
       - name: Download and install old OMR

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -526,7 +526,7 @@ jobs:
 
   e2e-migrate:
     name: E2E Mirror Migrate
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     needs: [test, schema-sync]
     timeout-minutes: 30
     steps:
@@ -581,27 +581,6 @@ jobs:
           mkdir -p /tmp/omr && tar xzf /tmp/mirror-registry.tar.gz -C /tmp/omr
           cd /tmp/omr
           mkdir -p /tmp/e2e-migrate-diagnostics
-
-          # GHA ubuntu-22.04 runner image 20260810+ ships conmon without
-          # journald support.  OMR v2.0.11 packages its Ansible templates
-          # inside execution-environment.tar, so patch the archive before
-          # the installer imports it and starts the target services.
-          ee_template=./runner/project/roles/mirror_appliance/templates/quay.service.j2
-          if ! tar -tf execution-environment.tar | grep -Fxq "$ee_template"; then
-            echo "::error::OMR execution environment is missing $ee_template"
-            exit 1
-          fi
-          mkdir -p /tmp/omr-ee
-          tar -xf execution-environment.tar -C /tmp/omr-ee "$ee_template"
-          sed -i 's/--log-driver=journald/--log-driver=passthrough/g' \
-            "/tmp/omr-ee/$ee_template"
-          tar --delete -f execution-environment.tar "$ee_template"
-          tar --append -f execution-environment.tar -C /tmp/omr-ee "$ee_template"
-          if tar xOf execution-environment.tar "$ee_template" | \
-              grep -Fq -- '--log-driver=journald'; then
-            echo "::error::journald log driver remains in patched OMR template"
-            exit 1
-          fi
 
           sudo ./mirror-registry install \
             --verbose \

--- a/.github/workflows/sentinel.yaml
+++ b/.github/workflows/sentinel.yaml
@@ -65,6 +65,9 @@ jobs:
               - '!cmd/**'
               - '!config-tool/**'
               - '!.github/workflows/ci-config-tool.yaml'
+              - '!.github/workflows/ci-go.yaml'
+              - '!.github/workflows/ci-python.yaml'
+              - '!.github/workflows/ci-lint.yaml'
 
   lint-ci:
     name: Lint


### PR DESCRIPTION
I think the e2e-migrate job is now failing because latest got bumped to ubuntu 24.04. Let's see if pinning it works 