### PR TITLE
PROJQUAY-11537: feat(database): add digest registration schema

### DIFF
--- a/data/database.py
+++ b/data/database.py
@@ -928,6 +928,8 @@ class User(BaseModel):
                 RepositoryActionCount,
                 TeamSync,
                 RepositorySearchScore,
+                RepositoryBlobDigest,
+                RepositoryManifestDigest,
                 DeletedNamespace,
                 DeletedRepository,
                 RepoMirrorRule,
@@ -1152,6 +1154,8 @@ class Repository(BaseModel):
             BlobUpload,
             Label,
             RepositorySearchScore,
+            RepositoryBlobDigest,
+            RepositoryManifestDigest,
             RepoMirrorConfig,
             RepoMirrorRule,
             DeletedRepository,
@@ -1711,6 +1715,21 @@ class UploadedBlob(BaseModel):
     expires_at = DateTimeField(index=True)
 
 
+class RepositoryBlobDigest(BaseModel):
+    repository = ForeignKeyField(Repository)
+    image_storage = ForeignKeyField(ImageStorage)
+    digest = CharField(max_length=1024)
+    created_at = DateTimeField(default=datetime.utcnow)
+
+    class Meta:
+        database = db
+        read_only_config = read_only_config
+        indexes = (
+            (("repository", "digest"), True),
+            (("repository", "image_storage"), False),
+        )
+
+
 class BlobUpload(BaseModel):
     repository = ForeignKeyField(Repository)
     repository_id: int
@@ -1725,6 +1744,8 @@ class BlobUpload(BaseModel):
     created = DateTimeField(default=datetime.now, index=True)
     piece_sha_state = ResumableSHA1Field(null=True)
     piece_hashes = Base64BinaryField(null=True)
+    requested_digest_algorithm = CharField(null=True)
+    requested_digest_state = TextField(null=True)
 
     class Meta:
         database = db
@@ -1973,6 +1994,21 @@ class ManifestBlob(BaseModel):
         database = db
         read_only_config = read_only_config
         indexes = ((("manifest", "blob"), True),)
+
+
+class RepositoryManifestDigest(BaseModel):
+    repository = ForeignKeyField(Repository)
+    manifest = ForeignKeyField(Manifest)
+    digest = CharField(max_length=1024)
+    created_at = DateTimeField(default=datetime.utcnow)
+
+    class Meta:
+        database = db
+        read_only_config = read_only_config
+        indexes = (
+            (("repository", "digest"), True),
+            (("repository", "manifest"), False),
+        )
 
 
 @unique

--- a/data/database.py
+++ b/data/database.py
@@ -1718,7 +1718,7 @@ class UploadedBlob(BaseModel):
 class RepositoryBlobDigest(BaseModel):
     repository = ForeignKeyField(Repository)
     image_storage = ForeignKeyField(ImageStorage)
-    digest = CharField(max_length=1024)
+    digest = CharField(max_length=255)
     created_at = DateTimeField(default=datetime.utcnow)
 
     class Meta:
@@ -1999,7 +1999,7 @@ class ManifestBlob(BaseModel):
 class RepositoryManifestDigest(BaseModel):
     repository = ForeignKeyField(Repository)
     manifest = ForeignKeyField(Manifest)
-    digest = CharField(max_length=1024)
+    digest = CharField(max_length=255)
     created_at = DateTimeField(default=datetime.utcnow)
 
     class Meta:

--- a/data/migrations/test/test_repository_digest_registration.py
+++ b/data/migrations/test/test_repository_digest_registration.py
@@ -2,6 +2,7 @@ import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 
+from data.database import RepositoryBlobDigest, RepositoryManifestDigest
 from data.migrations.tester import NoopTester
 from data.migrations.versions import (
     a2f338ee672c_add_repository_digest_registration_ as migration,
@@ -24,8 +25,28 @@ def _operations(connection):
     return Operations(context)
 
 
+def _columns_by_name(connection, table_name):
+    return {column["name"]: column for column in sa.inspect(connection).get_columns(table_name)}
+
+
 def _column_names(connection, table_name):
-    return {column["name"] for column in sa.inspect(connection).get_columns(table_name)}
+    return set(_columns_by_name(connection, table_name))
+
+
+def _foreign_key_targets(connection, table_name):
+    return {
+        foreign_key["name"]: (
+            foreign_key["constrained_columns"],
+            foreign_key["referred_table"],
+            foreign_key["referred_columns"],
+        )
+        for foreign_key in sa.inspect(connection).get_foreign_keys(table_name)
+    }
+
+
+def test_repository_digest_model_field_lengths():
+    assert RepositoryBlobDigest._meta.fields["digest"].max_length == 255
+    assert RepositoryManifestDigest._meta.fields["digest"].max_length == 255
 
 
 def test_repository_digest_registration_migration_upgrade_and_downgrade():
@@ -44,10 +65,21 @@ def test_repository_digest_registration_migration_upgrade_and_downgrade():
         table_names = set(sa.inspect(connection).get_table_names())
         assert "repositoryblobdigest" in table_names
         assert "repositorymanifestdigest" in table_names
+
+        blob_columns = _columns_by_name(connection, "repositoryblobdigest")
+        manifest_columns = _columns_by_name(connection, "repositorymanifestdigest")
+        assert blob_columns["digest"]["type"].length == 255
+        assert manifest_columns["digest"]["type"].length == 255
+
+        blob_upload_columns = _columns_by_name(connection, "blobupload")
         assert {
             "requested_digest_algorithm",
             "requested_digest_state",
-        } <= _column_names(connection, "blobupload")
+        } <= set(blob_upload_columns)
+        assert blob_upload_columns["requested_digest_algorithm"]["type"].length == 255
+        assert blob_upload_columns["requested_digest_algorithm"]["nullable"] is True
+        assert isinstance(blob_upload_columns["requested_digest_state"]["type"], sa.Text)
+        assert blob_upload_columns["requested_digest_state"]["nullable"] is True
         assert tester.populated_tables == [
             (
                 "repositoryblobdigest",
@@ -67,8 +99,37 @@ def test_repository_digest_registration_migration_upgrade_and_downgrade():
             index["name"]: index
             for index in sa.inspect(connection).get_indexes("repositorymanifestdigest")
         }
-        assert blob_indexes["repositoryblobdigest_repository_id_digest"]["unique"] == 1
-        assert manifest_indexes["repositorymanifestdigest_repository_id_digest"]["unique"] == 1
+        blob_digest_index = blob_indexes["repositoryblobdigest_repository_id_digest"]
+        manifest_digest_index = manifest_indexes["repositorymanifestdigest_repository_id_digest"]
+        assert blob_digest_index["column_names"] == ["repository_id", "digest"]
+        assert blob_digest_index["unique"] == 1
+        assert manifest_digest_index["column_names"] == ["repository_id", "digest"]
+        assert manifest_digest_index["unique"] == 1
+
+        assert _foreign_key_targets(connection, "repositoryblobdigest") == {
+            "fk_repositoryblobdigest_repository_id": (
+                ["repository_id"],
+                "repository",
+                ["id"],
+            ),
+            "fk_repositoryblobdigest_image_storage_id": (
+                ["image_storage_id"],
+                "imagestorage",
+                ["id"],
+            ),
+        }
+        assert _foreign_key_targets(connection, "repositorymanifestdigest") == {
+            "fk_repositorymanifestdigest_repository_id": (
+                ["repository_id"],
+                "repository",
+                ["id"],
+            ),
+            "fk_repositorymanifestdigest_manifest_id": (
+                ["manifest_id"],
+                "manifest",
+                ["id"],
+            ),
+        }
 
         migration.downgrade(_operations(connection), None, NoopTester())
 

--- a/data/migrations/test/test_repository_digest_registration.py
+++ b/data/migrations/test/test_repository_digest_registration.py
@@ -1,0 +1,79 @@
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from data.migrations.tester import NoopTester
+from data.migrations.versions import (
+    a2f338ee672c_add_repository_digest_registration_ as migration,
+)
+
+
+class RecordingTester(NoopTester):
+    def __init__(self):
+        self.populated_tables = []
+
+    def populate_table(self, table_name, fields):
+        self.populated_tables.append((table_name, [field_name for field_name, _ in fields]))
+
+    def populate_column(self, table_name, col_name, field_type):
+        raise AssertionError("new tables must be populated with populate_table")
+
+
+def _operations(connection):
+    context = MigrationContext.configure(connection, opts={"render_as_batch": True})
+    return Operations(context)
+
+
+def _column_names(connection, table_name):
+    return {column["name"] for column in sa.inspect(connection).get_columns(table_name)}
+
+
+def test_repository_digest_registration_migration_upgrade_and_downgrade():
+    engine = sa.create_engine("sqlite://")
+    metadata = sa.MetaData()
+    sa.Table("repository", metadata, sa.Column("id", sa.Integer(), primary_key=True))
+    sa.Table("imagestorage", metadata, sa.Column("id", sa.Integer(), primary_key=True))
+    sa.Table("manifest", metadata, sa.Column("id", sa.Integer(), primary_key=True))
+    sa.Table("blobupload", metadata, sa.Column("id", sa.Integer(), primary_key=True))
+    tester = RecordingTester()
+
+    with engine.begin() as connection:
+        metadata.create_all(connection)
+        migration.upgrade(_operations(connection), None, tester)
+
+        table_names = set(sa.inspect(connection).get_table_names())
+        assert "repositoryblobdigest" in table_names
+        assert "repositorymanifestdigest" in table_names
+        assert {
+            "requested_digest_algorithm",
+            "requested_digest_state",
+        } <= _column_names(connection, "blobupload")
+        assert tester.populated_tables == [
+            (
+                "repositoryblobdigest",
+                ["repository_id", "image_storage_id", "digest", "created_at"],
+            ),
+            (
+                "repositorymanifestdigest",
+                ["repository_id", "manifest_id", "digest", "created_at"],
+            ),
+        ]
+
+        blob_indexes = {
+            index["name"]: index
+            for index in sa.inspect(connection).get_indexes("repositoryblobdigest")
+        }
+        manifest_indexes = {
+            index["name"]: index
+            for index in sa.inspect(connection).get_indexes("repositorymanifestdigest")
+        }
+        assert blob_indexes["repositoryblobdigest_repository_id_digest"]["unique"] == 1
+        assert manifest_indexes["repositorymanifestdigest_repository_id_digest"]["unique"] == 1
+
+        migration.downgrade(_operations(connection), None, NoopTester())
+
+        table_names = set(sa.inspect(connection).get_table_names())
+        assert "repositoryblobdigest" not in table_names
+        assert "repositorymanifestdigest" not in table_names
+        assert "requested_digest_algorithm" not in _column_names(connection, "blobupload")
+        assert "requested_digest_state" not in _column_names(connection, "blobupload")

--- a/data/migrations/versions/a2f338ee672c_add_repository_digest_registration_.py
+++ b/data/migrations/versions/a2f338ee672c_add_repository_digest_registration_.py
@@ -20,7 +20,7 @@ def upgrade(op, tables, tester):
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("repository_id", sa.Integer(), nullable=False),
         sa.Column("image_storage_id", sa.Integer(), nullable=False),
-        sa.Column("digest", sa.String(length=1024), nullable=False),
+        sa.Column("digest", sa.String(length=255), nullable=False),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.ForeignKeyConstraint(
             ["repository_id"],
@@ -59,7 +59,7 @@ def upgrade(op, tables, tester):
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("repository_id", sa.Integer(), nullable=False),
         sa.Column("manifest_id", sa.Integer(), nullable=False),
-        sa.Column("digest", sa.String(length=1024), nullable=False),
+        sa.Column("digest", sa.String(length=255), nullable=False),
         sa.Column("created_at", sa.DateTime(), nullable=False),
         sa.ForeignKeyConstraint(
             ["repository_id"],

--- a/data/migrations/versions/a2f338ee672c_add_repository_digest_registration_.py
+++ b/data/migrations/versions/a2f338ee672c_add_repository_digest_registration_.py
@@ -1,0 +1,131 @@
+"""add repository digest registration tables and upload hashing columns
+
+Revision ID: a2f338ee672c
+Revises: 9fa37f66a9b6
+Create Date: 2026-08-18 16:01:07.720229
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "a2f338ee672c"
+down_revision = "9fa37f66a9b6"
+
+import sqlalchemy as sa
+
+
+def upgrade(op, tables, tester):
+    # RepositoryBlobDigest
+    op.create_table(
+        "repositoryblobdigest",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("repository_id", sa.Integer(), nullable=False),
+        sa.Column("image_storage_id", sa.Integer(), nullable=False),
+        sa.Column("digest", sa.String(length=1024), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["repository_id"],
+            ["repository.id"],
+            name=op.f("fk_repositoryblobdigest_repository_id"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["image_storage_id"],
+            ["imagestorage.id"],
+            name=op.f("fk_repositoryblobdigest_image_storage_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_repositoryblobdigest")),
+    )
+    op.create_index(
+        "repositoryblobdigest_repository_id_digest",
+        "repositoryblobdigest",
+        ["repository_id", "digest"],
+        unique=True,
+    )
+    op.create_index(
+        "repositoryblobdigest_repository_id_image_storage_id",
+        "repositoryblobdigest",
+        ["repository_id", "image_storage_id"],
+        unique=False,
+    )
+    op.create_index(
+        "repositoryblobdigest_image_storage_id",
+        "repositoryblobdigest",
+        ["image_storage_id"],
+        unique=False,
+    )
+
+    # RepositoryManifestDigest
+    op.create_table(
+        "repositorymanifestdigest",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("repository_id", sa.Integer(), nullable=False),
+        sa.Column("manifest_id", sa.Integer(), nullable=False),
+        sa.Column("digest", sa.String(length=1024), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["repository_id"],
+            ["repository.id"],
+            name=op.f("fk_repositorymanifestdigest_repository_id"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["manifest_id"],
+            ["manifest.id"],
+            name=op.f("fk_repositorymanifestdigest_manifest_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_repositorymanifestdigest")),
+    )
+    op.create_index(
+        "repositorymanifestdigest_repository_id_digest",
+        "repositorymanifestdigest",
+        ["repository_id", "digest"],
+        unique=True,
+    )
+    op.create_index(
+        "repositorymanifestdigest_repository_id_manifest_id",
+        "repositorymanifestdigest",
+        ["repository_id", "manifest_id"],
+        unique=False,
+    )
+    op.create_index(
+        "repositorymanifestdigest_manifest_id",
+        "repositorymanifestdigest",
+        ["manifest_id"],
+        unique=False,
+    )
+
+    # BlobUpload columns
+    op.add_column(
+        "blobupload",
+        sa.Column("requested_digest_algorithm", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "blobupload",
+        sa.Column("requested_digest_state", sa.Text(), nullable=True),
+    )
+
+    tester.populate_table(
+        "repositoryblobdigest",
+        [
+            ("repository_id", tester.TestDataType.Foreign("repository")),
+            ("image_storage_id", tester.TestDataType.Foreign("imagestorage")),
+            ("digest", tester.TestDataType.String),
+            ("created_at", tester.TestDataType.DateTime),
+        ],
+    )
+    tester.populate_table(
+        "repositorymanifestdigest",
+        [
+            ("repository_id", tester.TestDataType.Foreign("repository")),
+            ("manifest_id", tester.TestDataType.Foreign("manifest")),
+            ("digest", tester.TestDataType.String),
+            ("created_at", tester.TestDataType.DateTime),
+        ],
+    )
+
+
+def downgrade(op, tables, tester):
+    with op.batch_alter_table("blobupload") as batch_op:
+        batch_op.drop_column("requested_digest_state")
+        batch_op.drop_column("requested_digest_algorithm")
+
+    op.drop_table("repositorymanifestdigest")
+    op.drop_table("repositoryblobdigest")

--- a/initdb.py
+++ b/initdb.py
@@ -1573,6 +1573,8 @@ WHITELISTED_EMPTY_MODELS = [
     "TagNotificationSuccess",
     "TagPullStatistics",
     "ManifestPullStatistics",
+    "RepositoryBlobDigest",
+    "RepositoryManifestDigest",
     "NamespaceImmutabilityPolicy",
     "RepositoryImmutabilityPolicy",
     "OrganizationContactEmail",


### PR DESCRIPTION
## Summary

- add repository-scoped blob and manifest digest registration models
- add requested digest algorithm and resumable state fields to blob uploads
- add the Alembic migration and focused upgrade/downgrade coverage

## Testing

- Not run; draft opened after static review
- `git diff --check 1cd98025...1ffa45a5` — passed

## Tracking

- https://redhat.atlassian.net/browse/PROJQUAY-11537