### PR TITLE
[redhat-3.12] PROJQUAY-12475: fix(cve): CVE-2026-44705 - tmp

### DIFF
--- a/config-tool/pkg/lib/editor/package-lock.json
+++ b/config-tool/pkg/lib/editor/package-lock.json
@@ -1048,7 +1048,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.3.1",
@@ -1192,7 +1192,7 @@
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1865,7 +1865,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -3505,7 +3505,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3612,7 +3612,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4169,7 +4169,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5768,7 +5768,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -6153,15 +6153,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
@@ -6293,7 +6284,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7281,18 +7272,6 @@
         "node": ">= 6.9.0"
       }
     },
-    "node_modules/selenium-webdriver/node_modules/tmp": {
-      "version": "0.0.30",
-      "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-      "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz",
@@ -8113,30 +8092,13 @@
       "optional": true
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "devOptional": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=8.17.0"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "devOptional": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -10206,7 +10168,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "devOptional": true
+      "dev": true
     },
     "base64-js": {
       "version": "1.3.1",
@@ -10333,7 +10295,7 @@
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10830,7 +10792,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "devOptional": true
+      "dev": true
     },
     "connect": {
       "version": "3.7.0",
@@ -11012,7 +10974,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "^0.2.6",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -12076,7 +12038,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "devOptional": true
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.2",
@@ -12162,7 +12124,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12575,7 +12537,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -13092,7 +13054,7 @@
         "rimraf": "^3.0.2",
         "socket.io": "^4.4.1",
         "source-map": "^0.6.1",
-        "tmp": "^0.2.1",
+        "tmp": "^0.2.6",
         "ua-parser-js": "^0.7.30",
         "yargs": "^16.1.1"
       },
@@ -13815,7 +13777,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.18"
       }
@@ -14109,12 +14071,6 @@
         "mem": "^4.0.0"
       }
     },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
     "ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
@@ -14213,7 +14169,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "devOptional": true
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -14989,19 +14945,8 @@
       "requires": {
         "jszip": "^3.1.3",
         "rimraf": "^2.5.4",
-        "tmp": "0.0.30",
+        "tmp": "^0.2.6",
         "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.30",
-          "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-          "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
       }
     },
     "semver": {
@@ -15642,24 +15587,10 @@
       "optional": true
     },
     "tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "devOptional": true,
-      "requires": {
-        "rimraf": "^3.0.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "devOptional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "devOptional": true
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/config-tool/pkg/lib/editor/package.json
+++ b/config-tool/pkg/lib/editor/package.json
@@ -91,6 +91,7 @@
   },
   "overrides": {
     "brace-expansion": "^1.1.18",
+    "tmp": "^0.2.6",
     "request": {
       "qs": "^6.14.0"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4050,17 +4050,6 @@
         "tmp": "0.0.28"
       }
     },
-    "node_modules/git-package-json/node_modules/tmp": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/git-source": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/git-source/-/git-source-1.1.10.tgz",
@@ -7254,14 +7243,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz",
@@ -8831,18 +8812,6 @@
         "node": ">= 6.9.0"
       }
     },
-    "node_modules/selenium-webdriver/node_modules/tmp": {
-      "version": "0.0.30",
-      "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-      "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/semver": {
       "version": "5.3.0",
       "resolved": "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz",
@@ -9960,10 +9929,10 @@
       "integrity": "sha1-bchFBSywjr78GHRyO1jySmSMO28="
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true,
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
@@ -10987,15 +10956,6 @@
       },
       "engines": {
         "node": ">= 4.2.x"
-      }
-    },
-    "node_modules/webdriver-js-extender/node_modules/tmp": {
-      "version": "0.0.24",
-      "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.24.tgz",
-      "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/webdriver-js-extender/node_modules/xml2js": {
@@ -15096,17 +15056,7 @@
         "one-by-one": "^3.1.0",
         "r-json": "^1.2.1",
         "r-package-json": "^1.0.0",
-        "tmp": "0.0.28"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.28",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
+        "tmp": "^0.2.6"
       }
     },
     "git-source": {
@@ -16359,7 +16309,7 @@
         "rimraf": "^3.0.2",
         "socket.io": "^4.7.2",
         "source-map": "^0.6.1",
-        "tmp": "^0.2.1",
+        "tmp": "^0.2.6",
         "ua-parser-js": "^0.7.30",
         "yargs": "^16.1.1"
       },
@@ -17660,11 +17610,6 @@
       "requires": {
         "lcid": "^1.0.0"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
       "version": "1.0.0",
@@ -19003,19 +18948,8 @@
       "requires": {
         "adm-zip": "^0.4.7",
         "rimraf": "^2.5.4",
-        "tmp": "0.0.30",
+        "tmp": "^0.2.6",
         "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.30",
-          "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-          "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
       }
     },
     "semver": {
@@ -19888,10 +19822,9 @@
       "integrity": "sha1-bchFBSywjr78GHRyO1jySmSMO28="
     },
     "tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -20703,16 +20636,10 @@
           "requires": {
             "adm-zip": "0.4.4",
             "rimraf": "^2.2.8",
-            "tmp": "0.0.24",
+            "tmp": "^0.2.6",
             "ws": "^1.0.1",
             "xml2js": "0.4.4"
           }
-        },
-        "tmp": {
-          "version": "0.0.24",
-          "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.24.tgz",
-          "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
-          "dev": true
         },
         "xml2js": {
           "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "overrides": {
     "qs": "^6.14.0",
+    "tmp": "^0.2.6",
     "form-data": "^2.5.6",
     "brace-expansion": "^1.1.18",
     "js-yaml": "3.15.0"


### PR DESCRIPTION
Summary

```
Security fix for # CVE-2026-44705 affecting tmp
```

Details

```
CVE: # CVE-2026-44705
Severity: Important (CVSSv3: 7.7)
Impact: # path Traversal via unsanitized prefix/postfix enables directory escape
Component: tmp
Old Version: 0.0.24, 0.0.28, 0.0.30, 0.2.1, 0.2.3
New Version: 0.2.6
```

Changes

```
Fixed tmp to 0.2.6 package.json
Updated tmp from 0.0.24, 0.0.28, 0.0.30, 0.2.3 to 0.2.6 package-lock.json
Updated tmp from 0.2.1, 0.0.30 to 0.2.6 config-tool package-lock.json
```

References

```
https://www.cve.org/CVERecord?id=CVE-2026-44705
https://www.npmjs.com/package/tmp
``` 

Resolves: [PROJQUAY-12475](https://redhat.atlassian.net/browse/PROJQUAY-12475)
