### PR TITLE
[redhat-3.9] PROJQUAY-12481: fix(cve): CVE-2026-44705 - tmp

### DIFF
--- a/config-tool/pkg/lib/editor/package-lock.json
+++ b/config-tool/pkg/lib/editor/package-lock.json
@@ -6310,15 +6310,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz",
@@ -8210,18 +8201,6 @@
         "node": ">= 6.9.0"
       }
     },
-    "node_modules/selenium-webdriver/node_modules/tmp": {
-      "version": "0.0.30",
-      "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-      "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz",
@@ -9171,30 +9150,13 @@
       "integrity": "sha1-HRpW7fxRxD6GPLtTgqcjMONVVCM="
     },
     "node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=8.17.0"
-      }
-    },
-    "node_modules/tmp/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-arraybuffer": {
@@ -14668,7 +14630,7 @@
         "rimraf": "^3.0.2",
         "socket.io": "^4.4.1",
         "source-map": "^0.6.1",
-        "tmp": "^0.2.1",
+        "tmp": "^0.2.6",
         "ua-parser-js": "^0.7.30",
         "yargs": "^16.1.1"
       },
@@ -15825,12 +15787,6 @@
         "lcid": "^2.0.0",
         "mem": "^4.0.0"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
@@ -17397,19 +17353,8 @@
       "requires": {
         "jszip": "^3.1.3",
         "rimraf": "^2.5.4",
-        "tmp": "0.0.30",
+        "tmp": "^0.2.6",
         "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.30",
-          "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-          "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
       }
     },
     "semver": {
@@ -18200,24 +18145,10 @@
       "integrity": "sha1-HRpW7fxRxD6GPLtTgqcjMONVVCM="
     },
     "tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dev": true,
-      "requires": {
-        "rimraf": "^3.0.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",

--- a/config-tool/pkg/lib/editor/package.json
+++ b/config-tool/pkg/lib/editor/package.json
@@ -87,6 +87,7 @@
     "webpack-cli": "3.3.9"
   },
   "overrides": {
-    "brace-expansion": "^1.1.18"
+    "brace-expansion": "^1.1.18",
+    "tmp": "^0.2.6"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4268,17 +4268,6 @@
         "tmp": "0.0.28"
       }
     },
-    "node_modules/git-package-json/node_modules/tmp": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/git-source": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/git-source/-/git-source-1.1.10.tgz",
@@ -7285,14 +7274,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz",
@@ -8985,18 +8966,6 @@
         "node": ">= 6.9.0"
       }
     },
-    "node_modules/selenium-webdriver/node_modules/tmp": {
-      "version": "0.0.30",
-      "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-      "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-      "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/semver": {
       "version": "5.3.0",
       "resolved": "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz",
@@ -10009,15 +9978,12 @@
       "integrity": "sha1-bchFBSywjr78GHRyO1jySmSMO28="
     },
     "node_modules/tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha512-lfyEfOppKvWNeId5CArFLwgwef+iCnbEIy0JWYf1httIEXnx4ndL4Dr1adw7hPgeQfSlTbc/gqn6iaKcROpw5Q==",
-      "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-array": {
@@ -11025,15 +10991,6 @@
       },
       "engines": {
         "node": ">= 4.2.x"
-      }
-    },
-    "node_modules/webdriver-js-extender/node_modules/tmp": {
-      "version": "0.0.24",
-      "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.24.tgz",
-      "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/webdriver-js-extender/node_modules/xml2js": {
@@ -15372,17 +15329,7 @@
         "one-by-one": "^3.1.0",
         "r-json": "^1.2.1",
         "r-package-json": "^1.0.0",
-        "tmp": "0.0.28"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.28",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-          "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
+        "tmp": "^0.2.6"
       }
     },
     "git-source": {
@@ -16705,7 +16652,7 @@
         "safe-buffer": "^5.0.1",
         "socket.io": "1.7.3",
         "source-map": "^0.5.3",
-        "tmp": "0.0.31",
+        "tmp": "^0.2.6",
         "useragent": "^2.1.12"
       },
       "dependencies": {
@@ -17833,11 +17780,6 @@
       "requires": {
         "lcid": "^1.0.0"
       }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
       "version": "1.0.0",
@@ -19277,19 +19219,8 @@
       "requires": {
         "adm-zip": "^0.4.7",
         "rimraf": "^2.5.4",
-        "tmp": "0.0.30",
+        "tmp": "^0.2.6",
         "xml2js": "^0.4.17"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.30",
-          "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz",
-          "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
-        }
       }
     },
     "semver": {
@@ -20141,13 +20072,9 @@
       "integrity": "sha1-bchFBSywjr78GHRyO1jySmSMO28="
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha512-lfyEfOppKvWNeId5CArFLwgwef+iCnbEIy0JWYf1httIEXnx4ndL4Dr1adw7hPgeQfSlTbc/gqn6iaKcROpw5Q==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "~1.0.1"
-      }
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="
     },
     "to-array": {
       "version": "0.1.4",
@@ -20735,7 +20662,7 @@
       "dev": true,
       "requires": {
         "lru-cache": "4.1.x",
-        "tmp": "0.0.x"
+        "tmp": "^0.2.6"
       },
       "dependencies": {
         "lru-cache": {
@@ -20965,16 +20892,10 @@
           "requires": {
             "adm-zip": "0.4.4",
             "rimraf": "^2.2.8",
-            "tmp": "0.0.24",
+            "tmp": "^0.2.6",
             "ws": "^1.0.1",
             "xml2js": "0.4.4"
           }
-        },
-        "tmp": {
-          "version": "0.0.24",
-          "resolved": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.24.tgz",
-          "integrity": "sha1-1qXhmNFKmDXMby18PZ4wJCjIzxI=",
-          "dev": true
         },
         "xml2js": {
           "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   },
   "overrides": {
     "form-data": "^2.5.6",
+    "tmp": "^0.2.6",
     "brace-expansion": "^1.1.18",
     "js-yaml": "3.15.0"
   }


### PR DESCRIPTION
Summary

```
Security fix for # CVE-2026-44705 affecting tmp
```

Details

```
CVE: # CVE-2026-44705
Severity: Important (CVSSv3: 7.7)
Impact: # path Traversal via unsanitized prefix/postfix enables directory escape
Component: tmp
Old Version: 0.0.24, 0.0.28, 0.0.30, 0.2.1, 0.2.3
New Version: 0.2.6
```

Changes

```
Fixed tmp to 0.2.6 package.json
Updated tmp from 0.0.24, 0.0.28, 0.0.30, 0.2.3 to 0.2.6 package-lock.json
Updated tmp from 0.2.1, 0.0.30 to 0.2.6 config-tool package-lock.json
```

References

```
https://www.cve.org/CVERecord?id=CVE-2026-44705
https://www.npmjs.com/package/tmp
``` 

Resolves: [PROJQUAY-12481](https://redhat.atlassian.net/browse/PROJQUAY-12481)